### PR TITLE
fix: replace load test secret placeholder on redeploy

### DIFF
--- a/load-tests/setup/default/createCredsLoadTest.sh
+++ b/load-tests/setup/default/createCredsLoadTest.sh
@@ -14,8 +14,9 @@ NS="${1:-__NAMESPACE__}"
 # for the sed replacement and skip creation.
 if kubectl -n "$NS" get secret camunda-credentials &>/dev/null; then
   echo "Secret 'camunda-credentials' already exists in namespace '$NS'. Skipping creation."
+  echo "Reading existing orchestration secret from 'camunda-credentials' in namespace '$NS'."
   ORCHESTRATION_SECRET=$(kubectl -n "$NS" get secret camunda-credentials -o jsonpath='{.data.orchestration-security-authentication-oidc-secret}' | base64 -d)
-  echo "Replacing __SECRET__ in load-test-values.yaml with existing orchestration secret."
+  echo "Done Replacing __SECRET__ in load-test-values.yaml with existing orchestration secret."
   sed_inplace "s/__SECRET__/${ORCHESTRATION_SECRET}/g" load-test-values.yaml
   exit 0
 fi

--- a/load-tests/setup/default/createCredsLoadTest.sh
+++ b/load-tests/setup/default/createCredsLoadTest.sh
@@ -15,6 +15,7 @@ NS="${1:-__NAMESPACE__}"
 if kubectl -n "$NS" get secret camunda-credentials &>/dev/null; then
   echo "Secret 'camunda-credentials' already exists in namespace '$NS'. Skipping creation."
   ORCHESTRATION_SECRET=$(kubectl -n "$NS" get secret camunda-credentials -o jsonpath='{.data.orchestration-security-authentication-oidc-secret}' | base64 -d)
+  echo "Replacing __SECRET__ in load-test-values.yaml with existing orchestration secret."
   sed_inplace "s/__SECRET__/${ORCHESTRATION_SECRET}/g" load-test-values.yaml
   exit 0
 fi

--- a/load-tests/setup/default/createCredsLoadTest.sh
+++ b/load-tests/setup/default/createCredsLoadTest.sh
@@ -10,9 +10,12 @@ set -euo pipefail
 # Usage: ./createCredsLoadTest.sh [namespace]
 NS="${1:-__NAMESPACE__}"
 
-# Check if the secret already exists; if so, skip creation.
+# Check if the secret already exists; if so, retrieve the existing orchestration secret
+# for the sed replacement and skip creation.
 if kubectl -n "$NS" get secret camunda-credentials &>/dev/null; then
   echo "Secret 'camunda-credentials' already exists in namespace '$NS'. Skipping creation."
+  ORCHESTRATION_SECRET=$(kubectl -n "$NS" get secret camunda-credentials -o jsonpath='{.data.orchestration-security-authentication-oidc-secret}' | base64 -d)
+  sed_inplace "s/__SECRET__/${ORCHESTRATION_SECRET}/g" load-test-values.yaml
   exit 0
 fi
 


### PR DESCRIPTION
## Summary

- Fixes a bug where redeploying a load test via `camunda-load-test.yml` left the `__SECRET__` placeholder in `load-test-values.yaml` unreplaced, causing the load test starter/worker pods to use an invalid credential.

### Root cause

When a load test is redeployed to an existing namespace:
1. `newLoadTest.sh` copies fresh template files (including `load-test-values.yaml` with `__SECRET__` placeholder)
2. `createCredsLoadTest.sh` detects that the `camunda-credentials` secret already exists and exits early
3. The `sed_inplace` that replaces `__SECRET__` with the actual orchestration secret **never runs**

### Fix

When the secret already exists, retrieve the `orchestration-security-authentication-oidc-secret` from the existing Kubernetes secret and perform the sed replacement before exiting. This ensures `load-test-values.yaml` always has the correct credential value regardless of whether it's a fresh deploy or a redeploy.

## Test plan

- [x] Deploy a load test with `camunda-load-test.yml` (first deploy — creates namespace and secret)
- [x] Redeploy the same load test (same namespace) — verify `load-test-values.yaml` in the namespace dir has the actual secret value, not `__SECRET__`
- [x] Verify starter/worker pods authenticate successfully on redeploy

Run1: https://github.com/camunda/camunda/actions/runs/23893431681/attempts/1
Redeployed with same image and typical to max: Run2https://github.com/camunda/camunda/actions/runs/23894145438

closes #50388 