### PR TITLE
[Backport stable/8.9] ci: build frontends in dedicated steps before the testbench maven build

### DIFF
--- a/.github/workflows/zeebe-testbench.yaml
+++ b/.github/workflows/zeebe-testbench.yaml
@@ -99,6 +99,7 @@ jobs:
         with:
           directory: ./tasklist/client
           package-manager: npm
+<<<<<<< HEAD
       - name: Build identity frontend
         uses: ./.github/actions/build-frontend
         with:
@@ -106,6 +107,14 @@ jobs:
           package-manager: npm
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
+=======
+      - uses: ./.github/actions/build-zeebe
+        id: build-zeebe
+        with:
+          maven-extra-args: -PskipFrontendBuild
+      - uses: ./.github/actions/build-platform-docker
+        id: build-zeebe-docker
+>>>>>>> 1545164a (ci: build frontends in dedicated steps before the testbench maven build)
         with:
           maven-extra-args: -PskipFrontendBuild
       - uses: ./.github/actions/build-platform-docker


### PR DESCRIPTION
# Description
Backport of #48695 to `stable/8.9`.

relates to #48153