### PR TITLE
[Backport stable/8.9] ci: skip full CI for load-test workflow changes

### DIFF
--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -31,7 +31,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-common.outputs.java-code-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true' ||
         steps.filter-common.outputs.markdown-change == 'true'
@@ -52,7 +52,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-common.outputs.java-code-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true'
       }}
@@ -62,7 +62,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-identity.outputs.identity-frontend-change == 'true'
       }}
   operate-backend-changes:
@@ -71,7 +71,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-operate.outputs.operate-backend-change == 'true' ||
         steps.filter-common.outputs.webapps-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true' ||
@@ -83,7 +83,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-operate.outputs.operate-frontend-change == 'true'
       }}
   tasklist-frontend-changes:
@@ -92,7 +92,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-tasklist.outputs.tasklist-frontend-change == 'true'
       }}
   tasklist-backend-changes:
@@ -101,7 +101,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-tasklist.outputs.tasklist-backend-change == 'true' ||
         steps.filter-common.outputs.webapps-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true' ||
@@ -113,7 +113,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-optimize.outputs.optimize-frontend-change == 'true'
       }}
   optimize-backend-changes:
@@ -122,7 +122,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-optimize.outputs.optimize-backend-change == 'true' ||
         steps.filter-common.outputs.webapps-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true'
@@ -133,7 +133,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-common.outputs.java-code-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true' ||
         steps.filter-common.outputs.dockerfile-change == 'true' ||
@@ -145,7 +145,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-common.outputs.frontend-change == 'true' ||
         steps.filter-identity.outputs.frontend-identity == 'true'
       }}
@@ -155,7 +155,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-common.outputs.webapps-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true' ||
         steps.filter-zeebe.outputs.zeebe-change == 'true'
@@ -173,7 +173,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-common.outputs.openapi-change == 'true'
       }}
   stable-branch-changes:
@@ -189,7 +189,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-common.outputs.java-code-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true' ||
         steps.filter-common.outputs.rdbms-change == 'true'
@@ -200,7 +200,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-common.outputs.renovate-config-change == 'true'
       }}
   client-components-changes:
@@ -209,7 +209,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.ci-workflow-change == 'true' ||
         steps.filter-client-components.outputs.client-components-change == 'true'
       }}
   docs-changes:
@@ -232,6 +232,14 @@ runs:
         github-actions-change:
           - '.github/actions/**'
           - '.github/workflows/**'
+          - '.github/actionlint*'
+          - '.github/conftest-*.rego'
+
+        ci-workflow-change:
+          - '.github/actions/**'
+          - '.github/workflows/**'
+          - '!.github/workflows/*load-test*'
+          - '!.github/workflows/*load_test*'
           - '.github/actionlint*'
           - '.github/conftest-*.rego'
 

--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -240,6 +240,8 @@ runs:
           - '.github/workflows/**'
           - '!.github/workflows/*load-test*'
           - '!.github/workflows/*load_test*'
+          - '!.github/workflows/*benchmark*'
+          - '!.github/workflows/*testbench*'
           - '.github/actionlint*'
           - '.github/conftest-*.rego'
 

--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -15,7 +15,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.github-actions-change == 'true'
+        steps.filter-common.outputs.actionlint-related-change == 'true'
       }}
   commitlint:
     description: Output whether commit messages should be linted based on GitHub event and files changed
@@ -31,7 +31,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-common.outputs.java-code-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true' ||
         steps.filter-common.outputs.markdown-change == 'true'
@@ -52,7 +52,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-common.outputs.java-code-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true'
       }}
@@ -62,7 +62,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-identity.outputs.identity-frontend-change == 'true'
       }}
   operate-backend-changes:
@@ -71,7 +71,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-operate.outputs.operate-backend-change == 'true' ||
         steps.filter-common.outputs.webapps-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true' ||
@@ -83,7 +83,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-operate.outputs.operate-frontend-change == 'true'
       }}
   tasklist-frontend-changes:
@@ -92,7 +92,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-tasklist.outputs.tasklist-frontend-change == 'true'
       }}
   tasklist-backend-changes:
@@ -101,7 +101,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-tasklist.outputs.tasklist-backend-change == 'true' ||
         steps.filter-common.outputs.webapps-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true' ||
@@ -113,7 +113,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-optimize.outputs.optimize-frontend-change == 'true'
       }}
   optimize-backend-changes:
@@ -122,7 +122,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-optimize.outputs.optimize-backend-change == 'true' ||
         steps.filter-common.outputs.webapps-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true'
@@ -133,7 +133,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-common.outputs.java-code-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true' ||
         steps.filter-common.outputs.dockerfile-change == 'true' ||
@@ -145,7 +145,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-common.outputs.frontend-change == 'true' ||
         steps.filter-identity.outputs.frontend-identity == 'true'
       }}
@@ -155,7 +155,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-common.outputs.webapps-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true' ||
         steps.filter-zeebe.outputs.zeebe-change == 'true'
@@ -173,7 +173,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-common.outputs.openapi-change == 'true'
       }}
   stable-branch-changes:
@@ -189,7 +189,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-common.outputs.java-code-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true' ||
         steps.filter-common.outputs.rdbms-change == 'true'
@@ -200,7 +200,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-common.outputs.renovate-config-change == 'true'
       }}
   client-components-changes:
@@ -209,7 +209,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         github.event_name == 'schedule' ||
-        steps.filter-common.outputs.ci-workflow-change == 'true' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-client-components.outputs.client-components-change == 'true'
       }}
   docs-changes:
@@ -229,13 +229,13 @@ runs:
       base: ${{ github.event.merge_group.base_ref || '' }}
       ref: ${{ github.event.merge_group.head_ref || github.ref }}
       filters: |
-        github-actions-change:
+        actionlint-related-change:
           - '.github/actions/**'
           - '.github/workflows/**'
           - '.github/actionlint*'
           - '.github/conftest-*.rego'
 
-        ci-workflow-change:
+        github-actions-change:
           - '.github/actions/**'
           - '.github/workflows/**'
           - '!.github/workflows/*load-test*'


### PR DESCRIPTION
# Description
Backport of #49114 to `stable/8.9`.

relates to 