### PR TITLE
[Backport stable/8.6] ci: skip full CI for load-test workflow changes

### DIFF
--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -14,7 +14,7 @@ outputs:
     value: >-
       ${{
         github.event_name == 'push' ||
-        steps.filter-common.outputs.github-actions-change == 'true'
+        steps.filter-common.outputs.actionlint-related-change == 'true'
       }}
   commitlint:
     description: Output whether commit messages should be linted based on GitHub event and files changed
@@ -164,9 +164,19 @@ runs:
       base: ${{ github.event.merge_group.base_ref || '' }}
       ref: ${{ github.event.merge_group.head_ref || github.ref }}
       filters: |
+        actionlint-related-change:
+          - '.github/actions/**'
+          - '.github/workflows/**'
+          - '.github/actionlint*'
+          - '.github/conftest-*.rego'
+
         github-actions-change:
           - '.github/actions/**'
           - '.github/workflows/**'
+          - '!.github/workflows/*load-test*'
+          - '!.github/workflows/*load_test*'
+          - '!.github/workflows/*benchmark*'
+          - '!.github/workflows/*testbench*'
           - '.github/actionlint*'
           - '.github/conftest-*.rego'
 


### PR DESCRIPTION
# Description
Backport of #49114 to `stable/8.6`.

relates to 