### PR TITLE
deps: Downgrade surefire plugin version from 3.5.5 to 3.5.2

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -546,6 +546,19 @@
       "prBodyNotes": [
         "**Manual verification required before merging:** Check that [apache/maven-surefire#3203](https://github.com/apache/maven-surefire/issues/3203) (inner class test report bug in 3.5.4) is fixed in this version. Do **not** merge until confirmed."
       ]
+    },
+    {
+      "description": "maven-failsafe-plugin must be updated together with maven-surefire-plugin as they share a common codebase. See the surefire rule above for known issues blocking updates.",
+      "matchManagers": [
+        "maven"
+      ],
+      "matchPackageNames": [
+        "org.apache.maven.plugins:maven-failsafe-plugin"
+      ],
+      "automerge": false,
+      "prBodyNotes": [
+        "**Manual verification required before merging:** maven-failsafe-plugin must be updated together with maven-surefire-plugin. Check that [apache/maven-surefire#3203](https://github.com/apache/maven-surefire/issues/3203) (inner class test report bug in 3.5.4) and the ArchUnit issue in 3.5.3 are fixed before updating both plugins."
+      ]
     }
   ],
   "dockerfile": {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -224,7 +224,7 @@
     <plugin.version.dependency>3.10.0</plugin.version.dependency>
     <plugin.version.enforcer>3.6.2</plugin.version.enforcer>
     <plugin.version.exec>3.6.3</plugin.version.exec>
-    <plugin.version.failsafe>3.5.5</plugin.version.failsafe>
+    <plugin.version.failsafe>3.5.2</plugin.version.failsafe>
     <plugin.version.flaky-tests>2.1.1</plugin.version.flaky-tests>
     <plugin.version.jacoco>0.8.14</plugin.version.jacoco>
     <plugin.version.maven-jar>3.5.0</plugin.version.maven-jar>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -235,7 +235,7 @@
     <plugin.version.shade>3.6.2</plugin.version.shade>
     <plugin.version.sonar>3.9.1.2184</plugin.version.sonar>
     <plugin.version.spotbugs>4.9.8.3</plugin.version.spotbugs>
-    <plugin.version.surefire>3.5.5</plugin.version.surefire>
+    <plugin.version.surefire>3.5.2</plugin.version.surefire>
     <plugin.version.versions>2.21.0</plugin.version.versions>
     <plugin.version.frontend-maven>2.0.0</plugin.version.frontend-maven>
     <plugin.version.maven-source>3.4.0</plugin.version.maven-source>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Reverting https://github.com/camunda/camunda/pull/48629
See https://camunda.slack.com/archives/C071KP5BTHB/p1774947222718669

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
