### PR TITLE
fix: bootstrap full reactor to resolve unpublished SNAPSHOTs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,8 +188,8 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-      - name: Bootstrap Zeebe build tools
-        run: ./mvnw -B -T1C --no-snapshot-updates -DskipChecks=true -DskipTests=true -Dquickly=true -pl build-tools -am install
+      - name: Bootstrap reactor modules
+        run: ./mvnw -B -T1C --no-snapshot-updates -DskipChecks=true -DskipTests=true -Dquickly=true install
       - name: Generate flattened POMs
         run: ./mvnw -B -T1C --no-snapshot-updates -DskipChecks=true -Dcheckstyle.skip=true -DskipTests=true -Dquickly=false -PskipFrontendBuild process-resources
       - name: Validate flattened POM metadata


### PR DESCRIPTION
## Description

This pull request makes a small update to the CI workflow configuration. The change broadens the Maven bootstrap step to build all reactor modules instead of just the `build-tools` module, which should ensure all modules are built and dependencies are resolved earlier in the workflow.

* CI Workflow Update:
  * [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL191-R192): Changed the Maven bootstrap step from building only the `build-tools` module to building all reactor modules, improving build completeness and reliability.

Current issue can be seen in the following runs:
- https://github.com/camunda/camunda/actions/runs/23761340299/job/69346040880?pr=50053
- https://github.com/camunda/camunda/actions/runs/23761174517/job/69347191161?pr=50052

This was happening because the validate-pom-metadata pipeline failures on stable/8.6 and stable/8.7 caused by unresolvable SNAPSHOT dependencies after mergeback version bumps. The issue was introduced by[ #40004](https://github.com/camunda/camunda/issues/40004?reload=1?reload=1) — the bootstrap step only installed build-tools, so newly bumped SNAPSHOTs like zeebe-util:8.7.27-SNAPSHOT couldn't be resolved from any remote repo during POM flattening.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
