### PR TITLE
[Backport stable/8.9] fix: handle non-numeric formKey in FlowNodeInstanceMetadataBuilder

### DIFF
--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/FlowNodeInstanceMetadataBuilder.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/FlowNodeInstanceMetadataBuilder.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -39,6 +40,7 @@ public class FlowNodeInstanceMetadataBuilder {
       LoggerFactory.getLogger(FlowNodeInstanceMetadataBuilder.class);
 
   private static final String ID_PATTERN = "%s_%s";
+  private static final Pattern EMBEDDED_FORMS_PATTERN = Pattern.compile("^camunda-forms:bpmn:.*");
   private final DecisionInstanceReader decisionInstanceReader;
 
   private final ListViewReader listViewReader;
@@ -178,7 +180,7 @@ public class FlowNodeInstanceMetadataBuilder {
           .setFollowUpDate(task.getFollowUpDate())
           .setChangedAttributes(task.getChangedAttributes())
           .setTenantId(task.getTenantId())
-          .setFormKey(task.getFormKey() != null ? Long.parseLong(task.getFormKey()) : null)
+          .setFormKey(parseFormKeyOrNull(task.getFormKey()))
           .setExternalReference(task.getExternalFormReference())
           .setVariables(variablesMap);
     }
@@ -230,5 +232,17 @@ public class FlowNodeInstanceMetadataBuilder {
         generateEventId(flowNodeInstance),
         messageSubscription,
         job);
+  }
+
+  private static Long parseFormKeyOrNull(final String formKey) {
+    if (formKey == null || EMBEDDED_FORMS_PATTERN.matcher(formKey).matches()) {
+      return null;
+    }
+    try {
+      return Long.parseLong(formKey);
+    } catch (final NumberFormatException e) {
+      LOGGER.warn("Failed to parse formKey '{}' as Long, returning null", formKey);
+      return null;
+    }
   }
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/FlowNodeInstanceMetadataBuilder.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/FlowNodeInstanceMetadataBuilder.java
@@ -241,7 +241,7 @@ public class FlowNodeInstanceMetadataBuilder {
     try {
       return Long.parseLong(formKey);
     } catch (final NumberFormatException e) {
-      LOGGER.warn("Failed to parse formKey '{}' as Long, returning null", formKey);
+      LOGGER.debug("Failed to parse formKey '{}' as Long, returning null", formKey);
       return null;
     }
   }

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/FlowNodeInstanceMetadataBuilderTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/FlowNodeInstanceMetadataBuilderTest.java
@@ -168,6 +168,78 @@ class FlowNodeInstanceMetadataBuilderTest {
   }
 
   @Test
+  void buildUserTaskMetadataWithEmbeddedFormKey() {
+    final var flowNodeInstance = new FlowNodeInstanceEntity().setType(FlowNodeType.USER_TASK);
+    fillStandardValues(flowNodeInstance);
+    final var userTask =
+        Optional.of(
+            new TaskEntity().setKey(42L).setFormKey("camunda-forms:bpmn:userTaskForm_0pjtr0l"));
+    when(messageSubscriptionReader.getMessageSubscriptionEntityByFlowNodeInstanceId(
+            flowNodeInstance.getId()))
+        .thenReturn(
+            Optional.of(
+                new MessageSubscriptionEntity()
+                    .setMetadata(
+                        new MessageSubscriptionMetadataEntity()
+                            .setMessageName("Last order")
+                            .setCorrelationKey("23-05"))));
+    when(userTaskReader.getUserTaskByFlowNodeInstanceKey(flowNodeInstance.getKey()))
+        .thenReturn(userTask);
+    when(userTaskReader.getUserTaskVariables(userTask.get().getKey())).thenReturn(List.of());
+    final var metadata = (UserTaskInstanceMetadataDto) builder.buildFrom(flowNodeInstance);
+    assertThat(metadata.getFlowNodeType()).isEqualTo(FlowNodeType.USER_TASK);
+    assertStandardValues(metadata);
+    assertThat(metadata.getFormKey()).isNull();
+  }
+
+  @Test
+  void buildUserTaskMetadataWithNullFormKey() {
+    final var flowNodeInstance = new FlowNodeInstanceEntity().setType(FlowNodeType.USER_TASK);
+    fillStandardValues(flowNodeInstance);
+    final var userTask = Optional.of(new TaskEntity().setKey(42L).setFormKey(null));
+    when(messageSubscriptionReader.getMessageSubscriptionEntityByFlowNodeInstanceId(
+            flowNodeInstance.getId()))
+        .thenReturn(
+            Optional.of(
+                new MessageSubscriptionEntity()
+                    .setMetadata(
+                        new MessageSubscriptionMetadataEntity()
+                            .setMessageName("Last order")
+                            .setCorrelationKey("23-05"))));
+    when(userTaskReader.getUserTaskByFlowNodeInstanceKey(flowNodeInstance.getKey()))
+        .thenReturn(userTask);
+    when(userTaskReader.getUserTaskVariables(userTask.get().getKey())).thenReturn(List.of());
+    final var metadata = (UserTaskInstanceMetadataDto) builder.buildFrom(flowNodeInstance);
+    assertThat(metadata.getFlowNodeType()).isEqualTo(FlowNodeType.USER_TASK);
+    assertStandardValues(metadata);
+    assertThat(metadata.getFormKey()).isNull();
+  }
+
+  @Test
+  void buildUserTaskMetadataWithNonNumericFormKey() {
+    final var flowNodeInstance = new FlowNodeInstanceEntity().setType(FlowNodeType.USER_TASK);
+    fillStandardValues(flowNodeInstance);
+    final var userTask =
+        Optional.of(new TaskEntity().setKey(42L).setFormKey("custom-external-form"));
+    when(messageSubscriptionReader.getMessageSubscriptionEntityByFlowNodeInstanceId(
+            flowNodeInstance.getId()))
+        .thenReturn(
+            Optional.of(
+                new MessageSubscriptionEntity()
+                    .setMetadata(
+                        new MessageSubscriptionMetadataEntity()
+                            .setMessageName("Last order")
+                            .setCorrelationKey("23-05"))));
+    when(userTaskReader.getUserTaskByFlowNodeInstanceKey(flowNodeInstance.getKey()))
+        .thenReturn(userTask);
+    when(userTaskReader.getUserTaskVariables(userTask.get().getKey())).thenReturn(List.of());
+    final var metadata = (UserTaskInstanceMetadataDto) builder.buildFrom(flowNodeInstance);
+    assertThat(metadata.getFlowNodeType()).isEqualTo(FlowNodeType.USER_TASK);
+    assertStandardValues(metadata);
+    assertThat(metadata.getFormKey()).isNull();
+  }
+
+  @Test
   void buildServiceTaskMetadata() {
     final var flowNodeInstance = new FlowNodeInstanceEntity().setType(FlowNodeType.SERVICE_TASK);
     fillStandardValues(flowNodeInstance);


### PR DESCRIPTION
# Description
Backport of #50017 to `stable/8.9`.

relates to 