### PR TITLE
feat: migrate Slack webhook secrets to Vault in camunda8-getting-started-bundle.yaml

### DIFF
--- a/.github/workflows/camunda8-getting-started-bundle.yaml
+++ b/.github/workflows/camunda8-getting-started-bundle.yaml
@@ -771,9 +771,21 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@79632e33d6953d190b940ffa440bf97821cabd80
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_DEVELOPER_PORTAL_WEBHOOK;
+
       - name: Send Slack notification
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DEVELOPER_PORTAL_WEBHOOK }}
+          SLACK_WEBHOOK_URL: ${{ steps.secrets.outputs.SLACK_DEVELOPER_PORTAL_WEBHOOK }}
         run: |
           RELEASE_BASE_URL="https://github.com/camunda/camunda/releases/download/${C8RUN_VERSION}"
           
@@ -841,6 +853,17 @@ jobs:
     if: ${{ !inputs.dry_run && needs.upload-to-release.result == 'success' }}
     permissions: {}
     steps:
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@79632e33d6953d190b940ffa440bf97821cabd80
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_CAMUNDA_EX_RELEASE_WEBHOOK;
       - name: Send release announcement to Slack
         env:
           C8RUN_VERSION: ${{ needs.resolve-versions.outputs.c8run_version }}
@@ -862,7 +885,7 @@ jobs:
           
           PAYLOAD=$(jq -n --argjson blocks "$BLOCKS" '{blocks: $blocks}')
           
-          curl -X POST "${{ secrets.SLACK_CAMUNDA_EX_RELEASE_WEBHOOK }}" \
+          curl -X POST "${{ steps.secrets.outputs.SLACK_CAMUNDA_EX_RELEASE_WEBHOOK }}" \
             -H "Content-Type: application/json" \
             -d "$PAYLOAD"
 


### PR DESCRIPTION
## Summary

Migrates two Slack webhook secrets in `.github/workflows/camunda8-getting-started-bundle.yaml` from GitHub repository secrets to HashiCorp Vault.

## Changes

**`.github/workflows/camunda8-getting-started-bundle.yaml`**:

- **`notify-developer-portal`** job: added `Import Secrets` step to fetch `SLACK_DEVELOPER_PORTAL_WEBHOOK` from Vault; updated `env:` to use `steps.secrets.outputs`
- **`notify-release`** job: added `Import Secrets` step to fetch `SLACK_CAMUNDA_EX_RELEASE_WEBHOOK` from Vault; updated `curl` to use `steps.secrets.outputs`

**Vault path:** `secret/data/products/camunda/ci/github-actions`
<img width="1400" height="93" alt="image" src="https://github.com/user-attachments/assets/261a3855-7492-4fe4-bcf1-fd23c62cbbed" />


> **Note:** The repository secrets `SLACK_CAMUNDA_EX_RELEASE_WEBHOOK` and `SLACK_DEVELOPER_PORTAL_WEBHOOK` can be deleted after this PR is merged and verified.

## Related

Parent: #18211
