### PR TITLE
feat: replace BACKPORT_ACTION_PAT with Monorepo DevOps Automation GitHub App

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -14,9 +14,9 @@ jobs:
     name: Create backport PRs
     runs-on: ubuntu-latest
     # Only run when pull request is merged
-    # or when a comment starting with `/backport` is created by someone other than the
-    # https://github.com/backport-action bot user (user id: 97796249). Note that if you use your
-    # own PAT as `github_token`, that you should replace this id with yours.
+    # or when a comment starting with `/backport` is created by someone other than a bot:
+    # - https://github.com/backport-action bot user (user id: 97796249)
+    # - Monorepo DevOps Automation GitHub App bot user (user id: 248077375)
     if: >
       (
         github.event_name == 'pull_request' &&
@@ -25,18 +25,34 @@ jobs:
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
         github.event.comment.user.id != 97796249 &&
+        github.event.comment.user.id != 248077375 &&
         startsWith(github.event.comment.body, '/backport')
       )
+    # No GITHUB_TOKEN permissions needed; all GitHub operations use the
+    # Monorepo DevOps Automation GitHub App token generated in the first step.
+    permissions: {}
     steps:
+      - name: Generate GitHub token
+        id: github-token
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@fc4fa13813cbc1835129967f10a12f24aa7a393c # main
+        with:
+          github-app-id-vault-key: MONOREPO_DEVOPS_AUTOMATION_APP_ID
+          github-app-id-vault-path: secret/data/products/camunda/ci/camunda
+          github-app-private-key-vault-key: MONOREPO_DEVOPS_AUTOMATION_APP_PRIVATE_KEY
+          github-app-private-key-vault-path: secret/data/products/camunda/ci/camunda
+          vault-auth-method: approle
+          vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          vault-url: ${{ secrets.VAULT_ADDR }}
       - uses: actions/checkout@v6
         with:
           # Token for git actions, e.g. git push
-          token: ${{ secrets.BACKPORT_ACTION_PAT }}
+          token: ${{ steps.github-token.outputs.token }}
       - name: Create backport PRs
         uses: korthout/backport-action@v4
         with:
           # Token to authenticate requests to GitHub
-          github_token: ${{ secrets.BACKPORT_ACTION_PAT }}
+          github_token: ${{ steps.github-token.outputs.token }}
 
           # Template used as description in the pull requests created by this action.
           # Placeholders can be used to define variable values.


### PR DESCRIPTION
## Summary

Replaces the `BACKPORT_ACTION_PAT` personal access token in the backport workflow with a short-lived token generated from the **Monorepo DevOps Automation** GitHub App, fetched from Vault.

PATs are long-lived credentials tied to individual user accounts, which poses a security and maintenance risk. Using a GitHub App with scoped permissions and Vault-managed secrets is the established standard in this repo.

## Changes

**`.github/workflows/backport.yml`**:

- Added `Generate GitHub token` step using `camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets` to obtain a short-lived installation token from the Monorepo DevOps Automation GitHub App (keys: `MONOREPO_DEVOPS_AUTOMATION_APP_ID` / `MONOREPO_DEVOPS_AUTOMATION_APP_PRIVATE_KEY` at `secret/data/products/camunda/ci/camunda`)
- Replaced `secrets.BACKPORT_ACTION_PAT` with `steps.github-token.outputs.token` in both `actions/checkout` and `korthout/backport-action`
- Added explicit `permissions: contents: write, pull-requests: write` block
- Removed stale PAT-specific comment about replacing the bot user ID

## Prerequisites

The following secrets must be stored in Vault at `secret/data/products/camunda/ci/camunda` before merging:

| Vault Key | Description |
|---|---|
| `MONOREPO_DEVOPS_AUTOMATION_APP_ID` | App ID of the Monorepo DevOps Automation GitHub App |
| `MONOREPO_DEVOPS_AUTOMATION_APP_PRIVATE_KEY` | Private key (PEM) of the app |

Cli check:
<img width="985" height="104" alt="image" src="https://github.com/user-attachments/assets/0127beef-652b-4738-a53f-fcd45ee67221" />

The app requires **Contents: write** and **Pull requests: write** repository permissions on `camunda/camunda`.

Once merged and verified, the `BACKPORT_ACTION_PAT` repository secret can be deleted.

## Related
https://github.com/camunda/camunda/issues/50227
Part of #18211 (migrate repository secrets to Vault)
