### PR TITLE
fix: use setup-zeebe instead of setup-build

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -667,25 +667,4 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
-  snyk:
-    name: Snyk Monitor
-    needs: [ zeebe-docker, release ]
-    # skip if the version contains a dash as a quick test for -alpha, -rc, -SNAPSHOT, etc.
-    if: ${{ !contains(inputs.releaseVersion, '-') }}
-    concurrency:
-      group: release-snyk-${{ inputs.releaseVersion }}
-      cancel-in-progress: false
-    uses: ./.github/workflows/zeebe-snyk.yml
-    with:
-      # Can't reference env.RELEASE_BRANCH directly due to https://github.com/actions/runner/issues/2372
-      ref: ${{ needs.release.outputs.releaseBranch }}
-      version: ${{ inputs.releaseVersion }}
-      useMinorVersion: true
-      # test instead of monitor during dry-runs
-      monitor: ${{ !inputs.dryRun }}
-      # the docker image will not be pushed during a dry-run, so we need to build it locally
-      build: ${{ inputs.dryRun }}
-      dockerImage: ${{ inputs.dryRun && '' || format('camunda/zeebe:{0}', inputs.releaseVersion) }}
-    secrets: inherit
-
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,12 +84,12 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: ./.github/actions/setup-build
+      - uses: ./.github/actions/setup-zeebe
         with:
           maven-cache-key-modifier: validate-pom-metadata
-          vault-address: ${{ secrets.VAULT_ADDR }}
-          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
-          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
       - name: Bootstrap reactor modules
         run: ./mvnw -B -T1C --no-snapshot-updates -DskipChecks=true -DskipTests=true -Dquickly=true install
       - name: Generate flattened POMs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -439,12 +439,6 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
-  zeebe-ci:
-    if: needs.detect-changes.outputs.zeebe-changes == 'true'
-    needs: [detect-changes]
-    uses: ./.github/workflows/zeebe-ci.yml
-    secrets: inherit
-
   optimize-frontend-unit-tests:
     if: needs.detect-changes.outputs.optimize-frontend-changes == 'true'
     needs: [detect-changes]
@@ -594,7 +588,6 @@ jobs:
       - integration-tests
       - java-checks
       - build-platform-frontend
-      - zeebe-ci
       - optimize-frontend-unit-tests
       - optimize-backend-unit-tests
       - protobuf-checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
     name: "Lint / Flattened POM Metadata"
     needs: [ detect-changes ]
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 35
     permissions: { }  # GITHUB_TOKEN unused in this job
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/preview-env-build.yml
+++ b/.github/workflows/preview-env-build.yml
@@ -26,24 +26,6 @@ jobs:
       branch: ${{ github.head_ref }}
       pushDocker: true
 
-  build-operare:
-    if: github.event.pull_request.state != 'closed' && (contains( github.event.label.name, 'deploy-preview') || contains( github.event.pull_request.labels.*.name, 'deploy-preview'))
-    name: Operate Build
-    uses: ./.github/workflows/operate-ci-build-reusable.yml
-    secrets: inherit
-    with:
-      branch: ${{ github.head_ref }}
-      previewEnv: true
-
-  build-tasklist:
-    if: github.event.pull_request.state != 'closed' && (contains( github.event.label.name, 'deploy-preview') || contains( github.event.pull_request.labels.*.name, 'deploy-preview'))
-    name: Tasklist Build
-    uses: ./.github/workflows/tasklist-ci-build-reusable.yml
-    secrets: inherit
-    with:
-      branch: ${{ github.head_ref }}
-      previewEnv: true
-
   build-zeebe:
     if: github.event.pull_request.state != 'closed' && (contains( github.event.label.name, 'deploy-preview') || contains( github.event.pull_request.labels.*.name, 'deploy-preview'))
     name: Build Zeebe


### PR DESCRIPTION
## Description

This pull request updates the CI workflow configuration to use a new custom action for setting up Zeebe and changes how secret environment variables are passed to the action. The main change is replacing the previous `setup-build` action with `setup-zeebe`, along with updating the secret input variable names to match the new action's expected parameters.

Workflow configuration updates:

* Swapped out the `setup-build` action for the new `setup-zeebe` action in the CI workflow (`.github/workflows/ci.yml`).
* Updated secret input variable names from `vault-address`, `vault-role-id`, and `vault-secret-id` to `secret_vault_address`, `secret_vault_roleId`, and `secret_vault_secretId` to align with the requirements of the new `setup-zeebe` action (`.github/workflows/ci.yml`).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
