### PR TITLE
[Backport stable/8.9] fix: remove all registered meters when closing exporter metrics

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
@@ -26,8 +26,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class CamundaExporterMetrics implements AutoCloseable {
-  private static final String NAMESPACE = "zeebe.camunda.exporter";
 
+  private static final String NAMESPACE = "zeebe.camunda.exporter";
+  private static final String SINCE_LAST_FLUSH_SECONDS_METER_NAME =
+      meterName("since.last.flush.seconds");
+  private static final String PROCESS_INSTANCES_AWAITING_ARCHIVAL_METER_NAME =
+      meterName("process.instances.awaiting.archival");
+  private static final String FLUSH_FAILURE_TYPE_METER_NAME = meterName("flush.failure.type");
   private final MeterRegistry meterRegistry;
   private final InstantSource streamClock;
 
@@ -275,12 +280,12 @@ public class CamundaExporterMetrics implements AutoCloseable {
             .register(meterRegistry);
 
     TimeGauge.builder(
-            meterName("since.last.flush.seconds"), this::secondSinceLastFlush, TimeUnit.SECONDS)
+            SINCE_LAST_FLUSH_SECONDS_METER_NAME, this::secondSinceLastFlush, TimeUnit.SECONDS)
         .description("Time in seconds since the last successful flush")
         .register(meterRegistry);
 
     Gauge.builder(
-            meterName("process.instances.awaiting.archival"),
+            PROCESS_INSTANCES_AWAITING_ARCHIVAL_METER_NAME,
             processInstancesAwaitingArchival,
             AtomicInteger::get)
         .description("Number of process instances awaiting archival (approximate)")
@@ -387,7 +392,7 @@ public class CamundaExporterMetrics implements AutoCloseable {
   }
 
   public void recordFlushFailureType(final String failureType) {
-    meterRegistry.counter(meterName("flush.failure.type"), "failure_type", failureType).increment();
+    meterRegistry.counter(FLUSH_FAILURE_TYPE_METER_NAME, "failure_type", failureType).increment();
   }
 
   private double secondSinceLastFlush() {
@@ -415,7 +420,7 @@ public class CamundaExporterMetrics implements AutoCloseable {
         .forEach(duration -> recordExportDuration.record(duration, TimeUnit.MILLISECONDS));
   }
 
-  private String meterName(final String name) {
+  private static String meterName(final String name) {
     return NAMESPACE + "." + name;
   }
 
@@ -470,9 +475,11 @@ public class CamundaExporterMetrics implements AutoCloseable {
     meterRegistry.remove(auditLogsArchiving);
     meterRegistry.remove(auditLogsArchived);
 
+    meterRegistry.find(FLUSH_FAILURE_TYPE_METER_NAME).meters().forEach(meterRegistry::remove);
+
     // Remove custom gauges by their names if needed
-    removeGaugeIfExists(meterName("since.last.flush.seconds"));
-    removeGaugeIfExists(meterName("process.instances.awaiting.archival"));
+    removeGaugeIfExists(SINCE_LAST_FLUSH_SECONDS_METER_NAME);
+    removeGaugeIfExists(PROCESS_INSTANCES_AWAITING_ARCHIVAL_METER_NAME);
   }
 
   private void removeGaugeIfExists(final String meterName) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
@@ -461,6 +461,14 @@ public class CamundaExporterMetrics implements AutoCloseable {
     meterRegistry.remove(incidentUpdatesDocumentsUpdated);
     meterRegistry.remove(jobBatchMetricsArchiving);
     meterRegistry.remove(jobBatchMetricsArchived);
+    meterRegistry.remove(usageMetricsArchived);
+    meterRegistry.remove(usageMetricsArchiving);
+    meterRegistry.remove(usageMetricsTUArchived);
+    meterRegistry.remove(usageMetricsTUArchiving);
+    meterRegistry.remove(standaloneDecisionsArchiving);
+    meterRegistry.remove(standaloneDecisionsArchived);
+    meterRegistry.remove(auditLogsArchiving);
+    meterRegistry.remove(auditLogsArchived);
 
     // Remove custom gauges by their names if needed
     removeGaugeIfExists(meterName("since.last.flush.seconds"));

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/metrics/CamundaExporterMetricsTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/metrics/CamundaExporterMetricsTest.java
@@ -53,6 +53,11 @@ final class CamundaExporterMetricsTest {
   void shouldRemoveAllRegisteredMetersOnClose() {
     // given
     final var metrics = new CamundaExporterMetrics(registry, Instant::now);
+
+    // this will dynamically create meters
+    metrics.recordFlushFailureType("failure1");
+    metrics.recordFlushFailureType("failure2");
+
     assertThat(registry.getMeters()).isNotEmpty();
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/metrics/CamundaExporterMetricsTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/metrics/CamundaExporterMetricsTest.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.metrics;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
 import java.time.Instant;
@@ -46,5 +47,19 @@ final class CamundaExporterMetricsTest {
     assertThat(buckets[1].count())
         .as("then all values are in the next bucket <= 10ms")
         .isEqualTo(4);
+  }
+
+  @Test
+  void shouldRemoveAllRegisteredMetersOnClose() {
+    // given
+    final var metrics = new CamundaExporterMetrics(registry, Instant::now);
+    assertThat(registry.getMeters()).isNotEmpty();
+
+    // when
+    metrics.close();
+
+    // then
+    final var meterIds = registry.getMeters().stream().map(Meter::getId).toList();
+    assertThat(meterIds).isEmpty();
   }
 }


### PR DESCRIPTION
# Description
Backport of #49711 to `stable/8.9`.

relates to 