### PR TITLE
[Backport stable/8.8] Increase load test resources for Camunda

### DIFF
--- a/zeebe/benchmarks/camunda-platform-values.yaml
+++ b/zeebe/benchmarks/camunda-platform-values.yaml
@@ -143,10 +143,10 @@ orchestration:
   # Resources of the orchestration cluster
   resources:
     requests:
-      cpu: 2000m
+      cpu: 3500m
       memory: 2Gi
     limits:
-      cpu: 2000m
+      cpu: 3500m
       memory: 2Gi
 
   nodeSelector:

--- a/zeebe/benchmarks/camunda-platform-values.yaml
+++ b/zeebe/benchmarks/camunda-platform-values.yaml
@@ -143,10 +143,10 @@ orchestration:
   # Resources of the orchestration cluster
   resources:
     requests:
-      cpu: 3500m
+      cpu: 3000m
       memory: 2Gi
     limits:
-      cpu: 3500m
+      cpu: 3000m
       memory: 2Gi
 
   nodeSelector:


### PR DESCRIPTION
# Description
Backport of #42117 to `stable/8.8`.

relates to https://camunda.slack.com/archives/C06UWQNCU7M/p1775030865455459?thread_ts=1774975661.970389&cid=C06UWQNCU7M