### PR TITLE
Update stale backport prs

### DIFF
--- a/.ci/scripts/stale-backport-scripts/collect-stale-backports.sh
+++ b/.ci/scripts/stale-backport-scripts/collect-stale-backports.sh
@@ -126,7 +126,7 @@ for repo in "${REPO_LIST[@]}"; do
 
     if [[ "$is_draft" == "true" && "$has_conflict" == "false" ]]; then
       has_bc=$(gh pr view "$bp_num" --repo "$repo" --json commits \
-        --jq '[.commits[].messageHeadline] | any(. == "BACKPORT-CONFLICT")' 2>/dev/null || echo "false")
+        --jq '[.commits[].messageHeadline] | any(test("BACKPORT-CONFLICT"))' 2>/dev/null || echo "false")
       echo "$bp" | jq -c --argjson bc "$has_bc" '.has_conflict = (.has_conflict or $bc)'
     else
       echo "$bp"

--- a/.ci/scripts/stale-backport-scripts/collect-stale-backports.sh
+++ b/.ci/scripts/stale-backport-scripts/collect-stale-backports.sh
@@ -9,12 +9,12 @@
 # Optional env vars:
 #   REPOSITORIES          - Comma-separated list of owner/repo to scan (default: $GITHUB_REPOSITORY)
 #   GITHUB_REPOSITORY     - Fallback when REPOSITORIES is not set
-#   STALE_HOURS_THRESHOLD - Hours after which a backport PR is considered stale (default: 24)
+#   STALE_HOURS_THRESHOLD - Hours after which a backport PR is considered stale (default: 6)
 #   TARGET_BRANCH         - Filter to a specific stable branch (e.g. "stable/8.8"), empty = all
 
 set -euo pipefail
 
-STALE_HOURS_THRESHOLD="${STALE_HOURS_THRESHOLD:-24}"
+STALE_HOURS_THRESHOLD="${STALE_HOURS_THRESHOLD:-6}"
 TARGET_BRANCH="${TARGET_BRANCH:-}"
 
 # Build list of repositories to scan

--- a/.github/workflows/stale-backport-tracker.yml
+++ b/.github/workflows/stale-backport-tracker.yml
@@ -35,10 +35,10 @@ on:
       stale_hours_threshold:
         description: 'Hours after which a backport PR is considered stale'
         required: false
-        default: '24'
+        default: '6'
         type: string
       slack_channel_id:
-        description: 'Slack channel ID to post the report to. Required for manual runs — the default #top-monorepo-release channel is only used by the scheduled cron trigger.'
+        description: 'Slack channel ID to post the report to. Required for manual runs — the default #top-monorepo-ci channel is only used by the scheduled cron trigger.'
         required: false
         default: ''
         type: string
@@ -67,10 +67,10 @@ on:
       stale_hours_threshold:
         description: 'Hours after which a backport PR is considered stale'
         required: false
-        default: '24'
+        default: '6'
         type: string
       slack_channel_id:
-        description: 'Slack channel ID to post the report to. Required when notify_slack is true — the default #top-monorepo-release channel is only used by the scheduled cron trigger.'
+        description: 'Slack channel ID to post the report to. Required when notify_slack is true — the default #top-monorepo-ci channel is only used by the scheduled cron trigger.'
         required: false
         default: ''
         type: string
@@ -114,7 +114,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.github-token.outputs.token }}
           REPOSITORIES: "camunda/camunda,camunda/zeebe-process-test"
-          STALE_HOURS_THRESHOLD: ${{ inputs.stale_hours_threshold || '3' }}
+          STALE_HOURS_THRESHOLD: ${{ inputs.stale_hours_threshold || '6' }}
           TARGET_BRANCH: ${{ inputs.target_branch || '' }}
         run: |
           chmod +x .ci/scripts/stale-backport-scripts/collect-stale-backports.sh
@@ -212,7 +212,7 @@ jobs:
           exportEnv: false
           secrets: |
              secret/data/products/camunda/ci/github-actions SLACK_C8_MONOREPO_NOTIFICATIONS_BOT_TOKEN;
