### PR TITLE
fix: make result as nullable as it can be null when an expression failed to execute

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/expression.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/expression.yaml
@@ -69,6 +69,7 @@ components:
           description: The result value. Its type can vary.
           # Omitting type for this field generates Object in Java, and signals Any to other consumers. It can be anything.
           example: 30
+          nullable: true
         warnings:
           type: array
           description: List of warnings generated during expression evaluation


### PR DESCRIPTION
This pull request makes a minor change to the `expression.yaml` file for the Zeebe gateway protocol. The change clarifies that the result value can be explicitly set to `null` by marking the field as nullable. This helps consumers of the protocol handle cases where the result may not be present.

* Marked the result value field as `nullable: true` to indicate it can be `null` in the protocol definition (`zeebe/gateway-protocol/src/main/proto/v2/expression.yaml`).

closes https://github.com/camunda/camunda/issues/50091