### PR TITLE
[Backport stable/8.9] fix: make the liquibase setup retryable for specific exception messages

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/LiquibaseSchemaManager.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/LiquibaseSchemaManager.java
@@ -7,9 +7,12 @@
  */
 package io.camunda.db.rdbms;
 
+import io.camunda.zeebe.util.VisibleForTesting;
 import java.sql.Connection;
+import java.sql.SQLException;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Set;
 import liquibase.database.Database;
 import liquibase.database.DatabaseFactory;
 import liquibase.database.jvm.JdbcConnection;
@@ -32,6 +35,21 @@ public class LiquibaseSchemaManager extends MultiTenantSpringLiquibase
     implements RdbmsSchemaManager {
 
   private static final Logger LOG = LoggerFactory.getLogger(LiquibaseSchemaManager.class);
+  private static final int DEFAULT_MIGRATION_RETRY_ATTEMPTS = 3;
+  private static final Duration DEFAULT_RETRY_BACKOFF = Duration.ofMillis(200);
+
+  private static final Set<String> RETRYABLE_MESSAGES =
+      Set.of(
+          "deadlock" // MSSQL causes deadlocks in CI with parallel tests #50230
+          );
+  private static final Set<Integer> RETRYABLE_SQL_ERROR_CODES =
+      Set.of(
+          1205 // MSSQL deadlock victim #50230
+          );
+  private static final Set<String> RETRYABLE_SQL_STATES =
+      Set.of(
+          "40001" // transaction serialization failure #50230
+          );
 
   private volatile boolean initialized = false;
   private Duration ddlLockWaitTimeout;
@@ -39,9 +57,77 @@ public class LiquibaseSchemaManager extends MultiTenantSpringLiquibase
   @Override
   public void afterPropertiesSet() throws Exception {
     releaseStaleLockIfPresent();
-    super.afterPropertiesSet();
+    performMigrationWithRetry();
     initialized = true;
     LOG.debug("Liquibase migrations completed.");
+  }
+
+  /**
+   * Runs the Liquibase migration with bounded retries for transient, retryable failures. In CI,
+   * tests run concurrently with unique table prefixes, causing Liquibase to run multiple migrations
+   * in parallel against the same database, which can trigger transient errors such as deadlocks.
+   */
+  protected void performMigrationWithRetry() throws Exception {
+    var retryBackoff = DEFAULT_RETRY_BACKOFF;
+
+    for (int attempt = 1; attempt <= DEFAULT_MIGRATION_RETRY_ATTEMPTS; attempt++) {
+      try {
+        performMigration();
+        return;
+      } catch (final Exception e) {
+        final boolean shouldRetry =
+            isRetryableException(e) && attempt < DEFAULT_MIGRATION_RETRY_ATTEMPTS;
+        if (!shouldRetry) {
+          throw e;
+        }
+
+        LOG.warn(
+            "Liquibase migration failed due to a transient, retryable error (attempt {}/{}). Retrying in {}.",
+            attempt,
+            DEFAULT_MIGRATION_RETRY_ATTEMPTS,
+            retryBackoff,
+            e);
+
+        waitBeforeRetry(retryBackoff);
+        retryBackoff = retryBackoff.multipliedBy(2);
+      }
+    }
+  }
+
+  @VisibleForTesting
+  protected void performMigration() throws Exception {
+    super.afterPropertiesSet();
+  }
+
+  protected void waitBeforeRetry(final Duration retryBackoff) throws InterruptedException {
+    try {
+      Thread.sleep(retryBackoff.toMillis());
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw e;
+    }
+  }
+
+  private boolean isRetryableException(final Throwable throwable) {
+    var current = throwable;
+    while (current != null) {
+      if (current instanceof final SQLException sqlException
+          && (RETRYABLE_SQL_ERROR_CODES.contains(sqlException.getErrorCode())
+              || RETRYABLE_SQL_STATES.contains(sqlException.getSQLState()))) {
+        return true;
+      }
+
+      final var message = current.getMessage();
+      if (message != null) {
+        final var normalizedMessage = message.toLowerCase();
+        if (RETRYABLE_MESSAGES.stream().anyMatch(normalizedMessage::contains)) {
+          return true;
+        }
+      }
+
+      current = current.getCause();
+    }
+    return false;
   }
 
   @Override

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/LiquibaseSchemaManagerTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/LiquibaseSchemaManagerTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.sql.Connection;
+import java.sql.SQLException;
 import java.time.Duration;
 import java.util.Date;
 import javax.sql.DataSource;
@@ -153,6 +154,100 @@ class LiquibaseSchemaManagerTest {
     schemaManager.releaseStaleLockIfPresent();
   }
 
+  @Test
+  void shouldRetryMigrationWhenDeadlockOccursAndThenSucceed() throws Exception {
+    // given
+    final var schemaManager =
+        new RetryableMigrationSchemaManager(
+            1,
+            new RuntimeException(
+                "liquibase migration failed",
+                new SQLException(
+                    "Transaction was deadlocked on lock resources and has been chosen as the deadlock victim.",
+                    "40001",
+                    1205)));
+
+    // when
+    schemaManager.afterPropertiesSet();
+
+    // then
+    assertThat(schemaManager.isInitialized()).isTrue();
+    assertThat(schemaManager.attempts).isEqualTo(2);
+    assertThat(schemaManager.waits).isEqualTo(1);
+  }
+
+  @Test
+  void shouldFailWhenDeadlockRetriesAreExhausted() {
+    // given
+    final var schemaManager =
+        new RetryableMigrationSchemaManager(
+            3,
+            new RuntimeException(
+                "liquibase migration failed", new SQLException("deadlock victim", "40001", 1205)));
+
+    // when / then
+    assertThatThrownBy(schemaManager::afterPropertiesSet)
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("liquibase migration failed");
+
+    assertThat(schemaManager.isInitialized()).isFalse();
+    assertThat(schemaManager.attempts).isEqualTo(3);
+    assertThat(schemaManager.waits).isEqualTo(2);
+  }
+
+  @Test
+  void shouldNotRetryWhenMigrationFailureIsNotDeadlock() {
+    // given
+    final var schemaManager =
+        new RetryableMigrationSchemaManager(1, new RuntimeException("non-retryable failure"));
+
+    // when / then
+    assertThatThrownBy(schemaManager::afterPropertiesSet)
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("non-retryable failure");
+
+    assertThat(schemaManager.isInitialized()).isFalse();
+    assertThat(schemaManager.attempts).isEqualTo(1);
+    assertThat(schemaManager.waits).isZero();
+  }
+
+  @Test
+  void shouldRetryWhenSqlStateIndicatesRetryableFailure() throws Exception {
+    // given
+    final var schemaManager =
+        new RetryableMigrationSchemaManager(
+            1,
+            new RuntimeException(
+                "liquibase migration failed", new SQLException("transient conflict", "40001", 0)));
+
+    // when
+    schemaManager.afterPropertiesSet();
+
+    // then
+    assertThat(schemaManager.isInitialized()).isTrue();
+    assertThat(schemaManager.attempts).isEqualTo(2);
+    assertThat(schemaManager.waits).isEqualTo(1);
+  }
+
+  @Test
+  void shouldRetryWhenSqlErrorCodeIndicatesRetryableFailure() throws Exception {
+    // given
+    final var schemaManager =
+        new RetryableMigrationSchemaManager(
+            1,
+            new RuntimeException(
+                "liquibase migration failed",
+                new SQLException("generic db failure", "S0001", 1205)));
+
+    // when
+    schemaManager.afterPropertiesSet();
+
+    // then
+    assertThat(schemaManager.isInitialized()).isTrue();
+    assertThat(schemaManager.attempts).isEqualTo(2);
+    assertThat(schemaManager.waits).isEqualTo(1);
+  }
+
   /**
    * Test implementation that overrides the parent's afterPropertiesSet to avoid actual Liquibase
    * initialization. Designed for extension by test subclasses (e.g. {@code TestableSchemaManager}).
@@ -167,6 +262,7 @@ class LiquibaseSchemaManagerTest {
       setInitialized();
     }
 
+    @Override
     protected void performMigration() {
       // No-op for testing, can be overridden in spy
     }
@@ -210,6 +306,32 @@ class LiquibaseSchemaManagerTest {
     @Override
     protected LockService getLockService(final Database database) {
       return mockLockService;
+    }
+  }
+
+  private static final class RetryableMigrationSchemaManager extends LiquibaseSchemaManager {
+    private int remainingFailures;
+    private final RuntimeException failure;
+    private int attempts;
+    private int waits;
+
+    private RetryableMigrationSchemaManager(
+        final int failuresBeforeSuccess, final RuntimeException failure) {
+      remainingFailures = failuresBeforeSuccess;
+      this.failure = failure;
+    }
+
+    @Override
+    protected void performMigration() {
+      attempts++;
+      if (remainingFailures-- > 0) {
+        throw failure;
+      }
+    }
+
+    @Override
+    protected void waitBeforeRetry(final Duration retryBackoff) {
+      waits++;
     }
   }
 }


### PR DESCRIPTION
# Description
Backport of #50232 to `stable/8.9`.

relates to #50230