### PR TITLE
fix(cpt): round scores to two decimal places before comparison

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/JudgeEvaluation.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/JudgeEvaluation.java
@@ -18,6 +18,8 @@ package io.camunda.process.test.impl.assertions;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.process.test.api.judge.ChatModelAdapter;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -173,21 +175,32 @@ class JudgeEvaluation {
   /** The result of an LLM-based evaluation, containing a score and reasoning. */
   static class Result {
 
+    private final double rawScore;
     private final double score;
     private final String reasoning;
 
-    public Result(final double score, final String reasoning) {
-      this.score = score;
+    public Result(final double rawScore, final String reasoning) {
+      this.rawScore = rawScore;
+      this.score = BigDecimal.valueOf(rawScore).setScale(2, RoundingMode.HALF_UP).doubleValue();
       this.reasoning = reasoning;
     }
 
     /**
-     * Returns the evaluation score between 0.0 and 1.0.
+     * Returns the evaluation score rounded to 2 decimal places.
      *
-     * @return the score
+     * @return the rounded score
      */
     public double getScore() {
       return score;
+    }
+
+    /**
+     * Returns the raw evaluation score with full precision.
+     *
+     * @return the raw score
+     */
+    public double getRawScore() {
+      return rawScore;
     }
 
     /**
@@ -200,13 +213,16 @@ class JudgeEvaluation {
     }
 
     /**
-     * Returns whether the evaluation passed the given threshold.
+     * Returns whether the evaluation passed the given threshold. Both the score and threshold are
+     * compared at 2 decimal places.
      *
      * @param threshold the threshold score (0-1)
      * @return true if the score is greater than or equal to the threshold
      */
     public boolean passed(final double threshold) {
-      return score >= threshold;
+      final double roundedThreshold =
+          BigDecimal.valueOf(threshold).setScale(2, RoundingMode.HALF_UP).doubleValue();
+      return score >= roundedThreshold;
     }
 
     @Override

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/JudgeEvaluation.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/JudgeEvaluation.java
@@ -175,13 +175,11 @@ class JudgeEvaluation {
   /** The result of an LLM-based evaluation, containing a score and reasoning. */
   static class Result {
 
-    private final double rawScore;
-    private final double score;
+    private final BigDecimal score;
     private final String reasoning;
 
-    public Result(final double rawScore, final String reasoning) {
-      this.rawScore = rawScore;
-      this.score = BigDecimal.valueOf(rawScore).setScale(2, RoundingMode.HALF_UP).doubleValue();
+    public Result(final double score, final String reasoning) {
+      this.score = BigDecimal.valueOf(score).setScale(2, RoundingMode.HALF_UP);
       this.reasoning = reasoning;
     }
 
@@ -191,16 +189,7 @@ class JudgeEvaluation {
      * @return the rounded score
      */
     public double getScore() {
-      return score;
-    }
-
-    /**
-     * Returns the raw evaluation score with full precision.
-     *
-     * @return the raw score
-     */
-    public double getRawScore() {
-      return rawScore;
+      return score.doubleValue();
     }
 
     /**
@@ -214,20 +203,20 @@ class JudgeEvaluation {
 
     /**
      * Returns whether the evaluation passed the given threshold. Both the score and threshold are
-     * compared at 2 decimal places.
+     * compared at 2 decimal places using exact decimal arithmetic.
      *
      * @param threshold the threshold score (0-1)
      * @return true if the score is greater than or equal to the threshold
      */
     public boolean passed(final double threshold) {
-      final double roundedThreshold =
-          BigDecimal.valueOf(threshold).setScale(2, RoundingMode.HALF_UP).doubleValue();
-      return score >= roundedThreshold;
+      final BigDecimal roundedThreshold =
+          BigDecimal.valueOf(threshold).setScale(2, RoundingMode.HALF_UP);
+      return score.compareTo(roundedThreshold) >= 0;
     }
 
     @Override
     public String toString() {
-      return String.format("EvaluationResult{score=%.2f, reasoning='%s'}", score, reasoning);
+      return String.format("EvaluationResult{score=%.2f, reasoning='%s'}", getScore(), reasoning);
     }
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/SimilarityEvaluation.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/SimilarityEvaluation.java
@@ -17,6 +17,8 @@ package io.camunda.process.test.impl.assertions;
 
 import io.camunda.process.test.api.similarity.EmbeddingModelAdapter;
 import io.camunda.process.test.api.similarity.TextPreprocessor;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.List;
 
 /** An evaluation that uses text embeddings to assess semantic similarity between two texts. */
@@ -53,29 +55,43 @@ public class SimilarityEvaluation {
   /** The result of a semantic similarity evaluation, containing a score. */
   public static class Result {
 
+    private final double rawScore;
     private final double score;
 
-    public Result(final double score) {
-      this.score = score;
+    public Result(final double rawScore) {
+      this.rawScore = rawScore;
+      this.score = BigDecimal.valueOf(rawScore).setScale(2, RoundingMode.HALF_UP).doubleValue();
     }
 
     /**
-     * Returns the similarity score between 0.0 and 1.0.
+     * Returns the similarity score rounded to 2 decimal places.
      *
-     * @return the score
+     * @return the rounded score
      */
     public double getScore() {
       return score;
     }
 
     /**
-     * Returns whether the evaluation passed the given threshold.
+     * Returns the raw similarity score with full precision.
+     *
+     * @return the raw score
+     */
+    public double getRawScore() {
+      return rawScore;
+    }
+
+    /**
+     * Returns whether the evaluation passed the given threshold. Both the score and threshold are
+     * compared at 2 decimal places.
      *
      * @param threshold the threshold score (0-1)
      * @return true if the score is greater than or equal to the threshold
      */
     public boolean passed(final double threshold) {
-      return score >= threshold;
+      final double roundedThreshold =
+          BigDecimal.valueOf(threshold).setScale(2, RoundingMode.HALF_UP).doubleValue();
+      return score >= roundedThreshold;
     }
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/SimilarityEvaluation.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/SimilarityEvaluation.java
@@ -55,12 +55,10 @@ public class SimilarityEvaluation {
   /** The result of a semantic similarity evaluation, containing a score. */
   public static class Result {
 
-    private final double rawScore;
-    private final double score;
+    private final BigDecimal score;
 
-    public Result(final double rawScore) {
-      this.rawScore = rawScore;
-      this.score = BigDecimal.valueOf(rawScore).setScale(2, RoundingMode.HALF_UP).doubleValue();
+    public Result(final double score) {
+      this.score = BigDecimal.valueOf(score).setScale(2, RoundingMode.HALF_UP);
     }
 
     /**
@@ -69,29 +67,20 @@ public class SimilarityEvaluation {
      * @return the rounded score
      */
     public double getScore() {
-      return score;
-    }
-
-    /**
-     * Returns the raw similarity score with full precision.
-     *
-     * @return the raw score
-     */
-    public double getRawScore() {
-      return rawScore;
+      return score.doubleValue();
     }
 
     /**
      * Returns whether the evaluation passed the given threshold. Both the score and threshold are
-     * compared at 2 decimal places.
+     * compared at 2 decimal places using exact decimal arithmetic.
      *
      * @param threshold the threshold score (0-1)
      * @return true if the score is greater than or equal to the threshold
      */
     public boolean passed(final double threshold) {
-      final double roundedThreshold =
-          BigDecimal.valueOf(threshold).setScale(2, RoundingMode.HALF_UP).doubleValue();
-      return score >= roundedThreshold;
+      final BigDecimal roundedThreshold =
+          BigDecimal.valueOf(threshold).setScale(2, RoundingMode.HALF_UP);
+      return score.compareTo(roundedThreshold) >= 0;
     }
   }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/assertions/JudgeEvaluationTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/assertions/JudgeEvaluationTest.java
@@ -115,4 +115,32 @@ class JudgeEvaluationTest {
         .cause()
         .hasMessageContaining("Empty response from judge");
   }
+
+  @Test
+  void shouldRoundScoreToTwoDecimalPlaces() {
+    // given
+    final JudgeEvaluation.Result result = new JudgeEvaluation.Result(0.6951, "reasoning");
+
+    // then
+    assertThat(result.getScore()).isEqualTo(0.70);
+    assertThat(result.getRawScore()).isEqualTo(0.6951);
+  }
+
+  @Test
+  void shouldPassWhenScoreRoundsUpToThreshold() {
+    // given — raw score 0.6951 rounds to 0.70, which meets the threshold
+    final JudgeEvaluation.Result result = new JudgeEvaluation.Result(0.6951, "reasoning");
+
+    // then
+    assertThat(result.passed(0.70)).isTrue();
+  }
+
+  @Test
+  void shouldNotPassWhenScoreRoundsDownBelowThreshold() {
+    // given — raw score 0.6940 rounds to 0.69, which is below the threshold
+    final JudgeEvaluation.Result result = new JudgeEvaluation.Result(0.6940, "reasoning");
+
+    // then
+    assertThat(result.passed(0.70)).isFalse();
+  }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/assertions/JudgeEvaluationTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/assertions/JudgeEvaluationTest.java
@@ -118,18 +118,17 @@ class JudgeEvaluationTest {
 
   @Test
   void shouldRoundScoreToTwoDecimalPlaces() {
-    // given
-    final JudgeEvaluation.Result result = new JudgeEvaluation.Result(0.6951, "reasoning");
+    // given — 0.695 is the HALF_UP tie case: third decimal exactly 5 rounds up
+    final JudgeEvaluation.Result result = new JudgeEvaluation.Result(0.695, "reasoning");
 
     // then
     assertThat(result.getScore()).isEqualTo(0.70);
-    assertThat(result.getRawScore()).isEqualTo(0.6951);
   }
 
   @Test
   void shouldPassWhenScoreRoundsUpToThreshold() {
-    // given — raw score 0.6951 rounds to 0.70, which meets the threshold
-    final JudgeEvaluation.Result result = new JudgeEvaluation.Result(0.6951, "reasoning");
+    // given — 0.695 rounds to 0.70, which meets the threshold
+    final JudgeEvaluation.Result result = new JudgeEvaluation.Result(0.695, "reasoning");
 
     // then
     assertThat(result.passed(0.70)).isTrue();
@@ -142,5 +141,23 @@ class JudgeEvaluationTest {
 
     // then
     assertThat(result.passed(0.70)).isFalse();
+  }
+
+  @Test
+  void shouldPassWhenThresholdRoundsDownToScore() {
+    // given — score 0.70, threshold 0.7049 rounds down to 0.70 → passes
+    final JudgeEvaluation.Result result = new JudgeEvaluation.Result(0.70, "reasoning");
+
+    // then
+    assertThat(result.passed(0.7049)).isTrue();
+  }
+
+  @Test
+  void shouldNotPassWhenThresholdRoundsUpAboveScore() {
+    // given — score 0.70, threshold 0.705 rounds up to 0.71 → fails
+    final JudgeEvaluation.Result result = new JudgeEvaluation.Result(0.70, "reasoning");
+
+    // then
+    assertThat(result.passed(0.705)).isFalse();
   }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/assertions/SimilarityEvaluationTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/assertions/SimilarityEvaluationTest.java
@@ -92,7 +92,36 @@ class SimilarityEvaluationTest {
     final SimilarityEvaluation.Result result = evaluation.evaluate("b");
 
     // then
-    assertThat(result.getScore()).isCloseTo(0.8, within(1e-9));
+    assertThat(result.getScore()).isEqualTo(0.8);
+    assertThat(result.getRawScore()).isCloseTo(0.8, within(1e-9));
+  }
+
+  @Test
+  void shouldRoundScoreToTwoDecimalPlaces() {
+    // given
+    final SimilarityEvaluation.Result result = new SimilarityEvaluation.Result(0.6951);
+
+    // then
+    assertThat(result.getScore()).isEqualTo(0.70);
+    assertThat(result.getRawScore()).isEqualTo(0.6951);
+  }
+
+  @Test
+  void shouldPassWhenScoreRoundsUpToThreshold() {
+    // given — raw score 0.6951 rounds to 0.70, which meets the threshold
+    final SimilarityEvaluation.Result result = new SimilarityEvaluation.Result(0.6951);
+
+    // then
+    assertThat(result.passed(0.70)).isTrue();
+  }
+
+  @Test
+  void shouldNotPassWhenScoreRoundsDownBelowThreshold() {
+    // given — raw score 0.6940 rounds to 0.69, which is below the threshold
+    final SimilarityEvaluation.Result result = new SimilarityEvaluation.Result(0.6940);
+
+    // then
+    assertThat(result.passed(0.70)).isFalse();
   }
 
   @Test

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/assertions/SimilarityEvaluationTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/assertions/SimilarityEvaluationTest.java
@@ -93,23 +93,21 @@ class SimilarityEvaluationTest {
 
     // then
     assertThat(result.getScore()).isEqualTo(0.8);
-    assertThat(result.getRawScore()).isCloseTo(0.8, within(1e-9));
   }
 
   @Test
   void shouldRoundScoreToTwoDecimalPlaces() {
-    // given
-    final SimilarityEvaluation.Result result = new SimilarityEvaluation.Result(0.6951);
+    // given — 0.695 is the HALF_UP tie case: third decimal exactly 5 rounds up
+    final SimilarityEvaluation.Result result = new SimilarityEvaluation.Result(0.695);
 
     // then
     assertThat(result.getScore()).isEqualTo(0.70);
-    assertThat(result.getRawScore()).isEqualTo(0.6951);
   }
 
   @Test
   void shouldPassWhenScoreRoundsUpToThreshold() {
-    // given — raw score 0.6951 rounds to 0.70, which meets the threshold
-    final SimilarityEvaluation.Result result = new SimilarityEvaluation.Result(0.6951);
+    // given — 0.695 rounds to 0.70, which meets the threshold
+    final SimilarityEvaluation.Result result = new SimilarityEvaluation.Result(0.695);
 
     // then
     assertThat(result.passed(0.70)).isTrue();
@@ -122,6 +120,24 @@ class SimilarityEvaluationTest {
 
     // then
     assertThat(result.passed(0.70)).isFalse();
+  }
+
+  @Test
+  void shouldPassWhenThresholdRoundsDownToScore() {
+    // given — score 0.70, threshold 0.7049 rounds down to 0.70 → passes
+    final SimilarityEvaluation.Result result = new SimilarityEvaluation.Result(0.70);
+
+    // then
+    assertThat(result.passed(0.7049)).isTrue();
+  }
+
+  @Test
+  void shouldNotPassWhenThresholdRoundsUpAboveScore() {
+    // given — score 0.70, threshold 0.705 rounds up to 0.71 → fails
+    final SimilarityEvaluation.Result result = new SimilarityEvaluation.Result(0.70);
+
+    // then
+    assertThat(result.passed(0.705)).isFalse();
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
When a judge or semantic similarity assertion fails, in the failure message we show a message that contains the score and threshold formatted to two decimal places. In some cases this message could be misleading. For example, if the score is 0.7966 and the threshold is 0.80 then the assertion fails and the assertion error will contain `Score: 0.80 (threshold: 0.80)`. This leads to confusion.
To avoid this issue we can round the score and threshold to two decimal places before comparing them.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #50583
