### PR TITLE
feat: auto submit after applying json editor modal changes

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/Footer/NewVariable.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/Footer/NewVariable.tsx
@@ -109,6 +109,7 @@ const NewVariable: React.FC = () => {
           }}
           onApply={(value) => {
             form.change('value', value);
+            form.submit();
             setIsModalVisible(false);
             tracking.track({
               eventName: 'json-editor-saved',

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/VariablesTable.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/VariablesTable.tsx
@@ -177,6 +177,7 @@ const VariablesTable: React.FC<Props> = ({
                         cellContent: (
                           <Operations>
                             <ViewFullVariableButton
+                              shouldSubmitOnApply={false}
                               mode="add"
                               scopeId={scopeId}
                               variableName={variableName}

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/ViewFullVariableButton/Add/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/ViewFullVariableButton/Add/index.tsx
@@ -20,6 +20,7 @@ import {MaximizeButton} from '../MaximizeButton';
 const ViewFullVariableButtonAdd: React.FC<ViewFullVariableButtonAddProps> = ({
   variableName,
   scopeId,
+  shouldSubmitOnApply,
 }) => {
   const [isModalVisible, setIsModalVisible] = useState(false);
   const valueFieldName = createNewVariableFieldName(variableName, 'value');
@@ -49,6 +50,9 @@ const ViewFullVariableButtonAdd: React.FC<ViewFullVariableButtonAddProps> = ({
           }}
           onApply={(value) => {
             form.change(valueFieldName, value);
+            if (shouldSubmitOnApply) {
+              form.submit();
+            }
             setIsModalVisible(false);
             if (value !== undefined) {
               createModification({

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/ViewFullVariableButton/Edit/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/ViewFullVariableButton/Edit/index.tsx
@@ -19,6 +19,7 @@ const ViewFullVariableButtonEdit: React.FC<ViewFullVariableButtonEditProps> = ({
   variableName,
   variableKey,
   variableValue,
+  shouldSubmitOnApply,
 }) => {
   const [isModalVisible, setIsModalVisible] = useState(false);
   const {data: variable} = useVariable(variableKey, {
@@ -56,6 +57,9 @@ const ViewFullVariableButtonEdit: React.FC<ViewFullVariableButtonEditProps> = ({
           }}
           onApply={(value) => {
             form.change(variableEditor.fieldName, value);
+            if (shouldSubmitOnApply) {
+              form.submit();
+            }
             setIsModalVisible(false);
             tracking.track({
               eventName: 'json-editor-saved',

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/ViewFullVariableButton/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/ViewFullVariableButton/index.tsx
@@ -14,21 +14,32 @@ import type {ViewFullVariableWrapperProps} from './types';
 const ViewFullVariableButton: React.FC<ViewFullVariableWrapperProps> = (
   props,
 ) => {
+  const shouldSubmitOnApply = props.shouldSubmitOnApply ?? true;
+
   if (props.mode === 'add') {
     return (
       <ViewFullVariableButtonAdd
-        mode="add"
-        scopeId={props.scopeId}
-        variableName={props.variableName}
+        {...props}
+        shouldSubmitOnApply={shouldSubmitOnApply}
       />
     );
   }
 
   if (props.mode === 'edit') {
-    return <ViewFullVariableButtonEdit {...props} />;
+    return (
+      <ViewFullVariableButtonEdit
+        {...props}
+        shouldSubmitOnApply={shouldSubmitOnApply}
+      />
+    );
   }
 
-  return <ViewFullVariableButtonShow {...props} />;
+  return (
+    <ViewFullVariableButtonShow
+      {...props}
+      shouldSubmitOnApply={shouldSubmitOnApply}
+    />
+  );
 };
 
 export {ViewFullVariableButton};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/ViewFullVariableButton/types.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/ViewFullVariableButton/types.ts
@@ -11,22 +11,24 @@ export interface MaximizeButtonProps {
   onClick: () => void;
 }
 
-export interface ViewFullVariableButtonAddProps {
-  mode: 'add';
+interface ViewFullVariableBaseProps {
   variableName: string;
+  shouldSubmitOnApply?: boolean;
+}
+
+export interface ViewFullVariableButtonAddProps extends ViewFullVariableBaseProps {
+  mode: 'add';
   scopeId: string | null;
 }
 
-export interface ViewFullVariableButtonEditProps {
+export interface ViewFullVariableButtonEditProps extends ViewFullVariableBaseProps {
   mode: 'edit';
-  variableName: string;
   variableValue: string;
   variableKey: string;
 }
 
-export interface ViewFullVariableButtonShowProps {
+export interface ViewFullVariableButtonShowProps extends ViewFullVariableBaseProps {
   mode: 'show';
-  variableName: string;
   variableValue: string;
   variableKey: string;
 }

--- a/operate/client/src/App/Processes/ListView/Filters/VariableField/index.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariableField/index.tsx
@@ -172,6 +172,7 @@ const Variable: React.FC = observer(() => {
               }}
               onApply={(value) => {
                 form.change('variableValues', value);
+                form.submit();
                 setIsModalVisible(false);
                 tracking.track({
                   eventName: 'json-editor-saved',


### PR DESCRIPTION
## Description

Auto submit Variables form after apply button is clicked in JSONEditorModal to avoid having to click twice

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #49273
