### PR TITLE
fix: use node 24 for identity in ci

### DIFF
--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -147,6 +147,7 @@ jobs:
         with:
           directory: ./identity/client
           package-manager: "npm"
+          node-version: 24
       - uses: ./.github/actions/build-zeebe
         name: Build Zeebe
         id: build-zeebe

--- a/.github/workflows/zeebe-testbench.yaml
+++ b/.github/workflows/zeebe-testbench.yaml
@@ -104,6 +104,7 @@ jobs:
         with:
           directory: ./identity/client
           package-manager: npm
+          node-version: 24
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
         with:


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
use node 24 for identity in missed ci workflows

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
