### PR TITLE
[Backport stable/8.9] fix: display root cause decision in incidents table

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/IncidentsTable/tests/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/IncidentsTable/tests/index.test.tsx
@@ -9,12 +9,22 @@
 import {IncidentsTable} from '..';
 import {formatDate} from 'modules/utils/date';
 import {render, screen, within} from 'modules/testing-library';
+<<<<<<< HEAD
 import {Wrapper, incidentsMock, firstIncident, secondIncident} from './mocks';
 import {
   createEnhancedIncident,
   createProcessInstance,
   createUser,
 } from 'modules/testUtils';
+=======
+import {
+  Wrapper,
+  incidentsMock,
+  firstIncident,
+  secondIncident,
+} from './mocks';
+import {createEnhancedIncident} from 'modules/testUtils';
+>>>>>>> f2ba9fed (fix: display root cause decision in incidents table)
 import {mockFetchProcessInstance as mockFetchProcessInstanceV2} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
 import {mockMe} from 'modules/mocks/api/v2/me';
 import {getIncidentErrorName} from 'modules/utils/incidents';

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/IncidentsTab/index.tsx
@@ -26,6 +26,11 @@ import {IncidentsTable} from './IncidentsTable';
 import {PanelHeader} from 'modules/components/PanelHeader';
 import {Container} from './styled';
 import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
+<<<<<<< HEAD
+=======
+import {Navigate, useLocation} from 'react-router-dom';
+import {Paths} from 'modules/Routes';
+>>>>>>> f2ba9fed (fix: display root cause decision in incidents table)
 import {useDecisionInstancesSearch} from 'modules/queries/decisionInstances/useDecisionInstancesSearch';
 import {useMemo} from 'react';
 
@@ -123,6 +128,21 @@ const IncidentsTab: React.FC = observer(() => {
       }, {}),
     [decisionInstancesResult],
   );
+<<<<<<< HEAD
+=======
+
+  if (processInstance?.hasIncident === false) {
+    return (
+      <Navigate
+        to={{
+          ...location,
+          pathname: Paths.processInstanceVariables({processInstanceId}),
+        }}
+        replace
+      />
+    );
+  }
+>>>>>>> f2ba9fed (fix: display root cause decision in incidents table)
 
   return (
     <Container>


### PR DESCRIPTION
# Description
Backport of #49743 to `stable/8.9`.

relates to #49425