### PR TITLE
build: parameterize ElasticsearchExporterMigrationIT

### DIFF
--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -642,6 +642,11 @@
       <artifactId>commons-compress</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>tools.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <repositories>
@@ -678,7 +683,7 @@
               <value>${version.identity}</value>
             </property>
           </systemProperties>
-          <excludedGroups>rdbms, multi-db-test, compatibility-test</excludedGroups>
+          <excludedGroups>rdbms, multi-db-test, compatibility-test, nightly</excludedGroups>
         </configuration>
         <dependencies>
           <dependency>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/schema/ElasticsearchExporterMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/schema/ElasticsearchExporterMigrationIT.java
@@ -21,22 +21,30 @@ import io.camunda.zeebe.qa.util.actuator.ExportingActuator;
 import io.camunda.zeebe.qa.util.actuator.PartitionsActuator;
 import io.camunda.zeebe.qa.util.cluster.TestHealthProbe;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.util.VersionUtil;
+import java.io.IOException;
 import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.concurrent.TimeUnit;
 import org.apache.http.HttpHost;
 import org.awaitility.Awaitility;
 import org.elasticsearch.client.RestClient;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
@@ -45,26 +53,34 @@ import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.utility.DockerImageName;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Full lifecycle upgrade test that validates the ES exporter works correctly after upgrading from
- * Camunda 8.8 to 8.9 with an export backlog. If strict mapping or other export issues exist, this
- * test will fail because backlog records won't be exported and jobs won't complete.
+ * Camunda previous to current version with an export backlog. If strict mapping or other export
+ * issues exist, this test will fail because backlog records won't be exported and jobs won't
+ * complete.
  *
- * <p>Data is shared between the 8.8 Docker container and the 8.9 in-JVM broker via a Docker volume
- * ({@link CamundaVolume}), which is extracted to the host filesystem using tar. This approach works
- * reliably in Docker-in-Docker (CI) environments. Pattern from qa/migration-tests on stable/8.8.
+ * <p>Data is shared between the previous Docker container and the current in-JVM broker via a
+ * Docker volume ({@link CamundaVolume}), which is extracted to the host filesystem using tar. This
+ * approach works reliably in Docker-in-Docker (CI) environments.
  */
 class ElasticsearchExporterMigrationIT {
 
   private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchExporterMigrationIT.class);
 
   private static final String ES_NETWORK_ALIAS = "test-elasticsearch";
-  private static final String CAMUNDA_8_8_IMAGE = "camunda/camunda:8.8.16";
   private static final String PROCESS_ID = "migration-test";
   private static final String JOB_TYPE = "test-job";
   private static final String CONTAINER_DATA_PATH = "/usr/local/camunda/data";
   private static final int BACKLOG_COUNT = 3;
+  private static final String CURRENT_VERSION = getMinorVersion(VersionUtil.getVersion());
+  private static final String BASE_VERSION = getMinorVersion(VersionUtil.getPreviousVersion());
+  private static final String API_URL =
+      String.format(
+          "https://hub.docker.com/v2/repositories/camunda/camunda/tags?page_size=%d&name=%s",
+          100, BASE_VERSION);
 
   private static final BpmnModelInstance PROCESS_MODEL =
       Bpmn.createExecutableProcess(PROCESS_ID)
@@ -117,20 +133,36 @@ class ElasticsearchExporterMigrationIT {
     }
   }
 
-  @Test
+  @ParameterizedTest(name = "Migrate from {0} to current version")
+  @MethodSource("fetchLatestPatchFromPreviousMinor")
   @Timeout(value = 10, unit = TimeUnit.MINUTES)
