### PR TITLE
[Backport stable/8.9] fix: incorrect docs link

### DIFF
--- a/identity/client/src/pages/authorizations/modals/add-modal/AddModal.tsx
+++ b/identity/client/src/pages/authorizations/modals/add-modal/AddModal.tsx
@@ -311,7 +311,7 @@ export const AddModal: FC<UseEntityModalProps<ResourceType>> = ({
                   Select at least one permission. All available resource
                   permissions can be found{" "}
                   <DocumentationLink
-                    path="/docs/components/concepts/access-control/authorizations/#resources-and-permissions"
+                    path="/docs/components/concepts/access-control/authorizations/#available-resources"
                     withIcon
                   >
                     here


### PR DESCRIPTION
# Description
Backport of #50154 to `stable/8.9`.

relates to #40382