### PR TITLE
fix: normalize UserTaskEffectiveVariableSearchQueryRequest to extend SearchQueryRequest

### DIFF
--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryRequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryRequestMapper.java
@@ -579,7 +579,7 @@ public final class SearchQueryRequestMapper {
     }
 
     final var filter = SearchQueryFilterMapper.toUserTaskVariableFilter(request.getFilter());
-    final var page = toOffsetPagination(request.getPage());
+    final var page = toSearchQueryPage(request.getPage());
     final var sort =
         SearchQuerySortRequestMapper.toSearchQuerySort(
             SearchQuerySortRequestMapper.fromUserTaskVariableSearchQuerySortRequest(

--- a/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
@@ -847,15 +847,13 @@ components:
           description: The user task variable search filters.
 
     UserTaskEffectiveVariableSearchQueryRequest:
+      allOf:
+        - $ref: 'search-models.yaml#/components/schemas/SearchQueryRequest'
       description: >
-        User task effective variable search query request. Uses offset-based pagination only.
+        User task effective variable search query request.
       additionalProperties: false
       type: object
       properties:
-        page:
-          description: Pagination parameters.
-          allOf:
-            - $ref: 'search-models.yaml#/components/schemas/OffsetPagination'
         sort:
           description: Sort field criteria.
           type: array


### PR DESCRIPTION
## Description

The `UserTaskEffectiveVariableSearchQueryRequest` schema defines its `page` property inline with `OffsetPagination` instead of extending `SearchQueryRequest` like all other search query schemas. This prevents the code generator from discovering it as a search query request schema.

### Changes

**Schema normalization** (`user-tasks.yaml`):
- Add `allOf` ref to `SearchQueryRequest` (inherits `page` via `SearchQueryPageRequest`)
- Remove the inline `page` property definition that referenced `OffsetPagination` directly

**Mapper update** (`SearchQueryRequestMapper.java`):
- `toUserTaskEffectiveVariableQuery()` now calls `toSearchQueryPage()` instead of `toOffsetPagination()`, matching the normalized schema's page type

### Why this is safe

The offset-only pagination restriction is enforced in the service layer (`UserTaskServices.searchUserTaskEffectiveVariables`) which strips cursors from the response and does in-memory deduplication. Accepting the full `SearchQueryPageRequest` at the schema level is backwards compatible — the existing `OffsetPagination` payloads are a valid subset of `SearchQueryPageRequest`.

### Context

Part of the compile-time data contract initiative (parent: #48123). This normalization enables the code generator to discover the effective-variables search endpoint and generate a strict contract + controller for it, consistent with all other search endpoints.