### PR TITLE
ci: add missing actions/checkout step in load-test workflows

### DIFF
--- a/.github/workflows/camunda-pr-load-test.yaml
+++ b/.github/workflows/camunda-pr-load-test.yaml
@@ -32,6 +32,8 @@ jobs:
     outputs:
       sanitized-name: c8-${{ steps.sanitize.outputs.branch_name }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
       - id: sanitize
         uses: camunda/infra-global-github-actions/sanitize-branch-name@main
         with:
@@ -69,6 +71,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
       - name: Wait for load test to stabilize
         run: sleep 900  # 15 minutes
       - name: Observe build status
@@ -105,6 +109,8 @@ jobs:
       contents: 'read'
       pull-requests: 'write'
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
       - uses: actions/download-artifact@v8
         with:
           path: artifacts


### PR DESCRIPTION
## Description

The jobs are calling the observe-build-status local action which requires the repository to be checked out before being called.

See for instance the errors in this build: https://github.com/camunda/camunda/actions/runs/23807584553?pr=49541

The workflow step is configured with `continue-on-error: true`, so it never fails, although it technically does.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

similar:
* https://github.com/camunda/camunda/pull/49276
