### PR TITLE
[Backport stable/8.9] fix: make result as nullable as it can be null when an expression failed to execute

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/expression.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/expression.yaml
@@ -69,6 +69,7 @@ components:
           description: The result value. Its type can vary.
           # Omitting type for this field generates Object in Java, and signals Any to other consumers. It can be anything.
           example: 30
+          nullable: true
         warnings:
           type: array
           description: List of warnings generated during expression evaluation


### PR DESCRIPTION
# Description
Backport of #50157 to `stable/8.9`.

relates to camunda/camunda#50091