### PR TITLE
[Backport stable/8.9] fix: track RPI usage metrics for process instances started via message, timer, and signal

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -520,10 +520,19 @@ public final class EventAppliers implements EventApplier {
   private void registerProcessEventAppliers(final MutableProcessingState state) {
     register(
         ProcessEventIntent.TRIGGERING,
+        1,
         new ProcessEventTriggeringApplier(
             state.getEventScopeInstanceState(),
             state.getElementInstanceState(),
             state.getProcessState()));
+    register(
+        ProcessEventIntent.TRIGGERING,
+        2,
+        new ProcessEventTriggeringV2Applier(
+            state.getEventScopeInstanceState(),
+            state.getElementInstanceState(),
+            state.getProcessState(),
+            state.getUsageMetricState()));
     register(
         ProcessEventIntent.TRIGGERED,
         new ProcessEventTriggeredApplier(state.getEventScopeInstanceState()));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessEventTriggeringV2Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessEventTriggeringV2Applier.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessState;
+import io.camunda.zeebe.engine.state.mutable.MutableUsageMetricState;
+import io.camunda.zeebe.msgpack.value.DocumentValue;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessEventRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessEventIntent;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+
+final class ProcessEventTriggeringV2Applier
+    implements TypedEventApplier<ProcessEventIntent, ProcessEventRecord> {
+  private static final DirectBuffer NO_VARIABLES = new UnsafeBuffer();
+  private final MutableEventScopeInstanceState eventScopeState;
+  private final EventSubProcessInterruptionMarker eventSubProcessInterruptionMarker;
+  private final MutableUsageMetricState usageMetricState;
+
+  public ProcessEventTriggeringV2Applier(
+      final MutableEventScopeInstanceState eventScopeState,
+      final MutableElementInstanceState elementInstanceState,
+      final MutableProcessState processState,
+      final MutableUsageMetricState usageMetricState) {
+    this.eventScopeState = eventScopeState;
+    eventSubProcessInterruptionMarker =
+        new EventSubProcessInterruptionMarker(processState, elementInstanceState);
+    this.usageMetricState = usageMetricState;
+  }
+
+  @Override
+  public void applyState(final long key, final ProcessEventRecord value) {
+    var variables = value.getVariablesBuffer();
+    if (variables.equals(DocumentValue.EMPTY_DOCUMENT)) {
+      // avoid storing an empty document
+      variables = NO_VARIABLES;
+    }
+
+    final var targetElementIdBuffer = value.getTargetElementIdBuffer();
+    final var scopeKey = value.getScopeKey();
+    final var processInstanceKey = value.getProcessInstanceKey();
+
+    if (value.getProcessDefinitionKey() == scopeKey) {
+      // scopeKey equals processDefinitionKey only when activating a process-level start event
+      eventScopeState.triggerStartEvent(
+          scopeKey, key, targetElementIdBuffer, variables, processInstanceKey);
+      usageMetricState.recordRPIMetric(value.getTenantId());
+    } else {
+      eventScopeState.triggerEvent(
+          scopeKey, key, targetElementIdBuffer, variables, processInstanceKey);
+    }
+    eventSubProcessInterruptionMarker.markInstanceIfInterrupted(
+        scopeKey, value.getProcessDefinitionKey(), value.getTenantId(), targetElementIdBuffer);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/metrics/usage/UsageMetricRpiTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/metrics/usage/UsageMetricRpiTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.metrics.usage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import java.util.Map;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Tests that the RPI (Root Process Instance) usage metric is tracked for all process start types:
+ * API, message start event, timer start event, signal start event, and conditional start event.
+ */
+public class UsageMetricRpiTest {
+
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+
+  @Test
+  public void shouldTrackRpiMetricWhenProcessStartedViaApi() {
+    // given
+    final var process = Bpmn.createExecutableProcess("process").startEvent().endEvent().done();
+    engine.deployment().withXmlResource(process).deploy();
+
+    // when
+    engine.processInstance().ofBpmnProcessId("process").create();
+
+    // then
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .filterRootScope()
+        .getFirst();
+
+    final var bucket = engine.getProcessingState().getUsageMetricState().getActiveBucket();
+    assertThat(bucket).isNotNull();
+    assertThat(bucket.getTenantRPIMap()).containsEntry(TenantOwned.DEFAULT_TENANT_IDENTIFIER, 1L);
+  }
+
+  @Test
+  public void shouldTrackRpiMetricWhenProcessStartedViaMessageStartEvent() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .message("startMessage")
+            .endEvent()
+            .done();
+    engine.deployment().withXmlResource(process).deploy();
+
+    // when
+    engine.message().withName("startMessage").withCorrelationKey("key-1").publish();
+
+    // then
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .filterRootScope()
+        .getFirst();
+
+    final var bucket = engine.getProcessingState().getUsageMetricState().getActiveBucket();
+    assertThat(bucket).isNotNull();
+    assertThat(bucket.getTenantRPIMap()).containsEntry(TenantOwned.DEFAULT_TENANT_IDENTIFIER, 1L);
+  }
+
+  @Test
+  public void shouldTrackRpiMetricWhenProcessStartedViaTimerStartEvent() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .timerWithCycle("R1/PT1S")
+            .endEvent()
+            .done();
+    engine.deployment().withXmlResource(process).deploy();
+
+    // when
+    engine.increaseTime(Duration.ofSeconds(2));
+
+    // then
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .filterRootScope()
+        .getFirst();
+
+    final var bucket = engine.getProcessingState().getUsageMetricState().getActiveBucket();
+    assertThat(bucket).isNotNull();
+    assertThat(bucket.getTenantRPIMap()).containsEntry(TenantOwned.DEFAULT_TENANT_IDENTIFIER, 1L);
+  }
+
+  @Test
+  public void shouldTrackRpiMetricWhenProcessStartedViaSignalStartEvent() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .signal("startSignal")
+            .endEvent()
+            .done();
+    engine.deployment().withXmlResource(process).deploy();
+
+    // when
+    engine.signal().withSignalName("startSignal").broadcast();
+
+    // then
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .filterRootScope()
+        .getFirst();
+
+    final var bucket = engine.getProcessingState().getUsageMetricState().getActiveBucket();
+    assertThat(bucket).isNotNull();
+    assertThat(bucket.getTenantRPIMap()).containsEntry(TenantOwned.DEFAULT_TENANT_IDENTIFIER, 1L);
+  }
+
+  @Test
+  public void shouldTrackRpiMetricWhenProcessStartedViaConditionalStartEvent() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent("start")
+            .condition(c -> c.condition("=x > y"))
+            .endEvent()
+            .done();
+    engine.deployment().withXmlResource(process).deploy();
+
+    // when
+    engine.conditionalEvaluation().withVariables(Map.of("x", 1000, "y", 100)).evaluate();
+
+    // then
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .filterRootScope()
+        .getFirst();
+
+    final var bucket = engine.getProcessingState().getUsageMetricState().getActiveBucket();
+    assertThat(bucket).isNotNull();
+    assertThat(bucket.getTenantRPIMap()).containsEntry(TenantOwned.DEFAULT_TENANT_IDENTIFIER, 1L);
+  }
+
+  @Test
+  public void shouldNotTrackRpiMetricWhenRunningProcessReceivesMessageEvent() {
+    // given - a process that starts and then waits on an intermediate message catch event
+    final var process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .intermediateCatchEvent("catch")
+            .message(m -> m.name("waitMessage").zeebeCorrelationKeyExpression("key"))
+            .endEvent()
+            .done();
+    engine.deployment().withXmlResource(process).deploy();
+
+    // start the process so the baseline RPI count is 1
+    engine.processInstance().ofBpmnProcessId("process").withVariable("key", "key-1").create();
+
+    // wait until the instance is waiting at the catch event
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withElementId("catch")
+        .getFirst();
+
+    // when - the already-running instance receives the message (not a new root process instance)
+    engine.message().withName("waitMessage").withCorrelationKey("key-1").publish();
+
+    // then - the process completes, but the RPI count must still be 1
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+        .filterRootScope()
+        .getFirst();
+
+    final var bucket = engine.getProcessingState().getUsageMetricState().getActiveBucket();
+    assertThat(bucket).isNotNull();
+    assertThat(bucket.getTenantRPIMap()).containsEntry(TenantOwned.DEFAULT_TENANT_IDENTIFIER, 1L);
+  }
+
+  @Test
+  public void shouldTrackRpiMetricForEachProcessInstanceStartedViaSignal() {
+    // given - two processes with the same signal start event
+    final var process1 =
+        Bpmn.createExecutableProcess("process1")
+            .startEvent()
+            .signal("sharedSignal")
+            .endEvent()
+            .done();
+    final var process2 =
+        Bpmn.createExecutableProcess("process2")
+            .startEvent()
+            .signal("sharedSignal")
+            .endEvent()
+            .done();
+    engine.deployment().withXmlResource(process1).withXmlResource(process2).deploy();
+
+    // when
+    engine.signal().withSignalName("sharedSignal").broadcast();
+
+    // then - both process instances should be counted
+    final var instanceCount =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .filterRootScope()
+            .limit(2)
+            .count();
+    assertThat(instanceCount).isEqualTo(2);
+
+    final var bucket = engine.getProcessingState().getUsageMetricState().getActiveBucket();
+    assertThat(bucket).isNotNull();
+    assertThat(bucket.getTenantRPIMap()).containsEntry(TenantOwned.DEFAULT_TENANT_IDENTIFIER, 2L);
+  }
+}

