### PR TITLE
feat: handle nested incidents in the incidents tab

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/IncidentsTable/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/IncidentsTable/index.tsx
@@ -15,11 +15,13 @@ import {
   FieldLabel,
   ErrorMessageCell,
   FlexContainer,
+  ChildIncidentContainer,
 } from './styled';
 import {Link} from 'modules/components/Link';
+import {EmptyMessage} from 'modules/components/EmptyMessage';
 import {Paths} from 'modules/Routes';
 import {tracking} from 'modules/tracking';
-import {Button} from '@carbon/react';
+import {Button, Stack} from '@carbon/react';
 import {SortableTable} from 'modules/components/SortableTable';
 import {useState, useMemo} from 'react';
 import {JSONEditorModal} from 'modules/components/JSONEditorModal';
@@ -76,10 +78,17 @@ const getElementName = (
   return incident.elementName;
 };
 
+type ChildInstanceWithIncident = {
+  type: 'process' | 'decision';
+  key: string;
+  name: string;
+};
+
 type IncidentsTableProps = {
   processInstanceKey: string;
   incidents: EnhancedIncident[];
   decisionInstancesByElementKey?: DecisionInstanceLookup;
+  childInstanceWithIncident?: ChildInstanceWithIncident;
   state: React.ComponentProps<typeof SortableTable>['state'];
   onVerticalScrollStartReach?: React.ComponentProps<
     typeof SortableTable
@@ -95,6 +104,7 @@ const IncidentsTable: React.FC<IncidentsTableProps> = observer(
     incidents,
     processInstanceKey,
     decisionInstancesByElementKey,
+    childInstanceWithIncident,
     onVerticalScrollEndReach,
     onVerticalScrollStartReach,
   }) {
@@ -162,6 +172,28 @@ const IncidentsTable: React.FC<IncidentsTableProps> = observer(
         ),
       [incidents],
     );
+
+    if (state === 'empty' && childInstanceWithIncident) {
+      const {type, key, name} = childInstanceWithIncident;
+      const linkTo =
+        type === 'process'
+          ? Paths.processInstance(key)
+          : Paths.decisionInstance(key);
+
+      return (
+        <ChildIncidentContainer>
+          <Stack gap={5}>
+            <EmptyMessage
+              message="No incidents found on this element."
+              additionalInfo="The incident may originate from a called instance."
+            />
+            <Link to={linkTo} title={`View in ${name}`}>
+              {`View in ${name}`}
+            </Link>
+          </Stack>
+        </ChildIncidentContainer>
+      );
+    }
 
     return (
       <>

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/IncidentsTable/styled.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/IncidentsTable/styled.ts
@@ -37,10 +37,20 @@ const FlexContainer = styled.div`
   align-items: center;
 `;
 
+const ChildIncidentContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+  padding: var(--cds-spacing-05);
+  background-color: var(--cds-layer);
+`;
+
 export {
   ExpandedContent,
   ExpandedField,
   FieldLabel,
   ErrorMessageCell,
   FlexContainer,
+  ChildIncidentContainer,
 };

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/IncidentsTable/tests/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/IncidentsTable/tests/index.test.tsx
@@ -318,4 +318,56 @@ describe('IncidentsTable', () => {
     expect(withinRow.getByText(secondIncident.elementName)).toBeInTheDocument();
     expect(withinRow.queryByRole('link')).not.toBeInTheDocument();
   });
+
+  it('should show child process instance message when incident comes from called process', () => {
+    render(
+      <IncidentsTable
+        state="empty"
+        processInstanceKey="1"
+        incidents={[]}
+        childInstanceWithIncident={{
+          type: 'process',
+          key: '123456',
+          name: 'ChildProcess',
+        }}
+      />,
+      {wrapper: Wrapper},
+    );
+
+    expect(
+      screen.getByText(/The incident may originate from a called instance/),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('link', {
+        name: 'View in ChildProcess',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('should show child decision instance message when incident comes from called decision', () => {
+    render(
+      <IncidentsTable
+        state="empty"
+        processInstanceKey="1"
+        incidents={[]}
+        childInstanceWithIncident={{
+          type: 'decision',
+          key: '789012',
+          name: 'MyDecision',
+        }}
+      />,
+      {wrapper: Wrapper},
+    );
+
+    expect(
+      screen.getByText(/The incident may originate from a called instance/),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('link', {
+        name: 'View in MyDecision',
+      }),
+    ).toBeInTheDocument();
+  });
 });

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/index.tsx
@@ -27,6 +27,7 @@ import {PanelHeader} from 'modules/components/PanelHeader';
 import {Container} from './styled';
 import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
 import {useDecisionInstancesSearch} from 'modules/queries/decisionInstances/useDecisionInstancesSearch';
+import {useProcessInstancesSearch} from 'modules/queries/processInstance/useProcessInstancesSearch';
 import {useMemo} from 'react';
 
 const ROW_HEIGHT = 32;
@@ -124,6 +125,59 @@ const IncidentsTab: React.FC = observer(() => {
     [decisionInstancesResult],
   );
 
+  const hasIncidentFromChild =
+    isElementInstanceSelected &&
+    !!resolvedElementInstance?.hasIncident &&
+    totalIncidentsCount === 0;
+
+  const resolvedElementType = resolvedElementInstance?.type;
+
+  const {data: calledProcessInstances} = useProcessInstancesSearch(
+    {
+      filter: {
+        parentElementInstanceKey: resolvedElementInstanceKey ?? '',
+        hasIncident: true,
+      },
+    },
+    {
+      enabled: hasIncidentFromChild && resolvedElementType === 'CALL_ACTIVITY',
+    },
+  );
+
+  const {data: calledDecisionInstances} = useDecisionInstancesSearch(
+    {
+      filter: {
+        elementInstanceKey: resolvedElementInstanceKey ?? '',
+      },
+    },
+    {
+      enabled:
+        hasIncidentFromChild && resolvedElementType === 'BUSINESS_RULE_TASK',
+    },
+  );
+
+  const childInstanceWithIncident = useMemo(() => {
+    const calledProcess = calledProcessInstances?.items?.[0];
+    if (calledProcess) {
+      return {
+        type: 'process' as const,
+        key: calledProcess.processInstanceKey,
+        name: calledProcess.processDefinitionName,
+      };
+    }
+
+    const calledDecision = calledDecisionInstances?.items?.[0];
+    if (calledDecision) {
+      return {
+        type: 'decision' as const,
+        key: calledDecision.decisionEvaluationInstanceKey,
+        name: calledDecision.decisionDefinitionName,
+      };
+    }
+
+    return undefined;
+  }, [calledProcessInstances, calledDecisionInstances]);
+
   return (
     <Container>
       <PanelHeader count={totalIncidentsCount} size="sm">
@@ -136,6 +190,7 @@ const IncidentsTab: React.FC = observer(() => {
         processInstanceKey={processInstanceId}
         incidents={enhancedIncidents}
         decisionInstancesByElementKey={decisionInstancesByElementKey}
+        childInstanceWithIncident={childInstanceWithIncident}
       />
     </Container>
   );


### PR DESCRIPTION
## Description

Provides a special info message for incidents related to the called/child instance

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

related to #49165
