### PR TITLE
[Backport stable/8.9] Use G3-M cluster in e2e tests instead of Production M

### DIFF
--- a/.github/workflows/zeebe-e2e-testbench.yaml
+++ b/.github/workflows/zeebe-e2e-testbench.yaml
@@ -24,7 +24,7 @@ on:
         type: string
       clusterPlan:
         description: 'Cluster plan used by testbench to create the test cluster'
-        default: 'Production - M'
+        default: 'G3-M'
         required: false
         type: string
       fault:


### PR DESCRIPTION
# Description
Backport of #49843 to `stable/8.9`.

relates to 