### PR TITLE
address flakiness of BackupMultiPartitionTest

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupMultiPartitionTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupMultiPartitionTest.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.it.util.GrpcClientRule;
 import io.camunda.zeebe.it.util.RecordingJobHandler;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse;
 import io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse.PartitionCheckpointState;
 import io.camunda.zeebe.protocol.management.BackupStatusCode;
@@ -479,13 +480,20 @@ class BackupMultiPartitionTest {
     Awaitility.await()
         .until(
             () -> {
-              client
-                  .getClient()
-                  .newCreateInstanceCommand()
-                  .processDefinitionKey(processKey)
-                  .variables(Map.of(CORRELATION_KEY, CORRELATION_KEY_VALUE_FOR_PARTITION_2))
-                  .send()
-                  .join();
+              long piKey;
+
+              do {
+                piKey =
+                    client
+                        .getClient()
+                        .newCreateInstanceCommand()
+                        .processDefinitionKey(processKey)
+                        .variables(Map.of(CORRELATION_KEY, CORRELATION_KEY_VALUE_FOR_PARTITION_2))
+                        .send()
+                        .join()
+                        .getProcessInstanceKey();
+              } while (Protocol.decodePartitionId(piKey) != 1);
+
               // Ensure process instance is created on partition 1
               return RecordingExporter.processInstanceCreationRecords()
                   .withPartitionId(1)


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Most probably a side effect of https://github.com/camunda/camunda/pull/49710. To address this check whether the created PI matches partition 1's decoded value

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
