### PR TITLE
50295 test visiblefortesting usage on constructors

### DIFF
--- a/debug-cli/src/main/java/io/camunda/debug/cli/state/SnapshotUtil.java
+++ b/debug-cli/src/main/java/io/camunda/debug/cli/state/SnapshotUtil.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.debug.cli.state;
 
+import static io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration.DEFAULT_MEMORY_LIMIT;
+
 import io.camunda.debug.cli.concurrency.CurrentThreadConcurrencyControl;
 import io.camunda.zeebe.db.AccessMetricsConfiguration;
 import io.camunda.zeebe.db.AccessMetricsConfiguration.Kind;
@@ -15,6 +17,7 @@ import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.impl.rocksdb.ChecksumProviderRocksDBImpl;
 import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration;
 import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
+import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory.SharedRocksDbResources;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotId;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotMetadata;
@@ -35,7 +38,9 @@ public class SnapshotUtil {
             new RocksDbConfiguration().setWalDisabled(false),
             new ConsistencyChecksSettings(true, true),
             new AccessMetricsConfiguration(Kind.NONE, 1),
-            SimpleMeterRegistry::new);
+            SimpleMeterRegistry::new,
+            SharedRocksDbResources.allocate(DEFAULT_MEMORY_LIMIT),
+            3);
   }
 
   public ZeebeDb openSnapshot(final Path snapshotPath, final Path runtimePath) {

--- a/debug-cli/src/main/java/io/camunda/debug/cli/state/StateCommand.java
+++ b/debug-cli/src/main/java/io/camunda/debug/cli/state/StateCommand.java
@@ -7,12 +7,15 @@
  */
 package io.camunda.debug.cli.state;
 
+import static io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration.DEFAULT_MEMORY_LIMIT;
+
 import io.camunda.zeebe.db.AccessMetricsConfiguration;
 import io.camunda.zeebe.db.AccessMetricsConfiguration.Kind;
 import io.camunda.zeebe.db.ConsistencyChecksSettings;
 import io.camunda.zeebe.db.ZeebeDbFactory;
 import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration;
 import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
+import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory.SharedRocksDbResources;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import picocli.CommandLine.Command;
 
@@ -30,7 +33,9 @@ public class StateCommand {
             new RocksDbConfiguration().setWalDisabled(false),
             new ConsistencyChecksSettings(true, true),
             new AccessMetricsConfiguration(Kind.NONE, 1),
-            SimpleMeterRegistry::new);
+            SimpleMeterRegistry::new,
+            SharedRocksDbResources.allocate(DEFAULT_MEMORY_LIMIT),
+            3);
   }
 
   public ZeebeDbFactory getZeebeDbFactory() {

--- a/qa/archunit-tests/src/test/java/io/camunda/VisibleForTestingArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/VisibleForTestingArchTest.java
@@ -8,11 +8,13 @@
 package io.camunda;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.constructors;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
 
 import com.tngtech.archunit.core.domain.JavaAccess;
 import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaConstructor;
 import com.tngtech.archunit.core.domain.JavaField;
 import com.tngtech.archunit.core.domain.JavaMethod;
 import com.tngtech.archunit.core.importer.ImportOption;
@@ -59,6 +61,13 @@ public class VisibleForTestingArchTest {
           .areAnnotatedWith(VisibleForTesting.class)
           .should(beFieldAccessedBySelfOrTest());
 
+  @ArchTest
+  static final ArchRule CONSTRUCTOR_VISIBLE_FOR_TESTING_SHOULD_ONLY_BE_ACCESSED_FROM_TEST_OR_SELF =
+      constructors()
+          .that()
+          .areAnnotatedWith(VisibleForTesting.class)
+          .should(beConstructorAccessedBySelfOrTest());
+
   private static ArchCondition<JavaClass> beClassAccessedBySelfOrTest() {
     return new ArchCondition<>("be accessed from test or self") {
       @Override
@@ -91,6 +100,19 @@ public class VisibleForTestingArchTest {
             element.getAccessesToSelf(),
             element.getOwner(),
             "Field " + element.getFullName());
+      }
+    };
+  }
+
+  private static ArchCondition<JavaConstructor> beConstructorAccessedBySelfOrTest() {
+    return new ArchCondition<>("be accessed from test or self") {
+      @Override
+      public void check(final JavaConstructor element, final ConditionEvents events) {
+        validateAccessViolations(
+            events,
+            element.getAccessesToSelf(),
+            element.getOwner(),
+            "Constructor " + element.getFullName());
       }
     };
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManager.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManager.java
@@ -12,7 +12,6 @@ import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateRepository;
 import io.camunda.exporter.tasks.historydeletion.HistoryDeletionRepository;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository;
 import io.camunda.zeebe.util.CloseableSilently;
-import io.camunda.zeebe.util.VisibleForTesting;
 import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
@@ -35,7 +34,6 @@ public final class BackgroundTaskManager implements CloseableSilently {
 
   private int submittedTasks = 0;
 
-  @VisibleForTesting
   BackgroundTaskManager(
       final int partitionId,
       final @WillCloseWhenClosed ArchiverRepository archiverRepository,

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptor.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway.interceptors.impl;
 
+import io.camunda.security.entity.AuthenticationMethod;
 import io.camunda.zeebe.util.Either.Left;
 import io.camunda.zeebe.util.Either.Right;
 import io.camunda.zeebe.util.VisibleForTesting;
@@ -18,6 +19,7 @@ import io.grpc.ServerCall.Listener;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.Status;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 public class AuthenticationInterceptor implements ServerInterceptor {
   private static final Metadata.Key<String> AUTH_KEY =
@@ -28,7 +30,9 @@ public class AuthenticationInterceptor implements ServerInterceptor {
 
   @VisibleForTesting
   AuthenticationInterceptor(final AuthenticationHandler authenticationHandler) {
-    this(authenticationHandler, new AuthenticationMetrics());
+    this(
+        authenticationHandler,
+        new AuthenticationMetrics(new SimpleMeterRegistry(), AuthenticationMethod.BASIC));
   }
 
   public AuthenticationInterceptor(

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationMetrics.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationMetrics.java
@@ -10,21 +10,14 @@ package io.camunda.zeebe.gateway.interceptors.impl;
 import io.camunda.security.entity.AuthenticationMethod;
 import io.camunda.zeebe.gateway.interceptors.impl.AuthenticationMetricsDoc.AuthResultValues;
 import io.camunda.zeebe.gateway.interceptors.impl.AuthenticationMetricsDoc.LatencyKeyNames;
-import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.micrometer.MicrometerUtil;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 public final class AuthenticationMetrics {
   private final MeterRegistry meterRegistry;
   private final Timer successLatencyTimer;
   private final Timer failureLatencyTimer;
-
-  @VisibleForTesting
-  AuthenticationMetrics() {
-    this(new SimpleMeterRegistry(), AuthenticationMethod.BASIC);
-  }
 
   public AuthenticationMetrics(
       final MeterRegistry meterRegistry, final AuthenticationMethod method) {


### PR DESCRIPTION
## Description

This PR introduces an ArchUnit test checking the correct usage of the `@VisibleForTesting` annotation on constructors.
The incorrect usages of the annotation have also been fixed.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #50295