-             secret/data/products/camunda/ci/github-actions SLACK_TOPMONOREPORELEASE_CHANNEL_ID;
+             secret/data/products/camunda/ci/github-actions SLACK_TOPMONOREPOCI_CHANNEL_ID;
 
       - name: Resolve Slack user IDs
         id: slack-users
@@ -258,7 +258,7 @@ jobs:
         continue-on-error: true
         env:
           SLACK_BOT_TOKEN: ${{ steps.secrets.outputs.SLACK_C8_MONOREPO_NOTIFICATIONS_BOT_TOKEN }}
-          SLACK_CHANNEL: ${{ inputs.slack_channel_id || steps.secrets.outputs.SLACK_TOPMONOREPORELEASE_CHANNEL_ID }}
+          SLACK_CHANNEL: ${{ inputs.slack_channel_id || steps.secrets.outputs.SLACK_TOPMONOREPOCI_CHANNEL_ID }}
         run: |
           # Look for the bot's most recent "Stale Backport PRs" message posted today (since midnight UTC)
           oldest=$(date -u -d 'today 00:00:00' +%s 2>/dev/null || date -u -v0H -v0M -v0S +%s)
@@ -295,28 +295,71 @@ jobs:
           method: chat.update
           token: ${{ steps.secrets.outputs.SLACK_C8_MONOREPO_NOTIFICATIONS_BOT_TOKEN }}
           payload: |
-            channel: "${{ inputs.slack_channel_id || steps.secrets.outputs.SLACK_TOPMONOREPORELEASE_CHANNEL_ID }}"
+            channel: "${{ inputs.slack_channel_id || steps.secrets.outputs.SLACK_TOPMONOREPOCI_CHANNEL_ID }}"
             ts: "${{ steps.find-message.outputs.message_ts }}"
             text: "Stale backport report"
             blocks: ${{ toJSON(fromJSON(steps.format.outputs.payload).blocks) }}
 
