### PR TITLE
[Backport stable/optimize-8.6] deps: Exclude c3p0 and mchange-commons-java from quartz dependencies

### DIFF
--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -256,6 +256,15 @@
           <artifactId>slf4j-api</artifactId>
           <groupId>org.slf4j</groupId>
         </exclusion>
+        <!-- Excluding to resolve CVE-2026-27830, CVE-2026-27727 -->
+        <exclusion>
+          <groupId>com.mchange</groupId>
+          <artifactId>c3p0</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.mchange</groupId>
+          <artifactId>mchange-commons-java</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 


### PR DESCRIPTION
# Description
Backport of #47223 to `stable/optimize-8.6`.

relates to camunda/camunda#49733
original author: @danielkelemen