### PR TITLE
refactor: adjust thresholds of latency panels

### DIFF
--- a/monitor/grafana/release-overview.json
+++ b/monitor/grafana/release-overview.json
@@ -1,41 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_PROMETHEUS",
-      "label": "Prometheus",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
-  "__elements": {},
-  "__requires": [
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "12.0.2"
-    },
-    {
-      "type": "datasource",
-      "id": "prometheus",
-      "name": "Prometheus",
-      "version": "1.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "stat",
-      "name": "Stat",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "table",
-      "name": "Table",
-      "version": ""
-    }
-  ],
   "annotations": {
     "list": [
       {
@@ -81,6 +44,9 @@
               "type": "auto"
             },
             "filterable": true,
+            "footer": {
+              "reducers": []
+            },
             "inspect": false
           },
           "mappings": [],
@@ -88,7 +54,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               }
             ]
           }
@@ -141,7 +108,8 @@
                   "mode": "absolute",
                   "steps": [
                     {
-                      "color": "green"
+                      "color": "green",
+                      "value": 0
                     },
                     {
                       "color": "red",
@@ -201,7 +169,8 @@
                   "mode": "absolute",
                   "steps": [
                     {
-                      "color": "green"
+                      "color": "green",
+                      "value": 0
                     },
                     {
                       "color": "semi-dark-orange",
@@ -251,19 +220,11 @@
       "id": 294,
       "options": {
         "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
         "frameIndex": 0,
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "12.0.2",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
@@ -286,7 +247,6 @@
           "editorMode": "code",
           "expr": "atomix_role{namespace=~\"(c8-)?release-8.*\"} ",
           "format": "table",
-          "hide": false,
           "instant": true,
           "interval": "",
           "legendFormat": "",
@@ -389,7 +349,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "red"
+                "color": "red",
+                "value": 0
               },
               {
                 "color": "green",
@@ -428,7 +389,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.0.2",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
@@ -474,7 +435,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "red"
+                "color": "red",
+                "value": 0
               }
             ]
           },
@@ -509,7 +471,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.0.2",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
@@ -555,7 +517,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "red"
+                "color": "red",
+                "value": 0
               },
               {
                 "color": "green",
@@ -594,7 +557,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.0.2",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
@@ -627,7 +590,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "red"
+                "color": "red",
+                "value": 0
               },
               {
                 "color": "green",
@@ -662,18 +626,18 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.0.2",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "editorMode": "code",
           "expr": "sum(rate(zeebe_camunda_exporter_archiver_process_instances_total{namespace=~\"(c8-)?release-8.*\", state=\"archived\"}[$__rate_interval])) by (namespace)",
           "legendFormat": "__auto",
           "range": true,
-          "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          }
+          "refId": "A"
         }
       ],
       "title": "Archiving rate",
@@ -701,7 +665,6 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "fixedColor": "red",
             "mode": "thresholds"
           },
           "mappings": [
@@ -720,15 +683,16 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "yellow",
-                "value": 0.1
+                "value": 0.8
               },
               {
                 "color": "red",
-                "value": 0.2
+                "value": 1
               }
             ]
           },
@@ -746,7 +710,7 @@
       "options": {
         "colorMode": "value",
         "graphMode": "area",
-        "justifyMode": "auto",
+        "justifyMode": "center",
         "orientation": "auto",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
@@ -763,7 +727,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.0.2",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
@@ -772,9 +736,10 @@
           },
           "editorMode": "code",
           "expr": "histogram_quantile(0.50, sum(rate(zeebe_process_instance_execution_time_bucket{namespace=~\"(c8-)?release-8.*\"}[$__rate_interval])) by (le, namespace))",
-          "instant": true,
+          "instant": false,
           "interval": "",
           "legendFormat": "{{namespace}}",
+          "range": true,
           "refId": "B"
         },
         {
@@ -784,7 +749,6 @@
           },
           "editorMode": "code",
           "expr": "histogram_quantile(0.50, sum(rate(zeebe_process_instance_execution_time_seconds_bucket{namespace=~\"(c8-)?release-8.*\"}[$__rate_interval])) by (le, namespace))",
-          "hide": false,
           "instant": false,
           "legendFormat": "{{namespace}}",
           "range": true,
@@ -822,15 +786,16 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "yellow",
-                "value": 0.4
+                "value": 2
               },
               {
                 "color": "red",
-                "value": 0.6
+                "value": 4
               }
             ]
           },
@@ -865,7 +830,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.0.2",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
@@ -886,7 +851,6 @@
           },
           "editorMode": "code",
           "expr": "histogram_quantile(0.90, sum(rate(zeebe_process_instance_execution_time_seconds_bucket{namespace=~\"(c8-)?release-8.*\"}[$__rate_interval])) by (le, namespace))",
