### PR TITLE
Management identity architecutre documentation

### DIFF
--- a/docs/monorepo-docs/architecture/components/identity/management_identity_architecture_docs.md
+++ b/docs/monorepo-docs/architecture/components/identity/management_identity_architecture_docs.md
@@ -1,0 +1,296 @@
+---
+toc_min_heading_level: 2
+toc_max_heading_level: 5
+---
+
+# Management Identity architecture documentation
+
+## 1. Introduction and goals
+
+### 1.1 Overview
+
+Management Identity is the Self‑Managed Camunda 8 component that manages authentication and access control for platform‑level applications that sit outside the Orchestration Cluster:
+
+- Console
+- Web Modeler
+- Optimize
+
+It is responsible for:
+
+- User and machine authentication via OIDC or the bundled Keycloak.
+- Role‑based access control (RBAC) for Console, Web Modeler, and Optimize.
+- Managing users, groups, roles, permissions, tenants (Optimize), and mapping rules.
+
+By design, Management Identity does not control access for the Orchestration Cluster (Zeebe, Operate, Tasklist, Orchestration Cluster APIs). That is handled by Orchestration Cluster Identity, described in the Orchestration Cluster Identity architecture documentation:
+
+- Orchestration Cluster Identity architecture:
+  https://github.com/camunda/camunda/blob/identity_architecture_documentation/docs/monorepo-docs/architecture/components/identity/identity_architecture_docs.md
+
+Where concepts (users, groups, roles, mapping rules, tenants, RBAC) overlap between Management Identity and Orchestration Cluster Identity, the Orchestration Cluster Identity document is the primary reference. This document describes only the specifics of Management Identity.
+
+### Goals
+
+1. Provide a dedicated identity and access control layer for Web Modeler, Console, and Optimize in Self‑Managed deployments.
+2. Integrate with enterprise IdPs via OIDC, including using Keycloak either as primary IdP or as a broker to external IdPs.
+3. Offer a clear, UI‑driven experience to manage users, groups, roles, applications (clients), and tenants for Optimize.
+4. Keep platform‑level identity concerns separate from runtime (cluster) identity.
+
+### 1.2 Scope
+
+In scope:
+
+- Authentication and authorization for:
+  - Console
+  - Web Modeler
+  - Optimize
+- Management Identity UI and APIs
+- Integration with Keycloak and external OIDC providers
+- Platform‑level tenants for Optimize
+
+Out of scope (covered by Orchestration Cluster Identity):
+
+- Authentication and authorization for Zeebe, Operate, Tasklist, and Orchestration Cluster APIs.
+- Cluster‑local tenants and runtime resource authorizations.
+
+For those topics, see the Orchestration Cluster Identity architecture doc linked above.
+
+
+## 2. Constraints
+
+- Separate component
+  Management Identity runs as its own service (and supporting services such as Keycloak and Postgres) alongside the Orchestration Cluster in Self‑Managed setups.
+
+- Default IdP stack
+  Management Identity is, by default, wired to a packaged Keycloak and its database, but supports:
+  - Using an external existing Keycloak.
+  - Using a generic external OIDC provider via Keycloak’s identity brokering and/or a direct OIDC mode.
+
+- Protocols
+  Authentication flows are based on OAuth 2.0 and OIDC (authorization code flow for interactive users, client credentials for machine‑to‑machine).
+
+- Responsibility split
+  Management Identity must not be a dependency for Orchestration Cluster runtime access. Orchestration Cluster Identity is the source of truth for runtime IAM; Management Identity handles only platform apps.
+
+- Data ownership
+  Management Identity is the source of truth for:
+  - Platform users, groups, roles, and applications for Web Modeler, Console, and Optimize.
+  - Platform‑level tenants and mapping rules relevant to Optimize.
+    Runtime tenants and authorizations must not be managed in Management Identity after migration to Orchestration Cluster Identity.
+
+
+## 3. System context and scope
+
+### 3.1 Business context
+
+```mermaid
+---
+title: Management Identity - Business Context
+---
+flowchart TB
+  USER["Platform user\n(admin, developer, analyst)"]
+  APP_DEV["Application developer\n(job workers, CI/CD)"]
+  IDP[["Enterprise IdP\n(Keycloak, Entra, Okta, ...)"]]
+
+  subgraph PLATFORM["Camunda 8 Platform (Self-Managed)"]
+    MGMT_ID["Management Identity"]
+    CONSOLE["Console"]
+    WEB_MODEL["Web Modeler"]
+    OPT["Optimize"]
+    OC_ID["Orchestration Cluster Identity\n(runtime IAM)"]
+  end
+
+  USER -->|"Browser login"| CONSOLE
+  USER -->|"Browser login"| WEB_MODEL
+  USER -->|"Browser login"| OPT
+
+  CONSOLE --> MGMT_ID
+  WEB_MODEL --> MGMT_ID
+  OPT --> MGMT_ID
+
+  MGMT_ID -->|"OIDC auth / tokens"| IDP
+
+  APP_DEV -->|"Access to cluster APIs"| OC_ID
+```
+
+Main actors:
+
+- Platform user: administrators, modelers, and analysts using Console, Web Modeler, and Optimize.
+- Application developer: developers building job workers or integrations against Orchestration Clusters.
+- Management Identity: manages platform‑level authentication and RBAC for Console, Web Modeler, and Optimize.
+- Orchestration Cluster Identity: manages runtime authentication and RBAC for cluster components.
+- Enterprise IdP: central source of user identities and group claims (via Keycloak or other OIDC providers).
+
+Management Identity and Orchestration Cluster Identity are siblings: they serve different application surfaces but can share common identity concepts (users, groups, roles, mapping rules, tenants) and, over time, converge towards a unified model as described in the Orchestration Cluster Identity architecture doc.
+
+### 3.2 Technical context
+
+```mermaid
+---
+title: Management Identity - Technical Context
+---
+flowchart TB
+  BROWSER["Browser (Console, Web Modeler, Optimize)"]
+  APP_CLIENT["Platform client apps\n(Optimize backend, Console backend, Web Modeler backend)"]
+  IDP[("OIDC IdP / Keycloak")]
+  MGMT_DB[("Management Identity DB\n(Postgres)")]
+  KEYCLOAK_DB[("Keycloak DB")]
+
+  subgraph MGMT_ID["Management Identity"]
+    MGMT_UI["Management Identity UI"]
+    MGMT_API["Management Identity API"]
+    AUTHZ["RBAC / Permissions\n(roles, groups, tenants)"]
+    MAPPING["Mapping rules\n(JWT claims -> roles / tenants)"]
+  end
+
+  BROWSER -->|"Login / admin UI"| MGMT_UI
+  MGMT_UI --> MGMT_API
+  APP_CLIENT -->|"M2M tokens, user info"| MGMT_API
+
+  MGMT_API -->|"User, group, role, app, tenant mgmt"| MGMT_DB
+  MGMT_API -->|"RBAC decisions"| AUTHZ
+  MGMT_API -->|"Resolve mapping rules"| MAPPING
+
+  MGMT_API -->|"Client registrations,\nrealm config"| IDP
+  IDP -->|"OIDC tokens (users & clients)"| APP_CLIENT
+  IDP -->|"OIDC tokens / login"| BROWSER
+
+  IDP -->|"Users, groups, sessions"| KEYCLOAK_DB
+```
+
+Key points:
+
+- Console, Web Modeler, and Optimize UIs use OIDC login against the IdP (Keycloak or external), with Management Identity owning the configuration for:
+  - Clients
+  - Scopes
+  - Redirect URIs
+- Management Identity UI and API allow administrators to manage users, groups, roles, applications (clients), Optimize tenants, and mapping rules.
+- Application backends (Console, Web Modeler, Optimize) use client credentials and/or user tokens issued by the IdP, and consult Management Identity’s RBAC model when enforcing access.
+
+
+## 4. Solution strategy
+
+- Separate management plane for platform apps
+  Management Identity provides an independent authentication/authorization surface for Console, Web Modeler, and Optimize, without coupling cluster runtime IAM to platform app availability.
+
+- OIDC‑based SSO via Keycloak or external IdPs
+  Keycloak is provided as a default IdP and broker, with support for external enterprise IdPs via OIDC. Interactive users authenticate via authorization code flow; applications use client credentials.
+
+- RBAC for platform resources
+  A role‑based access model is used to protect:
+  - Console features (cluster registration, license, user management, etc.).
+  - Web Modeler workspaces, projects, and collaboration features.
+  - Optimize dashboards, reports, and data access.
+
+- Mapping rules and tenants for Optimize
+  Mapping rules connect IdP claims (for example groups, attributes) to roles and tenants in Management Identity. Optimize uses these tenants to segment data and access for different business units or customers.
+
+- Alignment with Orchestration Cluster Identity model
+  Where consistent and feasible, Management Identity uses naming and concepts aligned with Orchestration Cluster Identity (users, groups, roles, tenants, mapping rules, authorizations). Details of the shared model and runtime behavior are defined in the Orchestration Cluster Identity architecture doc.
+
+
+## 5. Building block view
+
+```mermaid
+---
+title: Management Identity - Building Blocks
+---
+flowchart TB
+  BROWSER["Admin / user browser"]
+  IDP[("Keycloak / OIDC IdP")]
+  MGMT_DB[("Management Identity DB")]
+
+  subgraph MGMT_ID["Management Identity"]
+    UI["Management Identity UI"]
+    API["Management Identity API"]
+    USERS["Users / Groups"]
+    ROLES["Roles / Permissions"]
+    APPS["Applications (clients)"]
+    TENANTS["Optimize Tenants"]
+    RULES["Mapping Rules"]
+  end
+
+  BROWSER -->|"Admin, user flows"| UI
+  UI --> API
+
+  API --> USERS
+  API --> ROLES
+  API --> APPS
+  API --> TENANTS
+  API --> RULES
+
+  API -->|"Configure clients,\nscopes, realms"| IDP
+  IDP -->|"Tokens"| BROWSER
+
+  USERS --> MGMT_DB
+  ROLES --> MGMT_DB
+  APPS --> MGMT_DB
+  TENANTS --> MGMT_DB
+  RULES --> MGMT_DB
+```
+
+Responsibilities:
+
+- Management Identity UI
+  Console for administrators to:
+  - Manage users, groups, roles, applications, and tenants.
+  - Define mapping rules.
+
+- Management Identity API
+  Backing services that store and retrieve identity data, render it to the UI, and integrate with the IdP.
+
+- Users and groups
+  Platform‑level principals and groupings for Console, Web Modeler, and Optimize.
+
+- Roles and permissions
+  Define what operations users and applications can perform in the platform apps.
+
+- Applications (clients)
+  Represent platform and external applications that consume tokens (for example Optimize backend, Web Modeler backend, custom tools).
+
+- Tenants (Optimize)
+  Logical partitions for reporting and data isolation in Optimize only.
+
+- Mapping rules
+  Connect IdP token claims to roles, groups, and tenants. The general mapping‑rules concept is shared with Orchestration Cluster Identity; see the mapping rules section in the Orchestration Cluster Identity architecture doc for a more detailed explanation of the pattern.
+
+
+## 6. Crosscutting concepts
+
+This section only highlights differences or specifics for Management Identity. For shared concepts (RBAC model, mapping rules, tenants, authorization checks), see the Orchestration Cluster Identity architecture doc.
+
+- Authentication
+  - OIDC via Keycloak or external IdP.
+  - Authorization code flow for human users.
+  - Client credentials for platform services and external tools.
+
+- Authorization
+  - RBAC model with roles, permissions, users, and groups controlling:
+    - Console features and views.
+    - Web Modeler access and collaboration features.
+    - Optimize data access and actions.
+  - Runtime resource authorizations for process instances, tasks, etc. are handled by Orchestration Cluster Identity and its RBAC engine, not by Management Identity.
+
+- Tenants
+  - Management Identity tenants apply to Optimize only (for data isolation in reporting and analytics).
+  - Runtime tenants for process execution live in Orchestration Cluster Identity.
+
+- Mapping rules
+  - Rules in Management Identity map IdP claims (for example group names) to:
+    - Roles (e.g. Console Admin, Optimize Analyst)
+    - Optimize tenants
+  - The same general pattern is used for Orchestration Cluster Identity; see the Orchestration Cluster Identity architecture doc for details.
+
+
+## 7. Quality goals
+
+- Clear separation of concerns
+  Platform‑level identity (Management Identity) and runtime identity (Orchestration Cluster Identity) are separated to avoid cross‑dependencies that affect availability.
+
+- Integratability
+  Straightforward integration with customer IdPs via Keycloak and OIDC, including support for common enterprise setups.
+
+- Operability
+  Management Identity should be observable and manageable (logging, metrics) as part of the broader Self‑Managed deployment.
+
+- Consistency with Orchestration Cluster Identity
+  Where feasible, concepts and naming are kept aligned with Orchestration Cluster Identity to reduce cognitive load and simplify documentation and tooling.

