### PR TITLE
[Backport main] fix: Trigger Exporter Flush If Flush Timer Exceded

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterMetrics.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterMetrics.java
@@ -85,7 +85,7 @@ public final class ExporterMetrics {
       final ValueType valueType, final long written, final long exporting) {
     exportingLatency
         .computeIfAbsent(valueType, this::registerExportingLatency)
-        .record(exporting - written, TimeUnit.MILLISECONDS);
+        .record(Math.max(0, exporting - written), TimeUnit.MILLISECONDS);
   }
 
   public CloseableSilently startExporterExportingTimer(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -300,7 +300,9 @@ public class CamundaExporter implements Exporter {
 
   private boolean shouldFlush() {
     return writer.getBatchSize() >= configuration.getBulk().getSize()
-        || writer.getBatchMemoryEstimateInMb() >= configuration.getBulk().getMemoryLimit();
+        || writer.getBatchMemoryEstimateInMb() >= configuration.getBulk().getMemoryLimit()
+        || (writer.getBatchSize() > 0
+            && (context.clock().millis() - lastFlushTimestamp) >= flushDelayMs);
   }
 
   private ExporterBatchWriter createBatchWriter() {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -139,7 +139,9 @@ public class CamundaExporter implements Exporter {
       writer = createBatchWriter();
       controller.readMetadata().ifPresent(metadata::deserialize);
       taskManager.start();
-      scheduleDelayedFlush(context.clock().millis());
+      final long now = context.clock().millis();
+      lastFlushTimestamp = now;
+      scheduleDelayedFlush(now);
 
       LOG.info("Exporter opened");
     } catch (final Exception e) {
@@ -342,15 +344,15 @@ public class CamundaExporter implements Exporter {
         writer.flush(batchRequest);
         metrics.recordFlushOccurrence(Instant.now());
         metrics.stopFlushLatencyMeasurement();
-        lastFlushTimestamp = context.clock().millis();
       } catch (final PersistenceException ex) {
         metrics.recordFailedFlush();
         throw new ExporterException(ex.getMessage(), ex);
       }
     }
 
-    // Update the record counters only after the flush was successful. If the synchronous flush
-    // fails then the exporter will be invoked with the same record again.
+    // Update record counters and lastFlushTimestamp only after the flush attempt was successful.
+    // If the synchronous flush fails then the exporter will be invoked with the same record again.
+    lastFlushTimestamp = context.clock().millis();
     updateLastExportedPosition(lastPosition);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
@@ -314,6 +314,7 @@ public class CamundaExporterMetrics implements AutoCloseable {
   public void stopFlushLatencyMeasurement() {
     if (flushLatencyMeasurement != null) {
       flushLatencyMeasurement.stop(flushLatency);
+      flushLatencyMeasurement = null;
     }
   }
 
@@ -410,7 +411,7 @@ public class CamundaExporterMetrics implements AutoCloseable {
   public void observeRecordExportLatencies(final Collection<Long> recordTimestamps) {
     final var now = streamClock.millis();
     recordTimestamps.stream()
-        .mapToLong(timestamp -> now - timestamp)
+        .mapToLong(timestamp -> Math.max(0, now - timestamp))
         .forEach(duration -> recordExportDuration.record(duration, TimeUnit.MILLISECONDS));
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.awaitility.Awaitility.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -252,7 +253,9 @@ final class CamundaExporterIT {
     spiedController.runScheduledTasks(Duration.ofSeconds(duration));
 
     // then
-    verify(spiedController, times(2)).scheduleCancellableTask(eq(Duration.ofSeconds(2)), any());
+    verify(spiedController, times(2))
+        .scheduleCancellableTask(
+            argThat(delay -> delay.getSeconds() >= 0 && delay.getSeconds() <= 2), any());
   }
 
   @TestTemplate

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
@@ -233,6 +233,10 @@ final class CamundaExporterTest {
   final class FlushTest {
     @Test
     void shouldUpdateMetadataOnFlush() {
+      final var clock = new MutableClock(0);
+      testContext.setClock(clock);
+      configuration.getBulk().setDelay(1);
+
       // given
       final var expected = new ExporterMetadata(TestObjectMapper.objectMapper());
       exporter = new CamundaExporter(resourceProvider, expected);
@@ -244,6 +248,8 @@ final class CamundaExporterTest {
       // when
       exporter.configure(testContext);
       exporter.open(testController);
+
+      clock.advance(1001);
       testController.runScheduledTasks(Duration.ofHours(1));
 
       // then

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
@@ -258,8 +258,10 @@ final class CamundaExporterTest {
   @Nested
   final class ScheduledFlushTest {
 
+    private final ProtocolFactory protocolFactory = new ProtocolFactory();
+
     private Record<?> stubRecord() {
-      return new ProtocolFactory().generateRecord(ValueType.VARIABLE);
+      return protocolFactory.generateRecord(ValueType.VARIABLE);
     }
 
     @Test
@@ -307,6 +309,51 @@ final class CamundaExporterTest {
       final var tasks = testController.getScheduledTasks();
       final var lastTask = tasks.getLast();
       assertThat(lastTask.getDelay()).isEqualTo(Duration.ofMillis(700));
+    }
+
+    @Test
+    void shouldFlushWhenExportIfDelayElapsed() {
+      // given — use a controllable clock so we can verify timing
+      final var clock = new MutableClock(0);
+      testContext.setClock(clock);
+      // bulk size = 10 so that a single export does NOT trigger a size-based flush;
+      // flushing only happens via the scheduled task
+      configuration.getBulk().setSize(10);
+      configuration.getBulk().setDelay(1);
+      exporter =
+          new CamundaExporter(
+              resourceProvider, new ExporterMetadata(TestObjectMapper.objectMapper()));
+      exporter.configure(testContext);
+      exporter.open(testController);
+
+      // export at t=500 — batch size < 10, no size-based flush
+      clock.advance(500);
+      final var record1 =
+          protocolFactory.generateRecord(ValueType.VARIABLE, b -> b.withPosition(1L));
+      exporter.export(record1);
+
+      // advance clock to trigger scheduled flush task at t=1000
+      clock.advance(500);
+      testController.runScheduledTasks(Duration.ofSeconds(1));
+
+      // then — validate record1 was exported (position updated after timed flush)
+      assertThat(testController.getPosition())
+          .as("Record1 should have been flushed and position updated")
+          .isEqualTo(record1.getPosition());
+
+      // advance clock beyond delay to exceed the flush duration
+      clock.advance(1001);
+
+      // next export record with a higher position
+      // batch size still < 10, but clock has advanced, so should flush
+      final var record2 =
+          protocolFactory.generateRecord(ValueType.VARIABLE, b -> b.withPosition(2L));
+      exporter.export(record2);
+
+      // then — validate record2 was exported (position updated after flush)
+      assertThat(testController.getPosition())
+          .as("Record2 should have been flushed and position updated")
+          .isEqualTo(record2.getPosition());
     }
 
     @Test


### PR DESCRIPTION
# Description
Backport of #49832 to `main`.

relates to camunda/camunda#49820