### PR TITLE
fix: validate official docker images require explicit reuse-tag

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -184,6 +184,11 @@ jobs:
     outputs:
       image-tag: ${{ inputs.reuse-tag != '' && inputs.reuse-tag || steps.image-tag.outputs.image-tag }}
     steps:
+      - name: Validate official images require explicit tag
+        if: ${{ inputs.use-official-docker-images == true && inputs.reuse-tag == '' }}
+        run: |
+          echo "::error::Invalid input combination: 'use-official-docker-images' is enabled but 'reuse-tag' is empty. Official Camunda Docker images require an explicit tag (e.g., '8.9.0-rc2') to pull from Docker Hub. Either provide a 'reuse-tag' or disable 'use-official-docker-images'."
+          exit 1
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}


### PR DESCRIPTION
## Summary

- Adds an early validation step in the `calculate-image-tag` job of `camunda-load-test.yml` that fails fast when `use-official-docker-images` is enabled but `reuse-tag` is empty
- This invalid combination previously caused broken deployments (e.g., 8.9.0-rc2 release load tests) because the workflow would build from source but resolve the image registry to `docker.io`, referencing a non-existent image like `docker.io/camunda/camunda:release-8-9-0-b1d6fb5f`

See related https://camunda.slack.com/archives/C06UWQNCU7M/p1774969483443949?thread_ts=1774864520.741799&cid=C06UWQNCU7M


## Test plan

- [x] Trigger `camunda-load-test` workflow with `use-official-docker-images: true` and empty `reuse-tag` — should fail immediately with a clear error message
    - [ ] https://github.com/camunda/camunda/actions/runs/23805580276
- [x] Trigger with `use-official-docker-images: true` and a valid `reuse-tag` (e.g., `8.9.0-rc2`) — should proceed normally (existing validation checks the tag exists on Docker Hub)
    - [ ] https://github.com/camunda/camunda/actions/runs/23805695853
- [x] Trigger with `use-official-docker-images: false` and empty `reuse-tag` — should proceed normally (builds from source)
    - [ ] https://github.com/camunda/camunda/actions/runs/23805755083
- [x] Trigger with `use-official-docker-images: false` and `reuse-tag` — should proceed normally (reused tag from internal)
    - [x] https://github.com/camunda/camunda/actions/runs/23805737229


<img width="1322" height="538" alt="2026-03-31_17-45" src="https://github.com/user-attachments/assets/de0461fb-0276-4245-be7e-010b5958ed7a" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)