--- a/docs/monorepo-docs/architecture/components/identity/management_identity_architecture_docs.md
+++ b/docs/monorepo-docs/architecture/components/identity/management_identity_architecture_docs.md
@@ -179,12 +179,14 @@ flowchart TB
     subgraph MGMT_API["Management Identity API (Spring Boot)"]
       SEC_CFG["Security Configuration<br>(WebSecurityConfig)"]
       SECURITY["Spring Security"]
+      IDENTITY_SDK["Identity SDK"]
       CONTROLLERS["REST Controllers"]
       SERVICES["Service Interfaces"]
       IMPL["Profile-specific implementations"]
       REPOSITORIES["Repositories<br>(Spring Data JPA)"]
 
       SEC_CFG --> SECURITY --> CONTROLLERS
+      SECURITY -->|"JWT validation"| IDENTITY_SDK
       CONTROLLERS --> SERVICES
       SERVICES --> IMPL
       IMPL --> REPOSITORIES
@@ -194,7 +196,7 @@ flowchart TB
   BROWSER --> UI
   UI --> SECURITY
 
-  SECURITY -->|"Token validation"| IDP
+  IDENTITY_SDK -->|"Token validation (JWKS)"| IDP
   IMPL -->|"Realm, client,<br>user config (keycloak profile)"| IDP
   REPOSITORIES --> MGMT_DB
 ```
@@ -204,6 +206,13 @@ Main building blocks:
 - Management Identity UI: React single-page application (served by `FrontendController`) for administrators to manage users, groups, roles, clients (OAuth2 applications), and tenants, and to define mapping rules.
 - Security Configuration (`WebSecurityConfig`): Spring configuration class that defines the security filter chain. It registers the `JwtFilter` implementation before the `BasicAuthenticationFilter` and explicitly permits unauthenticated access to paths such as `/auth/**`, `/actuator/**`, and public token-resolution endpoints.
 - Spring Security: Filter chain responsible for authenticating incoming requests (OIDC token validation via the configured IdP JWKS endpoint) and enforcing RBAC before delegating to controllers.
+- Identity SDK (`Authentication` interface): the SDK selects a provider-specific `Authentication` implementation at startup based on the configured `camunda.identity.type`:
+  - `KEYCLOAK` → `KeycloakAuthentication` (used in the `keycloak` profile)
+  - `MICROSOFT` → `MicrosoftAuthentication` (used in the `oidc` profile with Microsoft Entra as IdP; enables the certificate-backed `client_assertion` path)
+  - `GENERIC` → `GenericAuthentication` (used in the `oidc` profile with other external OIDC providers)
+  - `AUTH0` → `Auth0Authentication` (legacy / Auth0-specific)
+
+  This selection determines which token-endpoint interactions, claim-extraction logic, and client-authentication method are used by `SmJwtFilter` and all SDK-backed authentication calls. Where the documentation refers to the "Identity SDK", the behavior in practice is always one of these concrete implementations.
 - REST Controllers: Active controllers depend on the Spring profile (see section 5.2).
 - Service Interfaces: The API contract for each resource domain.
 - Profile-specific implementations - Concrete service implementations are organized by deployment mode:
@@ -224,7 +233,7 @@ The internal decomposition of the Management Identity API differs across the act
 
 #### 5.2.1 Default Keycloak deployment (profile `keycloak`)
 
-In the default configuration (Spring profile `keycloak`), Management Identity uses Keycloak both for token validation (via the Identity SDK + Keycloak JWKS) and for user and client synchronization via the Keycloak Admin REST API.
+In the default configuration (Spring profile `keycloak`), Management Identity uses Keycloak both for token validation (via the Identity SDK with `KEYCLOAK` type → `KeycloakAuthentication`) and for user and client synchronization via the Keycloak Admin REST API.
 
 Service implementations (`KeycloakUserServiceImpl`, etc.) hold user, client, group, and role state in Keycloak; the Management Identity DB stores tenants, authorizations, and access rules.
 
@@ -242,6 +251,8 @@ flowchart TB
   subgraph MGMT_API["Management Identity API (profile: keycloak)"]
     SEC_CFG["WebSecurityConfig<br>+ SmJwtFilter"]
 
+    IDENTITY_SDK["Identity SDK<br>(KeycloakAuthentication)"]
+
     CTRL_KC["REST Controllers<br>(users, clients, groups, roles,<br>tenants, resource servers, authorizations)"]
 
     SVC_KC["Keycloak Service Implementations<br>"]
@@ -249,9 +260,12 @@ flowchart TB
     REPO["Repositories<br>(tenants, authorizations, access rules)"]
 
     INIT["Keycloak Initializers<br>(realm, clients, roles, groups on startup)"]
+
+    SEC_CFG -->|"JWT validation"| IDENTITY_SDK
   end
 
-  SEC_CFG -->|"JWKS token validation"| KEYCLOAK
+  IDENTITY_SDK -->|"Token validation (JWKS)"| KEYCLOAK
+  SEC_CFG --> CTRL_KC
   CTRL_KC --> SVC_KC
   SVC_KC -->|"Users, clients, groups,<br>roles via Admin REST API"| KEYCLOAK
   SVC_KC --> REPO
@@ -275,7 +289,9 @@ Key responsibilities:
 
 When an external OIDC provider is used instead of Keycloak (Spring profile `oidc`), user and client management via an admin API is not available.
 Groups, roles, permissions, and mapping rules are stored in the Management Identity PostgreSQL database.
-Token validation is handled in the same way as in the `keycloak` profile: `SmJwtFilter` delegates to the Identity SDK, which uses the configured IdP metadata (issuer, JWKS, and token endpoints).
+Token validation is handled in the same way as in the `keycloak` profile: `SmJwtFilter` delegates to the Identity SDK, but the active `Authentication` implementation differs:
+- For Microsoft Entra: `MICROSOFT` type → `MicrosoftAuthentication`, which also supports certificate-backed client assertions (see section 6.6).
+- For other external OIDC providers (Okta, generic OIDC): `GENERIC` type → `GenericAuthentication`.
 
 OIDC service implementations (`OidcGroupService`, `OidcRoleServiceImpl`, `OidcPermissionServiceImpl`, `OidcMappingRuleServiceImpl`, `OidcTokenTenantService`, etc.) replace the Keycloak implementations.
 
@@ -292,6 +308,8 @@ flowchart TB
   subgraph MGMT_API["Management Identity API (profile: oidc)"]
     SEC_CFG["WebSecurityConfig<br>+ SmJwtFilter"]
 
+    IDENTITY_SDK["Identity SDK<br>(MicrosoftAuthentication<br>or GenericAuthentication)"]
+
     CTRL_OIDC["REST Controllers<br>(groups, roles, tenants, mapping rules,<br>resource servers, authorizations)<br>[UserController / ClientController not active]"]
 
     SVC_OIDC["OIDC Service Implementations<br>(profile: oidc)"]
@@ -299,9 +317,12 @@ flowchart TB
     REPO_OIDC["Repositories<br>(groups, roles, permissions, mapping rules,<br>tenants, authorizations, access rules)"]
 
     INIT_OIDC["OIDC Initializers<br>(roles, permissions, mapping rules on startup)"]
+
+    SEC_CFG -->|"JWT validation"| IDENTITY_SDK
   end
 
-  SEC_CFG -->|"JWKS token validation"| EXT_IDP
+  IDENTITY_SDK -->|"Token validation (JWKS)"| EXT_IDP
+  SEC_CFG --> CTRL_OIDC
   CTRL_OIDC --> SVC_OIDC
   SVC_OIDC --> REPO_OIDC
   REPO_OIDC --> MGMT_DB
@@ -528,56 +549,57 @@ sequenceDiagram
   MGMT_DB-->>MGMT_API: Resolved roles from mapping rules
   MGMT_API-->>SERVICE: API response
 ```
-### 6.6 OIDC with private_key_jwt client authentication (Management Identity server-side OAuth client)
+### 6.6 Entra-focused certificate-based client assertion (smaller `private_key_jwt` variant for Management Identity)
 
 > **Available since**: Camunda 8.9 (issue [#3328](https://github.com/camunda/identity/issues/3328)).
 
-Scenario: Management Identity itself needs to call the IdP token endpoint in OIDC mode (for example during authorization code exchange, refresh token flow, or to perform token introspection). For this Management Identity-side client authentication to the IdP, Management Identity can use either `client_secret_basic` or `private_key_jwt` instead of transmitting a static client secret.
+Scenario: in OIDC mode, Management Identity sometimes needs to call the IdP token endpoint itself (for example during authorization code exchange, refresh token renewal, or SDK-managed client-credentials requests). For this Management Identity-side client authentication, there is a smaller certificate-based variant that works with Microsoft Entra ID.
 
-When `private_key_jwt` is configured, Management Identity loads a private key from a keystore and builds a signed JWT (client assertion) to authenticate to the IdP. This is more secure than transmitting a client secret, as only the assertion signature needs validation at the IdP and the private key never leaves Management Identity.
+This is **not** the same generic OC server-side `private_key_jwt` implementation described in the [Orchestration Cluster Identity architecture](identity_architecture_docs.md#633-oidc-with-private_key_jwt-client-authentication-oc-server-side-oauth-client). Management Identity currently uses the narrower Microsoft / Entra path from the Identity SDK (`MicrosoftAuthentication` + `CertSignedJwt`). Instead of OC's generic Spring Security assertion stack, it signs a certificate-backed JWT assertion and sends it to the Microsoft token endpoint.
 
-Configured via (Management Identity-side):
+When this path is used, Management Identity loads a PKCS12 certificate and private key, creates a signed `client_assertion` JWT with an `x5t` certificate thumbprint header, and authenticates to Entra without sending a shared client secret. This should be read as Entra-focused support, not as feature parity with the broader Orchestration Cluster Identity implementation.
 
-- `camunda.security.authentication.oidc.clientAuthenticationMethod=private_key_jwt` (or omit to default to `client_secret_basic`)
-- `camunda.security.authentication.oidc.assertion.keystore.*` (path, password, keyAlias, keyPassword)
-- Optional `assertion.kidSource`, `assertion.kidDigestAlgorithm`, `assertion.kidEncoding`, `assertion.kidCase`
+Configured via (Management Identity / Identity SDK side):
+
+- Microsoft / Entra provider type (`MICROSOFT`)
+- Standard issuer, backend issuer, client ID, and audience settings
+- Either a client secret, or a PKCS12 certificate configuration in the Identity SDK (`certPath`, `certStorePassword`)
 
 Flow:
 
-1. Management Identity needs to call the IdP token endpoint (for example to exchange an authorization code for tokens).
-2. Management Identity loads the configured private key and certificate from the keystore and builds a JSON Web Key (JWK).
-3. A signed `client_assertion` JWT is created, containing the JWK information (including `kid` and `x5t#S256`).
+1. Management Identity, via the Identity SDK's Microsoft authentication path, needs to call the Microsoft Entra token endpoint.
+2. `CertSignedJwt` loads the configured PKCS12 certificate and private key.
+3. A signed `client_assertion` JWT is created with certificate-thumbprint information (`x5t`) in the header.
 4. Management Identity sends a token request with `client_assertion` and `client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer`.
-5. The IdP validates the assertion signature using the registered public key/certificate for that Management Identity OAuth client.
+5. Microsoft Entra validates the assertion against the certificate registered for that OAuth client.
 6. The IdP returns tokens (access token, ID token, or refresh token).
 
 ```mermaid
 sequenceDiagram
   box Management Identity
-    participant AUTHN as Spring Security / Token Handler
-    participant ASSERTION as AssertionJwkProvider
-    participant CONV as NimbusJwtClientAuthenticationParametersConverter
+    participant AUTHN as Management Identity / Identity SDK
+    participant MS_AUTH as MicrosoftAuthentication
+    participant ASSERTION as CertSignedJwt
   end
   box External
-    participant IDP as OIDC IdP
+    participant IDP as Microsoft Entra ID
   end
 
-  AUTHN->>ASSERTION: Load private key/cert from keystore
-  ASSERTION-->>AUTHN: JSON Web Key (JWK)
-  AUTHN->>CONV: Build signed client_assertion JWT
-  CONV-->>AUTHN: client_assertion
-  AUTHN->>IDP: Token request + client_assertion
+  AUTHN->>MS_AUTH: Request token endpoint interaction
+  MS_AUTH->>ASSERTION: Load certificate/private key and sign client_assertion
+  ASSERTION-->>MS_AUTH: Signed client_assertion
+  MS_AUTH->>IDP: Token request + client_assertion
   IDP->>IDP: Validate client assertion
-  IDP-->>AUTHN: Token response
+  IDP-->>MS_AUTH: Token response
+  MS_AUTH-->>AUTHN: Tokens
 ```
 
 Participants:
 
-* Spring Security: orchestrates Management Identity-side OAuth client calls to the IdP token endpoint.
-* Token Handler: wraps Spring Security OAuth2 client to build assertion-based token requests.
-* `AssertionJwkProvider`: loads key material and builds a JSON Web Key (JWK) for signing assertions.
-* `NimbusJwtClientAuthenticationParametersConverter`: builds and injects the signed `client_assertion`.
-* OIDC IdP: validates Management Identity's client assertion and issues tokens.
+* Management Identity / Identity SDK: triggers token endpoint calls needed for browser login and other OAuth interactions.
+* `MicrosoftAuthentication`: Microsoft-specific SDK authentication implementation used for Entra.
+* `CertSignedJwt`: loads the certificate/private key and builds the signed `client_assertion` JWT.
+* Microsoft Entra ID: validates Management Identity's certificate-backed assertion and issues tokens.
 
 ### 6.7 Admin operations: managing users and roles (Keycloak profile)
 
@@ -714,8 +736,8 @@ This section only highlights differences or specifics for Management Identity. F
 - Authentication
   - OIDC via Keycloak or external IdP.
   - Authorization code flow for human users; `AuthController` handles the OIDC callback and `CookieService` manages session cookies for browser-based UI access.
-  - Client credentials for platform services and external tools, using supported OAuth2 client authentication methods such as `client_secret_basic` and `private_key_jwt`.
-  - Token validation in active profiles is performed by `SmJwtFilter` (a `JwtFilter` subclass) using the Identity SDK.
+  - Client credentials for platform services and external tools, typically using `client_secret_basic`; for the current Microsoft / Entra SDK path, Management Identity can also use a certificate-backed `client_assertion` (`private_key_jwt`-style) flow.
+  - Token validation in active profiles is performed by `SmJwtFilter` (a `JwtFilter` subclass) using the Identity SDK. The concrete SDK `Authentication` implementation is selected by the `camunda.identity.type` setting and differs per deployment mode: `KEYCLOAK` in the `keycloak` profile; `MICROSOFT` or `GENERIC` in the `oidc` profile depending on the external IdP. This affects claim extraction, token-endpoint client authentication method, and availability of certificate assertion (see section 6.6).
 
 - Authorization
   - RBAC model with roles, permissions, users, and groups controlling:
@@ -804,11 +826,11 @@ Legacy `saas` profile and SaaS extended support
 | Tenant (Optimize)         | Logical partition for reporting and data isolation in Optimize. Stored in `TenantRepository`. Distinct from runtime tenants in Orchestration Cluster Identity. |
 | Mapping rule              | Entity mapping IdP token claims (for example group names, attributes) to Management Identity roles or Optimize tenants; evaluated by mapping rule services in the `oidc` profile. |
 | OIDC                      | OpenID Connect; the protocol used for authentication and token issuance between platform apps, IdP, and Management Identity. |
-| Client credentials grant  | OAuth2 flow for machine-to-machine access; a service authenticates as a client (for example with `client_secret_basic` or `private_key_jwt`) to obtain a token. |
+| Client credentials grant  | OAuth2 flow for machine-to-machine access; a service authenticates as a client (for example with `client_secret_basic`, or in the current Entra-focused Management Identity variant with a certificate-backed `client_assertion`) to obtain a token. |
 | Authorization code flow   | OAuth2/OIDC flow for interactive user login via a browser redirect to the IdP. |
 | JWKS                      | JSON Web Key Set; the public key endpoint exposed by Keycloak/IdP, used by JWT filters to validate incoming JWT signatures. |
-| `private_key_jwt`         | OAuth2 client authentication method where the client signs a JWT assertion with a private key instead of using a static secret; more secure and auditable than `client_secret_basic`. |
-| Client assertion          | Signed JWT used to authenticate Management Identity or a client to the IdP token endpoint when using `private_key_jwt` client authentication. |
+| `private_key_jwt`         | OAuth2 client authentication method where the client signs a JWT assertion with a private key instead of using a static secret. In Management Identity, the currently documented server-side variant is a smaller Microsoft Entra-focused implementation, not the broader Orchestration Cluster Identity implementation. |
+| Client assertion          | Signed JWT used to authenticate a client to the IdP token endpoint. In Management Identity's current Entra-focused variant, this assertion is certificate-backed and generated by the Identity SDK's Microsoft authentication path. |
 | WebSecurityConfig         | Spring configuration class that defines the security filter chain for the Management Identity API. |
 | SmJwtFilter               | Self-Managed JWT filter; validates tokens and handles session cookie refresh for browser flows. |
 | JwtAuthenticationToken    | Spring Security Authentication object set on the `SecurityContext` after JWT validation. |

--- a/docs/monorepo-docs/architecture/components/identity/management_identity_architecture_docs.md
+++ b/docs/monorepo-docs/architecture/components/identity/management_identity_architecture_docs.md
@@ -3,80 +3,63 @@ toc_min_heading_level: 2
 toc_max_heading_level: 5
 ---
 
-# Management Identity architecture documentation
+# Architecture Documentation
 
 ## 1. Introduction and goals
 
+This documentation is based on [arc42](https://arc42.org/overview), a common architecture documentation template for software systems. It covers constraints, system context, solution strategy, building blocks, runtime view, deployment, crosscutting concepts, and risks.
+
 ### 1.1 Overview
 
-Management Identity is the Self‑Managed Camunda 8 component that manages authentication and access control for platform‑level applications that sit outside the Orchestration Cluster:
+The Management Identity component in Camunda 8 Self-Managed manages authentication and authorization for components outside the Orchestration Cluster.
 
-- Console
-- Web Modeler
-- Optimize
+It provides:
 
-It is responsible for:
+- Unified access management for platform applications: Console, Web Modeler, Optimize.
+- Flexible authentication via OIDC:
+  - With the bundled Keycloak (default Self-Managed setup)
+  - With Keycloak acting as a broker to an external enterprise IdP
+  - Directly against an external enterprise IdP
+- Role-based access control (RBAC) for platform applications.
+- Management of users, groups, roles, permissions, OAuth2 clients, Optimize tenants, and mapping rules, depending on the active Spring profile.
 
-- User and machine authentication via OIDC or the bundled Keycloak.
-- Role‑based access control (RBAC) for Console, Web Modeler, and Optimize.
-- Managing users, groups, roles, permissions, tenants (Optimize), and mapping rules.
+Historically, the original Identity service covered both platform and runtime access control.
+With the introduction of Orchestration Cluster Identity, runtime IAM moved into the cluster.
+By design, Management Identity no longer controls access to the Orchestration Cluster;
+that is handled by Orchestration Cluster Identity, described in the Orchestration Cluster Identity architecture.
+- [Orchestration Cluster Identity architecture](identity_architecture_docs.md)
 
-By design, Management Identity does not control access for the Orchestration Cluster (Zeebe, Operate, Tasklist, Orchestration Cluster APIs). That is handled by Orchestration Cluster Identity, described in the Orchestration Cluster Identity architecture documentation:
+Where concepts such as users, groups, roles, mapping rules, tenants, and RBAC overlap between both systems, the Orchestration Cluster Identity document is the primary reference for the shared conceptual model. This document focuses on the specifics of Management Identity.
 
-- Orchestration Cluster Identity architecture:
-  https://github.com/camunda/camunda/blob/identity_architecture_documentation/docs/monorepo-docs/architecture/components/identity/identity_architecture_docs.md
+The user guide for Management Identity is available here:
 
-Where concepts (users, groups, roles, mapping rules, tenants, RBAC) overlap between Management Identity and Orchestration Cluster Identity, the Orchestration Cluster Identity document is the primary reference. This document describes only the specifics of Management Identity.
+- [User Guide](https://docs.camunda.io/docs/self-managed/components/management-identity/overview/)
+
 
 ### Goals
 
-1. Provide a dedicated identity and access control layer for Web Modeler, Console, and Optimize in Self‑Managed deployments.
-2. Integrate with enterprise IdPs via OIDC, including using Keycloak either as primary IdP or as a broker to external IdPs.
-3. Offer a clear, UI‑driven experience to manage users, groups, roles, applications (clients), and tenants for Optimize.
-4. Keep platform‑level identity concerns separate from runtime (cluster) identity.
-
-### 1.2 Scope
-
-In scope:
-
-- Authentication and authorization for:
-  - Console
-  - Web Modeler
-  - Optimize
-- Management Identity UI and APIs
-- Integration with Keycloak and external OIDC providers
-- Platform‑level tenants for Optimize
-
-Out of scope (covered by Orchestration Cluster Identity):
-
-- Authentication and authorization for Zeebe, Operate, Tasklist, and Orchestration Cluster APIs.
-- Cluster‑local tenants and runtime resource authorizations.
-
-For those topics, see the Orchestration Cluster Identity architecture doc linked above.
+1. Provide a dedicated identity and access control layer for Web Modeler, Console, and Optimize in Self-Managed deployments.
+2. Integrate with enterprise IdPs via OIDC, including using Keycloak either as a primary IdP or as a broker to external IdPs.
+3. Offer a clear, UI-driven experience to manage users, groups, roles, clients (OAuth2 applications), and tenants for Optimize.
+4. Keep platform-level identity concerns separate from runtime (cluster) identity.
 
 
 ## 2. Constraints
 
-- Separate component
-  Management Identity runs as its own service (and supporting services such as Keycloak and Postgres) alongside the Orchestration Cluster in Self‑Managed setups.
+Separate component
+: Management Identity runs as its own service (and supporting services such as Keycloak and Postgres) alongside the Orchestration Cluster in Self-Managed setups.
 
-- Default IdP stack
-  Management Identity is, by default, wired to a packaged Keycloak and its database, but supports:
-  - Using an external existing Keycloak.
-  - Using a generic external OIDC provider via Keycloak’s identity brokering and/or a direct OIDC mode.
+Default IdP stack
+: Management Identity is, by default, wired to a packaged Keycloak and its database but supports using an external existing OIDC provider and using an external database.
 
-- Protocols
-  Authentication flows are based on OAuth 2.0 and OIDC (authorization code flow for interactive users, client credentials for machine‑to‑machine).
+Protocols
+: Authentication flows are based on OAuth 2.0 and OIDC (authorization code flow for interactive users, client credentials for machine-to-machine).
 
-- Responsibility split
-  Management Identity must not be a dependency for Orchestration Cluster runtime access. Orchestration Cluster Identity is the source of truth for runtime IAM; Management Identity handles only platform apps.
+Responsibility split
+: Management Identity must not be a dependency for Orchestration Cluster runtime access. Orchestration Cluster Identity is the source of truth for runtime IAM; Management Identity handles only platform apps.
 
-- Data ownership
-  Management Identity is the source of truth for:
-  - Platform users, groups, roles, and applications for Web Modeler, Console, and Optimize.
-  - Platform‑level tenants and mapping rules relevant to Optimize.
-    Runtime tenants and authorizations must not be managed in Management Identity after migration to Orchestration Cluster Identity.
-
+Data ownership
+: Data ownership varies by active profile: `keycloak` stores users/groups/roles/clients in Keycloak while Management Identity stores tenants/authorizations; `oidc` stores groups/roles/permissions/mapping rules/tenants in Management Identity DB.
 
 ## 3. System context and scope
 
@@ -87,40 +70,31 @@ For those topics, see the Orchestration Cluster Identity architecture doc linked
 title: Management Identity - Business Context
 ---
 flowchart TB
-  USER["Platform user\n(admin, developer, analyst)"]
-  APP_DEV["Application developer\n(job workers, CI/CD)"]
-  IDP[["Enterprise IdP\n(Keycloak, Entra, Okta, ...)"]]
+  USER(["Platform user<br>(admin, developer, analyst)"])
+  IDP[["Enterprise IdP<br>(Keycloak, Entra, Okta, ...)"]]
 
   subgraph PLATFORM["Camunda 8 Platform (Self-Managed)"]
     MGMT_ID["Management Identity"]
     CONSOLE["Console"]
     WEB_MODEL["Web Modeler"]
     OPT["Optimize"]
-    OC_ID["Orchestration Cluster Identity\n(runtime IAM)"]
   end
 
-  USER -->|"Browser login"| CONSOLE
-  USER -->|"Browser login"| WEB_MODEL
-  USER -->|"Browser login"| OPT
+  USER --> CONSOLE
+  USER --> WEB_MODEL
+  USER --> OPT
 
   CONSOLE --> MGMT_ID
   WEB_MODEL --> MGMT_ID
   OPT --> MGMT_ID
 
   MGMT_ID -->|"OIDC auth / tokens"| IDP
-
-  APP_DEV -->|"Access to cluster APIs"| OC_ID
 ```
 
-Main actors:
+Entities:
 
-- Platform user: administrators, modelers, and analysts using Console, Web Modeler, and Optimize.
-- Application developer: developers building job workers or integrations against Orchestration Clusters.
-- Management Identity: manages platform‑level authentication and RBAC for Console, Web Modeler, and Optimize.
-- Orchestration Cluster Identity: manages runtime authentication and RBAC for cluster components.
+- Management Identity: manages platform-level authentication and RBAC for Console, Web Modeler, and Optimize.
 - Enterprise IdP: central source of user identities and group claims (via Keycloak or other OIDC providers).
-
-Management Identity and Orchestration Cluster Identity are siblings: they serve different application surfaces but can share common identity concepts (users, groups, roles, mapping rules, tenants) and, over time, converge towards a unified model as described in the Orchestration Cluster Identity architecture doc.
 
 ### 3.2 Technical context
 
@@ -129,168 +103,665 @@ Management Identity and Orchestration Cluster Identity are siblings: they serve 
 title: Management Identity - Technical Context
 ---
 flowchart TB
-  BROWSER["Browser (Console, Web Modeler, Optimize)"]
-  APP_CLIENT["Platform client apps\n(Optimize backend, Console backend, Web Modeler backend)"]
-  IDP[("OIDC IdP / Keycloak")]
-  MGMT_DB[("Management Identity DB\n(Postgres)")]
-  KEYCLOAK_DB[("Keycloak DB")]
+  BROWSER("Browser<br>(Console, Web Modeler, Optimize)")
+  IDP_UI[["IdP UI"]]
+  IDP[["IdP"]]
+  KEYCLOAK_DB[("Keycloak DB<br>(Postgres)")]
 
-  subgraph MGMT_ID["Management Identity"]
-    MGMT_UI["Management Identity UI"]
-    MGMT_API["Management Identity API"]
-    AUTHZ["RBAC / Permissions\n(roles, groups, tenants)"]
-    MAPPING["Mapping rules\n(JWT claims -> roles / tenants)"]
+  subgraph PLATFORM["Camunda 8 Platform (Self-Managed)"]
+    MGMT["Management Identity"]
+    APP_CLIENT["Platform client backends<br>(Optimize, Console, Web Modeler)"]
+    MGMT_DB[("Management Identity DB<br>(Postgres, ..)")]
   end
 
-  BROWSER -->|"Login / admin UI"| MGMT_UI
-  MGMT_UI --> MGMT_API
-  APP_CLIENT -->|"M2M tokens, user info"| MGMT_API
+  BROWSER -->|"Login"| IDP_UI
+  BROWSER --> MGMT
 
-  MGMT_API -->|"User, group, role, app, tenant mgmt"| MGMT_DB
-  MGMT_API -->|"RBAC decisions"| AUTHZ
-  MGMT_API -->|"Resolve mapping rules"| MAPPING
+  APP_CLIENT -->|"User context, RBAC lookups"| MGMT
 
-  MGMT_API -->|"Client registrations,\nrealm config"| IDP
-  IDP -->|"OIDC tokens (users & clients)"| APP_CLIENT
-  IDP -->|"OIDC tokens / login"| BROWSER
+  MGMT -->|"Group, role, client, tenant mgmt"| MGMT_DB
 
-  IDP -->|"Users, groups, sessions"| KEYCLOAK_DB
+  MGMT -->|"Client registrations,<br>realm config"| IDP
+  APP_CLIENT -->|"OIDC tokens (users & clients)"| IDP
+
+  IDP_UI --> IDP
+  IDP -.->|"if IdP is Keycloak"| KEYCLOAK_DB
 ```
 
-Key points:
+Entities:
 
-- Console, Web Modeler, and Optimize UIs use OIDC login against the IdP (Keycloak or external), with Management Identity owning the configuration for:
-  - Clients
-  - Scopes
-  - Redirect URIs
-- Management Identity UI and API allow administrators to manage users, groups, roles, applications (clients), Optimize tenants, and mapping rules.
-- Application backends (Console, Web Modeler, Optimize) use client credentials and/or user tokens issued by the IdP, and consult Management Identity’s RBAC model when enforcing access.
+- Browser: the user's browser accessing Console, Web Modeler, Optimize, and the Management Identity UI.
+- IdP UI: the login UI exposed by the IdP, such as the Keycloak login page or the login page of an external enterprise IdP.
+- Platform client backends: backend services for Console, Web Modeler, and Optimize that use OIDC user tokens and client credentials when calling Management Identity or the IdP.
+- Management Identity: the standalone service that serves the admin UI and API and manages platform users, groups, roles, clients, tenants, and mapping rules.
+- IdP: the OIDC identity provider used for authentication and token issuance. In the default setup this is Keycloak; it can also act as a bridge/broker to external enterprise IdPs, or Management Identity can be connected directly to an external OIDC provider.
+- Management Identity DB: PostgreSQL database used by Management Identity for its own persisted identity and authorization data, depending on the active profile.
+- Keycloak DB: PostgreSQL database used by Keycloak for users, groups, sessions, and realm configuration when the `keycloak` profile is active.
 
 
 ## 4. Solution strategy
 
-- Separate management plane for platform apps
-  Management Identity provides an independent authentication/authorization surface for Console, Web Modeler, and Optimize, without coupling cluster runtime IAM to platform app availability.
+Separate management plane for platform apps
+: Management Identity provides an independent authentication and authorization surface for Console, Web Modeler, and Optimize, without coupling platform IAM to Orchestration Cluster runtime availability.
 
-- OIDC‑based SSO via Keycloak or external IdPs
-  Keycloak is provided as a default IdP and broker, with support for external enterprise IdPs via OIDC. Interactive users authenticate via authorization code flow; applications use client credentials.
+OIDC-based SSO via Keycloak or external IdPs
+: Keycloak is provided as a default IdP and broker, with support for external enterprise IdPs via OIDC. Interactive users authenticate via authorization code flow; applications use client credentials.
 
-- RBAC for platform resources
-  A role‑based access model is used to protect:
-  - Console features (cluster registration, license, user management, etc.).
-  - Web Modeler workspaces, projects, and collaboration features.
-  - Optimize dashboards, reports, and data access.
+RBAC for platform resources
+: A role-based access model protects Console features, Web Modeler workspaces, and collaboration, and Optimize dashboards, reports, and data access.
 
-- Mapping rules and tenants for Optimize
-  Mapping rules connect IdP claims (for example groups, attributes) to roles and tenants in Management Identity. Optimize uses these tenants to segment data and access for different business units or customers.
+Mapping rules and Optimize tenants
+: Mapping rules connect IdP claims (for example groups and attributes) to roles and tenants in Management Identity. Optimize uses these tenants for data and access segmentation.
 
-- Alignment with Orchestration Cluster Identity model
-  Where consistent and feasible, Management Identity uses naming and concepts aligned with Orchestration Cluster Identity (users, groups, roles, tenants, mapping rules, authorizations). Details of the shared model and runtime behavior are defined in the Orchestration Cluster Identity architecture doc.
+Spring profile-based deployment modes
+: The active deployment modes are selected via Spring profiles (`keycloak`, `oidc`). The legacy `saas` profile remains in code for backward compatibility but is deprecated and no longer used in current deployments.
+
+Alignment with Orchestration Cluster Identity concepts
+: Where consistent and useful, Management Identity uses concepts aligned with Orchestration Cluster Identity (users, groups, roles, tenants, mapping rules, authorizations). Runtime-specific semantics remain defined by Orchestration Cluster Identity.
 
 
 ## 5. Building block view
+
+### 5.1 Whitebox overall system
 
 ```mermaid
 ---
 title: Management Identity - Building Blocks
 ---
 flowchart TB
-  BROWSER["Admin / user browser"]
-  IDP[("Keycloak / OIDC IdP")]
-  MGMT_DB[("Management Identity DB")]
+  BROWSER(["Admin / user browser"])
+  IDP[("IdP")]
+  MGMT_DB[("Management Identity DB<br>(Postgres)")]
 
   subgraph MGMT_ID["Management Identity"]
-    UI["Management Identity UI"]
-    API["Management Identity API"]
-    USERS["Users / Groups"]
-    ROLES["Roles / Permissions"]
-    APPS["Applications (clients)"]
-    TENANTS["Optimize Tenants"]
-    RULES["Mapping Rules"]
+    UI["Management Identity UI<br>(React SPA)"]
+
+    subgraph MGMT_API["Management Identity API (Spring Boot)"]
+      SEC_CFG["Security Configuration<br>(WebSecurityConfig)"]
+      SECURITY["Spring Security"]
+      CONTROLLERS["REST Controllers"]
+      SERVICES["Service Interfaces"]
+      IMPL["Profile-specific implementations"]
+      REPOSITORIES["Repositories<br>(Spring Data JPA)"]
+
+      SEC_CFG --> SECURITY --> CONTROLLERS
+      CONTROLLERS --> SERVICES
+      SERVICES --> IMPL
+      IMPL --> REPOSITORIES
+    end
   end
 
-  BROWSER -->|"Admin, user flows"| UI
-  UI --> API
+  BROWSER --> UI
+  UI --> SECURITY
 
-  API --> USERS
-  API --> ROLES
-  API --> APPS
-  API --> TENANTS
-  API --> RULES
-
-  API -->|"Configure clients,\nscopes, realms"| IDP
-  IDP -->|"Tokens"| BROWSER
-
-  USERS --> MGMT_DB
-  ROLES --> MGMT_DB
-  APPS --> MGMT_DB
-  TENANTS --> MGMT_DB
-  RULES --> MGMT_DB
+  SECURITY -->|"Token validation"| IDP
+  IMPL -->|"Realm, client,<br>user config (keycloak profile)"| IDP
+  REPOSITORIES --> MGMT_DB
 ```
 
-Responsibilities:
+Main building blocks:
 
-- Management Identity UI
-  Console for administrators to:
-  - Manage users, groups, roles, applications, and tenants.
-  - Define mapping rules.
-
-- Management Identity API
-  Backing services that store and retrieve identity data, render it to the UI, and integrate with the IdP.
-
-- Users and groups
-  Platform‑level principals and groupings for Console, Web Modeler, and Optimize.
-
-- Roles and permissions
-  Define what operations users and applications can perform in the platform apps.
-
-- Applications (clients)
-  Represent platform and external applications that consume tokens (for example Optimize backend, Web Modeler backend, custom tools).
-
-- Tenants (Optimize)
-  Logical partitions for reporting and data isolation in Optimize only.
-
-- Mapping rules
-  Connect IdP token claims to roles, groups, and tenants. The general mapping‑rules concept is shared with Orchestration Cluster Identity; see the mapping rules section in the Orchestration Cluster Identity architecture doc for a more detailed explanation of the pattern.
+- Management Identity UI: React single-page application (served by `FrontendController`) for administrators to manage users, groups, roles, clients (OAuth2 applications), and tenants, and to define mapping rules.
+- Security Configuration (`WebSecurityConfig`): Spring configuration class that defines the security filter chain. It registers the `JwtFilter` implementation before the `BasicAuthenticationFilter` and explicitly permits unauthenticated access to paths such as `/auth/**`, `/actuator/**`, and public token-resolution endpoints.
+- Spring Security: Filter chain responsible for authenticating incoming requests (OIDC token validation via the configured IdP JWKS endpoint) and enforcing RBAC before delegating to controllers.
+- REST Controllers: Active controllers depend on the Spring profile (see section 5.2).
+- Service Interfaces: The API contract for each resource domain.
+- Profile-specific implementations - Concrete service implementations are organized by deployment mode:
+  - Keycloak profile implementations (profile `keycloak`): back-end operations against Keycloak Admin REST API for users and clients; stores groups and roles in Keycloak.
+  - OIDC profile implementations (profile `oidc`): stores groups, roles, permissions, and mapping rules in the Management Identity PostgreSQL database; no user or client synchronization to an external IdP.
+  - Legacy SaaS-specific implementations (profile `saas`) still exist in code for compatibility but are deprecated and not used in current deployments.
+- Repositories: Spring Data JPA repositories providing CRUD access to the Management Identity PostgreSQL database. Active repositories depend on profile and feature flags:
+  - GroupRepository (profile `oidc`; also wired for deprecated `saas` profile)
+  - RoleRepository (profile `oidc`)
+  - MappingRuleRepository (profile `oidc`)
+  - In the `keycloak` profile, groups, roles, and most role assignments live in Keycloak’s own database and are managed via the Keycloak Admin REST API, so there is no dedicated JPA repository for them in Management Identity. In the active `oidc` profile there is no such admin API, so Management Identity itself becomes the source of truth for groups, roles, and mapping rules. Some repository wiring still includes the deprecated `saas` profile for legacy compatibility.
+- IdP: Keycloak instance (default, profile `keycloak`) or external OIDC provider (profile `oidc`).
 
 
-## 6. Crosscutting concepts
+### 5.2 Building blocks by deployment mode
 
-This section only highlights differences or specifics for Management Identity. For shared concepts (RBAC model, mapping rules, tenants, authorization checks), see the Orchestration Cluster Identity architecture doc.
+The internal decomposition of the Management Identity API differs across the active Spring profiles (`keycloak`, `oidc`). The controller and service-interface layers are largely shared; the difference lies in the concrete service implementations and the repositories that are active.
+
+#### 5.2.1 Default Keycloak deployment (profile `keycloak`)
+
+In the default configuration (Spring profile `keycloak`), Management Identity uses Keycloak both for token validation (via the Identity SDK + Keycloak JWKS) and for user and client synchronization via the Keycloak Admin REST API.
+
+Service implementations (`KeycloakUserServiceImpl`, etc.) hold user, client, group, and role state in Keycloak; the Management Identity DB stores tenants, authorizations, and access rules.
+
+Initializers (`KeycloakPresetInitializer`, `KeycloakEnvironmentInitializer`, etc.) configure the Keycloak realm, clients, roles, and groups on startup via the Keycloak Admin REST API.
+
+```mermaid
+---
+title: Management Identity API - Keycloak Profile
+---
+flowchart TB
+  KEYCLOAK[["Keycloak"]]
+  KEYCLOAK_DB[("Keycloak DB<br>(Postgres)<br>(groups, roles, users, sessions)")]
+  MGMT_DB[("Management Identity DB<br>(Postgres)<br>(tenants, authorizations, access rules)")]
+
+  subgraph MGMT_API["Management Identity API (profile: keycloak)"]
+    SEC_CFG["WebSecurityConfig<br>+ SmJwtFilter"]
+
+    CTRL_KC["REST Controllers<br>(users, clients, groups, roles,<br>tenants, resource servers, authorizations)"]
+
+    SVC_KC["Keycloak Service Implementations<br>"]
+
+    REPO["Repositories<br>(tenants, authorizations, access rules)"]
+
+    INIT["Keycloak Initializers<br>(realm, clients, roles, groups on startup)"]
+  end
+
+  SEC_CFG -->|"JWKS token validation"| KEYCLOAK
+  CTRL_KC --> SVC_KC
+  SVC_KC -->|"Users, clients, groups,<br>roles via Admin REST API"| KEYCLOAK
+  SVC_KC --> REPO
+  REPO --> MGMT_DB
+  INIT -->|"Realm setup on startup"| KEYCLOAK
+  KEYCLOAK --> KEYCLOAK_DB
+```
+
+Key responsibilities:
+
+- `WebSecurityConfig`: builds the security filter chain and registers `SmJwtFilter`.
+- `SmJwtFilter`: validates JWTs using the Identity SDK against the configured IdP (Keycloak in this profile); handles cookie-based session refresh for browser flows.
+- `UserController` (`/api/users`), `ClientController` (`/api/clients`): CRUD REST endpoints for users and OAuth2 clients (keycloak profile only).
+- `GroupController` (`/api/groups`), `RoleController` (`/api/roles`): CRUD REST endpoints for groups and roles.
+- `TenantController` (`/api/tenants`), `TenantApplicationController`, `TenantUserController`, `TenantGroupController`: tenant management and tenant-membership endpoints.
+- Keycloak service implementations: implement domain logic by delegating user, client, group, and role operations to Keycloak via the Keycloak Admin Client (e.g. `KeycloakUserServiceImpl`).
+- Repositories: Spring Data JPA repositories for tenants and authorization data stored in the Management Identity database.
+- Initializers: configure the Keycloak realm, pre-defined clients, roles, and groups on startup.
+
+#### 5.2.2 External OIDC deployment (profile `oidc`)
+
+When an external OIDC provider is used instead of Keycloak (Spring profile `oidc`), user and client management via an admin API is not available.
+Groups, roles, permissions, and mapping rules are stored in the Management Identity PostgreSQL database.
+Token validation is handled in the same way as in the `keycloak` profile: `SmJwtFilter` delegates to the Identity SDK, which uses the configured IdP metadata (issuer, JWKS, and token endpoints).
+
+OIDC service implementations (`OidcGroupService`, `OidcRoleServiceImpl`, `OidcPermissionServiceImpl`, `OidcMappingRuleServiceImpl`, `OidcTokenTenantService`, etc.) replace the Keycloak implementations.
+
+Initializers (`OidcPresetInitializer`, `OidcMappingRuleInitializer`, `OidcTenantInitializerService`, etc.) set up default roles, permissions, and mapping rules in the Management Identity DB on startup.
+
+```mermaid
+---
+title: Management Identity API - OIDC Profile
+---
+flowchart TB
+  EXT_IDP(["External OIDC Provider<br>(Okta, Entra, ...)"])
+  MGMT_DB[("Management Identity DB<br>(Postgres)")]
+
+  subgraph MGMT_API["Management Identity API (profile: oidc)"]
+    SEC_CFG["WebSecurityConfig<br>+ SmJwtFilter"]
+
+    CTRL_OIDC["REST Controllers<br>(groups, roles, tenants, mapping rules,<br>resource servers, authorizations)<br>[UserController / ClientController not active]"]
+
+    SVC_OIDC["OIDC Service Implementations<br>(profile: oidc)"]
+
+    REPO_OIDC["Repositories<br>(groups, roles, permissions, mapping rules,<br>tenants, authorizations, access rules)"]
+
+    INIT_OIDC["OIDC Initializers<br>(roles, permissions, mapping rules on startup)"]
+  end
+
+  SEC_CFG -->|"JWKS token validation"| EXT_IDP
+  CTRL_OIDC --> SVC_OIDC
+  SVC_OIDC --> REPO_OIDC
+  REPO_OIDC --> MGMT_DB
+  INIT_OIDC --> MGMT_DB
+```
+
+Key differences from the Keycloak variant:
+
+- Token validation is identical to the Keycloak variant: `SmJwtFilter` and the Identity SDK are used in both profiles; only the configured IdP endpoints differ.
+- `UserController` and `ClientController` are not active: there is no user or client synchronization to the external OIDC provider via an admin API.
+- `MappingRuleController` (`/api/mapping-rules`) is active only in the `oidc` profile, as mapping rules are the primary mechanism for resolving roles from IdP claims.
+- Groups, roles, permissions, and mapping rules are stored in the Management Identity database.
+- Role assignment from IdP claims relies on mapping rules evaluated against external token claims at login time.
+
+
+## 6. Runtime view
+
+### 6.1 User login via Keycloak (default)
+
+Scenario: a platform user logs into Console, Web Modeler, or Optimize using the default bundled Keycloak as the IdP.
+
+1. Browser navigates to Console, Web Modeler, or Optimize.
+2. The application redirects the browser to Keycloak for login (OIDC authorization code flow).
+3. The user authenticates with Keycloak.
+4. Keycloak redirects back to the application with an authorization code.
+5. The application exchanges the authorization code for tokens and requests user info.
+6. The application calls Management Identity’s public token-resolution endpoints (for example /api/authorizations/for-token, /api/tenants/for-token, /api/groups/for-token) with a Bearer access token. After SmJwtFilter validation, the corresponding controllers resolve roles/groups/tenants from Keycloak-backed data and Management Identity assignments.
+7. A session is established, and the application renders the requested view.
+
+```mermaid
+sequenceDiagram
+  actor USER as User (Browser)
+  box Platform Apps
+    participant APP as Console / Web Modeler / Optimize
+  end
+  box Management Identity
+    participant SEC as Spring Security (SmJwtFilter)
+    participant MGMT_API as Management Identity API Controllers
+  end
+  box External
+    participant MGMT_DB as Management Identity DB (Postgres)
+    participant KEYCLOAK as Keycloak (default IdP)
+  end
+  USER->>APP: Navigate to app
+  APP-->>USER: Redirect to Keycloak (OIDC authorization code flow)
+  USER->>KEYCLOAK: Enter credentials
+  KEYCLOAK->>KEYCLOAK: Authenticate user
+  KEYCLOAK-->>APP: Authorization code callback
+  APP->>KEYCLOAK: Exchange code for tokens
+  KEYCLOAK-->>APP: ID token + access token
+
+  APP->>SEC: Resolve identity (Bearer access token)
+  SEC->>SEC: Validate JWT via Identity SDK (Keycloak JWKS)
+  SEC->>MGMT_API: Forward authenticated request
+
+  MGMT_API->>KEYCLOAK: Read users/groups/roles (Keycloak Admin API)
+  KEYCLOAK-->>MGMT_API: Users, groups, roles
+
+  MGMT_API->>MGMT_DB: Read tenant and authorization assignments
+  MGMT_DB-->>MGMT_API: Tenants, authorization data
+
+  MGMT_API-->>APP: Resolved identity (roles, groups, tenants)
+  APP-->>USER: Session established, app rendered
+```
+
+### 6.2 User login via external OIDC IdP (Keycloak as broker)
+
+Scenario: the enterprise uses an external IdP (for example Okta or Microsoft Entra ID). Keycloak is configured as an OIDC broker and forwards authentication to the external IdP.
+
+1. Browser navigates to Console, Web Modeler, or Optimize.
+2. The application redirects to Keycloak; Keycloak in turn redirects to the external IdP.
+3. The external IdP authenticates the user and redirects back to Keycloak with an authorization code.
+4. Keycloak exchanges the code for external tokens, maps the external claims to local users/groups using Keycloak identity-provider mappers, and issues its own tokens.
+5. The application receives Keycloak tokens and proceeds as in the default login flow (6.1).
+6. Management Identity API validates the Keycloak token and resolves platform roles, groups, and tenants from Keycloak-backed assignments plus Management Identity tenant/authorization data.
+
+```mermaid
+sequenceDiagram
+  actor USER as User (Browser)
+  box Platform Apps
+    participant APP as Console / Web Modeler / Optimize
+  end
+  box Management Identity
+    participant SEC as Spring Security (SmJwtFilter)
+    participant MGMT_API as Management Identity API Controllers
+  end
+  box External
+    participant MGMT_DB as Management Identity DB (Postgres)
+    participant KEYCLOAK as Keycloak (broker)
+    participant EXT_IDP as External IdP (Okta, Entra, ...)
+  end
+
+  USER->>APP: Navigate to app
+  APP-->>USER: Redirect to Keycloak
+  USER->>KEYCLOAK: Keycloak login page
+  KEYCLOAK-->>USER: Redirect to external IdP
+  USER->>EXT_IDP: Authenticate with enterprise credentials
+  EXT_IDP-->>USER: Redirect to Keycloak with authorization code
+  USER->>KEYCLOAK: Authorization code
+  KEYCLOAK->>EXT_IDP: Exchange code for external tokens
+  EXT_IDP-->>KEYCLOAK: External ID token + claims
+  KEYCLOAK->>KEYCLOAK: Map external claims to local users/groups
+  KEYCLOAK-->>APP: ID token + access token (with mapped claims)
+  Note over KEYCLOAK,EXT_IDP: Keycloak acts as OIDC broker - user identity<br>originates from EXT_IDP, claims are mapped by Keycloak
+  APP->>SEC: Resolve identity (Bearer access token)
+  SEC->>SEC: Validate JWT via Identity SDK (Keycloak JWKS)
+  SEC->>MGMT_API: Forward authenticated request
+  Note over MGMT_API: Token is Keycloak-issued but<br>groups/roles reflect EXT_IDP claims mapped by Keycloak
+  MGMT_API->>KEYCLOAK: Resolve users/groups/roles from mapped claims
+  KEYCLOAK-->>MGMT_API: Groups, roles
+  MGMT_API->>MGMT_DB: Query tenant and authorization assignments
+  MGMT_DB-->>MGMT_API: Tenants, authorization data
+  MGMT_API-->>APP: Resolved identity (roles, groups, tenants)
+  APP-->>USER: Session established, app rendered
+```
+
+### 6.3 User login via direct external OIDC provider (profile `oidc`)
+
+Scenario: a platform user logs into Console, Web Modeler, or Optimize when Management Identity is configured directly against an external OIDC provider (no Keycloak involved).
+
+1. Browser navigates to Console, Web Modeler, or Optimize.
+2. The application redirects the browser directly to the external OIDC provider.
+3. The user authenticates with the enterprise IdP.
+4. The external OIDC provider issues an authorization code and the application exchanges it for tokens.
+5. The application calls the Management Identity API with the resulting token.
+6. `SmJwtFilter` validates the token via the Identity SDK against the configured issuer and JWKS endpoint.
+7. Management Identity evaluates mapping rules and stored assignments in the Management Identity database to resolve platform roles and Optimize tenants.
+8. A session is established and the requested view is rendered.
+
+```mermaid
+sequenceDiagram
+  actor USER as User (Browser)
+  box Platform Apps
+    participant APP as Console / Web Modeler / Optimize
+  end
+  box Management Identity
+    participant SEC as Spring Security (SmJwtFilter)
+    participant MGMT_API as Management Identity API Controllers
+  end
+  box External
+    participant MGMT_DB as Management Identity DB (Postgres)
+    participant EXT_IDP as External OIDC Provider
+  end
+
+  USER->>APP: Navigate to app
+  APP-->>USER: Redirect to external OIDC provider
+  USER->>EXT_IDP: Authenticate with enterprise credentials
+  EXT_IDP-->>APP: Authorization code callback
+  APP->>EXT_IDP: Exchange code for tokens
+  EXT_IDP-->>APP: ID token + access token
+  APP->>SEC: Resolve identity (Bearer access token)
+  SEC->>SEC: Validate JWT via Identity SDK (external JWKS)
+  SEC->>MGMT_API: Forward authenticated request
+  MGMT_API->>MGMT_DB: Evaluate mapping rules, query roles and Optimize tenants
+  MGMT_DB-->>MGMT_API: Resolved identity data
+  MGMT_API-->>APP: Resolved identity (roles, groups, tenants)
+  APP-->>USER: Session established, app rendered
+```
+
+### 6.4 Machine-to-machine access via Keycloak (client credentials)
+
+Scenario: an automated service calls the Management Identity API using client credentials against the default Keycloak IdP.
+
+This is not a typical use case; typical M2M integrations are carried out via orchestration cluster APIs, so OC Identity.
+
+1. The service requests a JWT access token from Keycloak using the OAuth2 client credentials grant.
+2. Keycloak validates the client credentials and issues an access token.
+3. The service sends the token as a `Bearer` header on each Management Identity API request.
+4. `SmJwtFilter` validates the token signature via the Identity SDK (Keycloak JWKS endpoint) and sets a `JwtAuthenticationToken` on the `SecurityContext`.
+5. Management Identity API resolves the client's roles and permissions from the database and processes the authorized request.
+
+```mermaid
+sequenceDiagram
+  box Customer System
+    participant SERVICE as Automated Service
+  end
+  box External
+    participant KEYCLOAK as Keycloak
+    participant MGMT_DB as Management Identity DB (Postgres)
+  end
+  box Management Identity
+    participant SEC as Spring Security (SmJwtFilter)
+    participant MGMT_API as Management Identity API Controllers
+  end
+
+  SERVICE->>KEYCLOAK: Request token (client credentials grant)
+  KEYCLOAK->>KEYCLOAK: Validate client credentials
+  KEYCLOAK-->>SERVICE: JWT access token
+  SERVICE->>SEC: API request + Bearer token
+  SEC->>SEC: Validate JWT via Identity SDK (Keycloak JWKS)
+  SEC->>MGMT_API: Forward authenticated request
+  MGMT_API->>MGMT_DB: Load client roles and permissions
+  MGMT_DB-->>MGMT_API: Client roles, permissions
+  MGMT_API-->>SERVICE: API response
+```
+
+### 6.5 Machine-to-machine access via external OIDC provider (client credentials)
+
+Scenario: an automated service calls the Management Identity API using a token issued directly by an external OIDC provider (no Keycloak involved).
+
+Note: unlike the Orchestration Cluster-side client support introduced in Camunda 8.8, `private_key_jwt` client authentication has not yet been ported to Management Identity. The flow described here therefore assumes standard client-credentials authentication at the external IdP.
+
+1. The service requests a JWT access token directly from the external OIDC provider using the OAuth2 client credentials grant.
+2. The external OIDC provider validates the client credentials and issues an access token.
+3. The service sends the token as a `Bearer` header on each Management Identity API request.
+4. `SmJwtFilter` validates the token signature via the Identity SDK (external OIDC JWKS endpoint) and sets a `JwtAuthenticationToken` on the `SecurityContext`.
+5. Management Identity API evaluates `MappingRule` entities to resolve the client's roles from the database and processes the authorized request.
+
+```mermaid
+sequenceDiagram
+  box Customer System
+    participant SERVICE as Automated Service
+  end
+  box External
+    participant EXT_IDP as External OIDC Provider
+    participant MGMT_DB as Management Identity DB (Postgres)
+  end
+  box Management Identity
+    participant SEC as Spring Security (SmJwtFilter)
+    participant MGMT_API as Management Identity API Controllers
+  end
+
+  SERVICE->>EXT_IDP: Request token (client credentials grant)
+  EXT_IDP->>EXT_IDP: Validate client credentials
+  EXT_IDP-->>SERVICE: JWT access token
+  SERVICE->>SEC: API request + Bearer token
+  SEC->>SEC: Validate JWT via Identity SDK (external JWKS)
+  SEC->>MGMT_API: Forward authenticated request
+  MGMT_API->>MGMT_DB: Evaluate MappingRule entities, load roles
+  MGMT_DB-->>MGMT_API: Resolved roles from mapping rules
+  MGMT_API-->>SERVICE: API response
+```
+
+### 6.6 Admin operations: managing users and roles (Keycloak profile)
+
+Scenario: a platform administrator uses the Management Identity UI to create a new user and assign a role to that user (keycloak profile only).
+
+1. Administrator logs into the Management Identity UI via the standard OIDC login flow (see 6.1). The `AuthController` handles the OIDC callback and issues session cookies via `CookieService`.
+2. Administrator navigates to Users and creates a new user.
+3. Management Identity UI sends a `POST /api/users` request to the Management Identity API.
+4. `UserController` delegates to `KeycloakUserServiceImpl`, which creates the user in the Keycloak realm via the Keycloak Admin Client.
+5. Administrator assigns a role to the user.
+6. Management Identity UI sends a `POST /api/users/{id}/roles` request.
+7. `UserController` delegates to `KeycloakUserServiceImpl`, which assigns the Keycloak realm role to the user.
+
+```mermaid
+sequenceDiagram
+  actor ADMIN as Administrator
+  box Management Identity
+    participant MGMT_UI as Management Identity UI (React)
+    participant AUTH_CTRL as AuthController (/auth/*)
+    participant SEC as Spring Security (SmJwtFilter)
+    participant MGMT_API as Management Identity API Controllers
+  end
+  box External
+    participant KEYCLOAK as Keycloak
+  end
+
+  ADMIN->>MGMT_UI: Navigate to Management Identity UI
+  MGMT_UI-->>ADMIN: Redirect to Keycloak (OIDC authorization code flow)
+  ADMIN->>KEYCLOAK: Authenticate
+  KEYCLOAK-->>AUTH_CTRL: Authorization code callback (/auth/callback)
+  AUTH_CTRL->>KEYCLOAK: Exchange code for tokens
+  KEYCLOAK-->>AUTH_CTRL: ID token + access token
+  AUTH_CTRL-->>ADMIN: Session cookies set, redirect to UI
+
+  ADMIN->>SEC: POST /api/users (create user)
+  SEC->>SEC: Validate session token via Identity SDK, RBAC check
+  SEC->>MGMT_API: Forward authenticated request
+  MGMT_API->>KEYCLOAK: KeycloakUserServiceImpl creates user in realm
+  KEYCLOAK-->>MGMT_API: User created
+  MGMT_API-->>ADMIN: 201 Created (user key)
+
+  ADMIN->>SEC: POST /api/users/{id}/roles (assign role)
+  SEC->>SEC: Validate session token via Identity SDK, RBAC check
+  SEC->>MGMT_API: Forward authenticated request
+  MGMT_API->>KEYCLOAK: KeycloakUserServiceImpl assigns realm role
+  KEYCLOAK-->>MGMT_API: Role assigned
+  MGMT_API-->>ADMIN: 200 OK
+```
+
+
+## 7. Deployment view
+
+Management Identity-specific aspects:
+
+- Standalone service
+  Management Identity is deployed separately from the Orchestration Cluster in Self-Managed setups.
+
+- Profile-based IdP integration
+  Deployment topology depends on the active profile (`keycloak` or `oidc`).
+
+- Storage
+  Management Identity uses its own PostgreSQL database. In the `keycloak` profile, Keycloak uses a separate PostgreSQL database for users, sessions, and realm config.
+
+### 7.1 Default Self-Managed deployment
+
+In the default setup (`keycloak` profile), Management Identity runs with bundled Keycloak.
+Platform apps authenticate via Keycloak and resolve platform RBAC via Management Identity.
+
+```mermaid
+---
+title: Management Identity - Deployment View (Default)
+---
+flowchart TB
+  CLIENTS["Platform Apps<br>(Console, Web Modeler, Optimize)"]
+  KEYCLOAK[("Keycloak")]
+  MGMT_DB[("Management Identity DB<br>(Postgres)")]
+  KEYCLOAK_DB[("Keycloak DB<br>(Postgres)")]
+
+  subgraph MGMT_STACK["Management Identity Stack"]
+    MGMT["Management Identity<br>(UI + API)"]
+  end
+
+  CLIENTS -->|"OIDC login"| KEYCLOAK
+  CLIENTS --> MGMT
+  MGMT --> MGMT_DB
+  MGMT --> KEYCLOAK
+  KEYCLOAK --> KEYCLOAK_DB
+```
+
+Key points:
+
+- Management Identity and Keycloak are separate services.
+- Management Identity stores tenants, authorizations, and access rules in its own DB.
+- Keycloak stores users, groups, roles, clients, sessions, and realm configuration in its own DB.
+
+### 7.2 External Keycloak or OIDC provider
+
+For enterprise setups, Management Identity can use:
+
+- External Keycloak (profile `keycloak`), or
+- Direct external OIDC provider (profile `oidc`).
+
+The deployment below shows the direct external OIDC mode (`oidc` profile).
+
+```mermaid
+---
+title: Management Identity - Deployment View (Direct OIDC)
+---
+flowchart TB
+  CLIENTS["Platform Apps<br>(Console, Web Modeler, Optimize)"]
+  EXT_IDP[("External OIDC Provider")]
+  MGMT_DB[("Management Identity DB<br>(Postgres)")]
+
+  subgraph MGMT_STACK["Management Identity Stack"]
+    MGMT["Management Identity<br>(UI + API)"]
+  end
+
+  CLIENTS -->|"OIDC login"| EXT_IDP
+  CLIENTS -->|"RBAC / user info"| MGMT
+  MGMT -->|"Token validation (JWKS)"| EXT_IDP
+  MGMT --> MGMT_DB
+```
+
+Key points:
+
+- In `oidc` profile, groups, roles, permissions, mapping rules, and tenants are stored in the Management Identity DB.
+- There is no Keycloak Admin API synchronization path in direct external OIDC mode.
+
+
+## 8. Crosscutting concepts
+
+This section only highlights differences or specifics for Management Identity. For shared concepts (RBAC model, mapping rules, tenants, authorization checks), see the [Orchestration Cluster Identity architecture doc](identity_architecture_docs.md).
 
 - Authentication
   - OIDC via Keycloak or external IdP.
-  - Authorization code flow for human users.
+  - Authorization code flow for human users; `AuthController` handles the OIDC callback and `CookieService` manages session cookies for browser-based UI access.
   - Client credentials for platform services and external tools.
+  - `private_key_jwt` client authentication support introduced for Orchestration Cluster-side clients has not yet been ported to Management Identity.
+  - Token validation in active profiles is performed by `SmJwtFilter` (a `JwtFilter` subclass) using the Identity SDK.
 
 - Authorization
   - RBAC model with roles, permissions, users, and groups controlling:
     - Console features and views.
     - Web Modeler access and collaboration features.
     - Optimize data access and actions.
+  - Method-level authorization is enforced by `@PreAuthorize` annotations on controller methods (configured via `GlobalMethodSecurityConfig` and `CustomMethodSecurityExpressionHandler`).
   - Runtime resource authorizations for process instances, tasks, etc. are handled by Orchestration Cluster Identity and its RBAC engine, not by Management Identity.
 
+- Spring profile-based feature toggling
+  - Active profiles (`keycloak`, `oidc`) select which service implementations, controllers, and repositories are active. This avoids runtime conditionals in business logic and allows each supported deployment mode to be tested in isolation.
+
 - Tenants
-  - Management Identity tenants apply to Optimize only (for data isolation in reporting and analytics).
+  - Management Identity tenants apply to Optimize only (for data isolation in reporting and analytics); they are stored in `TenantRepository` and gated by the `multi-tenancy` feature flag.
   - Runtime tenants for process execution live in Orchestration Cluster Identity.
 
 - Mapping rules
-  - Rules in Management Identity map IdP claims (for example group names) to:
-    - Roles (e.g. Console Admin, Optimize Analyst)
-    - Optimize tenants
-  - The same general pattern is used for Orchestration Cluster Identity; see the Orchestration Cluster Identity architecture doc for details.
+  - In the `oidc` profile, `MappingRule` entities (stored in `MappingRuleRepository`) map IdP token claims (for example group names, attributes) to roles and Optimize tenants.
+  - `OidcMappingRuleServiceImpl` (single-tenant) and `MultiTenantOidcMappingRuleServiceImpl` (multi-tenant) evaluate these rules on token validation.
+  - The same general pattern is used for Orchestration Cluster Identity; see the [Orchestration Cluster Identity architecture doc](identity_architecture_docs.md) for details.
+
+- Data storage
+  - Management Identity uses its own PostgreSQL database. Unlike Orchestration Cluster Identity, it does not reuse Zeebe's primary or secondary storage.
+  - In the `keycloak` profile, users, groups, roles, and clients are stored in Keycloak's database; only tenants and authorizations live in the Management Identity DB.
+  - In the `oidc` profile, all identity data (groups, roles, permissions, mapping rules, tenants) is stored in the Management Identity DB.
+  - Keycloak uses a separate PostgreSQL database for users, sessions, and realm configuration.
+
+- Startup initialization
+  - `ApplicationInitializer` validates that exactly one authentication backend profile is active on startup.
+  - Profile-specific initializers configure the IdP realm, clients, roles, groups, permissions, and mapping rules in the correct backend on first boot.
+  - `EnvironmentInitializer` seeds tenant data from common configuration when multi-tenancy is enabled.
 
 
-## 7. Quality goals
+## 9. Architectural decisions
 
-- Clear separation of concerns
-  Platform‑level identity (Management Identity) and runtime identity (Orchestration Cluster Identity) are separated to avoid cross‑dependencies that affect availability.
+The following decisions are specific to Management Identity. For decisions about Orchestration Cluster Identity (for example the decision to embed identity in the cluster rather than use Management Identity for runtime, or the resource-based authorization model), see the ADRs referenced in the [Orchestration Cluster Identity architecture doc](identity_architecture_docs.md#9-architectural-decisions).
 
-- Integratability
-  Straightforward integration with customer IdPs via Keycloak and OIDC, including support for common enterprise setups.
+Keycloak as default IdP
+: Management Identity ships Keycloak as the default bundled IdP for Self-Managed deployments. This provides an out-of-the-box OIDC-capable IdP with a well-known admin API that Management Identity can configure programmatically. External Keycloak and direct OIDC modes are also supported for enterprise environments.
 
-- Operability
-  Management Identity should be observable and manageable (logging, metrics) as part of the broader Self‑Managed deployment.
+Separate service (not cluster-embedded)
+: Management Identity is deployed as an independent service rather than being embedded in the Orchestration Cluster. This keeps platform-level IAM (Console, Web Modeler, Optimize) decoupled from cluster runtime availability. As Orchestration Cluster Identity is introduced and runtime IAM moves into the cluster, the trade-off is that two identity services must be operated in Self-Managed deployments.
 
-- Consistency with Orchestration Cluster Identity
-  Where feasible, concepts and naming are kept aligned with Orchestration Cluster Identity to reduce cognitive load and simplify documentation and tooling.
+Spring profiles for deployment-mode selection
+: Instead of runtime conditional logic, Management Identity uses Spring profiles (`keycloak`, `oidc`) to activate the correct service implementations, controllers, and repositories for each supported deployment mode. This isolates IdP-specific logic and allows each mode to be tested independently.
+
+Service-interface / implementation split
+: Service contracts are defined as service interfaces, with profile-specific implementations. This allows the same controllers to operate in all modes without knowing which IdP is backing them.
+
+Clients as the OAuth2 abstraction
+: The internal domain model uses the term "client" (aligned with OAuth2 terminology) for OAuth2 client registrations. The REST API is exposed under `/api/clients` and implemented by `ClientController` (keycloak profile only), with `KeycloakClientServiceImpl` managing client registration in Keycloak.
+
+PostgreSQL as persistence layer
+: Unlike Orchestration Cluster Identity, which reuses Zeebe's storage, Management Identity uses its own PostgreSQL database. This is consistent with its role as a standalone platform service.
+
+
+## 10. Risks and technical debt
+
+Dual identity model
+: Management Identity (for Console, Web Modeler, Optimize) and Orchestration Cluster Identity (for the runtime cluster) are both operated in Self-Managed environments. This creates a risk of confusion about the source of truth for identity data and duplicated configuration, because some applications use Management Identity while others use Orchestration Cluster Identity. Identity data may therefore need to be managed in two places for different applications. Mitigation: clear documentation of the responsibility boundary; alignment of concepts and naming across both models; and tooling that helps operators understand and audit where particular users, groups, and roles are configured.
+
+Keycloak operational complexity
+: Running Keycloak as a dependency adds operational overhead: version management, database maintenance, configuration management, and availability dependencies. Misconfigured realms or client registrations can break login for all platform apps.
+Mitigation: Helm chart automation for standard setups; detailed documentation for external Keycloak and direct OIDC configurations.
+
+External IdP dependency
+: For OIDC, availability and correctness of the external IdP (Keycloak or third-party) are critical. Misconfigured claims or mapping rules can lead to over- or under-provisioned access.
+Mitigation: mapping rule validation; comprehensive integration tests for common IdP configurations.
+
+
+## 11. Glossary
+
+| Term                      | Definition |
+|---------------------------|-----------|
+| Management Identity       | Standalone identity service (Self-Managed) for platform-level apps: Console, Web Modeler, and Optimize. |
+| Orchestration Cluster Identity | Cluster-embedded identity service for runtime IAM (Zeebe, Operate, Tasklist, Orchestration Cluster APIs). See [identity_architecture_docs.md](identity_architecture_docs.md). |
+| Keycloak                  | Open-source IdP bundled with Management Identity by default (Spring profile `keycloak`); also supports external Keycloak or direct OIDC providers. |
+| Spring profile            | Mechanism used to select deployment mode. Active profiles are `keycloak` (default) and `oidc` (external OIDC). |
+| Platform app              | Applications managed by Management Identity: Console, Web Modeler, Optimize. |
+| User                      | Human principal managed in Keycloak (keycloak profile) or referenced by ID from an external IdP (oidc profile). |
+| Group                     | Named collection of users; stored in Keycloak (keycloak profile) or in `GroupRepository` (oidc profile). |
+| Role                      | Set of permissions controlling what operations a user or service can perform in platform apps; stored in Keycloak (keycloak profile) or in `RoleRepository` (oidc profile). |
+| Client                    | OAuth2 client registered in Management Identity representing a platform or external app (for example Optimize backend, Web Modeler backend). |
+| Tenant (Optimize)         | Logical partition for reporting and data isolation in Optimize. Stored in `TenantRepository`. Distinct from runtime tenants in Orchestration Cluster Identity. |
+| Mapping rule              | Entity mapping IdP token claims (for example group names, attributes) to Management Identity roles or Optimize tenants; evaluated by mapping rule services in the `oidc` profile. |
+| OIDC                      | OpenID Connect; the protocol used for authentication and token issuance between platform apps, IdP, and Management Identity. |
+| Client credentials grant  | OAuth2 flow for machine-to-machine access; a service authenticates with its client ID and secret to obtain a token. |
+| Authorization code flow   | OAuth2/OIDC flow for interactive user login via a browser redirect to the IdP. |
+| JWKS                      | JSON Web Key Set; the public key endpoint exposed by Keycloak/IdP, used by JWT filters to validate incoming JWT signatures. |
+| WebSecurityConfig         | Spring configuration class that defines the security filter chain for the Management Identity API. |
+| SmJwtFilter               | Self-Managed JWT filter; validates tokens and handles session cookie refresh for browser flows. |
+| JwtAuthenticationToken    | Spring Security Authentication object set on the `SecurityContext` after JWT validation. |

--- a/docs/monorepo-docs/architecture/components/identity/management_identity_architecture_docs.md
+++ b/docs/monorepo-docs/architecture/components/identity/management_identity_architecture_docs.md
@@ -3,7 +3,7 @@ toc_min_heading_level: 2
 toc_max_heading_level: 5
 ---
 
-# Architecture Documentation
+# Management Identity Architecture Documentation
 
 ## 1. Introduction and goals
 
@@ -154,7 +154,7 @@ Mapping rules and Optimize tenants
 : Mapping rules connect IdP claims (for example groups and attributes) to roles and tenants in Management Identity. Optimize uses these tenants for data and access segmentation.
 
 Spring profile-based deployment modes
-: The active deployment modes are selected via Spring profiles (`keycloak`, `oidc`). The legacy `saas` profile remains in code for backward compatibility but is deprecated and no longer used in current deployments.
+: The active deployment modes are selected via Spring profiles (`keycloak`, `oidc`). The legacy `saas` profile remains in code for backward compatibility but is deprecated and no longer used in current deployments. See section 10. Technical dept.
 
 Alignment with Orchestration Cluster Identity concepts
 : Where consistent and useful, Management Identity uses concepts aligned with Orchestration Cluster Identity (users, groups, roles, tenants, mapping rules, authorizations). Runtime-specific semantics remain defined by Orchestration Cluster Identity.
@@ -366,7 +366,6 @@ sequenceDiagram
   MGMT_API-->>APP: Resolved identity (roles, groups, tenants)
   APP-->>USER: Session established, app rendered
 ```
-
 ### 6.2 User login via external OIDC IdP (Keycloak as broker)
 
 Scenario: the enterprise uses an external IdP (for example Okta or Microsoft Entra ID). Keycloak is configured as an OIDC broker and forwards authentication to the external IdP.
@@ -417,7 +416,6 @@ sequenceDiagram
   MGMT_API-->>APP: Resolved identity (roles, groups, tenants)
   APP-->>USER: Session established, app rendered
 ```
-
 ### 6.3 User login via direct external OIDC provider (profile `oidc`)
 
 Scenario: a platform user logs into Console, Web Modeler, or Optimize when Management Identity is configured directly against an external OIDC provider (no Keycloak involved).
@@ -460,12 +458,11 @@ sequenceDiagram
   MGMT_API-->>APP: Resolved identity (roles, groups, tenants)
   APP-->>USER: Session established, app rendered
 ```
-
 ### 6.4 Machine-to-machine access via Keycloak (client credentials)
 
 Scenario: an automated service calls the Management Identity API using client credentials against the default Keycloak IdP.
 
-This is not a typical use case; typical M2M integrations are carried out via orchestration cluster APIs, so OC Identity.
+This is not a typical use case; typical M2M integrations are carried out via orchestration cluster (OC) APIs.
 
 1. The service requests a JWT access token from Keycloak using the OAuth2 client credentials grant.
 2. Keycloak validates the client credentials and issues an access token.
@@ -497,12 +494,9 @@ sequenceDiagram
   MGMT_DB-->>MGMT_API: Client roles, permissions
   MGMT_API-->>SERVICE: API response
 ```
-
 ### 6.5 Machine-to-machine access via external OIDC provider (client credentials)
 
 Scenario: an automated service calls the Management Identity API using a token issued directly by an external OIDC provider (no Keycloak involved).
-
-Note: unlike the Orchestration Cluster-side client support introduced in Camunda 8.8, `private_key_jwt` client authentication has not yet been ported to Management Identity. The flow described here therefore assumes standard client-credentials authentication at the external IdP.
 
 1. The service requests a JWT access token directly from the external OIDC provider using the OAuth2 client credentials grant.
 2. The external OIDC provider validates the client credentials and issues an access token.
@@ -534,8 +528,58 @@ sequenceDiagram
   MGMT_DB-->>MGMT_API: Resolved roles from mapping rules
   MGMT_API-->>SERVICE: API response
 ```
+### 6.6 OIDC with private_key_jwt client authentication (Management Identity server-side OAuth client)
 
-### 6.6 Admin operations: managing users and roles (Keycloak profile)
+> **Available since**: Camunda 8.9 (issue [#3328](https://github.com/camunda/identity/issues/3328)).
+
+Scenario: Management Identity itself needs to call the IdP token endpoint in OIDC mode (for example during authorization code exchange, refresh token flow, or to perform token introspection). For this Management Identity-side client authentication to the IdP, Management Identity can use either `client_secret_basic` or `private_key_jwt` instead of transmitting a static client secret.
+
+When `private_key_jwt` is configured, Management Identity loads a private key from a keystore and builds a signed JWT (client assertion) to authenticate to the IdP. This is more secure than transmitting a client secret, as only the assertion signature needs validation at the IdP and the private key never leaves Management Identity.
+
+Configured via (Management Identity-side):
+
+- `camunda.security.authentication.oidc.clientAuthenticationMethod=private_key_jwt` (or omit to default to `client_secret_basic`)
+- `camunda.security.authentication.oidc.assertion.keystore.*` (path, password, keyAlias, keyPassword)
+- Optional `assertion.kidSource`, `assertion.kidDigestAlgorithm`, `assertion.kidEncoding`, `assertion.kidCase`
+
+Flow:
+
+1. Management Identity needs to call the IdP token endpoint (for example to exchange an authorization code for tokens).
+2. Management Identity loads the configured private key and certificate from the keystore and builds a JSON Web Key (JWK).
+3. A signed `client_assertion` JWT is created, containing the JWK information (including `kid` and `x5t#S256`).
+4. Management Identity sends a token request with `client_assertion` and `client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer`.
+5. The IdP validates the assertion signature using the registered public key/certificate for that Management Identity OAuth client.
+6. The IdP returns tokens (access token, ID token, or refresh token).
+
+```mermaid
+sequenceDiagram
+  box Management Identity
+    participant AUTHN as Spring Security / Token Handler
+    participant ASSERTION as AssertionJwkProvider
+    participant CONV as NimbusJwtClientAuthenticationParametersConverter
+  end
+  box External
+    participant IDP as OIDC IdP
+  end
+
+  AUTHN->>ASSERTION: Load private key/cert from keystore
+  ASSERTION-->>AUTHN: JSON Web Key (JWK)
+  AUTHN->>CONV: Build signed client_assertion JWT
+  CONV-->>AUTHN: client_assertion
+  AUTHN->>IDP: Token request + client_assertion
+  IDP->>IDP: Validate client assertion
+  IDP-->>AUTHN: Token response
+```
+
+Participants:
+
+* Spring Security: orchestrates Management Identity-side OAuth client calls to the IdP token endpoint.
+* Token Handler: wraps Spring Security OAuth2 client to build assertion-based token requests.
+* `AssertionJwkProvider`: loads key material and builds a JSON Web Key (JWK) for signing assertions.
+* `NimbusJwtClientAuthenticationParametersConverter`: builds and injects the signed `client_assertion`.
+* OIDC IdP: validates Management Identity's client assertion and issues tokens.
+
+### 6.7 Admin operations: managing users and roles (Keycloak profile)
 
 Scenario: a platform administrator uses the Management Identity UI to create a new user and assign a role to that user (keycloak profile only).
 
@@ -670,8 +714,7 @@ This section only highlights differences or specifics for Management Identity. F
 - Authentication
   - OIDC via Keycloak or external IdP.
   - Authorization code flow for human users; `AuthController` handles the OIDC callback and `CookieService` manages session cookies for browser-based UI access.
-  - Client credentials for platform services and external tools.
-  - `private_key_jwt` client authentication support introduced for Orchestration Cluster-side clients has not yet been ported to Management Identity.
+  - Client credentials for platform services and external tools, using supported OAuth2 client authentication methods such as `client_secret_basic` and `private_key_jwt`.
   - Token validation in active profiles is performed by `SmJwtFilter` (a `JwtFilter` subclass) using the Identity SDK.
 
 - Authorization
@@ -742,6 +785,8 @@ External IdP dependency
 : For OIDC, availability and correctness of the external IdP (Keycloak or third-party) are critical. Misconfigured claims or mapping rules can lead to over- or under-provisioned access.
 Mitigation: mapping rule validation; comprehensive integration tests for common IdP configurations.
 
+Legacy `saas` profile and SaaS extended support
+: Since 8.8, Management Identity is no longer used in SaaS to serve the web applications. The legacy saas Spring profile remains in parts of the Management Identity codebase, is deprecated and unused for current Self-Managed deployments, but must stay supported for SaaS extended support until April 2028.
 
 ## 11. Glossary
 
@@ -759,9 +804,11 @@ Mitigation: mapping rule validation; comprehensive integration tests for common 
 | Tenant (Optimize)         | Logical partition for reporting and data isolation in Optimize. Stored in `TenantRepository`. Distinct from runtime tenants in Orchestration Cluster Identity. |
 | Mapping rule              | Entity mapping IdP token claims (for example group names, attributes) to Management Identity roles or Optimize tenants; evaluated by mapping rule services in the `oidc` profile. |
 | OIDC                      | OpenID Connect; the protocol used for authentication and token issuance between platform apps, IdP, and Management Identity. |
-| Client credentials grant  | OAuth2 flow for machine-to-machine access; a service authenticates with its client ID and secret to obtain a token. |
+| Client credentials grant  | OAuth2 flow for machine-to-machine access; a service authenticates as a client (for example with `client_secret_basic` or `private_key_jwt`) to obtain a token. |
 | Authorization code flow   | OAuth2/OIDC flow for interactive user login via a browser redirect to the IdP. |
 | JWKS                      | JSON Web Key Set; the public key endpoint exposed by Keycloak/IdP, used by JWT filters to validate incoming JWT signatures. |
+| `private_key_jwt`         | OAuth2 client authentication method where the client signs a JWT assertion with a private key instead of using a static secret; more secure and auditable than `client_secret_basic`. |
+| Client assertion          | Signed JWT used to authenticate Management Identity or a client to the IdP token endpoint when using `private_key_jwt` client authentication. |
 | WebSecurityConfig         | Spring configuration class that defines the security filter chain for the Management Identity API. |
 | SmJwtFilter               | Self-Managed JWT filter; validates tokens and handles session cookie refresh for browser flows. |
 | JwtAuthenticationToken    | Spring Security Authentication object set on the `SecurityContext` after JWT validation. |

--- a/monorepo-docs-site/sidebars.js
+++ b/monorepo-docs-site/sidebars.js
@@ -83,6 +83,7 @@ const sidebars = {
                 },
               ],
             },
+            'architecture/components/identity/management_identity_architecture_docs',
           ],
         },
       ],

--- a/monorepo-docs-site/sidebars.js
+++ b/monorepo-docs-site/sidebars.js
@@ -83,7 +83,11 @@ const sidebars = {
                 },
               ],
             },
-            'architecture/components/identity/management_identity_architecture_docs',
+            {
+              type: 'doc',
+              id: 'architecture/components/identity/management_identity_architecture_docs',
+              label: 'Management Identity',
+            },
           ],
         },
       ],


### PR DESCRIPTION
# Description

This PR introduces a **Management Identity architecture documentation** in the monorepo docs, aligned with the arc42 structure and style used for `identity_architecture_docs.md`.

The document now clearly separates Management Identity responsibilities from Orchestration Cluster Identity, adds missing runtime coverage, and simplifies deployment views for readability.

To create the first draft for several narrative sections, AI-assisted authoring (Glean) was used and then iteratively refined. For technical sections and diagrams, Copilot-assisted drafting and multiple review/refinement rounds were used. Everything was manually reviewed and adjusted.

Preview is here: https://camunda.github.io/camunda/pr-preview/pr-50140/architecture/components/identity/management_identity_architecture_docs/

Diagrams can be viewed with Zoom possibility here: https://github.com/camunda/camunda/blob/management_identity_architecutre_documentation/docs/monorepo-docs/architecture/components/identity/management_identity_architecture_docs.md

# Related Issues

closes #48883
