### PR TITLE
test: assert global state restore in backup-restore test

### DIFF
--- a/operate/qa/backup-restore-tests/src/test/java/io/camunda/operate/qa/backup/BackupRestoreTest.java
+++ b/operate/qa/backup-restore-tests/src/test/java/io/camunda/operate/qa/backup/BackupRestoreTest.java
@@ -60,6 +60,7 @@ public class BackupRestoreTest {
   public static final String VERSION = "current-test";
   public static final String REPOSITORY_NAME = "testRepository";
   public static final Long BACKUP_ID = 123L;
+  public static final String OPERATE_TEMPLATE = "operate_template";
   private static final Logger LOGGER = LoggerFactory.getLogger(BackupRestoreTest.class);
   private static final String OPERATE_TEST_DOCKER_IMAGE = "localhost:5000/camunda/operate";
   @Autowired private OperateAPICaller operateAPICaller;
@@ -115,14 +116,9 @@ public class BackupRestoreTest {
     LOGGER.info("************ Index templates verified ************");
   }
 
-  private String componentTemplateName() {
-    return "operate_template";
-  }
-
   private void deleteComponentTemplate() throws Exception {
-    final String name = componentTemplateName();
     final var request =
-        new org.elasticsearch.client.Request("DELETE", "/_component_template/" + name);
+        new org.elasticsearch.client.Request("DELETE", "/_component_template/" + OPERATE_TEMPLATE);
     testContext.getEsClient().getLowLevelClient().performRequest(request);
     RetryOperation.newBuilder()
         .noOfRetry(10)
@@ -135,7 +131,7 @@ public class BackupRestoreTest {
                     .getEsClient()
                     .cluster()
                     .getComponentTemplate(
-                        new GetComponentTemplatesRequest(name), RequestOptions.DEFAULT);
+                        new GetComponentTemplatesRequest(OPERATE_TEMPLATE), RequestOptions.DEFAULT);
                 return false;
               } catch (final ElasticsearchStatusException e) {
                 if (e.status().getStatus() == 404) {
@@ -150,17 +146,16 @@ public class BackupRestoreTest {
   }
 
   private void assertComponentTemplateRestored() throws IOException {
-    final String name = componentTemplateName();
     final boolean exists =
         testContext
                 .getEsClient()
                 .cluster()
                 .getComponentTemplate(
-                    new GetComponentTemplatesRequest(name), RequestOptions.DEFAULT)
+                    new GetComponentTemplatesRequest(OPERATE_TEMPLATE), RequestOptions.DEFAULT)
                 .getComponentTemplates()
-                .get(name)
+                .get(OPERATE_TEMPLATE)
             != null;
-    assertThat(exists).as("Component template '%s' should be restored", name).isTrue();
+    assertThat(exists).as("Component template '%s' should be restored", OPERATE_TEMPLATE).isTrue();
     LOGGER.info("************ Component template verified ************");
   }
 

--- a/operate/qa/backup-restore-tests/src/test/java/io/camunda/operate/qa/backup/BackupRestoreTest.java
+++ b/operate/qa/backup-restore-tests/src/test/java/io/camunda/operate/qa/backup/BackupRestoreTest.java
@@ -8,6 +8,7 @@
 package io.camunda.operate.qa.backup;
 
 import static io.camunda.operate.qa.util.ContainerVersionsUtil.ZEEBE_CURRENTVERSION_PROPERTY_NAME;
+import static io.camunda.operate.schema.SchemaManager.OPERATE_DELETE_ARCHIVED_INDICES;
 import static io.camunda.operate.util.CollectionUtil.asMap;
 import static io.camunda.operate.webapp.management.dto.BackupStateDto.COMPLETED;
 import static io.camunda.operate.webapp.management.dto.BackupStateDto.IN_PROGRESS;
@@ -16,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.operate.exceptions.OperateRuntimeException;
 import io.camunda.operate.qa.util.ContainerVersionsUtil;
 import io.camunda.operate.qa.util.TestContainerUtil;
+import io.camunda.operate.schema.templates.TemplateDescriptor;
 import io.camunda.operate.util.RetryOperation;
 import io.camunda.operate.webapp.management.dto.GetBackupStateResponseDto;
 import io.camunda.operate.webapp.management.dto.TakeBackupResponseDto;
@@ -23,12 +25,18 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.http.HttpHost;
+import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryRequest;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotRequest;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.indexlifecycle.DeleteLifecyclePolicyRequest;
+import org.elasticsearch.client.indexlifecycle.GetLifecyclePolicyRequest;
+import org.elasticsearch.client.indices.DeleteComposableIndexTemplateRequest;
+import org.elasticsearch.client.indices.GetComponentTemplatesRequest;
+import org.elasticsearch.client.indices.GetComposableIndexTemplateRequest;
 import org.elasticsearch.client.indices.GetIndexRequest;
 import org.elasticsearch.repositories.fs.FsRepository;
 import org.junit.Before;
@@ -58,6 +66,8 @@ public class BackupRestoreTest {
 
   @Autowired private DataGenerator dataGenerator;
 
+  @Autowired private List<TemplateDescriptor> indexTemplateDescriptors;
+
   private GenericContainer operateContainer;
 
   private final TestContainerUtil testContainerUtil = new TestContainerUtil();
@@ -79,9 +89,129 @@ public class BackupRestoreTest {
     dataGenerator.assertDataAfterChange();
     stopOperate();
     deleteOperateIndices();
+    deleteComponentTemplate();
+    deleteIlmPolicy();
     restoreBackup();
+    assertIndexTemplates();
+    assertComponentTemplateRestored();
+    assertIlmPolicyRestored();
     startOperate();
     dataGenerator.assertData();
+  }
+
+  private void assertIndexTemplates() throws IOException {
+    for (final TemplateDescriptor descriptor : indexTemplateDescriptors) {
+      final String templateName = descriptor.getTemplateName();
+      final boolean exists =
+          !testContext
+              .getEsClient()
+              .indices()
+              .getIndexTemplate(
+                  new GetComposableIndexTemplateRequest(templateName), RequestOptions.DEFAULT)
+              .getIndexTemplates()
+              .isEmpty();
+      assertThat(exists).as("Index template '%s' should be restored", templateName).isTrue();
+    }
+    LOGGER.info("************ Index templates verified ************");
+  }
+
+  private String componentTemplateName() {
+    return "operate_template";
+  }
+
+  private void deleteComponentTemplate() throws Exception {
+    final String name = componentTemplateName();
+    final var request =
+        new org.elasticsearch.client.Request("DELETE", "/_component_template/" + name);
+    testContext.getEsClient().getLowLevelClient().performRequest(request);
+    RetryOperation.newBuilder()
+        .noOfRetry(10)
+        .delayInterval(2000, TimeUnit.MILLISECONDS)
+        .retryPredicate(result -> !(boolean) result)
+        .retryConsumer(
+            () -> {
+              try {
+                testContext
+                    .getEsClient()
+                    .cluster()
+                    .getComponentTemplate(
+                        new GetComponentTemplatesRequest(name), RequestOptions.DEFAULT);
+                return false;
+              } catch (final ElasticsearchStatusException e) {
+                if (e.status().getStatus() == 404) {
+                  return true;
+                }
+                throw e;
+              }
+            })
+        .build()
+        .retry();
+    LOGGER.info("************ Component template deleted ************");
+  }
+
+  private void assertComponentTemplateRestored() throws IOException {
+    final String name = componentTemplateName();
+    final boolean exists =
+        testContext
+                .getEsClient()
+                .cluster()
+                .getComponentTemplate(
+                    new GetComponentTemplatesRequest(name), RequestOptions.DEFAULT)
+                .getComponentTemplates()
+                .get(name)
+            != null;
+    assertThat(exists).as("Component template '%s' should be restored", name).isTrue();
+    LOGGER.info("************ Component template verified ************");
+  }
+
+  private void deleteIlmPolicy() throws Exception {
+    testContext
+        .getEsClient()
+        .indexLifecycle()
+        .deleteLifecyclePolicy(
+            new DeleteLifecyclePolicyRequest(OPERATE_DELETE_ARCHIVED_INDICES),
+            RequestOptions.DEFAULT);
+    RetryOperation.newBuilder()
+        .noOfRetry(10)
+        .delayInterval(2000, TimeUnit.MILLISECONDS)
+        .retryPredicate(result -> !(boolean) result)
+        .retryConsumer(
+            () -> {
+              try {
+                testContext
+                    .getEsClient()
+                    .indexLifecycle()
+                    .getLifecyclePolicy(
+                        new GetLifecyclePolicyRequest(OPERATE_DELETE_ARCHIVED_INDICES),
+                        RequestOptions.DEFAULT);
+                return false;
+              } catch (final ElasticsearchStatusException e) {
+                if (e.status().getStatus() == 404) {
+                  return true;
+                }
+                throw e;
+              }
+            })
+        .build()
+        .retry();
+    LOGGER.info("************ ILM policy deleted ************");
+  }
+
+  private void assertIlmPolicyRestored() throws IOException {
+    final boolean exists =
+        testContext
+                .getEsClient()
+                .indexLifecycle()
+                .getLifecyclePolicy(
+                    new GetLifecyclePolicyRequest(OPERATE_DELETE_ARCHIVED_INDICES),
+                    RequestOptions.DEFAULT)
+                .getPolicies()
+                .get(OPERATE_DELETE_ARCHIVED_INDICES)
+            != null;
+    assertThat(exists)
+        .as("ILM policy '%s' should be restored", OPERATE_DELETE_ARCHIVED_INDICES)
+        .isTrue();
+    LOGGER.info("************ ILM policy verified ************");
   }
 
   private void deleteOperateIndices() throws Exception {
@@ -108,6 +238,35 @@ public class BackupRestoreTest {
                       .exists(
                           new GetIndexRequest("operate*", ZEEBE_INDEX_PREFIX + "*"),
                           RequestOptions.DEFAULT))
+          .build()
+          .retry();
+      testContext
+          .getEsClient()
+          .indices()
+          .deleteIndexTemplate(
+              new DeleteComposableIndexTemplateRequest("operate*"), RequestOptions.DEFAULT);
+      RetryOperation.newBuilder()
+          .noOfRetry(10)
+          .delayInterval(2000, TimeUnit.MILLISECONDS)
+          .retryPredicate(result -> !(boolean) result)
+          .retryConsumer(
+              () -> {
+                try {
+                  return testContext
+                      .getEsClient()
+                      .indices()
+                      .getIndexTemplate(
+                          new GetComposableIndexTemplateRequest("operate*"), RequestOptions.DEFAULT)
+                      .getIndexTemplates()
+                      .isEmpty();
+                } catch (final ElasticsearchStatusException e) {
+                  if (e.status().getStatus() == 404) {
+                    return true;
+                  } else {
+                    throw e;
+                  }
+                }
+              })
           .build()
           .retry();
       LOGGER.info("************ Operate indices deleted ************");
@@ -157,6 +316,7 @@ public class BackupRestoreTest {
             .createOperateContainer(OPERATE_TEST_DOCKER_IMAGE, VERSION, testContext)
             .withLogConsumer(new Slf4jLogConsumer(LOGGER));
     operateContainer.withEnv("CAMUNDA_OPERATE_BACKUP_REPOSITORYNAME", REPOSITORY_NAME);
+    operateContainer.withEnv("CAMUNDA_OPERATE_ARCHIVER_ILMENABLED", "true");
 
     startOperate();
   }
@@ -174,22 +334,22 @@ public class BackupRestoreTest {
   }
 
   private void restoreBackup() {
-    snapshots.stream()
-        .forEach(
-            snapshot -> {
-              try {
-                testContext
-                    .getEsClient()
-                    .snapshot()
-                    .restore(
-                        new RestoreSnapshotRequest(REPOSITORY_NAME, snapshot)
-                            .waitForCompletion(true),
-                        RequestOptions.DEFAULT);
-              } catch (final IOException e) {
-                throw new OperateRuntimeException(
-                    "Exception occurred while restoring the backup: " + e.getMessage(), e);
-              }
-            });
+    snapshots.forEach(
+        snapshot -> {
+          try {
+            testContext
+                .getEsClient()
+                .snapshot()
+                .restore(
+                    new RestoreSnapshotRequest(REPOSITORY_NAME, snapshot)
+                        .waitForCompletion(true)
+                        .includeGlobalState(true),
+                    RequestOptions.DEFAULT);
+          } catch (final IOException e) {
+            throw new OperateRuntimeException(
+                "Exception occurred while restoring the backup: " + e.getMessage(), e);
+          }
+        });
     LOGGER.info("************ Backup restored ************");
   }
 
@@ -211,6 +371,9 @@ public class BackupRestoreTest {
     basePackages = {
       "io.camunda.operate.util.rest",
       "io.camunda.operate.qa.backup",
-      "io.camunda.operate.webapp.rest.dto"
+      "io.camunda.operate.webapp.rest.dto",
+      "io.camunda.operate.schema.templates",
+      "io.camunda.operate.property",
+      "io.camunda.operate.conditions"
     })
 class TestConfig {}


### PR DESCRIPTION
## Summary

Test run in the scope of this [incident](https://camunda.slack.com/archives/C0AN44Z6D24/p1774599709096919)

- Set `includeGlobalState(true)` on snapshot restore to restore cluster-level metadata
- Assert that index templates, component templates, and ILM policies are correctly restored after backup/restore
- Delete global state (composable index templates, component template, ILM policy) before restore to verify they come back from the snapshot

relates to #32806 