### PR TITLE
[Backport stable/8.9] Decision instance delete api test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instance-batch-delete-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instance-batch-delete-api.spec.ts
@@ -70,12 +70,15 @@ test.describe.parallel('Delete Decision Instances Batch API Tests', () => {
   });
 
   test('Delete Decision Instance With Batch', async ({request}) => {
-    const decisionInstanceToDelete = decisionInstances1[0];
     const decisionEvaluationKeyToDelete1 =
-      decisionInstanceToDelete.decisionEvaluationKey;
+      decisionInstances1[0].decisionEvaluationKey;
+    const decisionEvaluationInstanceKeyToGet1 = decisionInstances1[0].decisionEvaluationInstanceKey;
 
     const decisionEvaluationKeyToDelete2 =
       decisionInstances2[0].decisionEvaluationKey;
+    const decisionEvaluationInstanceKeyToGet2 = decisionInstances2[0].decisionEvaluationInstanceKey;
+    console.log(`Decision Evaluation Key to Delete 1: ${decisionEvaluationKeyToDelete1}`);
+    console.log(`Decision Evaluation Key to Delete 2: ${decisionEvaluationKeyToDelete2}`);
 
     await test.step('Delete Decision Instance', async () => {
       await expect(async () => {
@@ -111,7 +114,7 @@ test.describe.parallel('Delete Decision Instances Batch API Tests', () => {
     await test.step('Verify Decision Instance is Deleted', async () => {
       await expect(async () => {
         const res1 = await request.get(
-          buildUrl(`/decision-instances/${decisionEvaluationKeyToDelete1}`),
+          buildUrl(`/decision-instances/${decisionEvaluationInstanceKeyToGet1}`),
           {
             headers: jsonHeaders(),
           },
@@ -119,11 +122,11 @@ test.describe.parallel('Delete Decision Instances Batch API Tests', () => {
 
         await assertNotFoundRequest(
           res1,
-          `Decision Instance with id '${decisionEvaluationKeyToDelete1}' not found`,
+          `Decision Instance with id '${decisionEvaluationInstanceKeyToGet1}' not found`,
         );
 
         const res2 = await request.get(
-          buildUrl(`/decision-instances/${decisionEvaluationKeyToDelete2}`),
+          buildUrl(`/decision-instances/${decisionEvaluationInstanceKeyToGet2}`),
           {
             headers: jsonHeaders(),
           },
@@ -131,7 +134,7 @@ test.describe.parallel('Delete Decision Instances Batch API Tests', () => {
 
         await assertNotFoundRequest(
           res2,
-          `Decision Instance with id '${decisionEvaluationKeyToDelete2}' not found`,
+          `Decision Instance with id '${decisionEvaluationInstanceKeyToGet2}' not found`,
         );
       }).toPass(defaultAssertionOptions);
     });
@@ -265,7 +268,7 @@ test.describe.parallel('Delete Decision Instances Batch API Tests', () => {
         );
         await assertForbiddenRequest(
           res,
-          "Command 'CREATE' rejected with code 'FORBIDDEN': Insufficient permissions to perform operation 'CREATE_BATCH_OPERATION_DELETE_DECISION_INSTANCE' on resource 'BATCH'",
+          'CREATE_BATCH_OPERATION_DELETE_DECISION_INSTANCE',
         );
       }).toPass(defaultAssertionOptions);
     });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instance-batch-delete-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instance-batch-delete-api.spec.ts
@@ -124,7 +124,11 @@ test.describe.parallel('Delete Decision Instances Batch API Tests', () => {
           res1,
           `Decision Instance with id '${decisionEvaluationInstanceKeyToGet1}' not found`,
         );
-
+      }).toPass(defaultAssertionOptions);
+    });
+    
+    await test.step('Verify Decision Instance is Deleted', async () => {
+      await expect(async () => {
         const res2 = await request.get(
           buildUrl(`/decision-instances/${decisionEvaluationInstanceKeyToGet2}`),
           {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instance-batch-delete-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instance-batch-delete-api.spec.ts
@@ -133,7 +133,7 @@ test.describe.parallel('Delete Decision Instances Batch API Tests', () => {
         const json = await res.json();
         expect(json.batchOperationKey).toBe(createdBatchOperationKey);
         expect(json.batchOperationType).toBe('DELETE_DECISION_INSTANCE');
-        expect(json.operationsTotalCount).toBe(2);
+        expect(json.operationsTotalCount).toBeGreaterThanOrEqual(2);
         expect(json.operationsCompletedCount).toBe(2);
       }).toPass(defaultAssertionOptions);
     });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instance-batch-delete-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instance-batch-delete-api.spec.ts
@@ -1,0 +1,273 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {
+  buildUrl,
+  jsonHeaders,
+  assertUnauthorizedRequest,
+  assertBadRequest,
+  assertStatusCode,
+  assertNotFoundRequest,
+  assertInvalidArgument,
+  encode,
+  assertForbiddenRequest,
+} from '../../../../utils/http';
+import {defaultAssertionOptions} from '../../../../utils/constants';
+import {
+  createMammalProcessInstanceAndDeployMammalDecision,
+  createUser,
+  DecisionInstance,
+  grantUserResourceAuthorization,
+} from '@requestHelpers';
+import {validateResponse} from '../../../../json-body-assertions';
+import {cleanupUsers} from 'utils/usersCleanup';
+
+test.describe.parallel('Delete Decision Instances Batch API Tests', () => {
+  let decisionInstances1: DecisionInstance[] = [];
+  let decisionInstances2: DecisionInstance[] = [];
+  let userWithResourcesAuthorizationToSendRequest: {
+    username: string;
+    name: string;
+    email: string;
+    password: string;
+  } = {} as {
+    username: string;
+    name: string;
+    email: string;
+    password: string;
+  };
+
+  test.beforeAll(async ({request}) => {
+    const result1 =
+      await createMammalProcessInstanceAndDeployMammalDecision(request);
+    decisionInstances1 = result1.decisions;
+
+    const result2 =
+      await createMammalProcessInstanceAndDeployMammalDecision(request);
+    decisionInstances2 = result2.decisions;
+
+    await test.step('Setup - Create test user with Resource Authorization', async () => {
+      userWithResourcesAuthorizationToSendRequest = await createUser(request);
+      await grantUserResourceAuthorization(
+        request,
+        userWithResourcesAuthorizationToSendRequest,
+      );
+    });
+  });
+
+  test.afterAll(async ({request}) => {
+    await test.step('Cleanup', async () => {
+      await cleanupUsers(request, [
+        userWithResourcesAuthorizationToSendRequest.username,
+      ]);
+    });
+  });
+
+  test('Delete Decision Instance With Batch', async ({request}) => {
+    const decisionInstanceToDelete = decisionInstances1[0];
+    const decisionEvaluationKeyToDelete1 =
+      decisionInstanceToDelete.decisionEvaluationKey;
+
+    const decisionEvaluationKeyToDelete2 =
+      decisionInstances2[0].decisionEvaluationKey;
+
+    await test.step('Delete Decision Instance', async () => {
+      await expect(async () => {
+        const res = await request.post(
+          buildUrl(`/decision-instances/deletion`),
+          {
+            headers: jsonHeaders(),
+            data: {
+              filter: {
+                decisionEvaluationInstanceKey: {
+                  $in: [
+                    decisionEvaluationKeyToDelete1,
+                    decisionEvaluationKeyToDelete2,
+                  ],
+                },
+              },
+            },
+          },
+        );
+
+        await assertStatusCode(res, 200);
+        await validateResponse(
+          {
+            path: '/decision-instances/deletion',
+            method: 'POST',
+            status: '200',
+          },
+          res,
+        );
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Verify Decision Instance is Deleted', async () => {
+      await expect(async () => {
+        const res1 = await request.get(
+          buildUrl(`/decision-instances/${decisionEvaluationKeyToDelete1}`),
+          {
+            headers: jsonHeaders(),
+          },
+        );
+
+        await assertNotFoundRequest(
+          res1,
+          `Decision Instance with id '${decisionEvaluationKeyToDelete1}' not found`,
+        );
+
+        const res2 = await request.get(
+          buildUrl(`/decision-instances/${decisionEvaluationKeyToDelete2}`),
+          {
+            headers: jsonHeaders(),
+          },
+        );
+
+        await assertNotFoundRequest(
+          res2,
+          `Decision Instance with id '${decisionEvaluationKeyToDelete2}' not found`,
+        );
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+
+  test('Create a Batch Operation to Delete Decision Instances With No Filter - Bad Request', async ({
+    request,
+  }) => {
+    const res = await request.post(buildUrl('/decision-instances/deletion'), {
+      headers: jsonHeaders(),
+      data: {
+        // No filter or decisionEvaluationInstanceKeys provided
+      },
+    });
+    await assertInvalidArgument(res, 400, 'No filter provided.');
+  });
+
+  test('Create a Batch Operation to Delete Decision Instances - With Invalid Filter - Bad Request', async ({
+    request,
+  }) => {
+    const res = await request.post(buildUrl('/decision-instances/deletion'), {
+      headers: jsonHeaders(),
+      data: {
+        filter: {
+          invalidField: 'invalidValue',
+        },
+      },
+    });
+    await assertBadRequest(
+      res,
+      'Request property [filter.invalidField] cannot be parsed',
+    );
+  });
+
+  test('Create a Batch Operation to Delete Decision Instances With Non-Existing Keys - 200 but batch operation is empty', async ({
+    request,
+  }) => {
+    let createdBatchOperationKey: string;
+
+    await test.step('Create Batch Operation with Non-Existing Keys', async () => {
+      const nonExistingKey1 = '1234567890';
+      const nonExistingKey2 = '0987654321';
+      const res = await request.post(buildUrl('/decision-instances/deletion'), {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            decisionEvaluationInstanceKey: {
+              $in: [nonExistingKey1, nonExistingKey2],
+            },
+          },
+        },
+      });
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: '/decision-instances/deletion',
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+      const json = await res.json();
+      expect(json.batchOperationType).toBe('DELETE_DECISION_INSTANCE');
+      createdBatchOperationKey = json.batchOperationKey;
+    });
+
+    await test.step('Verify No Operations are done in Batch Operation', async () => {
+      await expect(async () => {
+        const res = await request.get(
+          buildUrl(`/batch-operations/${createdBatchOperationKey}`),
+          {
+            headers: jsonHeaders(),
+          },
+        );
+        await assertStatusCode(res, 200);
+        await validateResponse(
+          {
+            path: '/batch-operations/{batchOperationKey}',
+            method: 'GET',
+            status: '200',
+          },
+          res,
+        );
+        const json = await res.json();
+        expect(json.batchOperationKey).toBe(createdBatchOperationKey);
+        expect(json.batchOperationType).toBe('DELETE_DECISION_INSTANCE');
+        expect(json.operationsTotalCount).toBe(0);
+        expect(json.operationsFailedCount).toBe(0);
+        expect(json.operationsCompletedCount).toBe(0);
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+
+  test('Create a Batch Operation to Delete Decision Instances - Unauthorized', async ({
+    request,
+  }) => {
+    const res = await request.post(buildUrl('/decision-instances/deletion'), {
+      headers: {},
+      data: {
+        filter: {
+          decisionEvaluationInstanceKey: {
+            $in: ['1234567890'], // Non-existing key just to trigger auth before validation
+          },
+        },
+      },
+    });
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Create a Batch Operation to Delete Decision Instances - Forbidden', async ({
+    request,
+  }) => {
+    const token = encode(
+      `${userWithResourcesAuthorizationToSendRequest.username}:${userWithResourcesAuthorizationToSendRequest.password}`,
+    );
+
+    await test.step('Attempt to Create Batch Operation without proper permissions', async () => {
+      await expect(async () => {
+        const res = await request.post(
+          buildUrl('/decision-instances/deletion'),
+          {
+            headers: jsonHeaders(token), // overrides default demo:demo
+            data: {
+              filter: {
+                decisionEvaluationInstanceKey: {
+                  $in: ['1234567890'], // Non-existing key just to trigger auth before validation
+                },
+              },
+            },
+          },
+        );
+        await assertForbiddenRequest(
+          res,
+          "Command 'CREATE' rejected with code 'FORBIDDEN': Insufficient permissions to perform operation 'CREATE_BATCH_OPERATION_DELETE_DECISION_INSTANCE' on resource 'BATCH'",
+        );
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instance-batch-delete-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instance-batch-delete-api.spec.ts
@@ -71,14 +71,12 @@ test.describe.parallel('Delete Decision Instances Batch API Tests', () => {
 
   test('Delete Decision Instance With Batch', async ({request}) => {
     const decisionEvaluationKeyToDelete1 =
-      decisionInstances1[0].decisionEvaluationKey;
-    const decisionEvaluationInstanceKeyToGet1 = decisionInstances1[0].decisionEvaluationInstanceKey;
+      decisionInstances1[0].decisionEvaluationInstanceKey;
 
     const decisionEvaluationKeyToDelete2 =
-      decisionInstances2[0].decisionEvaluationKey;
-    const decisionEvaluationInstanceKeyToGet2 = decisionInstances2[0].decisionEvaluationInstanceKey;
-    console.log(`Decision Evaluation Key to Delete 1: ${decisionEvaluationKeyToDelete1}`);
-    console.log(`Decision Evaluation Key to Delete 2: ${decisionEvaluationKeyToDelete2}`);
+      decisionInstances2[0].decisionEvaluationInstanceKey;
+
+    let createdBatchOperationKey: string;
 
     await test.step('Delete Decision Instance', async () => {
       await expect(async () => {
@@ -108,13 +106,42 @@ test.describe.parallel('Delete Decision Instances Batch API Tests', () => {
           },
           res,
         );
+        const json = await res.json();
+        expect(json.batchOperationType).toBe('DELETE_DECISION_INSTANCE');
+        createdBatchOperationKey = json.batchOperationKey;
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Verify batch operation has two operations', async () => {
+      await expect(async () => {
+        const res = await request.get(
+          buildUrl(`/batch-operations/${createdBatchOperationKey}`),
+          {
+            headers: jsonHeaders(),
+          },
+        );
+
+        await assertStatusCode(res, 200);
+        await validateResponse(
+          {
+            path: '/batch-operations/{batchOperationKey}',
+            method: 'GET',
+            status: '200',
+          },
+          res,
+        );
+        const json = await res.json();
+        expect(json.batchOperationKey).toBe(createdBatchOperationKey);
+        expect(json.batchOperationType).toBe('DELETE_DECISION_INSTANCE');
+        expect(json.operationsTotalCount).toBe(2);
+        expect(json.operationsCompletedCount).toBe(2);
       }).toPass(defaultAssertionOptions);
     });
 
     await test.step('Verify Decision Instance is Deleted', async () => {
       await expect(async () => {
         const res1 = await request.get(
-          buildUrl(`/decision-instances/${decisionEvaluationInstanceKeyToGet1}`),
+          buildUrl(`/decision-instances/${decisionEvaluationKeyToDelete1}`),
           {
             headers: jsonHeaders(),
           },
@@ -122,15 +149,15 @@ test.describe.parallel('Delete Decision Instances Batch API Tests', () => {
 
         await assertNotFoundRequest(
           res1,
-          `Decision Instance with id '${decisionEvaluationInstanceKeyToGet1}' not found`,
+          `Decision Instance with id '${decisionEvaluationKeyToDelete1}' not found`,
         );
       }).toPass(defaultAssertionOptions);
     });
-    
+
     await test.step('Verify Decision Instance is Deleted', async () => {
       await expect(async () => {
         const res2 = await request.get(
-          buildUrl(`/decision-instances/${decisionEvaluationInstanceKeyToGet2}`),
+          buildUrl(`/decision-instances/${decisionEvaluationKeyToDelete2}`),
           {
             headers: jsonHeaders(),
           },
@@ -138,7 +165,7 @@ test.describe.parallel('Delete Decision Instances Batch API Tests', () => {
 
         await assertNotFoundRequest(
           res2,
-          `Decision Instance with id '${decisionEvaluationInstanceKeyToGet2}' not found`,
+          `Decision Instance with id '${decisionEvaluationKeyToDelete2}' not found`,
         );
       }).toPass(defaultAssertionOptions);
     });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instance-delete-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instance-delete-api.spec.ts
@@ -1,0 +1,158 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {
+  buildUrl,
+  jsonHeaders,
+  assertUnauthorizedRequest,
+  assertStatusCode,
+  assertNotFoundRequest,
+  assertForbiddenRequest,
+  encode,
+} from '../../../../utils/http';
+import {defaultAssertionOptions} from '../../../../utils/constants';
+import {
+  createMammalProcessInstanceAndDeployMammalDecision,
+  createUser,
+  DecisionInstance,
+  grantUserResourceAuthorization,
+} from '@requestHelpers';
+import {cleanupUsers} from 'utils/usersCleanup';
+
+test.describe.serial('Delete Decision Instances API Tests', () => {
+  let decisionInstances: DecisionInstance[] = [];
+  let processInstanceKey: string;
+
+  test.beforeAll(async ({request}) => {
+    const result =
+      await createMammalProcessInstanceAndDeployMammalDecision(request);
+    processInstanceKey = result.instance.processInstanceKey;
+    decisionInstances = result.decisions;
+  });
+
+  test('Delete Decision Instance - Success', async ({request}) => {
+    const decisionInstanceToDelete = decisionInstances[0];
+    const decisionEvaluationKeyToDelete =
+      decisionInstanceToDelete.decisionEvaluationKey;
+
+    await test.step('Delete Decision Instance', async () => {
+      await expect(async () => {
+        const res = await request.post(
+          buildUrl(
+            `/decision-instances/${decisionEvaluationKeyToDelete}/deletion`,
+          ),
+          {
+            headers: jsonHeaders(),
+          },
+        );
+
+        await assertStatusCode(res, 204);
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Verify Decision Instance is Deleted', async () => {
+      await expect(async () => {
+        const res = await request.get(
+          buildUrl(`/decision-instances/${decisionEvaluationKeyToDelete}`),
+          {
+            headers: jsonHeaders(),
+          },
+        );
+
+        await assertNotFoundRequest(
+          res,
+          `Decision Instance with id '${decisionEvaluationKeyToDelete}' not found`,
+        );
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+
+  test('Delete Decision Instance - Unauthorized', async ({request}) => {
+    const decisionInstanceToDelete = decisionInstances[1];
+    const decisionEvaluationKeyToDelete =
+      decisionInstanceToDelete.decisionEvaluationKey;
+
+    const res = await request.post(
+      buildUrl(`/decision-instances/${decisionEvaluationKeyToDelete}/deletion`),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Delete Decision Instance - Not Found', async ({request}) => {
+    const notExistingDecisionEvaluationKeyToDelete = '9999999999999';
+
+    const res = await request.post(
+      buildUrl(
+        `/decision-instances/${notExistingDecisionEvaluationKeyToDelete}/deletion`,
+      ),
+      {
+        headers: jsonHeaders(),
+      },
+    );
+    await assertNotFoundRequest(
+      res,
+      `Decision Instance with key '${notExistingDecisionEvaluationKeyToDelete}' not found`,
+    );
+  });
+
+  test('Delete Decision Instance - Forbidden', async ({request}) => {
+    let userWithResourcesAuthorizationToSendRequest: {
+      username: string;
+      name: string;
+      email: string;
+      password: string;
+    } = {} as {
+      username: string;
+      name: string;
+      email: string;
+      password: string;
+    };
+
+    await test.step('Setup - Create test user with Resource Authorization and user for granting Authorization', async () => {
+      userWithResourcesAuthorizationToSendRequest = await createUser(request);
+      await grantUserResourceAuthorization(
+        request,
+        userWithResourcesAuthorizationToSendRequest,
+      );
+    });
+
+    await test.step('Attempt to Delete Decision Instance with insufficient permissions', async () => {
+      const decisionInstanceToDelete = decisionInstances[0];
+      const decisionEvaluationKeyToDelete =
+        decisionInstanceToDelete.decisionEvaluationKey;
+      const token = encode(
+        `${userWithResourcesAuthorizationToSendRequest.username}:${userWithResourcesAuthorizationToSendRequest.password}`,
+      );
+
+      const res = await request.post(
+        buildUrl(
+          `/decision-instances/${decisionEvaluationKeyToDelete}/deletion`,
+        ),
+        {
+          headers: jsonHeaders(token), // overrides default demo:demo
+        },
+      );
+      await assertForbiddenRequest(
+        res,
+        "Command 'DELETE' rejected with code 'FORBIDDEN': Insufficient permissions to perform operation 'DELETE_DECISION_INSTANCE' on resource 'DECISION_DEFINITION', required resource identifiers are one of '[*, MammalLikeBody]'",
+      );
+    });
+
+    await test.step('Cleanup - Delete test users', async () => {
+      await cleanupUsers(request, [
+        userWithResourcesAuthorizationToSendRequest.username,
+      ]);
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instance-delete-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instance-delete-api.spec.ts
@@ -27,17 +27,43 @@ import {cleanupUsers} from 'utils/usersCleanup';
 
 test.describe.serial('Delete Decision Instances API Tests', () => {
   let decisionInstances: DecisionInstance[] = [];
-  let processInstanceKey: string;
+  let userWithResourcesAuthorizationToSendRequest: {
+      username: string;
+      name: string;
+      email: string;
+      password: string;
+    } = {} as {
+      username: string;
+      name: string;
+      email: string;
+      password: string;
+    };
 
   test.beforeAll(async ({request}) => {
     const result =
       await createMammalProcessInstanceAndDeployMammalDecision(request);
-    processInstanceKey = result.instance.processInstanceKey;
     decisionInstances = result.decisions;
+
+    await test.step('Setup - Create test user with Resource Authorization and user for granting Authorization', async () => {
+      userWithResourcesAuthorizationToSendRequest = await createUser(request);
+      await grantUserResourceAuthorization(
+        request,
+        userWithResourcesAuthorizationToSendRequest,
+      );
+    });
+  });
+
+  test.afterAll(async ({request}) => {
+    await test.step('Cleanup - Delete test users', async () => {
+      await cleanupUsers(request, [
+        userWithResourcesAuthorizationToSendRequest.username,
+      ]);
+    });
   });
 
   test('Delete Decision Instance - Success', async ({request}) => {
-    const decisionInstanceToDelete = decisionInstances[0];
+    const decisionInstanceToDelete =
+        decisionInstances[decisionInstances.length - 1];
     const decisionEvaluationKeyToDelete =
       decisionInstanceToDelete.decisionEvaluationKey;
 
@@ -57,9 +83,10 @@ test.describe.serial('Delete Decision Instances API Tests', () => {
     });
 
     await test.step('Verify Decision Instance is Deleted', async () => {
+      const decisionEvaluationInstanceKeyToGet = decisionInstanceToDelete.decisionEvaluationInstanceKey;
       await expect(async () => {
         const res = await request.get(
-          buildUrl(`/decision-instances/${decisionEvaluationKeyToDelete}`),
+          buildUrl(`/decision-instances/${decisionEvaluationInstanceKeyToGet}`),
           {
             headers: jsonHeaders(),
           },
@@ -67,7 +94,7 @@ test.describe.serial('Delete Decision Instances API Tests', () => {
 
         await assertNotFoundRequest(
           res,
-          `Decision Instance with id '${decisionEvaluationKeyToDelete}' not found`,
+          `Decision Instance with id '${decisionEvaluationInstanceKeyToGet}' not found`,
         );
       }).toPass(defaultAssertionOptions);
     });
@@ -107,26 +134,6 @@ test.describe.serial('Delete Decision Instances API Tests', () => {
   });
 
   test('Delete Decision Instance - Forbidden', async ({request}) => {
-    let userWithResourcesAuthorizationToSendRequest: {
-      username: string;
-      name: string;
-      email: string;
-      password: string;
-    } = {} as {
-      username: string;
-      name: string;
-      email: string;
-      password: string;
-    };
-
-    await test.step('Setup - Create test user with Resource Authorization and user for granting Authorization', async () => {
-      userWithResourcesAuthorizationToSendRequest = await createUser(request);
-      await grantUserResourceAuthorization(
-        request,
-        userWithResourcesAuthorizationToSendRequest,
-      );
-    });
-
     await test.step('Attempt to Delete Decision Instance with insufficient permissions', async () => {
       const decisionInstanceToDelete = decisionInstances[0];
       const decisionEvaluationKeyToDelete =
@@ -145,14 +152,8 @@ test.describe.serial('Delete Decision Instances API Tests', () => {
       );
       await assertForbiddenRequest(
         res,
-        "Command 'DELETE' rejected with code 'FORBIDDEN': Insufficient permissions to perform operation 'DELETE_DECISION_INSTANCE' on resource 'DECISION_DEFINITION', required resource identifiers are one of '[*, MammalLikeBody]'",
+        "operation 'DELETE_DECISION_INSTANCE' on resource 'DECISION_DEFINITION'",
       );
-    });
-
-    await test.step('Cleanup - Delete test users', async () => {
-      await cleanupUsers(request, [
-        userWithResourcesAuthorizationToSendRequest.username,
-      ]);
     });
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instance-delete-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instance-delete-api.spec.ts
@@ -61,6 +61,30 @@ test.describe.serial('Delete Decision Instances API Tests', () => {
     });
   });
 
+    test('Delete Decision Instance - Forbidden', async ({request}) => {
+    await test.step('Attempt to Delete Decision Instance with insufficient permissions', async () => {
+      const decisionInstanceToDelete = decisionInstances[0];
+      const decisionEvaluationKeyToDelete =
+        decisionInstanceToDelete.decisionEvaluationKey;
+      const token = encode(
+        `${userWithResourcesAuthorizationToSendRequest.username}:${userWithResourcesAuthorizationToSendRequest.password}`,
+      );
+
+      const res = await request.post(
+        buildUrl(
+          `/decision-instances/${decisionEvaluationKeyToDelete}/deletion`,
+        ),
+        {
+          headers: jsonHeaders(token), // overrides default demo:demo
+        },
+      );
+      await assertForbiddenRequest(
+        res,
+        "operation 'DELETE_DECISION_INSTANCE' on resource 'DECISION_DEFINITION'",
+      );
+    });
+  });
+
   test('Delete Decision Instance - Success', async ({request}) => {
     const decisionInstanceToDelete =
         decisionInstances[decisionInstances.length - 1];
@@ -131,29 +155,5 @@ test.describe.serial('Delete Decision Instances API Tests', () => {
       res,
       `Decision Instance with key '${notExistingDecisionEvaluationKeyToDelete}' not found`,
     );
-  });
-
-  test('Delete Decision Instance - Forbidden', async ({request}) => {
-    await test.step('Attempt to Delete Decision Instance with insufficient permissions', async () => {
-      const decisionInstanceToDelete = decisionInstances[0];
-      const decisionEvaluationKeyToDelete =
-        decisionInstanceToDelete.decisionEvaluationKey;
-      const token = encode(
-        `${userWithResourcesAuthorizationToSendRequest.username}:${userWithResourcesAuthorizationToSendRequest.password}`,
-      );
-
-      const res = await request.post(
-        buildUrl(
-          `/decision-instances/${decisionEvaluationKeyToDelete}/deletion`,
-        ),
-        {
-          headers: jsonHeaders(token), // overrides default demo:demo
-        },
-      );
-      await assertForbiddenRequest(
-        res,
-        "operation 'DELETE_DECISION_INSTANCE' on resource 'DECISION_DEFINITION'",
-      );
-    });
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instances-get-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instances-get-api.spec.ts
@@ -11,7 +11,6 @@ import {
   buildUrl,
   jsonHeaders,
   assertUnauthorizedRequest,
-  assertBadRequest,
   assertStatusCode,
   assertEqualsForKeys,
   assertNotFoundRequest,
@@ -26,7 +25,7 @@ import {
   decisionInstanceRequiredFields,
 } from 'utils/beans/requestBeans';
 
-test.describe.parallel('Search Decision Instances API Tests', () => {
+test.describe.parallel('Get Decision Instances API Tests', () => {
   let decisionInstances: DecisionInstance[] = [];
   let processInstanceKey: string;
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/authorization-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/authorization-requestHelpers.ts
@@ -20,7 +20,8 @@ import {
   authorizationRequiredFieldsWithoutPermissionTypes,
   authorizedComponentRequiredFields,
 } from '../beans/requestBeans';
-import { validateResponse } from 'json-body-assertions';
+import {validateResponse} from 'json-body-assertions';
+import {defaultAssertionOptions} from 'utils/constants';
 
 export interface Authorization {
   ownerId: string;
@@ -80,7 +81,24 @@ export async function grantUserResourceAuthorization(
     authRes,
    );
   const authBody = await authRes.json();
-  assertRequiredFields(authBody, ['authorizationKey']);
+
+  await expect(async () => {
+    const statusRes = await request.get(
+      buildUrl(`/authorizations/${authBody.authorizationKey}`),
+      {
+        headers: jsonHeaders(),
+      },
+    );
+    await assertStatusCode(statusRes, 200);
+    await validateResponse(
+      {
+        path: '/authorizations/{authorizationKey}',
+        method: 'GET',
+        status: '200',
+      },
+      statusRes,
+    );
+  }).toPass(defaultAssertionOptions);
   return {
     authorizationKey: authBody.authorizationKey,
   };


### PR DESCRIPTION
## Description
Backport of #49770 to `stable/8.9`.

## related issues

related to [this issue](https://github.com/camunda/team-test-automation/issues/62)
## On demand workflow
[Was all green on API](https://github.com/camunda/camunda/actions/runs/23746390923)