### PR TITLE
fix: use batch operation key when resuming batch operations

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationLifecycleManagementResumeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationLifecycleManagementResumeProcessor.java
@@ -145,7 +145,7 @@ public final class BatchOperationLifecycleManagementResumeProcessor
           "Processing distributed command to resume with key '{}': {}",
           batchOperationKey,
           recordValue);
-      resumeBatchOperation(command.getKey(), batchOperation.get(), recordValue);
+      resumeBatchOperation(batchOperationKey, batchOperation.get(), recordValue);
     } else {
       LOGGER.debug(
           "Distributed command to resume a batch operation with key '{}' will be ignored: {}",


### PR DESCRIPTION
## Description

Use `batchOperationKey` for resume batch operation events. Fixes the inconsistency within the audit log for batch operation lifecycle entity keys.

A regression test was added to `BatchOperationLifecycleManagementResumeProcessorTest` covering the `processDistributedCommand` path, asserting that `stateWriter.appendFollowUpEvent(...)` is called with `batchOperationKey` and not `command.getKey()`.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

related to #49513