### PR TITLE
[Backport release-8.9.0] fix: Handle null operationType in BatchOperations gracefully

### DIFF
--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/AbstractOperationHandler.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/AbstractOperationHandler.java
@@ -15,6 +15,7 @@ import io.camunda.operate.webapp.writer.BatchOperationWriter;
 import io.camunda.operate.webapp.zeebe.operation.adapter.OperateServicesAdapter;
 import io.camunda.webapps.schema.entities.operation.OperationEntity;
 import io.camunda.webapps.schema.entities.operation.OperationState;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -71,7 +72,7 @@ public abstract class AbstractOperationHandler implements OperationHandler {
         Metrics.TAG_KEY_STATUS,
         operation.getState().name(),
         Metrics.TAG_KEY_TYPE,
-        operation.getType().name());
+        Optional.ofNullable(operation.getType()).map(Enum::name).orElse(null));
   }
 
   protected boolean canForceFailOperation(final OperationEntity operation) {

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/AbstractOperationHandler.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/AbstractOperationHandler.java
@@ -72,7 +72,7 @@ public abstract class AbstractOperationHandler implements OperationHandler {
         Metrics.TAG_KEY_STATUS,
         operation.getState().name(),
         Metrics.TAG_KEY_TYPE,
-        Optional.ofNullable(operation.getType()).map(Enum::name).orElse(null));
+        Optional.ofNullable(operation.getType()).map(Enum::name).orElse("unknown"));
   }
 
   protected boolean canForceFailOperation(final OperationEntity operation) {

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/BatchOperationEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/BatchOperationEntityTransformer.java
@@ -14,11 +14,16 @@ import io.camunda.search.entities.BatchOperationEntity.BatchOperationErrorEntity
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationState;
 import io.camunda.search.entities.BatchOperationType;
 import java.util.Collections;
+import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class BatchOperationEntityTransformer
     implements ServiceTransformer<
         io.camunda.webapps.schema.entities.operation.BatchOperationEntity, BatchOperationEntity> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BatchOperationEntityTransformer.class);
 
   @Override
   public BatchOperationEntity apply(
@@ -44,10 +49,19 @@ public class BatchOperationEntityTransformer
 
   private BatchOperationEntity mapBatchOperation(
       final io.camunda.webapps.schema.entities.operation.BatchOperationEntity source) {
+    final var batchOperationType =
+        Optional.ofNullable(source.getType())
+            .map(Enum::name)
+            .map(BatchOperationType::valueOf)
+            .orElseGet(
+                () -> {
+                  LOG.warn("Batch operation with id '{}' has no type", source.getId());
+                  return null;
+                });
     return new BatchOperationEntity(
         source.getId(),
         BatchOperationState.valueOf(source.getState().name()),
-        BatchOperationType.valueOf(source.getType().name()),
+        batchOperationType,
         source.getStartDate(),
         source.getEndDate(),
         source.getActorType() != null

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/BatchOperationEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/BatchOperationEntityTransformer.java
@@ -55,7 +55,7 @@ public class BatchOperationEntityTransformer
             .map(BatchOperationType::valueOf)
             .orElseGet(
                 () -> {
-                  LOG.warn("Batch operation with id '{}' has no type", source.getId());
+                  LOG.debug("Batch operation with id '{}' has no type", source.getId());
                   return null;
                 });
     return new BatchOperationEntity(

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/entity/BatchOperationEntityTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/entity/BatchOperationEntityTransformerTest.java
@@ -144,4 +144,23 @@ class BatchOperationEntityTransformerTest {
     assertThat(searchEntity.operationsTotalCount()).isEqualTo(42);
     assertThat(searchEntity.operationsCompletedCount()).isEqualTo(42);
   }
+
+  @Test
+  void shouldTransformEntityWithNullTypeToSearchEntity() {
+    // given
+    final BatchOperationEntity entity = new BatchOperationEntity();
+    entity.setId("1");
+    entity.setType(null);
+    entity.setState(BatchOperationState.ACTIVE);
+    entity.setOperationsTotalCount(42);
+
+    // when
+    final var searchEntity = transformer.apply(entity);
+
+    // then
+    assertThat(searchEntity).isNotNull();
+    assertThat(searchEntity.batchOperationKey()).isEqualTo("1");
+    assertThat(searchEntity.operationType()).isNull();
+    assertThat(searchEntity.state().name()).isEqualTo(BatchOperationState.ACTIVE.name());
+  }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/batchoperation/ElasticSearchBatchOperationCacheLoader.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/batchoperation/ElasticSearchBatchOperationCacheLoader.java
@@ -53,10 +53,15 @@ public class ElasticSearchBatchOperationCacheLoader
             BatchOperationEntity.class);
     if (response.hits() != null && !response.hits().hits().isEmpty()) {
       final var entity = response.hits().hits().getFirst().source();
-      return new CachedBatchOperationEntity(entity.getId(), map(entity.getType()));
+      if (entity != null && entity.getType() != null) {
+        return new CachedBatchOperationEntity(entity.getId(), map(entity.getType()));
+      }
+      LOG.warn(
+          "Found BatchOperation '{}' in ElasticSearch but it is missing required fields or has invalid data",
+          batchOperationKey);
     } else {
-      LOG.debug("BatchOperation '{}' not found in Elasticsearch", batchOperationKey);
-      return null;
+      LOG.debug("BatchOperation '{}' not found in ElasticSearch", batchOperationKey);
     }
+    return null;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/batchoperation/OpenSearchBatchOperationCacheLoader.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/batchoperation/OpenSearchBatchOperationCacheLoader.java
@@ -52,10 +52,15 @@ public class OpenSearchBatchOperationCacheLoader
             BatchOperationEntity.class);
     if (response.hits() != null && !response.hits().hits().isEmpty()) {
       final var entity = response.hits().hits().getFirst().source();
-      return new CachedBatchOperationEntity(entity.getId(), map(entity.getType()));
+      if (entity != null && entity.getType() != null) {
+        return new CachedBatchOperationEntity(entity.getId(), map(entity.getType()));
+      }
+      LOG.warn(
+          "Found BatchOperation '{}' in OpenSearch but it is missing required fields or has invalid data",
+          batchOperationKey);
     } else {
       LOG.debug("BatchOperation '{}' not found in OpenSearch", batchOperationKey);
-      return null;
     }
+    return null;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedItemHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedItemHandler.java
@@ -90,15 +90,24 @@ public class BatchOperationChunkCreatedItemHandler
         item.getProcessInstanceKey(),
         indexName);
 
-    final var cachedEntity = batchOperationCache.get(String.valueOf(value.getBatchOperationKey()));
+    final var batchOperationKey = String.valueOf(value.getBatchOperationKey());
+
     entity
-        .setBatchOperationId(String.valueOf(value.getBatchOperationKey()))
+        .setBatchOperationId(batchOperationKey)
         .setType(
-            cachedEntity
+            batchOperationCache
+                .get(batchOperationKey)
                 .map(CachedBatchOperationEntity::type)
                 .map(String::valueOf)
                 .map(OperationType::valueOf)
-                .orElse(null))
+                .orElseGet(
+                    () -> {
+                      LOG.warn(
+                          "BatchOperation '{}' not found in cache or has null type. "
+                              + "The operation item will be written with null type. ",
+                          batchOperationKey);
+                      return null;
+                    }))
         .setState(OperationState.SCHEDULED)
         .setProcessInstanceKey(item.getProcessInstanceKey())
         .setItemKey(item.getItemKey());

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCreatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCreatedHandler.java
@@ -12,6 +12,7 @@ import static io.camunda.exporter.utils.ExporterUtil.map;
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.handlers.ExportHandler;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.entities.auditlog.AuditLogActorType;
 import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
 import io.camunda.webapps.schema.entities.operation.BatchOperationEntity.BatchOperationState;
