### PR TITLE
[Backport stable/8.8] feat: configure minimumReleaseAge for renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -322,6 +322,13 @@
         "org.apache.maven.plugins:maven-surefire-plugin"
       ],
       "enabled": false
+    },
+    {
+      "description": "Prevent supply-chain-attacks by not creating branches or PRs before the minimum release age.",
+      "matchPackageNames": ["*"],
+      "minimumReleaseAge": "3 days",
+      "prCreation": "not-pending",
+      "internalChecksFilter": "strict"
     }
   ],
   "dockerfile": {

--- a/c8run/e2e_tests/.npmrc
+++ b/c8run/e2e_tests/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=3

--- a/client-components/.npmrc
+++ b/client-components/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=3

--- a/identity/client/.npmrc
+++ b/identity/client/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=3

--- a/monorepo-docs-site/.npmrc
+++ b/monorepo-docs-site/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=3

--- a/operate/client/.npmrc
+++ b/operate/client/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=3

--- a/optimize/c4/.yarnrc.yml
+++ b/optimize/c4/.yarnrc.yml
@@ -1,1 +1,2 @@
 nodeLinker: node-modules
+npmMinimalAgeGate: "3d"

--- a/optimize/c4/.yarnrc.yml
+++ b/optimize/c4/.yarnrc.yml
@@ -1,2 +1,1 @@
 nodeLinker: node-modules
-npmMinimalAgeGate: "3d"

--- a/optimize/client/.yarnrc.yml
+++ b/optimize/client/.yarnrc.yml
@@ -1,0 +1,1 @@
+npmMinimalAgeGate: "3d"

--- a/qa/c8-orchestration-cluster-e2e-test-suite/.npmrc
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=3

--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/.npmrc
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=3

--- a/scripts/codeowners-utils/.npmrc
+++ b/scripts/codeowners-utils/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=3

--- a/tasklist/client/.npmrc
+++ b/tasklist/client/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=3

--- a/testing/camunda-process-test-coverage-frontend/.npmrc
+++ b/testing/camunda-process-test-coverage-frontend/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=3


### PR DESCRIPTION
# Description
Backport of #50101 to `stable/8.8`.

relates to 