### PR TITLE
fix: remove minimus version 21.0.10-dev

### DIFF
--- a/optimize/docker/test/docker-labels.golden.json
+++ b/optimize/docker/test/docker-labels.golden.json
@@ -18,6 +18,5 @@
   "org.opencontainers.image.url": "https://docs.camunda.io/docs/components/optimize/what-is-optimize/",
   "org.opencontainers.image.vendor": "Camunda Services GmbH",
   "org.opencontainers.image.version": $VERSION,
-  "io.minimus.images.line": "21",
-  "io.minimus.images.version": "21.0.10-dev"
+  "io.minimus.images.line": "21"
 }


### PR DESCRIPTION
## Description

the Snapshot_Artifacts_Stale alert for camunda/optimize:8-SNAPSHOT is firing again.

PR #49450 (runner switch) is merged but the workflow still fail.

Latest run: https://github.com/camunda/camunda/actions/runs/23726250493
The Deploy Artifacts step is now failing on a Docker label mismatch (io.minimus.images.version in optimize/docker/test/docker-labels.golden.json).

:thread: https://camunda.slack.com/archives/C071KP5BTHB/p1774343632113609

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
