### PR TITLE
fix: use conservative memory tracking for exporter flush

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ExporterBatchWriter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ExporterBatchWriter.java
@@ -42,7 +42,7 @@ public final class ExporterBatchWriter {
   private final Map<ValueType, List<ExportHandler>> handlers;
   private final BiConsumer<String, Error> customErrorHandler;
   private final CamundaExporterMetrics metrics;
-  private long memoryEstimation = 0L;
+  private long totalMemoryEstimate = 0L;
 
   private ExporterBatchWriter(
       final Map<ValueType, List<ExportHandler>> handlers,
@@ -76,13 +76,9 @@ public final class ExporterBatchWriter {
       final Record<?> record, final ExportHandler handler, final String id, final long length) {
     final var cacheKey = new EntityIdAndEntityType(id, handler.getEntityType());
 
+    totalMemoryEstimate += length;
     final ExporterEntity entity =
-        cachedEntities.computeIfAbsent(
-            cacheKey,
-            (k) -> {
-              memoryEstimation += length;
-              return handler.createNewEntity(id);
-            });
+        cachedEntities.computeIfAbsent(cacheKey, (k) -> handler.createNewEntity(id));
 
     handler.updateEntity(record, entity);
     cachedRecordTimestamps.put(record.getPosition(), record.getTimestamp());
@@ -116,7 +112,7 @@ public final class ExporterBatchWriter {
   }
 
   public int getBatchMemoryEstimateInMb() {
-    return (int) (memoryEstimation / (1024 * 1024));
+    return (int) (totalMemoryEstimate / (1024 * 1024));
   }
 
   private void observeRecordTimestamps() {
@@ -134,10 +130,15 @@ public final class ExporterBatchWriter {
     return cachedEntitiesToFlush.size();
   }
 
+  @VisibleForTesting
+  long getMemoryEstimateInBytes() {
+    return totalMemoryEstimate;
+  }
+
   private void reset() {
     cachedEntities.clear();
     cachedEntitiesToFlush.clear();
-    memoryEstimation = 0;
+    totalMemoryEstimate = 0L;
   }
 
   private long recordSize(final Record<?> record) {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ExporterBatchWriterTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ExporterBatchWriterTest.java
@@ -161,4 +161,85 @@ class ExporterBatchWriterTest {
     assertThat(batchWriter.getBatchSize()).isEqualTo(0);
     assertThat(batchWriter.getEntitiesToFlushSize()).isEqualTo(0);
   }
+
+  @Test
+  void shouldTrackMemoryEstimateForNewEntity() {
+    // given
+    final TestRecord record = new TestRecord(0, NULL_VAL);
+    final String id = "1";
+    final TestExporterEntity entity = new TestExporterEntity().setId(id);
+    when(handler.handlesRecord(eq(record))).thenReturn(true);
+    when(handler.generateIds(eq(record))).thenReturn(List.of(id));
+    when(handler.createNewEntity(eq(id))).thenReturn(entity);
+
+    // when
+    batchWriter.addRecord(record);
+
+    // then
+    assertThat(batchWriter.getMemoryEstimateInBytes()).isGreaterThan(0);
+  }
+
+  @Test
+  void shouldAccumulateMemoryEstimateWhenSameEntityIsUpdatedByMultipleRecords() {
+    // given
+    final TestRecord record = new TestRecord(0, NULL_VAL);
+    final String id = "1";
+    final TestExporterEntity entity = new TestExporterEntity().setId(id);
+    when(handler.handlesRecord(eq(record))).thenReturn(true);
+    when(handler.generateIds(eq(record))).thenReturn(List.of(id));
+    when(handler.createNewEntity(eq(id))).thenReturn(entity);
+
+    batchWriter.addRecord(record);
+    final long estimateAfterFirstRecord = batchWriter.getMemoryEstimateInBytes();
+
+    // when — add the same record again (same entity)
+    batchWriter.addRecord(record);
+
+    // then — estimate should be the sum of both records' sizes
+    assertThat(batchWriter.getMemoryEstimateInBytes()).isEqualTo(2 * estimateAfterFirstRecord);
+  }
+
+  @Test
+  void shouldIncreaseMemoryEstimateForDistinctEntities() {
+    // given
+    final TestRecord record1 = new TestRecord(0, NULL_VAL);
+    final TestRecord record2 = new TestRecord(1, NULL_VAL);
+    final TestExporterEntity entity1 = new TestExporterEntity().setId("1");
+    final TestExporterEntity entity2 = new TestExporterEntity().setId("2");
+    when(handler.handlesRecord(any())).thenReturn(true);
+    when(handler.generateIds(eq(record1))).thenReturn(List.of("1"));
+    when(handler.generateIds(eq(record2))).thenReturn(List.of("2"));
+    when(handler.createNewEntity(eq("1"))).thenReturn(entity1);
+    when(handler.createNewEntity(eq("2"))).thenReturn(entity2);
+
+    batchWriter.addRecord(record1);
+    final long estimateAfterFirst = batchWriter.getMemoryEstimateInBytes();
+
+    // when
+    batchWriter.addRecord(record2);
+
+    // then — estimate should grow for a new entity
+    assertThat(batchWriter.getMemoryEstimateInBytes()).isGreaterThan(estimateAfterFirst);
+  }
+
+  @Test
+  void shouldResetMemoryEstimateAfterFlush() throws PersistenceException {
+    // given
+    final TestRecord record = new TestRecord(0, NULL_VAL);
+    final String id = "1";
+    final TestExporterEntity entity = new TestExporterEntity().setId(id);
+    when(handler.handlesRecord(eq(record))).thenReturn(true);
+    when(handler.generateIds(eq(record))).thenReturn(List.of(id));
+    when(handler.createNewEntity(eq(id))).thenReturn(entity);
+
+    batchWriter.addRecord(record);
+    assertThat(batchWriter.getMemoryEstimateInBytes()).isGreaterThan(0);
+
+    // when
+    final BatchRequest batchRequest = mock(BatchRequest.class);
+    batchWriter.flush(batchRequest);
+
+    // then
+    assertThat(batchWriter.getMemoryEstimateInBytes()).isEqualTo(0);
+  }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

[Observed](https://github.com/camunda/camunda/pull/49964#discussion_r3008777107) during review of another PR and could be a fix for the issue reported [here](https://github.com/camunda/camunda/issues/46239).

Right now we only update the tracked `memoryEstimation` if the entity is _not_ already in the cache. If an entity already exists in the cache, and then is later enriched with a lot more data on subsequent addition of a new record, this new data would not be reflected. This could be one explanation as to why we still see the reported error above.

To avoid any additional serialization, this PR defensively sums the serialized size of each contributing record to keep track of the entity size for writing. Basically, we favour overestimating and flushing early rather than underestimating and blocking the exporter.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
