### PR TITLE
test: add IT for standalone decision instance history cleanup

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/historycleanup/StandaloneDecisionHistoryCleanupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/historycleanup/StandaloneDecisionHistoryCleanupIT.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.historycleanup;
+
+import static io.camunda.it.util.DmnBuilderHelper.getDmnModelInstance;
+import static io.camunda.it.util.TestHelper.deployDmnModel;
+import static io.camunda.it.util.TestHelper.evaluateDecision;
+import static io.camunda.it.util.TestHelper.waitForDecisionInstanceCount;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension.DatabaseType;
+import io.camunda.qa.util.multidb.HistoryMultiDbTest;
+import io.camunda.zeebe.test.util.Strings;
+import java.time.Duration;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@HistoryMultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class StandaloneDecisionHistoryCleanupIT {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(StandaloneDecisionHistoryCleanupIT.class);
+
+  private static CamundaClient camundaClient;
+  private static DatabaseType databaseType;
+  private static Duration cleanupTimeout;
+
+  @BeforeAll
+  static void setup() {
+    cleanupTimeout =
+        switch (databaseType) {
+          case OS, AWS_OS -> Duration.ofMinutes(5);
+          default -> Duration.ofSeconds(30);
+        };
+  }
+
+  @Test
+  void shouldCleanupStandaloneDecisionInstances() {
+    // given — deploy a DMN and evaluate it outside any process context (standalone)
+    final var decisionId = Strings.newRandomValidBpmnId();
+    final var dmnModel = getDmnModelInstance(decisionId);
+    final var decision =
+        deployDmnModel(camundaClient, dmnModel, dmnModel.getModel().getModelName());
+
+    evaluateDecision(camundaClient, decision.getDecisionKey(), "{}");
+    evaluateDecision(camundaClient, decision.getDecisionKey(), "{}");
+
+    // wait for both decision instances to be visible in secondary storage
+    waitForDecisionInstanceCount(
+        camundaClient, f -> f.decisionDefinitionId(decision.getDmnDecisionId()), 2);
+
+    // then — the archiver should pick them up and ILM/ISM should delete them
+    Awaitility.await("Wait for standalone decision instances to be cleaned up")
+        .logging(LOGGER::trace)
+        .timeout(cleanupTimeout)
+        .pollInterval(Duration.ofSeconds(5))
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newDecisionInstanceSearchRequest()
+                            .filter(f -> f.decisionDefinitionId(decision.getDmnDecisionId()))
+                            .send()
+                            .join()
+                            .items())
+                    .isEmpty());
+  }
+}

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
@@ -282,8 +282,13 @@ public class CamundaMultiDBExtension
       return DatabaseType.valueOf(property.toUpperCase());
     }
 
-    return AnnotationSupport.findAnnotation(context.getRequiredTestClass(), MultiDbTest.class)
-        .map(MultiDbTest::value)
+    final Class<?> testClass = context.getRequiredTestClass();
+    return AnnotationSupport.findAnnotation(testClass, HistoryMultiDbTest.class)
+        .map(HistoryMultiDbTest::value)
+        .or(
+            () ->
+                AnnotationSupport.findAnnotation(testClass, MultiDbTest.class)
+                    .map(MultiDbTest::value))
         .orElse(DatabaseType.LOCAL);
   }
 

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/HistoryMultiDbTest.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/HistoryMultiDbTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.qa.util.multidb;
 
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension.DatabaseType;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -26,4 +27,16 @@ import org.junit.jupiter.api.Tag;
 @Retention(RetentionPolicy.RUNTIME)
 @Tag("history")
 @MultiDbTest
-public @interface HistoryMultiDbTest {}
+public @interface HistoryMultiDbTest {
+
+  /**
+   * Setting this is only for local testing purposes; setting the property {@link
+   * CamundaMultiDBExtension#PROP_CAMUNDA_IT_DATABASE_TYPE} will override this. This is NOT a way to
+   * limit which DB a test or class should run with; for that, use JUnit's {@code @DisabledIf}
+   * matching on the property.
+   *
+   * @return the database type to run the test with. By default, the test will run with the local
+   *     database type as defined in the test configuration.
+   */
+  DatabaseType value() default DatabaseType.LOCAL;
+}

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
@@ -283,6 +283,8 @@ public class MultiDbConfigurator {
                       "maxHistoryCleanupInterval",
                       retentionEnabled ? "PT5S" : "PT2H",
                       "defaultBatchOperationHistoryTTL",
+                      retentionEnabled ? "PT1S" : "PT1H",
+                      "decisionInstanceTTL",
                       retentionEnabled ? "PT1S" : "PT1H")));
         });
   }


### PR DESCRIPTION
## Summary
- Adds an integration test verifying that standalone decision instances (evaluated outside a process instance context) are cleaned up by the archiver and ILM/ISM policies.

## Test plan
- [ ] Run `StandaloneDecisionHistoryCleanupIT` against ES and OS

🤖 Generated with [Claude Code](https://claude.com/claude-code)