-  void shouldCompleteUpgradeWithBacklogAndExportAllRecords() throws Exception {
+  void shouldCompleteUpgradeWithBacklogAndExportAllRecordsAgainstLatestReleasePatch(
+      final String param) throws Exception {
+    shouldCompleteUpgradeWithBacklogAndExportAllRecords(param);
+  }
+
+  @ParameterizedTest(name = "Migrate from {0} to current version")
+  @MethodSource("fetchAllPatchesFromPreviousMinor")
+  @Tag("nightly")
+  @Timeout(value = 10, unit = TimeUnit.MINUTES)
+  void shouldCompleteUpgradeWithBacklogAndExportAllRecordsAgainstReleasePatches(final String param)
+      throws Exception {
+    shouldCompleteUpgradeWithBacklogAndExportAllRecords(param);
+  }
+
+  void shouldCompleteUpgradeWithBacklogAndExportAllRecords(final String version) throws Exception {
     final var esInternalUrl = "http://" + ES_NETWORK_ALIAS + ":9200";
     final var esExternalUrl = "http://" + esContainer.getHttpHostAddress();
     final List<Long> instanceKeys = new ArrayList<>();
 
-    // Create a Docker volume for sharing data between 8.8 container and 8.9 in-JVM broker
+    // Create a Docker volume for sharing data between the previous version and the current version
+    // in-JVM broker
     final var volume = CamundaVolume.newCamundaVolume();
 
-    // ---- Phase 1: Start 8.8, deploy process, create & complete instance #1 ----
-    LOG.info("Phase 1: Starting Camunda 8.8");
-    final GenericContainer<?> camunda88 =
-        new GenericContainer<>(CAMUNDA_8_8_IMAGE)
+    // ---- Phase 1: Start previous version, deploy process, create & complete instance #1 ----
+    LOG.info("Phase 1: Starting Camunda " + version + " in Docker...");
+    final GenericContainer<?> camundaPrevious =
+        new GenericContainer<>("camunda/camunda:" + version)
             .withNetwork(network)
             .withExposedPorts(26500, 8080, 9600)
             .withCreateContainerCmdModifier(
@@ -154,31 +186,31 @@ class ElasticsearchExporterMigrationIT {
                     .forPort(9600)
                     .forPath("/actuator/health")
                     .withReadTimeout(Duration.ofSeconds(120)))
-            .withLogConsumer(new Slf4jLogConsumer(LOG).withPrefix("camunda-8.8"));
+            .withLogConsumer(new Slf4jLogConsumer(LOG).withPrefix("camunda-" + BASE_VERSION));
 
-    camunda88.start();
+    camundaPrevious.start();
 
     try {
-      final var grpcPort = camunda88.getMappedPort(26500);
-      final var monitoringPort = camunda88.getMappedPort(9600);
+      final var grpcPort = camundaPrevious.getMappedPort(26500);
+      final var monitoringPort = camundaPrevious.getMappedPort(9600);
 
-      try (final var client88 =
+      try (final var clientPrevious =
           CamundaClient.newClientBuilder()
               .grpcAddress(URI.create("http://localhost:" + grpcPort))
               .preferRestOverGrpc(false)
               .build()) {
 
         // Deploy process
-        client88
+        clientPrevious
             .newDeployResourceCommand()
             .addProcessModel(PROCESS_MODEL, "migration-test.bpmn")
             .send()
             .join(30, TimeUnit.SECONDS);
-        LOG.info("Deployed process on 8.8");
+        LOG.info("Deployed process on version " + version);
 
         // Create instance #1 and complete its job
         final var instance1 =
-            client88
+            clientPrevious
                 .newCreateInstanceCommand()
                 .bpmnProcessId(PROCESS_ID)
                 .latestVersion()
@@ -187,7 +219,7 @@ class ElasticsearchExporterMigrationIT {
         instanceKeys.add(instance1.getProcessInstanceKey());
         LOG.info("Created instance #1: {}", instance1.getProcessInstanceKey());
 
-        completeJobs(client88, 1);
+        completeJobs(clientPrevious, 1);
         LOG.info("Completed job for instance #1");
 
         // Wait for instance #1 to be exported to ES
@@ -212,7 +244,7 @@ class ElasticsearchExporterMigrationIT {
 
         for (int i = 0; i < BACKLOG_COUNT; i++) {
           final var instance =
-              client88
+              clientPrevious
                   .newCreateInstanceCommand()
                   .bpmnProcessId(PROCESS_ID)
                   .latestVersion()
@@ -223,12 +255,12 @@ class ElasticsearchExporterMigrationIT {
         }
       }
 
-      // ---- Phase 3: Stop 8.8, extract volume to host ----
-      LOG.info("Phase 3: Stopping Camunda 8.8 and extracting volume");
-      camunda88.stop();
+      // ---- Phase 3: Stop previous version, extract volume to host ----
+      LOG.info("Phase 3: Stopping Camunda " + BASE_VERSION + " and extracting volume");
+      camundaPrevious.stop();
 
     } catch (final Exception e) {
-      camunda88.stop();
+      camundaPrevious.stop();
       throw e;
     }
 
@@ -256,13 +288,14 @@ class ElasticsearchExporterMigrationIT {
           "Could not find data directory in extracted volume: " + extractedPath);
     }
 
-    // ---- Phase 4: Start 8.9 in-JVM, resume exporter, create instance #5 ----
-    LOG.info("Phase 4: Starting Camunda 8.9 (in-JVM) with working dir: {}", workingDir);
+    // ---- Phase 4: Start current version in-JVM, resume exporter, create instance #5 ----
+    LOG.info(
+        "Phase 4: Starting Camunda {} (in-JVM) with working dir: {}", CURRENT_VERSION, workingDir);
     assertThat(Files.exists(workingDir.resolve("data")))
         .as("data directory should exist after extraction")
         .isTrue();
 
-    final var broker89 =
+    final var brokerCurrent =
         new TestStandaloneBroker()
             .withWorkingDirectory(workingDir)
             .withUnifiedConfig(cfg -> cfg.getSystem().getUpgrade().setEnableVersionCheck(false))
@@ -282,25 +315,27 @@ class ElasticsearchExporterMigrationIT {
             .withProperty("camunda.rest.enabled", "false");
 
     try {
-      broker89.start().await(TestHealthProbe.READY, Duration.ofMinutes(3));
-      LOG.info("Camunda 8.9 broker started");
+      brokerCurrent.start().await(TestHealthProbe.READY, Duration.ofMinutes(3));
+      LOG.info("Camunda " + CURRENT_VERSION + " broker started");
 
       // Resume exporter
-      ExportingActuator.of(broker89).resume();
-      LOG.info("Resumed exporter on 8.9");
+      ExportingActuator.of(brokerCurrent).resume();
+      LOG.info("Resumed exporter on " + CURRENT_VERSION);
 
-      try (final var client89 = broker89.newClientBuilder().preferRestOverGrpc(false).build()) {
-        // Create instance #5 on 8.9 — retry because the process definition from 8.8
+      try (final var clientCurrent =
+          brokerCurrent.newClientBuilder().preferRestOverGrpc(false).build()) {
+        // Create instance #5 on current version — retry because the process definition from
+        // previous version
         // may not be immediately available after log replay
         final var instanceKey5 = new long[1];
-        Awaitility.await("create instance #5 on 8.9")
+        Awaitility.await("create instance #5 on " + CURRENT_VERSION)
             .atMost(Duration.ofSeconds(60))
             .pollInterval(Duration.ofSeconds(2))
             .ignoreExceptions()
             .until(
                 () -> {
                   final var result =
-                      client89
+                      clientCurrent
                           .newCreateInstanceCommand()
                           .bpmnProcessId(PROCESS_ID)
                           .latestVersion()
@@ -310,16 +345,16 @@ class ElasticsearchExporterMigrationIT {
                   return true;
                 });
         instanceKeys.add(instanceKey5[0]);
-        LOG.info("Created instance #5 on 8.9: {}", instanceKey5[0]);
+        LOG.info("Created instance #5 on {}: {}", CURRENT_VERSION, instanceKey5[0]);
 
         // ---- Phase 5: Complete all remaining jobs (#2-5) ----
         LOG.info("Phase 5: Completing remaining jobs");
-        completeJobs(client89, BACKLOG_COUNT + 1);
+        completeJobs(clientCurrent, BACKLOG_COUNT + 1);
         LOG.info("Completed all remaining jobs");
 
         // ---- Phase 6: Verify everything exported and completed ----
         LOG.info("Phase 6: Verifying all records exported");
-        final var partitionsActuator = PartitionsActuator.of(broker89);
+        final var partitionsActuator = PartitionsActuator.of(brokerCurrent);
 
         // Wait for exporter to catch up (exportedPosition == processedPosition)
         Awaitility.await("exporter should catch up")
@@ -354,7 +389,7 @@ class ElasticsearchExporterMigrationIT {
             .isGreaterThanOrEqualTo(5);
       }
     } finally {
-      broker89.close();
+      brokerCurrent.close();
     }
 
     LOG.info(
@@ -384,5 +419,88 @@ class ElasticsearchExporterMigrationIT {
               }
               return completed.size() >= expectedCount;
             });
+  }
+
+  private static List<String> fetchLatestPatchFromPreviousMinor()
+      throws IOException, InterruptedException {
+    final List<String> allVersions = fetchAllPatchesFromPreviousMinor();
+    final int len = allVersions.size();
+    return List.of(allVersions.get(len - 2)); // skip SNAPSHOT from the end of the list
+  }
+
+  private static List<String> fetchAllPatchesFromPreviousMinor()
+      throws IOException, InterruptedException {
+    final HttpClient client = HttpClient.newHttpClient();
+    final ObjectMapper mapper = new ObjectMapper();
+
+    final List<String> allTags = new ArrayList<>();
+    String url = API_URL;
+
+    while (true) {
+      final HttpRequest request = HttpRequest.newBuilder().uri(URI.create(url)).GET().build();
+      final HttpResponse<String> response =
+          client.send(request, HttpResponse.BodyHandlers.ofString());
+      final JsonNode root = mapper.readTree(response.body());
+
+      for (final JsonNode tag : root.get("results")) {
+        allTags.add(tag.get("name").asString());
+      }
+
+      // pagination
+      final JsonNode next = root.get("next");
+      if (next == null || next.isNull()) { // NOTE: edge case
+        break;
+      }
+
+      url = next.asString();
+    }
+
+    final List<String> allVersions = new ArrayList<>();
+    for (final String tag : allTags) {
+      if (!tag.startsWith(BASE_VERSION)) {
+        continue;
+      }
+
+      final String[] components = tag.split("\\.");
+      if (components.length != 3) {
+        continue;
+      }
+
+      try {
+        Integer.parseInt(components[2]);
+      } catch (final NumberFormatException ignored) {
+        continue;
+      }
+
+      allVersions.add(tag);
+    }
+
+    if (allVersions.isEmpty()) {
+      throw new NoSuchElementException("No release images found for " + BASE_VERSION);
+    }
+
+    allVersions.sort(ElasticsearchExporterMigrationIT::comparePatches);
+
+    final String snapshotVersion = BASE_VERSION + "-SNAPSHOT";
+    if (allTags.contains(snapshotVersion)) {
+      allVersions.add(snapshotVersion);
+    }
+
+    return allVersions;
+  }
+
+  private static int comparePatches(final String v1, final String v2) {
+    final String[] components1 = v1.split("\\.");
+    final int patch1 = Integer.parseInt(components1[2]);
+
+    final String[] components2 = v2.split("\\.");
+    final int patch2 = Integer.parseInt(components2[2]);
+
+    return Integer.compare(patch1, patch2);
+  }
+
+  private static String getMinorVersion(final String version) {
+    final String[] components = version.split("\\.");
+    return components[0] + "." + components[1];
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Context:
https://github.com/camunda/camunda/issues/50371

With this PR, we're preparing `stable/8.9` to have a test against the latest patch of 8.8, while the rest of the versions will be tested at night, with a workflow that has to be in `main` and fetch from `stable/8.8` (will be done in a separate PR; currently WIP here: https://github.com/camunda/camunda/pull/50510).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

part of https://github.com/camunda/camunda/issues/50371

## Expected result

<img width="726" height="56" alt="image" src="https://github.com/user-attachments/assets/6b3f5d80-12cc-42dd-974b-40ba8bae03d0" />
