### PR TITLE
[Backport stable/8.8] fix: handle assignment/unassignment/completion notification for lack of permissions

### DIFF
--- a/tasklist/client/src/common/i18n/locales/de.json
+++ b/tasklist/client/src/common/i18n/locales/de.json
@@ -36,6 +36,7 @@
     "forbiddenPageTitle": "Sie haben keinen Zugriff auf diese Komponente",
     "forbiddenPageDesc": "Es scheint, als ob Sie nicht über die erforderlichen Berechtigungen verfügen würden, um auf diese Komponente zuzugreifen. <strong>Bitte kontaktieren Sie Ihren Cluster-Administrator</strong>, um Zugriff anzufordern.",
     "forbiddenPageLinkLabel": "Erfahren Sie mehr über Rollen und Berechtigungen",
+    "taskActionForbidden": "Sie verfügen nicht über die erforderlichen Berechtigungen. Wenden Sie sich an Ihren Administrator, um Zugriff anzufordern.",
     "taskDetailsResetDiagramZoom": "Diagrammzoom zurücksetzen",
     "taskDetailsZoomInDiagram": "Diagramm vergrößern",
     "taskDetailsZoomOutDiagram": "Diagramm verkleinern",

--- a/tasklist/client/src/common/i18n/locales/en.json
+++ b/tasklist/client/src/common/i18n/locales/en.json
@@ -36,6 +36,7 @@
     "forbiddenPageTitle": "You don’t have access to this component",
     "forbiddenPageDesc": " It looks like you don’t have the necessary permissions to access this component. <strong>Please contact your cluster admin</strong> to request access.",
     "forbiddenPageLinkLabel": "Learn more about roles and permissions",
+    "taskActionForbidden": "You don't have the necessary permissions. Contact your admin to request access.",
     "taskDetailsResetDiagramZoom": "Reset diagram zoom",
     "taskDetailsZoomInDiagram": "Zoom in diagram",
     "taskDetailsZoomOutDiagram": "Zoom out diagram",

--- a/tasklist/client/src/common/i18n/locales/es.json
+++ b/tasklist/client/src/common/i18n/locales/es.json
@@ -36,6 +36,7 @@
     "forbiddenPageTitle": "No tienes acceso a este componente",
     "forbiddenPageDesc": "Parece que no tienes los permisos necesarios para acceder a este componente. <strong>Ponte en contacto con tu administrador de clúster</strong> para solicitar acceso.",
     "forbiddenPageLinkLabel": "Más información sobre roles y permisos",
+    "taskActionForbidden": "No tienes los permisos necesarios. Ponte en contacto con tu administrador para solicitar acceso.",
     "taskDetailsResetDiagramZoom": "Restablecer el zoom del diagrama",
     "taskDetailsZoomInDiagram": "Acercar el diagrama",
     "taskDetailsZoomOutDiagram": "Alejar el diagrama",

--- a/tasklist/client/src/common/i18n/locales/fr.json
+++ b/tasklist/client/src/common/i18n/locales/fr.json
@@ -36,6 +36,7 @@
     "forbiddenPageTitle": "Vous n'avez pas accès à ce composant",
     "forbiddenPageDesc": "Il semble que vous n'ayez pas les autorisations nécessaires pour accéder à ce composant. <strong>Veuillez contacter votre administrateur de cluster</strong> pour demander l'accès.",
     "forbiddenPageLinkLabel": "En savoir plus sur les rôles et les permissions",
+    "taskActionForbidden": "Vous ne disposez pas des autorisations nécessaires. Contactez votre administrateur pour demander l'accès.",
     "taskDetailsResetDiagramZoom": "Réinitialiser le zoom du diagramme",
     "taskDetailsZoomInDiagram": "Zoomer sur le diagramme",
     "taskDetailsZoomOutDiagram": "Dézoomer le diagramme",

--- a/tasklist/client/src/v2/TaskDetails/index.test.tsx
+++ b/tasklist/client/src/v2/TaskDetails/index.test.tsx
@@ -409,7 +409,7 @@ describe('<Task />', () => {
           return HttpResponse.json(
             taskMocks.assignedTask({
               userTaskKey: MOCK_USER_TASK_KEY,
-              formKey: null,
+              formKey: undefined,
             }),
           );
         },

--- a/tasklist/client/src/v2/TaskDetails/index.test.tsx
+++ b/tasklist/client/src/v2/TaskDetails/index.test.tsx
@@ -401,6 +401,91 @@ describe('<Task />', () => {
     ).toBeInTheDocument();
   });
 
