### PR TITLE
test: reenable decision navigation tests after Operate UI update

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDiagramPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDiagramPage.ts
@@ -20,7 +20,6 @@ export class OperateDiagramPage {
   readonly monacoScrollableElement: Locator;
   readonly showIncidentButton: Locator;
   readonly showMetadataButton: Locator;
-  readonly viewRootCauseDecisionLink: Locator;
   readonly popoverLink: (name: string | RegExp) => Locator;
 
   constructor(page: Page) {
@@ -46,9 +45,6 @@ export class OperateDiagramPage {
     });
     this.showMetadataButton = this.popover.getByRole('button', {
       name: 'show more metadata',
-    });
-    this.viewRootCauseDecisionLink = this.page.getByRole('link', {
-      name: /View root cause decision/i,
     });
   }
 
@@ -220,15 +216,6 @@ export class OperateDiagramPage {
 
   async closeMetadataModal(): Promise<void> {
     await this.metadataModalCloseButton.click();
-  }
-
-  async clickViewRootCauseDecisionLink(): Promise<void> {
-    await this.viewRootCauseDecisionLink.scrollIntoViewIfNeeded();
-    await this.viewRootCauseDecisionLink.waitFor({
-      state: 'visible',
-      timeout: 30000,
-    });
-    await this.viewRootCauseDecisionLink.click();
   }
 
   async clickPopoverLink(name: string | RegExp): Promise<void> {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -748,6 +748,15 @@ class OperateProcessInstancePage {
       .click();
   }
 
+  async navigateToFailingElementForIncident(
+    incidentType: string | RegExp,
+    failingElement: string,
+  ): Promise<void> {
+    await this.getIncidentRow(incidentType)
+      .getByRole('link', {name: failingElement})
+      .click();
+  }
+
   async cancelInstance(instanceId: string): Promise<void> {
     await this.cancelInstanceButton(instanceId).click();
     await this.applyButton.click();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionNavigation.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionNavigation.spec.ts
@@ -12,7 +12,6 @@ import {deploy, createSingleInstance} from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {sleep} from 'utils/sleep';
-import {waitForAssertion} from 'utils/waitForAssertion';
 
 type ProcessInstance = {
   processInstanceKey: string;
@@ -44,13 +43,11 @@ test.describe('Decision Navigation', () => {
     await captureFailureVideo(page, testInfo);
   });
 
-  // skipped due to bug 49425: https://github.com/camunda/camunda/issues/49425
-  test.skip('Navigation between process and decision', async ({
+  test('Navigation between process and decision', async ({
     operateProcessInstancePage,
     operateDecisionInstancePage,
     operateDecisionsPage,
     operateHomePage,
-    operateDiagramPage,
   }) => {
     const processInstanceKey =
       processInstanceWithFailedDecision.processInstanceKey;
@@ -68,12 +65,10 @@ test.describe('Decision Navigation', () => {
       ).toBeVisible();
     });
 
-    await test.step('Wait for incidents banner to be visible', async () => {
+    await test.step('Wait for incidents tab to be visible', async () => {
       await expect
         .poll(
-          async () => {
-            return await operateProcessInstancePage.incidentsTab.isVisible();
-          },
+          async () => await operateProcessInstancePage.incidentsTab.isVisible(),
           {timeout: 30000},
         )
         .toBe(true);
@@ -83,36 +78,12 @@ test.describe('Decision Navigation', () => {
       await operateProcessInstancePage.clickDiagramElement('Activity_1tjwahx');
     });
 
-    await test.step('Verify popover appears and navigate to decision', async () => {
-      await waitForAssertion({
-        assertion: async () => {
-          await expect(operateDiagramPage.popover).toBeVisible();
-        },
-        onFailure: async () => {
-          await operateProcessInstancePage.clickDiagramElement(
-            'Activity_1tjwahx',
-          );
-          await operateProcessInstancePage.clickDiagramElement(
-            'Activity_1tjwahx',
-          );
-        },
-      });
-      await waitForAssertion({
-        assertion: async () => {
-          await expect(
-            operateDiagramPage.viewRootCauseDecisionLink,
-          ).toBeVisible();
-        },
-        onFailure: async () => {
-          await operateProcessInstancePage.clickDiagramElement(
-            'Activity_1tjwahx',
-          );
-          await operateProcessInstancePage.clickDiagramElement(
-            'Activity_1tjwahx',
-          );
-        },
-      });
-      await operateDiagramPage.clickViewRootCauseDecisionLink();
+    await test.step('Navigate to failing root cause decision', async () => {
+      await operateProcessInstancePage.clickIncidentsTab();
+      await operateProcessInstancePage.navigateToFailingElementForIncident(
+        'Decision evaluation error.',
+        'Invoice Classification',
+      );
     });
 
     await test.step('Verify decision panel is visible', async () => {


### PR DESCRIPTION
## Description

This PR reenables the skipped "Navigation between process and decision" test. With https://github.com/camunda/camunda/pull/49743 merged, users are now able to navigate to the root cause decision through the incidents table.

On demand test run: https://github.com/camunda/camunda/actions/runs/23839885027

## Related issues

closes #49227
