### PR TITLE
test: give ES more Java heap + pod memory

### DIFF
--- a/zeebe/benchmarks/camunda-platform-values.yaml
+++ b/zeebe/benchmarks/camunda-platform-values.yaml
@@ -350,7 +350,7 @@ elasticsearch:
     pdb:
       minAvailable: 2
     ## @param elasticsearch.master.heapSize
-    heapSize: 3g
+    heapSize: 4g
     persistence:
       ## @param elasticsearch.master.persistence.size
       size: 512Gi


### PR DESCRIPTION
I noticed that  in https://github.com/camunda/camunda/pull/47985 we doubled the CPU and RAM (more or less) given to ES pods, but we did not also increase the java heap to match.

I've doubled the java heap from 3G to 6G so ES can actual make use of the extra RAM provided this should still give an extra 2G for non-heap memory + general JVM overhead (and maybe a little bit towards file system caching?)

Doing this shows a big decrease in the GC activity:

<img width="793" height="307" alt="image" src="https://github.com/user-attachments/assets/63b3fef5-f180-4c65-be30-7aafb81cda2a" />

The "young" GC gets cut in half and "G1 concurrent GC" is a lot less too (maybe even 10x less).

This doesn't seem to translate into a massive boost during `max` benchmarks, but it hopefully it'll avoid ES slowing down under heavy load (less time doing GC = more time doing other stuff).

Refs: #41206