### PR TITLE
test: set max load test throughput to 450

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -271,7 +271,7 @@ jobs:
               echo "platform-additional-config=" >> "$GITHUB_OUTPUT"
               ;;
             max)
-              echo "load-test-load=--set starter.rate=300" >> "$GITHUB_OUTPUT"
+              echo "load-test-load=--set starter.rate=450" >> "$GITHUB_OUTPUT"
               # For the max stress scenario, disable the experimental consistency checks to avoid overhead.
               # We inject the overrides via --set-file into extraConfiguration[1] (application-override.yml),
               # which is loaded after (and thus takes priority over) the base application.yml.


### PR DESCRIPTION
## Description
In the latest `max` load tests we were able to satured the 300 throughput, let's bump it to 450.
<img width="539" height="243" alt="image" src="https://github.com/user-attachments/assets/30150494-ba88-41c9-9808-7bec81ca8018" />


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
