### PR TITLE
test: unskip test, regenerate responses

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/responses.json
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/responses.json
@@ -1,10 +1,10 @@
 {
   "metadata": {
     "sourceRepo": "https://github.com/camunda/camunda",
-    "commit": "d9ee604e14acb7f581d0d444c6d3c3808a8e0ed1",
-    "generatedAt": "2026-03-30T15:37:04.041Z",
+    "commit": "1ff50fc22791ae07c6353bfc72e62e0f4775f1df",
+    "generatedAt": "2026-04-01T13:31:56.835Z",
     "specPath": "zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml",
-    "specSha256": "90305bc3eba6229e64df751ad79548d2bebb7dcf84675609f468a753d5dcc70d"
+    "specSha256": "36365a7879894180284f12a90a1afaa1c73061c07dfa3f5d45c8300c9301030d"
   },
   "responses": [
     {
@@ -3061,7 +3061,8 @@
           },
           {
             "name": "result",
-            "type": "unknown"
+            "type": "unknown",
+            "nullable": true
           },
           {
             "name": "warnings",

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/expression/expression-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/expression/expression-api-tests.spec.ts
@@ -44,13 +44,12 @@ const successTestCases: ExpressionTestCase[] = [
     variables: {},
     result: false,
   },
-   //Skipped due to bug 50091 : https://github.com/camunda/camunda/issues/50091
-  //   {
-  //     description: 'Should evaluate null literal - Success',
-  //     expression: '=x',
-  //     variables: {x: null},
-  //     result: null,
-  //   },
+  {
+    description: 'Should evaluate null literal - Success',
+    expression: '=x',
+    variables: {x: null},
+    result: null,
+  },
   {
     description: 'Should evaluate simple variable read - Success',
     expression: '=x',
@@ -234,11 +233,10 @@ test.describe('Expression API Tests', () => {
         tc.variables,
       );
       await assertStatusCode(response, 200);
-      //Skipped due to bug 50091 : https://github.com/camunda/camunda/issues/50091
-      //   await validateResponse(
-      //     {path: EXPRESSION_URL, method: 'POST', status: '200'},
-      //     response,
-      //   );
+      await validateResponse(
+        {path: EXPRESSION_URL, method: 'POST', status: '200'},
+        response,
+      );
       const body = await response.json();
       const warnings = [];
       for (const w of body.warnings) {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/expression/expression-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/expression/expression-api-tests.spec.ts
@@ -45,7 +45,7 @@ const successTestCases: ExpressionTestCase[] = [
     result: false,
   },
   {
-    description: 'Should evaluate null literal - Success',
+    description: 'Should evaluate null variable - Success',
     expression: '=x',
     variables: {x: null},
     result: null,


### PR DESCRIPTION
## Description

This PR unskips tests as the bug was fixed. Also regenerates responses

## related issues

related to [this issue](https://github.com/camunda/team-test-automation/issues/62)
https://github.com/camunda/camunda/issues/50091
## On demand workflow
[Was all green on API](https://github.com/camunda/camunda/actions/runs/23853240854)
