### PR TITLE
[Backport stable/8.7] feat: support configurable rate unit and fractional rates in load tester

### DIFF
--- a/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/config/StarterCfg.java
+++ b/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/config/StarterCfg.java
@@ -21,7 +21,8 @@ import java.util.List;
 public class StarterCfg {
 
   private String processId;
-  private int rate;
+  private double rate;
+  private Duration rateDuration = Duration.ofSeconds(1);
   private int threads;
 
   /** Paths are relative to classpath. */
@@ -64,12 +65,24 @@ public class StarterCfg {
     this.processId = processId;
   }
 
-  public int getRate() {
+  public double getRate() {
     return rate;
   }
 
-  public void setRate(final int rate) {
+  public void setRate(final double rate) {
     this.rate = rate;
+  }
+
+  public Duration getRateDuration() {
+    return rateDuration;
+  }
+
+  public void setRateDuration(final Duration rateDuration) {
+    this.rateDuration = rateDuration;
+  }
+
+  public double getRatePerSecond() {
+    return rate / (rateDuration.toNanos() / 1_000_000_000.0);
   }
 
   public int getThreads() {

--- a/zeebe/benchmarks/project/src/main/resources/application.conf
+++ b/zeebe/benchmarks/project/src/main/resources/application.conf
@@ -7,6 +7,7 @@ app {
   starter {
     processId = "benchmark"
     rate = 300
+    rateDuration = 1s
     threads = 2
     bpmnXmlPath = "bpmn/one_task.bpmn"
     extraBpmnModels = []

--- a/zeebe/benchmarks/project/src/test/java/io/camunda/zeebe/config/ConfigTest.java
+++ b/zeebe/benchmarks/project/src/test/java/io/camunda/zeebe/config/ConfigTest.java
@@ -16,7 +16,9 @@
 package io.camunda.zeebe.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 
+import java.time.Duration;
 import org.junit.jupiter.api.Test;
 
 public class ConfigTest {
@@ -38,7 +40,8 @@ public class ConfigTest {
     assertThat(starterCfg).isNotNull();
 
     assertThat(starterCfg.getProcessId()).isEqualTo("benchmark");
-    assertThat(starterCfg.getRate()).isEqualTo(300);
+    assertThat(starterCfg.getRate()).isEqualTo(300.0);
+    assertThat(starterCfg.getRateDuration()).hasSeconds(1);
     assertThat(starterCfg.getThreads()).isEqualTo(2);
     assertThat(starterCfg.getBpmnXmlPath()).isEqualTo("bpmn/one_task.bpmn");
     assertThat(starterCfg.getExtraBpmnModels()).isEmpty();
@@ -85,7 +88,9 @@ public class ConfigTest {
     assertThat(starterCfg).isNotNull();
 
     assertThat(starterCfg.getProcessId()).isEqualTo("benchmark");
-    assertThat(starterCfg.getRate()).isEqualTo(300);
+    assertThat(starterCfg.getRate()).isEqualTo(30.5);
+    assertThat(starterCfg.getRateDuration()).hasMinutes(5);
+    assertThat(starterCfg.getRatePerSecond()).isCloseTo(30.5 / 300.0, within(1e-9));
     assertThat(starterCfg.getThreads()).isEqualTo(2);
     assertThat(starterCfg.getBpmnXmlPath())
         .isEqualTo("bpmn/realistic/bankCustomerComplaintDisputeHandling.bpmn");
@@ -118,5 +123,33 @@ public class ConfigTest {
     assertThat(workerCfg.getMessageName()).isEqualTo("msg");
     assertThat(workerCfg.isSendMessage()).isTrue();
     assertThat(workerCfg.getCorrelationKeyVariableName()).isEqualTo("var");
+  }
+
+  @Test
+  public void shouldConvertFractionalRateWithCustomDuration() {
+    // given
+    final var starterCfg = new StarterCfg();
+    starterCfg.setRate(30.5);
+    starterCfg.setRateDuration(Duration.ofMinutes(1));
+
+    // when
+    final double ratePerSecond = starterCfg.getRatePerSecond();
+
+    // then
+    assertThat(ratePerSecond).isCloseTo(30.5 / 60.0, within(1e-9));
+  }
+
+  @Test
+  public void shouldReturnRateUnchangedForOneSecondDuration() {
+    // given
+    final var starterCfg = new StarterCfg();
+    starterCfg.setRate(0.5);
+    starterCfg.setRateDuration(Duration.ofSeconds(1));
+
+    // when
+    final double ratePerSecond = starterCfg.getRatePerSecond();
+
+    // then
+    assertThat(ratePerSecond).isEqualTo(0.5);
   }
 }

--- a/zeebe/benchmarks/project/src/test/resources/different-application.conf
+++ b/zeebe/benchmarks/project/src/test/resources/different-application.conf
@@ -6,7 +6,8 @@ app {
 
   starter {
     processId = "benchmark"
-    rate = 300
+    rate = 30.5
+    rateDuration = 5m
     threads = 2
     bpmnXmlPath = "bpmn/realistic/bankCustomerComplaintDisputeHandling.bpmn"
     extraBpmnModels = ["bpmn/realistic/determineFraudRatingConfidence.dmn", "bpmn/realistic/refundingProcess.bpmn"]


### PR DESCRIPTION
## Description

Backport of #49531 to `stable/8.7`.

The `setupDataReadMeter` method from the original PR was excluded from this backport as it references classes (`DataReadMeter`, `DataReadMeterQueryProvider`, `CamundaClient`, `Pair`) that do not exist in `stable/8.7`. All other changes are included: `rate` type change to `double`, `rateDuration` field, `getRatePerSecond()` method, updated config files, and new tests.

## Related issues

relates to

<!-- START COPILOT CODING AGENT TIPS -->
---

✨ Let Copilot coding agent [set things up for you](https://github.com/camunda/camunda/issues/new?title=✨+Set+up+Copilot+instructions&body=Configure%20instructions%20for%20this%20repository%20as%20documented%20in%20%5BBest%20practices%20for%20Copilot%20coding%20agent%20in%20your%20repository%5D%28https://gh.io/copilot-coding-agent-tips%29%2E%0A%0A%3COnboard%20this%20repo%3E&assignees=copilot) — coding agent works faster and does higher quality work when set up for your repo.
