### PR TITLE
[Backport stable/8.8] ci: skip full CI for load-test workflow changes

### DIFF
--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -31,7 +31,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-common.outputs.java-code-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true' ||
         steps.filter-common.outputs.markdown-change == 'true'
@@ -42,7 +42,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-common.outputs.java-code-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true'
       }}
@@ -52,7 +52,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-identity.outputs.identity-frontend-change == 'true'
       }}
   operate-backend-changes:
@@ -61,7 +61,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-operate.outputs.operate-backend-change == 'true' ||
         steps.filter-common.outputs.webapps-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true' ||
@@ -73,7 +73,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-operate.outputs.operate-frontend-change == 'true'
       }}
   tasklist-frontend-changes:
@@ -82,7 +82,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-tasklist.outputs.tasklist-frontend-change == 'true'
       }}
   tasklist-backend-changes:
@@ -91,7 +91,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-tasklist.outputs.tasklist-backend-change == 'true' ||
         steps.filter-common.outputs.webapps-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true' ||
@@ -103,7 +103,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-optimize.outputs.optimize-frontend-change == 'true'
       }}
   optimize-backend-changes:
@@ -112,7 +112,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-optimize.outputs.optimize-backend-change == 'true' ||
         steps.filter-common.outputs.webapps-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true'
@@ -123,7 +123,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-common.outputs.java-code-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true' ||
         steps.filter-common.outputs.dockerfile-change == 'true' ||
@@ -135,7 +135,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-common.outputs.frontend-change == 'true' ||
         steps.filter-identity.outputs.frontend-identity == 'true'
       }}
@@ -145,7 +145,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-common.outputs.webapps-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true' ||
         steps.filter-zeebe.outputs.zeebe-change == 'true'
@@ -163,7 +163,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-common.outputs.openapi-change == 'true'
       }}
   stable-branch-changes:
@@ -179,7 +179,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-common.outputs.java-code-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true' ||
         steps.filter-common.outputs.rdbms-change == 'true'
@@ -190,7 +190,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-common.outputs.renovate-config-change == 'true'
       }}
   client-components-changes:
@@ -199,7 +199,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-client-components.outputs.client-components-change == 'true'
       }}
 
@@ -216,6 +216,14 @@ runs:
         github-actions-change:
           - '.github/actions/**'
           - '.github/workflows/**'
+          - '.github/actionlint*'
+          - '.github/conftest-*.rego'
+
+        ci-workflow-change:
+          - '.github/actions/**'
+          - '.github/workflows/**'
+          - '!.github/workflows/*load-test*'
+          - '!.github/workflows/*load_test*'
           - '.github/actionlint*'
           - '.github/conftest-*.rego'
 

--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -15,7 +15,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true'
+        steps.filter-common.outputs.actionlint-related-change == 'true'
       }}
   commitlint:
     description: Output whether commit messages should be linted based on GitHub event and files changed
@@ -31,7 +31,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-common.outputs.java-code-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true' ||
         steps.filter-common.outputs.markdown-change == 'true'
@@ -42,7 +42,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-common.outputs.java-code-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true'
       }}
@@ -52,7 +52,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-identity.outputs.identity-frontend-change == 'true'
       }}
   operate-backend-changes:
@@ -61,7 +61,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-operate.outputs.operate-backend-change == 'true' ||
         steps.filter-common.outputs.webapps-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true' ||
@@ -73,7 +73,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-operate.outputs.operate-frontend-change == 'true'
       }}
   tasklist-frontend-changes:
@@ -82,7 +82,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-tasklist.outputs.tasklist-frontend-change == 'true'
       }}
   tasklist-backend-changes:
@@ -91,7 +91,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-tasklist.outputs.tasklist-backend-change == 'true' ||
         steps.filter-common.outputs.webapps-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true' ||
@@ -103,7 +103,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-optimize.outputs.optimize-frontend-change == 'true'
       }}
   optimize-backend-changes:
@@ -112,7 +112,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-optimize.outputs.optimize-backend-change == 'true' ||
         steps.filter-common.outputs.webapps-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true'
@@ -123,7 +123,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-common.outputs.java-code-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true' ||
         steps.filter-common.outputs.dockerfile-change == 'true' ||
@@ -135,7 +135,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-common.outputs.frontend-change == 'true' ||
         steps.filter-identity.outputs.frontend-identity == 'true'
       }}
@@ -145,7 +145,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-common.outputs.webapps-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true' ||
         steps.filter-zeebe.outputs.zeebe-change == 'true'
@@ -163,7 +163,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-common.outputs.openapi-change == 'true'
       }}
   stable-branch-changes:
@@ -179,7 +179,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-common.outputs.java-code-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true' ||
         steps.filter-common.outputs.rdbms-change == 'true'
@@ -190,7 +190,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-common.outputs.renovate-config-change == 'true'
       }}
   client-components-changes:
@@ -199,7 +199,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-client-components.outputs.client-components-change == 'true'
       }}
 
@@ -213,13 +213,13 @@ runs:
       base: ${{ github.event.merge_group.base_ref || '' }}
       ref: ${{ github.event.merge_group.head_ref || github.ref }}
       filters: |
-        github-actions-change:
+        actionlint-related-change:
           - '.github/actions/**'
           - '.github/workflows/**'
           - '.github/actionlint*'
           - '.github/conftest-*.rego'
 
-        ci-workflow-change:
+        github-actions-change:
           - '.github/actions/**'
           - '.github/workflows/**'
           - '!.github/workflows/*load-test*'

--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -224,6 +224,8 @@ runs:
           - '.github/workflows/**'
           - '!.github/workflows/*load-test*'
           - '!.github/workflows/*load_test*'
+          - '!.github/workflows/*benchmark*'
+          - '!.github/workflows/*testbench*'
           - '.github/actionlint*'
           - '.github/conftest-*.rego'
 


### PR DESCRIPTION
# Description
Backport of #49114 to `stable/8.8`.

relates to 