### PR TITLE
fix: improve event applier golden file test experience

### DIFF
--- a/docs/zeebe/event-applier-golden-files.md
+++ b/docs/zeebe/event-applier-golden-files.md
@@ -154,7 +154,7 @@ not cost much effort.
 `NoChangesTest` contains an inner class `GoldenFileUpdater` with a `main` method. It iterates all
 registered appliers and copies each source file to its golden file (or creates an empty file for
 NOOP appliers). You can run it from your IDE (IntelliJ shows a run gutter icon) or from the command
-line.
+line. It will prompt for confirmation before overwriting any files.
 
 Only use this when you have many new golden files to create at once — for example, after adding
 several new appliers. Always review each failing test case first to confirm that updating the golden

--- a/docs/zeebe/event-applier-golden-files.md
+++ b/docs/zeebe/event-applier-golden-files.md
@@ -1,0 +1,145 @@
+# Event Applier Golden Files
+
+## Background
+
+Event appliers in Zeebe run in two contexts: during **processing** (when events are initially
+appended to the log) and during **replay** (to rebuild state from the event log). Replay must
+produce the exact same state mutations as the original processing — if it doesn't, leaders and
+followers can end up with divergent state on updates, which would be a critical bug.
+
+Golden files enforce this invariant by snapshotting the source code of each event applier. The
+`NoChangesTest` in `EventAppliersTest` compares each applier's current source against its golden
+copy and fails when they differ. This catches accidental or unreviewed changes before they reach
+production.
+
+## Rules of thumb
+
+**It's always safe to add a new event applier version**. Instead of changing an existing event
+applier, register a new version. It's usually the safer choice and does not cost much effort.
+
+**Always keep event applier versions aligned across minor versions**. If you add a new event
+applier version in a minor version, add it to all newer minor versions as well. This allows users
+to safely update to the next minor version without any breaking changes in replay.
+
+## Common cases
+
+The following scenarios where the test fails are common and should be straightforward to resolve.
+
+### I added a new event applier (or a new version)
+
+Create the golden file. The test failure message includes a ready-to-run `cp` command. Just
+copy-paste it. Adding a new event applier is always safe.
+
+### I intentionally changed an existing event applier
+
+**Don't update the golden file.** Register a new applier version instead. The previous version must
+remain unchanged so that older events replay correctly. Ensure the new version is registered in all
+newer minor versions as well.
+
+For exceptions, see the ["Allowed Changes"](#allowed-changes) section below.
+
+## High-stakes back- and forward porting cases
+
+These cases can occur when you port an event applier from one Zeebe version to another and the
+golden files differ. It's important that an older Zeebe version can update to a newer Zeebe version
+and can then replay all existing events in the exact same way as before. If the golden files differ,
+this means that the older Zeebe version and the newer Zeebe version will replay the same events
+differently. This is a severe problem that we must resolve carefully.
+
+> [!WARNING]
+> These cases require careful consideration! Please read the instructions below with attention if
+> you find yourself in one of these scenarios. If you are unsure how to proceed, ask for help.
+
+### Backported applier (newer → older version)
+
+If you ported an applier from a newer Zeebe version to an older one and the golden file differs, you
+may have found a **critical bug**. What happens now depends on whether the newer Zeebe version was
+already released or not:
+
+#### Not yet released
+
+If it was not yet released, you can still align the newer Zeebe version with the older Zeebe version
+by updating the golden file in the newer Zeebe version to match the older Zeebe version. This is
+safe because the newer Zeebe version has not yet been released, so you can still change its behavior
+without breaking production.
+
+🔧 **Action:** Ensure that the newer Zeebe version aligns with the older Zeebe version first. Do not
+adjust event appliers in the older Zeebe version. All event appliers known to the older Zeebe
+version must be copied to the newer Zeebe version. Next, you can introduce the intended changes to
+both versions.
+
+#### Already released
+
+If the applier in the newer Zeebe version was already released with different behavior, then you
+cannot align the newer Zeebe version with the older Zeebe version by just overwriting them.
+
+🔧 **Action:** Instead, keep the misalignment **and** register a new event applier version in the
+older version such that you can also add those same versions to the newer version. This way, the
+older Zeebe version can still safely update to the newer Zeebe version without any breaking
+changes for any recently written events. The misalignment will remain for some specific event
+applier versions, but it is contained. Note that we require users to update to the latest patch
+of a minor version before they can update to the next minor version. So hopefully, this
+misalignment does not pose problems. Once you've aligned the currently used appliers, you can
+introduce the intended changes to both versions. Lastly, we should consider documenting that
+snapshots should be taken on all partitions before updating to the newer Zeebe version to ensure
+that no misaligned events have to be replayed.
+
+💡 **Example:** You backport a newly created event applier (A v2) from a newer Zeebe version to an
+older Zeebe version, but the golden file differs from the older version's applier (A v2 already
+exists here and is different). The newer Zeebe version was already released with the different A v2,
+so you cannot align the newer Zeebe version with the older Zeebe version by just overwriting the
+golden file in the newer Zeebe version. Instead, you keep the misalignment and register a new event
+applier version (A v3) as a copy of A v2 in the older Zeebe version. You also add A v3 to the newer
+Zeebe version. Next, you can introduce the intended changes to both versions in A v4. Any events of
+A v3 will be replayed the same way in both versions, so there are no breaking changes for any
+recently written events. The misalignment of A v2 will remain, but it is contained. Lastly, document
+the warning mentioned above about snapshots.
+
+### Forward-ported applier (older → newer version)
+
+If you ported an applier from an older version to a newer one and the golden file differs, you may
+have found a **critical bug** — the newer version may already be running different behavior in
+production.
+
+#### Not yet released
+
+If it was not yet released, you can still align the newer Zeebe version with the older Zeebe version
+by updating the golden file in the newer Zeebe version to match the older Zeebe version. You may
+need to reintroduce some of the event appliers already present in the newer Zeebe version as new
+event applier versions. This is safe because the newer Zeebe version has not yet been released, so
+you can still change its behavior without breaking production.
+
+🔧 **Action:** Ensure that the newer Zeebe version aligns with the older Zeebe version first. Do not
+adjust event appliers in the older Zeebe version. All event appliers known to the older Zeebe
+version must be copied to the newer Zeebe version. Next, you can reintroduce any newer event applier
+changes as new event applier versions in the newer Zeebe version.
+
+#### Already released
+
+If the applier in the newer Zeebe version was already released with different behavior, then you
+cannot align the newer Zeebe version with the older Zeebe version by just overwriting them.
+
+🔧 **Action:** Instead, you should keep the misalignment and register new event applier versions in the
+newer version such that you can also add those same versions to the older version. This way, the
+older Zeebe version can still safely update to the newer Zeebe version without any breaking changes
+for any recently written events. The misalignment will remain for some specific event applier
+versions, but it is contained. Note that we require users to update to the latest patch of a minor
+version before they can update to the next minor version. So hopefully, this misalignment does not
+pose problems. Once you've aligned the currently used appliers, you can introduce the intended
+changes to both versions. Lastly, we should consider documenting that snapshots should be taken on
+all partitions before updating to the newer Zeebe version to ensure that no misaligned events have
+to be replayed.
+
+## Allowed changes
+
+In rare cases, updating the golden file is acceptable:
+
+- **Cosmetic changes**: comments, formatting, import reordering — anything that doesn't affect
+  runtime behavior.
+- **The change does not lead to different state mutations**, i.e. you guarantee that existing events
+  will still replay to the same state, e.g. because you know they cannot contain a newly added
+  optional field and the event applier logic is designed to handle the field being absent. Even in
+  this case, consider carefully whether it's truly safe to update the golden file.
+
+When in doubt, register a new applier version. A new version is usually the safer choice and does
+not cost much effort.

