### PR TITLE
feat: migrate SLACK_CAMUNDA_EX_CI_WEBHOOK from repo secret to Vault

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-forward-compatibility-tests.yml
+++ b/.github/workflows/c8-orchestration-cluster-forward-compatibility-tests.yml
@@ -294,13 +294,23 @@ jobs:
      steps:
        - uses: actions/checkout@v6
 
+       - name: Import Secrets
+         id: secrets
+         uses: hashicorp/vault-action@79632e33d6953d190b940ffa440bf97821cabd80
+         with:
+           url: ${{ secrets.VAULT_ADDR }}
+           method: approle
+           roleId: ${{ secrets.VAULT_ROLE_ID }}
+           secretId: ${{ secrets.VAULT_SECRET_ID }}
+           exportEnv: false
+           secrets: |
+             secret/data/products/camunda/ci/github-actions SLACK_CAMUNDA_EX_CI_WEBHOOK;
+
        - name: Notify failure
          uses: slackapi/slack-github-action@v3.0.1
-         if: env.SLACK_CAMUNDA_EX_CI_WEBHOOK != ''
-         env:
-           SLACK_CAMUNDA_EX_CI_WEBHOOK: ${{ secrets.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
+         if: steps.secrets.outputs.SLACK_CAMUNDA_EX_CI_WEBHOOK != ''
          with:
-           webhook: ${{ secrets.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
+           webhook: ${{ steps.secrets.outputs.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
            webhook-type: incoming-webhook
            payload: |
             {

--- a/.github/workflows/camunda-client-compatibility-test.yml
+++ b/.github/workflows/camunda-client-compatibility-test.yml
@@ -447,13 +447,22 @@ jobs:
     permissions: {}
     steps:
       - uses: actions/checkout@v6
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@79632e33d6953d190b940ffa440bf97821cabd80
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_CAMUNDA_EX_CI_WEBHOOK;
       - name: Notify failure
         uses: slackapi/slack-github-action@v3.0.1
-        if: env.SLACK_CAMUNDA_EX_CI_WEBHOOK != ''
-        env:
-          SLACK_CAMUNDA_EX_CI_WEBHOOK: ${{ secrets.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
+        if: steps.secrets.outputs.SLACK_CAMUNDA_EX_CI_WEBHOOK != ''
         with:
-          webhook: ${{ secrets.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
+          webhook: ${{ steps.secrets.outputs.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
           webhook-type: incoming-webhook
           payload: |
            {

--- a/.github/workflows/camunda-process-test-compatibility.yml
+++ b/.github/workflows/camunda-process-test-compatibility.yml
@@ -571,13 +571,22 @@ jobs:
     permissions: {}
     steps:
       - uses: actions/checkout@v6
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@79632e33d6953d190b940ffa440bf97821cabd80
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_CAMUNDA_EX_CI_WEBHOOK;
       - name: Notify failure
         uses: slackapi/slack-github-action@v3.0.1
-        if: env.SLACK_CAMUNDA_EX_CI_WEBHOOK != ''
-        env:
-          SLACK_CAMUNDA_EX_CI_WEBHOOK: ${{ secrets.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
+        if: steps.secrets.outputs.SLACK_CAMUNDA_EX_CI_WEBHOOK != ''
         with:
-          webhook: ${{ secrets.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
+          webhook: ${{ steps.secrets.outputs.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
           webhook-type: incoming-webhook
           payload: |
            {

--- a/.github/workflows/camunda-spring-boot-starter-compatibility-test.yml
+++ b/.github/workflows/camunda-spring-boot-starter-compatibility-test.yml
@@ -444,13 +444,22 @@ jobs:
     permissions: {}
     steps:
       - uses: actions/checkout@v6
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@79632e33d6953d190b940ffa440bf97821cabd80
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_CAMUNDA_EX_CI_WEBHOOK;
       - name: Notify failure
         uses: slackapi/slack-github-action@v3.0.1
-        if: env.SLACK_CAMUNDA_EX_CI_WEBHOOK != ''
-        env:
-          SLACK_CAMUNDA_EX_CI_WEBHOOK: ${{ secrets.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
+        if: steps.secrets.outputs.SLACK_CAMUNDA_EX_CI_WEBHOOK != ''
         with:
-          webhook: ${{ secrets.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
+          webhook: ${{ steps.secrets.outputs.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
           webhook-type: incoming-webhook
           payload: |
            {

--- a/.github/workflows/camunda8-getting-started-bundle.yaml
+++ b/.github/workflows/camunda8-getting-started-bundle.yaml
@@ -884,7 +884,20 @@ jobs:
     if: always() && (needs.build-bundle.result == 'failure' || needs.test-bundle.result == 'failure' || needs.upload-to-release.result == 'failure')
     permissions: {}
     steps:
+      - uses: actions/checkout@v6
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@79632e33d6953d190b940ffa440bf97821cabd80
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_CAMUNDA_EX_CI_WEBHOOK;
       - name: Send failure notification to Slack
+        if: steps.secrets.outputs.SLACK_CAMUNDA_EX_CI_WEBHOOK != ''
         run: |
           WORKFLOW_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           BLOCKS=$(cat <<EOF
@@ -902,7 +915,7 @@ jobs:
           
           PAYLOAD=$(jq -n --argjson blocks "$BLOCKS" '{blocks: $blocks}')
           
-          curl -X POST "${{ secrets.SLACK_CAMUNDA_EX_CI_WEBHOOK }}" \
+          curl -X POST "${{ steps.secrets.outputs.SLACK_CAMUNDA_EX_CI_WEBHOOK }}" \
             -H "Content-Type: application/json" \
             -d "$PAYLOAD"
 


### PR DESCRIPTION
## Summary

Migrates the `SLACK_CAMUNDA_EX_CI_WEBHOOK` secret targeting the the `#team-camunda-ex-ci` channel from a GitHub repository secret to HashiCorp Vault across all 5 affected workflows.

**Vault path:** `secret/data/products/camunda/ci/github-actions`
<img width="1325" height="36" alt="image" src="https://github.com/user-attachments/assets/2598a9df-a0ab-4dcf-a918-35954876ac22" />


## Changed workflows

- `.github/workflows/c8-orchestration-cluster-forward-compatibility-tests.yml`
- `.github/workflows/camunda-client-compatibility-test.yml`
- `.github/workflows/camunda-process-test-compatibility.yml`
- `.github/workflows/camunda-spring-boot-starter-compatibility-test.yml`
- `.github/workflows/camunda8-getting-started-bundle.yaml`

## Change pattern

Each `notify-failure` job now:
1. Fetches `SLACK_CAMUNDA_EX_CI_WEBHOOK` via `hashicorp/vault-action` with `exportEnv: false`
2. Guards the Slack notification step with `if: steps.secrets.outputs.SLACK_CAMUNDA_EX_CI_WEBHOOK != ''`
3. References the secret as `${{ steps.secrets.outputs.SLACK_CAMUNDA_EX_CI_WEBHOOK }}`

The repository secret `SLACK_CAMUNDA_EX_CI_WEBHOOK` can be deleted after this PR is merged and verified.

Related to
Subtask:
https://github.com/camunda/camunda/issues/50234
Parent:
https://github.com/camunda/camunda/issues/18211
