### PR TITLE
[Backport stable/8.8] fix: Trigger Exporter Flush If Flush Timer Exceded

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterMetrics.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterMetrics.java
@@ -85,7 +85,7 @@ public final class ExporterMetrics {
       final ValueType valueType, final long written, final long exporting) {
     exportingLatency
         .computeIfAbsent(valueType, this::registerExportingLatency)
-        .record(exporting - written, TimeUnit.MILLISECONDS);
+        .record(Math.max(0, exporting - written), TimeUnit.MILLISECONDS);
   }
 
   public CloseableSilently startExporterExportingTimer(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -368,7 +368,9 @@ public class CamundaExporter implements Exporter {
 
   private boolean shouldFlush() {
     return writer.getBatchSize() >= configuration.getBulk().getSize()
-        || writer.getBatchMemoryEstimateInMb() >= configuration.getBulk().getMemoryLimit();
+        || writer.getBatchMemoryEstimateInMb() >= configuration.getBulk().getMemoryLimit()
+        || (writer.getBatchSize() > 0
+            && (context.clock().millis() - lastFlushTimestamp) >= flushDelayMs);
   }
 
   private ExporterBatchWriter createBatchWriter() {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -136,7 +136,7 @@ public class CamundaExporter implements Exporter {
       }
 
       writer = createBatchWriter();
-
+      lastFlushTimestamp = context.clock().millis();
       checkImportersCompletedAndReschedule();
       controller.readMetadata().ifPresent(metadata::deserialize);
       taskManager.start();
@@ -452,15 +452,15 @@ public class CamundaExporter implements Exporter {
         writer.flush(batchRequest);
         metrics.recordFlushOccurrence(Instant.now());
         metrics.stopFlushLatencyMeasurement();
-        lastFlushTimestamp = context.clock().millis();
       } catch (final PersistenceException ex) {
         metrics.recordFailedFlush();
         throw new ExporterException(ex.getMessage(), ex);
       }
     }
 
-    // Update the record counters only after the flush was successful. If the synchronous flush
-    // fails then the exporter will be invoked with the same record again.
+    // Update record counters and lastFlushTimestamp only after the flush attempt was successful.
+    // If the synchronous flush fails then the exporter will be invoked with the same record again.
+    lastFlushTimestamp = context.clock().millis();
     updateLastExportedPosition(lastPosition);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
@@ -281,6 +281,7 @@ public class CamundaExporterMetrics implements AutoCloseable {
   public void stopFlushLatencyMeasurement() {
     if (flushLatencyMeasurement != null) {
       flushLatencyMeasurement.stop(flushLatency);
+      flushLatencyMeasurement = null;
     }
   }
 
@@ -361,7 +362,7 @@ public class CamundaExporterMetrics implements AutoCloseable {
   public void observeRecordExportLatencies(final Collection<Long> recordTimestamps) {
     final var now = streamClock.millis();
     recordTimestamps.stream()
-        .mapToLong(timestamp -> now - timestamp)
+        .mapToLong(timestamp -> Math.max(0, now - timestamp))
         .forEach(duration -> recordExportDuration.record(duration, TimeUnit.MILLISECONDS));
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.awaitility.Awaitility.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doReturn;
@@ -262,7 +263,9 @@ final class CamundaExporterIT {
     spiedController.runScheduledTasks(Duration.ofSeconds(duration));
 
     // then
-    verify(spiedController, times(2)).scheduleCancellableTask(eq(Duration.ofSeconds(2)), any());
+    verify(spiedController, times(2))
+        .scheduleCancellableTask(
+            argThat(delay -> delay.getSeconds() >= 0 && delay.getSeconds() <= 2), any());
   }
 
   @TestTemplate

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
@@ -349,5 +349,33 @@ final class CamundaExporterTest {
             .isEqualTo(Duration.ofMillis(500));
       }
     }
+
+    @Test
+    void shouldKeepStableDelayAcrossMultipleFlushCyclesWhenBatchIsEmpty() {
+      // Regression test: the rescheduled flush delay must remain stable across
+      // repeated flush cycles and not degrade to zero.
+
+      // given
+      final var clock = new MutableClock(0);
+      testContext.setClock(clock);
+      configuration.getBulk().setSize(1); // every export() triggers size-based flush
+      configuration.getBulk().setDelay(1); // 1 second
+      configuration.getIndex().setShouldWaitForImporters(false); // do not wait for importers
+      exporter =
+          new CamundaExporter(
+              resourceProvider, new ExporterMetadata(TestObjectMapper.objectMapper()));
+      exporter.configure(testContext);
+      exporter.open(testController);
+
+      // when
+      for (int cycle = 0; cycle < 4; cycle++) {
+        testController.runScheduledTasks(Duration.ofSeconds(2));
+        clock.advance(1000);
+
+        // then
+        final var tasks = testController.getScheduledTasks();
+        assertThat(tasks.getLast().getDelay()).isEqualTo(Duration.ofMillis(1000));
+      }
+    }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
@@ -186,6 +186,10 @@ final class CamundaExporterTest {
   final class FlushTest {
     @Test
     void shouldUpdateMetadataOnFlush() {
+      final var clock = new MutableClock(0);
+      testContext.setClock(clock);
+      configuration.getBulk().setDelay(1);
+
       // given
       final var expected = new ExporterMetadata(TestObjectMapper.objectMapper());
       exporter = new CamundaExporter(resourceProvider, expected);
@@ -200,6 +204,8 @@ final class CamundaExporterTest {
       // when
       exporter.configure(testContext);
       exporter.open(testController);
+
+      clock.advance(1001);
       testController.runScheduledTasks(Duration.ofHours(1));
 
       // then

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
@@ -267,6 +267,53 @@ final class CamundaExporterTest {
     }
 
     @Test
+    void shouldFlushWhenExportIfDelayElapsed() {
+      // given — use a controllable clock so we can verify timing
+      final var clock = new MutableClock(0);
+      testContext.setClock(clock);
+      // bulk size = 10 so that a single export does NOT trigger a size-based flush;
+      // flushing only happens via the scheduled task
+      configuration.getBulk().setSize(10);
+      configuration.getBulk().setDelay(1);
+      exporter =
+          new CamundaExporter(
+              resourceProvider, new ExporterMetadata(TestObjectMapper.objectMapper()));
+      exporter.configure(testContext);
+      exporter.open(testController);
+
+      // export at t=500 — batch size < 10, no size-based flush
+      clock.advance(500);
+      final var record1 =
+          factory.generateRecord(
+              ValueType.VARIABLE, b -> b.withPosition(1L).withBrokerVersion("8.8.0"));
+      exporter.export(record1);
+
+      // advance clock to trigger scheduled flush task at t=1000
+      clock.advance(500);
+      testController.runScheduledTasks(Duration.ofSeconds(1));
+
+      // then — validate record1 was exported (position updated after timed flush)
+      assertThat(testController.getPosition())
+          .as("Record1 should have been flushed and position updated")
+          .isEqualTo(record1.getPosition());
+
+      // advance clock beyond delay to exceed the flush duration
+      clock.advance(1001);
+
+      // next export record with a higher position
+      // batch size still < 10, but clock has advanced, so should flush
+      final var record2 =
+          factory.generateRecord(
+              ValueType.VARIABLE, b -> b.withPosition(2L).withBrokerVersion("8.8.0"));
+      exporter.export(record2);
+
+      // then — validate record2 was exported (position updated after flush)
+      assertThat(testController.getPosition())
+          .as("Record2 should have been flushed and position updated")
+          .isEqualTo(record2.getPosition());
+    }
+
+    @Test
     void shouldKeepStableDelayAcrossMultipleFlushCycles() {
       // Regression test: the rescheduled flush delay must remain stable across
       // repeated flush cycles and not degrade to zero.


### PR DESCRIPTION
# Description
Backport of #49832 to `stable/8.8`.

relates to camunda/camunda#49820