### PR TITLE
feat: Update job runner

### DIFF
--- a/.github/workflows/auto-merge-back-to-stable.yml
+++ b/.github/workflows/auto-merge-back-to-stable.yml
@@ -17,7 +17,7 @@ jobs:
     # Only run for PRs from release branches created by release automation
     if: startsWith(github.head_ref, 'release-') && github.actor == 'camundait'
     name: Auto-merge release to stable
-    runs-on: ubuntu-slim
+    runs-on: gcp-core-2-longrunning
     timeout-minutes: 240
     permissions:
       contents: read

--- a/.github/workflows/auto-merge-back-to-stable.yml
+++ b/.github/workflows/auto-merge-back-to-stable.yml
@@ -17,7 +17,7 @@ jobs:
     # Only run for PRs from release branches created by release automation
     if: startsWith(github.head_ref, 'release-') && github.actor == 'camundait'
     name: Auto-merge release to stable
-    runs-on: gcp-core-2-longrunning
+    runs-on: ubuntu-latest
     timeout-minutes: 240
     permissions:
       contents: read


### PR DESCRIPTION
## Description

The currently used runner for the [Auto-merge release to stable](https://github.com/camunda/camunda/actions/workflows/auto-merge-back-to-stable.yml) workflow is `ubtuntu-slim` which has a hard limit of [15 minutes TTL](https://docs.github.com/en/actions/reference/runners/github-hosted-runners#usage-limits). As the workflow is running for a much longer time (240 minutes max), the runner have to be updated for a more stable long running runner.

[Sample cancelled workflow](https://github.com/camunda/camunda/actions/runs/23800708682/job/69360037759)
