### PR TITLE
[Backport stable/8.6] ci: split GH release into 2 parts + create changelog file + fisrt update assests

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -702,6 +702,8 @@ jobs:
     needs: [release, zeebe-docker, operate-docker, tasklist-docker, camunda-docker]
     name: Github Release
     runs-on: ubuntu-latest
+    outputs:
+      releaseBodyUpdateOutcome: ${{ steps.update-github-release-body.outcome }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
@@ -763,14 +765,8 @@ jobs:
             isDraftRelease="false"
           fi
 
-          # With multiline strings the output needs to be set differently.
-          #
-          # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-a-multiline-string
-          #
-          echo 'CHANGELOG<<EOF' >> $GITHUB_OUTPUT
-          echo "$changelog" >> $GITHUB_OUTPUT
-          echo 'EOF' >> $GITHUB_OUTPUT
-          echo "isDraftRelease=$isDraftRelease" >> "$GITHUB_OUTPUT"
+          # Persist full changelog to a file and pass it via bodyFile to avoid ARG_MAX/env limits.
+          printf '%s\n' "$changelog" > changelog.md
 
           # To show the changelog also as step summary
           echo "$changelog" >> $GITHUB_STEP_SUMMARY
@@ -779,6 +775,10 @@ jobs:
         with:
           name: release-artifacts-${{ inputs.releaseVersion }}
           path: release-artifacts
+      - name: Add Full Changelog to Release Artifacts
+        if: ${{ !inputs.dryRun }}
+        run: |
+          cp changelog.md "release-artifacts/CHANGELOG-${RELEASE_VERSION}.md"
       - name: Create Artifact Checksums
         id: checksum
         working-directory: ./release-artifacts
@@ -803,7 +803,7 @@ jobs:
           shopt -u nocasematch # reset it
           echo "result=${PRE_RELEASE}" >> $GITHUB_OUTPUT
       - name: Create Github release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd
         if: ${{ !inputs.dryRun }}
         with:
           name: ${{ env.RELEASE_TAG }}
@@ -811,10 +811,33 @@ jobs:
           artifactErrorsFailBuild: true
           draft: ${{ inputs.releaseProcessDryRun || steps.gen-changelog.outputs.isDraftRelease }}
           makeLatest: ${{ inputs.isLatest }}
-          body: ${{ steps.gen-changelog.outputs.changelog }}
+          body: Release ${{ env.RELEASE_TAG }} - changelog will be added shortly. Full changelog is available as CHANGELOG-${{ env.RELEASE_VERSION }}.md in the release assets.
           token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: ${{ steps.pre-release.outputs.result }}
           tag: ${{ env.RELEASE_TAG }}
+      - name: Update Github release body from changelog file
+        id: update-github-release-body
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd
+        if: ${{ !inputs.dryRun }}
+        continue-on-error: true
+        with:
+          allowUpdates: true
+          bodyFile: changelog.md
+          omitBodyDuringUpdate: false
+          omitNameDuringUpdate: true
+          omitDraftDuringUpdate: true
+          omitPrereleaseDuringUpdate: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ env.RELEASE_TAG }}
+      - name: Warn if Github release body update failed
+        if: ${{ !inputs.dryRun && steps.update-github-release-body.outcome == 'failure' }}
+        run: |
+          {
+            echo "## Github release body update failed"
+            echo
+            echo "Release assets were published successfully."
+            echo "The inline release body was not updated; use release asset CHANGELOG-${RELEASE_VERSION}.md as the source changelog."
+          } >> "$GITHUB_STEP_SUMMARY"
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -877,7 +900,8 @@ jobs:
             secret/data/products/camunda/ci/github-actions SLACK_TOPMONOREPORELEASE_WEBHOOK_URL;
 
       - name: Send success Slack notification
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        if: ${{ needs.github.outputs.releaseBodyUpdateOutcome != 'failure' }}
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           webhook: ${{ steps.secrets.outputs.SLACK_TOPMONOREPORELEASE_WEBHOOK_URL }}
           webhook-type: incoming-webhook
@@ -890,6 +914,33 @@ jobs:
                   "text": {
                     "type": "mrkdwn",
                     "text": ":success: *Release job for ${{ inputs.releaseVersion }}* succeeded! (excluding Maven Central publishing - this is done separately)\n"
+                  }
+                }
+              ]
+            }
+
+      - name: Send success Slack notification with manual follow-up
+        if: ${{ needs.github.outputs.releaseBodyUpdateOutcome == 'failure' }}
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
+        with:
+          webhook: ${{ steps.secrets.outputs.SLACK_TOPMONOREPORELEASE_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          # For posting a rich message using Block Kit
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":success: *Release job for ${{ inputs.releaseVersion }}* succeeded! (excluding Maven Central publishing - this is done separately)\n"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":warning: GitHub release body update failed due to size/API constraints. This is non-blocking; release artifacts were published. Please update release notes manually using `CHANGELOG-${{ inputs.releaseVersion }}.md` from release assets."
                   }
                 }
               ]


### PR DESCRIPTION
# Description
Backport of #49768 to `stable/8.6`.

relates to 