@@ -24,6 +25,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue;
 import io.camunda.zeebe.util.SemanticVersion;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -98,10 +100,23 @@ public class BatchOperationCreatedHandler
     // the same document. An index operation would fully replace the document, potentially
     // overwriting operationsTotalCount increments or state transitions applied by other partitions.
     // With upsert: if the document does not yet exist, it is created from the entity; if it
-    // already exists, the empty update map is a no-op — all fields in the CREATED event are
-    // idempotent across partitions (same values regardless of which partition exports), so there
-    // is nothing to update on an existing document.
-    batchRequest.upsert(indexName, entity.getId(), entity, Map.of());
+    // already exists, only the specified fields are updated without affecting other fields.
+    // Note: STATE is intentionally excluded from updateFields because a late CREATED event from a
+    // slow partition could overwrite a state that has already advanced (e.g., ACTIVE or COMPLETED).
+    // The state is set correctly on initial document creation via the entity.
+    final Map<String, Object> updateFields = new HashMap<>();
+    updateFields.put(BatchOperationTemplate.TYPE, entity.getType());
+
+    final var actorType = entity.getActorType();
+    if (actorType != null) {
+      updateFields.put(BatchOperationTemplate.ACTOR_TYPE, actorType);
+    }
+
+    final var actorId = entity.getActorId();
+    if (actorId != null) {
+      updateFields.put(BatchOperationTemplate.ACTOR_ID, actorId);
+    }
+    batchRequest.upsert(indexName, entity.getId(), entity, updateFields);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/cache/BatchOperationCacheIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/cache/BatchOperationCacheIT.java
@@ -97,6 +97,21 @@ class BatchOperationCacheIT {
   }
 
   @ParameterizedTest
