### PR TITLE
Expression api test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/index.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/index.ts
@@ -584,6 +584,11 @@ export const RESPONSE_INDEX = {
       '200': 1,
     },
   },
+  '/user-tasks/{userTaskKey}/effective-variables/search': {
+    POST: {
+      '200': 1,
+    },
+  },
   '/user-tasks/{userTaskKey}/form': {
     GET: {
       '200': 1,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/responses.json
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/responses.json
@@ -1,10 +1,10 @@
 {
   "metadata": {
     "sourceRepo": "https://github.com/camunda/camunda",
-    "commit": "50b29f7ba8a2263e69873a7c3a666795ef32197e",
-    "generatedAt": "2026-03-13T15:32:22.956Z",
+    "commit": "d9ee604e14acb7f581d0d444c6d3c3808a8e0ed1",
+    "generatedAt": "2026-03-30T15:37:04.041Z",
     "specPath": "zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml",
-    "specSha256": "3af1e48dc5806105ff4719c0a680f76f3f78553725cdc54fd5275069f28241ee"
+    "specSha256": "90305bc3eba6229e64df751ad79548d2bebb7dcf84675609f468a753d5dcc70d"
   },
   "responses": [
     {
@@ -3065,7 +3065,16 @@
           },
           {
             "name": "warnings",
-            "type": "array<string>"
+            "type": "array<object>",
+            "children": {
+              "required": [
+                {
+                  "name": "message",
+                  "type": "string"
+                }
+              ],
+              "optional": []
+            }
           }
         ],
         "optional": []
@@ -7884,6 +7893,85 @@
                   "name": "userTaskKey",
                   "type": "string",
                   "nullable": true
+                }
+              ],
+              "optional": []
+            }
+          },
+          {
+            "name": "page",
+            "type": "object",
+            "children": {
+              "required": [
+                {
+                  "name": "endCursor",
+                  "type": "string",
+                  "nullable": true
+                },
+                {
+                  "name": "hasMoreTotalItems",
+                  "type": "boolean"
+                },
+                {
+                  "name": "startCursor",
+                  "type": "string",
+                  "nullable": true
+                },
+                {
+                  "name": "totalItems",
+                  "type": "number"
+                }
+              ],
+              "optional": []
+            }
+          }
+        ],
+        "optional": []
+      }
+    },
+    {
+      "path": "/user-tasks/{userTaskKey}/effective-variables/search",
+      "method": "POST",
+      "status": "200",
+      "schema": {
+        "required": [
+          {
+            "name": "items",
+            "type": "array<0>",
+            "children": {
+              "required": [
+                {
+                  "name": "isTruncated",
+                  "type": "boolean"
+                },
+                {
+                  "name": "name",
+                  "type": "string"
+                },
+                {
+                  "name": "processInstanceKey",
+                  "type": "string"
+                },
+                {
+                  "name": "rootProcessInstanceKey",
+                  "type": "string",
+                  "nullable": true
+                },
+                {
+                  "name": "scopeKey",
+                  "type": "string"
+                },
+                {
+                  "name": "tenantId",
+                  "type": "string"
+                },
+                {
+                  "name": "value",
+                  "type": "string"
+                },
+                {
+                  "name": "variableKey",
+                  "type": "string"
                 }
               ],
               "optional": []

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instance-delete-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instance-delete-api.spec.ts
@@ -28,16 +28,16 @@ import {cleanupUsers} from 'utils/usersCleanup';
 test.describe.serial('Delete Decision Instances API Tests', () => {
   let decisionInstances: DecisionInstance[] = [];
   let userWithResourcesAuthorizationToSendRequest: {
-      username: string;
-      name: string;
-      email: string;
-      password: string;
-    } = {} as {
-      username: string;
-      name: string;
-      email: string;
-      password: string;
-    };
+    username: string;
+    name: string;
+    email: string;
+    password: string;
+  } = {} as {
+    username: string;
+    name: string;
+    email: string;
+    password: string;
+  };
 
   test.beforeAll(async ({request}) => {
     const result =
@@ -61,7 +61,7 @@ test.describe.serial('Delete Decision Instances API Tests', () => {
     });
   });
 
-    test('Delete Decision Instance - Forbidden', async ({request}) => {
+  test('Delete Decision Instance - Forbidden', async ({request}) => {
     await test.step('Attempt to Delete Decision Instance with insufficient permissions', async () => {
       const decisionInstanceToDelete = decisionInstances[0];
       const decisionEvaluationKeyToDelete =
@@ -87,7 +87,7 @@ test.describe.serial('Delete Decision Instances API Tests', () => {
 
   test('Delete Decision Instance - Success', async ({request}) => {
     const decisionInstanceToDelete =
-        decisionInstances[decisionInstances.length - 1];
+      decisionInstances[decisionInstances.length - 1];
     const decisionEvaluationKeyToDelete =
       decisionInstanceToDelete.decisionEvaluationKey;
 
@@ -107,7 +107,8 @@ test.describe.serial('Delete Decision Instances API Tests', () => {
     });
 
     await test.step('Verify Decision Instance is Deleted', async () => {
-      const decisionEvaluationInstanceKeyToGet = decisionInstanceToDelete.decisionEvaluationInstanceKey;
+      const decisionEvaluationInstanceKeyToGet =
+        decisionInstanceToDelete.decisionEvaluationInstanceKey;
       await expect(async () => {
         const res = await request.get(
           buildUrl(`/decision-instances/${decisionEvaluationInstanceKeyToGet}`),

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/expression/expression-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/expression/expression-api-tests.spec.ts
@@ -1,0 +1,276 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {
+  buildUrl,
+  jsonHeaders,
+  assertStatusCode,
+  assertInvalidArgument,
+} from '../../../../utils/http';
+import {validateResponse} from '../../../../json-body-assertions';
+
+const EXPRESSION_URL = '/expression/evaluation';
+
+async function evaluateExpression(
+  request: any,
+  expression: string,
+  variables: Record<string, unknown>,
+) {
+  return request.post(buildUrl(EXPRESSION_URL), {
+    headers: jsonHeaders(),
+    data: {expression, variables},
+  });
+}
+
+type ExpressionTestCase = {
+  description: string;
+  expression: string;
+  variables: Record<string, unknown>;
+  result?: unknown;
+  warnings?: string[];
+  errorDetail?: string;
+};
+
+const successTestCases: ExpressionTestCase[] = [
+  {
+    description: 'Should evaluate literal number addition - Success',
+    expression: '=1 + 2',
+    variables: {},
+    result: 3,
+  },
+  {
+    description: 'Should evaluate literal string concatenation - Success',
+    expression: '="foo" + "bar"',
+    variables: {},
+    result: 'foobar',
+  },
+  {
+    description: 'Should evaluate boolean logic - Success',
+    expression: '=true and false',
+    variables: {},
+    result: false,
+  },
+   //Skipped due to bug 50091 : https://github.com/camunda/camunda/issues/50091
+  //   {
+  //     description: 'Should evaluate null literal - Success',
+  //     expression: '=x',
+  //     variables: {x: null},
+  //     result: 'null',
+  //   },
+  {
+    description: 'Should evaluate simple variable read - Success',
+    expression: '=x',
+    variables: {x: 5},
+    result: 5,
+  },
+  {
+    description: 'Should evaluate variable arithmetic - Success',
+    expression: '=x + 1',
+    variables: {x: 5},
+    result: 6,
+  },
+  {
+    description: 'Should evaluate string variable concatenation - Success',
+    expression: '=firstName + " " + lastName',
+    variables: {firstName: 'Jane', lastName: 'Doe'},
+    result: 'Jane Doe',
+  },
+  {
+    description: 'Should evaluate nested context comparison - Success',
+    expression: '=person.age >= 18',
+    variables: {person: {age: 18}},
+    result: true,
+  },
+  {
+    description: 'Should evaluate deep property access - Success',
+    expression: '=person.address.city',
+    variables: {person: {address: {city: 'Berlin'}}},
+    result: 'Berlin',
+  },
+  {
+    description: 'Should evaluate list sum - Success',
+    expression: '=sum(numbers)',
+    variables: {numbers: [1, 2, 3]},
+    result: 6,
+  },
+  {
+    description: 'Should evaluate list filter - Success',
+    expression: '=numbers[ item > 2 ]',
+    variables: {numbers: [1, 2, 3, 4]},
+    result: [3, 4],
+  },
+  {
+    description: 'Should evaluate quantifier expression - Success',
+    expression: '=some n in numbers satisfies n > 3',
+    variables: {numbers: [1, 2, 3, 4]},
+    result: true,
+  },
+  {
+    description: 'Should evaluate comparison and logic - Success',
+    expression: '=x > 10 and y < 5',
+    variables: {x: 11, y: 4},
+    result: true,
+  },
+  {
+    description: 'Should evaluate equality with null - Success',
+    expression: '=x = null',
+    variables: {x: null},
+    result: true,
+  },
+  {
+    description: 'Should evaluate if-then-else - Success',
+    expression: '=if x > 5 then "big" else "small"',
+    variables: {x: 10},
+    result: 'big',
+  },
+  {
+    description: 'Should evaluate date literal function comparison - Success',
+    expression: '=date("2024-01-01") < date("2024-02-01")',
+    variables: {},
+    result: true,
+  },
+  {
+    description: 'Should evaluate date variable comparison - Success',
+    expression: '=date(dateVar) > date("2024-01-01")',
+    variables: {dateVar: '2024-02-01'},
+    result: true,
+  },
+  {
+    description: 'Should evaluate string function - Success',
+    expression: '=substring(text, 2, 3)',
+    variables: {text: 'camunda'},
+    result: 'amu',
+  },
+  {
+    description: 'Should evaluate mixed types with context - Success',
+    expression: '=person.age + bonus',
+    variables: {person: {age: 30}, bonus: 5},
+    result: 35,
+  },
+  {
+    description: 'Should evaluate collection of contexts filter - Success',
+    expression: '=employees[department = "QA"].name',
+    variables: {
+      employees: [
+        {name: 'Alice', department: 'QA'},
+        {name: 'Bob', department: 'Eng'},
+      ],
+    },
+    result: ['Alice'],
+  },
+];
+
+const warningTestCases: ExpressionTestCase[] = [
+  {
+    description: 'Should reject unknown variable - Warning',
+    expression: '=x + 1',
+    variables: {},
+    warnings: ["No variable found with name 'x'", "Can't add '1' to 'null'"],
+  },
+  {
+    description: 'Should reject type mismatch - Warning',
+    expression: '=x + 1',
+    variables: {x: 'foo'},
+    warnings: ["Can't add '1' to '\"foo\"'"],
+  },
+  {
+    description: 'Should reject wrong type for list operation - Warning',
+    expression: '=sum(numbers)',
+    variables: {numbers: ['a', 'b']},
+    warnings: [
+      "Failed to invoke function 'sum': expected number but found '\"a\"'",
+    ],
+  },
+  {
+    description: 'Should reject bad date literal - Warning',
+    expression: '=date(meow)',
+    variables: {meow: '2024-13-01'},
+    warnings: [
+      "Failed to invoke function 'date': Failed to parse date from '2024-13-01'",
+    ],
+  },
+  {
+    description: 'Should reject unexpected null in arithmetic - Warning',
+    expression: '=x + 1',
+    variables: {x: null},
+    warnings: ["Can't add '1' to 'null'"],
+  },
+];
+
+const errorTestCases: ExpressionTestCase[] = [
+  {
+    description:
+      'Should reject invalid FEEL syntax (trailing operator) - Error',
+    expression: '=x +',
+    variables: {x: 1},
+    errorDetail: 'Failed to parse expression',
+  },
+  {
+    description: 'Should reject invalid FEEL syntax (missing else) - Error',
+    expression: '=if x > 5 then "big"',
+    variables: {x: 10},
+    errorDetail: 'Failed to parse expression',
+  },
+];
+
+test.describe('Expression API Tests', () => {
+  for (const tc of successTestCases) {
+    test(tc.description, async ({request}) => {
+      const response = await evaluateExpression(
+        request,
+        tc.expression,
+        tc.variables,
+      );
+      await assertStatusCode(response, 200);
+      await validateResponse(
+        {path: EXPRESSION_URL, method: 'POST', status: '200'},
+        response,
+      );
+      const body = await response.json();
+      expect(body.expression).toBe(tc.expression);
+      expect(body.result).toEqual(tc.result);
+    });
+  }
+
+  for (const tc of warningTestCases) {
+    test(tc.description, async ({request}) => {
+      const response = await evaluateExpression(
+        request,
+        tc.expression,
+        tc.variables,
+      );
+      await assertStatusCode(response, 200);
+      //Skipped due to bug 50091 : https://github.com/camunda/camunda/issues/50091
+      //   await validateResponse(
+      //     {path: EXPRESSION_URL, method: 'POST', status: '200'},
+      //     response,
+      //   );
+      const body = await response.json();
+      const warnings = [];
+      for (const w of body.warnings) {
+        warnings.push(w.message);
+      }
+      for (const expected of tc.warnings!) {
+        expect(warnings).toContain(expected);
+      }
+      expect(body.result).toBeNull();
+    });
+  }
+
+  for (const tc of errorTestCases) {
+    test(tc.description, async ({request}) => {
+      const response = await evaluateExpression(
+        request,
+        tc.expression,
+        tc.variables,
+      );
+      await assertInvalidArgument(response, 400, tc.errorDetail!);
+    });
+  }
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/expression/expression-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/expression/expression-api-tests.spec.ts
@@ -8,25 +8,13 @@
 
 import {test, expect, APIRequestContext} from '@playwright/test';
 import {
-  buildUrl,
-  jsonHeaders,
   assertStatusCode,
   assertInvalidArgument,
 } from '../../../../utils/http';
 import {validateResponse} from '../../../../json-body-assertions';
+import {evaluateExpression, EXPRESSION_URL} from '@requestHelpers'
 
-const EXPRESSION_URL = '/expression/evaluation';
 
-async function evaluateExpression(
-  request: APIRequestContext,
-  expression: string,
-  variables: Record<string, unknown>,
-) {
-  return request.post(buildUrl(EXPRESSION_URL), {
-    headers: jsonHeaders(),
-    data: {expression, variables},
-  });
-}
 
 type ExpressionTestCase = {
   description: string;

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/expression/expression-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/expression/expression-api-tests.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {test, expect} from '@playwright/test';
+import {test, expect, APIRequestContext} from '@playwright/test';
 import {
   buildUrl,
   jsonHeaders,
@@ -18,7 +18,7 @@ import {validateResponse} from '../../../../json-body-assertions';
 const EXPRESSION_URL = '/expression/evaluation';
 
 async function evaluateExpression(
-  request: any,
+  request: APIRequestContext,
   expression: string,
   variables: Record<string, unknown>,
 ) {
@@ -61,7 +61,7 @@ const successTestCases: ExpressionTestCase[] = [
   //     description: 'Should evaluate null literal - Success',
   //     expression: '=x',
   //     variables: {x: null},
-  //     result: 'null',
+  //     result: null,
   //   },
   {
     description: 'Should evaluate simple variable read - Success',
@@ -206,13 +206,13 @@ const warningTestCases: ExpressionTestCase[] = [
 const errorTestCases: ExpressionTestCase[] = [
   {
     description:
-      'Should reject invalid FEEL syntax (trailing operator) - Error',
+      'Should return warning when invalid FEEL syntax (trailing operator) - Error',
     expression: '=x +',
     variables: {x: 1},
     errorDetail: 'Failed to parse expression',
   },
   {
-    description: 'Should reject invalid FEEL syntax (missing else) - Error',
+    description: 'Should return warning when invalid FEEL syntax (missing else) - Error',
     expression: '=if x > 5 then "big"',
     variables: {x: 10},
     errorDetail: 'Failed to parse expression',

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/expression-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/expression-requestHelpers.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {APIRequestContext} from '@playwright/test';
+import {
+  buildUrl,
+  jsonHeaders,
+} from '../http';
+
+export const EXPRESSION_URL = '/expression/evaluation';
+
+export async function evaluateExpression(
+  request: APIRequestContext,
+  expression: string,
+  variables: Record<string, unknown>,
+) {
+  return request.post(buildUrl(EXPRESSION_URL), {
+    headers: jsonHeaders(),
+    data: {expression, variables},
+  });
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
@@ -91,3 +91,4 @@ export {
   type GlobalTaskListenerBody,
 } from './global-task-listener-requestHelpers';
 export {type AuditLog} from './audit-log-requestHelpers';
+export {evaluateExpression, EXPRESSION_URL} from './expression-requestHelpers';


### PR DESCRIPTION
## Description

This PR introduces [Evaluate an expression](https://docs.camunda.io/docs/next/apis-tools/orchestration-cluster-api-rest/specifications/evaluate-expression/) API tests that are grouped into successTestCases, warningTestCases and errorTestCases. Currently `validateResponse()` is skipped for warningTestCases due to this issue https://github.com/camunda/camunda/issues/50091. Because of the same issue one of the successTestCases is also skipped. Reached out to team [here in Slack](https://camunda.slack.com/archives/C08MRKHJ0CD/p1774882643487249)
Also this PR present regenerated responses as well as lint fix.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

related to [this issue](https://github.com/camunda/team-test-automation/issues/62)
related to https://github.com/camunda/camunda/issues/50091
## On demand workflow
[Was all green](https://github.com/camunda/camunda/actions/runs/23791176662)
