### PR TITLE
[Backport stable/8.8] fix: clarify NOT_FOUND error when correlating blocked message start events with active instances

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.engine.state.immutable.MessageStartEventSubscriptionStat
 import io.camunda.zeebe.engine.state.immutable.MessageState;
 import io.camunda.zeebe.engine.state.immutable.MessageSubscriptionState;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+import java.util.Collection;
 import org.agrona.DirectBuffer;
 
 public final class MessageCorrelateBehavior {
@@ -42,6 +43,13 @@ public final class MessageCorrelateBehavior {
 
   public void correlateToMessageStartEvents(
       final MessageData messageData, final Subscriptions correlatingSubscriptions) {
+    correlateToMessageStartEvents(messageData, correlatingSubscriptions, null);
+  }
+
+  public void correlateToMessageStartEvents(
+      final MessageData messageData,
+      final Subscriptions correlatingSubscriptions,
+      final Collection<String> blockedProcessIds) {
     startEventSubscriptionState.visitSubscriptionsByMessageName(
         messageData.tenantId(),
         messageData.messageName(),
@@ -49,13 +57,15 @@ public final class MessageCorrelateBehavior {
           final var subscriptionRecord = subscription.getRecord();
           final var bpmnProcessIdBuffer = subscriptionRecord.getBpmnProcessIdBuffer();
 
+          if (correlatingSubscriptions.contains(bpmnProcessIdBuffer)) {
+            return;
+          }
+
           // create only one instance of a process per correlation key
           // - allow multiple instance if correlation key is empty
-          if (!correlatingSubscriptions.contains(bpmnProcessIdBuffer)
-              && (messageData.correlationKey().capacity() == 0
-                  || !messageState.existActiveProcessInstance(
-                      messageData.tenantId(), bpmnProcessIdBuffer, messageData.correlationKey()))) {
-
+          if (messageData.correlationKey().capacity() == 0
+              || !messageState.existActiveProcessInstance(
+                  messageData.tenantId(), bpmnProcessIdBuffer, messageData.correlationKey())) {
             final var processInstanceKey =
                 eventHandle.triggerMessageStartEvent(
                     subscription.getKey(),
@@ -67,6 +77,8 @@ public final class MessageCorrelateBehavior {
 
             subscriptionRecord.setProcessInstanceKey(processInstanceKey);
             correlatingSubscriptions.add(subscriptionRecord);
+          } else if (blockedProcessIds != null) {
+            blockedProcessIds.add(subscriptionRecord.getBpmnProcessId());
           }
         });
   }
@@ -84,13 +96,15 @@ public final class MessageCorrelateBehavior {
           final var subscriptionRecord = subscription.getRecord();
           final var bpmnProcessIdBuffer = subscriptionRecord.getBpmnProcessIdBuffer();
 
+          if (correlatingSubscriptions.contains(bpmnProcessIdBuffer)) {
+            return;
+          }
+
           // create only one instance of a process per correlation key
           // - allow multiple instance if correlation key is empty
-          if (!correlatingSubscriptions.contains(bpmnProcessIdBuffer)
-              && (messageData.correlationKey().capacity() == 0
-                  || !messageState.existActiveProcessInstance(
-                      messageData.tenantId(), bpmnProcessIdBuffer, messageData.correlationKey()))) {
-
+          if (messageData.correlationKey().capacity() == 0
+              || !messageState.existActiveProcessInstance(
+                  messageData.tenantId(), bpmnProcessIdBuffer, messageData.correlationKey())) {
             // Just collect, don't trigger events yet
             correlatingSubscriptions.add(subscriptionRecord);
           }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
@@ -35,6 +35,7 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import java.util.HashSet;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -43,6 +44,12 @@ public final class MessageCorrelationCorrelateProcessor
 
   private static final String SUBSCRIPTION_NOT_FOUND =
       "Expected to find subscription for message with name '%s' and correlation key '%s', but none was found.";
+
+  private static final String SUBSCRIPTION_BLOCKED_BY_ACTIVE_INSTANCE =
+      "Expected to find subscription for message with name '%s' and correlation key '%s', but no "
+          + "active subscription was found. A process instance with this correlation key is already active "
+          + "for a message start event with this message name in process IDs %s. Only one active "
+          + "process instance per correlation key is allowed for message start events.";
 
   private final MessageCorrelateBehavior correlateBehavior;
   private final KeyGenerator keyGenerator;
@@ -142,13 +149,24 @@ public final class MessageCorrelationCorrelateProcessor
         messageKey, MessageCorrelationIntent.CORRELATING, messageCorrelationRecord);
 
     // Now actually correlate with state writes
+    final var blockedProcessIds = new HashSet<String>();
     correlateBehavior.correlateToMessageEvents(messageData, correlatingSubscriptions);
-    correlateBehavior.correlateToMessageStartEvents(messageData, correlatingSubscriptions);
+    correlateBehavior.correlateToMessageStartEvents(
+        messageData, correlatingSubscriptions, blockedProcessIds);
 
     if (correlatingSubscriptions.isEmpty()) {
-      final var errorMessage =
-          SUBSCRIPTION_NOT_FOUND.formatted(
-              command.getValue().getName(), command.getValue().getCorrelationKey());
+      final String errorMessage;
+      if (!blockedProcessIds.isEmpty()) {
+        errorMessage =
+            SUBSCRIPTION_BLOCKED_BY_ACTIVE_INSTANCE.formatted(
+                command.getValue().getName(),
+                command.getValue().getCorrelationKey(),
+                blockedProcessIds);
+      } else {
+        errorMessage =
+            SUBSCRIPTION_NOT_FOUND.formatted(
+                command.getValue().getName(), command.getValue().getCorrelationKey());
+      }
       rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, errorMessage);
       responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
       return;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/CorrelateMessageTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/CorrelateMessageTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.MessageCorrelationIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
@@ -60,6 +61,52 @@ public final class CorrelateMessageTest {
                 .getValue())
         .hasName(MESSAGE_NAME)
         .hasCorrelationKey(CORRELATION_KEY);
+  }
+
+  @Test
+  public void shouldRejectWithClarifyingMessageWhenStartEventBlockedByActiveInstance() {
+    // given - deploy a process that stays active (with a user task) and correlate a message to
+    // start the instance
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("process")
+                .startEvent()
+                .message(MESSAGE_NAME)
+                .userTask()
+                .endEvent()
+                .done())
+        .deploy();
+
+    engine
+        .messageCorrelation()
+        .withCorrelationKey(CORRELATION_KEY)
+        .withName(MESSAGE_NAME)
+        .correlate();
+
+    // wait for the process instance to be active at the user task
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withBpmnProcessId("process")
+        .withElementType(BpmnElementType.USER_TASK)
+        .await();
+
+    // when - correlate the same message again while the instance is still active
+    final var rejection =
+        engine
+            .messageCorrelation()
+            .withCorrelationKey(CORRELATION_KEY)
+            .withName(MESSAGE_NAME)
+            .expectRejection()
+            .correlate();
+
+    // then - rejection with NOT_FOUND and a clarifying message mentioning the active instance
+    Assertions.assertThat(rejection).hasRejectionType(RejectionType.NOT_FOUND);
+    assertThat(rejection.getRejectionReason())
+        .contains(MESSAGE_NAME)
+        .contains(CORRELATION_KEY)
+        .contains("active process instance")
+        .contains("correlation key")
+        .contains("process IDs [process]");
   }
 
   @Test


### PR DESCRIPTION
# Description
Backport of #49804 to `stable/8.8`.

relates to #49802 