### PR TITLE
fix: use correct process ID in batch suspend test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
@@ -87,7 +87,10 @@ test.describe('Suspend & Resume Batch Operation Tests', () => {
   test('Suspend finished batch operation returns 404', async ({request}) => {
     const key =
       await test.step('Create completed batch operation', async () => {
-        return createCompletedBatchOperation(request);
+        return createCompletedBatchOperation(
+          request,
+          'batch_suspension_process',
+        );
       });
 
     const res = await suspendBatchOperation(request, key, 404);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/batch-operation-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/batch-operation-requestHelpers.ts
@@ -64,8 +64,11 @@ export async function resumeBatchOperation(
 
 export async function createCompletedBatchOperation(
   request: APIRequestContext,
+  processDefinitionId?: string,
 ) {
-  const key = await createCancellationBatch(request);
+  const key = processDefinitionId
+    ? await createCancellationBatch(request, 3, processDefinitionId)
+    : await createCancellationBatch(request);
 
   await expect(async () => {
     const res = await request.get(buildUrl(`/batch-operations/${key}`), {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/batch-operation-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/batch-operation-requestHelpers.ts
@@ -67,7 +67,7 @@ export async function createCompletedBatchOperation(
   processDefinitionId?: string,
 ) {
   const key = processDefinitionId
-    ? await createCancellationBatch(request, 3, processDefinitionId)
+    ? await createCancellationBatch(request, undefined, processDefinitionId)
     : await createCancellationBatch(request);
 
   await expect(async () => {


### PR DESCRIPTION
## Description

Closes #49783

`createCompletedBatchOperation` defaults to using `batch_cancellation_process`, but the suspend test's `beforeAll` only deploys `batch_suspension_process`. This causes the "Suspend finished batch operation returns 404" test to fail with `Process with key batch_cancellation_process not found`.

## Changes

1. **`batch-operation-requestHelpers.ts`**: Add optional `processDefinitionId` parameter to `createCompletedBatchOperation`. When provided, it is forwarded to `createCancellationBatch`; otherwise the existing default behavior is preserved.

2. **`batch-operations-suspend-api-tests.spec.ts`**: Pass `'batch_suspension_process'` to `createCompletedBatchOperation` so the helper targets the process actually deployed by the test's `beforeAll`.

## Testing

Verified with `--repeat-each=3 --workers=1` on the batch suspend tests — all 5 non-skipped tests pass consistently (previously the "Suspend finished" test failed).