### PR TITLE
[Backport stable/8.9] test: migrate process-instance-migration QA tests after Operate redesign

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDiagramPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDiagramPage.ts
@@ -252,7 +252,7 @@ export class OperateDiagramPage {
 
   async verifyStateOverlay(
     flowNodeName: string,
-    state: 'active' | 'canceled' | 'completedEndEvents',
+    state: 'active' | 'incidents' | 'canceled' | 'completedEndEvents',
     tokenAmount?: number,
   ): Promise<void> {
     const stateOverlayFlowNode =

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateFiltersPanelPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateFiltersPanelPage.ts
@@ -183,6 +183,12 @@ export class OperateFiltersPanelPage {
     if (await this.processNameClearButton.isVisible()) {
       await this.processNameClearButton.click();
       await expect(this.processVersionFilter).toBeDisabled();
+      await expect
+        .poll(() => this.page.url())
+        .not.toContain('processDefinitionId');
+      await expect
+        .poll(() => this.page.url())
+        .not.toContain('processDefinitionVersion');
     }
     await this.processNameFilter.click();
     await this.getOptionByName(option).click({timeout: 30000});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -991,6 +991,23 @@ class OperateProcessInstancePage {
     const actualCount = await this.getIncidentCount();
     expect(actualCount).toBe(expectedCount);
   }
+
+  async verifyIncidents(errorTypes: string[], elementId?: string) {
+    if (elementId) {
+      await this.clickOnElementInDiagram(elementId);
+    }
+    await this.clickIncidentsTab();
+    await expect(this.incidentsTab).toContainText(
+      `Incidents${errorTypes.length}`,
+      {
+        timeout: 30000,
+      },
+    );
+    for (const errorType of errorTypes) {
+      const incidentRow = await this.getIncidentRowByErrorType(errorType);
+      await expect(incidentRow).toBeVisible({timeout: 30000});
+    }
+  }
 }
 
 export {OperateProcessInstancePage};

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -997,12 +997,7 @@ class OperateProcessInstancePage {
       await this.clickOnElementInDiagram(elementId);
     }
     await this.clickIncidentsTab();
-    await expect(this.incidentsTab).toContainText(
-      `Incidents${errorTypes.length}`,
-      {
-        timeout: 30000,
-      },
-    );
+    await this.verifyIncidentCount(errorTypes.length);
     for (const errorType of errorTypes) {
       const incidentRow = await this.getIncidentRowByErrorType(errorType);
       await expect(incidentRow).toBeVisible({timeout: 30000});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -650,250 +650,90 @@ test.describe.serial('Process Instance Migration', () => {
     });
   });
 
-  //Skipped due to bug 49095: https://github.com/camunda/camunda/issues/49095
-  test.skip('Migrated tasks', async ({
-    operateFiltersPanelPage,
-    operateProcessesPage,
-    operateDiagramPage,
-    page,
-  }) => {
-    const targetBpmnProcessId = testProcesses.processV3.bpmnProcessId;
-    const targetVersion = testProcesses.processV3.version.toString();
-
-    await test.step('Navigate to first migrated process instance', async () => {
-      await operateFiltersPanelPage.selectProcess(targetBpmnProcessId);
-      await operateFiltersPanelPage.selectVersion(targetVersion);
-
-      await expect(operateProcessesPage.resultsText.first()).toBeVisible({
-        timeout: 30000,
-      });
-
-      await operateProcessesPage.clickProcessInstanceLink();
-      await operateDiagramPage.resetDiagramZoomButton.click();
-    });
-
-    await test.step('Verify Send task migration', async () => {
-      await operateDiagramPage.verifyFlowNodeMetadata('SendTask2', {
-        hiddenText: 'expected worker failure',
-      });
-    });
-
-    await test.step('Verify Task G migration', async () => {
-      await operateDiagramPage.verifyFlowNodeMetadata('TaskG', {
-        expectedText: 'endDate',
-        hiddenText: '"endDate": "null"',
-      });
-    });
-
-    await test.step('Verify Business rule task incident migration', async () => {
-      await waitForAssertion({
-        assertion: async () => {
-          await operateDiagramPage.clickFlowNode('BusinessRuleTask2');
-          await operateDiagramPage.verifyIncidentInPopover(
-            /invalid.*decision/i,
-          );
-        },
-        onFailure: async () => {
-          await page.reload();
-        },
-      });
-    });
-  });
-
-  test.skip('Migrated message events', async ({
-    operateFiltersPanelPage,
-    operateProcessesPage,
-    operateDiagramPage,
-  }) => {
-    const targetBpmnProcessId = testProcesses.processV3.bpmnProcessId;
-    const targetVersion = testProcesses.processV3.version.toString();
-
-    await test.step('Navigate to first migrated process instance', async () => {
-      await operateFiltersPanelPage.selectProcess(targetBpmnProcessId);
-      await operateFiltersPanelPage.selectVersion(targetVersion);
-
-      await expect(operateProcessesPage.resultsText.first()).toBeVisible({
-        timeout: 30000,
-      });
-
-      await operateProcessesPage.clickProcessInstanceLink();
-      await operateDiagramPage.resetDiagramZoomButton.click();
-    });
-
-    await test.step('Verify Task A2 correlation key migration', async () => {
-      await operateDiagramPage.verifyFlowNodeMetadata('TaskA2', {
-        expectedText: [
-          '"correlationKey": "mySecondCorrelationKey"',
-          '"messageName": "Message_2",',
-        ],
-      });
-    });
-
-    await test.step('Verify Task C2 correlation key migration', async () => {
-      await operateDiagramPage.verifyFlowNodeMetadata('TaskC2', {
-        expectedText: [
-          '"correlationKey": "myFirstCorrelationKey"',
-          '"messageName": "Message_1",',
-        ],
-      });
-    });
-
-    await test.step('Verify Message receive task migration', async () => {
-      await sleep(500);
-      await operateDiagramPage.verifyFlowNodeMetadata('MessageReceiveTask2', {
-        expectedText: [
-          '"correlationKey": "myFirstCorrelationKey"',
-          '"messageName": "Message_5",',
-        ],
-      });
-    });
-
-    await test.step('Verify Message intermediate catch event migration', async () => {
-      await operateDiagramPage.verifyFlowNodeMetadata(
-        'MessageIntermediateCatch2',
-        {
-          expectedText: [
-            '"correlationKey": "myFirstCorrelationKey"',
-            '"messageName": "Message_3",',
-          ],
-        },
-      );
-    });
-  });
-
-  //Skipped due to bug 49095: https://github.com/camunda/camunda/issues/49095
-  test.skip('Migrated gateways', async ({
-    operateFiltersPanelPage,
-    operateProcessesPage,
-    operateDiagramPage,
-  }) => {
-    const targetBpmnProcessId = testProcesses.processV3.bpmnProcessId;
-    const targetVersion = testProcesses.processV3.version.toString();
-
-    await test.step('Navigate to first migrated process instance', async () => {
-      await operateFiltersPanelPage.selectProcess(targetBpmnProcessId);
-      await operateFiltersPanelPage.selectVersion(targetVersion);
-
-      await expect(operateProcessesPage.resultsText.first()).toBeVisible({
-        timeout: 30000,
-      });
-
-      await operateProcessesPage.clickProcessInstanceLink();
-      await operateDiagramPage.resetDiagramZoomButton.click();
-    });
-
-    await test.step('Verify Event based gateway correlation key update', async () => {
-      await operateDiagramPage.verifyFlowNodeMetadata('EventBasedGateway2', {
-        expectedText: [
-          '"correlationKey": "myFirstCorrelationKey"',
-          '"messageName": "Message_3",',
-        ],
-      });
-    });
-
-    await test.step('Verify Exclusive gateway incident migration', async () => {
-      await operateDiagramPage.verifyFlowNodeMetadata('ExclusiveGateway2', {
-        expectedText: '"hasIncident": true,',
-      });
-    });
-  });
-
-  //Skipped due to bug 49095: https://github.com/camunda/camunda/issues/49095
-  test.skip('Migrated signal elements', async ({
-    page,
-    operateFiltersPanelPage,
-    operateProcessesPage,
-    operateDiagramPage,
-  }) => {
-    const targetBpmnProcessId = testProcesses.processV3.bpmnProcessId;
-    const targetVersion = testProcesses.processV3.version.toString();
-
-    await test.step('Navigate to migrated process instance', async () => {
-      await operateFiltersPanelPage.selectProcess(targetBpmnProcessId);
-      await operateFiltersPanelPage.selectVersion(targetVersion);
-
-      await expect(page.getByText('results').first()).toBeVisible({
-        timeout: 30000,
-      });
-
-      await operateProcessesPage.clickProcessInstanceLink();
-      await operateDiagramPage.resetDiagramZoomButton.click();
-    });
-
-    await test.step('Verify signal intermediate catch event migration', async () => {
-      await operateDiagramPage.verifyFlowNodeMetadata(
-        'SignalIntermediateCatch2',
-        {
-          expectedText: 'endDate',
-          hiddenText: '"endDate": "null"',
-        },
-      );
-    });
-  });
-
-  //Skipped due to bug 49095: https://github.com/camunda/camunda/issues/49095
-  test.skip('Migrated multi instance elements', async ({
-    page,
-    operateFiltersPanelPage,
-    operateProcessesPage,
-    operateDiagramPage,
-  }) => {
-    const targetBpmnProcessId = testProcesses.processV3.bpmnProcessId;
-    const targetVersion = testProcesses.processV3.version.toString();
-
-    await test.step('Navigate to migrated process instance', async () => {
-      await operateFiltersPanelPage.selectProcess(targetBpmnProcessId);
-      await operateFiltersPanelPage.selectVersion(targetVersion);
-
-      await expect(page.getByText('results').first()).toBeVisible({
-        timeout: 30000,
-      });
-
-      await operateProcessesPage.clickProcessInstanceLink();
-      await operateDiagramPage.resetDiagramZoomButton.click();
-    });
-
-    await test.step('Verify multi instance sub process migration', async () => {
-      await operateDiagramPage.verifyFlowNodeMetadata(
-        'MultiInstanceSubProcess2',
-        {
-          expectedText: 'endDate',
-          hiddenText: '"endDate": "null"',
-          isSubProcess: true,
-        },
-      );
-    });
-
-    await test.step('Verify multi instance task migration', async () => {
-      const executionCount =
-        operateDiagramPage.getStateOverlay('MultiInstanceTask2');
-      await expect(executionCount.locator('span')).toHaveText('2');
-    });
-  });
-
-  //Skipped due to bug 49095: https://github.com/camunda/camunda/issues/49095
-  test.skip('Verify migrated tag on process instance', async ({
-    page,
+  test('Migrated process instances', async ({
     operateFiltersPanelPage,
     operateProcessesPage,
     operateProcessInstancePage,
+    operateDiagramPage,
   }) => {
     const targetBpmnProcessId = testProcesses.processV3.bpmnProcessId;
     const targetVersion = testProcesses.processV3.version.toString();
 
-    await test.step('Navigate to target process instances and apply filter to retrieve processes', async () => {
+    await test.step('Navigate to migrated process instance', async () => {
       await operateFiltersPanelPage.selectProcess(targetBpmnProcessId);
       await operateFiltersPanelPage.selectVersion(targetVersion);
 
-      await expect(page.getByText('3 results')).toBeVisible({timeout: 30000});
-    });
+      await expect(operateProcessesPage.resultsText).toContainText(
+        '3 results',
+        {timeout: 30000},
+      );
 
-    await test.step('Open first migrated instance', async () => {
       await operateProcessesPage.clickProcessInstanceLink();
     });
 
     await test.step('Verify migrated tag is visible on the instance', async () => {
       await expect(operateProcessInstancePage.migratedTag).toBeVisible();
+    });
+
+    await test.step('Verify element instances migration', async () => {
+      await operateDiagramPage.verifyStateOverlay('SendTask2', 'active', 1);
+      await operateDiagramPage.verifyStateOverlay('TaskG', 'active', 1);
+      await operateDiagramPage.verifyStateOverlay(
+        'BusinessRuleTask2',
+        'incidents',
+        1,
+      );
+      await operateDiagramPage.verifyStateOverlay('TaskA2', 'active', 1);
+      await operateDiagramPage.verifyStateOverlay('TaskC2', 'active', 1);
+      await operateDiagramPage.verifyStateOverlay(
+        'MessageReceiveTask2',
+        'active',
+        1,
+      );
+      await operateDiagramPage.verifyStateOverlay(
+        'MessageIntermediateCatch2',
+        'active',
+        1,
+      );
+      await operateDiagramPage.verifyStateOverlay(
+        'EventBasedGateway2',
+        'active',
+        1,
+      );
+      await operateDiagramPage.verifyStateOverlay(
+        'ExclusiveGateway2',
+        'incidents',
+        1,
+      );
+      await operateDiagramPage.verifyStateOverlay(
+        'SignalIntermediateCatch2',
+        'active',
+        1,
+      );
+      await operateDiagramPage.verifyStateOverlay(
+        'MultiInstanceSubProcess2',
+        'active',
+        2,
+      );
+      await operateDiagramPage.verifyStateOverlay(
+        'MultiInstanceTask2',
+        'active',
+        2,
+      );
+    });
+
+    await test.step('Verify Business rule task incident migration', async () => {
+      await operateProcessInstancePage.verifyIncidents(
+        ['Called decision error.'],
+        'BusinessRuleTask2',
+      );
+    });
+
+    await test.step('Verify Exclusive gateway incident migration', async () => {
+      await operateProcessInstancePage.verifyIncidents(
+        ['Extract value error.'],
+        'ExclusiveGateway2',
+      );
     });
   });
 });


### PR DESCRIPTION
# Description
Backport of #50158 to `stable/8.9`.

On demand test run: https://github.com/camunda/camunda/actions/runs/23843633709

relates to #49251 #49233 #49260 #49251