### PR TITLE
perf: add actor_id index in audit_log

### DIFF
--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.9.0.xml
@@ -2180,4 +2180,22 @@
     </createIndex>
   </changeSet>
 
+  <changeSet id="create_audit_log_actor_id_index" author="camunda">
+    <!-- Index for ACTOR_ID - optimizes querying audit log entries by actor -->
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_AUDIT_LOG_ACTOR_ID" tableName="${prefix}AUDIT_LOG"/>
+      </not>
+    </preConditions>
+    <sql dbms="mysql,mariadb,h2,oracle">
+      CREATE INDEX ${prefix}IDX_AUDIT_LOG_ACTOR_ID
+        ON ${prefix}AUDIT_LOG (ACTOR_ID)
+    </sql>
+    <!-- Since actor_id is sparse (nullable), we allow Postgres and MSSQL to exclude null values -->
+    <sql dbms="postgresql,mssql">
+      CREATE INDEX ${prefix}IDX_AUDIT_LOG_ACTOR_ID
+        ON ${prefix}AUDIT_LOG (ACTOR_ID) WHERE ACTOR_ID IS NOT NULL
+    </sql>
+  </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
## Description

- Introduces a new Liquibase changeset to create IDX_AUDIT_LOG_ACTOR_ID on the AUDIT_LOG table.
- Uses a filtered/partial index for PostgreSQL and MSSQL to exclude NULL ACTOR_ID values (column is nullable/sparse).

better response times, operate and identity UI

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates #48525
