### PR TITLE
[Backport stable/8.8] fix(cpt): Use gRPC for client connection and enable long-polling 

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
@@ -105,6 +105,11 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
   @Override
   public CamundaClient createClient(final Consumer<CamundaClientBuilder> modifier) {
     final CamundaClientBuilder builder = camundaClientBuilderFactory.get();
+<<<<<<< HEAD
+=======
+    // Instead of using the default REST connection, we use gRPC for now to avoid issues with stale
+    // long-polling connection of job workers. See https://github.com/camunda/camunda/issues/45177.
+>>>>>>> 251aa46b (feat: Use gRPC for CPT clients)
     builder.preferRestOverGrpc(false);
 
     modifier.accept(builder);


### PR DESCRIPTION
# Description
Backport of #49831 to `stable/8.8`.

relates to camunda/camunda#45177 camunda/camunda#45667