### PR TITLE
test: update locators and tests

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstanceViewModificationMode.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstanceViewModificationMode.ts
@@ -152,39 +152,41 @@ export class OperateProcessInstanceViewModificationModePage {
       jsonEditorButton: this.page
         .getByTestId(`variable-newVariables[${index}]`)
         .getByRole('cell')
-        .nth(1)
-        .getByRole('button'),
+        .nth(2)
+        .getByRole('button')
+        .nth(0),
       deleteButton: this.page
         .getByTestId(`variable-newVariables[${index}]`)
         .getByRole('cell')
         .nth(2)
-        .getByRole('button'),
+        .getByRole('button')
+        .nth(1),
       jsonEditorModal: {
         header: this.page
           .getByTestId(`variable-newVariables[${index}]`)
           .getByRole('cell')
-          .nth(1)
+          .nth(2)
           .getByRole('presentation')
           .getByRole('dialog')
           .getByText('Edit a new Variable'),
         cancelButton: this.page
           .getByTestId(`variable-newVariables[${index}]`)
           .getByRole('cell')
-          .nth(1)
+          .nth(2)
           .getByRole('presentation')
           .getByRole('dialog')
           .getByRole('button', {name: 'Cancel'}),
         applyButton: this.page
           .getByTestId(`variable-newVariables[${index}]`)
           .getByRole('cell')
-          .nth(1)
+          .nth(2)
           .getByRole('presentation')
           .getByRole('dialog')
           .getByRole('button', {name: 'Apply'}),
         inputField: this.page
           .getByTestId(`variable-newVariables[${index}]`)
           .getByRole('cell')
-          .nth(1)
+          .nth(2)
           .getByRole('presentation')
           .getByRole('dialog')
           .getByRole('code')
@@ -210,34 +212,34 @@ export class OperateProcessInstanceViewModificationModePage {
       jsonEditorButton: this.page
         .getByTestId(`variable-${name}`)
         .getByRole('cell')
-        .nth(1)
+        .nth(2)
         .getByRole('button'),
       jsonEditorModal: {
         header: this.page
           .getByTestId(`variable-${name}`)
           .getByRole('cell')
-          .nth(1)
+          .nth(2)
           .getByRole('presentation')
           .getByRole('dialog')
           .getByText(`Edit Variable "${name}"`),
         cancelButton: this.page
           .getByTestId(`variable-${name}`)
           .getByRole('cell')
-          .nth(1)
+          .nth(2)
           .getByRole('presentation')
           .getByRole('dialog')
           .getByRole('button', {name: 'Cancel'}),
         applyButton: this.page
           .getByTestId(`variable-${name}`)
           .getByRole('cell')
-          .nth(1)
+          .nth(2)
           .getByRole('presentation')
           .getByRole('dialog')
           .getByRole('button', {name: 'Apply'}),
         inputField: this.page
           .getByTestId(`variable-${name}`)
           .getByRole('cell')
-          .nth(1)
+          .nth(2)
           .getByRole('presentation')
           .getByRole('dialog')
           .getByRole('code')

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -832,7 +832,8 @@ test.describe.serial('Process Instance Migration', () => {
     });
   });
 
-  test('Migrated multi instance elements', async ({
+  //Skipped due to bug 49095: https://github.com/camunda/camunda/issues/49095
+  test.skip('Migrated multi instance elements', async ({
     page,
     operateFiltersPanelPage,
     operateProcessesPage,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -761,7 +761,7 @@ test.describe.serial('Process Instance Migration', () => {
     });
   });
 
-  // skipped due to bug 49095: https://github.com/camunda/camunda/issues/49095
+  //Skipped due to bug 49095: https://github.com/camunda/camunda/issues/49095
   test.skip('Migrated gateways', async ({
     page,
     operateFiltersPanelPage,
@@ -799,7 +799,8 @@ test.describe.serial('Process Instance Migration', () => {
     });
   });
 
-  test('Migrated signal elements', async ({
+  //Skipped due to bug 49095: https://github.com/camunda/camunda/issues/49095
+  test.skip('Migrated signal elements', async ({
     page,
     operateFiltersPanelPage,
     operateProcessesPage,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
@@ -618,30 +618,25 @@ test.describe('Process Instances Filters', () => {
         },
       });
 
-      await operateProcessesPage.selectProcessCheckboxByPIK(
-        processToCancelInstanceMeowIK,
-        processToCancelInstanceGawIK,
-      );
+      await operateProcessesPage.selectAllRowsCheckbox.click();
 
       await operateProcessesPage.clickCancelBatchOperationButton();
 
       await operateProcessesPage.clickCancelProcessInstanceDialogButton();
 
+      await operateProcessesPage.clickGoToOperationDetailsButton();
+
+      await sleep(1_000);
+      await expect(operateOperationsDetailsPage.state).toBeVisible();
       await waitForAssertion({
         assertion: async () => {
-          await expect(
-            operateProcessesPage.noMatchingInstancesMessage,
-          ).toBeVisible({timeout: 30000});
+          const batchOperationStatus = await operateOperationsDetailsPage.getBatchOperationStatus();
+          expect(batchOperationStatus).toBe('Completed');
         },
         onFailure: async () => {
           await page.reload();
         },
       });
-
-      await operateProcessesPage.clickGoToOperationDetailsButton();
-
-      await sleep(1_000);
-      await expect(operateOperationsDetailsPage.state).toBeVisible();
 
       const operationId =
         await operateOperationsDetailsPage.getBatchOperationId();


### PR DESCRIPTION
## Description

This PR changes locators in Operate pages, as some changes were introduced in variable modification UI. Also in this PR some additional tests were skipped due to https://github.com/camunda/camunda/issues/49095 and https://github.com/camunda/camunda/issues/49260 was updated accordingly. Additionally this PR updates `processInstancesFilters.spec.ts`  to reduce flakines 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

related https://github.com/camunda/camunda/issues/49095

## On demand workflow
[Was all green on v2 mode](https://github.com/camunda/camunda/actions/runs/23644888999)