### PR TITLE
[Backport stable/8.8] fix: use --reset-then-reuse-values in install-load-test Makefile targets

### DIFF
--- a/zeebe/benchmarks/setup/cloud-default/Makefile
+++ b/zeebe/benchmarks/setup/cloud-default/Makefile
@@ -28,7 +28,7 @@ install-load-test:
 	helm upgrade $(namespace)-test camunda-load-tests/camunda-load-tests \
 		--install \
 		--namespace $(namespace) \
-		--reuse-values \
+		--reset-then-reuse-values \
 		--render-subchart-notes \
 		--set saas.enabled=true \
 		--set saas.credentials.clientId="$${ZEEBE_CLIENT_ID}" \

--- a/zeebe/benchmarks/setup/default/Makefile
+++ b/zeebe/benchmarks/setup/default/Makefile
@@ -116,7 +116,7 @@ install-load-test:
 	helm upgrade $(namespace)-test camunda-load-tests/camunda-load-tests \
 		--install \
 		--namespace $(namespace) \
-		--reuse-values \
+		--reset-then-reuse-values \
 		--render-subchart-notes \
 		-f load-test-values.yaml \
 		$(additional_load_test_configuration)


### PR DESCRIPTION
# Description
Backport of #50205 to `stable/8.8`.

relates to 