### PR TITLE
test: update forbidden get usage metrics test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/usage-metrics/usage-metrics-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/usage-metrics/usage-metrics-api.spec.ts
@@ -193,6 +193,32 @@ test.describe('Get Usage Metrics API Tests - User with no permission', () => {
         await assertStatusCode(res, 204);
       }).toPass(defaultAssertionOptions);
     });
+
+
+    await test.step('Setup - Verify limited user is included in limited role', async () => {
+      await expect(async () => {
+        const res = await request.post(buildUrl('/roles/{roleId}/users/search', {roleId: LIMITED_ROLE.roleId}), {
+          headers: jsonHeaders(),
+        });
+        await assertStatusCode(res, 200);
+        const body = await res.json();
+
+        const usernames = body.items.map((item: {username: string}) => item.username);
+        expect(usernames).toContain(LIMITED_USER.username);
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Setup - Verify limited authorization is included in role authorizations', async () => {
+      await expect(async () => {
+        const res = await request.get(buildUrl(`/authorizations/${limitedAuthorizationKey}`), {
+          headers: jsonHeaders(),
+        });
+        await assertStatusCode(res, 200);
+        const body = await res.json();
+
+        expect(body.authorizationKey).toBe(limitedAuthorizationKey);
+      }).toPass(defaultAssertionOptions);
+    });
   });
 
   test.afterAll(async ({request}) => {
@@ -231,7 +257,17 @@ test.describe('Get Usage Metrics API Tests - User with no permission', () => {
           headers: jsonHeaders(token), // overrides default demo:demo
         },
       );
-      await assertUnauthorizedRequest(res);
+      await assertStatusCode(res, 200);
+      await validateResponse({
+        path: USAGE_METRICS_GET_ENDPOINT,
+        method: 'GET',
+        status: '200',
+      }, res);
+      const body = await res.json();
+      expect(body.activeTenants).toBe(0);
+      expect(body.processInstances).toBe(0);
+      expect(body.decisionInstances).toBe(0);
+      expect(body.assignees).toBe(0);
     }).toPass(defaultAssertionOptions);
   });
 });


### PR DESCRIPTION
## Description
this PR introduces updates in get usage metrics test so it verifies empty response as expected

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## On demand workflow
[Was here](https://github.com/camunda/camunda/actions/runs/23857165304)