+  @MethodSource("provideBatchOperationCache")
+  void shouldReturnEmptyOptionalIfBatchOperationHasNullType(
+      final BatchOperationCacheArgument batchOperationCacheArgument) {
+    // given
+    final var batchOperationEntity = new BatchOperationEntity().setId("4").setType(null);
+    batchOperationCacheArgument.indexer().accept(batchOperationEntity);
+
+    // when
+    final var batchOperation = batchOperationCacheArgument.batchOperationCache().get("4");
+
+    // then
+    assertThat(batchOperation).isEmpty();
+  }
+
+  @ParameterizedTest
   @MethodSource("provideFailingBatchOperationCache")
   void shouldThrowExceptionIfQueryToElasticFailed(
       final BatchOperationCacheArgument batchOperationCacheArgument) {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedItemHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedItemHandlerTest.java
@@ -135,9 +135,7 @@ class BatchOperationChunkCreatedItemHandlerTest {
     // given
     when(batchOperationCache.get("42")).thenReturn(Optional.empty());
 
-    final int numItems = 1;
-    final Record<BatchOperationChunkRecordValue> record =
-        aChunkRecordWithMultipleItems(42L, numItems);
+    final Record<BatchOperationChunkRecordValue> record = aChunkRecordWithMultipleItems(42L, 1);
     final var item = record.getValue().getItems().getFirst();
     final String expectedId =
         String.format(ID_PATTERN, record.getValue().getBatchOperationKey(), item.getItemKey());

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedItemHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedItemHandlerTest.java
@@ -131,6 +131,31 @@ class BatchOperationChunkCreatedItemHandlerTest {
   }
 
   @Test
+  void shouldUpdateEntityWithNullTypeWhenCacheIsEmpty() {
+    // given
+    when(batchOperationCache.get("42")).thenReturn(Optional.empty());
+
+    final int numItems = 1;
+    final Record<BatchOperationChunkRecordValue> record =
+        aChunkRecordWithMultipleItems(42L, numItems);
+    final var item = record.getValue().getItems().getFirst();
+    final String expectedId =
+        String.format(ID_PATTERN, record.getValue().getBatchOperationKey(), item.getItemKey());
+
+    // when
+    final var entity = underTest.createNewEntity(expectedId);
+    underTest.updateEntity(record, entity);
+
+    // then
+    verify(batchOperationCache).get("42");
+    assertThat(entity.getId()).isEqualTo(expectedId);
+    assertThat(entity.getType()).isNull();
+    assertThat(entity.getBatchOperationId()).isEqualTo("42");
+    assertThat(entity.getState()).isEqualTo(OperationState.SCHEDULED);
+    assertThat(entity.getProcessInstanceKey()).isEqualTo(item.getProcessInstanceKey());
+  }
+
+  @Test
   void shouldFlushEntity() {
     // given
     final var mockRequest = mock(BatchRequest.class);
@@ -151,6 +176,31 @@ class BatchOperationChunkCreatedItemHandlerTest {
     verify(mockRequest).add(eq(indexName), entityCaptor.capture());
     final var capturedEntity = entityCaptor.getValue();
     assertThat(capturedEntity).isEqualTo(entity);
+  }
+
+  @Test
+  void shouldFlushEntityWithNullType() {
+    // given
+    when(batchOperationCache.get("42")).thenReturn(Optional.empty());
+
+    final var mockRequest = mock(BatchRequest.class);
+    final Record<BatchOperationChunkRecordValue> record = aChunkRecordWithMultipleItems(42L, 1);
+    final var item = record.getValue().getItems().getFirst();
+    final String expectedId =
+        String.format(ID_PATTERN, record.getValue().getBatchOperationKey(), item.getItemKey());
+    final var entity = underTest.createNewEntity(expectedId);
+    underTest.updateEntity(record, entity);
+
+    // when
+    underTest.flush(entity, mockRequest);
+
+    // then
+    verify(batchOperationCache).get("42"); // verify cache was consulted
+    final var entityCaptor = ArgumentCaptor.forClass(OperationEntity.class);
+    verify(mockRequest).add(eq(indexName), entityCaptor.capture());
+    final var capturedEntity = entityCaptor.getValue();
+    assertThat(capturedEntity.getType()).isNull();
+    assertThat(capturedEntity.getState()).isEqualTo(OperationState.SCHEDULED);
   }
 
   private Record<BatchOperationChunkRecordValue> aChunkRecordWithMultipleItems(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCreatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCreatedHandlerTest.java
@@ -206,7 +206,7 @@ class BatchOperationCreatedHandlerTest {
   }
 
   @Test
-  void shouldUpsertWithEmptyUpdateFieldsOnFlush() throws PersistenceException {
+  void shouldUpsertWithPopulatedUpdateFieldsOnFlush() throws PersistenceException {
     // given
     final var entity =
         new BatchOperationEntity()
@@ -220,6 +220,15 @@ class BatchOperationCreatedHandlerTest {
     underTest.flush(entity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).upsert(eq(indexName), eq("123"), eq(entity), eq(Map.of()));
+    verify(mockRequest, times(1))
+        .upsert(
+            eq(indexName),
+            eq("123"),
+            eq(entity),
+            eq(
+                Map.of(
+                    BatchOperationTemplate.TYPE, entity.getType(),
+                    BatchOperationTemplate.ACTOR_ID, entity.getActorId(),
+                    BatchOperationTemplate.ACTOR_TYPE, entity.getActorType())));
   }
 }


### PR DESCRIPTION
# Description
Backport of #49827 to `release-8.9.0`.

relates to camunda/camunda#49765