--- a/docs/zeebe/event-applier-golden-files.md
+++ b/docs/zeebe/event-applier-golden-files.md
@@ -143,3 +143,19 @@ In rare cases, updating the golden file is acceptable:
 
 When in doubt, register a new applier version. A new version is usually the safer choice and does
 not cost much effort.
+
+## Bulk Updates with GoldenFileUpdater
+
+> [!WARNING]
+> `GoldenFileUpdater` overwrites **all** golden files unconditionally. Running it without reviewing
+> each failure individually can hide breaking changes that cause leader/follower state divergence in
+> production.
+
+`NoChangesTest` contains an inner class `GoldenFileUpdater` with a `main` method. It iterates all
+registered appliers and copies each source file to its golden file (or creates an empty file for
+NOOP appliers). You can run it from your IDE (IntelliJ shows a run gutter icon) or from the command
+line.
+
+Only use this when you have many new golden files to create at once — for example, after adding
+several new appliers. Always review each failing test case first to confirm that updating the golden
+file is the right action.

--- a/zeebe/engine/README.md
+++ b/zeebe/engine/README.md
@@ -362,6 +362,9 @@ K10 <-> 2251799813685258
 
 ### Event appliers are not allowed to be changed after having been released
 
+See [Event Applier Golden Files](../../docs/zeebe/event-applier-golden-files.md) for an in-depth
+guide on golden files, common scenarios, and porting pitfalls.
+
 - Events must be applied in the same way on replay as when they were initially appended.
 - **Don't** change the event applier implementation.
 - **Do** register a new version of an event applier.

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
 import java.io.IOException;
