### PR TITLE
deps: update zeebe version

### DIFF
--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -48,7 +48,7 @@
     <project.previousVersion>8.7.0</project.previousVersion>
     <camunda.maven.artifacts.version>7.22.0</camunda.maven.artifacts.version>
 
-    <zeebe.version>${project.parent.version}</zeebe.version>
+    <zeebe.version>8.8.21</zeebe.version>
     <!-- We use this for the Zeebe test container version only -->
     <zeebe.docker.version>8.7.0-alpha4</zeebe.docker.version>
 


### PR DESCRIPTION
## Description
Zeebe updated to `8.8.21` -- will be reverted on mergeback to `stable/8.8`
Identity `8.8.10` -- inherited from parent

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
