### PR TITLE
[Backport stable/8.8] test: verify that after when batch is empty delay is not zero

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -265,7 +265,7 @@ final class CamundaExporterIT {
     // then
     verify(spiedController, times(2))
         .scheduleCancellableTask(
-            argThat(delay -> delay.getSeconds() >= 0 && delay.getSeconds() <= 2), any());
+            argThat(delay -> delay.toMillis() > 0 && delay.toMillis() <= 2 * 1000L), any());
   }
 
   @TestTemplate

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
@@ -358,7 +358,6 @@ final class CamundaExporterTest {
       // given
       final var clock = new MutableClock(1000);
       testContext.setClock(clock);
-      configuration.getBulk().setSize(1); // every export() triggers size-based flush
       configuration.getBulk().setDelay(1); // 1 second
       configuration.getIndex().setShouldWaitForImporters(false); // do not wait for importers
       exporter =

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
@@ -186,7 +186,7 @@ final class CamundaExporterTest {
   final class FlushTest {
     @Test
     void shouldUpdateMetadataOnFlush() {
-      final var clock = new MutableClock(0);
+      final var clock = new MutableClock(1000);
       testContext.setClock(clock);
       configuration.getBulk().setDelay(1);
 
@@ -246,7 +246,7 @@ final class CamundaExporterTest {
     @Test
     void shouldNotFlushBeforeDelayElapses() {
       // given — use a controllable clock so we can verify timing
-      final var clock = new MutableClock(0);
+      final var clock = new MutableClock(1000);
       testContext.setClock(clock);
       // bulk size = 1 so that export() triggers an immediate size-based flush,
       // which sets lastFlushTimestamp without needing the scheduled task to flush
@@ -275,7 +275,7 @@ final class CamundaExporterTest {
     @Test
     void shouldFlushWhenExportIfDelayElapsed() {
       // given — use a controllable clock so we can verify timing
-      final var clock = new MutableClock(0);
+      final var clock = new MutableClock(1000);
       testContext.setClock(clock);
       // bulk size = 10 so that a single export does NOT trigger a size-based flush;
       // flushing only happens via the scheduled task
@@ -325,7 +325,7 @@ final class CamundaExporterTest {
       // repeated flush cycles and not degrade to zero.
 
       // given
-      final var clock = new MutableClock(0);
+      final var clock = new MutableClock(1000);
       testContext.setClock(clock);
       configuration.getBulk().setSize(1); // every export() triggers size-based flush
       configuration.getBulk().setDelay(1); // 1 second
@@ -356,7 +356,7 @@ final class CamundaExporterTest {
       // repeated flush cycles and not degrade to zero.
 
       // given
-      final var clock = new MutableClock(0);
+      final var clock = new MutableClock(1000);
       testContext.setClock(clock);
       configuration.getBulk().setSize(1); // every export() triggers size-based flush
       configuration.getBulk().setDelay(1); // 1 second


### PR DESCRIPTION
# Description
Backport of #50015 to `stable/8.8`.

relates to #50003