+import java.lang.reflect.Proxy;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -391,6 +392,80 @@ public class EventAppliersTest {
               See %s"""
                   .formatted(applierClassName, version, repoSourcePath, repoGoldenPath, DOCS_URL))
           .isEqualTo(goldenFileContents);
+    }
+
+    /**
+     * Utility to update all golden files at once. Run from an IDE or command line.
+     *
+     * <p>Usage: Run {@code GoldenFileUpdater.main()} — it iterates all registered appliers and
+     * copies each source file to its golden file (or creates an empty golden file for NOOPs).
+     *
+     * <p>To run this, make sure to add the following VM option to your run configuration:
+     *
+     * <pre>--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED</pre>
+     */
+    public static class GoldenFileUpdater {
+
+      public static void main(final String[] args) throws IOException {
+        System.out.println(
+            """
+            WARNING: This overwrites ALL golden files unconditionally.
+            Only run this after reviewing each failing test case.
+            Updating golden files for changed appliers may hide breaking changes.
+
+            Do you want to continue? (y/N)""");
+
+        try (final var scanner = new java.util.Scanner(System.in)) {
+          final var input = scanner.nextLine().trim();
+          if (!input.equalsIgnoreCase("y")) {
+            System.out.println("Aborted.");
+            return;
+          }
+        }
+
+        // Use a JDK Proxy instead of Mockito so this main() method can run without a test
+        // framework. All methods return null (or 0 for primitives) because applier constructors
+        // only store these references and never call methods on them.
+        @SuppressWarnings("SuspiciousInvocationHandlerImplementation")
+        final var state =
+            (MutableProcessingState)
+                Proxy.newProxyInstance(
+                    MutableProcessingState.class.getClassLoader(),
+                    new Class<?>[] {MutableProcessingState.class},
+                    (proxy, method, params) -> method.getReturnType().isPrimitive() ? 0 : null);
+
+        final var eventAppliers = new EventAppliers();
+        eventAppliers.registerEventAppliers(state);
+
+        final var goldenDir = Paths.get(MODULE_PATH + GOLDEN_FILES_FOLDER);
+        Files.createDirectories(goldenDir);
+
+        for (final var intentEntry : eventAppliers.getRegisteredAppliers().entrySet()) {
+          final var intent = intentEntry.getKey();
+          final var valueTypeName = intent.getClass().getSimpleName().replace("Intent", "");
+
+          for (final var applierEntry : intentEntry.getValue().entrySet()) {
+            final var version = applierEntry.getKey();
+            final var applier = applierEntry.getValue();
+            final var applierClassName = applier.getClass().getSimpleName();
+
+            final var goldenFilename = "%s_%s_v%s.golden".formatted(valueTypeName, intent, version);
+            final var goldenFilePath = goldenDir.resolve(goldenFilename);
+
+            final var sourcePath =
+                Paths.get(
+                    "%s%s/%s.java".formatted(MODULE_PATH, EVENT_APPLIERS_FOLDER, applierClassName));
+            if (Files.exists(sourcePath)) {
+              Files.copy(
+                  sourcePath, goldenFilePath, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+              System.out.printf("Copied %s.java -> %s%n", applierClassName, goldenFilename);
+            } else {
+              Files.writeString(goldenFilePath, "");
+              System.out.printf("Created empty %s (NOOP applier)%n", goldenFilename);
+            }
+          }
+        }
+      }
     }
 
     private record RegisteredApplier(Intent intent, int version, TypedEventApplier applier) {}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
 import java.io.IOException;
 import java.lang.reflect.Proxy;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.stream.Stream;
@@ -437,7 +438,8 @@ public class EventAppliersTest {
         final var eventAppliers = new EventAppliers();
         eventAppliers.registerEventAppliers(state);
 
-        final var goldenDir = Paths.get(MODULE_PATH + GOLDEN_FILES_FOLDER);
+        final var basePath = resolveBasePath();
+        final var goldenDir = basePath.resolve(GOLDEN_FILES_FOLDER);
         Files.createDirectories(goldenDir);
 
         for (final var intentEntry : eventAppliers.getRegisteredAppliers().entrySet()) {
@@ -453,8 +455,7 @@ public class EventAppliersTest {
             final var goldenFilePath = goldenDir.resolve(goldenFilename);
 
             final var sourcePath =
-                Paths.get(
-                    "%s%s/%s.java".formatted(MODULE_PATH, EVENT_APPLIERS_FOLDER, applierClassName));
+                basePath.resolve("%s/%s.java".formatted(EVENT_APPLIERS_FOLDER, applierClassName));
             if (Files.exists(sourcePath)) {
               Files.copy(
                   sourcePath, goldenFilePath, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
@@ -465,6 +466,26 @@ public class EventAppliersTest {
             }
           }
         }
+      }
+
+      /**
+       * Determines the base path to the module directory by checking whether the CWD is the repo
+       * root or the module directory. Fails fast if neither matches.
+       */
+      private static Path resolveBasePath() {
+        // CWD is the module directory (e.g. IntelliJ default, or Surefire)
+        if (Paths.get(EVENT_APPLIERS_FOLDER).toFile().isDirectory()) {
+          return Paths.get("");
+        }
+        // CWD is the repo root
+        if (Paths.get(MODULE_PATH + EVENT_APPLIERS_FOLDER).toFile().isDirectory()) {
+          return Paths.get(MODULE_PATH);
+        }
+        throw new IllegalStateException(
+            """
+            Cannot find event appliers folder. \
+            Run GoldenFileUpdater from the repo root or the %s module directory."""
+                .formatted(MODULE_PATH));
       }
     }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
@@ -309,7 +309,7 @@ public class EventAppliersTest {
               });
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{0}")
     @MethodSource("registeredAppliers")
     void shouldNotChangeImplementation(final RegisteredApplier registeredApplier)
         throws IOException {
@@ -489,6 +489,16 @@ public class EventAppliersTest {
       }
     }
 
-    private record RegisteredApplier(Intent intent, int version, TypedEventApplier applier) {}
+    private record RegisteredApplier(Intent intent, int version, TypedEventApplier applier) {
+      @Override
+      public String toString() {
+        final var valueType = intent.getClass().getSimpleName().replace("Intent", "");
+        final var applierName =
+            applier == EventAppliers.NOOP_EVENT_APPLIER
+                ? "NOOP applier"
+                : applier.getClass().getSimpleName();
+        return "%s for '%s.%s' (v%d)".formatted(applierName, valueType, intent, version);
+      }
+    }
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
@@ -23,7 +23,6 @@ import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.stream.Stream;
@@ -272,8 +271,24 @@ public class EventAppliersTest {
             });
   }
 
+  /**
+   * Verifies that event applier source files match their golden copies.
+   *
+   * @see <a
+   *     href="https://github.com/camunda/camunda/blob/main/docs/zeebe/event-applier-golden-files.md">Event
+   *     Applier Golden Files</a>
+   */
   @Nested
   class NoChangesTest {
+
+    // Paths relative to repo root, for use in describedAs messages and GoldenFileUpdater.
+    // Surefire runs from the module directory (zeebe/engine/), so we prefix with the module path.
+    private static final String MODULE_PATH = "zeebe/engine/";
+    private static final String EVENT_APPLIERS_FOLDER =
+        "src/main/java/io/camunda/zeebe/engine/state/appliers";
+    private static final String GOLDEN_FILES_FOLDER = "src/test/resources/state/appliers/golden";
+    private static final String DOCS_URL =
+        "https://github.com/camunda/camunda/blob/main/docs/zeebe/event-applier-golden-files.md";
 
     private static Stream<RegisteredApplier> registeredAppliers() {
       final var eventAppliers = new EventAppliers();
@@ -292,18 +307,10 @@ public class EventAppliersTest {
               });
     }
 
-    /**
-     * EventAppliers are not allowed to change (with a few exceptions). This test ensures that event
-     * appliers don't change by verifying source files of the event applier classes match golden
-     * copies.
-     */
     @ParameterizedTest
     @MethodSource("registeredAppliers")
     void shouldNotChangeImplementation(final RegisteredApplier registeredApplier)
         throws IOException {
-      final var eventAppliersFolder = "src/main/java/io/camunda/zeebe/engine/state/appliers";
-      final var goldenFilesFolder = "src/test/resources/state/appliers/golden";
-
       final var intent = registeredApplier.intent;
       final var version = registeredApplier.version;
       final var applier = registeredApplier.applier;
@@ -311,20 +318,35 @@ public class EventAppliersTest {
 
       // find source file
       final var applierClassName = applier.getClass().getSimpleName();
-      final var applierSourceFile = "%s/%s.java".formatted(eventAppliersFolder, applierClassName);
+      final var applierSourceFile = "%s/%s.java".formatted(EVENT_APPLIERS_FOLDER, applierClassName);
       final var applierSourcePath = Paths.get(applierSourceFile);
 
       // find golden file
       final var goldenFilename = "%s_%s_v%s.golden".formatted(valueTypeName, intent, version);
-      final var goldenFilePath = Paths.get("%s/%s".formatted(goldenFilesFolder, goldenFilename));
+      final var goldenFilePath = Paths.get("%s/%s".formatted(GOLDEN_FILES_FOLDER, goldenFilename));
+
+      // repo-root-relative paths for use in copy commands
+      final var repoSourcePath = MODULE_PATH + applierSourceFile;
+      final var repoGoldenPath = MODULE_PATH + GOLDEN_FILES_FOLDER + "/" + goldenFilename;
+
       if (!goldenFilePath.toFile().exists()) {
         LOG.error("Golden file for {} does not exist.", applierClassName);
-        printWarningAboutChangingGoldenFiles();
-        printCommandToCreateGoldenFile(applierSourcePath, goldenFilePath);
+        final var copyCommand =
+            applierSourcePath.toFile().exists()
+                ? "  cp %s %s".formatted(repoSourcePath, repoGoldenPath)
+                : "  echo -n > %s".formatted(repoGoldenPath);
+        assertThat(goldenFilePath.toFile())
+            .describedAs(
+                """
+                Event appliers must not change after release.
+                Expected golden file to exist for %s (v%d) but it was missing — create it with:
+                %s
+                For bulk updates, run GoldenFileUpdater.main() in NoChangesTest — \
+                this overwrites ALL golden files, review each failure first.
+                See %s"""
+                    .formatted(applierClassName, version, copyCommand, DOCS_URL))
+            .exists();
       }
-      assertThat(goldenFilePath.toFile())
-          .describedAs("Expected to find golden file for %s", applierClassName)
-          .exists();
 
       // if the source file does not exist, expect that the golden file's content is empty
       // this ensures we also check golden files for NOOP appliers
@@ -332,10 +354,21 @@ public class EventAppliersTest {
       if (!applierSourcePath.toFile().exists()) {
         if (!goldenFileContents.isEmpty()) {
           LOG.error("Golden file is not empty, even though this is a NOOP applier.");
-          printWarningAboutChangingGoldenFiles();
-          printCommandToCreateGoldenFile(applierSourcePath, goldenFilePath);
         }
-        assertThat(goldenFileContents).describedAs("Expected an empty golden file").isEmpty();
+        assertThat(goldenFileContents)
+            .describedAs(
+                """
+                Event appliers must not change after release.
+                Expected empty golden file for NOOP applier %s (v%d) but it has content.
+                The most common fix is to register a new applier version, \
+                not update the golden file.
+                If you're sure the golden file should change:
+                  echo -n > %s
+                For bulk updates, run GoldenFileUpdater.main() in NoChangesTest — \
+                this overwrites ALL golden files, review each failure first.
+                See %s"""
+                    .formatted(applierClassName, version, repoGoldenPath, DOCS_URL))
+            .isEmpty();
         return;
       }
 
@@ -343,85 +376,21 @@ public class EventAppliersTest {
       final String sourceContents = Files.readString(applierSourcePath);
       if (!sourceContents.equals(goldenFileContents)) {
         LOG.error("Golden file for {} does not match source file.", applierClassName);
-        printWarningAboutChangingGoldenFiles();
-        printCommandToCreateGoldenFile(applierSourcePath, goldenFilePath);
       }
       assertThat(sourceContents)
-          .describedAs("Expected source file of class %s to match golden copy", applierClassName)
+          .describedAs(
+              """
+              Event appliers must not change after release.
+              Expected golden file to match source for %s (v%d) but they differ.
+              The most common fix is to register a new applier version, \
+              not update the golden file.
+              If you're sure the golden file should change:
+                cp %s %s
+              For bulk updates, run GoldenFileUpdater.main() in NoChangesTest — \
+              this overwrites ALL golden files, review each failure first.
+              See %s"""
+                  .formatted(applierClassName, version, repoSourcePath, repoGoldenPath, DOCS_URL))
           .isEqualTo(goldenFileContents);
-    }
-
-    private static void printWarningAboutChangingGoldenFiles() {
-      LOG.warn(
-          """
-          Event appliers are not allowed to change once registered and released/used in production.
-          The golden files exist to ensure that we carefully review changes to the appliers.
-
-          Context: In Zeebe, an event must be replayed in the exact same way as it was applied to
-          the state when it was initially written. This ensures that we can rebuild the state from
-          all events by replaying them. Changes to the appliers can lead to replaying the events
-          differently when updating to a new version. This can lead to serious bugs as the leader
-          and followers may be ending up with different state. It is thus vital that we find ways
-          to avoid such bugs. This failing test is one such way.
-
-          But the test failed! What to do now? Please consider the following scenarios:
-
-          1. If you've introduced a new event applier in another version, ported it here, and then
-          found that the golden file is different, then you need to carefully consider the case:
-
-          - If the applier was backported: this is a breaking change, and we need to
-            abandon it. Please rollback the change in the newer version. Instead, register a new
-            applier version, and ensure that is is available in all newer versions before adding
-            it here.
-
-          - If the applier was forward ported: you may have found a critical bug if the current
-            code is already released. In that case, we need to carefully consider the changes and
-            see if we can allow them or not. There's no standard process here. If the current code
-            is not released yet, we can simply update the golden file to align with the older
-            version.
-
-          2. If you've introduced a new event applier, but an empty golden file already existed:
-
-          - You're trying to change the applier. Please register a new version instead of adjusting
-            the golden file. Please ensure that you also register the new applier in all newer minor
-            versions.
-
-          3. If you've introduced a new event applier, and the golden file didn't exist yet:
-
-          - You can simply create a new golden file. You can safely register a new version. Please
-            ensure that you also register the new applier in all newer minor versions.
-
-          Lastly, there are a few cases where changing the event applier is allowed:
-
-          - If the changes are purely cosmetic, such as changing comments or refactoring.
-
-          - If the change doesn't strictly need to be consistent between versions, such as storing a
-            new optional field that is always used in a same way and where it's acceptable that the
-            field may or may not be present in the state. However, we should always be cautious of
-            these cases, and consider whether they are truly safe.
-          """);
-    }
-
-    private static void printCommandToCreateGoldenFile(
-        final Path applierSourcePath, final Path goldenFilePathSystem) {
-      // use absolute paths so it's easy to run anywhere
-      final var sourcePath = applierSourcePath.toAbsolutePath();
-      final var targetPath = goldenFilePathSystem.toAbsolutePath();
-      if (Files.exists(sourcePath)) {
-        LOG.info(
-            """
-            To create/overwrite the golden file, run the following command:
-            cp {} {}""",
-            sourcePath,
-            targetPath);
-      } else {
-        // if there is no source file, we expect the golden file to be empty
-        LOG.info(
-            """
-            To create/overwrite the golden file, run the following command:
-            echo -n > {}""",
-            targetPath);
-      }
     }
 
     private record RegisteredApplier(Intent intent, int version, TypedEventApplier applier) {}


### PR DESCRIPTION
## Summary

- Add a developer guide at `docs/zeebe/event-applier-golden-files.md` covering background, common scenarios, high-stakes porting cases, and allowed changes
- Replace `LOG.warn`/`LOG.info` helper methods in `NoChangesTest` with tailored `describedAs` messages that are actually visible in CI (surefire redirects stdout/stderr to sidecar files)
- Add `GoldenFileUpdater` inner class with a `main` method for bulk golden file updates from an IDE
- Add cross-references to the new docs page from `zeebe/engine/README.md` and the golden files `README.md`

Closes #36434