### PR TITLE
fix: Operate modification only cancels 10 tokens

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/property/OperationExecutorProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/OperationExecutorProperties.java
@@ -21,6 +21,7 @@ public class OperationExecutorProperties {
   private static final int DEFAULT_IMPORT_THREADS_COUNT = 3;
 
   private static final int DEFAULT_IMPORT_QUEUE_SIZE = 10;
+  private static final int DEFAULT_MODIFY_TOKENS_LIMIT = 500;
 
   /**
    * Amount of process instances, that will be processed by one run of operation executor. This
@@ -42,11 +43,18 @@ public class OperationExecutorProperties {
 
   private int queueSize = DEFAULT_IMPORT_QUEUE_SIZE;
 
+  /**
+   * Maximum number of flow node instances (tokens) that can be canceled or moved in a single
+   * process-instance modification for one element ID. Requests above this limit are truncated to
+   * avoid Zeebe command timeouts.
+   */
+  private int maxModifyTokensLimit = DEFAULT_MODIFY_TOKENS_LIMIT;
+
   public int getBatchSize() {
     return batchSize;
   }
 
-  public void setBatchSize(int batchSize) {
+  public void setBatchSize(final int batchSize) {
     this.batchSize = batchSize;
   }
 
@@ -54,7 +62,7 @@ public class OperationExecutorProperties {
     return deletionBatchSize;
   }
 
-  public void setDeletionBatchSize(int deletionBatchSize) {
+  public void setDeletionBatchSize(final int deletionBatchSize) {
     this.deletionBatchSize = deletionBatchSize;
   }
 
@@ -62,7 +70,7 @@ public class OperationExecutorProperties {
     return workerId;
   }
 
-  public void setWorkerId(String workerId) {
+  public void setWorkerId(final String workerId) {
     this.workerId = workerId;
   }
 
@@ -70,7 +78,7 @@ public class OperationExecutorProperties {
     return lockTimeout;
   }
 
-  public void setLockTimeout(long lockTimeout) {
+  public void setLockTimeout(final long lockTimeout) {
     this.lockTimeout = lockTimeout;
   }
 
@@ -78,7 +86,7 @@ public class OperationExecutorProperties {
     return executorEnabled;
   }
 
-  public void setExecutorEnabled(boolean executorEnabled) {
+  public void setExecutorEnabled(final boolean executorEnabled) {
     this.executorEnabled = executorEnabled;
   }
 
@@ -86,7 +94,7 @@ public class OperationExecutorProperties {
     return threadsCount;
   }
 
-  public void setThreadsCount(int threadsCount) {
+  public void setThreadsCount(final int threadsCount) {
     this.threadsCount = threadsCount;
   }
 
@@ -94,7 +102,15 @@ public class OperationExecutorProperties {
     return queueSize;
   }
 
-  public void setQueueSize(int queueSize) {
+  public void setQueueSize(final int queueSize) {
     this.queueSize = queueSize;
+  }
+
+  public int getMaxModifyTokensLimit() {
+    return maxModifyTokensLimit;
+  }
+
+  public void setMaxModifyTokensLimit(final int maxModifyTokensLimit) {
+    this.maxModifyTokensLimit = maxModifyTokensLimit;
   }
 }

--- a/operate/common/src/main/java/io/camunda/operate/property/ZeebeProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/ZeebeProperties.java
@@ -7,12 +7,15 @@
  */
 package io.camunda.operate.property;
 
+import java.time.Duration;
+
 public class ZeebeProperties {
 
   private String brokerContactPoint;
   private String gatewayAddress = "localhost:26500";
   private boolean isSecure = false;
   private String certificatePath = null;
+  private Duration requestTimeout = null;
 
   public boolean isSecure() {
     return isSecure;
@@ -48,6 +51,15 @@ public class ZeebeProperties {
 
   public ZeebeProperties setGatewayAddress(final String gatewayAddress) {
     this.gatewayAddress = gatewayAddress;
+    return this;
+  }
+
+  public Duration getRequestTimeout() {
+    return requestTimeout;
+  }
+
+  public ZeebeProperties setRequestTimeout(final Duration requestTimeout) {
+    this.requestTimeout = requestTimeout;
     return this;
   }
 }

--- a/operate/common/src/main/java/io/camunda/operate/zeebe/ZeebeConnector.java
+++ b/operate/common/src/main/java/io/camunda/operate/zeebe/ZeebeConnector.java
@@ -38,6 +38,9 @@ public class ZeebeConnector {
         ZeebeClient.newClientBuilder()
             .gatewayAddress(gatewayAddress)
             .defaultJobWorkerMaxJobsActive(JOB_WORKER_MAX_JOBS_ACTIVE);
+    if (zeebeProperties.getRequestTimeout() != null) {
+      builder.defaultRequestTimeout(zeebeProperties.getRequestTimeout());
+    }
     if (zeebeProperties.isSecure()) {
       builder.caCertificatePath(zeebeProperties.getCertificatePath());
       LOGGER.info("Use TLS connection to zeebe");

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/ModifyProcessInstanceOperationZeebeIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/ModifyProcessInstanceOperationZeebeIT.java
@@ -871,30 +871,37 @@ public class ModifyProcessInstanceOperationZeebeIT extends OperateZeebeAbstractI
   }
 
   @Test
-  public void shouldCancelMultiInstance() throws Exception {
-    // Given
+  public void shouldCancelAllMultiInstance() throws Exception {
+    // given
     tester
         .deployProcess("usertest/multiInstance_v_2.bpmn")
         .and()
-        .startProcessInstance("multiInstanceProcess", "{ \"items\": [1,2,3]}")
+        .startProcessInstance(
+            "multiInstanceProcess",
+            "{ \"items\": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]}")
         .waitUntil()
         .processInstanceIsStarted()
         .and()
-        .flowNodesAreActive("filterMapSubProcess", 3);
+        .flowNodesAreActive("filterTask", 30);
     // when
     tester
         .modifyProcessInstanceOperation(
             List.of(
                 new Modification()
                     .setModification(Modification.Type.CANCEL_TOKEN)
-                    .setFromFlowNodeId("filterMapSubProcess")))
+                    .setFromFlowNodeId("filterTask")
+                    .setNewTokensCount(0)))
         .waitUntil()
         .operationIsCompleted()
         .and()
         .flowNodeIsTerminated("filterMapSubProcess");
-
-    assertThat(tester.getFlowNodeStateFor("filterMapSubProcess"))
-        .isEqualTo(FlowNodeStateDto.TERMINATED);
+    // then - verify that both the multi-instance body and the inner task are terminated
+    tester.getAllFlowNodeInstances(tester.getProcessInstanceKey()).stream()
+        .filter(
+            i ->
+                i.getFlowNodeId().equals("filterTask")
+                    || i.getFlowNodeId().equals("filterMapSubProcess"))
+        .forEach(i -> assertThat(i.getState()).isEqualTo(FlowNodeState.TERMINATED));
   }
 
   private List<String> varsToStrings(final List<Long> flowNodeKeys) {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/properties/PropertiesIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/properties/PropertiesIT.java
@@ -49,6 +49,7 @@ public class PropertiesIT {
     assertThat(operateProperties.getOperationExecutor().getWorkerId()).isEqualTo("someWorker");
     assertThat(operateProperties.getOperationExecutor().getLockTimeout()).isEqualTo(15000);
     assertThat(operateProperties.getOperationExecutor().isExecutorEnabled()).isFalse();
+    assertThat(operateProperties.getOperationExecutor().getMaxModifyTokensLimit()).isEqualTo(1000);
     assertThat(operateProperties.getIdentity().getIssuerUrl()).isEqualTo("https://issueUrl:555");
     assertThat(operateProperties.getIdentity().getIssuerBackendUrl())
         .isEqualTo("https://issuerBackendUrl:555");

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/properties/PropertiesIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/properties/PropertiesIT.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.util.apps.nobeans.TestApplicationWithNoBeans;
+import java.time.Duration;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,6 +46,7 @@ public class PropertiesIT {
     assertThat(operateProperties.getZeebeElasticsearch().getBatchSize()).isEqualTo(222);
     assertThat(operateProperties.getZeebeElasticsearch().getPrefix()).isEqualTo("somePrefix");
     assertThat(operateProperties.getZeebe().getGatewayAddress()).isEqualTo("someZeebeHost:999");
+    assertThat(operateProperties.getZeebe().getRequestTimeout()).isEqualTo(Duration.ofSeconds(50));
     assertThat(operateProperties.getOperationExecutor().getBatchSize()).isEqualTo(555);
     assertThat(operateProperties.getOperationExecutor().getWorkerId()).isEqualTo("someWorker");
     assertThat(operateProperties.getOperationExecutor().getLockTimeout()).isEqualTo(15000);

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/zeebe/operation/process/modify/ModifyProcessInstanceOperationIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/zeebe/operation/process/modify/ModifyProcessInstanceOperationIT.java
@@ -246,7 +246,7 @@ public class ModifyProcessInstanceOperationIT extends OperateSearchAbstractIT {
     searchContainerManager.refreshIndices("*operation*");
 
     // Validate that the flow node instance ids were read
-    verify(mockFlowNodeInstanceReader, times(2))
+    verify(mockFlowNodeInstanceReader, times(1))
         .getFlowNodeInstanceKeysByIdAndStates(
             MOCK_PROCESS_INSTANCE_KEY, "taskA", List.of(FlowNodeState.ACTIVE));
 

--- a/operate/qa/integration-tests/src/test/resources/config/application-test-properties.yml
+++ b/operate/qa/integration-tests/src/test/resources/config/application-test-properties.yml
@@ -20,6 +20,7 @@ camunda.operate:
     workerId: someWorker
     lockTimeout: 15000
     executorEnabled: false
+    maxModifyTokensLimit: 1000
   identity:
     issuerUrl: https://issueUrl:555
     issuerBackendUrl: https://issuerBackendUrl:555

--- a/operate/qa/integration-tests/src/test/resources/config/application-test-properties.yml
+++ b/operate/qa/integration-tests/src/test/resources/config/application-test-properties.yml
@@ -15,6 +15,7 @@ camunda.operate:
     startLoadingDataOnStartup: false
   zeebe:
     gatewayAddress: someZeebeHost:999
+    requestTimeout: PT50S
   operationExecutor:
     batchSize: 555
     workerId: someWorker

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/FlowNodeInstanceReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/FlowNodeInstanceReader.java
@@ -69,7 +69,6 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.document.DocumentField;
 import org.elasticsearch.index.query.*;
 import org.elasticsearch.search.SearchHit;
-import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.Aggregations;
@@ -222,7 +221,7 @@ public class FlowNodeInstanceReader extends AbstractReader
     final List<Long> flowNodeInstanceKeys = new ArrayList<>();
     try {
       final SearchRequest searchRequest =
-          new SearchRequest(flowNodeInstanceTemplate.getAlias())
+          ElasticsearchUtil.createSearchRequest(flowNodeInstanceTemplate)
               .source(
                   new SearchSourceBuilder()
                       .query(
@@ -236,12 +235,20 @@ public class FlowNodeInstanceReader extends AbstractReader
                                           .map(Enum::name)
                                           .collect(Collectors.toList()))))
                       .fetchField(ID));
-      final SearchHits searchHits = tenantAwareClient.search(searchRequest).getHits();
-
-      for (final SearchHit searchHit : searchHits) {
-        final Map<String, DocumentField> documentFields = searchHit.getDocumentFields();
-        flowNodeInstanceKeys.add(Long.parseLong(documentFields.get(ID).getValue()));
-      }
+      tenantAwareClient.search(
+          searchRequest,
+          () -> {
+            ElasticsearchUtil.scroll(
+                searchRequest,
+                (hits) -> {
+                  for (final SearchHit searchHit : hits) {
+                    final Map<String, DocumentField> documentFields = searchHit.getDocumentFields();
+                    flowNodeInstanceKeys.add(Long.parseLong(documentFields.get(ID).getValue()));
+                  }
+                },
+                esClient);
+            return null;
+          });
     } catch (final IOException e) {
       throw new OperateRuntimeException(
           String.format("Could not retrieve flowNodeInstanceKey for flowNodeId %s ", flowNodeId),

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchFlowNodeInstanceReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchFlowNodeInstanceReader.java
@@ -227,7 +227,7 @@ public class OpensearchFlowNodeInstanceReader extends OpensearchAbstractReader
   public List<Long> getFlowNodeInstanceKeysByIdAndStates(
       final Long processInstanceId, final String flowNodeId, final List<FlowNodeState> states) {
     final var searchRequestBuilder =
-        searchRequestBuilder(flowNodeInstanceTemplate.getAlias())
+        searchRequestBuilder(flowNodeInstanceTemplate)
             .query(
                 withTenantCheck(
                     and(
@@ -238,7 +238,7 @@ public class OpensearchFlowNodeInstanceReader extends OpensearchAbstractReader
 
     record Result(String id) {}
 
-    return richOpenSearchClient.doc().searchValues(searchRequestBuilder, Result.class).stream()
+    return richOpenSearchClient.doc().scrollValues(searchRequestBuilder, Result.class).stream()
         .map(r -> Long.parseLong(r.id()))
         .toList();
   }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/process/modify/CancelTokenHandler.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/process/modify/CancelTokenHandler.java
@@ -9,6 +9,7 @@ package io.camunda.operate.webapp.zeebe.operation.process.modify;
 
 import io.camunda.operate.entities.FlowNodeState;
 import io.camunda.operate.exceptions.OperateRuntimeException;
+import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.webapp.reader.FlowNodeInstanceReader;
 import io.camunda.operate.webapp.rest.dto.operation.ModifyProcessInstanceRequestDto.Modification;
 import io.camunda.zeebe.client.api.command.ModifyProcessInstanceCommandStep1;
@@ -23,9 +24,13 @@ import org.springframework.util.StringUtils;
 public class CancelTokenHandler {
   private static final Logger LOGGER = LoggerFactory.getLogger(CancelTokenHandler.class);
   private final FlowNodeInstanceReader flowNodeInstanceReader;
+  private final OperateProperties operateProperties;
 
-  public CancelTokenHandler(final FlowNodeInstanceReader flowNodeInstanceReader) {
+  public CancelTokenHandler(
+      final FlowNodeInstanceReader flowNodeInstanceReader,
+      final OperateProperties operateProperties) {
     this.flowNodeInstanceReader = flowNodeInstanceReader;
+    this.operateProperties = operateProperties;
   }
 
   public ModifyProcessInstanceCommandStep1.ModifyProcessInstanceCommandStep2 cancelToken(
@@ -40,9 +45,22 @@ public class CancelTokenHandler {
       LOGGER.debug("Cancel token from flowNodeInstanceKey {} ", flowNodeInstanceKey);
       flowNodeInstanceKeys = List.of(Long.parseLong(flowNodeInstanceKey));
     } else {
-      flowNodeInstanceKeys =
+      final int limit = operateProperties.getOperationExecutor().getMaxModifyTokensLimit();
+      final List<Long> allKeys =
           flowNodeInstanceReader.getFlowNodeInstanceKeysByIdAndStates(
               processInstanceKey, modification.getFromFlowNodeId(), List.of(FlowNodeState.ACTIVE));
+      if (allKeys.size() > limit) {
+        LOGGER.warn(
+            "Found {} active instances for flow node '{}' in process instance {}, "
+                + "limiting cancellation to {} due to maxModifyTokensLimit",
+            allKeys.size(),
+            modification.getFromFlowNodeId(),
+            processInstanceKey,
+            limit);
+        flowNodeInstanceKeys = allKeys.subList(0, limit);
+      } else {
+        flowNodeInstanceKeys = allKeys;
+      }
     }
 
     if (flowNodeInstanceKeys.isEmpty()) {

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/process/modify/MoveTokenHandler.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/process/modify/MoveTokenHandler.java
@@ -9,6 +9,7 @@ package io.camunda.operate.webapp.zeebe.operation.process.modify;
 
 import io.camunda.operate.entities.FlowNodeState;
 import io.camunda.operate.exceptions.OperateRuntimeException;
+import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.webapp.reader.FlowNodeInstanceReader;
 import io.camunda.operate.webapp.rest.dto.operation.ModifyProcessInstanceRequestDto.Modification;
 import io.camunda.zeebe.client.api.command.ModifyProcessInstanceCommandStep1;
@@ -26,9 +27,13 @@ import org.springframework.util.StringUtils;
 public class MoveTokenHandler {
   private static final Logger LOGGER = LoggerFactory.getLogger(MoveTokenHandler.class);
   private final FlowNodeInstanceReader flowNodeInstanceReader;
+  private final OperateProperties operateProperties;
 
-  public MoveTokenHandler(final FlowNodeInstanceReader flowNodeInstanceReader) {
+  public MoveTokenHandler(
+      final FlowNodeInstanceReader flowNodeInstanceReader,
+      final OperateProperties operateProperties) {
     this.flowNodeInstanceReader = flowNodeInstanceReader;
+    this.operateProperties = operateProperties;
   }
 
   public ModifyProcessInstanceCommandStep1.ModifyProcessInstanceCommandStep2 moveToken(
@@ -36,23 +41,101 @@ public class MoveTokenHandler {
       final Long processInstanceKey,
       final Modification modification) {
 
-    final int newTokensCount = calculateNewTokensCount(modification, processInstanceKey);
+    final Integer specificTokensCount = modification.getNewTokensCount();
+    if (specificTokensCount != null && specificTokensCount <= 0) {
+      LOGGER.debug(
+          "Skipping MOVE_TOKEN processing for flowNode {} and process instance {} since newTokensCount is {}",
+          modification.getFromFlowNodeId(),
+          processInstanceKey,
+          specificTokensCount);
+      return null;
+    }
+
+    final List<Long> flowNodeInstanceKeysToCancel =
+        resolveFlowNodeInstanceKeysToCancel(processInstanceKey, modification);
+
+    final int newTokensCount = resolveNewTokensCount(modification, flowNodeInstanceKeysToCancel);
 
     if (newTokensCount > 0) {
+      // The number of tokens activated must equal the number cancelled so that the process
+      // instance token count stays consistent when the max modification limit kicks in.
+      final List<Long> keysToCancel =
+          flowNodeInstanceKeysToCancel.subList(
+              0, Math.min(newTokensCount, flowNodeInstanceKeysToCancel.size()));
+
+      if (keysToCancel.isEmpty()) {
+        throw new OperateRuntimeException(
+            String.format(
+                "Abort MOVE_TOKEN (CANCEL step): Can't find not finished flowNodeInstance keys for process instance %s and flowNode id %s",
+                processInstanceKey, modification.getFromFlowNodeId()));
+      }
+
       final ModifyProcessInstanceCommandStep1.ModifyProcessInstanceCommandStep3 nextStep =
           activateNewNodes(currentStep, modification, newTokensCount);
 
       moveGlobalVariables(nextStep, modification);
 
-      return cancelTokensOnOriginalNodes(nextStep, processInstanceKey, modification);
+      return cancelTokensOnOriginalNodes(nextStep, keysToCancel);
     } else {
-      LOGGER.info(
+      LOGGER.debug(
           "Skipping MOVE_TOKEN processing for flowNode {} and process instance {} since newTokensCount is {}",
           modification.getFromFlowNodeId(),
           processInstanceKey,
           newTokensCount);
       return null;
     }
+  }
+
+  private List<Long> resolveFlowNodeInstanceKeysToCancel(
+      final Long processInstanceKey, final Modification modification) {
+    if (StringUtils.hasText(modification.getFromFlowNodeInstanceKey())) {
+      return List.of(Long.parseLong(modification.getFromFlowNodeInstanceKey()));
+    } else if (StringUtils.hasText(modification.getFromFlowNodeId())) {
+      final int limit = operateProperties.getOperationExecutor().getMaxModifyTokensLimit();
+      final List<Long> keys =
+          flowNodeInstanceReader.getFlowNodeInstanceKeysByIdAndStates(
+              processInstanceKey, modification.getFromFlowNodeId(), List.of(FlowNodeState.ACTIVE));
+      if (keys.size() > limit) {
+        LOGGER.warn(
+            "Found {} active instances for flow node '{}' in process instance {}, "
+                + "limiting to {} due to maxModifyTokensLimit",
+            keys.size(),
+            modification.getFromFlowNodeId(),
+            processInstanceKey,
+            limit);
+        return keys.subList(0, limit);
+      }
+      return keys;
+    } else {
+      return List.of();
+    }
+  }
+
+  private int resolveNewTokensCount(
+      final Modification modification, final List<Long> resolvedCancelKeys) {
+    Integer newTokensCount = modification.getNewTokensCount();
+    if (newTokensCount == null) {
+      if (StringUtils.hasText(modification.getFromFlowNodeInstanceKey())) {
+        newTokensCount = 1;
+      } else if (StringUtils.hasText(modification.getFromFlowNodeId())) {
+        newTokensCount = resolvedCancelKeys.size();
+      } else {
+        LOGGER.warn(
+            "MOVE_TOKEN attempted with no flowNodeId, flowNodeInstanceKey, or newTokenCount specified");
+        newTokensCount = 0;
+      }
+    } else {
+      final int limit = operateProperties.getOperationExecutor().getMaxModifyTokensLimit();
+      if (newTokensCount > limit) {
+        LOGGER.warn(
+            "newTokensCount {} exceeds maxModifyTokensLimit {}, capping to limit",
+            newTokensCount,
+            limit);
+        newTokensCount = limit;
+      }
+    }
+    LOGGER.debug("MOVE_TOKEN has a newTokensCount value of {}", newTokensCount);
+    return newTokensCount;
   }
 
   private ModifyProcessInstanceCommandStep1.ModifyProcessInstanceCommandStep3 activateNewNodes(
@@ -129,63 +212,12 @@ public class MoveTokenHandler {
   private ModifyProcessInstanceCommandStep1.ModifyProcessInstanceCommandStep2
       cancelTokensOnOriginalNodes(
           final ModifyProcessInstanceCommandStep1.ModifyProcessInstanceCommandStep2 nextStep,
-          final Long processInstanceKey,
-          final Modification modification) {
-    final String fromFlowNodeId = modification.getFromFlowNodeId();
-    final String fromFlowNodeInstanceKey = modification.getFromFlowNodeInstanceKey();
-    final List<Long> flowNodeInstanceKeysToCancel;
-
-    // Build the list of instances to cancel
-    if (StringUtils.hasText(fromFlowNodeInstanceKey)) {
-      final Long flowNodeInstanceKey = Long.parseLong(fromFlowNodeInstanceKey);
-      flowNodeInstanceKeysToCancel = List.of(flowNodeInstanceKey);
-    } else {
-      flowNodeInstanceKeysToCancel =
-          flowNodeInstanceReader.getFlowNodeInstanceKeysByIdAndStates(
-              processInstanceKey, fromFlowNodeId, List.of(FlowNodeState.ACTIVE));
-    }
-
-    if (flowNodeInstanceKeysToCancel.isEmpty()) {
-      throw new OperateRuntimeException(
-          String.format(
-              "Abort MOVE_TOKEN (CANCEL step): Can't find not finished flowNodeInstance keys for process instance %s and flowNode id %s",
-              processInstanceKey, fromFlowNodeId));
-    }
-
+          final List<Long> flowNodeInstanceKeysToCancel) {
     LOGGER.debug(
         "Move [Cancel token from flowNodeInstanceKeys: {} ]", flowNodeInstanceKeysToCancel);
     for (final Long flowNodeInstanceKey : flowNodeInstanceKeysToCancel) {
       nextStep.and().terminateElement(flowNodeInstanceKey);
     }
-
     return nextStep;
-  }
-
-  private int calculateNewTokensCount(
-      final Modification modification, final Long processInstanceKey) {
-    Integer newTokensCount = modification.getNewTokensCount();
-
-    if (newTokensCount == null) {
-      if (modification.getFromFlowNodeInstanceKey() != null) {
-        // If a flow node instance key was specified, assume that flow node is valid. Zeebe
-        // will correctly fail attempts to migrate off an invalid flow node
-        newTokensCount = 1;
-      } else if (modification.getFromFlowNodeId() != null) {
-        newTokensCount =
-            flowNodeInstanceReader
-                .getFlowNodeInstanceKeysByIdAndStates(
-                    processInstanceKey,
-                    modification.getFromFlowNodeId(),
-                    List.of(FlowNodeState.ACTIVE))
-                .size();
-      } else {
-        LOGGER.warn(
-            "MOVE_TOKEN attempted with no flowNodeId, flowNodeInstanceKey, or newTokenCount specified");
-        newTokensCount = 0;
-      }
-    }
-
-    LOGGER.info("MOVE_TOKEN has a newTokensCount value of {}", newTokensCount);
-    return newTokensCount;
   }
 }

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/zeebe/operation/process/modify/CancelTokenHandlerTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/zeebe/operation/process/modify/CancelTokenHandlerTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.webapp.zeebe.operation.process.modify;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+import io.camunda.operate.entities.FlowNodeState;
+import io.camunda.operate.exceptions.OperateRuntimeException;
+import io.camunda.operate.property.OperateProperties;
+import io.camunda.operate.webapp.reader.FlowNodeInstanceReader;
+import io.camunda.operate.webapp.rest.dto.operation.ModifyProcessInstanceRequestDto.Modification;
+import io.camunda.operate.webapp.rest.dto.operation.ModifyProcessInstanceRequestDto.Modification.Type;
+import io.camunda.zeebe.client.api.command.ModifyProcessInstanceCommandStep1;
+import io.camunda.zeebe.client.api.command.ModifyProcessInstanceCommandStep1.ModifyProcessInstanceCommandStep2;
+import io.camunda.zeebe.client.api.command.ModifyProcessInstanceCommandStep1.ModifyProcessInstanceCommandStep3;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class CancelTokenHandlerTest {
+  @Mock private FlowNodeInstanceReader mockFlowNodeInstanceReader;
+
+  private CancelTokenHandler cancelTokenHandler;
+
+  private ModifyProcessInstanceCommandStep1 mockZeebeCommand;
+
+  @BeforeEach
+  public void setup() {
+    cancelTokenHandler =
+        new CancelTokenHandler(mockFlowNodeInstanceReader, new OperateProperties());
+
+    mockZeebeCommand =
+        Mockito.mock(
+            ModifyProcessInstanceCommandStep1.class,
+            withSettings()
+                .extraInterfaces(
+                    ModifyProcessInstanceCommandStep2.class,
+                    ModifyProcessInstanceCommandStep3.class));
+
+    when(mockZeebeCommand.terminateElement(anyLong()))
+        .thenReturn((ModifyProcessInstanceCommandStep2) mockZeebeCommand);
+    when(((ModifyProcessInstanceCommandStep2) mockZeebeCommand).and()).thenReturn(mockZeebeCommand);
+  }
+
+  @Test
+  public void testCancelTokenByInstanceKey() {
+    // given
+    final Modification modification =
+        new Modification().setModification(Type.CANCEL_TOKEN).setFromFlowNodeInstanceKey("456");
+
+    // when
+    final ModifyProcessInstanceCommandStep2 result =
+        cancelTokenHandler.cancelToken(mockZeebeCommand, 123L, modification);
+
+    // then
+    assertThat(result).isNotNull();
+    verify(mockZeebeCommand, times(1)).terminateElement(456L);
+    verifyNoInteractions(mockFlowNodeInstanceReader);
+  }
+
+  @Test
+  public void testCancelTokenByFlowNodeId() {
+    // given
+    when(mockFlowNodeInstanceReader.getFlowNodeInstanceKeysByIdAndStates(
+            123L, "taskA", List.of(FlowNodeState.ACTIVE)))
+        .thenReturn(List.of(100L, 200L));
+
+    // when
+    final Modification modification =
+        new Modification().setModification(Type.CANCEL_TOKEN).setFromFlowNodeId("taskA");
+
+    final ModifyProcessInstanceCommandStep2 result =
+        cancelTokenHandler.cancelToken(mockZeebeCommand, 123L, modification);
+
+    // then
+    assertThat(result).isNotNull();
+    verify(mockZeebeCommand, times(1)).terminateElement(100L);
+    verify(mockZeebeCommand, times(1)).terminateElement(200L);
+    verify(mockFlowNodeInstanceReader, times(1))
+        .getFlowNodeInstanceKeysByIdAndStates(123L, "taskA", List.of(FlowNodeState.ACTIVE));
+  }
+
+  @Test
+  public void testCancelTokenThrowsWhenNoInstancesFound() {
+    // given
+    when(mockFlowNodeInstanceReader.getFlowNodeInstanceKeysByIdAndStates(
+            anyLong(), anyString(), Mockito.anyList()))
+        .thenReturn(List.of());
+
+    // when - then
+    final Modification modification =
+        new Modification().setModification(Type.CANCEL_TOKEN).setFromFlowNodeId("taskA");
+
+    assertThatThrownBy(() -> cancelTokenHandler.cancelToken(mockZeebeCommand, 123L, modification))
+        .isInstanceOf(OperateRuntimeException.class)
+        .hasMessageContaining("Abort CANCEL_TOKEN");
+
+    verify(mockZeebeCommand, never()).terminateElement(anyLong());
+  }
+
+  @Test
+  public void testCancelTokenLimitedByMaxLimit() {
+    // given
+    final int testLimit = 5;
+    final OperateProperties operateProperties = new OperateProperties();
+    operateProperties.getOperationExecutor().setMaxModifyTokensLimit(testLimit);
+    final CancelTokenHandler limitedHandler =
+        new CancelTokenHandler(mockFlowNodeInstanceReader, operateProperties);
+
+    final List<Long> allKeys = List.of(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L);
+    when(mockFlowNodeInstanceReader.getFlowNodeInstanceKeysByIdAndStates(
+            123L, "taskA", List.of(FlowNodeState.ACTIVE)))
+        .thenReturn(allKeys);
+
+    // when
+    final Modification modification =
+        new Modification().setModification(Type.CANCEL_TOKEN).setFromFlowNodeId("taskA");
+
+    final ModifyProcessInstanceCommandStep2 result =
+        limitedHandler.cancelToken(mockZeebeCommand, 123L, modification);
+
+    // then
+    assertThat(result).isNotNull();
+    verify(mockZeebeCommand, times(testLimit)).terminateElement(anyLong());
+    verify(mockZeebeCommand, never()).terminateElement(6L);
+  }
+}

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/zeebe/operation/process/modify/MoveTokenHandlerTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/zeebe/operation/process/modify/MoveTokenHandlerTest.java
@@ -8,6 +8,7 @@
 package io.camunda.operate.webapp.zeebe.operation.process.modify;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -18,6 +19,8 @@ import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
 import io.camunda.operate.entities.FlowNodeState;
+import io.camunda.operate.exceptions.OperateRuntimeException;
+import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.webapp.reader.FlowNodeInstanceReader;
 import io.camunda.operate.webapp.rest.dto.operation.ModifyProcessInstanceRequestDto.Modification;
 import io.camunda.operate.webapp.rest.dto.operation.ModifyProcessInstanceRequestDto.Modification.Type;
@@ -46,7 +49,7 @@ public class MoveTokenHandlerTest {
 
   @BeforeEach
   public void setup() {
-    moveTokenHandler = new MoveTokenHandler(mockFlowNodeInstanceReader);
+    moveTokenHandler = new MoveTokenHandler(mockFlowNodeInstanceReader, new OperateProperties());
 
     mockZeebeCommand =
         Mockito.mock(
@@ -162,7 +165,7 @@ public class MoveTokenHandlerTest {
     verify(mockZeebeCommand, times(1)).terminateElement(456L);
     verify((ModifyProcessInstanceCommandStep2) mockZeebeCommand, times(1)).and();
 
-    verify(mockFlowNodeInstanceReader, times(2))
+    verify(mockFlowNodeInstanceReader, times(1))
         .getFlowNodeInstanceKeysByIdAndStates(123L, "taskA", List.of(FlowNodeState.ACTIVE));
   }
 
@@ -214,6 +217,87 @@ public class MoveTokenHandlerTest {
     verify((ModifyProcessInstanceCommandStep2) mockZeebeCommand, times(1)).and();
 
     verifyNoInteractions(mockFlowNodeInstanceReader);
+  }
+
+  @Test
+  public void testMoveTokenLimitedByMaxLimit() {
+    // given
+    final int testLimit = 5;
+    final OperateProperties operateProperties = new OperateProperties();
+    operateProperties.getOperationExecutor().setMaxModifyTokensLimit(testLimit);
+    final MoveTokenHandler limitedHandler =
+        new MoveTokenHandler(mockFlowNodeInstanceReader, operateProperties);
+
+    final List<Long> allKeys = List.of(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L);
+    when(mockFlowNodeInstanceReader.getFlowNodeInstanceKeysByIdAndStates(
+            123L, "taskA", List.of(FlowNodeState.ACTIVE)))
+        .thenReturn(allKeys);
+
+    // when
+    final Modification modification =
+        new Modification()
+            .setModification(Type.MOVE_TOKEN)
+            .setFromFlowNodeId("taskA")
+            .setToFlowNodeId("taskB");
+
+    final ModifyProcessInstanceCommandStep1.ModifyProcessInstanceCommandStep2 result =
+        limitedHandler.moveToken(mockZeebeCommand, 123L, modification);
+
+    // then
+    assertThat(result).isNotNull();
+    verify(mockZeebeCommand, times(testLimit)).activateElement("taskB");
+    verify(mockZeebeCommand, times(testLimit)).terminateElement(anyLong());
+    verify(mockZeebeCommand, Mockito.never()).terminateElement(6L);
+  }
+
+  @Test
+  public void testMoveTokenSpecificCountCappedByMaxLimit() {
+    // given
+    final int testLimit = 5;
+    final OperateProperties operateProperties = new OperateProperties();
+    operateProperties.getOperationExecutor().setMaxModifyTokensLimit(testLimit);
+    final MoveTokenHandler limitedHandler =
+        new MoveTokenHandler(mockFlowNodeInstanceReader, operateProperties);
+
+    final List<Long> allKeys = List.of(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L);
+    when(mockFlowNodeInstanceReader.getFlowNodeInstanceKeysByIdAndStates(
+            123L, "taskA", List.of(FlowNodeState.ACTIVE)))
+        .thenReturn(allKeys);
+
+    // when
+    final Modification modification =
+        new Modification()
+            .setModification(Type.MOVE_TOKEN)
+            .setFromFlowNodeId("taskA")
+            .setToFlowNodeId("taskB")
+            .setNewTokensCount(testLimit + 2);
+
+    final ModifyProcessInstanceCommandStep1.ModifyProcessInstanceCommandStep2 result =
+        limitedHandler.moveToken(mockZeebeCommand, 123L, modification);
+
+    // then
+    assertThat(result).isNotNull();
+    verify(mockZeebeCommand, times(testLimit)).activateElement("taskB");
+    verify(mockZeebeCommand, times(testLimit)).terminateElement(anyLong());
+  }
+
+  @Test
+  public void testMoveTokenThrowsWhenNoInstancesFound() {
+    // given
+    when(mockFlowNodeInstanceReader.getFlowNodeInstanceKeysByIdAndStates(
+            123L, "taskA", List.of(FlowNodeState.ACTIVE)))
+        .thenReturn(List.of());
+
+    final Modification modification =
+        new Modification()
+            .setModification(Type.MOVE_TOKEN)
+            .setFromFlowNodeId("taskA")
+            .setToFlowNodeId("taskB")
+            .setNewTokensCount(2);
+
+    assertThatThrownBy(() -> moveTokenHandler.moveToken(mockZeebeCommand, 123L, modification))
+        .isInstanceOf(OperateRuntimeException.class)
+        .hasMessageContaining("Abort MOVE_TOKEN (CANCEL step)");
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Fix process instance modification only canceling a maximum of 10 instances in multi-instance bodies.

I didn't add new ITs for this since the setup for them takes forever, so it's not feasible.

Introducing a maximum limit of tokens that can be canceled/moved within the same element instance `camunda.operate.operationExecutor.maxModifyTokensLimit`. Default is set to 500, because I locally already got the timeout at 2000. It can be configured to be higher if needed for specific use cases.
The limit is enforced during execution of the operation (not during creation) to allow for adjusting this limit if a cluster is stuck on the operation (since the operation will be endlessly retried, due to the timeout error being expected to mostly occur during temporary network issues).

This PR is also introducing a configuration property for setting the Operate zeebe client request timeout `camunda.operate.zeebe.requestTimeout` (if not set, the default from the zeebe client config is used, which is 10s). This allows for increasing the max modify limit while also increasing the request timeout if this is the preferred solution by a customer (though the timeout between the gateway in broker will likely also have to be increased in that case).

I will add documentation for the limitation and the new properties once this approach is approved.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates to https://github.com/camunda/camunda/issues/37282
