### PR TITLE
test: unskip audit log tests

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateOperationsLogPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateOperationsLogPage.ts
@@ -11,13 +11,39 @@ import type {Locator, Page} from '@playwright/test';
 export class OperateOperationsLogPage {
   private page: Page;
   readonly operationsLogTable: Locator;
+  readonly operationsLogTableRows: Locator;
+  readonly operationsLogHeading: Locator;
   readonly processInstanceKeyFilter: Locator;
+  readonly processInstanceCells: Locator;
+  readonly operationTypeColumnHeader: Locator;
+  readonly entityTypeColumnHeader: Locator;
+  readonly entityKeyColumnHeader: Locator;
+  readonly actorColumnHeader: Locator;
+  readonly dateColumnHeader: Locator;
   readonly resetFiltersButton: Locator;
 
   constructor(page: Page) {
     this.page = page;
     this.operationsLogTable = page.getByRole('table');
+    this.operationsLogTableRows = this.operationsLogTable.getByRole('row');
+    this.operationsLogHeading = page.getByRole('heading', {
+      name: /operations log/i,
+    });
     this.processInstanceKeyFilter = page.getByLabel('Process instance key');
+    this.processInstanceCells = this.operationsLogTable.getByRole('cell', {
+      name: /process instance/i,
+    });
+    this.operationTypeColumnHeader = page.getByRole('columnheader', {
+      name: 'Operation type',
+    });
+    this.entityTypeColumnHeader = page.getByRole('columnheader', {
+      name: 'Entity type',
+    });
+    this.entityKeyColumnHeader = page.getByRole('columnheader', {
+      name: 'Entity key',
+    });
+    this.actorColumnHeader = page.getByRole('columnheader', {name: 'Actor'});
+    this.dateColumnHeader = page.getByRole('columnheader', {name: 'Date'});
     this.resetFiltersButton = page.getByRole('button', {
       name: /reset filters/i,
     });
@@ -37,5 +63,9 @@ export class OperateOperationsLogPage {
         `${process.env.CORE_APPLICATION_URL}/operate/operations-log`,
       );
     }
+  }
+
+  async getRowCount(): Promise<number> {
+    return this.operationsLogTableRows.count();
   }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/auditLog.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/auditLog.spec.ts
@@ -48,26 +48,19 @@ test.describe('Audit Log (Operations Log)', () => {
   });
 
   test('Operations Log page is accessible and shows table headers', async ({
-    page,
     operateOperationsLogPage,
   }) => {
     await operateOperationsLogPage.gotoOperationsLogPage();
 
-    await expect(
-      page.getByRole('heading', {name: /operations log/i}),
-    ).toBeVisible();
+    await expect(operateOperationsLogPage.operationsLogHeading).toBeVisible();
 
     await expect(
-      page.getByRole('columnheader', {name: 'Operation type'}),
+      operateOperationsLogPage.operationTypeColumnHeader,
     ).toBeVisible();
-    await expect(
-      page.getByRole('columnheader', {name: 'Entity type'}),
-    ).toBeVisible();
-    await expect(
-      page.getByRole('columnheader', {name: 'Entity key'}),
-    ).toBeVisible();
-    await expect(page.getByRole('columnheader', {name: 'Actor'})).toBeVisible();
-    await expect(page.getByRole('columnheader', {name: 'Date'})).toBeVisible();
+    await expect(operateOperationsLogPage.entityTypeColumnHeader).toBeVisible();
+    await expect(operateOperationsLogPage.entityKeyColumnHeader).toBeVisible();
+    await expect(operateOperationsLogPage.actorColumnHeader).toBeVisible();
+    await expect(operateOperationsLogPage.dateColumnHeader).toBeVisible();
   });
 
   test('Audit log entries are visible after instance creation', async ({
@@ -76,16 +69,13 @@ test.describe('Audit Log (Operations Log)', () => {
     await operateOperationsLogPage.gotoOperationsLogPage();
 
     await expect
-      .poll(
-        async () =>
-          operateOperationsLogPage.operationsLogTable.getByRole('row').count(),
-        {timeout: 60000},
-      )
+      .poll(async () => operateOperationsLogPage.getRowCount(), {
+        timeout: 60000,
+      })
       .toBeGreaterThan(1);
   });
 
-  test.skip('Audit log entries can be filtered by process instance key', async ({
-    page,
+  test('Audit log entries can be filtered by process instance key', async ({
     operateOperationsLogPage,
   }) => {
     const {processInstanceKey} = process.instance;
@@ -94,26 +84,20 @@ test.describe('Audit Log (Operations Log)', () => {
       searchParams: {processInstanceKey},
     });
 
-    await expect(
-      page.getByRole('heading', {name: /operations log/i}),
-    ).toBeVisible();
+    await expect(operateOperationsLogPage.operationsLogHeading).toBeVisible();
 
     await expect(operateOperationsLogPage.processInstanceKeyFilter).toHaveValue(
       processInstanceKey,
     );
 
     await expect
-      .poll(
-        async () =>
-          operateOperationsLogPage.operationsLogTable.getByRole('row').count(),
-        {timeout: 60000},
-      )
+      .poll(async () => operateOperationsLogPage.getRowCount(), {
+        timeout: 60000,
+      })
       .toBeGreaterThan(1);
 
     await expect(
-      operateOperationsLogPage.operationsLogTable
-        .getByRole('cell', {name: /process instance/i})
-        .first(),
+      operateOperationsLogPage.processInstanceCells.first(),
     ).toBeVisible();
   });
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Unskip `Audit log entries can be filtered by process instance key` since the dependent changes were updated in a different PR.
Also refactored the Operations Log (Audit Log) tests to follow consistent page object model patterns by extracting inline selectors into reusable locators.

[Test Run 🧪 ](https://github.com/camunda/camunda/actions/runs/23744912229)
❗ Un-skipped test passed, some other tests are failing and will be investigated seperately

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/49225