+      - name: Unpin previous day's Slack message
+        if: steps.find-message.outputs.found != 'true'
+        continue-on-error: true
+        env:
+          SLACK_BOT_TOKEN: ${{ steps.secrets.outputs.SLACK_C8_MONOREPO_NOTIFICATIONS_BOT_TOKEN }}
+          SLACK_CHANNEL: ${{ inputs.slack_channel_id || steps.secrets.outputs.SLACK_TOPMONOREPOCI_CHANNEL_ID }}
+        run: |
+          pinned=$(curl -sf \
+            -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+            "https://slack.com/api/pins.list?channel=${SLACK_CHANNEL}")
+          echo "pins.list ok: $(echo "$pinned" | jq -r '.ok')" >&2
+          echo "$pinned" | jq -r '
+            [(.items // [])[] | select(
+              .type == "message" and
+              .message.bot_id != null and
+              (.message.blocks[]?.text?.text? // "" | test("Stale Backport PRs"))
+            ) | .message.ts] | .[]' | while read -r ts; do
+            echo "Unpinning old message: $ts" >&2
+            curl -sf -X POST "https://slack.com/api/pins.remove" \
+              -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+              -H "Content-Type: application/json" \
+              -d "{\"channel\":\"${SLACK_CHANNEL}\",\"timestamp\":\"${ts}\"}"
+          done
+
       - name: Post new Slack message
         if: steps.find-message.outputs.found != 'true'
+        id: post-message
         uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         continue-on-error: true
         with:
           method: chat.postMessage
           token: ${{ steps.secrets.outputs.SLACK_C8_MONOREPO_NOTIFICATIONS_BOT_TOKEN }}
           payload: |
-            channel: "${{ inputs.slack_channel_id || steps.secrets.outputs.SLACK_TOPMONOREPORELEASE_CHANNEL_ID }}"
+            channel: "${{ inputs.slack_channel_id || steps.secrets.outputs.SLACK_TOPMONOREPOCI_CHANNEL_ID }}"
             text: "Stale backport report"
             blocks: ${{ toJSON(fromJSON(steps.format.outputs.payload).blocks) }}
+
+      - name: Pin new Slack message
+        if: steps.find-message.outputs.found != 'true'
+        continue-on-error: true
+        env:
+          SLACK_BOT_TOKEN: ${{ steps.secrets.outputs.SLACK_C8_MONOREPO_NOTIFICATIONS_BOT_TOKEN }}
+          SLACK_CHANNEL: ${{ inputs.slack_channel_id || steps.secrets.outputs.SLACK_TOPMONOREPOCI_CHANNEL_ID }}
+          POST_RESPONSE: ${{ steps.post-message.outputs.response }}
+        run: |
+          message_ts=$(echo "$POST_RESPONSE" | jq -r '.ts // empty')
+          if [[ -z "$message_ts" ]]; then
+            echo "No message ts in response, skipping pin" >&2
+            exit 0
+          fi
+          curl -sf -X POST "https://slack.com/api/pins.add" \
+            -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "{\"channel\":\"${SLACK_CHANNEL}\",\"timestamp\":\"${message_ts}\"}"
 
       - name: Log notification status
         if: always()
         run: |
           total="${{ needs.collect-stale-backports.outputs.total_stale }}"
-          echo "::notice::Stale backport report: ${total} stale PR(s) posted to #top-monorepo-release"
+          echo "::notice::Stale backport report: ${total} stale PR(s) posted to #top-monorepo-ci"
 
       - name: Observe build status
         if: always()

--- a/.github/workflows/stale-backport-tracker.yml
+++ b/.github/workflows/stale-backport-tracker.yml
@@ -287,10 +287,18 @@ jobs:
             pinned_response=$(curl -s \
               -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
               "https://slack.com/api/pins.list?channel=${SLACK_CHANNEL}")
-            is_pinned=$(echo "$pinned_response" | jq -r --arg ts "$message_ts" '
-              [(.items // [])[] | select(.type == "message" and .message.ts == $ts)] | length | . > 0')
-            echo "Message is already pinned: $is_pinned" >&2
-            echo "is_pinned=$is_pinned" >> "$GITHUB_OUTPUT"
+            pins_ok=$(echo "$pinned_response" | jq -r '.ok')
+            pins_error=$(echo "$pinned_response" | jq -r '.error // "none"')
+            echo "pins.list ok: $pins_ok, error: $pins_error" >&2
+            if [[ "$pins_ok" != "true" ]]; then
+              echo "pins.list failed — defaulting is_pinned=false" >&2
+              echo "is_pinned=false" >> "$GITHUB_OUTPUT"
+            else
+              is_pinned=$(echo "$pinned_response" | jq -r --arg ts "$message_ts" '
+                [(.items // [])[] | select(.type == "message" and .message.ts == $ts)] | length | . > 0')
+              echo "Message is already pinned: $is_pinned" >&2
+              echo "is_pinned=$is_pinned" >> "$GITHUB_OUTPUT"
+            fi
           else
             echo "No existing message found — will post new" >&2
             echo "found=false" >> "$GITHUB_OUTPUT"
@@ -318,10 +326,14 @@ jobs:
           SLACK_CHANNEL: ${{ inputs.slack_channel_id || steps.secrets.outputs.SLACK_TOPMONOREPOCI_CHANNEL_ID }}
           MESSAGE_TS: ${{ steps.find-message.outputs.message_ts }}
         run: |
-          curl -sf -X POST "https://slack.com/api/pins.add" \
+          response=$(curl -s -X POST "https://slack.com/api/pins.add" \
             -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
             -H "Content-Type: application/json" \
-            -d "{\"channel\":\"${SLACK_CHANNEL}\",\"timestamp\":\"${MESSAGE_TS}\"}"
+            -d "{\"channel\":\"${SLACK_CHANNEL}\",\"timestamp\":\"${MESSAGE_TS}\"}") 
+          ok=$(echo "$response" | jq -r '.ok')
+          err=$(echo "$response" | jq -r '.error // "none"')
+          echo "pins.add ok: $ok, error: $err" >&2
+          [[ "$ok" == "true" || "$err" == "already_pinned" ]]
 
       - name: Unpin previous day's Slack message
         if: steps.find-message.outputs.found != 'true'
@@ -330,10 +342,15 @@ jobs:
           SLACK_BOT_TOKEN: ${{ steps.secrets.outputs.SLACK_C8_MONOREPO_NOTIFICATIONS_BOT_TOKEN }}
           SLACK_CHANNEL: ${{ inputs.slack_channel_id || steps.secrets.outputs.SLACK_TOPMONOREPOCI_CHANNEL_ID }}
         run: |
-          pinned=$(curl -sf \
+          pinned=$(curl -s \
             -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
             "https://slack.com/api/pins.list?channel=${SLACK_CHANNEL}")
-          echo "pins.list ok: $(echo "$pinned" | jq -r '.ok')" >&2
+          pins_ok=$(echo "$pinned" | jq -r '.ok')
+          echo "pins.list ok: $pins_ok, error: $(echo "$pinned" | jq -r '.error // "none"')" >&2
+          if [[ "$pins_ok" != "true" ]]; then
+            echo "pins.list failed — skipping unpin" >&2
+            exit 0
+          fi
           echo "$pinned" | jq -r '
             [(.items // [])[] | select(
               .type == "message" and
@@ -341,10 +358,11 @@ jobs:
               (.message.blocks[]?.text?.text? // "" | test("Stale Backport PRs"))
             ) | .message.ts] | .[]' | while read -r ts; do
             echo "Unpinning old message: $ts" >&2
-            curl -sf -X POST "https://slack.com/api/pins.remove" \
+            resp=$(curl -s -X POST "https://slack.com/api/pins.remove" \
               -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
               -H "Content-Type: application/json" \
-              -d "{\"channel\":\"${SLACK_CHANNEL}\",\"timestamp\":\"${ts}\"}"
+              -d "{\"channel\":\"${SLACK_CHANNEL}\",\"timestamp\":\"${ts}\"}") 
+            echo "pins.remove ok: $(echo "$resp" | jq -r '.ok'), error: $(echo "$resp" | jq -r '.error // "none"')" >&2
           done
 
       - name: Post new Slack message
@@ -373,16 +391,14 @@ jobs:
             echo "No message ts in response, skipping pin" >&2
             exit 0
           fi
-          curl -sf -X POST "https://slack.com/api/pins.add" \
+          response=$(curl -s -X POST "https://slack.com/api/pins.add" \
             -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
             -H "Content-Type: application/json" \
-            -d "{\"channel\":\"${SLACK_CHANNEL}\",\"timestamp\":\"${message_ts}\"}"
-
-      - name: Log notification status
-        if: always()
-        run: |
-          total="${{ needs.collect-stale-backports.outputs.total_stale }}"
-          echo "::notice::Stale backport report: ${total} stale PR(s) posted to #top-monorepo-ci"
+            -d "{\"channel\":\"${SLACK_CHANNEL}\",\"timestamp\":\"${message_ts}\"}") 
+          ok=$(echo "$response" | jq -r '.ok')
+          err=$(echo "$response" | jq -r '.error // "none"')
+          echo "pins.add ok: $ok, error: $err" >&2
+          [[ "$ok" == "true" || "$err" == "already_pinned" ]]
 
       - name: Observe build status
         if: always()

--- a/.github/workflows/stale-backport-tracker.yml
+++ b/.github/workflows/stale-backport-tracker.yml
@@ -260,8 +260,8 @@ jobs:
           SLACK_BOT_TOKEN: ${{ steps.secrets.outputs.SLACK_C8_MONOREPO_NOTIFICATIONS_BOT_TOKEN }}
           SLACK_CHANNEL: ${{ inputs.slack_channel_id || steps.secrets.outputs.SLACK_TOPMONOREPORELEASE_CHANNEL_ID }}
         run: |
-          # Look for the bot's most recent "Stale Backport PRs" message in the channel (last 24h)
-          oldest=$(date -u -d '24 hours ago' +%s 2>/dev/null || date -u -v-24H +%s)
+          # Look for the bot's most recent "Stale Backport PRs" message posted today (since midnight UTC)
+          oldest=$(date -u -d 'today 00:00:00' +%s 2>/dev/null || date -u -v0H -v0M -v0S +%s)
           response=$(curl -s \
             -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
             "https://slack.com/api/conversations.history?channel=${SLACK_CHANNEL}&oldest=${oldest}&limit=50")

--- a/.github/workflows/stale-backport-tracker.yml
+++ b/.github/workflows/stale-backport-tracker.yml
@@ -282,9 +282,19 @@ jobs:
             echo "Found existing message: $message_ts — will update" >&2
             echo "message_ts=$message_ts" >> "$GITHUB_OUTPUT"
             echo "found=true" >> "$GITHUB_OUTPUT"
+
+            # Check if the existing message is already pinned
+            pinned_response=$(curl -s \
+              -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+              "https://slack.com/api/pins.list?channel=${SLACK_CHANNEL}")
+            is_pinned=$(echo "$pinned_response" | jq -r --arg ts "$message_ts" '
+              [(.items // [])[] | select(.type == "message" and .message.ts == $ts)] | length | . > 0')
+            echo "Message is already pinned: $is_pinned" >&2
+            echo "is_pinned=$is_pinned" >> "$GITHUB_OUTPUT"
           else
             echo "No existing message found — will post new" >&2
             echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "is_pinned=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Update existing Slack message
@@ -299,6 +309,19 @@ jobs:
             ts: "${{ steps.find-message.outputs.message_ts }}"
             text: "Stale backport report"
             blocks: ${{ toJSON(fromJSON(steps.format.outputs.payload).blocks) }}
+
+      - name: Pin existing Slack message if not already pinned
+        if: steps.find-message.outputs.found == 'true' && steps.find-message.outputs.is_pinned == 'false'
+        continue-on-error: true
+        env:
+          SLACK_BOT_TOKEN: ${{ steps.secrets.outputs.SLACK_C8_MONOREPO_NOTIFICATIONS_BOT_TOKEN }}
+          SLACK_CHANNEL: ${{ inputs.slack_channel_id || steps.secrets.outputs.SLACK_TOPMONOREPOCI_CHANNEL_ID }}
+          MESSAGE_TS: ${{ steps.find-message.outputs.message_ts }}
+        run: |
+          curl -sf -X POST "https://slack.com/api/pins.add" \
+            -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "{\"channel\":\"${SLACK_CHANNEL}\",\"timestamp\":\"${MESSAGE_TS}\"}"
 
       - name: Unpin previous day's Slack message
         if: steps.find-message.outputs.found != 'true'


### PR DESCRIPTION
## Description

*Changes in this update*

*Channel*
• Moved Slack target from `#top-monorepo-release` to `#top-monorepo-ci`. The channel ID is now read from Vault (`SLACK_TOPMONOREPOCI_CHANNEL_ID`)

*Stale threshold*
• Default lowered from *24h → 6h* across: `workflow_dispatch` input default, `workflow_call` input default, scheduled-run fallback, and `collect-stale-backports.sh` script default.

*Slack report pinning*
• First run each day: previous days' pinned bot messages are *unpinned*, then the new message is *pinned* after posting.
• Subsequent runs same day (update path): the existing message is updated in-place. If for any reason it is not already pinned, it is *re-pinned*.

*How to test manually*
```
gh workflow run stale-backport-tracker.yml \
  --ref collect-stale-backport-prs \
  --field notify_slack=true \
  --field notify_github=false \
  --field dry_run=false \
  --field slack_channel_id=<your-public-test-channel-id>
```

Tested on [test-public-channel](https://camunda.slack.com/archives/C0AN1P08K6K/p1774944686258329) with workflow run of https://github.com/camunda/camunda/actions/runs/23789671315/job/69321752798
## Related issues
https://github.com/camunda/camunda/issues/40006
