### PR TITLE
fix: fix inconsistent batch operation key behaviour for audit logs

### DIFF
--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/BatchOperationCreationAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/BatchOperationCreationAuditLogTransformer.java
@@ -24,5 +24,6 @@ public class BatchOperationCreationAuditLogTransformer
       final Record<BatchOperationCreationRecordValue> record, final AuditLogEntry log) {
     final var value = record.getValue();
     log.setBatchOperationType(value.getBatchOperationType());
+    log.setEntityKey(String.valueOf(value.getBatchOperationKey()));
   }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/BatchOperationLifecycleManagementAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/BatchOperationLifecycleManagementAuditLogTransformer.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.exporter.common.auditlog.transformers;
 
+import io.camunda.zeebe.exporter.common.auditlog.AuditLogEntry;
+import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.value.BatchOperationLifecycleManagementRecordValue;
 
 public class BatchOperationLifecycleManagementAuditLogTransformer
@@ -15,5 +17,13 @@ public class BatchOperationLifecycleManagementAuditLogTransformer
   @Override
   public TransformerConfig config() {
     return AuditLogTransformerConfigs.BATCH_OPERATION_LIFECYCLE_MANAGEMENT_CONFIG;
+  }
+
+  @Override
+  public void transform(
+      final Record<BatchOperationLifecycleManagementRecordValue> record, final AuditLogEntry log) {
+    // Since RESUME, CANCEL and SUSPEND logs use a different key, we override the entity key
+    // to ensure that the key is always the batch operation key
+    log.setEntityKey(String.valueOf(record.getValue().getBatchOperationKey()));
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/BatchOperationCreationAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/BatchOperationCreationAuditLogTransformerTest.java
@@ -33,6 +33,7 @@ class BatchOperationCreationAuditLogTransformerTest {
         ImmutableBatchOperationCreationRecordValue.builder()
             .from(factory.generateObject(BatchOperationCreationRecordValue.class))
             .withBatchOperationType(BatchOperationType.MODIFY_PROCESS_INSTANCE)
+            .withBatchOperationKey(456L)
             .build();
 
     final Record<BatchOperationCreationRecordValue> record =
@@ -45,6 +46,7 @@ class BatchOperationCreationAuditLogTransformerTest {
     transformer.transform(record, entity);
 
     // then
+    assertThat(entity.getEntityKey()).isEqualTo("456");
     assertThat(entity.getBatchOperationType())
         .isEqualTo(BatchOperationType.MODIFY_PROCESS_INSTANCE);
     assertThat(entity.getOperationType()).isEqualTo(AuditLogOperationType.CREATE);

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/BatchOperationLifecycleManagementAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/BatchOperationLifecycleManagementAuditLogTransformerTest.java
@@ -44,6 +44,7 @@ class BatchOperationLifecycleManagementAuditLogTransformerTest {
     transformer.transform(record, entity);
 
     // then
+    assertThat(entity.getEntityKey()).isEqualTo("456");
     assertThat(entity.getOperationType()).isEqualTo(AuditLogOperationType.SUSPEND);
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Fix the inconsistent batch operation key stored as entity key by pinning the batch operation key as the entity key for batch operation transformers.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

related to #50311 and #49513
