### PR TITLE
feat: improve variables tooltip positioning and labelling

### DIFF
--- a/operate/client/e2e-playwright/a11y/processInstance.spec.ts
+++ b/operate/client/e2e-playwright/a11y/processInstance.spec.ts
@@ -108,12 +108,11 @@ test.describe('process detail', () => {
       .disableRules(['aria-required-parent', 'list'])
       .analyze();
 
-    await page
-      .getByRole('button', {name: /edit variable loopCounter/i})
-      .click();
+    const row = page.getByRole('row', {name: 'loopCounter'});
+    await row.getByRole('button', {name: /edit/i}).click();
 
     validateResults(resultsWithEditVariableState);
-    await page.getByRole('button', {name: /exit edit mode/i}).click();
+    await page.getByRole('button', {name: /exit/i}).click();
 
     // add variable state
     const resultsWithAddVariableState = await makeAxeBuilder()

--- a/operate/client/e2e-playwright/docs-screenshots/variables-and-incidents.spec.ts
+++ b/operate/client/e2e-playwright/docs-screenshots/variables-and-incidents.spec.ts
@@ -140,8 +140,9 @@ test.describe('variables and incidents', () => {
 
     await page.getByRole('link', {name: 'Variables'}).click();
 
-    const editVariableButton = page.getByRole('button', {
-      name: 'Edit variable orderValue',
+    const row = page.getByRole('row', {name: /orderValue/});
+    const editVariableButton = row.getByRole('button', {
+      name: 'Edit',
     });
 
     await commonPage.addUpArrow(editVariableButton);
@@ -161,7 +162,7 @@ test.describe('variables and incidents', () => {
     await editableField.fill('99');
 
     const saveVariableButton = await page.getByRole('button', {
-      name: 'Save variable',
+      name: 'Save',
     });
 
     await expect(saveVariableButton).toBeEnabled();

--- a/operate/client/e2e-playwright/visual/processInstance.spec.ts
+++ b/operate/client/e2e-playwright/visual/processInstance.spec.ts
@@ -152,7 +152,7 @@ test.describe('process instance page', () => {
 
     await page
       .getByRole('button', {
-        name: /edit variable/i,
+        name: /edit/i,
       })
       .click();
 

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/EditButtons.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/EditButtons.tsx
@@ -30,9 +30,9 @@ const EditButtons: React.FC = () => {
       <Button
         kind="ghost"
         size="sm"
-        iconDescription="Exit edit mode"
+        iconDescription="Exit"
         aria-label="Exit edit mode"
-        tooltipPosition="left"
+        tooltipPosition="top"
         onClick={() => {
           form.reset({});
         }}
@@ -47,9 +47,9 @@ const EditButtons: React.FC = () => {
         <Button
           kind="ghost"
           size="sm"
-          iconDescription="Save variable"
+          iconDescription="Save"
           aria-label="Save variable"
-          tooltipPosition="left"
+          tooltipPosition="top"
           disabled={
             initialValues?.value === values?.value ||
             validating ||

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/Footer/NewVariable.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/Footer/NewVariable.tsx
@@ -79,7 +79,6 @@ const NewVariable: React.FC = () => {
         </Field>
         <Operations>
           <MaximizeButton
-            label="Open JSON editor"
             onClick={() => {
               setIsModalVisible(true);
               tracking.track({

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/Footer/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/Footer/index.tsx
@@ -20,7 +20,7 @@ const Footer: React.FC<Props> = ({variant}) => {
   const form = useForm();
 
   return (
-    <FooterContainer>
+    <FooterContainer data-testid="variables-footer">
       {variant === 'add-variable' && <NewVariable />}
       {['initial', 'disabled'].includes(variant) && (
         <AddVariableButton

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/NewVariableModification/Operation.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/NewVariableModification/Operation.tsx
@@ -34,8 +34,8 @@ const Operation: React.FC<Props> = ({variableName, onRemove}) => {
       size="sm"
       hasIconOnly
       renderIcon={TrashCan}
-      iconDescription="Delete Variable"
-      tooltipPosition="left"
+      iconDescription="Delete"
+      tooltipPosition="top"
       onClick={() => {
         onRemove();
         modificationsStore.removeVariableModification(

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/VariablesTable.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/VariablesTable.tsx
@@ -107,8 +107,8 @@ const VariablesTable: React.FC<Props> = ({
                     <Button
                       kind="ghost"
                       size="sm"
-                      tooltipPosition="left"
-                      iconDescription={`Edit variable ${name}`}
+                      tooltipPosition="top"
+                      iconDescription="Edit"
                       aria-label={`Edit variable ${name}`}
                       disabled={
                         isFetchingNextPage || form.getState().submitting

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/ViewFullVariableButton/Add/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/ViewFullVariableButton/Add/index.tsx
@@ -35,7 +35,6 @@ const ViewFullVariableButtonAdd: React.FC<ViewFullVariableButtonAddProps> = ({
   return (
     <>
       <MaximizeButton
-        label="Open JSON editor"
         onClick={() => {
           setIsModalVisible(true);
         }}

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/ViewFullVariableButton/Edit/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/ViewFullVariableButton/Edit/index.tsx
@@ -32,7 +32,6 @@ const ViewFullVariableButtonEdit: React.FC<ViewFullVariableButtonEditProps> = ({
   return (
     <>
       <MaximizeButton
-        label="Open JSON editor"
         onClick={() => {
           if (variableEditor.isSubmittingForm) {
             return;

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/ViewFullVariableButton/MaximizeButton.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/ViewFullVariableButton/MaximizeButton.tsx
@@ -18,8 +18,8 @@ const MaximizeButton: React.FC<MaximizeButtonProps> = ({onClick, label}) => {
       renderIcon={Maximize}
       size="sm"
       aria-label={label}
-      iconDescription={label}
-      tooltipPosition="left"
+      iconDescription="Expand"
+      tooltipPosition="top"
       onClick={onClick}
     />
   );

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/ViewFullVariableButton/MaximizeButton.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/ViewFullVariableButton/MaximizeButton.tsx
@@ -10,15 +10,15 @@ import {Button} from '@carbon/react';
 import {Maximize} from '@carbon/react/icons';
 import type {MaximizeButtonProps} from './types';
 
-const MaximizeButton: React.FC<MaximizeButtonProps> = ({onClick, label}) => {
+const MaximizeButton: React.FC<MaximizeButtonProps> = ({onClick}) => {
   return (
     <Button
       kind="ghost"
       hasIconOnly
       renderIcon={Maximize}
       size="sm"
-      aria-label={label}
-      iconDescription="Expand"
+      aria-label="Open variable"
+      iconDescription="Open"
       tooltipPosition="top"
       onClick={onClick}
     />

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/ViewFullVariableButton/Show/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/ViewFullVariableButton/Show/index.tsx
@@ -28,7 +28,6 @@ const ViewFullVariableButtonShow: React.FC<ViewFullVariableButtonShowProps> = ({
   ) : (
     <>
       <MaximizeButton
-        label={`View full value of ${variableName}`}
         onClick={() => {
           setIsModalVisible(true);
         }}

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/ViewFullVariableButton/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/ViewFullVariableButton/index.test.tsx
@@ -73,7 +73,7 @@ describe('<ViewFullVariableButton />', () => {
 
     await user.click(
       screen.getByRole('button', {
-        name: `View full value of ${mockVariableName}`,
+        name: `Expand`,
       }),
     );
 
@@ -119,7 +119,7 @@ describe('<ViewFullVariableButton />', () => {
 
     await user.click(
       screen.getByRole('button', {
-        name: 'Open JSON editor',
+        name: 'Expand',
       }),
     );
 
@@ -145,7 +145,7 @@ describe('<ViewFullVariableButton />', () => {
 
     await user.click(
       screen.getByRole('button', {
-        name: 'Open JSON editor',
+        name: 'Expand',
       }),
     );
 

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/ViewFullVariableButton/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/ViewFullVariableButton/index.test.tsx
@@ -73,7 +73,7 @@ describe('<ViewFullVariableButton />', () => {
 
     await user.click(
       screen.getByRole('button', {
-        name: `Expand`,
+        name: 'Open',
       }),
     );
 
@@ -119,7 +119,7 @@ describe('<ViewFullVariableButton />', () => {
 
     await user.click(
       screen.getByRole('button', {
-        name: 'Expand',
+        name: 'Open',
       }),
     );
 
@@ -145,7 +145,7 @@ describe('<ViewFullVariableButton />', () => {
 
     await user.click(
       screen.getByRole('button', {
-        name: 'Expand',
+        name: 'Open',
       }),
     );
 

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/ViewFullVariableButton/types.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/ViewFullVariableButton/types.ts
@@ -7,7 +7,6 @@
  */
 
 export interface MaximizeButtonProps {
-  label: string;
   onClick: () => void;
 }
 

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/index.test.tsx
@@ -72,7 +72,7 @@ describe('VariablesTab', () => {
     ).not.toBeInTheDocument();
     expect(
       screen.getByRole('button', {
-        name: /view full value of testVariableName/i,
+        name: /Expand/i,
       }),
     ).toBeInTheDocument();
   });

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/index.test.tsx
@@ -72,7 +72,7 @@ describe('VariablesTab', () => {
     ).not.toBeInTheDocument();
     expect(
       screen.getByRole('button', {
-        name: /Expand/i,
+        name: /Open/i,
       }),
     ).toBeInTheDocument();
   });

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/NewVariableModifications.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/NewVariableModifications.test.tsx
@@ -836,7 +836,7 @@ describe('New Variable Modifications', () => {
     });
 
     const [deleteFirstAddedVariable] = screen.getAllByRole('button', {
-      name: /delete variable/i,
+      name: /delete/i,
     });
     await user.click(deleteFirstAddedVariable!);
 

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/addVariable.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/addVariable.test.tsx
@@ -70,7 +70,7 @@ describe('Add variable', () => {
         name: /value/i,
       }),
     ).toBeInTheDocument();
-    await user.click(screen.getByRole('button', {name: /exit edit mode/i}));
+    await user.click(screen.getByRole('button', {name: /exit/i}));
 
     expect(
       screen.queryByRole('textbox', {
@@ -106,9 +106,7 @@ describe('Add variable', () => {
     await user.click(screen.getByRole('button', {name: /add variable/i}));
 
     await waitFor(() =>
-      expect(
-        screen.getByRole('button', {name: /save variable/i}),
-      ).toBeDisabled(),
+      expect(screen.getByRole('button', {name: /save/i})).toBeDisabled(),
     );
 
     await user.type(
@@ -117,7 +115,7 @@ describe('Add variable', () => {
       }),
       'test',
     );
-    expect(screen.getByRole('button', {name: /save variable/i})).toBeDisabled();
+    expect(screen.getByRole('button', {name: /save/i})).toBeDisabled();
 
     await user.type(
       screen.getByRole('textbox', {
@@ -126,7 +124,7 @@ describe('Add variable', () => {
       '    ',
     );
 
-    expect(screen.getByRole('button', {name: /save variable/i})).toBeDisabled();
+    expect(screen.getByRole('button', {name: /save/i})).toBeDisabled();
     expect(screen.queryByTitle('Value has to be JSON')).not.toBeInTheDocument();
 
     vi.runOnlyPendingTimers();
@@ -160,7 +158,7 @@ describe('Add variable', () => {
 
     expect(
       await screen.findByRole('button', {
-        name: /save variable/i,
+        name: /save/i,
       }),
     ).toBeDisabled();
 
@@ -173,7 +171,7 @@ describe('Add variable', () => {
 
     expect(
       screen.getByRole('button', {
-        name: /save variable/i,
+        name: /save/i,
       }),
     ).toBeDisabled();
     vi.runOnlyPendingTimers();
@@ -195,7 +193,7 @@ describe('Add variable', () => {
 
     expect(
       screen.getByRole('button', {
-        name: /save variable/i,
+        name: /save/i,
       }),
     ).toBeDisabled();
 
@@ -264,7 +262,7 @@ describe('Add variable', () => {
 
     expect(
       screen.getByRole('button', {
-        name: /save variable/i,
+        name: /save/i,
       }),
     ).toBeDisabled();
     await user.type(
@@ -276,7 +274,7 @@ describe('Add variable', () => {
 
     expect(
       screen.getByRole('button', {
-        name: /save variable/i,
+        name: /save/i,
       }),
     ).toBeDisabled();
     expect(screen.queryByText('Name should be unique')).not.toBeInTheDocument();
@@ -298,7 +296,7 @@ describe('Add variable', () => {
 
     expect(
       screen.getByRole('button', {
-        name: /save variable/i,
+        name: /save/i,
       }),
     ).toBeDisabled();
     expect(
@@ -324,7 +322,7 @@ describe('Add variable', () => {
     await waitFor(() =>
       expect(
         screen.getByRole('button', {
-          name: /save variable/i,
+          name: /save/i,
         }),
       ).toBeEnabled(),
     );
@@ -356,7 +354,7 @@ describe('Add variable', () => {
 
     expect(
       screen.getByRole('button', {
-        name: /save variable/i,
+        name: /save/i,
       }),
     ).toBeDisabled();
     await user.type(
@@ -377,7 +375,7 @@ describe('Add variable', () => {
     expect(await screen.findByText('Name is invalid')).toBeInTheDocument();
     expect(
       screen.getByRole('button', {
-        name: /save variable/i,
+        name: /save/i,
       }),
     ).toBeDisabled();
 
@@ -398,7 +396,7 @@ describe('Add variable', () => {
     await waitFor(() =>
       expect(
         screen.getByRole('button', {
-          name: /save variable/i,
+          name: /save/i,
         }),
       ).toBeEnabled(),
     );
@@ -427,9 +425,7 @@ describe('Add variable', () => {
       expect(screen.getByTestId('variable-clientNo')).toBeInTheDocument();
     });
     const withinVariable = within(screen.getByTestId('variable-clientNo'));
-    await user.click(
-      withinVariable.getByRole('button', {name: /edit variable/i}),
-    );
+    await user.click(withinVariable.getByRole('button', {name: /edit/i}));
     expect(
       screen.queryByTitle('Name should be unique'),
     ).not.toBeInTheDocument();
@@ -524,7 +520,11 @@ describe('Add variable', () => {
       await screen.findByRole('button', {name: /add variable/i}),
     ).toBeInTheDocument();
     await user.click(screen.getByRole('button', {name: /add variable/i}));
-    await user.click(screen.getByRole('button', {name: /open json editor/i}));
+    await user.click(
+      within(screen.getByTestId('variables-footer')).getByRole('button', {
+        name: /Expand/i,
+      }),
+    );
 
     expect(
       within(screen.getByRole('dialog')).getByRole('button', {name: /cancel/i}),

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/addVariable.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/addVariable.test.tsx
@@ -522,7 +522,7 @@ describe('Add variable', () => {
     await user.click(screen.getByRole('button', {name: /add variable/i}));
     await user.click(
       within(screen.getByTestId('variables-footer')).getByRole('button', {
-        name: /Expand/i,
+        name: /Open/i,
       }),
     );
 

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/editVariable.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/editVariable.test.tsx
@@ -609,7 +609,7 @@ describe('Edit variable', () => {
     );
 
     mockFetchProcessDefinitionXml().withSuccess('');
-    await user.click(screen.getByRole('button', {name: /expand/i}));
+    await user.click(screen.getByRole('button', {name: /open/i}));
 
     await waitFor(() =>
       expect(screen.getByTestId('monaco-editor')).toHaveValue('123456'),
@@ -646,7 +646,7 @@ describe('Edit variable', () => {
     ).toBeInTheDocument();
     mockFetchProcessDefinitionXml().withSuccess('');
     await user.click(screen.getByRole('button', {name: /edit/i}));
-    await user.click(screen.getByRole('button', {name: /expand/i}));
+    await user.click(screen.getByRole('button', {name: /open/i}));
 
     expect(
       within(screen.getByRole('dialog')).getByRole('button', {
@@ -750,7 +750,7 @@ describe('Edit variable', () => {
     ).not.toBeInTheDocument();
     expect(
       screen.getByRole('button', {
-        name: /expand/i,
+        name: /open/i,
       }),
     ).toBeInTheDocument();
   });

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/editVariable.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/editVariable.test.tsx
@@ -90,11 +90,11 @@ describe('Edit variable', () => {
     );
 
     const firstEditButton = within(firstVariableContainer).getByRole('button', {
-      name: /edit variable/i,
+      name: /edit/i,
     });
     const secondEditButton = within(secondVariableContainer).getByRole(
       'button',
-      {name: /edit variable/i},
+      {name: /edit/i},
     );
 
     expect(firstEditButton).toBeEnabled();
@@ -112,7 +112,7 @@ describe('Edit variable', () => {
     vi.runOnlyPendingTimers();
 
     const saveButton = within(firstVariableContainer).getByRole('button', {
-      name: /save variable/i,
+      name: /save/i,
     });
     await waitFor(() => {
       expect(saveButton).toBeEnabled();
@@ -167,28 +167,26 @@ describe('Edit variable', () => {
       withinFirstVariable.queryByTestId('edit-variable-value'),
     ).not.toBeInTheDocument();
     expect(
-      withinFirstVariable.queryByRole('button', {name: /exit edit mode/i}),
+      withinFirstVariable.queryByRole('button', {name: /exit/i}),
     ).not.toBeInTheDocument();
     expect(
-      withinFirstVariable.queryByRole('button', {name: /save variable/i}),
+      withinFirstVariable.queryByRole('button', {name: /save/i}),
     ).not.toBeInTheDocument();
 
     expect(
-      await withinFirstVariable.findByRole('button', {name: /edit variable/i}),
+      await withinFirstVariable.findByRole('button', {name: /edit/i}),
     ).toBeInTheDocument();
     mockFetchProcessDefinitionXml().withSuccess('');
-    await user.click(
-      withinFirstVariable.getByRole('button', {name: /edit variable/i}),
-    );
+    await user.click(withinFirstVariable.getByRole('button', {name: /edit/i}));
 
     expect(
       await withinFirstVariable.findByTestId('edit-variable-value'),
     ).toBeInTheDocument();
     expect(
-      withinFirstVariable.getByRole('button', {name: /exit edit mode/i}),
+      withinFirstVariable.getByRole('button', {name: /exit/i}),
     ).toBeInTheDocument();
     expect(
-      withinFirstVariable.getByRole('button', {name: /save variable/i}),
+      withinFirstVariable.getByRole('button', {name: /save/i}),
     ).toBeInTheDocument();
   });
 
@@ -211,15 +209,13 @@ describe('Edit variable', () => {
     const withinFirstVariable = within(screen.getByTestId(`variable-clientNo`));
 
     expect(
-      await withinFirstVariable.findByRole('button', {name: /edit variable/i}),
+      await withinFirstVariable.findByRole('button', {name: /edit/i}),
     ).toBeInTheDocument();
     mockFetchProcessDefinitionXml().withSuccess('');
-    await user.click(
-      withinFirstVariable.getByRole('button', {name: /edit variable/i}),
-    );
+    await user.click(withinFirstVariable.getByRole('button', {name: /edit/i}));
 
     expect(
-      withinFirstVariable.getByRole('button', {name: /save variable/i}),
+      withinFirstVariable.getByRole('button', {name: /save/i}),
     ).toBeDisabled();
   });
 
@@ -246,9 +242,7 @@ describe('Edit variable', () => {
     const withinFirstVariable = within(screen.getByTestId(`variable-clientNo`));
 
     mockFetchProcessDefinitionXml().withSuccess('');
-    await user.click(
-      withinFirstVariable.getByRole('button', {name: /edit variable/i}),
-    );
+    await user.click(withinFirstVariable.getByRole('button', {name: /edit/i}));
 
     expect(
       await screen.findByTestId('edit-variable-value'),
@@ -258,7 +252,7 @@ describe('Edit variable', () => {
       "{{invalidKey: 'value'}}",
     );
 
-    expect(screen.getByRole('button', {name: /save variable/i})).toBeDisabled();
+    expect(screen.getByRole('button', {name: /save/i})).toBeDisabled();
     expect(screen.queryByText('Value has to be JSON')).not.toBeInTheDocument();
     vi.runOnlyPendingTimers();
     expect(await screen.findByText('Value has to be JSON')).toBeInTheDocument();
@@ -268,9 +262,7 @@ describe('Edit variable', () => {
 
     vi.runOnlyPendingTimers();
     await waitFor(() =>
-      expect(
-        screen.getByRole('button', {name: /save variable/i}),
-      ).toBeEnabled(),
+      expect(screen.getByRole('button', {name: /save/i})).toBeEnabled(),
     );
 
     expect(screen.queryByText('Value has to be JSON')).not.toBeInTheDocument();
@@ -340,7 +332,7 @@ describe('Edit variable', () => {
     mockFetchProcessDefinitionXml().withSuccess('');
     await user.click(
       within(screen.getByTestId('variable-clientNo')).getByRole('button', {
-        name: /edit variable/i,
+        name: /edit/i,
       }),
     );
 
@@ -353,7 +345,7 @@ describe('Edit variable', () => {
     });
     expect(
       within(screen.getByTestId('variable-mwst')).getByRole('button', {
-        name: /edit variable/i,
+        name: /edit/i,
       }),
     ).toBeEnabled();
 
@@ -409,7 +401,7 @@ describe('Edit variable', () => {
       within(screen.getByTestId('variable-testVariableName')).getByRole(
         'button',
         {
-          name: /edit variable/i,
+          name: /edit/i,
         },
       ),
     );
@@ -469,7 +461,7 @@ describe('Edit variable', () => {
       within(screen.getByTestId('variable-testVariableName')).getByRole(
         'button',
         {
-          name: /edit variable/i,
+          name: /edit/i,
         },
       ),
     );
@@ -617,7 +609,7 @@ describe('Edit variable', () => {
     );
 
     mockFetchProcessDefinitionXml().withSuccess('');
-    await user.click(screen.getByRole('button', {name: /open json editor/i}));
+    await user.click(screen.getByRole('button', {name: /expand/i}));
 
     await waitFor(() =>
       expect(screen.getByTestId('monaco-editor')).toHaveValue('123456'),
@@ -650,11 +642,11 @@ describe('Edit variable', () => {
     });
 
     expect(
-      await screen.findByRole('button', {name: /edit variable/i}),
+      await screen.findByRole('button', {name: /edit/i}),
     ).toBeInTheDocument();
     mockFetchProcessDefinitionXml().withSuccess('');
-    await user.click(screen.getByRole('button', {name: /edit variable/i}));
-    await user.click(screen.getByRole('button', {name: /open json editor/i}));
+    await user.click(screen.getByRole('button', {name: /edit/i}));
+    await user.click(screen.getByRole('button', {name: /expand/i}));
 
     expect(
       within(screen.getByRole('dialog')).getByRole('button', {
@@ -754,11 +746,11 @@ describe('Edit variable', () => {
     });
 
     expect(
-      screen.queryByRole('button', {name: /edit variable/i}),
+      screen.queryByRole('button', {name: /edit/i}),
     ).not.toBeInTheDocument();
     expect(
       screen.getByRole('button', {
-        name: /view full value of testVariableName/i,
+        name: /expand/i,
       }),
     ).toBeInTheDocument();
   });

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/footer.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/footer.test.tsx
@@ -133,17 +133,17 @@ describe('Footer', () => {
       ).not.toBeInTheDocument(),
     );
 
-    await user.click(screen.getByRole('button', {name: /exit edit mode/i}));
+    await user.click(screen.getByRole('button', {name: /exit/i}));
     expect(screen.getByRole('button', {name: /add variable/i})).toBeEnabled();
 
     const [firstEditVariableButton] = screen.getAllByRole('button', {
-      name: /edit variable/i,
+      name: /edit/i,
     });
     expect(firstEditVariableButton).toBeInTheDocument();
     await user.click(firstEditVariableButton!);
     expect(screen.getByRole('button', {name: /add variable/i})).toBeDisabled();
 
-    await user.click(screen.getByRole('button', {name: /exit edit mode/i}));
+    await user.click(screen.getByRole('button', {name: /exit/i}));
     expect(screen.getByRole('button', {name: /add variable/i})).toBeEnabled();
   });
 

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/index.test.tsx
@@ -190,7 +190,7 @@ describe('VariablesTab', () => {
     await waitFor(() =>
       expect(
         screen.getByRole('button', {
-          name: /save variable/i,
+          name: /save/i,
         }),
       ).toBeEnabled(),
     );
@@ -230,7 +230,7 @@ describe('VariablesTab', () => {
 
     await user.click(
       screen.getByRole('button', {
-        name: /save variable/i,
+        name: /save/i,
       }),
     );
     expect(
@@ -335,7 +335,7 @@ describe('VariablesTab', () => {
     await waitFor(() =>
       expect(
         screen.getByRole('button', {
-          name: /save variable/i,
+          name: /save/i,
         }),
       ).toBeEnabled(),
     );
@@ -450,13 +450,13 @@ describe('VariablesTab', () => {
     await waitFor(() =>
       expect(
         screen.getByRole('button', {
-          name: /save variable/i,
+          name: /save/i,
         }),
       ).toBeEnabled(),
     );
     await user.click(
       screen.getByRole('button', {
-        name: /save variable/i,
+        name: /save/i,
       }),
     );
 

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/notification.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/notification.test.tsx
@@ -79,7 +79,7 @@ describe('VariablesTab notifications', () => {
     await waitFor(() =>
       expect(
         screen.getByRole('button', {
-          name: /save variable/i,
+          name: /save/i,
         }),
       ).toBeEnabled(),
     );
@@ -98,7 +98,7 @@ describe('VariablesTab notifications', () => {
 
     await user.click(
       screen.getByRole('button', {
-        name: /save variable/i,
+        name: /save/i,
       }),
     );
 
@@ -155,7 +155,7 @@ describe('VariablesTab notifications', () => {
     await waitFor(() =>
       expect(
         screen.getByRole('button', {
-          name: /save variable/i,
+          name: /save/i,
         }),
       ).toBeEnabled(),
     );
@@ -174,7 +174,7 @@ describe('VariablesTab notifications', () => {
 
     await user.click(
       screen.getByRole('button', {
-        name: /save variable/i,
+        name: /save/i,
       }),
     );
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -130,7 +130,7 @@ class OperateProcessInstancePage {
     this.statusVariable = page.getByTestId('variable-status');
     this.editVariableButton = page.getByTestId('edit-variable-button');
     this.editVariableButtonInList = this.variablesList.getByRole('button', {
-      name: /edit variable/i,
+      name: /edit/i,
     });
     this.variableValueInput = page.getByTestId('edit-variable-value');
     this.instanceHeader = page.getByTestId('instance-header');


### PR DESCRIPTION
## Description

Improve action tooltips UX by not overlapping other actions (positioned at top) and revisiting the tooltip text content to be shortened

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #49272