+  it('should show error notification with subtitle on unauthorized task completion', async () => {
+    nodeMockServer.use(
+      http.get(
+        '/v2/user-tasks/:userTaskKey',
+        () => {
+          return HttpResponse.json(
+            taskMocks.assignedTask({
+              userTaskKey: MOCK_USER_TASK_KEY,
+              formKey: null,
+            }),
+          );
+        },
+        {once: true},
+      ),
+      http.get(
+        '/v2/authentication/me',
+        () => {
+          return HttpResponse.json(userMocks.currentUser);
+        },
+        {once: true},
+      ),
+      http.post(
+        '/v2/user-tasks/:userTaskKey/completion',
+        () => {
+          return HttpResponse.json(
+            {
+              type: 'about:blank',
+              title: 'FORBIDDEN',
+              status: 403,
+              detail:
+                "Unauthorized to perform operation 'UPDATE' on resource 'USER_TASK'",
+              instance: '/v2/user-tasks/0/completion',
+            },
+            {status: 403},
+          );
+        },
+        {once: true},
+      ),
+      http.post(
+        '/v2/user-tasks/:userTaskKey/effective-variables/search',
+        () => {
+          return HttpResponse.json(getQueryVariablesResponseMock([]));
+        },
+        {once: true},
+      ),
+      http.post(
+        '/v2/user-tasks/search',
+        async () => {
+          return HttpResponse.json(
+            getQueryTasksResponseMock(tasksMocks.unassignedTasks),
+          );
+        },
+        {once: true},
+      ),
+      http.get(
+        '/v2/process-definitions/:processDefinitionKey/xml',
+        async () => new HttpResponse(undefined, {status: 404}),
+      ),
+    );
+
+    const {user} = render(<Component />, {
+      wrapper: getWrapper(),
+    });
+
+    await user.click(
+      await screen.findByRole('button', {name: /complete task/i}),
+    );
+
+    expect(await screen.findByText('Completion failed')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(notificationsStore.displayNotification).toHaveBeenCalledWith({
+        kind: 'error',
+        title: 'Task could not be completed',
+        subtitle:
+          "You don't have the necessary permissions. Contact your admin to request access.",
+        isDismissable: true,
+      });
+    });
+
+    expect(
+      await screen.findByRole('button', {name: /complete task/i}),
+    ).toBeInTheDocument();
+  });
+
   it('should show a skeleton while loading', async () => {
     nodeMockServer.use(
       http.get(

--- a/tasklist/client/src/v2/TaskDetails/index.test.tsx
+++ b/tasklist/client/src/v2/TaskDetails/index.test.tsx
@@ -401,7 +401,7 @@ describe('<Task />', () => {
     ).toBeInTheDocument();
   });
 
-  it('should show error notification with subtitle on unauthorized task completion', async () => {
+  it('should show error notification with subtitle on forbidden task completion', async () => {
     nodeMockServer.use(
       http.get(
         '/v2/user-tasks/:userTaskKey',

--- a/tasklist/client/src/v2/TaskDetails/index.tsx
+++ b/tasklist/client/src/v2/TaskDetails/index.tsx
@@ -99,15 +99,24 @@ const TaskDetails: React.FC = observer(() => {
   async function handleSubmissionFailure(error: unknown) {
     const {data: parsedError, success} = requestErrorSchema.safeParse(error);
     if (success && parsedError.variant === 'failed-response') {
-      notificationsStore.displayNotification({
-        kind: 'error',
-        title: t('taskCouldNotBeCompletedNotification'),
-        subtitle: parseDenialReason(
-          await parsedError?.response?.json(),
-          'completion',
-        ),
-        isDismissable: true,
-      });
+      if (parsedError.response.status === 403) {
+        notificationsStore.displayNotification({
+          kind: 'error',
+          title: t('taskCouldNotBeCompletedNotification'),
+          subtitle: t('taskActionForbidden'),
+          isDismissable: true,
+        });
+      } else {
+        notificationsStore.displayNotification({
+          kind: 'error',
+          title: t('taskCouldNotBeCompletedNotification'),
+          subtitle: parseDenialReason(
+            await parsedError?.response?.json(),
+            'completion',
+          ),
+          isDismissable: true,
+        });
+      }
       return;
     }
 

--- a/tasklist/client/src/v2/TaskDetailsLayout/AssignButton/index.test.tsx
+++ b/tasklist/client/src/v2/TaskDetailsLayout/AssignButton/index.test.tsx
@@ -209,7 +209,7 @@ describe('AssignButton', () => {
     const {user} = render(
       <AssignButton
         id={mockUnassignedTask.userTaskKey}
-        assignee={null}
+        assignee={undefined}
         taskState={mockUnassignedTask.state}
         currentUser={currentUser.username}
       />,

--- a/tasklist/client/src/v2/TaskDetailsLayout/AssignButton/index.test.tsx
+++ b/tasklist/client/src/v2/TaskDetailsLayout/AssignButton/index.test.tsx
@@ -183,4 +183,100 @@ describe('AssignButton', () => {
       });
     });
   });
+
+  it('should show error notification with subtitle on unauthorized assignment', async () => {
+    const mockUnassignedTask = unassignedTask();
+
+    nodeMockServer.use(
+      http.post(
+        '/v2/user-tasks/:userTaskKey/assignment',
+        () =>
+          HttpResponse.json(
+            {
+              type: 'about:blank',
+              title: 'FORBIDDEN',
+              status: 403,
+              detail:
+                "Unauthorized to perform operation 'UPDATE' on resource 'USER_TASK'",
+              instance: '/v2/user-tasks/123/assignment',
+            },
+            {status: 403},
+          ),
+        {once: true},
+      ),
+    );
+
+    const {user} = render(
+      <AssignButton
+        id={mockUnassignedTask.userTaskKey}
+        assignee={null}
+        taskState={mockUnassignedTask.state}
+        currentUser={currentUser.username}
+      />,
+      {wrapper: getWrapper()},
+    );
+
+    await user.click(screen.getByRole('button', {name: 'Assign to me'}));
+
+    await waitFor(() => {
+      expect(notificationsStore.displayNotification).toHaveBeenCalledWith({
+        kind: 'error',
+        title: 'Task could not be assigned',
+        subtitle:
+          "You don't have the necessary permissions. Contact your admin to request access.",
+        isDismissable: true,
+      });
+    });
+
+    expect(
+      await screen.findByRole('button', {name: 'Assign to me'}),
+    ).toBeVisible();
+  });
+
+  it('should show error notification with subtitle on unauthorized unassignment', async () => {
+    const mockAssignedTask = assignedTask();
+
+    nodeMockServer.use(
+      http.delete(
+        '/v2/user-tasks/:userTaskKey/assignee',
+        () =>
+          HttpResponse.json(
+            {
+              type: 'about:blank',
+              title: 'FORBIDDEN',
+              status: 403,
+              detail:
+                "Unauthorized to perform operation 'UPDATE' on resource 'USER_TASK'",
+              instance: '/v2/user-tasks/123/assignee',
+            },
+            {status: 403},
+          ),
+        {once: true},
+      ),
+    );
+
+    const {user} = render(
+      <AssignButton
+        id={mockAssignedTask.userTaskKey}
+        assignee={currentUser.username}
+        taskState={mockAssignedTask.state}
+        currentUser={currentUser.username}
+      />,
+      {wrapper: getWrapper()},
+    );
+
+    await user.click(screen.getByRole('button', {name: 'Unassign'}));
+
+    await waitFor(() => {
+      expect(notificationsStore.displayNotification).toHaveBeenCalledWith({
+        kind: 'error',
+        title: 'Task could not be unassigned',
+        subtitle:
+          "You don't have the necessary permissions. Contact your admin to request access.",
+        isDismissable: true,
+      });
+    });
+
+    expect(await screen.findByRole('button', {name: 'Unassign'})).toBeVisible();
+  });
 });

--- a/tasklist/client/src/v2/TaskDetailsLayout/AssignButton/index.test.tsx
+++ b/tasklist/client/src/v2/TaskDetailsLayout/AssignButton/index.test.tsx
@@ -184,7 +184,7 @@ describe('AssignButton', () => {
     });
   });
 
-  it('should show error notification with subtitle on unauthorized assignment', async () => {
+  it('should show error notification with subtitle on forbidden assignment', async () => {
     const mockUnassignedTask = unassignedTask();
 
     nodeMockServer.use(

--- a/tasklist/client/src/v2/TaskDetailsLayout/AssignButton/index.tsx
+++ b/tasklist/client/src/v2/TaskDetailsLayout/AssignButton/index.tsx
@@ -96,8 +96,6 @@ const AssignButton: React.FC<Props> = ({
       const {data: parsedError, success} = requestErrorSchema.safeParse(error);
 
       if (success && parsedError.variant === 'failed-response') {
-        const errorData = await parsedError.response.json();
-
         if (parsedError.response.status === 403) {
           notificationsStore.displayNotification({
             kind: 'error',
@@ -109,7 +107,10 @@ const AssignButton: React.FC<Props> = ({
           notificationsStore.displayNotification({
             kind: 'error',
             title: t('taskDetailsTaskAssignmentError'),
-            subtitle: parseDenialReason(errorData, 'assignment'),
+            subtitle: parseDenialReason(
+              await parsedError.response.json(),
+              'assignment',
+            ),
             isDismissable: true,
           });
         }
@@ -153,7 +154,7 @@ const AssignButton: React.FC<Props> = ({
             kind: 'error',
             title: t('taskDetailsTaskUnassignmentError'),
             subtitle: parseDenialReason(
-              await parsedError?.response?.json(),
+              await parsedError.response.json(),
               'unassignment',
             ),
             isDismissable: true,

--- a/tasklist/client/src/v2/TaskDetailsLayout/AssignButton/index.tsx
+++ b/tasklist/client/src/v2/TaskDetailsLayout/AssignButton/index.tsx
@@ -98,16 +98,23 @@ const AssignButton: React.FC<Props> = ({
       if (success && parsedError.variant === 'failed-response') {
         const errorData = await parsedError.response.json();
 
-        notificationsStore.displayNotification({
-          kind: 'error',
-          title: t('taskDetailsTaskAssignmentError'),
-          subtitle: parseDenialReason(errorData, 'assignment'),
-          isDismissable: true,
-        });
-
-        if (errorData.title !== 'DEADLINE_EXCEEDED') {
-          setAssignmentStatus('off');
+        if (parsedError.response.status === 403) {
+          notificationsStore.displayNotification({
+            kind: 'error',
+            title: t('taskDetailsTaskAssignmentError'),
+            subtitle: t('taskActionForbidden'),
+            isDismissable: true,
+          });
+        } else {
+          notificationsStore.displayNotification({
+            kind: 'error',
+            title: t('taskDetailsTaskAssignmentError'),
+            subtitle: parseDenialReason(errorData, 'assignment'),
+            isDismissable: true,
+          });
         }
+
+        setAssignmentStatus('off');
         return;
       }
 
@@ -134,15 +141,26 @@ const AssignButton: React.FC<Props> = ({
       const {data: parsedError, success} = requestErrorSchema.safeParse(error);
 
       if (success && parsedError.variant === 'failed-response') {
-        notificationsStore.displayNotification({
-          kind: 'error',
-          title: t('taskDetailsTaskUnassignmentError'),
-          subtitle: parseDenialReason(
-            await parsedError?.response?.json(),
-            'unassignment',
-          ),
-          isDismissable: true,
-        });
+        if (parsedError.response.status === 403) {
+          notificationsStore.displayNotification({
+            kind: 'error',
+            title: t('taskDetailsTaskUnassignmentError'),
+            subtitle: t('taskActionForbidden'),
+            isDismissable: true,
+          });
+        } else {
+          notificationsStore.displayNotification({
+            kind: 'error',
+            title: t('taskDetailsTaskUnassignmentError'),
+            subtitle: parseDenialReason(
+              await parsedError?.response?.json(),
+              'unassignment',
+            ),
+            isDismissable: true,
+          });
+        }
+
+        setAssignmentStatus('off');
         return;
       }
 

--- a/tasklist/client/src/v2/api/useAssignTask.mutation.ts
+++ b/tasklist/client/src/v2/api/useAssignTask.mutation.ts
@@ -51,7 +51,7 @@ function useAssignTask() {
           requestErrorSchema.safeParse(error);
 
         if (success && parsedError.variant === 'failed-response') {
-          if (isTaskTimeoutError(await parsedError.response.json())) {
+          if (isTaskTimeoutError(await parsedError.response.clone().json())) {
             const currentTask = client.getQueryData<UserTask>(
               getUseTaskQueryKey(params.userTaskKey),
             );

--- a/tasklist/client/src/v2/api/useCompleteTask.mutation.ts
+++ b/tasklist/client/src/v2/api/useCompleteTask.mutation.ts
@@ -52,7 +52,7 @@ function useCompleteTask() {
           requestErrorSchema.safeParse(error);
 
         if (success && parsedError.variant === 'failed-response') {
-          if (isTaskTimeoutError(await parsedError.response.json())) {
+          if (isTaskTimeoutError(await parsedError.response.clone().json())) {
             const currentTask = client.getQueryData<UserTask>(
               getUseTaskQueryKey(params.userTaskKey),
             );


### PR DESCRIPTION
# Description
Backport of #49872 to `stable/8.8`.

relates to #37230