### PR TITLE
[Backport stable/8.8] feat: add disabledQueries config to filter out read benchmark queries

### DIFF
--- a/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/Starter.java
+++ b/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/Starter.java
@@ -176,7 +176,7 @@ public class Starter extends App {
             registry,
             Executors.newScheduledThreadPool(2),
             client,
-            DataReadMeterQueryProvider.getDefaultQueries());
+            DataReadMeterQueryProvider.getDefaultQueries(config.getDisabledQueriesList()));
     dataReadMeter.setContextProcessDefinitionId(starterCfg.getProcessId());
     dataReadMeter.setContextBusinessKeySupplier(
         () ->

--- a/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/config/AppCfg.java
+++ b/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/config/AppCfg.java
@@ -8,6 +8,8 @@
 package io.camunda.zeebe.config;
 
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
 
 public class AppCfg {
 
@@ -21,6 +23,8 @@ public class AppCfg {
   private boolean monitorDataAvailability = true;
   private Duration monitorDataAvailabilityInterval = Duration.ofMillis(250);
   private boolean performReadBenchmarks = false;
+
+  private String disabledQueries = "";
 
   public String getBrokerUrl() {
     return brokerUrl;
@@ -100,5 +104,23 @@ public class AppCfg {
 
   public void setPerformReadBenchmarks(final boolean performReadBenchmarks) {
     this.performReadBenchmarks = performReadBenchmarks;
+  }
+
+  public String getDisabledQueries() {
+    return disabledQueries;
+  }
+
+  public void setDisabledQueries(final String disabledQueries) {
+    this.disabledQueries = disabledQueries;
+  }
+
+  public List<String> getDisabledQueriesList() {
+    if (disabledQueries == null || disabledQueries.isBlank()) {
+      return List.of();
+    }
+    return Arrays.stream(disabledQueries.split(","))
+        .map(String::trim)
+        .filter(s -> !s.isBlank())
+        .toList();
   }
 }

--- a/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/read/DataReadMeterQueryProvider.java
+++ b/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/read/DataReadMeterQueryProvider.java
@@ -11,12 +11,17 @@ import io.camunda.client.api.search.enums.ProcessInstanceState;
 import io.camunda.client.api.search.sort.ProcessInstanceSort;
 import io.camunda.zeebe.read.DataReadMeter.ReadQuery;
 import java.time.Duration;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
 public final class DataReadMeterQueryProvider {
 
   private DataReadMeterQueryProvider() {}
+
+  public static List<ReadQuery> getDefaultQueries(final Collection<String> disabledQueries) {
+    return getDefaultQueries().stream().filter(q -> !disabledQueries.contains(q.name())).toList();
+  }
 
   public static List<ReadQuery> getDefaultQueries() {
     return List.of(

--- a/zeebe/benchmarks/project/src/main/resources/application.conf
+++ b/zeebe/benchmarks/project/src/main/resources/application.conf
@@ -10,6 +10,8 @@ app {
   monitorDataAvailability = true
   monitorDataAvailabilityInterval = 250ms
   performReadBenchmarks = false
+  disabledQueries = ""
+  disabledQueries = ${?ZEEBE_DISABLED_QUERIES}
 
   auth {
     type = "NONE" # NONE, BASIC

--- a/zeebe/benchmarks/project/src/test/java/io/camunda/zeebe/config/ConfigTest.java
+++ b/zeebe/benchmarks/project/src/test/java/io/camunda/zeebe/config/ConfigTest.java
@@ -30,6 +30,7 @@ public class ConfigTest {
     assertThat(appCfg.isMonitorDataAvailability()).isTrue();
     assertThat(appCfg.getMonitorDataAvailabilityInterval()).hasMillis(250);
     assertThat(appCfg.isPerformReadBenchmarks()).isFalse();
+    assertThat(appCfg.getDisabledQueriesList()).isEmpty();
 
     // authentication
     final var authCfg = appCfg.getAuth();
@@ -87,6 +88,8 @@ public class ConfigTest {
     assertThat(appCfg.isMonitorDataAvailability()).isFalse();
     assertThat(appCfg.getMonitorDataAvailabilityInterval()).hasMillis(50);
     assertThat(appCfg.isPerformReadBenchmarks()).isTrue();
+    assertThat(appCfg.getDisabledQueriesList())
+        .containsExactlyInAnyOrder("process_instances_active", "audit_log_by_category");
 
     // authentication
     final var authCfg = appCfg.getAuth();
@@ -168,5 +171,31 @@ public class ConfigTest {
 
     // then
     assertThat(ratePerSecond).isEqualTo(0.5);
+  }
+
+  @Test
+  public void shouldParseDisabledQueriesFromCommaSeparatedString() {
+    // given
+    final var appCfg = new AppCfg();
+    appCfg.setDisabledQueries("query_a, query_b ,query_c");
+
+    // when
+    final var result = appCfg.getDisabledQueriesList();
+
+    // then
+    assertThat(result).containsExactly("query_a", "query_b", "query_c");
+  }
+
+  @Test
+  public void shouldReturnEmptyListForBlankDisabledQueries() {
+    // given
+    final var appCfg = new AppCfg();
+    appCfg.setDisabledQueries(",,");
+
+    // when
+    final var result = appCfg.getDisabledQueriesList();
+
+    // then
+    assertThat(result).isEmpty();
   }
 }

--- a/zeebe/benchmarks/project/src/test/java/io/camunda/zeebe/read/DataReadMeterQueryProviderTest.java
+++ b/zeebe/benchmarks/project/src/test/java/io/camunda/zeebe/read/DataReadMeterQueryProviderTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.read;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.read.DataReadMeter.ReadQuery;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+final class DataReadMeterQueryProviderTest {
+
+  @Test
+  void shouldReturnAllQueriesWhenNoneDisabled() {
+    // given
+    final var allQueries = DataReadMeterQueryProvider.getDefaultQueries();
+
+    // when
+    final var result = DataReadMeterQueryProvider.getDefaultQueries(Set.of());
+
+    // then
+    assertThat(result).hasSameSizeAs(allQueries);
+  }
+
+  @Test
+  void shouldFilterOutDisabledQueries() {
+    // given
+    final var disabled = Set.of("process_instances_active", "audit_log_by_category");
+
+    // when
+    final var result = DataReadMeterQueryProvider.getDefaultQueries(disabled);
+
+    // then
+    assertThat(result)
+        .extracting(ReadQuery::name)
+        .doesNotContainAnyElementsOf(disabled)
+        .isNotEmpty();
+  }
+
+  @Test
+  void shouldReturnEmptyListWhenAllQueriesDisabled() {
+    // given
+    final var allNames =
+        DataReadMeterQueryProvider.getDefaultQueries().stream()
+            .map(ReadQuery::name)
+            .collect(java.util.stream.Collectors.toSet());
+
+    // when
+    final var result = DataReadMeterQueryProvider.getDefaultQueries(allNames);
+
+    // then
+    assertThat(result).isEmpty();
+  }
+}

--- a/zeebe/benchmarks/project/src/test/resources/different-application.conf
+++ b/zeebe/benchmarks/project/src/test/resources/different-application.conf
@@ -8,6 +8,7 @@ app {
   monitorDataAvailability = false
   monitorDataAvailabilityInterval = 50ms
   performReadBenchmarks = true
+  disabledQueries = "process_instances_active,audit_log_by_category"
 
   auth {
     type = "BASIC" # NONE, BASIC


### PR DESCRIPTION
# Description
Backport of #50111 to `stable/8.8`.

relates to 