### PR TITLE
feat: migrate AUTOMERGE_TOKEN to Monorepo Release GitHub App via Vault

### DIFF
--- a/.github/workflows/ci-zeebe.yml
+++ b/.github/workflows/ci-zeebe.yml
@@ -535,12 +535,24 @@ jobs:
     permissions:
       checks: read
       pull-requests: write
-    env:
-      GITHUB_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}
     steps:
+      - name: Generate GitHub token
+        id: github-token
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
+        with:
+          github-app-id-vault-key: MONOREPO_RELEASE_APP_ID
+          github-app-id-vault-path: secret/data/products/camunda/ci/camunda
+          github-app-private-key-vault-key: MONOREPO_RELEASE_APP_PRIVATE_KEY
+          github-app-private-key-vault-path: secret/data/products/camunda/ci/camunda
+          vault-auth-method: approle
+          vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          vault-url: ${{ secrets.VAULT_ADDR }}
       - uses: actions/checkout@v6
       - id: approve-and-merge-backport-renovate
         name: Approve and merge backport PR
+        env:
+          GITHUB_TOKEN: ${{ steps.github-token.outputs.token }}
         run: |
           gh pr review ${{ github.event.pull_request.number }} --approve
           # Call the API directly to work around https://github.com/cli/cli/issues/8352

--- a/.github/workflows/ci-zeebe.yml
+++ b/.github/workflows/ci-zeebe.yml
@@ -538,7 +538,7 @@ jobs:
     steps:
       - name: Generate GitHub token
         id: github-token
-        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@fc4fa13813cbc1835129967f10a12f24aa7a393c # main
         with:
           github-app-id-vault-key: MONOREPO_RELEASE_APP_ID
           github-app-id-vault-path: secret/data/products/camunda/ci/camunda


### PR DESCRIPTION
## Summary

Replaces the static `AUTOMERGE_TOKEN` PAT (belonging to `@camundait`) in the `auto-merge` job of `ci-zeebe.yml` with a short-lived GitHub App token generated at runtime using the `Monorepo Release GitHub App` credentials already stored in Vault.

## Changes

**`.github/workflows/ci-zeebe.yml`** — `auto-merge` job:
- Removed job-level `env: GITHUB_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}`
- Added `Generate GitHub token` step via `camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main`
- Scoped `GITHUB_TOKEN` to only the `approve-and-merge` step

Vault path: `secret/data/products/camunda/ci/camunda`
Keys: `MONOREPO_RELEASE_APP_ID`, `MONOREPO_RELEASE_APP_PRIVATE_KEY`

> **Note:** The repository secret `AUTOMERGE_TOKEN` can be deleted once this PR is merged and verified.

## Related

Closes #50226
Parent: #18211
