### PR TITLE
feat: configure minimumReleaseAge for renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -559,6 +559,13 @@
       "prBodyNotes": [
         "**Manual verification required before merging:** maven-failsafe-plugin must be updated together with maven-surefire-plugin. Check that [apache/maven-surefire#3203](https://github.com/apache/maven-surefire/issues/3203) (inner class test report bug in 3.5.4) and the ArchUnit issue in 3.5.3 are fixed before updating both plugins."
       ]
+    },
+    {
+      "description": "Prevent supply-chain-attacks by not creating branches or PRs before the minimum release age.",
+      "matchPackageNames": ["*"],
+      "minimumReleaseAge": "3 days",
+      "prCreation": "not-pending",
+      "internalChecksFilter": "strict"
     }
   ],
   "dockerfile": {

--- a/c8run/e2e_tests/.npmrc
+++ b/c8run/e2e_tests/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=3

--- a/client-components/.npmrc
+++ b/client-components/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=3

--- a/identity/client/.npmrc
+++ b/identity/client/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=3

--- a/monorepo-docs-site/.npmrc
+++ b/monorepo-docs-site/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=3

--- a/operate/client/.npmrc
+++ b/operate/client/.npmrc
@@ -1,1 +1,2 @@
 install-links=true
+min-release-age=3

--- a/optimize/c4/.yarnrc.yml
+++ b/optimize/c4/.yarnrc.yml
@@ -1,1 +1,2 @@
 nodeLinker: node-modules
+npmMinimalAgeGate: "3d"

--- a/optimize/client/.yarnrc.yml
+++ b/optimize/client/.yarnrc.yml
@@ -1,0 +1,1 @@
+npmMinimalAgeGate: "3d"

--- a/qa/c8-orchestration-cluster-e2e-test-suite/.npmrc
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=3

--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/.npmrc
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=3

--- a/scripts/codeowners-utils/.npmrc
+++ b/scripts/codeowners-utils/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=3

--- a/tasklist/client/.npmrc
+++ b/tasklist/client/.npmrc
@@ -1,1 +1,2 @@
 install-links=true
+min-release-age=3

--- a/testing/camunda-process-test-coverage-frontend/.npmrc
+++ b/testing/camunda-process-test-coverage-frontend/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=3


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Given the latest supply-chain-attacks (e.g. [axios](https://www.stepsecurity.io/blog/axios-compromised-on-npm-malicious-versions-drop-remote-access-trojan), [litellm](https://cyberinsider.com/new-supply-chain-attack-hits-litellm-with-95m-monthly-downloads/)) I came across a very neat configuration for renovate called `minimumReleaseAge`.
As in both mentioned cases infected packages were removed from registries within hours, this setting would effectively protect from these kinds of attacks.

see: https://docs.renovatebot.com/configuration-options/#minimumreleaseage

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
