### PR TITLE
fix: hide incidents tab when selected element has no incidents

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.test.tsx
@@ -20,7 +20,6 @@ import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fe
 import {mockSearchProcessInstances} from 'modules/mocks/api/v2/processInstances/searchProcessInstances';
 import {mockSearchDecisionInstances} from 'modules/mocks/api/v2/decisionInstances/searchDecisionInstances';
 import {searchResult} from 'modules/testUtils';
-import {LocationLog} from 'modules/utils/LocationLog';
 import type {
   ElementInstance,
   Job,
@@ -171,10 +170,6 @@ function getWrapper(initialSearchParams?: string) {
               path: Paths.processInstanceDetails({isRelative: true}),
               element: children,
             },
-            {
-              path: Paths.processInstanceVariables({isRelative: true}),
-              element: <LocationLog />,
-            },
           ],
         },
       ],
@@ -200,18 +195,6 @@ describe('<DetailsTab />', () => {
     mockSearchJobs().withSuccess(searchResult([]));
     mockSearchProcessInstances().withSuccess(searchResult([]));
     mockSearchDecisionInstances().withSuccess(searchResult([]));
-  });
-
-  it('should redirect to variables when no element is selected', () => {
-    render(<DetailsTab />, {
-      wrapper: getWrapper(),
-    });
-
-    expect(screen.getByTestId('pathname')).toHaveTextContent(
-      Paths.processInstanceVariables({
-        processInstanceId: PROCESS_INSTANCE_ID,
-      }),
-    );
   });
 
   it('should show multi-instance message when multiple instances exist', async () => {

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.tsx
@@ -7,7 +7,6 @@
  */
 
 import {useMemo} from 'react';
-import {Navigate, useLocation} from 'react-router-dom';
 import {StructuredListSkeleton} from '@carbon/react';
 import {Link} from 'modules/components/Link';
 import {Paths, Locations} from 'modules/Routes';
@@ -22,7 +21,6 @@ import {getExecutionDuration} from './getExecutionDuration';
 import {EmptyMessageContainer, Container, Callout} from './styled';
 import {StructuredList} from 'modules/components/StructuredList';
 import {useProcessInstance} from 'modules/queries/processInstance/useProcessInstance';
-import {useProcessInstancePageParams} from '../../useProcessInstancePageParams';
 
 const DetailsTab: React.FC = () => {
   const {
@@ -30,11 +28,8 @@ const DetailsTab: React.FC = () => {
     selectedElementId,
     selectedInstancesCount,
     isFetchingElement,
-    hasSelection,
   } = useProcessInstanceElementSelection();
 
-  const {processInstanceId} = useProcessInstancePageParams();
-  const location = useLocation();
   const {data: processInstance} = useProcessInstance();
   const {data: xmlData} = useProcessInstanceXml({
     processDefinitionKey: processInstance?.processDefinitionKey,
@@ -245,18 +240,6 @@ const DetailsTab: React.FC = () => {
     processInstance,
     calledDecisionInstance,
   ]);
-
-  if (!hasSelection) {
-    return (
-      <Navigate
-        to={{
-          ...location,
-          pathname: Paths.processInstanceVariables({processInstanceId}),
-        }}
-        replace
-      />
-    );
-  }
 
   if (isFetchingElement) {
     return <StructuredListSkeleton rowCount={5} />;

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/index.test.tsx
@@ -9,7 +9,6 @@
 import {
   render,
   screen,
-  waitFor,
   waitForElementToBeRemoved,
   within,
 } from 'modules/testing-library';
@@ -28,7 +27,6 @@ import {mockProcessInstance} from 'modules/mocks/api/v2/mocks/processInstance';
 import {createIncident, searchResult} from 'modules/testUtils';
 import {incidentsPanelStore} from 'modules/stores/incidentsPanel';
 import {getIncidentErrorName} from 'modules/utils/incidents';
-import {LocationLog} from 'modules/utils/LocationLog';
 
 const PROCESS_INSTANCE_ID = mockProcessInstance.processInstanceKey;
 
@@ -54,10 +52,6 @@ function getWrapper(searchParams?: Record<string, string>) {
       >
         <Routes>
           <Route path={Paths.processInstanceIncidents()} element={children} />
-          <Route
-            path={Paths.processInstanceVariables()}
-            element={<LocationLog />}
-          />
         </Routes>
       </MemoryRouter>
     </QueryClientProvider>
@@ -76,25 +70,6 @@ describe('IncidentsTab', () => {
 
   afterEach(() => {
     incidentsPanelStore.clearSelection();
-  });
-
-  it('should redirect to variables when the process instance has no incidents', async () => {
-    const mockInstanceWithoutIncidents = {
-      ...mockProcessInstance,
-      hasIncident: false,
-    };
-    mockFetchProcessInstance().withSuccess(mockInstanceWithoutIncidents);
-    render(<IncidentsTab />, {
-      wrapper: getWrapper(),
-    });
-
-    await waitFor(() =>
-      expect(screen.getByTestId('pathname')).toHaveTextContent(
-        Paths.processInstanceVariables({
-          processInstanceId: PROCESS_INSTANCE_ID,
-        }),
-      ),
-    );
   });
 
   it('should render the incidents table with correct columns', async () => {

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/index.tsx
@@ -26,15 +26,12 @@ import {IncidentsTable} from './IncidentsTable';
 import {PanelHeader} from 'modules/components/PanelHeader';
 import {Container} from './styled';
 import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
-import {Navigate, useLocation} from 'react-router-dom';
-import {Paths} from 'modules/Routes';
 import {useDecisionInstancesSearch} from 'modules/queries/decisionInstances/useDecisionInstancesSearch';
 import {useMemo} from 'react';
 
 const ROW_HEIGHT = 32;
 
 const IncidentsTab: React.FC = observer(() => {
-  const location = useLocation();
   const {processInstanceId = ''} = useProcessInstancePageParams();
   const {data: processInstance} = useProcessInstance();
   const {selectedElementId, resolvedElementInstance, isFetchingElement} =
@@ -126,18 +123,6 @@ const IncidentsTab: React.FC = observer(() => {
       }, {}),
     [decisionInstancesResult],
   );
-
-  if (processInstance?.hasIncident === false) {
-    return (
-      <Navigate
-        to={{
-          ...location,
-          pathname: Paths.processInstanceVariables({processInstanceId}),
-        }}
-        replace
-      />
-    );
-  }
 
   return (
     <Container>

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/InputMappingsTab.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/InputMappingsTab.tsx
@@ -6,27 +6,14 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {Navigate, useLocation} from 'react-router-dom';
 import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
-import {useProcessInstancePageParams} from '../useProcessInstancePageParams';
-import {Paths} from 'modules/Routes';
 import {InputOutputMappings} from './InputOutputMappings';
 
 const InputMappingsTab: React.FC = () => {
   const {selectedElementId} = useProcessInstanceElementSelection();
-  const {processInstanceId} = useProcessInstancePageParams();
-  const location = useLocation();
 
   if (selectedElementId === null) {
-    return (
-      <Navigate
-        to={{
-          ...location,
-          pathname: Paths.processInstanceVariables({processInstanceId}),
-        }}
-        replace
-      />
-    );
+    return null;
   }
 
   return <InputOutputMappings type="Input" elementId={selectedElementId} />;

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/OutputMappingsTab.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/OutputMappingsTab.tsx
@@ -6,27 +6,14 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {Navigate, useLocation} from 'react-router-dom';
 import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
-import {useProcessInstancePageParams} from '../useProcessInstancePageParams';
-import {Paths} from 'modules/Routes';
 import {InputOutputMappings} from './InputOutputMappings';
 
 const OutputMappingsTab: React.FC = () => {
   const {selectedElementId} = useProcessInstanceElementSelection();
-  const {processInstanceId} = useProcessInstancePageParams();
-  const location = useLocation();
 
   if (selectedElementId === null) {
-    return (
-      <Navigate
-        to={{
-          ...location,
-          pathname: Paths.processInstanceVariables({processInstanceId}),
-        }}
-        replace
-      />
-    );
+    return null;
   }
 
   return <InputOutputMappings type="Output" elementId={selectedElementId} />;

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/index.test.tsx
@@ -170,6 +170,43 @@ describe('<BottomPanelTabs />', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('should not show Incidents tab when selected element instance has no incidents', async () => {
+    const elementInstanceKey = '456';
+    mockFetchProcessInstance().withSuccess(
+      createProcessInstance({
+        processInstanceKey: PROCESS_INSTANCE_ID,
+        hasIncident: true,
+      }),
+    );
+    mockFetchElementInstance(':key').withSuccess({
+      elementInstanceKey,
+      processInstanceKey: PROCESS_INSTANCE_ID,
+      processDefinitionKey: '2223894723423800',
+      processDefinitionId: 'someKey',
+      startDate: '2024-01-01T00:00:00.000Z',
+      endDate: null,
+      state: 'ACTIVE',
+      incidentKey: null,
+      elementId: 'someElement',
+      elementName: null,
+      type: 'SERVICE_TASK',
+      tenantId: '<default>',
+      hasIncident: false,
+      rootProcessInstanceKey: null,
+    });
+    mockSearchIncidentsByElementInstance(':key').withSuccess(
+      searchResult([], 0),
+    );
+
+    const path = `${Paths.processInstance(PROCESS_INSTANCE_ID)}?elementId=someElement&elementInstanceKey=${elementInstanceKey}`;
+    render(<BottomPanelTabs />, {wrapper: getWrapper(path)});
+
+    expect(screen.getByRole('link', {name: /^Variables$/i})).toBeVisible();
+    expect(
+      screen.queryByRole('link', {name: /^Incidents$/i}),
+    ).not.toBeInTheDocument();
+  });
+
   it('should show Incidents tab when process instance has an incident', async () => {
     mockSearchIncidentsByProcessInstance(':instanceId').withSuccess(
       searchResult([], 3),
@@ -508,5 +545,123 @@ describe('<BottomPanelTabs />', () => {
       await screen.findByRole('link', {name: /^Incidents$/i}),
     ).toBeVisible();
     expect(await screen.findByText('3')).toBeVisible();
+  });
+
+  it('should redirect incidents tab when process instance has no incidents', async () => {
+    mockFetchProcessInstance().withSuccess(
+      createProcessInstance({
+        processInstanceKey: PROCESS_INSTANCE_ID,
+        hasIncident: false,
+      }),
+    );
+
+    const path = Paths.processInstanceIncidents({
+      processInstanceId: PROCESS_INSTANCE_ID,
+    });
+    render(<BottomPanelTabs />, {wrapper: getWrapper(path)});
+
+    expect(await screen.findByTestId('pathname')).toHaveTextContent(
+      Paths.processInstanceVariables({
+        processInstanceId: PROCESS_INSTANCE_ID,
+      }),
+    );
+  });
+
+  it('should redirect incidents tab when selected element has no incidents', async () => {
+    const elementInstanceKey = '456';
+    mockFetchProcessInstance().withSuccess(
+      createProcessInstance({
+        processInstanceKey: PROCESS_INSTANCE_ID,
+        hasIncident: true,
+      }),
+    );
+    mockFetchElementInstance(':key').withSuccess({
+      elementInstanceKey,
+      processInstanceKey: PROCESS_INSTANCE_ID,
+      processDefinitionKey: '2223894723423800',
+      processDefinitionId: 'someKey',
+      startDate: '2024-01-01T00:00:00.000Z',
+      endDate: null,
+      state: 'ACTIVE',
+      incidentKey: null,
+      elementId: 'someElement',
+      elementName: null,
+      type: 'SERVICE_TASK',
+      tenantId: '<default>',
+      hasIncident: false,
+      rootProcessInstanceKey: null,
+    });
+    mockSearchIncidentsByElementInstance(':key').withSuccess(
+      searchResult([], 0),
+    );
+
+    const path = `${Paths.processInstanceIncidents({processInstanceId: PROCESS_INSTANCE_ID})}?elementId=someElement&elementInstanceKey=${elementInstanceKey}`;
+    render(<BottomPanelTabs />, {wrapper: getWrapper(path)});
+
+    expect(await screen.findByTestId('pathname')).toHaveTextContent(
+      Paths.processInstanceVariables({
+        processInstanceId: PROCESS_INSTANCE_ID,
+      }),
+    );
+  });
+
+  it('should redirect input mappings tab when no element is selected', async () => {
+    mockFetchProcessInstance().withSuccess(
+      createProcessInstance({
+        processInstanceKey: PROCESS_INSTANCE_ID,
+        hasIncident: false,
+      }),
+    );
+
+    const inputMappingsPath = Paths.processInstanceInputMappings({
+      processInstanceId: PROCESS_INSTANCE_ID,
+    });
+    render(<BottomPanelTabs />, {wrapper: getWrapper(inputMappingsPath)});
+
+    expect(await screen.findByTestId('pathname')).toHaveTextContent(
+      Paths.processInstanceVariables({
+        processInstanceId: PROCESS_INSTANCE_ID,
+      }),
+    );
+  });
+
+  it('should redirect output mappings tab when no element is selected', async () => {
+    mockFetchProcessInstance().withSuccess(
+      createProcessInstance({
+        processInstanceKey: PROCESS_INSTANCE_ID,
+        hasIncident: false,
+      }),
+    );
+
+    const outputMappingsPath = Paths.processInstanceOutputMappings({
+      processInstanceId: PROCESS_INSTANCE_ID,
+    });
+    render(<BottomPanelTabs />, {wrapper: getWrapper(outputMappingsPath)});
+
+    expect(await screen.findByTestId('pathname')).toHaveTextContent(
+      Paths.processInstanceVariables({
+        processInstanceId: PROCESS_INSTANCE_ID,
+      }),
+    );
+  });
+
+  it('should redirect details tab when no element is selected', async () => {
+    mockFetchProcessInstance().withSuccess(
+      createProcessInstance({
+        processInstanceKey: PROCESS_INSTANCE_ID,
+        hasIncident: false,
+      }),
+    );
+
+    const path = Paths.processInstanceDetails({
+      processInstanceId: PROCESS_INSTANCE_ID,
+    });
+    render(<BottomPanelTabs />, {wrapper: getWrapper(path)});
+
+    expect(await screen.findByTestId('pathname')).toHaveTextContent(
+      Paths.processInstanceVariables({
+        processInstanceId: PROCESS_INSTANCE_ID,
+      }),
+    );
   });
 });

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/index.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {Outlet} from 'react-router-dom';
+import {Navigate, Outlet, useLocation} from 'react-router-dom';
 import {Paths} from 'modules/Routes';
 import {Container, TabContent} from './styled';
 import {TabListNav} from './TabListNav';
@@ -30,16 +30,18 @@ function useSelectionAwareIncidentsCount(
     resolvedElementInstanceKey !== undefined &&
     resolvedElementInstanceKey !== processInstanceKey;
 
-  const processIncidentsCount = useProcessInstanceIncidentsCount(
+  const {data: processIncidentsCount} = useProcessInstanceIncidentsCount(
     processInstanceKey ?? '',
     {
       enabled: hasIncident && !isElementInstanceSelected && !isFetchingElement,
       filter: {elementId: selectedElementId ?? undefined},
     },
   );
-  const elementIncidentsCount = useElementInstanceIncidentsCount(
+  const {data: elementIncidentsCount} = useElementInstanceIncidentsCount(
     resolvedElementInstanceKey ?? '',
-    {enabled: hasIncident && isElementInstanceSelected},
+    {
+      enabled: hasIncident && isElementInstanceSelected,
+    },
   );
 
   return isElementInstanceSelected
@@ -52,6 +54,7 @@ const BottomPanelTabs: React.FC = () => {
   const {data: processInstance} = useProcessInstance();
   const {processInstanceId} = useProcessInstancePageParams();
   const {currentPage} = useCurrentPage();
+  const location = useLocation();
   const hasIncident = processInstance?.hasIncident === true;
   const incidentsCount = useSelectionAwareIncidentsCount(
     processInstanceId ?? '',
@@ -65,8 +68,9 @@ const BottomPanelTabs: React.FC = () => {
       key: 'incidents',
       selected: currentPage === 'process-details-incidents',
       title: 'Incidents',
-      visible: hasIncident,
-      tagText: incidentsCount,
+      visible:
+        hasIncident && (incidentsCount === undefined || incidentsCount > 0),
+      tagText: incidentsCount ?? 0,
     },
     {
       label: 'Details',
@@ -120,12 +124,23 @@ const BottomPanelTabs: React.FC = () => {
     },
   ] satisfies React.ComponentProps<typeof TabListNav>['items'];
 
+  const selectedTab = tabItems.find((tab) => tab.selected);
+
   return (
     <Container>
       <TabListNav label="Process Instance Bottom Panel Tabs" items={tabItems} />
       <TabContent>
         <Outlet />
       </TabContent>
+      {selectedTab?.visible === false && (
+        <Navigate
+          to={{
+            ...location,
+            pathname: Paths.processInstanceVariables({processInstanceId}),
+          }}
+          replace
+        />
+      )}
     </Container>
   );
 };

--- a/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/index.tsx
+++ b/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/index.tsx
@@ -87,9 +87,12 @@ const ProcessInstanceHeader: React.FC<Props> = ({processInstance}) => {
   const {isPending, data: processInstanceXmlData} = useProcessInstanceXml({
     processDefinitionKey,
   });
-  const incidentsCount = useProcessInstanceIncidentsCount(processInstanceKey, {
-    enabled: hasIncident,
-  });
+  const {data: incidentsCount = 0} = useProcessInstanceIncidentsCount(
+    processInstanceKey,
+    {
+      enabled: hasIncident,
+    },
+  );
 
   if (processInstance === null || isPending) {
     return <Skeleton headerColumns={skeletonColumns} />;

--- a/operate/client/src/modules/queries/incidents/useElementInstanceIncidentsCount.ts
+++ b/operate/client/src/modules/queries/incidents/useElementInstanceIncidentsCount.ts
@@ -17,8 +17,8 @@ type CountQueryOptions = {
 function useElementInstanceIncidentsCount(
   elementInstanceKey: string,
   options?: CountQueryOptions,
-): number {
-  const {data} = useQuery({
+) {
+  return useQuery({
     queryKey:
       queryKeys.incidents.elementInstanceIncidentsCount(elementInstanceKey),
     enabled: options?.enabled ?? !!elementInstanceKey,
@@ -36,8 +36,6 @@ function useElementInstanceIncidentsCount(
       throw error;
     },
   });
-
-  return data ?? 0;
 }
 
 export {useElementInstanceIncidentsCount};

--- a/operate/client/src/modules/queries/incidents/useProcessInstanceIncidentsCount.ts
+++ b/operate/client/src/modules/queries/incidents/useProcessInstanceIncidentsCount.ts
@@ -19,13 +19,13 @@ type CountQueryOptions = {
 function useProcessInstanceIncidentsCount(
   processInstanceKey: string,
   options?: CountQueryOptions,
-): number {
+) {
   const filter: QueryProcessInstanceIncidentsRequestBody['filter'] = {
     state: 'ACTIVE',
     ...options?.filter,
   };
 
-  const {data} = useQuery({
+  return useQuery({
     queryKey: queryKeys.incidents.processInstanceIncidentsCount(
       processInstanceKey,
       filter,
@@ -45,8 +45,6 @@ function useProcessInstanceIncidentsCount(
       throw error;
     },
   });
-
-  return data ?? 0;
 }
 
 export {useProcessInstanceIncidentsCount};


### PR DESCRIPTION
## Description

This PR hides the incident tab when the current selection has no incidents. Changes in this PR:
- Refactored `useProcessInstanceIncidentsCount` and `useElementInstanceIncidentsCount` to return the `useQuery` result instead of `number`.
  - Thought I will need the loading state... Didn't need it in the end, but I think this is still a good change to make the hooks more flexible.
- Moved and unified "redirect when tab is not visible" logic into `BottomPanelTabs`.
- Hides incidents tab when incidents count is loaded and greater zero.

I have not been sure how the UI should behave while the incidents count is loading. Obviously, the redirect has to be delayed until we are sure there are no incidents... Initially, I tried to hide the tab but not redirect immediately, which works but can cause UI inconsistencies during loading when the incidents tab is selected. The implemented solution shows the tab with `0` as the count while the actual count is loading => Switching between tabs with no incidents shows/flickers the incident tab in the tab bar while the count is loading. This is not perfect, but looks more consistent than the other option. I am option for other reasonable ideas how this should behave...


## Related issues

closes #50002
