### PR TITLE
fix: add decision dependant filter and update archiver logic

### DIFF
--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/DecisionInstanceDependant.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/DecisionInstanceDependant.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.webapps.schema.descriptors;
 
+import java.util.Map;
+
 /**
  * Marker interface for descriptors that are dependant on decision instances. Used to identify
  * related documents that need to be archived together with decision instances.
@@ -21,5 +23,15 @@ public interface DecisionInstanceDependant extends IndexTemplateDescriptor {
 
   default String getDecisionDependantField() {
     return DECISION_INSTANCE_KEY;
+  }
+
+  /**
+   * Returns additional filter criteria when archiving dependant documents. This is useful when only
+   * a subset of documents for a given decision instance key should be archived.
+   *
+   * @return a map of field names to values that must match for a document to be archived
+   */
+  default Map<String, String> getDecisionDependantFilters() {
+    return Map.of();
   }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/AuditLogTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/AuditLogTemplate.java
@@ -10,6 +10,7 @@ package io.camunda.webapps.schema.descriptors.template;
 import io.camunda.webapps.schema.descriptors.AbstractTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.BatchOperationDependant;
 import io.camunda.webapps.schema.descriptors.ComponentNames;
+import io.camunda.webapps.schema.descriptors.DecisionInstanceDependant;
 import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
 import io.camunda.webapps.schema.descriptors.backup.Prio4Backup;
 import io.camunda.webapps.schema.entities.auditlog.AuditLogEntityType;
@@ -19,7 +20,10 @@ import java.util.Map;
 import java.util.Optional;
 
 public class AuditLogTemplate extends AbstractTemplateDescriptor
-    implements ProcessInstanceDependant, BatchOperationDependant, Prio4Backup {
+    implements ProcessInstanceDependant,
+        DecisionInstanceDependant,
+        BatchOperationDependant,
+        Prio4Backup {
 
   public static final String INDEX_NAME = "audit-log";
   public static final String INDEX_VERSION = "8.9.0";
@@ -96,5 +100,15 @@ public class AuditLogTemplate extends AbstractTemplateDescriptor
   @Override
   public Map<String, String> getBatchOperationDependantFilters() {
     return Map.of(AuditLogTemplate.ENTITY_TYPE, AuditLogEntityType.BATCH.toString());
+  }
+
+  @Override
+  public String getDecisionDependantField() {
+    return ENTITY_KEY;
+  }
+
+  @Override
+  public Map<String, String> getDecisionDependantFilters() {
+    return Map.of(AuditLogTemplate.ENTITY_TYPE, AuditLogEntityType.DECISION.toString());
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AuditLogHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AuditLogHandler.java
@@ -109,7 +109,11 @@ public class AuditLogHandler<R extends RecordValue> implements ExportHandler<Aud
     final var entity = new AuditLogEntity().setId(batch.getId());
     batch.setAuditLogEntity(mapToEntity(log, entity));
 
-    if (transformer.triggersCleanUp(record)) {
+    // archiving of decision instances is done by the StandaloneDecisionArchiverJob
+    final boolean decisionLog =
+        log.getEntityType()
+            == io.camunda.search.entities.AuditLogEntity.AuditLogEntityType.DECISION;
+    if (transformer.triggersCleanUp(record) && !decisionLog) {
       final var cleanupEntity = new AuditLogCleanupEntity().setId(batch.getId());
       batch.setAuditLogCleanupEntity(mapToCleanupEntity(record, log, cleanupEntity));
     }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/StandaloneDecisionArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/StandaloneDecisionArchiverJob.java
@@ -91,7 +91,9 @@ public class StandaloneDecisionArchiverJob extends ArchiverJob<BasicArchiveBatch
   private CompletableFuture<Void> archiveDecisionDependants(final BasicArchiveBatch batch) {
     final var moveDependentDocuments =
         decisionInstanceDependants.stream()
-            .map(dependant -> super.archive(dependant, batch))
+            .map(
+                dependant ->
+                    super.archive(dependant, batch, dependant.getDecisionDependantFilters()))
             .toArray(CompletableFuture[]::new);
     return CompletableFuture.allOf(moveDependentDocuments);
   }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/StandaloneDecisionArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/StandaloneDecisionArchiverJobTest.java
@@ -13,6 +13,7 @@ import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.exporter.tasks.archiver.TestRepository.DocumentMove;
 import io.camunda.webapps.schema.descriptors.DecisionInstanceDependant;
+import io.camunda.webapps.schema.descriptors.template.AuditLogTemplate;
 import io.camunda.webapps.schema.descriptors.template.DecisionInstanceTemplate;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
@@ -34,7 +35,7 @@ final class StandaloneDecisionArchiverJobTest extends ArchiverJobRecordingMetric
   private final TestRepository repository = new TestRepository();
   private final DecisionInstanceTemplate decisionInstanceTemplate =
       new DecisionInstanceTemplate("", true);
-  private final WeirdlyNamedDependant dependantTemplate = new WeirdlyNamedDependant();
+  private final AuditLogTemplate auditLogTemplate = new AuditLogTemplate("", true);
 
   private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
   private final CamundaExporterMetrics metrics = new CamundaExporterMetrics(meterRegistry);
@@ -46,7 +47,7 @@ final class StandaloneDecisionArchiverJobTest extends ArchiverJobRecordingMetric
           metrics,
           LOGGER,
           executor,
-          List.of(dependantTemplate));
+          List.of(auditLogTemplate));
 
   @BeforeEach
   void setUp() {
@@ -113,9 +114,10 @@ final class StandaloneDecisionArchiverJobTest extends ArchiverJobRecordingMetric
     assertThat(repository.moves)
         .containsExactly(
             new DocumentMove(
-                dependantTemplate.getFullQualifiedName(),
-                dependantTemplate.getFullQualifiedName() + "2024-01-01",
-                Map.of(dependantTemplate.getDecisionDependantField(), List.of("1", "2", "3")),
+                auditLogTemplate.getFullQualifiedName(),
+                auditLogTemplate.getFullQualifiedName() + "2024-01-01",
+                Map.of(auditLogTemplate.getDecisionDependantField(), List.of("1", "2", "3")),
+                Map.of(AuditLogTemplate.ENTITY_TYPE, "DECISION"),
                 executor),
             new DocumentMove(
                 decisionInstanceTemplate.getFullQualifiedName(),
@@ -138,7 +140,7 @@ final class StandaloneDecisionArchiverJobTest extends ArchiverJobRecordingMetric
     assertThat(repository.moves)
         .map(DocumentMove::sourceIndexName)
         .containsExactly(
-            dependantTemplate.getFullQualifiedName(),
+            auditLogTemplate.getFullQualifiedName(),
             decisionInstanceTemplate.getFullQualifiedName());
   }
 


### PR DESCRIPTION
## Description

- Introduced `getDecisionDependantFilters` method in `DecisionInstanceDependant` to support custom filter criteria.
- Updated `StandaloneDecisionArchiverJob` to use filters during archiving.
- Added `DecisionInstanceDependant` implementation to `AuditLogTemplate`.
- Adjusted tests to reflect new archiving behavior and replace unused templates.

## Related issues

closes https://github.com/camunda/camunda/issues/49844
