### PR TITLE
feat: use REST API by default in load tests

### DIFF
--- a/.github/workflows/camunda-daily-load-tests.yml
+++ b/.github/workflows/camunda-daily-load-tests.yml
@@ -74,10 +74,23 @@ jobs:
       scenario: max
       build-frontend: true
 
+  setup-max-grpc-load-test:
+    name: Setup max gRPC load test
+    needs:
+      - benchmark-data
+    uses: ./.github/workflows/camunda-load-test.yml
+    secrets: inherit
+    with:
+      name: ${{ needs.benchmark-data.outputs.benchmark }}-grpc
+      ttl: 1
+      scenario: max
+      build-frontend: true
+      load-test-load: --set global.preferRest.enabled=false
+
   notify:
     name: Notify on failure
     runs-on: ubuntu-latest
-    needs: [ setup-max-load-test ]
+    needs: [ setup-max-load-test, setup-max-grpc-load-test ]
     if: failure()
     timeout-minutes: 5
     permissions: { }

--- a/load-tests/load-test-values.yaml
+++ b/load-tests/load-test-values.yaml
@@ -1,3 +1,7 @@
+global:
+  preferRest:
+    enabled: true
+
 # Saas configuration to run load tests against Camunda SaaS environment
 saas:
   # Saas.enabled if true enables the load tests to run against Camunda SaaS

--- a/load-tests/load-tester/src/main/resources/application.conf
+++ b/load-tests/load-tester/src/main/resources/application.conf
@@ -5,7 +5,7 @@ app {
   brokerRestUrl = ${?ZEEBE_REST_ADDRESS}
   tls = false
   tls = ${?TLS}
-  preferRest = false
+  preferRest = true
   monitoringPort = 9600
   monitorDataAvailability = true
   monitorDataAvailabilityInterval = 250ms

--- a/load-tests/load-tester/src/test/java/io/camunda/zeebe/config/ConfigTest.java
+++ b/load-tests/load-tester/src/test/java/io/camunda/zeebe/config/ConfigTest.java
@@ -25,7 +25,7 @@ public class ConfigTest {
     // then
     assertThat(appCfg.getBrokerUrl()).isEqualTo("http://localhost:26500");
     assertThat(appCfg.getBrokerRestUrl()).isEqualTo("http://localhost:8080");
-    assertThat(appCfg.isPreferRest()).isFalse();
+    assertThat(appCfg.isPreferRest()).isTrue();
     assertThat(appCfg.getMonitoringPort()).isEqualTo(9600);
     assertThat(appCfg.isMonitorDataAvailability()).isTrue();
     assertThat(appCfg.getMonitorDataAvailabilityInterval()).hasMillis(250);


### PR DESCRIPTION
## Summary
- Changes the load test application default from gRPC to REST API (`preferRest = true`), since REST is the customer-facing default and our long-running tests should reflect realistic conditions.
- Adds a separate daily gRPC load test variant (`setup-max-grpc-load-test`) to still detect gRPC-specific regressions.

Depends on #47585 (merged).

closes https://github.com/camunda/camunda/issues/48977
closes https://github.com/camunda/camunda/issues/48976

## Test plan
- [x] `ConfigTest` passes with updated default assertion
- [ ] Verify daily workflow creates both REST (default) and gRPC load test namespaces
- [ ] Confirm existing weekly/release load tests inherit the new REST default

🤖 Generated with [Claude Code](https://claude.com/claude-code)