### PR TITLE
fix: silence log spam for user tasks without due date

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/usertask/ZeebeUserTaskDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/usertask/ZeebeUserTaskDataDto.java
@@ -46,11 +46,16 @@ public class ZeebeUserTaskDataDto implements UserTaskRecordValue {
 
   @JsonIgnore
   public OffsetDateTime getDateForDueDate() {
+    if (dueDate == null || dueDate.isBlank()) {
+      return null;
+    }
     return DateFormatterUtil.getOffsetDateTimeFromIsoZoneDateTimeString(dueDate)
         .orElseGet(
             () -> {
-              LOG.info(
-                  "Unable to parse due date of userTask record: {}. UserTask will be imported without dueDate data.",
+              LOG.debug(
+                  "Unable to parse due date of userTask record with elementId '{}' and userTaskKey '{}': {}. UserTask will be imported without dueDate data.",
+                  elementId,
+                  userTaskKey,
                   dueDate);
               return null;
             });

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/usertask/ZeebeUserTaskDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/usertask/ZeebeUserTaskDataDto.java
@@ -52,7 +52,7 @@ public class ZeebeUserTaskDataDto implements UserTaskRecordValue {
     return DateFormatterUtil.getOffsetDateTimeFromIsoZoneDateTimeString(dueDate)
         .orElseGet(
             () -> {
-              LOG.debug(
+              LOG.info(
                   "Unable to parse due date of userTask record with elementId '{}' and userTaskKey '{}': {}. UserTask will be imported without dueDate data.",
                   elementId,
                   userTaskKey,


### PR DESCRIPTION
## Description

Silence INFO log spam during Optimize user task import when user tasks have no due date configured.

- Null/empty `dueDate`: return `null` silently (no log)
- Non-empty but unparseable `dueDate`: log at DEBUG with `elementId` and `userTaskKey` for identification

Also prevents a latent NPE: `ZonedDateTime.parse(null)` throws `NullPointerException`, which the existing `DateTimeParseException` catch block would not handle.

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #50145