### PR TITLE
perf: batch RocksDB transactions in ExportersState.setExporterState

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExportersState.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExportersState.java
@@ -46,8 +46,6 @@ public final class ExportersState {
       final String exporterId, final long position, final DirectBuffer metadata) {
     transactionContext.runInTransaction(
         () -> {
-          this.exporterId.wrapString(exporterId);
-
           final var exporterStateEntry =
               findExporterStateEntry(exporterId).orElseGet(ExporterStateEntry::new);
           exporterStateEntry.setPosition(position);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExportersState.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExportersState.java
@@ -25,11 +25,13 @@ public final class ExportersState {
 
   private static final UnsafeBuffer METADATA_NOT_FOUND = new UnsafeBuffer();
 
+  private final TransactionContext transactionContext;
   private final DbString exporterId;
   private final ColumnFamily<DbString, ExporterStateEntry> exporterPositionColumnFamily;
 
   public ExportersState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
+    this.transactionContext = transactionContext;
     exporterId = new DbString();
     exporterPositionColumnFamily =
         zeebeDb.createColumnFamily(
@@ -42,15 +44,18 @@ public final class ExportersState {
 
   public void setExporterState(
       final String exporterId, final long position, final DirectBuffer metadata) {
-    this.exporterId.wrapString(exporterId);
+    transactionContext.runInTransaction(
+        () -> {
+          this.exporterId.wrapString(exporterId);
 
-    final var exporterStateEntry =
-        findExporterStateEntry(exporterId).orElse(new ExporterStateEntry());
-    exporterStateEntry.setPosition(position);
-    if (metadata != null) {
-      exporterStateEntry.setMetadata(metadata);
-    }
-    exporterPositionColumnFamily.upsert(this.exporterId, exporterStateEntry);
+          final var exporterStateEntry =
+              findExporterStateEntry(exporterId).orElse(new ExporterStateEntry());
+          exporterStateEntry.setPosition(position);
+          if (metadata != null) {
+            exporterStateEntry.setMetadata(metadata);
+          }
+          exporterPositionColumnFamily.upsert(this.exporterId, exporterStateEntry);
+        });
   }
 
   public void initializeExporterState(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExportersState.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExportersState.java
@@ -49,7 +49,7 @@ public final class ExportersState {
           this.exporterId.wrapString(exporterId);
 
           final var exporterStateEntry =
-              findExporterStateEntry(exporterId).orElse(new ExporterStateEntry());
+              findExporterStateEntry(exporterId).orElseGet(ExporterStateEntry::new);
           exporterStateEntry.setPosition(position);
           if (metadata != null) {
             exporterStateEntry.setMetadata(metadata);


### PR DESCRIPTION
## Description

### Problem

`ExportersState.setExporterState` performed two separate RocksDB transactions on every call:

1. **Read** – `findExporterStateEntry` opens its own transaction to look up the current entry.
2. **Write** – `exporterPositionColumnFamily.upsert` opens a second transaction to persist the updated entry.

Each RocksDB transaction carries its own commit overhead (WAL write, mutex acquisition, memtable insert). On the exporter hot path—called once per exporter per record—this doubled overhead adds up.

### Solution

Wrap the read + write in a single `transactionContext.runInTransaction(...)` block. The inner `TransactionalColumnFamily` operations detect the already-open transaction via `ensureInOpenTransaction` and reuse it, collapsing two commits into one.

### What changed

- Stored the `TransactionContext` as a field in `ExportersState` (previously only used transiently in the constructor).
- Wrapped the body of `setExporterState` in `transactionContext.runInTransaction(...)`.
- No behavioral change—only the transaction batching is different.

## Checklist

<!-- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #50120