### PR TITLE
[Backport stable/8.6] deps: Downgrade surefire plugin version from 3.5.5 to 3.5.2

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -65,7 +65,7 @@
     <version.httpcore5>5.3.6</version.httpcore5>
     <version.httpcomponents>4.4.16</version.httpcomponents>
     <version.identity>8.6.29</version.identity>
-    <version.surefire>3.5.5</version.surefire>
+    <version.surefire>3.5.2</version.surefire>
     <version.jackson>2.18.6</version.jackson>
     <version.junit>5.11.4</version.junit>
     <version.junit4>4.13.2</version.junit4>
@@ -212,7 +212,8 @@
     <plugin.version.dependency>3.8.1</plugin.version.dependency>
     <plugin.version.enforcer>3.5.0</plugin.version.enforcer>
     <plugin.version.exec>3.4.1</plugin.version.exec>
-    <plugin.version.failsafe>3.5.5</plugin.version.failsafe>
+    <!-- Keep failsafe aligned with surefire -->
+    <plugin.version.failsafe>3.5.2</plugin.version.failsafe>
     <plugin.version.flaky-tests>2.1.1</plugin.version.flaky-tests>
     <plugin.version.jacoco>0.8.14</plugin.version.jacoco>
     <plugin.version.maven-jar>3.4.2</plugin.version.maven-jar>
@@ -223,7 +224,7 @@
     <plugin.version.shade>3.6.2</plugin.version.shade>
     <plugin.version.sonar>3.9.1.2184</plugin.version.sonar>
     <plugin.version.spotbugs>4.8.6.8</plugin.version.spotbugs>
-    <plugin.version.surefire>3.5.5</plugin.version.surefire>
+    <plugin.version.surefire>3.5.2</plugin.version.surefire>
     <plugin.version.versions>2.17.1</plugin.version.versions>
     <plugin.version.frontend-maven>1.15.4</plugin.version.frontend-maven>
     <plugin.version.maven-source>3.3.1</plugin.version.maven-source>


### PR DESCRIPTION
# Description
Backport of #50098 to `stable/8.6`.

relates to 