### PR TITLE
Use same ratio for cache to total memory as in 8.7.

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCache.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCache.java
@@ -27,16 +27,17 @@ public class RocksDbSharedCache {
     final int partitionsCount = brokerCfg.getCluster().getPartitionsCount();
 
     final var rocksdbCfg = brokerCfg.getExperimental().getRocksdb();
-    final long blockCacheBytes = getBlockCacheBytes(rocksdbCfg, partitionsCount);
+    final long rocksDbMemoryLimit = getBlockCacheBytes(rocksdbCfg, partitionsCount);
     final var memoryAllocationStrategy = rocksdbCfg.getMemoryAllocationStrategy();
     final long totalMemorySize =
         ((OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean()).getTotalMemorySize();
 
     LOGGER.info(
-        "Allocating {} bytes ({} MB) for RocksDB block cache, with memory allocation strategy: {}. "
+        "Allocating {} bytes ({} MB) for RocksDB memory Limit (with {} MB cache size), with memory allocation strategy: {}. "
             + "Total system memory: {} bytes ({} MB). Partitions count: {}",
-        blockCacheBytes,
-        blockCacheBytes / (1024 * 1024),
+        rocksDbMemoryLimit,
+        rocksDbMemoryLimit / (1024 * 1024),
+        rocksDbMemoryLimit / SharedRocksDbResources.CACHE_RATIO_OF_MEMORY_LIMIT / (1024 * 1024),
         memoryAllocationStrategy,
         totalMemorySize,
         totalMemorySize / (1024 * 1024),
@@ -44,7 +45,7 @@ public class RocksDbSharedCache {
 
     RocksDbSharedCacheMetrics.registerAllocationStrategy(meterRegistry, memoryAllocationStrategy);
 
-    return SharedRocksDbResources.allocate(blockCacheBytes);
+    return SharedRocksDbResources.allocate(rocksDbMemoryLimit);
   }
 
   public static long getBlockCacheBytes(final RocksdbCfg rocksdbCfg, final int partitionsCount) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCache.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCache.java
@@ -27,28 +27,31 @@ public class RocksDbSharedCache {
     final int partitionsCount = brokerCfg.getCluster().getPartitionsCount();
 
     final var rocksdbCfg = brokerCfg.getExperimental().getRocksdb();
-    final long rocksDbMemoryLimit = getBlockCacheBytes(rocksdbCfg, partitionsCount);
+    final long rocksDbMemoryLimit = getMemoryLimitBytes(rocksdbCfg, partitionsCount);
     final var memoryAllocationStrategy = rocksdbCfg.getMemoryAllocationStrategy();
     final long totalMemorySize =
         ((OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean()).getTotalMemorySize();
 
+    RocksDbSharedCacheMetrics.registerAllocationStrategy(meterRegistry, memoryAllocationStrategy);
+
+    final SharedRocksDbResources rocksDbResources =
+        SharedRocksDbResources.allocate(rocksDbMemoryLimit);
+
     LOGGER.info(
         "Allocating {} bytes ({} MB) for RocksDB memory Limit (with {} MB cache size), with memory allocation strategy: {}. "
             + "Total system memory: {} bytes ({} MB). Partitions count: {}",
-        rocksDbMemoryLimit,
-        rocksDbMemoryLimit / (1024 * 1024),
-        rocksDbMemoryLimit / SharedRocksDbResources.CACHE_RATIO_OF_MEMORY_LIMIT / (1024 * 1024),
+        rocksDbResources.memoryLimit(),
+        rocksDbResources.memoryLimit() / (1024 * 1024),
+        rocksDbResources.blockCacheSize() / (1024 * 1024),
         memoryAllocationStrategy,
         totalMemorySize,
         totalMemorySize / (1024 * 1024),
         partitionsCount);
 
-    RocksDbSharedCacheMetrics.registerAllocationStrategy(meterRegistry, memoryAllocationStrategy);
-
-    return SharedRocksDbResources.allocate(rocksDbMemoryLimit);
+    return rocksDbResources;
   }
 
-  public static long getBlockCacheBytes(final RocksdbCfg rocksdbCfg, final int partitionsCount) {
+  public static long getMemoryLimitBytes(final RocksdbCfg rocksdbCfg, final int partitionsCount) {
 
     return switch (rocksdbCfg.getMemoryAllocationStrategy()) {
       case BROKER -> rocksdbCfg.getMemoryLimit().toBytes();
@@ -66,7 +69,7 @@ public class RocksDbSharedCache {
   }
 
   public static void validateRocksDbMemory(final RocksdbCfg rocksdbCfg, final int partitionsCount) {
-    final long blockCacheBytes = getBlockCacheBytes(rocksdbCfg, partitionsCount);
+    final long blockCacheBytes = getMemoryLimitBytes(rocksdbCfg, partitionsCount);
 
     final long totalMemorySize =
         ((OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean()).getTotalMemorySize();

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
@@ -235,7 +235,8 @@ public final class ZeebeRocksDbFactory<
 
     // recommended by RocksDB, but we could tweak it; keep in mind we're also caching the indexes
     // and filters into the block cache, so we don't need to account for more memory there
-    final var blockCacheMemory = totalMemoryBudgetPerPartition / 3;
+    final var blockCacheMemory =
+        totalMemoryBudgetPerPartition / SharedRocksDbResources.CACHE_RATIO_OF_MEMORY_LIMIT;
     // flushing the memtables is done asynchronously, so there may be multiple memtables in memory,
     // although only a single one is writable. once we have too many memtables, writes will stop.
     // since prefix iteration is our bread n butter, we will build an additional filter for each
@@ -370,6 +371,15 @@ public final class ZeebeRocksDbFactory<
       LRUCache sharedCache, WriteBufferManager sharedWbm, long reservedMemory)
       implements AutoCloseable {
 
+    // memoryLimit represents the total memory budget we expect RocksDB to use on this node.
+    // We follow the recommended heuristic where roughly 1/3 of that total budget is assigned to
+    // the block cache (cacheSize). This ratio can be tuned if needed.
+    // When sizing memoryLimit, remember that RocksDB's total memory footprint includes block
+    // cache, index and bloom filters, memtables, and blocks pinned by iterators. See:
+    // https://github.com/facebook/rocksdb/wiki/Setup-Options-and-Basic-Tuning#block-cache-size
+    // https://github.com/facebook/rocksdb/wiki/Memory-usage-in-RocksDB
+    public static final long CACHE_RATIO_OF_MEMORY_LIMIT = 3;
+
     static {
       RocksDB.loadLibrary();
     }
@@ -378,13 +388,7 @@ public final class ZeebeRocksDbFactory<
       // (#DBs) × write_buffer_size × max_write_buffer_number should be comfortably ≤ your WBM
       // limit, with headroom for memtable bloom/filter overhead. write_buffer_size is calculated in
       // zeebeRocksDBFactory.
-      // We use the recommended 1/3 as the ratio between the total expected memory utilized and
-      // cache, this could be tweaked; keep in mind we're also caching the total Rocks DB memory
-      // footprint should take into consideration block cache, index and bloom filters, memtables
-      // and blocks pinned by iterators. See:
-      // https://github.com/facebook/rocksdb/wiki/Setup-Options-and-Basic-Tuning#block-cache-size
-      // https://github.com/facebook/rocksdb/wiki/Memory-usage-in-RocksDB
-      final long cacheSize = memoryLimit / 3;
+      final long cacheSize = memoryLimit / CACHE_RATIO_OF_MEMORY_LIMIT;
       final LRUCache sharedCache = new LRUCache(cacheSize, 8, false, 0.15);
       final WriteBufferManager sharedWbm = new WriteBufferManager(cacheSize / 4, sharedCache);
       return new SharedRocksDbResources(sharedCache, sharedWbm, memoryLimit);

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
@@ -235,8 +235,7 @@ public final class ZeebeRocksDbFactory<
 
     // recommended by RocksDB, but we could tweak it; keep in mind we're also caching the indexes
     // and filters into the block cache, so we don't need to account for more memory there
-    final var blockCacheMemory =
-        totalMemoryBudgetPerPartition / SharedRocksDbResources.CACHE_RATIO_OF_MEMORY_LIMIT;
+    final var blockCacheMemoryPerPartition = sharedRocksDbResources.cacheSize / partitionCount;
     // flushing the memtables is done asynchronously, so there may be multiple memtables in memory,
     // although only a single one is writable. once we have too many memtables, writes will stop.
     // since prefix iteration is our bread n butter, we will build an additional filter for each
@@ -251,7 +250,7 @@ public final class ZeebeRocksDbFactory<
     final var memtablePrefixFilterMemory = 0.15;
     final var memtableMemory =
         Math.round(
-            ((totalMemoryBudgetPerPartition - blockCacheMemory)
+            ((totalMemoryBudgetPerPartition - blockCacheMemoryPerPartition)
                     / (double) maxConcurrentMemtableCount)
                 * (1 - memtablePrefixFilterMemory));
 
@@ -368,7 +367,7 @@ public final class ZeebeRocksDbFactory<
   }
 
   public record SharedRocksDbResources(
-      LRUCache sharedCache, WriteBufferManager sharedWbm, long reservedMemory)
+      LRUCache sharedCache, WriteBufferManager sharedWbm, long reservedMemory, long cacheSize)
       implements AutoCloseable {
 
     // memoryLimit represents the total memory budget we expect RocksDB to use on this node.
@@ -391,7 +390,7 @@ public final class ZeebeRocksDbFactory<
       final long cacheSize = memoryLimit / CACHE_RATIO_OF_MEMORY_LIMIT;
       final LRUCache sharedCache = new LRUCache(cacheSize, 8, false, 0.15);
       final WriteBufferManager sharedWbm = new WriteBufferManager(cacheSize / 4, sharedCache);
-      return new SharedRocksDbResources(sharedCache, sharedWbm, memoryLimit);
+      return new SharedRocksDbResources(sharedCache, sharedWbm, memoryLimit, cacheSize);
     }
 
     @Override

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
@@ -374,14 +374,20 @@ public final class ZeebeRocksDbFactory<
       RocksDB.loadLibrary();
     }
 
-    public static SharedRocksDbResources allocate(final long cacheSize) {
+    public static SharedRocksDbResources allocate(final long memoryLimit) {
       // (#DBs) × write_buffer_size × max_write_buffer_number should be comfortably ≤ your WBM
-      // limit,
-      // with headroom for memtable bloom/filter overhead. write_buffer_size is calculated in
+      // limit, with headroom for memtable bloom/filter overhead. write_buffer_size is calculated in
       // zeebeRocksDBFactory.
+      // We use the recommended 1/3 as the ratio between the total expected memory utilized and
+      // cache, this could be tweaked; keep in mind we're also caching the total Rocks DB memory
+      // footprint should take into consideration block cache, index and bloom filters, memtables
+      // and blocks pinned by iterators. See:
+      // https://github.com/facebook/rocksdb/wiki/Setup-Options-and-Basic-Tuning#block-cache-size
+      // https://github.com/facebook/rocksdb/wiki/Memory-usage-in-RocksDB
+      final long cacheSize = memoryLimit / 3;
       final LRUCache sharedCache = new LRUCache(cacheSize, 8, false, 0.15);
       final WriteBufferManager sharedWbm = new WriteBufferManager(cacheSize / 4, sharedCache);
-      return new SharedRocksDbResources(sharedCache, sharedWbm, cacheSize);
+      return new SharedRocksDbResources(sharedCache, sharedWbm, memoryLimit);
     }
 
     @Override

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
@@ -230,12 +230,11 @@ public final class ZeebeRocksDbFactory<
    * centralizes memory calculations to avoid duplication.
    */
   MemoryConfiguration calculateMemoryConfiguration() {
-    final var totalMemoryBudgetPerPartition =
-        sharedRocksDbResources.reservedMemory / partitionCount;
+    final var totalMemoryBudgetPerPartition = sharedRocksDbResources.memoryLimit / partitionCount;
 
     // recommended by RocksDB, but we could tweak it; keep in mind we're also caching the indexes
     // and filters into the block cache, so we don't need to account for more memory there
-    final var blockCacheMemoryPerPartition = sharedRocksDbResources.cacheSize / partitionCount;
+    final var blockCacheMemoryPerPartition = sharedRocksDbResources.blockCacheSize / partitionCount;
     // flushing the memtables is done asynchronously, so there may be multiple memtables in memory,
     // although only a single one is writable. once we have too many memtables, writes will stop.
     // since prefix iteration is our bread n butter, we will build an additional filter for each
@@ -367,7 +366,7 @@ public final class ZeebeRocksDbFactory<
   }
 
   public record SharedRocksDbResources(
-      LRUCache sharedCache, WriteBufferManager sharedWbm, long reservedMemory, long cacheSize)
+      LRUCache sharedCache, WriteBufferManager sharedWbm, long memoryLimit, long blockCacheSize)
       implements AutoCloseable {
 
     // memoryLimit represents the total memory budget we expect RocksDB to use on this node.
@@ -377,7 +376,7 @@ public final class ZeebeRocksDbFactory<
     // cache, index and bloom filters, memtables, and blocks pinned by iterators. See:
     // https://github.com/facebook/rocksdb/wiki/Setup-Options-and-Basic-Tuning#block-cache-size
     // https://github.com/facebook/rocksdb/wiki/Memory-usage-in-RocksDB
-    public static final long CACHE_RATIO_OF_MEMORY_LIMIT = 3;
+    private static final long CACHE_RATIO_OF_MEMORY_LIMIT = 3;
 
     static {
       RocksDB.loadLibrary();
@@ -387,10 +386,10 @@ public final class ZeebeRocksDbFactory<
       // (#DBs) × write_buffer_size × max_write_buffer_number should be comfortably ≤ your WBM
       // limit, with headroom for memtable bloom/filter overhead. write_buffer_size is calculated in
       // zeebeRocksDBFactory.
-      final long cacheSize = memoryLimit / CACHE_RATIO_OF_MEMORY_LIMIT;
-      final LRUCache sharedCache = new LRUCache(cacheSize, 8, false, 0.15);
-      final WriteBufferManager sharedWbm = new WriteBufferManager(cacheSize / 4, sharedCache);
-      return new SharedRocksDbResources(sharedCache, sharedWbm, memoryLimit, cacheSize);
+      final long blockCacheSize = memoryLimit / CACHE_RATIO_OF_MEMORY_LIMIT;
+      final LRUCache sharedCache = new LRUCache(blockCacheSize, 8, false, 0.15);
+      final WriteBufferManager sharedWbm = new WriteBufferManager(blockCacheSize / 4, sharedCache);
+      return new SharedRocksDbResources(sharedCache, sharedWbm, memoryLimit, blockCacheSize);
     }
 
     @Override


### PR DESCRIPTION
## Description

In 8.7, when we configure the memory limit, it's in fact an approximation of the total memory limit, where we expect, through the rest of the configuration, that cache will be approximately 1/3 of the total memory used by each instance of RocksDB. While in 8.8 and on, we are using this configuration to calculate the cache size, in effect increasing the total cache size by 3, which also increases mem tables usage (since these are proportional to the cache).

This PR simply corrects the bug introduced.

This should be backported to 8.8 and 8.9.

Related with incident https://jira.camunda.com/browse/SUPPORT-31711?atlLinkOrigin=c2xhY2staW50ZWdyYXRpb258aXNzdWU%3D.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/50109
