### PR TITLE
test: verify that after when batch is empty delay is not zero

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -255,7 +255,7 @@ final class CamundaExporterIT {
     // then
     verify(spiedController, times(2))
         .scheduleCancellableTask(
-            argThat(delay -> delay.getSeconds() >= 0 && delay.getSeconds() <= 2), any());
+            argThat(delay -> delay.toMillis() > 0 && delay.toMillis() <= 2 * 1000L), any());
   }
 
   @TestTemplate

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
@@ -142,13 +142,13 @@ final class CamundaExporterTest {
     }
 
     @Override
-    public CacheLoader<Long, CachedDecisionRequirementsEntity> getDecisionRequirementsCacheLoader(
-        final String decisionIndexName) {
+    public CacheLoader<String, CachedFormEntity> getFormCacheLoader(final String formIndexName) {
       return k -> null;
     }
 
     @Override
-    public CacheLoader<String, CachedFormEntity> getFormCacheLoader(final String formIndexName) {
+    public CacheLoader<Long, CachedDecisionRequirementsEntity> getDecisionRequirementsCacheLoader(
+        final String decisionIndexName) {
       return k -> null;
     }
   }
@@ -401,7 +401,6 @@ final class CamundaExporterTest {
       // given
       final var clock = new MutableClock(0);
       testContext.setClock(clock);
-      configuration.getBulk().setSize(1); // every export() triggers size-based flush
       configuration.getBulk().setDelay(1); // 1 second
       exporter =
           new CamundaExporter(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
@@ -233,7 +233,7 @@ final class CamundaExporterTest {
   final class FlushTest {
     @Test
     void shouldUpdateMetadataOnFlush() {
-      final var clock = new MutableClock(0);
+      final var clock = new MutableClock(1000);
       testContext.setClock(clock);
       configuration.getBulk().setDelay(1);
 
@@ -291,7 +291,7 @@ final class CamundaExporterTest {
     @Test
     void shouldNotFlushBeforeDelayElapses() {
       // given — use a controllable clock so we can verify timing
-      final var clock = new MutableClock(0);
+      final var clock = new MutableClock(1000);
       testContext.setClock(clock);
       // bulk size = 1 so that export() triggers an immediate size-based flush,
       // which sets lastFlushTimestamp without needing the scheduled task to flush
@@ -320,7 +320,7 @@ final class CamundaExporterTest {
     @Test
     void shouldFlushWhenExportIfDelayElapsed() {
       // given — use a controllable clock so we can verify timing
-      final var clock = new MutableClock(0);
+      final var clock = new MutableClock(1000);
       testContext.setClock(clock);
       // bulk size = 10 so that a single export does NOT trigger a size-based flush;
       // flushing only happens via the scheduled task
@@ -368,7 +368,7 @@ final class CamundaExporterTest {
       // repeated flush cycles and not degrade to zero.
 
       // given
-      final var clock = new MutableClock(0);
+      final var clock = new MutableClock(1000);
       testContext.setClock(clock);
       configuration.getBulk().setSize(1); // every export() triggers size-based flush
       configuration.getBulk().setDelay(1); // 1 second
@@ -399,7 +399,7 @@ final class CamundaExporterTest {
       // repeated flush cycles and not degrade to zero.
 
       // given
-      final var clock = new MutableClock(0);
+      final var clock = new MutableClock(1000);
       testContext.setClock(clock);
       configuration.getBulk().setDelay(1); // 1 second
       exporter =

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
@@ -392,5 +392,32 @@ final class CamundaExporterTest {
             .isEqualTo(Duration.ofMillis(500));
       }
     }
+
+    @Test
+    void shouldKeepStableDelayAcrossMultipleFlushCyclesWhenBatchIsEmpty() {
+      // Regression test: the rescheduled flush delay must remain stable across
+      // repeated flush cycles and not degrade to zero.
+
+      // given
+      final var clock = new MutableClock(0);
+      testContext.setClock(clock);
+      configuration.getBulk().setSize(1); // every export() triggers size-based flush
+      configuration.getBulk().setDelay(1); // 1 second
+      exporter =
+          new CamundaExporter(
+              resourceProvider, new ExporterMetadata(TestObjectMapper.objectMapper()));
+      exporter.configure(testContext);
+      exporter.open(testController);
+
+      // when
+      for (int cycle = 0; cycle < 4; cycle++) {
+        testController.runScheduledTasks(Duration.ofSeconds(2));
+        clock.advance(1000);
+
+        // then
+        final var tasks = testController.getScheduledTasks();
+        assertThat(tasks.getLast().getDelay()).isEqualTo(Duration.ofMillis(1000));
+      }
+    }
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Backport of missing unit test for exporter

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #50003