--- a/zeebe/engine/src/test/resources/state/appliers/golden/ProcessEvent_TRIGGERING_v2.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/ProcessEvent_TRIGGERING_v2.golden
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessState;
+import io.camunda.zeebe.engine.state.mutable.MutableUsageMetricState;
+import io.camunda.zeebe.msgpack.value.DocumentValue;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessEventRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessEventIntent;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+
+final class ProcessEventTriggeringV2Applier
+    implements TypedEventApplier<ProcessEventIntent, ProcessEventRecord> {
+  private static final DirectBuffer NO_VARIABLES = new UnsafeBuffer();
+  private final MutableEventScopeInstanceState eventScopeState;
+  private final EventSubProcessInterruptionMarker eventSubProcessInterruptionMarker;
+  private final MutableUsageMetricState usageMetricState;
+
+  public ProcessEventTriggeringV2Applier(
+      final MutableEventScopeInstanceState eventScopeState,
+      final MutableElementInstanceState elementInstanceState,
+      final MutableProcessState processState,
+      final MutableUsageMetricState usageMetricState) {
+    this.eventScopeState = eventScopeState;
+    eventSubProcessInterruptionMarker =
+        new EventSubProcessInterruptionMarker(processState, elementInstanceState);
+    this.usageMetricState = usageMetricState;
+  }
+
+  @Override
+  public void applyState(final long key, final ProcessEventRecord value) {
+    var variables = value.getVariablesBuffer();
+    if (variables.equals(DocumentValue.EMPTY_DOCUMENT)) {
+      // avoid storing an empty document
+      variables = NO_VARIABLES;
+    }
+
+    final var targetElementIdBuffer = value.getTargetElementIdBuffer();
+    final var scopeKey = value.getScopeKey();
+    final var processInstanceKey = value.getProcessInstanceKey();
+
+    if (value.getProcessDefinitionKey() == scopeKey) {
+      // scopeKey equals processDefinitionKey only when activating a process-level start event
+      eventScopeState.triggerStartEvent(
+          scopeKey, key, targetElementIdBuffer, variables, processInstanceKey);
+      usageMetricState.recordRPIMetric(value.getTenantId());
+    } else {
+      eventScopeState.triggerEvent(
+          scopeKey, key, targetElementIdBuffer, variables, processInstanceKey);
+    }
+    eventSubProcessInterruptionMarker.markInstanceIfInterrupted(
+        scopeKey, value.getProcessDefinitionKey(), value.getTenantId(), targetElementIdBuffer);
+  }
+}


### PR DESCRIPTION
# Description
Backport of #50012 to `stable/8.9`.

relates to camunda/camunda#50010