### PR TITLE
ci: remove typical workload from weekly load tests

### DIFF
--- a/.github/workflows/camunda-weekly-load-tests.yml
+++ b/.github/workflows/camunda-weekly-load-tests.yml
@@ -1,4 +1,4 @@
-# description: Deploys new Camunda load tests weekly. Multiple kinds of load tests are created - typical, realistic, latency
+# description: Deploys new Camunda load tests weekly. Multiple kinds of load tests are created - realistic, latency
 # type: CI
 # owner: @camunda/reliability-testing
 name: Camunda weekly medic load test
@@ -163,25 +163,6 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
-  setup-typical-load-test:
-    name: Typical load test
-    needs:
-      - test-data
-      - build-camunda-image
-      - build-load-test-images
-    if: |
-      always() &&
-      needs.test-data.result == 'success' &&
-      (needs.build-camunda-image.result == 'success' || needs.build-camunda-image.result == 'skipped') &&
-      (needs.build-load-test-images.result == 'success' || needs.build-load-test-images.result == 'skipped')
-    uses: ./.github/workflows/camunda-load-test.yml
-    secrets: inherit
-    with:
-      name: ${{ needs.test-data.outputs.image-tag }}-typical
-      ttl: ${{ fromJSON(inputs.ttl || '28') }}
-      reuse-tag: ${{ needs.test-data.outputs.image-tag }}
-      scenario: typical
-
   setup-rdbms-realistic-load-test:
     name: Postgres realistic load test
     needs:
@@ -243,7 +224,7 @@ jobs:
   notify:
     name: Notify on failure
     runs-on: ubuntu-latest
-    needs: [ build-camunda-image, build-load-test-images, setup-typical-load-test, setup-rdbms-realistic-load-test, setup-realistic-test, setup-latency-test ]
+    needs: [ build-camunda-image, build-load-test-images, setup-rdbms-realistic-load-test, setup-realistic-test, setup-latency-test ]
     if: failure()
     timeout-minutes: 5
     permissions: { }

--- a/docs/testing/reliability-testing.md
+++ b/docs/testing/reliability-testing.md
@@ -288,7 +288,9 @@ Results are posted to the `#reliability-testing-alerts` Slack channel.
 
 #### Weekly load tests
 
-In addition to our release tests, we ran weekly load tests for all [endurance test variants](#endurance-test-variants) based on the state of the **main** branch (from the [Camunda mono repository](https://github.com/camunda/camunda)) with our [Camunda load test GitHub workflow](https://github.com/camunda/camunda/actions/workflows/camunda-load-test.yml). The load tests are automatically created every Monday and run for 4 weeks. They are automatically cleaned up by our [TTL checker](https://github.com/camunda/camunda/blob/main/.github/workflows/camunda-load-test-clean-up.yml). This means we have four variants per week times four weeks running at the same time (makes 16 weekly load tests running concurrently).
+In addition to our release tests, we ran weekly load tests based on the state of the **main** branch (from the [Camunda mono repository](https://github.com/camunda/camunda)) with our [Camunda load test GitHub workflow](https://github.com/camunda/camunda/actions/workflows/camunda-load-test.yml). The load tests are automatically created every Monday and run for 4 weeks. They are automatically cleaned up by our [TTL checker](https://github.com/camunda/camunda/blob/main/.github/workflows/camunda-load-test-clean-up.yml). This means we have three variants per week times four weeks running at the same time (makes 12 weekly load tests running concurrently).
+
+The weekly tests cover the [realistic load](#realistic-load) (with both Elasticsearch and PostgreSQL secondary storage) and the [latency test](#latency-load-test).
 
 **Goal:** Validating the reliability of our current main, and detecting earlier issues, allowing us to detect newly introduced instabilities and potential memory leaks or performance degradation.
 
@@ -299,16 +301,12 @@ As an example, we have the following tests running:
 * medic-y-2025-cw-22-a60d64da-test-latency
 * medic-y-2025-cw-22-a60d64da-test-realistic
 * medic-y-2025-cw-22-a60d64da-test-rdbms-realistic
-* medic-y-2025-cw-22-a60d64da-test-typical
-* medic-y-2025-cw-23-a799b041-test-typical
 * medic-y-2025-cw-23-a799b041-test-latency
 * medic-y-2025-cw-23-a799b041-test-realistic
 * medic-y-2025-cw-23-a799b041-test-rdbms-realistic
-* medic-y-2025-cw-24-0c3f2664-test-typical
 * medic-y-2025-cw-24-0c3f2664-test-latency
 * medic-y-2025-cw-24-0c3f2664-test-realistic
 * medic-y-2025-cw-24-0c3f2664-test-rdbms-realistic
-* medic-y-2025-cw-25-59a095c4-test-typical
 * medic-y-2025-cw-25-59a095c4-test-latency
 * medic-y-2025-cw-25-59a095c4-test-realistic
 * medic-y-2025-cw-25-59a095c4-test-rdbms-realistic

--- a/docs/testing/reliability-testing.md
+++ b/docs/testing/reliability-testing.md
@@ -290,7 +290,7 @@ Results are posted to the `#reliability-testing-alerts` Slack channel.
 
 In addition to our release tests, we ran weekly load tests based on the state of the **main** branch (from the [Camunda mono repository](https://github.com/camunda/camunda)) with our [Camunda load test GitHub workflow](https://github.com/camunda/camunda/actions/workflows/camunda-load-test.yml). The load tests are automatically created every Monday and run for 4 weeks. They are automatically cleaned up by our [TTL checker](https://github.com/camunda/camunda/blob/main/.github/workflows/camunda-load-test-clean-up.yml). This means we have three variants per week times four weeks running at the same time (makes 12 weekly load tests running concurrently).
 
-The weekly tests cover the [realistic load](#realistic-load) (with both Elasticsearch and PostgreSQL secondary storage) and the [latency test](#latency-load-test).
+The weekly tests cover two [realistic load](#realistic-load) variants (one with Elasticsearch secondary storage and one with PostgreSQL secondary storage) plus the [latency test](#latency-load-test).
 
 **Goal:** Validating the reliability of our current main, and detecting earlier issues, allowing us to detect newly introduced instabilities and potential memory leaks or performance degradation.
 


### PR DESCRIPTION
## Summary

- Removes the typical load test from the weekly medic load tests workflow
- Updates reliability testing docs to reflect 3 weekly variants (realistic, rdbms-realistic, latency) instead of 4
- Frees up cluster resources (from 16 to 12 concurrent weekly tests)
- Note: On purpose I kept the process models, and workload selection, as it might be necessary to run the workload in some cases - I will wait until we completely remove them (I think it doesn't do harm)

## Why

The realistic load test already covers the straight-through processing (STP) use case. Running both causes confusion with no additional value. The realistic workload is data-backed and will be promoted as the standard for performance and sizing (#prj-pdp-3530-camunda-performance-and-sizing).

Announced here https://camunda.slack.com/archives/C0807665N8G/p1774623522939479

## Test plan

- [ ] Verify weekly workflow triggers correctly without the typical job
- [ ] Confirm notify job still depends on remaining test jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)