### PR TITLE
fix: provide default value for old checkpoint infos

### DIFF
--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/CheckpointInfo.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/state/CheckpointInfo.java
@@ -17,7 +17,7 @@ import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 public final class CheckpointInfo extends UnpackedObject implements DbValue {
   private final LongProperty idProperty = new LongProperty("id");
   private final LongProperty positionProperty = new LongProperty("position");
-  private final LongProperty timestamp = new LongProperty("timestamp");
+  private final LongProperty timestamp = new LongProperty("timestamp", -1L);
   private final EnumProperty<CheckpointType> typeProperty =
       new EnumProperty<>("type", CheckpointType.class, CheckpointType.MANUAL_BACKUP);
   private final LongProperty firstLogPositionProperty = new LongProperty("firstLogPosition", -1L);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupMultiPartitionTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupMultiPartitionTest.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.it.util.GrpcClientRule;
 import io.camunda.zeebe.it.util.RecordingJobHandler;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse;
 import io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse.PartitionCheckpointState;
 import io.camunda.zeebe.protocol.management.BackupStatusCode;
@@ -479,18 +480,16 @@ class BackupMultiPartitionTest {
     Awaitility.await()
         .until(
             () -> {
-              client
-                  .getClient()
-                  .newCreateInstanceCommand()
-                  .processDefinitionKey(processKey)
-                  .variables(Map.of(CORRELATION_KEY, CORRELATION_KEY_VALUE_FOR_PARTITION_2))
-                  .send()
-                  .join();
+              final var createInstanceResult =
+                  client
+                      .getClient()
+                      .newCreateInstanceCommand()
+                      .processDefinitionKey(processKey)
+                      .variables(Map.of(CORRELATION_KEY, CORRELATION_KEY_VALUE_FOR_PARTITION_2))
+                      .send()
+                      .join();
               // Ensure process instance is created on partition 1
-              return RecordingExporter.processInstanceCreationRecords()
-                  .withPartitionId(1)
-                  .findFirst()
-                  .isPresent();
+              return 1 == Protocol.decodePartitionId(createInstanceResult.getProcessInstanceKey());
             });
     assertThat(
             RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/backup/BackupCompatibilityAcceptance.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/backup/BackupCompatibilityAcceptance.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.qa.util.actuator.BackupActuator;
 import io.camunda.zeebe.qa.util.actuator.PartitionsActuator;
 import io.camunda.zeebe.qa.util.cluster.TestRestoreApp;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.test.util.junit.RegressionTest;
 import io.camunda.zeebe.util.VersionUtil;
 import io.zeebe.containers.ZeebeContainer;
 import io.zeebe.containers.ZeebeTopologyWaitStrategy;
@@ -141,6 +142,49 @@ public interface BackupCompatibilityAcceptance {
   }
 
   /**
+   * Verifies that checkpoint state written by the previous version can be deserialized after
+   * restore. This is a regression test for <a
+   * href="https://github.com/camunda/camunda/issues/49812">a bug</a> where the {@code timestamp}
+   * property was added to {@code CheckpointInfo} without a default value, causing deserialization
+   * to fail when reading old-format data that lacks the property.
+   *
+   * <p>The existing {@link #shouldRestoreBackupFromPreviousVersion()} test does not catch this
+   * because its snapshot predates the checkpoint record — the checkpoint info is only ever written
+   * by the current version during log replay. This test forces the scenario where the snapshot
+   * already contains checkpoint state from the previous version.
+   */
+  @RegressionTest("https://github.com/camunda/camunda/issues/49812")
+  default void shouldRestoreBackupWhenSnapshotContainsCheckpointFromPreviousVersion() {
+    // given -- two backups: the first writes checkpoint info to RocksDB, and the
+    // second's snapshot captures that old-format checkpoint state
+    final var firstBackupId = 1L;
+    final var secondBackupId = 2L;
+    try (final var broker = createOldBroker()) {
+      broker.start();
+      createProcessInstanceWithJob(broker);
+      takeBackup(broker, firstBackupId);
+
+      // Checkpoint info from backup #1 is now persisted in RocksDB.
+      // Take a second backup whose snapshot includes that state.
+      takeBackupWithFreshSnapshot(broker, secondBackupId);
+    }
+
+    // when -- restore the second backup using the current version
+    final Path restoredDataDir;
+    try (final var restoreApp =
+        new TestRestoreApp()
+            .withUnifiedConfig(this::configureCurrentBackupStore)
+            .withBackupId(secondBackupId)
+            .start()) {
+      restoredDataDir = restoreApp.getWorkingDirectory();
+    }
+
+    // then -- the current-version broker must deserialize old checkpoint state from the
+    // snapshot without errors and replay the remaining log successfully
+    verifyRestoredJobCanBeCompleted(restoredDataDir);
+  }
+
+  /**
    * Starts a current-version broker on the restored data directory and verifies that the service
    * task job created before the backup can be activated and completed.
    */
@@ -206,11 +250,41 @@ public interface BackupCompatibilityAcceptance {
     // Initiate additional processing to progress logstream so that backup doesn't fail
     createProcessInstanceWithJob(broker);
 
-    // Use the 8.8 actuator path (/actuator/backups) rather than the current
-    // /actuator/backupRuntime
-    final var backupActuator =
-        BackupActuator.of(
-            String.format("http://%s/actuator/backups", broker.getExternalMonitoringAddress()));
+    final var backupActuator = BackupActuator.of(broker);
+    backupActuator.take(backupId);
+
+    Awaitility.await("until backup is completed")
+        .atMost(Duration.ofSeconds(120))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var status = backupActuator.status(backupId);
+              assertThat(status)
+                  .describedAs("Backup status (failureReason=%s)", status.getFailureReason())
+                  .returns(StateCode.COMPLETED, BackupInfo::getState);
+            });
+  }
+
+  /**
+   * Takes a backup after forcing a fresh snapshot, ensuring the snapshot captures the current
+   * RocksDB state (including any checkpoint info written by prior backups). Unlike {@link
+   * #takeBackup}, this waits for the snapshot ID to actually change before proceeding.
+   */
+  private void takeBackupWithFreshSnapshot(final ZeebeContainer broker, final long backupId) {
+    final var partitionsActuator = PartitionsActuator.of(broker);
+    final var previousSnapshotId = partitionsActuator.query().get(1).snapshotId();
+
+    partitionsActuator.takeSnapshot();
+    Awaitility.await("Fresh snapshot capturing checkpoint state")
+        .atMost(Duration.ofSeconds(60))
+        .until(
+            () -> partitionsActuator.query().get(1).snapshotId(),
+            id -> id != null && !id.equals(previousSnapshotId));
+
+    // Progress the logstream past the snapshot position
+    createProcessInstanceWithJob(broker);
+
+    final var backupActuator = BackupActuator.of(broker);
     backupActuator.take(backupId);
 
     Awaitility.await("until backup is completed")


### PR DESCRIPTION
Provides a default value for the timestamp in `CheckpointInfo` so that we can still deserialize old entries.

closes #49812
