### PR TITLE
Fix incorrect usages of `@VisibleForTesting`

### DIFF
--- a/qa/archunit-tests/src/test/java/io/camunda/VisibleForTestingArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/VisibleForTestingArchTest.java
@@ -42,8 +42,7 @@ public class VisibleForTestingArchTest {
 
   static final List<String> EXCLUDED_CLASS_NAMES =
       List.of(
-          "io.camunda.zeebe.broker.system.partitions.impl.MigrationSnapshotDirector",
-          "io.camunda.zeebe.util.micrometer.StatefulGauge");
+          "io.camunda.zeebe.broker.system.partitions.impl.MigrationSnapshotDirector");
 
   @ArchTest
   static final ArchRule CLASS_VISIBLE_FOR_TESTING_SHOULD_ONLY_BE_ACCESSED_FROM_TEST_OR_SELF =

--- a/qa/archunit-tests/src/test/java/io/camunda/VisibleForTestingArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/VisibleForTestingArchTest.java
@@ -22,7 +22,6 @@ import com.tngtech.archunit.lang.ArchRule;
 import com.tngtech.archunit.lang.ConditionEvents;
 import com.tngtech.archunit.lang.SimpleConditionEvent;
 import io.camunda.zeebe.util.VisibleForTesting;
-import java.util.List;
 
 /**
  * ArchUnit rules to enforce correct usage of the {@link io.camunda.zeebe.util.VisibleForTesting}
@@ -32,15 +31,10 @@ import java.util.List;
  * accessed from test code or from within the same class (self-usage). This prevents accidental
  * usage in production code outside their intended scope.
  *
- * <p>Some classes are excluded from these rules via the {@code EXCLUDED_CLASS_NAMES} list. These
- * should be investigated and removed from the exclusion list over time.
- *
  * @see io.camunda.zeebe.util.VisibleForTesting
  */
 @AnalyzeClasses(packages = "io.camunda", importOptions = ImportOption.DoNotIncludeTests.class)
 public class VisibleForTestingArchTest {
-
-  static final List<String> EXCLUDED_CLASS_NAMES = List.of();
 
   @ArchTest
   static final ArchRule CLASS_VISIBLE_FOR_TESTING_SHOULD_ONLY_BE_ACCESSED_FROM_TEST_OR_SELF =
@@ -121,9 +115,7 @@ public class VisibleForTestingArchTest {
   }
 
   private static boolean isViolation(final JavaClass javaOwner, final JavaClass javaOriginOwner) {
-    return !isCalledBySelf(javaOwner, javaOriginOwner)
-        && !isTestClass(javaOriginOwner)
-        && !isExcludedClass(javaOwner);
+    return !isCalledBySelf(javaOwner, javaOriginOwner) && !isTestClass(javaOriginOwner);
   }
 
   private static boolean isTestClass(final JavaClass javaClass) {
@@ -144,9 +136,5 @@ public class VisibleForTestingArchTest {
       topLevelClass = topLevelClass.getEnclosingClass().get();
     }
     return topLevelClass;
-  }
-
-  private static boolean isExcludedClass(final JavaClass javaClass) {
-    return EXCLUDED_CLASS_NAMES.contains(javaClass.getFullName());
   }
 }

