### PR TITLE
When port is not available complete exceptionally, and log error.

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/gateway/GatewayModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/GatewayModuleConfiguration.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.util.CloseableSilently;
 import io.camunda.zeebe.util.VersionUtil;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -93,7 +94,7 @@ public class GatewayModuleConfiguration implements CloseableSilently {
     this.passwordEncoder = passwordEncoder;
     this.jwtDecoder = jwtDecoder;
     this.meterRegistry = meterRegistry;
-    this.maxVariableNameLength = gatewayRestConfiguration.getMaxNameFieldLength();
+    maxVariableNameLength = gatewayRestConfiguration.getMaxNameFieldLength();
   }
 
   @Bean(destroyMethod = "close")
@@ -103,7 +104,9 @@ public class GatewayModuleConfiguration implements CloseableSilently {
         configuration.config().getCluster().getMemberId(),
         VersionUtil.getVersion());
 
-    atomixCluster.start();
+    // doing it async as potentially slow (messagingService → unicastService →
+    // membershipService → communicationService → eventService).
+    final CompletableFuture<Void> atomixClusterStartFuture = atomixCluster.start();
     jobStreamClient.start().join();
 
     // before we can add the job stream client as a topology listener, we need to wait for the
@@ -131,6 +134,7 @@ public class GatewayModuleConfiguration implements CloseableSilently {
                 .map(BrokerTopologyManager::getTopology));
     springGatewayBridge.registerJobStreamClient(() -> jobStreamClient);
 
+    atomixClusterStartFuture.join();
     gateway.start().join(30, TimeUnit.SECONDS);
     LOGGER.info("Standalone gateway is started!");
 

--- a/dist/src/test/java/io/camunda/zeebe/gateway/StandaloneGatewaySecurityTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/gateway/StandaloneGatewaySecurityTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -88,7 +89,21 @@ final class StandaloneGatewaySecurityTest {
                 gateway = buildGateway(cfg);
                 gateway.gateway();
               })
-          .hasRootCauseInstanceOf(BindException.class);
+          .satisfies(
+              throwable -> {
+                final var rootCause = throwable.getCause();
+                assertThat(rootCause)
+                    .isNotNull()
+                    .matches(
+                        cause ->
+                            cause instanceof BindException
+                                || cause
+                                    .getClass()
+                                    .getName()
+                                    .equals("io.netty.channel.unix.Errors$NativeIoException"),
+                        "is a bind-related exception")
+                    .hasMessageContaining("Address already in use");
+              });
     }
   }
 

--- a/dist/src/test/java/io/camunda/zeebe/gateway/StandaloneGatewaySecurityTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/gateway/StandaloneGatewaySecurityTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.gateway;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.atomix.cluster.AtomixCluster;
 import io.camunda.application.commons.actor.ActorClockConfiguration;
@@ -34,7 +35,10 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.BindException;
 import java.net.InetSocketAddress;
+import java.net.ServerSocket;
 import java.nio.file.Files;
 import java.security.KeyStore;
 import java.security.cert.Certificate;
@@ -63,6 +67,29 @@ final class StandaloneGatewaySecurityTest {
   public void tearDown() {
     CloseHelper.quietCloseAll(
         gateway, brokerClient, jobStreamClient, actorScheduler, () -> atomixCluster.stop().join());
+  }
+
+  @Test
+  void shouldFailToStartWhenClusterPortIsAlreadyInUse() throws IOException {
+    // given
+    final var clusterAddress = SocketUtil.getNextAddress();
+
+    // bind the cluster port before the gateway tries to use it
+    try (final var serverSocket = new ServerSocket()) {
+      serverSocket.setReuseAddress(true);
+      serverSocket.bind(
+          new InetSocketAddress(clusterAddress.getHostName(), clusterAddress.getPort()));
+
+      final var cfg = createGatewayCfg(clusterAddress);
+
+      // when - then
+      assertThatThrownBy(
+              () -> {
+                gateway = buildGateway(cfg);
+                gateway.gateway();
+              })
+          .hasRootCauseInstanceOf(BindException.class);
+    }
   }
 
   @Test
@@ -189,6 +216,16 @@ final class StandaloneGatewaySecurityTest {
                     .setEnabled(true)
                     .setCertificateChainPath(certificate.certificate())
                     .setPrivateKeyPath(certificate.privateKey())));
+    return config;
+  }
+
+  private GatewayBasedProperties createGatewayCfg(final InetSocketAddress clusterAddress) {
+    final var gatewayAddress = SocketUtil.getNextAddress();
+    final var config = new GatewayBasedProperties();
+    config.setNetwork(
+        new NetworkCfg().setHost(gatewayAddress.getHostName()).setPort(gatewayAddress.getPort()));
+    config.setCluster(
+        new ClusterCfg().setHost(clusterAddress.getHostName()).setPort(clusterAddress.getPort()));
     return config;
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -943,17 +943,19 @@ public final class NettyMessagingService implements ManagedMessagingService {
                       serverChannel = f.channel();
                       bind(bootstrap, addressIterator, future);
                     } else {
-                      if (f.cause() instanceof BindException) {
+                      final Throwable cause = f.cause();
+                      final Throwable rootCause = Throwables.getRootCause(cause);
+                      if (rootCause instanceof BindException) {
                         log.error(
                             "Failed to bind TCP server to port {}. The port is already in use. "
                                 + "Either free the port or configure a different value.",
                             address,
-                            f.cause());
+                            rootCause);
                       } else {
                         log.error(
-                            "Failed to bind TCP server to port {} due to {}", address, f.cause());
+                            "Failed to bind TCP server to port {} due to {}", address, cause);
                       }
-                      future.completeExceptionally(f.cause());
+                      future.completeExceptionally(cause);
                     }
                   });
     } else {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -952,8 +952,7 @@ public final class NettyMessagingService implements ManagedMessagingService {
                             address,
                             rootCause);
                       } else {
-                        log.error(
-                            "Failed to bind TCP server to port {} due to {}", address, cause);
+                        log.error("Failed to bind TCP server to port {} due to {}", address, cause);
                       }
                       future.completeExceptionally(cause);
                     }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -74,6 +74,7 @@ import io.netty.util.concurrent.Future;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.net.BindException;
 import java.net.ConnectException;
 import java.net.InetSocketAddress;
 import java.security.KeyStore;
@@ -942,8 +943,16 @@ public final class NettyMessagingService implements ManagedMessagingService {
                       serverChannel = f.channel();
                       bind(bootstrap, addressIterator, future);
                     } else {
-                      log.warn(
-                          "Failed to bind TCP server to port {} due to {}", address, f.cause());
+                      if (f.cause() instanceof BindException) {
+                        log.error(
+                            "Failed to bind TCP server to port {}. The port is already in use. "
+                                + "Either free the port or configure a different value.",
+                            address,
+                            f.cause());
+                      } else {
+                        log.error(
+                            "Failed to bind TCP server to port {} due to {}", address, f.cause());
+                      }
                       future.completeExceptionally(f.cause());
                     }
                   });


### PR DESCRIPTION
Whenever port is not available this will cause the gateway or broker startup to fail. For this, we also need to wait for the initialization of the Atomix cluster in the gateway. Nothing is needed to add in the broker since ClusterServicesStep waits before start the next step, and these can be completed exceptionally.

In the gateway we initialize the atomix in async since this can potentially take longer that the other initialisations, since it needs to serially initialize messagingService, unicastService, membershipService, communicationService, and eventService.

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/42581
