### PR TITLE
fix: revert judge and similarity model adapter bean name prefixing

### DIFF
--- a/testing/camunda-process-test-langchain4j/README.md
+++ b/testing/camunda-process-test-langchain4j/README.md
@@ -88,11 +88,10 @@ CamundaAssert.setJudgeConfig(JudgeConfig.of(model::chat));
 ### Spring bean registration
 
 To use a custom `ChatModelAdapter` bean instead of the SPI, register it with the bean name
-`"judge.<provider>"`. The `judge.` prefix avoids name collisions with beans registered for other
-features (e.g. semantic similarity):
+`"<provider>"`:
 
 ```java
-@Bean("judge.openai")
+@Bean("openai")
 ChatModelAdapter myChatModelAdapter() {
   // custom OpenAI chat model adapter ...
 }
@@ -186,12 +185,11 @@ camunda:
         model: text-embedding-3-small
 ```
 
-Alternatively, register an `EmbeddingModelAdapter` bean with the name `"similarity.<provider>"`.
-When the provider is configured, the resolver looks for a bean named
-`"similarity.<provider>"`:
+Alternatively, register an `EmbeddingModelAdapter` bean with the name `"<provider>"`.
+When the provider is configured, the resolver looks for a bean named `"<provider>"`:
 
 ```java
-@Bean("similarity.openai")
+@Bean("openai")
 EmbeddingModelAdapter myEmbeddingModelAdapter() {
   EmbeddingModel model = OpenAiEmbeddingModel.builder()
     .apiKey(System.getenv("OPENAI_API_KEY"))

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/judge/JudgeConfigResolver.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/judge/JudgeConfigResolver.java
@@ -30,14 +30,11 @@ import org.springframework.context.ApplicationContext;
  *
  * <ol>
  *   <li>If exactly one {@link ChatModelAdapter} bean exists and no provider is configured, use it.
- *   <li>If a provider is configured and a bean named {@code "judge.<provider>"} exists, use that
- *       bean.
+ *   <li>If a provider is configured and a bean named {@code "<provider>"} exists, use that bean.
  *   <li>Otherwise, fall back to SPI-based resolution via {@link ChatModelAdapterResolver}.
  * </ol>
  */
 public final class JudgeConfigResolver {
-
-  static final String BEAN_NAME_PREFIX = "judge.";
 
   private JudgeConfigResolver() {}
 
@@ -88,10 +85,10 @@ public final class JudgeConfigResolver {
       return beans.values().iterator().next();
     }
 
-    // Provider configured: match by prefixed bean name ("judge.<provider>")
+    // Provider configured: match by provider bean name
     if (judgeConfiguration.hasProviderConfigured()) {
       final String provider = judgeConfiguration.getChatModel().getProvider().trim();
-      return beans.get(BEAN_NAME_PREFIX + provider);
+      return beans.get(provider);
     }
 
     return null;

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/similarity/SemanticSimilarityConfigResolver.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/similarity/SemanticSimilarityConfigResolver.java
@@ -31,14 +31,11 @@ import org.springframework.context.ApplicationContext;
  * <ol>
  *   <li>If exactly one {@link EmbeddingModelAdapter} bean exists and no provider is configured, use
  *       it.
- *   <li>If a provider is configured and a bean named {@code "similarity.<provider>"} exists, use
- *       that bean.
+ *   <li>If a provider is configured and a bean named {@code "<provider>"} exists, use that bean.
  *   <li>Otherwise, fall back to SPI-based resolution via {@link EmbeddingModelAdapterResolver}.
  * </ol>
  */
 public final class SemanticSimilarityConfigResolver {
-
-  static final String BEAN_NAME_PREFIX = "similarity.";
 
   private SemanticSimilarityConfigResolver() {}
 
@@ -97,10 +94,10 @@ public final class SemanticSimilarityConfigResolver {
       return beans.values().iterator().next();
     }
 
-    // Provider configured: match by prefixed bean name ("similarity.<provider>")
+    // Provider configured: match by provider bean name
     if (similarityConfiguration.hasProviderConfigured()) {
       final String provider = similarityConfiguration.getEmbeddingModel().getProvider().trim();
-      return beans.get(BEAN_NAME_PREFIX + provider);
+      return beans.get(provider);
     }
 
     return null;

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/JudgeConfigBootstrapTest.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/JudgeConfigBootstrapTest.java
@@ -618,12 +618,12 @@ public class JudgeConfigBootstrapTest {
     @Configuration
     static class MultipleChatModelAdapterConfig {
 
-      @Bean("judge.my-custom")
+      @Bean("my-custom")
       ChatModelAdapter customChatModelAdapter() {
         return ADAPTER_A;
       }
 
-      @Bean("judge.another-provider")
+      @Bean("another-provider")
       ChatModelAdapter anotherChatModelAdapter() {
         return ADAPTER_B;
       }
@@ -667,12 +667,12 @@ public class JudgeConfigBootstrapTest {
     @Configuration
     static class MultipleChatModelAdapterConfig {
 
-      @Bean("judge.my-custom")
+      @Bean("my-custom")
       ChatModelAdapter customChatModelAdapter() {
         return ADAPTER_A;
       }
 
-      @Bean("judge.another-provider")
+      @Bean("another-provider")
       ChatModelAdapter anotherChatModelAdapter() {
         return ADAPTER_B;
       }
@@ -698,12 +698,12 @@ public class JudgeConfigBootstrapTest {
     @Configuration
     static class MultipleChatModelAdapterConfig {
 
-      @Bean("judge.my-custom")
+      @Bean("my-custom")
       ChatModelAdapter customChatModelAdapter() {
         return ADAPTER_A;
       }
 
-      @Bean("judge.another-provider")
+      @Bean("another-provider")
       ChatModelAdapter anotherChatModelAdapter() {
         return ADAPTER_B;
       }
@@ -771,7 +771,7 @@ public class JudgeConfigBootstrapTest {
     @Configuration
     static class GenericChatModelAdapterConfig {
 
-      @Bean("judge.my-generic")
+      @Bean("my-generic")
       ChatModelAdapter genericChatModelAdapter() {
         return ADAPTER_A;
       }

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/SemanticSimilarityConfigBootstrapTest.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/SemanticSimilarityConfigBootstrapTest.java
@@ -437,12 +437,12 @@ public class SemanticSimilarityConfigBootstrapTest {
     @Configuration
     static class MultipleEmbeddingModelAdapterConfig {
 
-      @Bean("similarity.my-custom")
+      @Bean("my-custom")
       EmbeddingModelAdapter customEmbeddingModelAdapter() {
         return ADAPTER_A;
       }
 
-      @Bean("similarity.another-provider")
+      @Bean("another-provider")
       EmbeddingModelAdapter anotherEmbeddingModelAdapter() {
         return ADAPTER_B;
       }
@@ -488,12 +488,12 @@ public class SemanticSimilarityConfigBootstrapTest {
     @Configuration
     static class MultipleEmbeddingModelAdapterConfig {
 
-      @Bean("similarity.my-custom")
+      @Bean("my-custom")
       EmbeddingModelAdapter customEmbeddingModelAdapter() {
         return ADAPTER_A;
       }
 
-      @Bean("similarity.another-provider")
+      @Bean("another-provider")
       EmbeddingModelAdapter anotherEmbeddingModelAdapter() {
         return ADAPTER_B;
       }
@@ -521,12 +521,12 @@ public class SemanticSimilarityConfigBootstrapTest {
     @Configuration
     static class MultipleEmbeddingModelAdapterConfig {
 
-      @Bean("similarity.my-custom")
+      @Bean("my-custom")
       EmbeddingModelAdapter customEmbeddingModelAdapter() {
         return ADAPTER_A;
       }
 
-      @Bean("similarity.another-provider")
+      @Bean("another-provider")
       EmbeddingModelAdapter anotherEmbeddingModelAdapter() {
         return ADAPTER_B;
       }
@@ -594,7 +594,7 @@ public class SemanticSimilarityConfigBootstrapTest {
     @Configuration
     static class GenericEmbeddingModelAdapterConfig {
 
-      @Bean("similarity.my-generic")
+      @Bean("my-generic")
       EmbeddingModelAdapter genericEmbeddingModelAdapter() {
         return ADAPTER_A;
       }

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/impl/judge/JudgeConfigResolverTest.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/impl/judge/JudgeConfigResolverTest.java
@@ -82,7 +82,7 @@ class JudgeConfigResolverTest {
   @Test
   void shouldMatchSingleBeanByNameWhenProviderConfigured() {
     when(applicationContext.getBeansOfType(ChatModelAdapter.class))
-        .thenReturn(Map.of("judge.my-adapter", ADAPTER_A));
+        .thenReturn(Map.of("my-adapter", ADAPTER_A));
 
     final JudgeConfiguration config = new JudgeConfiguration();
     config.getChatModel().setProvider("my-adapter");
@@ -112,7 +112,7 @@ class JudgeConfigResolverTest {
   @Test
   void shouldSelectBeanByProviderName() {
     when(applicationContext.getBeansOfType(ChatModelAdapter.class))
-        .thenReturn(Map.of("judge.my-custom", ADAPTER_A, "judge.another", ADAPTER_B));
+        .thenReturn(Map.of("my-custom", ADAPTER_A, "another", ADAPTER_B));
 
     final JudgeConfiguration config = new JudgeConfiguration();
     config.getChatModel().setProvider("my-custom");

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/impl/similarity/SemanticSimilarityConfigResolverTest.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/impl/similarity/SemanticSimilarityConfigResolverTest.java
@@ -83,7 +83,7 @@ class SemanticSimilarityConfigResolverTest {
   @Test
   void shouldMatchSingleBeanByNameWhenProviderConfigured() {
     when(applicationContext.getBeansOfType(EmbeddingModelAdapter.class))
-        .thenReturn(Map.of("similarity.my-adapter", ADAPTER_A));
+        .thenReturn(Map.of("my-adapter", ADAPTER_A));
 
     final SemanticSimilarityConfiguration config = new SemanticSimilarityConfiguration();
     config.getEmbeddingModel().setProvider("my-adapter");
@@ -115,7 +115,7 @@ class SemanticSimilarityConfigResolverTest {
   @Test
   void shouldSelectBeanByProviderName() {
     when(applicationContext.getBeansOfType(EmbeddingModelAdapter.class))
-        .thenReturn(Map.of("similarity.my-custom", ADAPTER_A, "similarity.another", ADAPTER_B));
+        .thenReturn(Map.of("my-custom", ADAPTER_A, "another", ADAPTER_B));
 
     final SemanticSimilarityConfiguration config = new SemanticSimilarityConfiguration();
     config.getEmbeddingModel().setProvider("my-custom");


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
In https://github.com/camunda/camunda/pull/48752 we introduced bean name prefixes for judge an similarity model adapters. This would introduce a breaking change between 8.9 and 8.10 since this change was not backported into 8.9. In the end it would be a better option to remove the prefixes and let the user chose unique provider names.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