--- a/qa/archunit-tests/src/test/java/io/camunda/VisibleForTestingArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/VisibleForTestingArchTest.java
@@ -40,9 +40,7 @@ import java.util.List;
 @AnalyzeClasses(packages = "io.camunda", importOptions = ImportOption.DoNotIncludeTests.class)
 public class VisibleForTestingArchTest {
 
-  static final List<String> EXCLUDED_CLASS_NAMES =
-      List.of(
-          "io.camunda.zeebe.broker.system.partitions.impl.MigrationSnapshotDirector");
+  static final List<String> EXCLUDED_CLASS_NAMES = List.of();
 
   @ArchTest
   static final ArchRule CLASS_VISIBLE_FOR_TESTING_SHOULD_ONLY_BE_ACCESSED_FROM_TEST_OR_SELF =

--- a/qa/archunit-tests/src/test/java/io/camunda/VisibleForTestingArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/VisibleForTestingArchTest.java
@@ -14,9 +14,7 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
 import com.tngtech.archunit.core.domain.JavaAccess;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaField;
-import com.tngtech.archunit.core.domain.JavaMember;
 import com.tngtech.archunit.core.domain.JavaMethod;
-import com.tngtech.archunit.core.domain.properties.HasName.AndFullName;
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
@@ -42,46 +40,77 @@ public class VisibleForTestingArchTest {
 
   @ArchTest
   static final ArchRule CLASS_VISIBLE_FOR_TESTING_SHOULD_ONLY_BE_ACCESSED_FROM_TEST_OR_SELF =
-      classes().that().areAnnotatedWith(VisibleForTesting.class).should(beAccessedBySelfOrTest());
+      classes()
+          .that()
+          .areAnnotatedWith(VisibleForTesting.class)
+          .should(beClassAccessedBySelfOrTest());
 
   @ArchTest
   static final ArchRule METHOD_VISIBLE_FOR_TESTING_SHOULD_ONLY_BE_ACCESSED_FROM_TEST_OR_SELF =
-      methods().that().areAnnotatedWith(VisibleForTesting.class).should(beAccessedBySelfOrTest());
+      methods()
+          .that()
+          .areAnnotatedWith(VisibleForTesting.class)
+          .should(beMethodAccessedBySelfOrTest());
 
   @ArchTest
   static final ArchRule FIELD_VISIBLE_FOR_TESTING_SHOULD_ONLY_BE_ACCESSED_FROM_TEST_OR_SELF =
-      fields().that().areAnnotatedWith(VisibleForTesting.class).should(beAccessedBySelfOrTest());
+      fields()
+          .that()
+          .areAnnotatedWith(VisibleForTesting.class)
+          .should(beFieldAccessedBySelfOrTest());
 
-  private static <T extends AndFullName> ArchCondition<T> beAccessedBySelfOrTest() {
+  private static ArchCondition<JavaClass> beClassAccessedBySelfOrTest() {
     return new ArchCondition<>("be accessed from test or self") {
       @Override
-      public void check(final T element, final ConditionEvents events) {
-
-        final Set<? extends JavaAccess<?>> accessesToSelf;
-        final JavaClass owner;
-        if (element instanceof final JavaClass javaClass) {
-          accessesToSelf = javaClass.getAccessesToSelf();
-          owner = javaClass;
-        } else if (element instanceof final JavaMember javaMember) {
-          accessesToSelf = javaMember.getAccessesToSelf();
-          owner = javaMember.getOwner();
-        } else {
-          return;
-        }
-
-        accessesToSelf.stream()
-            .filter(access -> isViolation(owner, access.getOriginOwner()))
-            .forEach(
-                violationAccess ->
-                    events.add(
-                        SimpleConditionEvent.violated(
-                            violationAccess,
-                            String.format(
-                                "%s is accessed from %s, which is not a test but still requires extended visibility.",
-                                displayName(element),
-                                violationAccess.getOriginOwner().getFullName()))));
+      public void check(final JavaClass element, final ConditionEvents events) {
+        validateAccessViolations(
+            events, element.getAccessesToSelf(), element, "Class " + element.getFullName());
       }
     };
+  }
+
+  private static ArchCondition<JavaMethod> beMethodAccessedBySelfOrTest() {
+    return new ArchCondition<>("be accessed from test or self") {
+      @Override
+      public void check(final JavaMethod element, final ConditionEvents events) {
+        validateAccessViolations(
+            events,
+            element.getAccessesToSelf(),
+            element.getOwner(),
+            "Method " + element.getFullName());
+      }
+    };
+  }
+
+  private static ArchCondition<JavaField> beFieldAccessedBySelfOrTest() {
+    return new ArchCondition<>("be accessed from test or self") {
+      @Override
+      public void check(final JavaField element, final ConditionEvents events) {
+        validateAccessViolations(
+            events,
+            element.getAccessesToSelf(),
+            element.getOwner(),
+            "Field " + element.getFullName());
+      }
+    };
+  }
+
+  private static void validateAccessViolations(
+      final ConditionEvents events,
+      final Set<? extends JavaAccess<?>> accessesToSelf,
+      final JavaClass owner,
+      final String displayName) {
+
+    accessesToSelf.stream()
+        .filter(access -> isViolation(owner, access.getOriginOwner()))
+        .forEach(
+            violationAccess ->
+                events.add(
+                    SimpleConditionEvent.violated(
+                        violationAccess,
+                        String.format(
+                            "%s is accessed from %s, which is not a test but still requires extended visibility.",
+                            displayName, violationAccess.getOriginOwner().getFullName()))));
   }
 
   private static boolean isViolation(final JavaClass javaOwner, final JavaClass javaOriginOwner) {
@@ -106,14 +135,5 @@ public class VisibleForTestingArchTest {
       topLevelClass = topLevelClass.getEnclosingClass().get();
     }
     return topLevelClass;
-  }
-
-  private static String displayName(final AndFullName element) {
-    return switch (element) {
-      case final JavaClass javaClass -> "Class " + element.getFullName();
-      case final JavaMethod javaMethod -> "Method " + element.getFullName();
-      case final JavaField javaField -> "Field " + element.getFullName();
-      default -> element.getFullName();
-    };
   }
 }

--- a/qa/archunit-tests/src/test/java/io/camunda/VisibleForTestingArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/VisibleForTestingArchTest.java
@@ -11,9 +11,12 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
 
+import com.tngtech.archunit.core.domain.JavaAccess;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaField;
+import com.tngtech.archunit.core.domain.JavaMember;
 import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.domain.properties.HasName.AndFullName;
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
@@ -22,6 +25,7 @@ import com.tngtech.archunit.lang.ArchRule;
 import com.tngtech.archunit.lang.ConditionEvents;
 import com.tngtech.archunit.lang.SimpleConditionEvent;
 import io.camunda.zeebe.util.VisibleForTesting;
+import java.util.Set;
 
 /**
  * ArchUnit rules to enforce correct usage of the {@link io.camunda.zeebe.util.VisibleForTesting}
@@ -38,77 +42,43 @@ public class VisibleForTestingArchTest {
 
   @ArchTest
   static final ArchRule CLASS_VISIBLE_FOR_TESTING_SHOULD_ONLY_BE_ACCESSED_FROM_TEST_OR_SELF =
-      classes()
-          .that()
-          .areAnnotatedWith(VisibleForTesting.class)
-          .should(classAccessedBySelfOrTest());
+      classes().that().areAnnotatedWith(VisibleForTesting.class).should(beAccessedBySelfOrTest());
 
   @ArchTest
   static final ArchRule METHOD_VISIBLE_FOR_TESTING_SHOULD_ONLY_BE_ACCESSED_FROM_TEST_OR_SELF =
-      methods()
-          .that()
-          .areAnnotatedWith(VisibleForTesting.class)
-          .should(methodAccessedBySelfOrTest());
+      methods().that().areAnnotatedWith(VisibleForTesting.class).should(beAccessedBySelfOrTest());
 
   @ArchTest
   static final ArchRule FIELD_VISIBLE_FOR_TESTING_SHOULD_ONLY_BE_ACCESSED_FROM_TEST_OR_SELF =
-      fields().that().areAnnotatedWith(VisibleForTesting.class).should(fieldAccessedBySelfOrTest());
+      fields().that().areAnnotatedWith(VisibleForTesting.class).should(beAccessedBySelfOrTest());
 
-  private static ArchCondition<JavaClass> classAccessedBySelfOrTest() {
+  private static <T extends AndFullName> ArchCondition<T> beAccessedBySelfOrTest() {
     return new ArchCondition<>("be accessed from test or self") {
       @Override
-      public void check(final JavaClass javaClass, final ConditionEvents events) {
+      public void check(final T element, final ConditionEvents events) {
 
-        javaClass.getAccessesToSelf().stream()
-            .filter(access -> isViolation(javaClass, access.getOriginOwner()))
+        final Set<? extends JavaAccess<?>> accessesToSelf;
+        final JavaClass owner;
+        if (element instanceof final JavaClass javaClass) {
+          accessesToSelf = javaClass.getAccessesToSelf();
+          owner = javaClass;
+        } else if (element instanceof final JavaMember javaMember) {
+          accessesToSelf = javaMember.getAccessesToSelf();
+          owner = javaMember.getOwner();
+        } else {
+          return;
+        }
+
+        accessesToSelf.stream()
+            .filter(access -> isViolation(owner, access.getOriginOwner()))
             .forEach(
                 violationAccess ->
                     events.add(
                         SimpleConditionEvent.violated(
                             violationAccess,
                             String.format(
-                                "Class %s is accessed from %s, which is not a test but still requires extended visibility.",
-                                javaClass.getFullName(),
-                                violationAccess.getOriginOwner().getFullName()))));
-      }
-    };
-  }
-
-  private static ArchCondition<JavaMethod> methodAccessedBySelfOrTest() {
-    return new ArchCondition<>("be accessed from test or self") {
-      @Override
-      public void check(final JavaMethod javaMethod, final ConditionEvents events) {
-
-        javaMethod.getAccessesToSelf().stream()
-            .filter(access -> isViolation(javaMethod.getOwner(), access.getOriginOwner()))
-            .forEach(
-                violationCall ->
-                    events.add(
-                        SimpleConditionEvent.violated(
-                            violationCall,
-                            String.format(
-                                "Method %s is called from %s, which is not a test but still requires extended visibility.",
-                                javaMethod.getFullName(),
-                                violationCall.getOriginOwner().getFullName()))));
-      }
-    };
-  }
-
-  private static ArchCondition<JavaField> fieldAccessedBySelfOrTest() {
-    return new ArchCondition<>("be accessed from test or self") {
-      @Override
-      public void check(final JavaField javaField, final ConditionEvents events) {
-
-        javaField.getAccessesToSelf().stream()
-            .filter(fieldAccess -> isViolation(javaField.getOwner(), fieldAccess.getOriginOwner()))
-            .forEach(
-                violationAccess ->
-                    events.add(
-                        SimpleConditionEvent.violated(
-                            violationAccess,
-                            String.format(
-                                "Field %s is accessed from %s, which is not a test but still requires extended visibility.",
-                                javaField.getFullName(),
+                                "%s is accessed from %s, which is not a test but still requires extended visibility.",
+                                displayName(element),
                                 violationAccess.getOriginOwner().getFullName()))));
       }
     };
@@ -136,5 +106,14 @@ public class VisibleForTestingArchTest {
       topLevelClass = topLevelClass.getEnclosingClass().get();
     }
     return topLevelClass;
+  }
+
+  private static String displayName(final AndFullName element) {
+    return switch (element) {
+      case final JavaClass javaClass -> "Class " + element.getFullName();
+      case final JavaMethod javaMethod -> "Method " + element.getFullName();
+      case final JavaField javaField -> "Field " + element.getFullName();
+      default -> element.getFullName();
+    };
   }
 }

--- a/qa/archunit-tests/src/test/java/io/camunda/VisibleForTestingArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/VisibleForTestingArchTest.java
@@ -43,12 +43,7 @@ public class VisibleForTestingArchTest {
   static final List<String> EXCLUDED_CLASS_NAMES =
       List.of(
           "io.camunda.zeebe.broker.system.partitions.impl.MigrationSnapshotDirector",
-          "io.camunda.zeebe.gateway.impl.stream.StreamJobsHandler$AsyncJobStreamRemover",
-          "io.camunda.zeebe.util.micrometer.StatefulGauge",
-          "io.camunda.application.commons.console.ping.PingConsoleTask$RetriableException",
-          "io.camunda.search.schema.IndexMappingDifference$OrderInsensitiveEquivalence",
-          "io.camunda.zeebe.gateway.impl.stream.StreamJobsHandler$JobStreamConsumer",
-          "io.camunda.zeebe.shared.management.ActorClockEndpoint$Response");
+          "io.camunda.zeebe.util.micrometer.StatefulGauge");
 
   @ArchTest
   static final ArchRule CLASS_VISIBLE_FOR_TESTING_SHOULD_ONLY_BE_ACCESSED_FROM_TEST_OR_SELF =
@@ -69,7 +64,7 @@ public class VisibleForTestingArchTest {
       fields().that().areAnnotatedWith(VisibleForTesting.class).should(fieldAccessedBySelfOrTest());
 
   private static ArchCondition<JavaClass> classAccessedBySelfOrTest() {
-    return new ArchCondition<>("Classes should be accessed from test or self") {
+    return new ArchCondition<>("be accessed from test or self") {
       @Override
       public void check(final JavaClass javaClass, final ConditionEvents events) {
 
@@ -81,7 +76,7 @@ public class VisibleForTestingArchTest {
                         SimpleConditionEvent.violated(
                             violationAccess,
                             String.format(
-                                "Class %s is accessed from %s, which is not a test or self class.",
+                                "Class %s is accessed from %s, which is not a test but still requires extended visibility.",
                                 javaClass.getFullName(),
                                 violationAccess.getOriginOwner().getFullName()))));
       }
@@ -89,7 +84,7 @@ public class VisibleForTestingArchTest {
   }
 
   private static ArchCondition<JavaMethod> methodAccessedBySelfOrTest() {
-    return new ArchCondition<>("Methods should be accessed from test or self") {
+    return new ArchCondition<>("be accessed from test or self") {
       @Override
       public void check(final JavaMethod javaMethod, final ConditionEvents events) {
 
@@ -101,7 +96,7 @@ public class VisibleForTestingArchTest {
                         SimpleConditionEvent.violated(
                             violationCall,
                             String.format(
-                                "Method %s is called from %s, which is not a test or self class.",
+                                "Method %s is called from %s, which is not a test but still requires extended visibility.",
                                 javaMethod.getFullName(),
                                 violationCall.getOriginOwner().getFullName()))));
       }
@@ -109,7 +104,7 @@ public class VisibleForTestingArchTest {
   }
 
   private static ArchCondition<JavaField> fieldAccessedBySelfOrTest() {
-    return new ArchCondition<>("Fields should be accessed from test or self") {
+    return new ArchCondition<>("be accessed from test or self") {
       @Override
       public void check(final JavaField javaField, final ConditionEvents events) {
 
@@ -121,7 +116,7 @@ public class VisibleForTestingArchTest {
                         SimpleConditionEvent.violated(
                             violationAccess,
                             String.format(
-                                "Field %s is accessed from %s, which is not a test or self class.",
+                                "Field %s is accessed from %s, which is not a test but still requires extended visibility.",
                                 javaField.getFullName(),
                                 violationAccess.getOriginOwner().getFullName()))));
       }
@@ -139,9 +134,19 @@ public class VisibleForTestingArchTest {
     return javaClassSource.isPresent() && javaClassSource.get().toString().contains("test");
   }
 
-  private static boolean isCalledBySelf(
-      final JavaClass javaMethodOwner, final JavaClass javaMethodCallOriginOwner) {
-    return javaMethodCallOriginOwner.equals(javaMethodOwner);
+  private static boolean isCalledBySelf(final JavaClass calledClass, final JavaClass callingClass) {
+    // If the calling class is the same as the called class, it's a self-access
+    // This also covers the case of nested classes, as they can access private members of their
+    // enclosing class and vice versa
+    return topLevelClass(callingClass).equals(topLevelClass(calledClass));
+  }
+
+  private static JavaClass topLevelClass(final JavaClass javaClass) {
+    var topLevelClass = javaClass;
+    while (topLevelClass.getEnclosingClass().isPresent()) {
+      topLevelClass = topLevelClass.getEnclosingClass().get();
+    }
+    return topLevelClass;
   }
 
   private static boolean isExcludedClass(final JavaClass javaClass) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/MigrationSnapshotDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/MigrationSnapshotDirector.java
@@ -64,14 +64,14 @@ public class MigrationSnapshotDirector implements HealthMonitorable, CloseableSi
     }
   }
 
-  public void scheduleSnapshot() {
+  private void scheduleSnapshot() {
     if (!snapshotTaken) {
       LOG.debug("Scheduling snapshot for migration.");
       forceSnapshotUntilSuccessful();
     }
   }
 
-  public void cancelScheduledSnapshot() {
+  private void cancelScheduledSnapshot() {
     if (runningSnapshot != null) {
       runningSnapshot.cancel();
       runningSnapshot = null;

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/MigrationSnapshotDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/MigrationSnapshotDirector.java
@@ -13,7 +13,6 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.util.CloseableSilently;
 import io.camunda.zeebe.util.ExponentialBackoff;
-import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.health.FailureListener;
 import io.camunda.zeebe.util.health.HealthIssue;
 import io.camunda.zeebe.util.health.HealthMonitor;
@@ -79,7 +78,6 @@ public class MigrationSnapshotDirector implements HealthMonitorable, CloseableSi
     }
   }
 
-  @VisibleForTesting
   public boolean isSnapshotTaken() {
     return snapshotTaken;
   }

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/StatefulGauge.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/StatefulGauge.java
@@ -107,6 +107,10 @@ public final class StatefulGauge extends AbstractMeter implements Gauge {
     return delegate;
   }
 
+  boolean isSameMeter(final Meter meter) {
+    return delegate == meter;
+  }
+
   /** Returns a builder for a meter with the given name. */
   public static StatefulGauge.Builder builder(final String name) {
     return new Builder(name);

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/StatefulMeterRegistry.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/StatefulMeterRegistry.java
@@ -60,7 +60,7 @@ final class StatefulMeterRegistry extends CompositeMeterRegistry {
     final var existing = gauges.get(meter.getId());
 
     // we explicitly compare identity, because the meters should be the same
-    if (existing != null && existing.delegate() != meter) {
+    if (existing != null && !existing.isSameMeter(meter)) {
       LOGGER.warn(
           """
           A new meter {} was added a the stateful meter registry, but there was already an \


### PR DESCRIPTION
## Description

This pull request refactors and improves the enforcement of `@VisibleForTesting` usage and fixes current usages not following the correct convention.

In particular:
- changes the rules in `VisibleForTestingArchTest` to allow the usage of elements `@VisibleForTesting` in non-test code when the caller is inside the same "top-level" class (i.e. nothing would change if the element was `private`)
- fixes the remaining problems in `StatefulGauge` and `MigrationSnapshotDirector`
- refactors `VisibleForTestingArchTest` to improve maintainability

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #39788 
