### PR TITLE
fix: remove pretty-print JSON serialization in UserTaskCompletionVariableHandler

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskCompletionVariableHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskCompletionVariableHandler.java
@@ -9,7 +9,6 @@ package io.camunda.exporter.handlers;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
 import io.camunda.exporter.handlers.UserTaskCompletionVariableHandler.SnapshotTaskVariableBatch;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.SnapshotTaskVariableTemplate;
@@ -35,13 +34,13 @@ public class UserTaskCompletionVariableHandler
   private static final String ID_PATTERN = "%s-%s";
   protected final int variableSizeThreshold;
   private final String indexName;
-  private final ObjectWriter objectWriter;
+  private final ObjectMapper objectMapper;
 
   public UserTaskCompletionVariableHandler(
       final String indexName, final int variableSizeThreshold, final ObjectMapper objectMapper) {
     this.indexName = indexName;
     this.variableSizeThreshold = variableSizeThreshold;
-    objectWriter = objectMapper.writerWithDefaultPrettyPrinter();
+    this.objectMapper = objectMapper;
   }
 
   @Override
@@ -138,7 +137,7 @@ public class UserTaskCompletionVariableHandler
 
   private String toJsonString(final Object value) {
     try {
-      return objectWriter.writeValueAsString(value);
+      return objectMapper.writeValueAsString(value);
     } catch (final JsonProcessingException e) {
       LOGGER.error("Failed to parse variable value '{}'", value, e);
       return "";

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskCompletionVariableHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskCompletionVariableHandler.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.exporter.handlers;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.handlers.UserTaskCompletionVariableHandler.SnapshotTaskVariableBatch;
@@ -108,7 +110,7 @@ public class UserTaskCompletionVariableHandler
     final var variableName = e.getKey();
     final var variableValue = e.getValue();
 
-    final var variableValueAsString = toJsonString(variableValue);
+    final var variableValueAsBytes = toJsonBytes(variableValue);
     final var snapshotVariableEntity =
         new SnapshotTaskVariableEntity()
             .setId(String.format(ID_PATTERN, userTaskKey, variableName))
@@ -119,14 +121,17 @@ public class UserTaskCompletionVariableHandler
             .setProcessInstanceKey(recordValue.getProcessInstanceKey())
             .setTaskId(String.valueOf(record.getValue().getUserTaskKey()));
 
-    if (variableValueAsString.length() > variableSizeThreshold) {
+    if (variableValueAsBytes.length > variableSizeThreshold) {
       // store preview
       snapshotVariableEntity
-          .setValue(variableValueAsString.substring(0, variableSizeThreshold))
-          .setFullValue(variableValueAsString)
+          .setValue(new String(variableValueAsBytes, 0, variableSizeThreshold, UTF_8))
+          .setFullValue(new String(variableValueAsBytes, UTF_8))
           .setIsPreview(true);
     } else {
-      snapshotVariableEntity.setValue(variableValueAsString).setFullValue(null).setIsPreview(false);
+      snapshotVariableEntity
+          .setValue(new String(variableValueAsBytes, UTF_8))
+          .setFullValue(null)
+          .setIsPreview(false);
     }
     final long rootProcessInstanceKey = record.getValue().getRootProcessInstanceKey();
     if (rootProcessInstanceKey > 0) {
@@ -135,12 +140,12 @@ public class UserTaskCompletionVariableHandler
     return snapshotVariableEntity;
   }
 
-  private String toJsonString(final Object value) {
+  private byte[] toJsonBytes(final Object value) {
     try {
-      return objectMapper.writeValueAsString(value);
+      return objectMapper.writeValueAsBytes(value);
     } catch (final JsonProcessingException e) {
       LOGGER.error("Failed to parse variable value '{}'", value, e);
-      return "";
+      return new byte[0];
     }
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskCompletionVariableHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskCompletionVariableHandlerTest.java
@@ -195,6 +195,24 @@ public class UserTaskCompletionVariableHandlerTest {
   }
 
   @Test
+  void shouldSerializeVariableValuesAsCompactJson() {
+    // given
+    final long scopeKey = 456;
+    final var nestedValue = new java.util.LinkedHashMap<String, Object>();
+    nestedValue.put("key1", "value1");
+    nestedValue.put("key2", List.of(1, 2, 3));
+    final var taskRecord = generateRecordWithVariables(scopeKey, Map.of("var1", nestedValue));
+
+    // when
+    final var batch = new SnapshotTaskVariableBatch(String.valueOf(scopeKey), new ArrayList<>());
+    underTest.updateEntity(taskRecord, batch);
+
+    // then
+    final var variableEntity = batch.variables().getFirst();
+    assertThat(variableEntity.getValue()).isEqualTo("{\"key1\":\"value1\",\"key2\":[1,2,3]}");
+  }
+
+  @Test
   void shouldUpdateEntityFromRecordWithFullValue() {
     // given
     final long scopeKey = 456;


### PR DESCRIPTION
## Summary

- `UserTaskCompletionVariableHandler` used `writerWithDefaultPrettyPrinter()` to serialize completion variable values, inflating them with unnecessary whitespace (30-50%+ for nested JSON). 
- Replaced with `objectMapper.writeValueAsString()` directly, removing the intermediate `ObjectWriter` field.


relates to https://github.com/camunda/camunda/issues/46239