### PR TITLE
fix: skip snapshot rolling update tests when minor version gap exceeds 1

### DIFF
--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/VersionCompatibilityMatrix.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/VersionCompatibilityMatrix.java
@@ -173,6 +173,22 @@ final class VersionCompatibilityMatrix {
             .max()
             .orElse(-1); // -1 is a sentinel: no previous released minor found
 
+    // Rolling updates are only supported between consecutive minor versions (N -> N+1). If the
+    // highest released minor is more than 1 behind the current version (e.g. 8.8 when current is
+    // 8.10, because 8.9 was never released), skip cross-minor tests entirely — they would test
+    // an unsupported upgrade path and produce false failures.
+    if (previousMinor >= 0 && current.minor() - previousMinor > 1) {
+      LOG.info(
+          "Skipping cross-minor snapshot tests: highest released minor 8.{} is more than 1 minor"
+              + " behind current version {}. Only intra-minor upgrades will be tested.",
+          previousMinor,
+          current);
+      return allPreviousVersions.stream()
+          .filter(version -> version.minor() == current.minor())
+          .filter(version -> isCompatible(version, current))
+          .map(version -> Arguments.of(version.toString(), "CURRENT"));
+    }
+
     // Build upgrade paths to CURRENT by:
     // 1. keeping all patch releases from the previous minor (e.g. 8.8.0, 8.8.1, 8.8.2 when
     //    previousMinor == 8), so each of those becomes a starting point for an upgrade to CURRENT.

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/VersionCompatibilityMatrixTest.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/VersionCompatibilityMatrixTest.java
@@ -121,10 +121,45 @@ class VersionCompatibilityMatrixTest {
             .map(args -> Stream.of(args.get()).map(Object::toString).toList())
             .toList();
 
-    // Should include all patches of the highest released minor (8.8.x), not be empty
-    assertThat(paths)
-        .containsExactlyInAnyOrder(
-            List.of("8.8.0", "CURRENT"), List.of("8.8.1", "CURRENT"), List.of("8.8.2", "CURRENT"));
+    // Should be empty — rolling updates only support consecutive minors (N -> N+1).
+    // 8.8 -> 8.10 skips a minor, so cross-minor tests are not valid.
+    assertThat(paths).isEmpty();
+  }
+
+  @Test
+  void testFromPreviousPatchesToCurrentWithTwoMinorGapIncludesIntraMinorPatches() {
+    // Simulates the case where the dev version is 8.10.1-SNAPSHOT, 8.9 was skipped,
+    // but 8.10.0 has already been released. The method should still return the intra-minor
+    // upgrade path 8.10.0 -> CURRENT, while excluding cross-minor paths (8.8.x -> CURRENT).
+    final var snapshotMatrix =
+        new VersionCompatibilityMatrix(
+            () ->
+                Stream.of(
+                    VersionInfo.of("8.7.0"),
+                    VersionInfo.of("8.8.0"),
+                    VersionInfo.of("8.8.1"),
+                    VersionInfo.of("8.8.2"),
+                    VersionInfo.of("8.10.0")),
+            new VersionCompatibilityConfig() {
+              @Override
+              public SemanticVersion getCurrentVersion() {
+                return SemanticVersion.parse("8.10.1-SNAPSHOT").orElseThrow();
+              }
+
+              @Override
+              public Optional<SemanticVersion> getPreviousMinorVersion() {
+                return SemanticVersion.parse("8.10.0");
+              }
+            });
+
+    final var paths =
+        snapshotMatrix
+            .fromPreviousPatchesToCurrent()
+            .map(args -> Stream.of(args.get()).map(Object::toString).toList())
+            .toList();
+
+    // Only the intra-minor patch upgrade should be returned
+    assertThat(paths).containsExactly(List.of("8.10.0", "CURRENT"));
   }
 
   @Test


### PR DESCRIPTION
## Description

When the current development version skips a minor (e.g. 8.10.0-SNAPSHOT while 8.9 was never released), fromPreviousPatchesToCurrent() was generating upgrade paths from 8.8.x to 8.10, which is a 2-minor jump. Rolling updates only support consecutive minors (N → N+1), so these tests produced false failures.

Skip cross-minor snapshot tests when the highest released minor is more than 1 behind the current version, keeping only intra-minor patch upgrade tests.

## Related issues

related to https://camunda.slack.com/archives/C013MEVQ4M9/p1774784106550479
