### PR TITLE
feat(clients/java): add batch() method to DeployResourceCommandStep1

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/command/DeployResourceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/DeployResourceCommandStep1.java
@@ -96,6 +96,14 @@ public interface DeployResourceCommandStep1
   DeployResourceCommandStep2 addProcessModel(
       BpmnModelInstance processDefinition, String resourceName);
 
+    /**
+     * Returns a step2 command that allows adding resources without requiring
+     * at least one resource to be added first.
+     *
+     * @return the builder for this command allowing batch addition of resources.
+     */
+    DeployResourceCommandStep2 batch();
+
   interface DeployResourceCommandStep2
       extends DeployResourceCommandStep1,
           CommandWithTenantStep<DeployResourceCommandStep2>,

--- a/clients/java/src/main/java/io/camunda/client/impl/command/DeployResourceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/DeployResourceCommandImpl.java
@@ -177,6 +177,11 @@ public final class DeployResourceCommandImpl
     return addResourceBytes(outStream.toByteArray(), resourceName);
   }
 
+    @Override
+    public DeployResourceCommandStep2 batch() {
+        return this;
+    }
+
   @Override
   public FinalCommandStep<DeploymentEvent> requestTimeout(final Duration requestTimeout) {
     this.requestTimeout = requestTimeout;

--- a/clients/java/src/main/java/io/camunda/client/impl/command/DeployResourceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/DeployResourceCommandImpl.java
@@ -70,6 +70,7 @@ public final class DeployResourceCommandImpl
   private boolean useRest;
   private final JsonMapper jsonMapper;
   private String tenantId;
+  private boolean hasResourceAdded = false;
 
   public DeployResourceCommandImpl(
       final GatewayStub asyncStub,
@@ -92,7 +93,7 @@ public final class DeployResourceCommandImpl
   @Override
   public DeployResourceCommandStep2 addResourceBytes(
       final byte[] resource, final String resourceName) {
-
+      hasResourceAdded = true;
     if (useRest) {
       multipartEntityBuilder.addBinaryBody(
           RESOURCES_FIELD_NAME, resource, ContentType.APPLICATION_OCTET_STREAM, resourceName);
@@ -191,6 +192,10 @@ public final class DeployResourceCommandImpl
 
   @Override
   public CamundaFuture<DeploymentEvent> send() {
+      if (!hasResourceAdded) {
+          throw new IllegalStateException(
+                  "At least one resource must be added before sending the command");
+      }
     if (useRest) {
       // adding here the tenantId because in the multipart request fields are only appended
       multipartEntityBuilder.addTextBody(TENANT_FIELD_NAME, tenantId);

--- a/clients/java/src/main/java/io/camunda/client/impl/command/DeployResourceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/DeployResourceCommandImpl.java
@@ -39,6 +39,7 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.Resource;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.grpc.stub.StreamObserver;
+
 import java.io.ByteArrayOutputStream;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -49,211 +50,212 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
+
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
 import org.apache.hc.core5.http.ContentType;
 
 public final class DeployResourceCommandImpl
-    implements DeployResourceCommandStep1, DeployResourceCommandStep2 {
+        implements DeployResourceCommandStep1, DeployResourceCommandStep2 {
 
-  private static final String RESOURCES_FIELD_NAME = "resources";
-  private static final String TENANT_FIELD_NAME = "tenantId";
+    private static final String RESOURCES_FIELD_NAME = "resources";
+    private static final String TENANT_FIELD_NAME = "tenantId";
 
-  private final MultipartEntityBuilder multipartEntityBuilder =
-      MultipartEntityBuilder.create().setContentType(ContentType.MULTIPART_FORM_DATA);
-  private final DeployResourceRequest.Builder requestBuilder = DeployResourceRequest.newBuilder();
-  private final GatewayStub asyncStub;
-  private final Predicate<StatusCode> retryPredicate;
-  private Duration requestTimeout;
-  private final HttpClient httpClient;
-  private final RequestConfig.Builder httpRequestConfig;
-  private boolean useRest;
-  private final JsonMapper jsonMapper;
-  private String tenantId;
-  private boolean hasResourceAdded = false;
+    private final MultipartEntityBuilder multipartEntityBuilder =
+            MultipartEntityBuilder.create().setContentType(ContentType.MULTIPART_FORM_DATA);
+    private final DeployResourceRequest.Builder requestBuilder = DeployResourceRequest.newBuilder();
+    private final GatewayStub asyncStub;
+    private final Predicate<StatusCode> retryPredicate;
+    private Duration requestTimeout;
+    private final HttpClient httpClient;
+    private final RequestConfig.Builder httpRequestConfig;
+    private boolean useRest;
+    private final JsonMapper jsonMapper;
+    private String tenantId;
+    private boolean hasResourceAdded = false;
 
-  public DeployResourceCommandImpl(
-      final GatewayStub asyncStub,
-      final CamundaClientConfiguration config,
-      final Predicate<StatusCode> retryPredicate,
-      final HttpClient httpClient,
-      final boolean preferRestOverGrpc,
-      final JsonMapper jsonMapper) {
-    this.asyncStub = asyncStub;
-    requestTimeout = config.getDefaultRequestTimeout();
-    this.retryPredicate = retryPredicate;
-    tenantId(config.getDefaultTenantId());
-    this.httpClient = httpClient;
-    httpRequestConfig = httpClient.newRequestConfig();
-    useRest = preferRestOverGrpc;
-    this.jsonMapper = jsonMapper;
-    requestTimeout(requestTimeout);
-  }
-
-  @Override
-  public DeployResourceCommandStep2 addResourceBytes(
-      final byte[] resource, final String resourceName) {
-      hasResourceAdded = true;
-    if (useRest) {
-      multipartEntityBuilder.addBinaryBody(
-          RESOURCES_FIELD_NAME, resource, ContentType.APPLICATION_OCTET_STREAM, resourceName);
-      return this;
+    public DeployResourceCommandImpl(
+            final GatewayStub asyncStub,
+            final CamundaClientConfiguration config,
+            final Predicate<StatusCode> retryPredicate,
+            final HttpClient httpClient,
+            final boolean preferRestOverGrpc,
+            final JsonMapper jsonMapper) {
+        this.asyncStub = asyncStub;
+        requestTimeout = config.getDefaultRequestTimeout();
+        this.retryPredicate = retryPredicate;
+        tenantId(config.getDefaultTenantId());
+        this.httpClient = httpClient;
+        httpRequestConfig = httpClient.newRequestConfig();
+        useRest = preferRestOverGrpc;
+        this.jsonMapper = jsonMapper;
+        requestTimeout(requestTimeout);
     }
 
-    requestBuilder.addResources(
-        Resource.newBuilder()
-            .setName(resourceName)
-            .setContent(ByteString.copyFrom(resource))
-            .build());
-    return this;
-  }
+    @Override
+    public DeployResourceCommandStep2 addResourceBytes(
+            final byte[] resource, final String resourceName) {
+        hasResourceAdded = true;
+        if (useRest) {
+            multipartEntityBuilder.addBinaryBody(
+                    RESOURCES_FIELD_NAME, resource, ContentType.APPLICATION_OCTET_STREAM, resourceName);
+            return this;
+        }
 
-  @Override
-  public DeployResourceCommandStep2 addResourceString(
-      final String resource, final Charset charset, final String resourceName) {
-    return addResourceBytes(resource.getBytes(charset), resourceName);
-  }
-
-  @Override
-  public DeployResourceCommandStep2 addResourceStringUtf8(
-      final String resourceString, final String resourceName) {
-    return addResourceString(resourceString, StandardCharsets.UTF_8, resourceName);
-  }
-
-  @Override
-  public DeployResourceCommandStep2 addResourceStream(
-      final InputStream resourceStream, final String resourceName) {
-    ensureNotNull("resource stream", resourceStream);
-
-    try {
-      final byte[] bytes = StreamUtil.readInputStream(resourceStream);
-
-      return addResourceBytes(bytes, resourceName);
-    } catch (final IOException e) {
-      final String exceptionMsg =
-          String.format("Cannot deploy bpmn resource from stream. %s", e.getMessage());
-      throw new ClientException(exceptionMsg, e);
+        requestBuilder.addResources(
+                Resource.newBuilder()
+                        .setName(resourceName)
+                        .setContent(ByteString.copyFrom(resource))
+                        .build());
+        return this;
     }
-  }
 
-  @Override
-  public DeployResourceCommandStep2 addResourceFromClasspath(final String classpathResource) {
-    ensureNotNull("classpath resource", classpathResource);
-
-    try (final InputStream resourceStream =
-        getClass().getClassLoader().getResourceAsStream(classpathResource)) {
-      if (resourceStream != null) {
-        return addResourceStream(resourceStream, classpathResource);
-      } else {
-        throw new FileNotFoundException(classpathResource);
-      }
-
-    } catch (final IOException e) {
-      final String exceptionMsg =
-          String.format("Cannot deploy resource from classpath. %s", e.getMessage());
-      throw new RuntimeException(exceptionMsg, e);
+    @Override
+    public DeployResourceCommandStep2 addResourceString(
+            final String resource, final Charset charset, final String resourceName) {
+        return addResourceBytes(resource.getBytes(charset), resourceName);
     }
-  }
 
-  @Override
-  public DeployResourceCommandStep2 addResourceFile(final String filename) {
-    ensureNotNull("filename", filename);
-
-    try (final InputStream resourceStream = new FileInputStream(filename)) {
-      return addResourceStream(resourceStream, filename);
-    } catch (final IOException e) {
-      final String exceptionMsg =
-          String.format("Cannot deploy resource from file. %s", e.getMessage());
-      throw new RuntimeException(exceptionMsg, e);
+    @Override
+    public DeployResourceCommandStep2 addResourceStringUtf8(
+            final String resourceString, final String resourceName) {
+        return addResourceString(resourceString, StandardCharsets.UTF_8, resourceName);
     }
-  }
 
-  @Override
-  public DeployResourceCommandStep2 addProcessModel(
-      final BpmnModelInstance processDefinition, final String resourceName) {
-    ensureNotNull("process model", processDefinition);
+    @Override
+    public DeployResourceCommandStep2 addResourceStream(
+            final InputStream resourceStream, final String resourceName) {
+        ensureNotNull("resource stream", resourceStream);
 
-    final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
-    Bpmn.writeModelToStream(outStream, processDefinition);
-    return addResourceBytes(outStream.toByteArray(), resourceName);
-  }
+        try {
+            final byte[] bytes = StreamUtil.readInputStream(resourceStream);
+
+            return addResourceBytes(bytes, resourceName);
+        } catch (final IOException e) {
+            final String exceptionMsg =
+                    String.format("Cannot deploy bpmn resource from stream. %s", e.getMessage());
+            throw new ClientException(exceptionMsg, e);
+        }
+    }
+
+    @Override
+    public DeployResourceCommandStep2 addResourceFromClasspath(final String classpathResource) {
+        ensureNotNull("classpath resource", classpathResource);
+
+        try (final InputStream resourceStream =
+                     getClass().getClassLoader().getResourceAsStream(classpathResource)) {
+            if (resourceStream != null) {
+                return addResourceStream(resourceStream, classpathResource);
+            } else {
+                throw new FileNotFoundException(classpathResource);
+            }
+
+        } catch (final IOException e) {
+            final String exceptionMsg =
+                    String.format("Cannot deploy resource from classpath. %s", e.getMessage());
+            throw new RuntimeException(exceptionMsg, e);
+        }
+    }
+
+    @Override
+    public DeployResourceCommandStep2 addResourceFile(final String filename) {
+        ensureNotNull("filename", filename);
+
+        try (final InputStream resourceStream = new FileInputStream(filename)) {
+            return addResourceStream(resourceStream, filename);
+        } catch (final IOException e) {
+            final String exceptionMsg =
+                    String.format("Cannot deploy resource from file. %s", e.getMessage());
+            throw new RuntimeException(exceptionMsg, e);
+        }
+    }
+
+    @Override
+    public DeployResourceCommandStep2 addProcessModel(
+            final BpmnModelInstance processDefinition, final String resourceName) {
+        ensureNotNull("process model", processDefinition);
+
+        final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+        Bpmn.writeModelToStream(outStream, processDefinition);
+        return addResourceBytes(outStream.toByteArray(), resourceName);
+    }
 
     @Override
     public DeployResourceCommandStep2 batch() {
         return this;
     }
 
-  @Override
-  public FinalCommandStep<DeploymentEvent> requestTimeout(final Duration requestTimeout) {
-    this.requestTimeout = requestTimeout;
-    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
-    return this;
-  }
-
-  @Override
-  public CamundaFuture<DeploymentEvent> send() {
-      if (!hasResourceAdded) {
-          throw new IllegalStateException(
-                  "At least one resource must be added before sending the command");
-      }
-    if (useRest) {
-      // adding here the tenantId because in the multipart request fields are only appended
-      multipartEntityBuilder.addTextBody(TENANT_FIELD_NAME, tenantId);
-      return sendRestRequest();
-    } else {
-      return sendGrpcRequest();
+    @Override
+    public FinalCommandStep<DeploymentEvent> requestTimeout(final Duration requestTimeout) {
+        this.requestTimeout = requestTimeout;
+        httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+        return this;
     }
-  }
 
-  @Override
-  public DeployResourceCommandStep2 tenantId(final String tenantId) {
-    this.tenantId = tenantId;
-    requestBuilder.setTenantId(tenantId);
-    return this;
-  }
+    @Override
+    public CamundaFuture<DeploymentEvent> send() {
+        if (!hasResourceAdded) {
+            throw new IllegalStateException(
+                    "At least one resource must be added before sending the command");
+        }
+        if (useRest) {
+            // adding here the tenantId because in the multipart request fields are only appended
+            multipartEntityBuilder.addTextBody(TENANT_FIELD_NAME, tenantId);
+            return sendRestRequest();
+        } else {
+            return sendGrpcRequest();
+        }
+    }
 
-  @Override
-  public DeployResourceCommandStep2 useRest() {
-    useRest = true;
-    return this;
-  }
+    @Override
+    public DeployResourceCommandStep2 tenantId(final String tenantId) {
+        this.tenantId = tenantId;
+        requestBuilder.setTenantId(tenantId);
+        return this;
+    }
 
-  @Override
-  public DeployResourceCommandStep2 useGrpc() {
-    useRest = false;
-    return this;
-  }
+    @Override
+    public DeployResourceCommandStep2 useRest() {
+        useRest = true;
+        return this;
+    }
 
-  private CamundaFuture<DeploymentEvent> sendRestRequest() {
-    final HttpCamundaFuture<DeploymentEvent> result = new HttpCamundaFuture<>();
-    httpClient.postMultipart(
-        "/deployments",
-        multipartEntityBuilder,
-        httpRequestConfig.build(),
-        DeploymentResult.class,
-        DeploymentEventImpl::new,
-        result);
-    return result;
-  }
+    @Override
+    public DeployResourceCommandStep2 useGrpc() {
+        useRest = false;
+        return this;
+    }
 
-  private CamundaFuture<DeploymentEvent> sendGrpcRequest() {
-    final DeployResourceRequest request = requestBuilder.build();
+    private CamundaFuture<DeploymentEvent> sendRestRequest() {
+        final HttpCamundaFuture<DeploymentEvent> result = new HttpCamundaFuture<>();
+        httpClient.postMultipart(
+                "/deployments",
+                multipartEntityBuilder,
+                httpRequestConfig.build(),
+                DeploymentResult.class,
+                DeploymentEventImpl::new,
+                result);
+        return result;
+    }
 
-    final RetriableClientFutureImpl<DeploymentEvent, DeployResourceResponse> future =
-        new RetriableClientFutureImpl<>(
-            DeploymentEventImpl::new,
-            retryPredicate,
-            streamObserver -> sendGrpcRequest(request, streamObserver));
+    private CamundaFuture<DeploymentEvent> sendGrpcRequest() {
+        final DeployResourceRequest request = requestBuilder.build();
 
-    sendGrpcRequest(request, future);
+        final RetriableClientFutureImpl<DeploymentEvent, DeployResourceResponse> future =
+                new RetriableClientFutureImpl<>(
+                        DeploymentEventImpl::new,
+                        retryPredicate,
+                        streamObserver -> sendGrpcRequest(request, streamObserver));
 
-    return future;
-  }
+        sendGrpcRequest(request, future);
 
-  private void sendGrpcRequest(
-      final DeployResourceRequest request, final StreamObserver streamObserver) {
-    asyncStub
-        .withDeadlineAfter(requestTimeout.toMillis(), TimeUnit.MILLISECONDS)
-        .deployResource(request, streamObserver);
-  }
+        return future;
+    }
+
+    private void sendGrpcRequest(
+            final DeployResourceRequest request, final StreamObserver streamObserver) {
+        asyncStub
+                .withDeadlineAfter(requestTimeout.toMillis(), TimeUnit.MILLISECONDS)
+                .deployResource(request, streamObserver);
+    }
 }

--- a/clients/java/src/test/java/io/camunda/client/resource/DeployResourceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/resource/DeployResourceTest.java
@@ -471,4 +471,16 @@ public final class DeployResourceTest extends ClientTest {
         assertThat(resource2.getContent().toByteArray()).isEqualTo(getBytes(BPMN_2_FILENAME));
     }
 
+    @Test
+    public void shouldFailWhenBatchSendWithoutResources() {
+        // when/then
+        assertThatThrownBy(() ->
+                client.newDeployResourceCommand()
+                        .batch()
+                        .send()
+                        .join()
+        ).isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("At least one resource must be added");
+    }
+
 }

--- a/clients/java/src/test/java/io/camunda/client/resource/DeployResourceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/resource/DeployResourceTest.java
@@ -443,4 +443,32 @@ public final class DeployResourceTest extends ClientTest {
             new FormImpl(formId1, 1, 1, filename1, DEFAULT_TENANT),
             new FormImpl(formId2, 1, 2, filename2, DEFAULT_TENANT));
   }
+    @Test
+    public void shouldDeployResourcesUsingBatch() {
+        // given
+        final String filename1 = BPMN_1_FILENAME.substring(1);
+        final String filename2 = BPMN_2_FILENAME.substring(1);
+
+        // when
+        client
+                .newDeployResourceCommand()
+                .batch()
+                .addResourceFromClasspath(filename1)
+                .addResourceFromClasspath(filename2)
+                .send()
+                .join();
+
+        // then
+        final DeployResourceRequest request = gatewayService.getLastRequest();
+        assertThat(request.getResourcesList()).hasSize(2);
+
+        final Resource resource1 = request.getResources(0);
+        assertThat(resource1.getName()).isEqualTo(filename1);
+        assertThat(resource1.getContent().toByteArray()).isEqualTo(getBytes(BPMN_1_FILENAME));
+
+        final Resource resource2 = request.getResources(1);
+        assertThat(resource2.getName()).isEqualTo(filename2);
+        assertThat(resource2.getContent().toByteArray()).isEqualTo(getBytes(BPMN_2_FILENAME));
+    }
+
 }


### PR DESCRIPTION
## Description

Closes #39685

Adds a `batch()` method to `DeployResourceCommandStep1` that returns a `DeployResourceCommandStep2` instance, allowing users to add an arbitrary list of resources without requiring at least one resource to be added upfront.

**Before:**
```java
DeployResourceCommandStep2 deployCommand =
    client.newDeployResourceCommand().addResourceFromClasspath(resources[0]);
for (int i = 1; i < resources.length; i++) {
    deployCommand = deployCommand.addResourceFromClasspath(resources[i]);
}
deployCommand.send().join();
```

**After:**
```java
final DeployResourceCommandStep2 deploymentCommand = 
    client.newDeployResourceCommand().batch();
Arrays.stream(resources).forEach(deploymentCommand::addResourceFromClasspath);
deploymentCommand.send().join();
```

## Checklist
- [x] I have added tests for my changes
- [x] Backward compatibility is maintained