### PR TITLE
[Backport stable/8.9] Expression api test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/responses.json
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/responses.json
@@ -1,10 +1,10 @@
 {
   "metadata": {
     "sourceRepo": "https://github.com/camunda/camunda",
-    "commit": "a622c619c0dbbbe115fd1525d8b7ecf79ba49aad",
-    "generatedAt": "2026-03-31T11:58:42.393Z",
+    "commit": "d66c1010ba763acc8d46ba6dfd6a2985666da1f6",
+    "generatedAt": "2026-04-01T13:19:15.552Z",
     "specPath": "zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml",
-    "specSha256": "70cff54862f8c0054a8601f80c980dcea2cf7eb70bf059dbe1ecdd893d47fad3"
+    "specSha256": "4df2979bd242a68afe211051c31d5317eb9ca4edb6f818dc97902e8eb6316038"
   },
   "responses": [
     {
@@ -3061,7 +3061,8 @@
           },
           {
             "name": "result",
-            "type": "unknown"
+            "type": "unknown",
+            "nullable": true
           },
           {
             "name": "warnings",

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instance-delete-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instance-delete-api.spec.ts
@@ -28,16 +28,16 @@ import {cleanupUsers} from 'utils/usersCleanup';
 test.describe.serial('Delete Decision Instances API Tests', () => {
   let decisionInstances: DecisionInstance[] = [];
   let userWithResourcesAuthorizationToSendRequest: {
-      username: string;
-      name: string;
-      email: string;
-      password: string;
-    } = {} as {
-      username: string;
-      name: string;
-      email: string;
-      password: string;
-    };
+    username: string;
+    name: string;
+    email: string;
+    password: string;
+  } = {} as {
+    username: string;
+    name: string;
+    email: string;
+    password: string;
+  };
 
   test.beforeAll(async ({request}) => {
     const result =
@@ -61,7 +61,7 @@ test.describe.serial('Delete Decision Instances API Tests', () => {
     });
   });
 
-    test('Delete Decision Instance - Forbidden', async ({request}) => {
+  test('Delete Decision Instance - Forbidden', async ({request}) => {
     await test.step('Attempt to Delete Decision Instance with insufficient permissions', async () => {
       const decisionInstanceToDelete = decisionInstances[0];
       const decisionEvaluationKeyToDelete =
@@ -87,7 +87,7 @@ test.describe.serial('Delete Decision Instances API Tests', () => {
 
   test('Delete Decision Instance - Success', async ({request}) => {
     const decisionInstanceToDelete =
-        decisionInstances[decisionInstances.length - 1];
+      decisionInstances[decisionInstances.length - 1];
     const decisionEvaluationKeyToDelete =
       decisionInstanceToDelete.decisionEvaluationKey;
 
@@ -107,7 +107,8 @@ test.describe.serial('Delete Decision Instances API Tests', () => {
     });
 
     await test.step('Verify Decision Instance is Deleted', async () => {
-      const decisionEvaluationInstanceKeyToGet = decisionInstanceToDelete.decisionEvaluationInstanceKey;
+      const decisionEvaluationInstanceKeyToGet =
+        decisionInstanceToDelete.decisionEvaluationInstanceKey;
       await expect(async () => {
         const res = await request.get(
           buildUrl(`/decision-instances/${decisionEvaluationInstanceKeyToGet}`),

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/expression/expression-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/expression/expression-api-tests.spec.ts
@@ -7,14 +7,9 @@
  */
 
 import {test, expect, APIRequestContext} from '@playwright/test';
-import {
-  assertStatusCode,
-  assertInvalidArgument,
-} from '../../../../utils/http';
+import {assertStatusCode, assertInvalidArgument} from '../../../../utils/http';
 import {validateResponse} from '../../../../json-body-assertions';
-import {evaluateExpression, EXPRESSION_URL} from '@requestHelpers'
-
-
+import {evaluateExpression, EXPRESSION_URL} from '@requestHelpers';
 
 type ExpressionTestCase = {
   description: string;
@@ -44,13 +39,12 @@ const successTestCases: ExpressionTestCase[] = [
     variables: {},
     result: false,
   },
-   //Skipped due to bug 50091 : https://github.com/camunda/camunda/issues/50091
-  //   {
-  //     description: 'Should evaluate null literal - Success',
-  //     expression: '=x',
-  //     variables: {x: null},
-  //     result: null,
-  //   },
+  {
+    description: 'Should evaluate null literal - Success',
+    expression: '=x',
+    variables: {x: null},
+    result: null,
+  },
   {
     description: 'Should evaluate simple variable read - Success',
     expression: '=x',
@@ -200,7 +194,8 @@ const errorTestCases: ExpressionTestCase[] = [
     errorDetail: 'Failed to parse expression',
   },
   {
-    description: 'Should return warning when invalid FEEL syntax (missing else) - Error',
+    description:
+      'Should return warning when invalid FEEL syntax (missing else) - Error',
     expression: '=if x > 5 then "big"',
     variables: {x: 10},
     errorDetail: 'Failed to parse expression',
@@ -234,11 +229,10 @@ test.describe('Expression API Tests', () => {
         tc.variables,
       );
       await assertStatusCode(response, 200);
-      //Skipped due to bug 50091 : https://github.com/camunda/camunda/issues/50091
-      //   await validateResponse(
-      //     {path: EXPRESSION_URL, method: 'POST', status: '200'},
-      //     response,
-      //   );
+      await validateResponse(
+        {path: EXPRESSION_URL, method: 'POST', status: '200'},
+        response,
+      );
       const body = await response.json();
       const warnings = [];
       for (const w of body.warnings) {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/expression/expression-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/expression/expression-api-tests.spec.ts
@@ -1,0 +1,276 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {
+  buildUrl,
+  jsonHeaders,
+  assertStatusCode,
+  assertInvalidArgument,
+} from '../../../../utils/http';
+import {validateResponse} from '../../../../json-body-assertions';
+
+const EXPRESSION_URL = '/expression/evaluation';
+
+async function evaluateExpression(
+  request: any,
+  expression: string,
+  variables: Record<string, unknown>,
+) {
+  return request.post(buildUrl(EXPRESSION_URL), {
+    headers: jsonHeaders(),
+    data: {expression, variables},
+  });
+}
+
+type ExpressionTestCase = {
+  description: string;
+  expression: string;
+  variables: Record<string, unknown>;
+  result?: unknown;
+  warnings?: string[];
+  errorDetail?: string;
+};
+
+const successTestCases: ExpressionTestCase[] = [
+  {
+    description: 'Should evaluate literal number addition - Success',
+    expression: '=1 + 2',
+    variables: {},
+    result: 3,
+  },
+  {
+    description: 'Should evaluate literal string concatenation - Success',
+    expression: '="foo" + "bar"',
+    variables: {},
+    result: 'foobar',
+  },
+  {
+    description: 'Should evaluate boolean logic - Success',
+    expression: '=true and false',
+    variables: {},
+    result: false,
+  },
+   //Skipped due to bug 50091 : https://github.com/camunda/camunda/issues/50091
+  //   {
+  //     description: 'Should evaluate null literal - Success',
+  //     expression: '=x',
+  //     variables: {x: null},
+  //     result: 'null',
+  //   },
+  {
+    description: 'Should evaluate simple variable read - Success',
+    expression: '=x',
+    variables: {x: 5},
+    result: 5,
+  },
+  {
+    description: 'Should evaluate variable arithmetic - Success',
+    expression: '=x + 1',
+    variables: {x: 5},
+    result: 6,
+  },
+  {
+    description: 'Should evaluate string variable concatenation - Success',
+    expression: '=firstName + " " + lastName',
+    variables: {firstName: 'Jane', lastName: 'Doe'},
+    result: 'Jane Doe',
+  },
+  {
+    description: 'Should evaluate nested context comparison - Success',
+    expression: '=person.age >= 18',
+    variables: {person: {age: 18}},
+    result: true,
+  },
+  {
+    description: 'Should evaluate deep property access - Success',
+    expression: '=person.address.city',
+    variables: {person: {address: {city: 'Berlin'}}},
+    result: 'Berlin',
+  },
+  {
+    description: 'Should evaluate list sum - Success',
+    expression: '=sum(numbers)',
+    variables: {numbers: [1, 2, 3]},
+    result: 6,
+  },
+  {
+    description: 'Should evaluate list filter - Success',
+    expression: '=numbers[ item > 2 ]',
+    variables: {numbers: [1, 2, 3, 4]},
+    result: [3, 4],
+  },
+  {
+    description: 'Should evaluate quantifier expression - Success',
+    expression: '=some n in numbers satisfies n > 3',
+    variables: {numbers: [1, 2, 3, 4]},
+    result: true,
+  },
+  {
+    description: 'Should evaluate comparison and logic - Success',
+    expression: '=x > 10 and y < 5',
+    variables: {x: 11, y: 4},
+    result: true,
+  },
+  {
+    description: 'Should evaluate equality with null - Success',
+    expression: '=x = null',
+    variables: {x: null},
+    result: true,
+  },
+  {
+    description: 'Should evaluate if-then-else - Success',
+    expression: '=if x > 5 then "big" else "small"',
+    variables: {x: 10},
+    result: 'big',
+  },
+  {
+    description: 'Should evaluate date literal function comparison - Success',
+    expression: '=date("2024-01-01") < date("2024-02-01")',
+    variables: {},
+    result: true,
+  },
+  {
+    description: 'Should evaluate date variable comparison - Success',
+    expression: '=date(dateVar) > date("2024-01-01")',
+    variables: {dateVar: '2024-02-01'},
+    result: true,
+  },
+  {
+    description: 'Should evaluate string function - Success',
+    expression: '=substring(text, 2, 3)',
+    variables: {text: 'camunda'},
+    result: 'amu',
+  },
+  {
+    description: 'Should evaluate mixed types with context - Success',
+    expression: '=person.age + bonus',
+    variables: {person: {age: 30}, bonus: 5},
+    result: 35,
+  },
+  {
+    description: 'Should evaluate collection of contexts filter - Success',
+    expression: '=employees[department = "QA"].name',
+    variables: {
+      employees: [
+        {name: 'Alice', department: 'QA'},
+        {name: 'Bob', department: 'Eng'},
+      ],
+    },
+    result: ['Alice'],
+  },
+];
+
+const warningTestCases: ExpressionTestCase[] = [
+  {
+    description: 'Should reject unknown variable - Warning',
+    expression: '=x + 1',
+    variables: {},
+    warnings: ["No variable found with name 'x'", "Can't add '1' to 'null'"],
+  },
+  {
+    description: 'Should reject type mismatch - Warning',
+    expression: '=x + 1',
+    variables: {x: 'foo'},
+    warnings: ["Can't add '1' to '\"foo\"'"],
+  },
+  {
+    description: 'Should reject wrong type for list operation - Warning',
+    expression: '=sum(numbers)',
+    variables: {numbers: ['a', 'b']},
+    warnings: [
+      "Failed to invoke function 'sum': expected number but found '\"a\"'",
+    ],
+  },
+  {
+    description: 'Should reject bad date literal - Warning',
+    expression: '=date(meow)',
+    variables: {meow: '2024-13-01'},
+    warnings: [
+      "Failed to invoke function 'date': Failed to parse date from '2024-13-01'",
+    ],
+  },
+  {
+    description: 'Should reject unexpected null in arithmetic - Warning',
+    expression: '=x + 1',
+    variables: {x: null},
+    warnings: ["Can't add '1' to 'null'"],
+  },
+];
+
+const errorTestCases: ExpressionTestCase[] = [
+  {
+    description:
+      'Should reject invalid FEEL syntax (trailing operator) - Error',
+    expression: '=x +',
+    variables: {x: 1},
+    errorDetail: 'Failed to parse expression',
+  },
+  {
+    description: 'Should reject invalid FEEL syntax (missing else) - Error',
+    expression: '=if x > 5 then "big"',
+    variables: {x: 10},
+    errorDetail: 'Failed to parse expression',
+  },
+];
+
+test.describe('Expression API Tests', () => {
+  for (const tc of successTestCases) {
+    test(tc.description, async ({request}) => {
+      const response = await evaluateExpression(
+        request,
+        tc.expression,
+        tc.variables,
+      );
+      await assertStatusCode(response, 200);
+      await validateResponse(
+        {path: EXPRESSION_URL, method: 'POST', status: '200'},
+        response,
+      );
+      const body = await response.json();
+      expect(body.expression).toBe(tc.expression);
+      expect(body.result).toEqual(tc.result);
+    });
+  }
+
+  for (const tc of warningTestCases) {
+    test(tc.description, async ({request}) => {
+      const response = await evaluateExpression(
+        request,
+        tc.expression,
+        tc.variables,
+      );
+      await assertStatusCode(response, 200);
+      //Skipped due to bug 50091 : https://github.com/camunda/camunda/issues/50091
+      //   await validateResponse(
+      //     {path: EXPRESSION_URL, method: 'POST', status: '200'},
+      //     response,
+      //   );
+      const body = await response.json();
+      const warnings = [];
+      for (const w of body.warnings) {
+        warnings.push(w.message);
+      }
+      for (const expected of tc.warnings!) {
+        expect(warnings).toContain(expected);
+      }
+      expect(body.result).toBeNull();
+    });
+  }
+
+  for (const tc of errorTestCases) {
+    test(tc.description, async ({request}) => {
+      const response = await evaluateExpression(
+        request,
+        tc.expression,
+        tc.variables,
+      );
+      await assertInvalidArgument(response, 400, tc.errorDetail!);
+    });
+  }
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/expression/expression-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/expression/expression-api-tests.spec.ts
@@ -8,25 +8,13 @@
 
 import {test, expect, APIRequestContext} from '@playwright/test';
 import {
-  buildUrl,
-  jsonHeaders,
   assertStatusCode,
   assertInvalidArgument,
 } from '../../../../utils/http';
 import {validateResponse} from '../../../../json-body-assertions';
+import {evaluateExpression, EXPRESSION_URL} from '@requestHelpers'
 
-const EXPRESSION_URL = '/expression/evaluation';
 
-async function evaluateExpression(
-  request: APIRequestContext,
-  expression: string,
-  variables: Record<string, unknown>,
-) {
-  return request.post(buildUrl(EXPRESSION_URL), {
-    headers: jsonHeaders(),
-    data: {expression, variables},
-  });
-}
 
 type ExpressionTestCase = {
   description: string;

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/expression/expression-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/expression/expression-api-tests.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {test, expect} from '@playwright/test';
+import {test, expect, APIRequestContext} from '@playwright/test';
 import {
   buildUrl,
   jsonHeaders,
@@ -18,7 +18,7 @@ import {validateResponse} from '../../../../json-body-assertions';
 const EXPRESSION_URL = '/expression/evaluation';
 
 async function evaluateExpression(
-  request: any,
+  request: APIRequestContext,
   expression: string,
   variables: Record<string, unknown>,
 ) {
@@ -61,7 +61,7 @@ const successTestCases: ExpressionTestCase[] = [
   //     description: 'Should evaluate null literal - Success',
   //     expression: '=x',
   //     variables: {x: null},
-  //     result: 'null',
+  //     result: null,
   //   },
   {
     description: 'Should evaluate simple variable read - Success',
@@ -206,13 +206,13 @@ const warningTestCases: ExpressionTestCase[] = [
 const errorTestCases: ExpressionTestCase[] = [
   {
     description:
-      'Should reject invalid FEEL syntax (trailing operator) - Error',
+      'Should return warning when invalid FEEL syntax (trailing operator) - Error',
     expression: '=x +',
     variables: {x: 1},
     errorDetail: 'Failed to parse expression',
   },
   {
-    description: 'Should reject invalid FEEL syntax (missing else) - Error',
+    description: 'Should return warning when invalid FEEL syntax (missing else) - Error',
     expression: '=if x > 5 then "big"',
     variables: {x: 10},
     errorDetail: 'Failed to parse expression',

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesFilters.spec.ts
@@ -617,30 +617,26 @@ test.describe('Process Instances Filters', () => {
         },
       });
 
-      await operateProcessesPage.selectProcessCheckboxByPIK(
-        processToCancelInstanceMeowIK,
-        processToCancelInstanceGawIK,
-      );
+      await operateProcessesPage.selectAllRowsCheckbox.click();
 
       await operateProcessesPage.clickCancelBatchOperationButton();
 
       await operateProcessesPage.clickCancelProcessInstanceDialogButton();
 
-      await waitForAssertion({
-        assertion: async () => {
-          await expect(
-            operateProcessesPage.noMatchingInstancesMessage,
-          ).toBeVisible({timeout: 30000});
-        },
-        onFailure: async () => {
-          await page.reload();
-        },
-      });
-
       await operateProcessesPage.clickGoToOperationDetailsButton();
 
       await sleep(1_000);
       await expect(operateOperationsDetailsPage.state).toBeVisible();
+      await waitForAssertion({
+        assertion: async () => {
+          const batchOperationStatus = await operateOperationsDetailsPage.getBatchOperationStatus();
+          expect(batchOperationStatus).toBe('Completed');
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+        maxRetries: 6,
+      });
 
       const operationId =
         await operateOperationsDetailsPage.getBatchOperationId();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/expression-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/expression-requestHelpers.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {APIRequestContext} from '@playwright/test';
+import {
+  buildUrl,
+  jsonHeaders,
+} from '../http';
+
+export const EXPRESSION_URL = '/expression/evaluation';
+
+export async function evaluateExpression(
+  request: APIRequestContext,
+  expression: string,
+  variables: Record<string, unknown>,
+) {
+  return request.post(buildUrl(EXPRESSION_URL), {
+    headers: jsonHeaders(),
+    data: {expression, variables},
+  });
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
@@ -87,3 +87,4 @@ export {
   CORRELATED_MESSAGE_SUBSCRIPTION_SEARCH_ENDPOINT,
 } from './message-requestHelpers';
 export {type AuditLog} from './audit-log-requestHelpers';
+export {evaluateExpression, EXPRESSION_URL} from './expression-requestHelpers';


### PR DESCRIPTION
## Description
Backport of #50033 to `stable/8.9`. Additional fix for Operate test and regeneration of response schema

## related issues

relates to camunda/camunda#50091
related to [this issue](https://github.com/camunda/team-test-automation/issues/62)
## On demand workflow
[Was all green](https://github.com/camunda/camunda/actions/runs/23854062003)