-          "hide": false,
           "instant": false,
           "legendFormat": "{{namespace}}",
           "range": true,
@@ -924,15 +888,16 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "yellow",
-                "value": 0.6
+                "value": 7
               },
               {
                 "color": "red",
-                "value": 0.8
+                "value": 10
               }
             ]
           },
@@ -967,7 +932,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.0.2",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
@@ -988,7 +953,6 @@
           },
           "editorMode": "code",
           "expr": "histogram_quantile(0.99, sum(rate(zeebe_process_instance_execution_time_seconds_bucket{namespace=~\"(c8-)?release-8.*\"}[$__rate_interval])) by (le, namespace))",
-          "hide": false,
           "instant": false,
           "legendFormat": "{{namespace}}",
           "range": true,
@@ -1013,11 +977,12 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
-                "value": 80
+                "value": 5
               }
             ]
           },
@@ -1040,7 +1005,7 @@
         "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
-            "max"
+            "lastNotNull"
           ],
           "fields": "",
           "values": false
@@ -1049,7 +1014,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.0.2",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "adhocFilters": [],
@@ -1084,11 +1049,12 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
-                "value": 80
+                "value": 5
               }
             ]
           },
@@ -1111,7 +1077,7 @@
         "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
-            "max"
+            "lastNotNull"
           ],
           "fields": "",
           "values": false
@@ -1120,7 +1086,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.0.2",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "adhocFilters": [],
@@ -1155,7 +1121,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -1182,7 +1149,7 @@
         "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
-            "max"
+            "lastNotNull"
           ],
           "fields": "",
           "values": false
@@ -1191,7 +1158,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.0.2",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "adhocFilters": [],
@@ -1241,7 +1208,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -1277,7 +1245,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.0.2",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
@@ -1310,7 +1278,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -1346,7 +1315,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.0.2",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
@@ -1379,12 +1348,14 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               }
             ]
           },
           "unit": "decbytes"
-        }
+        },
+        "overrides": []
       },
       "gridPos": {
         "h": 5,
@@ -1410,7 +1381,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.0.2",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
@@ -1420,7 +1391,6 @@
           "editorMode": "code",
           "expr": "sum(container_memory_rss{namespace=~\"(c8-)?release-8.*\",pod=~\"camunda.*|zeebe.*\"}) by (namespace)",
           "format": "time_series",
-          "hide": false,
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{namespace}} RSS",
@@ -1435,7 +1405,7 @@
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
-      },      
+      },
       "description": "Container memory rss of the elastic pods, based on k8 metrics.",
       "fieldConfig": {
         "defaults": {
@@ -1448,12 +1418,14 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               }
             ]
           },
           "unit": "decbytes"
-        }
+        },
+        "overrides": []
       },
       "gridPos": {
         "h": 5,
@@ -1479,7 +1451,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.0.2",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
@@ -1489,7 +1461,6 @@
           "editorMode": "code",
           "expr": "sum(container_memory_rss{namespace=~\"(c8-)?release-8.*\",pod=~\".*elastic.*\", container=~\"elasticsearch\"}) by (namespace)",
           "format": "time_series",
-          "hide": false,
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{namespace}} RSS",
@@ -1516,7 +1487,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -1552,7 +1524,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.0.2",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
@@ -1586,7 +1558,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -1622,7 +1595,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "12.0.2",
+      "pluginVersion": "12.4.2",
       "targets": [
         {
           "datasource": {
@@ -1641,8 +1614,9 @@
       "type": "stat"
     }
   ],
+  "preload": false,
   "refresh": "1m",
-  "schemaVersion": 41,
+  "schemaVersion": 42,
   "tags": [],
   "templating": {
     "list": [
@@ -1679,7 +1653,6 @@
   "timezone": "browser",
   "title": "Release overview",
   "uid": "chl4qs5",
-  "version": 0,
-  "weekStart": "monday",
-  "id": null
+  "version": 1,
+  "weekStart": "monday"
 }


### PR DESCRIPTION
# Description

 * Latency panels were showing all red - with new workload
 * Thresholds have been adjusted to be more sensitive to the workload
 * Data avail latency panels have been fixed to show the last value


## Before

<img width="3073" height="428" alt="2026-04-01_09-59" src="https://github.com/user-attachments/assets/fe77aae3-fa8d-43e1-bc0e-38231168b3df" />


## After

<img width="3064" height="423" alt="2026-04-01_09-53" src="https://github.com/user-attachments/assets/2f6ae3ab-9ef1-4903-9181-ce9dc04a9002" />

