### PR TITLE
[Backport jm/aync] fix: Trigger Exporter Flush If Flush Timer Exceded #49896

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterMetrics.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterMetrics.java
@@ -85,7 +85,7 @@ public final class ExporterMetrics {
       final ValueType valueType, final long written, final long exporting) {
     exportingLatency
         .computeIfAbsent(valueType, this::registerExportingLatency)
-        .record(exporting - written, TimeUnit.MILLISECONDS);
+        .record(Math.max(0, exporting - written), TimeUnit.MILLISECONDS);
   }
 
   public CloseableSilently startExporterExportingTimer(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -415,7 +415,9 @@ public class CamundaExporter implements Exporter {
 
   private boolean shouldFlush() {
     return writer.getBatchSize() >= configuration.getBulk().getSize()
-        || writer.getBatchMemoryEstimateInMb() >= configuration.getBulk().getMemoryLimit();
+        || writer.getBatchMemoryEstimateInMb() >= configuration.getBulk().getMemoryLimit()
+        || (writer.getBatchSize() > 0
+            && (context.clock().millis() - lastFlushTimestamp) >= flushDelayMs);
   }
 
   private ExporterBatchWriter createBatchWriter() {
@@ -506,16 +508,17 @@ public class CamundaExporter implements Exporter {
   void waitForPendingFlush() {
     if (pendingFlush != null) {
       pendingFlush.waitForCompletion();
+      // Update the record counters only after the flush was successful. If the asynchronous flush
+      // fails then the exporter will be invoked with the same record again.
+      updateLastExportedPosition(pendingFlush.getLastPosition());
+      updateLastFlushTimestamp(pendingFlush);
     }
   }
 
   private void flush() {
     if (pendingFlush != null) {
-      pendingFlush.waitForCompletion();
-      // Update the record counters only after the flush was successful. If the asynchronous flush
-      // fails then the exporter will be invoked with the same record again.
-      updateLastExportedPosition(pendingFlush.getLastPosition());
-      updateLastFlushTimestamp(pendingFlush);
+      // wait for completion and update record counters and last flush time
+      waitForPendingFlush();
       pendingFlush = null;
     }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -161,6 +161,7 @@ public class CamundaExporter implements Exporter {
       checkImportersCompletedAndReschedule();
       controller.readMetadata().ifPresent(metadata::deserialize);
       taskManager.start();
+      lastFlushTimestamp = context.clock().millis();
 
       LOG.info("Exporter opened");
     } catch (final Exception e) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
@@ -281,6 +281,7 @@ public class CamundaExporterMetrics implements AutoCloseable {
   public void stopFlushLatencyMeasurement() {
     if (flushLatencyMeasurement != null) {
       flushLatencyMeasurement.stop(flushLatency);
+      flushLatencyMeasurement = null;
     }
   }
 
@@ -361,7 +362,7 @@ public class CamundaExporterMetrics implements AutoCloseable {
   public void observeRecordExportLatencies(final Collection<Long> recordTimestamps) {
     final var now = streamClock.millis();
     recordTimestamps.stream()
-        .mapToLong(timestamp -> now - timestamp)
+        .mapToLong(timestamp -> Math.max(0, now - timestamp))
         .forEach(duration -> recordExportDuration.record(duration, TimeUnit.MILLISECONDS));
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.awaitility.Awaitility.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doReturn;
@@ -294,7 +295,9 @@ final class CamundaExporterIT {
     spiedController.runScheduledTasks(Duration.ofSeconds(duration));
 
     // then
-    verify(spiedController, times(2)).scheduleCancellableTask(eq(Duration.ofSeconds(2)), any());
+    verify(spiedController, times(2))
+        .scheduleCancellableTask(
+            argThat(delay -> delay.getSeconds() >= 0 && delay.getSeconds() <= 2), any());
   }
 
   @TestTemplate

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
@@ -314,6 +314,10 @@ final class CamundaExporterTest {
   final class FlushTest {
     @Test
     void shouldUpdateMetadataOnFlush() {
+      final var clock = new MutableClock(0);
+      testContext.setClock(clock);
+      configuration.getBulk().setDelay(1);
+
       // given
       final var expected = new ExporterMetadata(TestObjectMapper.objectMapper());
 
@@ -330,6 +334,7 @@ final class CamundaExporterTest {
       exporter.configure(testContext);
       exporter.open(testController);
 
+      clock.advance(1001);
       testController.runScheduledTasks(Duration.ofHours(1));
 
       // force wait for pending flush to update metadata
@@ -414,7 +419,9 @@ final class CamundaExporterTest {
       configuration.getBulk().setDelay(1);
       exporter =
           new CamundaExporter(
-              resourceProvider, new ExporterMetadata(TestObjectMapper.objectMapper()));
+              resourceProvider,
+              new ExporterMetadata(TestObjectMapper.objectMapper()),
+              RunImmediately::new);
       exporter.configure(testContext);
       exporter.open(testController);
 
@@ -429,6 +436,7 @@ final class CamundaExporterTest {
       clock.advance(501);
       testController.runScheduledTasks(Duration.ofSeconds(1));
 
+      // wait for exporter to update positions
       exporter.waitForPendingFlush();
 
       // then — validate record1 was exported (position updated after timed flush)
@@ -446,6 +454,7 @@ final class CamundaExporterTest {
               ValueType.VARIABLE, b -> b.withPosition(2L).withBrokerVersion("8.8.0"));
       exporter.export(record2);
 
+      // wait for exporter to update positions
       exporter.waitForPendingFlush();
 
       // then — validate record2 was exported (position updated after flush)

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
@@ -404,6 +404,57 @@ final class CamundaExporterTest {
     }
 
     @Test
+    void shouldFlushWhenExportIfDelayElapsed() {
+      // given — use a controllable clock so we can verify timing
+      final var clock = new MutableClock(0);
+      testContext.setClock(clock);
+      // bulk size = 10 so that a single export does NOT trigger a size-based flush;
+      // flushing only happens via the scheduled task
+      configuration.getBulk().setSize(10);
+      configuration.getBulk().setDelay(1);
+      exporter =
+          new CamundaExporter(
+              resourceProvider, new ExporterMetadata(TestObjectMapper.objectMapper()));
+      exporter.configure(testContext);
+      exporter.open(testController);
+
+      // export at t=500 — batch size < 10, no size-based flush
+      clock.advance(500);
+      final var record1 =
+          factory.generateRecord(
+              ValueType.VARIABLE, b -> b.withPosition(1L).withBrokerVersion("8.8.0"));
+      exporter.export(record1);
+
+      // advance clock to trigger scheduled flush task at t=1000
+      clock.advance(501);
+      testController.runScheduledTasks(Duration.ofSeconds(1));
+
+      exporter.waitForPendingFlush();
+
+      // then — validate record1 was exported (position updated after timed flush)
+      assertThat(testController.getPosition())
+          .as("Record1 should have been flushed and position updated")
+          .isEqualTo(record1.getPosition());
+
+      // advance clock beyond delay to exceed the flush duration
+      clock.advance(1001);
+
+      // next export record with a higher position
+      // batch size still < 10, but clock has advanced, so should flush
+      final var record2 =
+          factory.generateRecord(
+              ValueType.VARIABLE, b -> b.withPosition(2L).withBrokerVersion("8.8.0"));
+      exporter.export(record2);
+
+      exporter.waitForPendingFlush();
+
+      // then — validate record2 was exported (position updated after flush)
+      assertThat(testController.getPosition())
+          .as("Record2 should have been flushed and position updated")
+          .isEqualTo(record2.getPosition());
+    }
+
+    @Test
     void shouldKeepStableDelayAcrossMultipleFlushCycles() {
       // Regression test: the rescheduled flush delay must remain stable across
       // repeated flush cycles and not degrade to zero.
@@ -439,14 +490,6 @@ final class CamundaExporterTest {
 
   @Nested
   final class AsyncFlushTest {
-
-    private final ProtocolFactory factory = new ProtocolFactory();
-
-    private Record<?> stubRecord() {
-      final var record = spy(factory.generateRecord(ValueType.VARIABLE));
-      when(record.getBrokerVersion()).thenReturn("8.8.0");
-      return record;
-    }
 
     @Test
     void shouldUpdatePositionAfterAsyncFlushOnNextExport() {
@@ -574,7 +617,10 @@ final class CamundaExporterTest {
           .thenReturn(failingAdapter);
 
       // don't flush immediately on export, so we can verify scheduled flush behavior
+      final var clock = new MutableClock(0);
+      testContext.setClock(clock);
       configuration.getBulk().setSize(100);
+      configuration.getBulk().setDelay(1);
       exporter =
           new CamundaExporter(
               resourceProvider, new ExporterMetadata(TestObjectMapper.objectMapper()));
@@ -586,6 +632,7 @@ final class CamundaExporterTest {
 
       // then
       final var initialPosition = testController.getPosition();
+      clock.advance(1001);
       testController.runScheduledTasks(Duration.ofHours(1));
       assertThat(testController.getPosition()).isEqualTo(initialPosition);
 


### PR DESCRIPTION
## Description

Backport of https://github.com/camunda/camunda/pull/49832 to 41206-async-camunda-exporter-flush-8-8.

relates to https://github.com/camunda/camunda/issues/49820


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
