### PR TITLE
test: Update identity with admin

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/identity-users-flows.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/identity-users-flows.spec.ts
@@ -64,7 +64,7 @@ test.describe('Identity User Flows', () => {
       `${relativizePath(Paths.login('admin'))}?next=/admin/`,
     );
 
-    await test.step(`Deleted user cannot access Identity`, async () => {
+    await test.step(`Deleted user cannot access Admin`, async () => {
       await navigateToApp(page, `admin`);
       await loginPage.login(testUser.username, testUser.password);
       await expect(page).toHaveURL(new RegExp(`admin`));

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/identity-users-flows.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/identity-users-flows.spec.ts
@@ -61,11 +61,11 @@ test.describe('Identity User Flows', () => {
     await identityUsersPage.deleteUser(testUser);
     await identityHeader.logout();
     await expect(page).toHaveURL(
-      `${relativizePath(Paths.login('identity'))}?next=/admin/`,
+      `${relativizePath(Paths.login('admin'))}?next=/admin/`,
     );
 
     await test.step(`Deleted user cannot access Identity`, async () => {
-      await navigateToApp(page, `identity`);
+      await navigateToApp(page, `admin`);
       await loginPage.login(testUser.username, testUser.password);
       await expect(page).toHaveURL(new RegExp(`admin`));
       await loginPage.expectInvalidCredentialsError();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/v1/identity-users-flows.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/v1/identity-users-flows.spec.ts
@@ -64,7 +64,7 @@ test.describe('Identity User Flows', () => {
       `${relativizePath(Paths.login('admin'))}?next=/admin/`,
     );
 
-    await test.step(`Deleted user cannot access Identity`, async () => {
+    await test.step(`Deleted user cannot access Admin`, async () => {
       await navigateToApp(page, `admin`);
       await loginPage.login(testUser.username, testUser.password);
       await expect(page).toHaveURL(new RegExp(`admin`));

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/v1/identity-users-flows.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/common-flows/v1/identity-users-flows.spec.ts
@@ -61,11 +61,11 @@ test.describe('Identity User Flows', () => {
     await identityUsersPage.deleteUser(testUser);
     await identityHeader.logout();
     await expect(page).toHaveURL(
-      `${relativizePath(Paths.login('identity'))}?next=/admin/`,
+      `${relativizePath(Paths.login('admin'))}?next=/admin/`,
     );
 
     await test.step(`Deleted user cannot access Identity`, async () => {
-      await navigateToApp(page, `identity`);
+      await navigateToApp(page, `admin`);
       await loginPage.login(testUser.username, testUser.password);
       await expect(page).toHaveURL(new RegExp(`admin`));
       await loginPage.expectInvalidCredentialsError();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/login.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/login.spec.ts
@@ -26,13 +26,13 @@ test.describe.parallel('login page', () => {
     await expect(loginPage.passwordInput).toHaveAttribute('type', 'password');
 
     await loginPage.login('demo', 'wrong-password');
-    await expect(page).toHaveURL(`${relativizePath(Paths.login('identity'))}`);
+    await expect(page).toHaveURL(`${relativizePath(Paths.login('admin'))}`);
 
     await expect(loginPage.errorMessage).toContainText(
       "Username and password don't match",
     );
 
-    await expect(page).toHaveURL(`${relativizePath(Paths.login('identity'))}`);
+    await expect(page).toHaveURL(`${relativizePath(Paths.login('admin'))}`);
   });
 
   test('Log in with valid user account', async ({loginPage, page}) => {
@@ -46,15 +46,15 @@ test.describe.parallel('login page', () => {
     await expect(page).toHaveURL(`${relativizePath(Paths.users())}`);
     await identityHeader.logout();
     await expect(page).toHaveURL(
-      `${relativizePath(Paths.login('identity'))}?next=/admin/`,
+      `${relativizePath(Paths.login('admin'))}?next=/admin/`,
     );
   });
 
   test('Redirect to initial page after login', async ({loginPage, page}) => {
-    await expect(page).toHaveURL(`${relativizePath(Paths.login('identity'))}`);
+    await expect(page).toHaveURL(`${relativizePath(Paths.login('admin'))}`);
     await page.goto(`${relativizePath(Paths.users())}`);
     await expect(page).toHaveURL(
-      `${relativizePath(Paths.login('identity'))}?next=${Paths.users()}`,
+      `${relativizePath(Paths.login('admin'))}?next=${Paths.users()}`,
     );
 
     await loginPage.login('demo', 'demo');

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/relativizePath.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/relativizePath.ts
@@ -8,17 +8,9 @@
 
 export const Paths = {
   login(application: string): string {
-    // TODO(#46027): This can be removed after sufficient migration period.
-    if (application === 'identity') {
-      return '/admin/login';
-    }
     return `/${application}/login`;
   },
   forbidden(application: string): string {
-    // TODO(#46027): This can be removed after sufficient migration period.
-    if (application === 'identity') {
-      return '/admin/forbidden';
-    }
     return `/${application}/forbidden`;
   },
   mappingRules() {


### PR DESCRIPTION
## Description

As part of https://github.com/camunda/camunda/issues/44427 we want to rename OC Identity into OC admin. We have already done some work and the FE labels are now showing "admin". The identity/ URLs are redirecting to admin/. We should also update all test references to reflect this way forward.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates to https://github.com/camunda/camunda/issues/46027
