### PR TITLE
fix: rework message batch expiry to avoid scheduled command cache

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
@@ -14,7 +14,7 @@ import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
 import io.camunda.zeebe.engine.Engine;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
-import io.camunda.zeebe.protocol.record.intent.MessageIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
@@ -158,7 +158,7 @@ public final class StreamProcessorTransitionStep implements PartitionTransitionS
             TimerIntent.TRIGGER,
             JobIntent.TIME_OUT,
             JobIntent.RECUR_AFTER_BACKOFF,
-            MessageIntent.EXPIRE);
+            MessageBatchIntent.EXPIRE);
     final var processingFilter =
         SkipPositionsFilter.of(context.getBrokerCfg().getProcessing().skipPositions());
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
@@ -29,7 +29,7 @@ final class EngineCfgTest {
     final var configuration = cfg.getExperimental().getEngine().createEngineConfiguration();
 
     // then
-    assertThat(configuration.getMessagesTtlCheckerBatchLimit()).isEqualTo(Integer.MAX_VALUE);
+    assertThat(configuration.getMessagesTtlCheckerBatchLimit()).isEqualTo(100);
     assertThat(configuration.getMessagesTtlCheckerInterval()).isEqualTo(Duration.ofMinutes(1));
     assertThat(configuration.getDrgCacheCapacity()).isEqualTo(1000L);
     assertThat(configuration.getJobsTimeoutCheckerPollingInterval())

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -11,7 +11,7 @@ import java.time.Duration;
 
 public final class EngineConfiguration {
 
-  public static final int DEFAULT_MESSAGES_TTL_CHECKER_BATCH_LIMIT = Integer.MAX_VALUE;
+  public static final int DEFAULT_MESSAGES_TTL_CHECKER_BATCH_LIMIT = 100;
   public static final Duration DEFAULT_MESSAGES_TTL_CHECKER_INTERVAL = Duration.ofMinutes(1);
 
   public static final int DEFAULT_MAX_ERROR_MESSAGE_SIZE = 10000;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageBatchExpireProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageBatchExpireProcessor.java
@@ -7,95 +7,78 @@
  */
 package io.camunda.zeebe.engine.processing.message;
 
-import static io.camunda.zeebe.protocol.record.intent.MessageIntent.*;
-
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.state.immutable.MessageState;
-import io.camunda.zeebe.engine.state.message.StoredMessage;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
-import io.camunda.zeebe.protocol.record.RejectionType;
-import io.camunda.zeebe.stream.api.records.ExceededBatchRecordSizeException;
+import io.camunda.zeebe.protocol.record.intent.MessageBatchIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.time.InstantSource;
+import org.agrona.collections.MutableLong;
 
 @ExcludeAuthorizationCheck
 public final class MessageBatchExpireProcessor implements TypedRecordProcessor<MessageBatchRecord> {
 
-  private static final Logger LOG = LoggerFactory.getLogger(MessageBatchExpireProcessor.class);
+  /** The safety margin to ensure that we can always write an empty EXPIRE command at the end. */
+  private static final int FOLLOWUP_COMMAND_SAFETY_MARGIN = 8192;
+
   private final StateWriter stateWriter;
-  private final TypedRejectionWriter rejectionWriter;
+  private final TypedCommandWriter commandWriter;
   private final MessageState messageState;
+  private final int batchLimit;
   private final boolean appendMessageBodyOnExpired;
+  private final InstantSource clock;
 
   private final MessageRecord emptyDeleteMessageCommand =
       new MessageRecord().setName("").setCorrelationKey("").setTimeToLive(-1L);
 
   public MessageBatchExpireProcessor(
       final StateWriter stateWriter,
-      final TypedRejectionWriter rejectionWriter,
+      final TypedCommandWriter commandWriter,
       final MessageState messageState,
-      final boolean appendMessageBodyOnExpired) {
+      final int batchLimit,
+      final boolean appendMessageBodyOnExpired,
+      final InstantSource clock) {
     this.stateWriter = stateWriter;
-    this.rejectionWriter = rejectionWriter;
+    this.commandWriter = commandWriter;
     this.messageState = messageState;
+    this.batchLimit = batchLimit;
     this.appendMessageBodyOnExpired = appendMessageBodyOnExpired;
+    this.clock = clock;
   }
 
   @Override
   public void processRecord(final TypedRecord<MessageBatchRecord> record) {
-    int expiredMessagesCount = 0;
-    final int totalMessagesCount = record.getValue().getMessageKeys().size();
+    final var expiredCount = new MutableLong(0);
+    final boolean hasMore =
+        messageState.visitMessagesWithDeadlineBeforeTimestamp(
+            clock.millis(),
+            null,
+            (deadline, messageKey) -> {
+              final var expiredMessageRecord =
+                  appendMessageBodyOnExpired
+                      ? messageState.getMessage(messageKey).getMessage()
+                      : emptyDeleteMessageCommand;
 
-    for (final long messageKey : record.getValue().getMessageKeys()) {
-      try {
-        if (appendMessageBodyOnExpired) {
-          expiredMessagesCount += expireWithMessageBody(messageKey);
-        } else {
-          stateWriter.appendFollowUpEvent(messageKey, EXPIRED, emptyDeleteMessageCommand);
-          expiredMessagesCount++;
-        }
-      } catch (final ExceededBatchRecordSizeException exceededBatchRecordSizeException) {
-        LOG.warn(
-            "Expected to expire messages in a batch, but exceeded the resulting batch size after expiring {} out of {} messages. "
-                + "Try using a lower Message TTL Checker's batch limit.",
-            expiredMessagesCount,
-            totalMessagesCount);
-        break;
-      }
-    }
+              final var requiredCapacity =
+                  expiredMessageRecord.getLength() + FOLLOWUP_COMMAND_SAFETY_MARGIN;
+              if (stateWriter.canWriteEventOfLength(requiredCapacity)
+                  && expiredCount.getAndIncrement() < batchLimit) {
+                stateWriter.appendFollowUpEvent(
+                    messageKey, MessageIntent.EXPIRED, expiredMessageRecord);
+                return true;
+              } else {
+                return false;
+              }
+            });
 
-    if (appendMessageBodyOnExpired && expiredMessagesCount == 0) {
-      rejectionWriter.appendRejection(
-          record,
-          RejectionType.NOT_FOUND,
-          String.format(
-              "Expected to expire %d messages in a batch, but none of the messages were found in the state.",
-              totalMessagesCount));
-    }
-  }
-
-  /**
-   * Expires a message and appends the message body to the follow-up event.
-   *
-   * @param messageKey the key of the message to expire
-   * @return the number of messages expired (1 if successful, 0 if not found)
-   */
-  private int expireWithMessageBody(final long messageKey) {
-    final StoredMessage persistedMessage = messageState.getMessage(messageKey);
-    if (persistedMessage != null) {
-      stateWriter.appendFollowUpEvent(messageKey, EXPIRED, persistedMessage.getMessage());
-      return 1;
-    } else {
-      // the message was expired before processing it here, so we can skip it
-      LOG.warn(
-          "Expected to expire messages in a batch, but message with key {} was not found.",
-          messageKey);
-      return 0;
+    if (hasMore) {
+      commandWriter.appendFollowUpCommand(
+          record.getKey(), MessageBatchIntent.EXPIRE, new MessageBatchRecord());
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -84,9 +84,11 @@ public final class MessageEventProcessors {
             MessageBatchIntent.EXPIRE,
             new MessageBatchExpireProcessor(
                 writers.state(),
-                writers.rejection(),
+                writers.command(),
                 messageState,
-                featureFlags.enableMessageBodyOnExpired()))
+                config.getMessagesTtlCheckerBatchLimit(),
+                featureFlags.enableMessageBodyOnExpired(),
+                clock))
         .onCommand(
             ValueType.MESSAGE, MessageIntent.EXPIRE, new MessageExpireProcessor(writers.state()))
         .onCommand(
@@ -147,7 +149,6 @@ public final class MessageEventProcessors {
         .withListener(
             new MessageTimeToLiveCheckScheduler(
                 config.getMessagesTtlCheckerInterval(),
-                config.getMessagesTtlCheckerBatchLimit(),
                 featureFlags.enableMessageTTLCheckerAsync(),
                 scheduledTaskStateFactory.get().getMessageState()))
         .withListener(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageTimeToLiveCheckScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageTimeToLiveCheckScheduler.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.engine.processing.message;
 
 import io.camunda.zeebe.engine.state.immutable.MessageState;
-import io.camunda.zeebe.engine.state.immutable.MessageState.Index;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageBatchRecord;
 import io.camunda.zeebe.protocol.record.intent.MessageBatchIntent;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
@@ -19,92 +18,39 @@ import io.camunda.zeebe.stream.api.scheduling.TaskResult;
 import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
 import java.time.Duration;
 import java.time.InstantSource;
-import org.agrona.collections.MutableInteger;
 
 /**
- * The Message TTL Checker looks for expired message deadlines, and for each of those it writes an
- * EXPIRE Message command.
- *
- * <p>To prevent that it clogs the log stream with too many EXPIRE Message commands, it only writes
- * a limited number of these commands in a single run of {@link #execute(TaskResultBuilder)}.
- *
- * <p>It determines whether to reschedule itself immediately, or after the configured {@link
- * #executionInterval interval}. If it reschedules itself immediately, then it will continue where
- * it left off the last time. Otherwise, it starts with the first expired message deadline it can
- * find.
+ * Periodically checks for expired message deadlines and writes a {@link MessageBatchIntent#EXPIRE}
+ * trigger command when any are found. The actual expiry work (querying state and writing {@code
+ * EXPIRED} events) is done by the {@link MessageBatchExpireProcessor}.
  */
 public final class MessageTimeToLiveCheckScheduler implements Task, StreamProcessorLifecycleAware {
 
-  /** This determines the duration that the TTL checker is idle after it completes an execution. */
   private final Duration executionInterval;
-
-  /** This determines the maximum number of EXPIRE commands it will attempt to fit in the result. */
-  private final int batchLimit;
-
-  /** This determines whether to run this checker async or not. */
   private final boolean enableMessageTtlCheckerAsync;
-
-  private ProcessingScheduleService scheduleService;
   private final MessageState messageState;
 
-  /** Keeps track of the timestamp to compare the message deadlines against. */
-  private long currentTimestamp = -1;
-
-  /** Keeps track of where to continue between iterations. */
-  private MessageState.Index lastIndex;
-
+  private ProcessingScheduleService scheduleService;
   private InstantSource clock;
 
   public MessageTimeToLiveCheckScheduler(
       final Duration executionInterval,
-      final int batchLimit,
       final boolean enableMessageTtlCheckerAsync,
       final MessageState messageState) {
     this.executionInterval = executionInterval;
-    this.batchLimit = batchLimit;
     this.enableMessageTtlCheckerAsync = enableMessageTtlCheckerAsync;
     this.messageState = messageState;
-    lastIndex = null;
   }
 
   @Override
   public TaskResult execute(final TaskResultBuilder taskResultBuilder) {
-    if (currentTimestamp == -1) {
-      currentTimestamp = clock.millis();
-    }
-
-    final var counter = new MutableInteger(0);
-    final MessageBatchRecord messageBatchRecord = new MessageBatchRecord();
-    final boolean shouldContinueWhereLeftOff =
+    final boolean hasExpired =
         messageState.visitMessagesWithDeadlineBeforeTimestamp(
-            currentTimestamp,
-            lastIndex,
-            (deadline, expiredMessageKey) -> {
-              final var newIndex = new Index(expiredMessageKey, deadline);
-              final boolean wasIndexAlreadyVisitedLastTime = newIndex.equals(lastIndex);
-              lastIndex = newIndex;
-
-              if (wasIndexAlreadyVisitedLastTime) {
-                // skip this entry
-                return true;
-              }
-
-              messageBatchRecord.addMessageKey(expiredMessageKey);
-              return counter.incrementAndGet() < batchLimit;
-            });
-
-    if (!messageBatchRecord.isEmpty()) {
-      taskResultBuilder.appendCommandRecord(MessageBatchIntent.EXPIRE, messageBatchRecord);
+            clock.millis(), null, (deadline, key) -> false);
+    if (hasExpired) {
+      taskResultBuilder.appendCommandRecord(MessageBatchIntent.EXPIRE, new MessageBatchRecord());
     }
-
-    if (shouldContinueWhereLeftOff) {
-      reschedule(Duration.ZERO);
-    } else {
-      lastIndex = null;
-      currentTimestamp = -1;
-      reschedule(executionInterval);
-    }
-
+    reschedule(executionInterval);
     return taskResultBuilder.build();
   }
 
@@ -121,11 +67,6 @@ public final class MessageTimeToLiveCheckScheduler implements Task, StreamProces
   public void onRecovered(final ReadonlyStreamProcessorContext context) {
     scheduleService = context.getScheduleService();
     clock = context.getClock();
-    final var timestamp = clock.millis() + executionInterval.toMillis();
-    if (enableMessageTtlCheckerAsync) {
-      scheduleService.runAtAsync(timestamp, this);
-    } else {
-      scheduleService.runAt(timestamp, this);
-    }
+    reschedule(executionInterval);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/ExpireMessageSelfChainingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/ExpireMessageSelfChainingTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.MessageBatchIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageIntent;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Tests that the batch expiry processor self-chains when there are more expired messages than the
+ * batch limit allows in a single processing cycle.
+ */
+public final class ExpireMessageSelfChainingTest {
+
+  private static final int BATCH_LIMIT = 3;
+
+  @ClassRule
+  public static final EngineRule ENGINE_RULE =
+      EngineRule.singlePartition()
+          .withEngineConfig(cfg -> cfg.setMessagesTtlCheckerBatchLimit(BATCH_LIMIT));
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldSelfChainWhenMoreMessagesThanBatchLimit() {
+    // given — publish more messages than the batch limit
+    final int messageCount = BATCH_LIMIT * 2 + 1; // 7 messages, limit is 3
+    final long timeToLive = 100;
+
+    final List<Long> publishedKeys =
+        LongStream.range(0, messageCount)
+            .mapToObj(
+                i ->
+                    ENGINE_RULE
+                        .message()
+                        .withCorrelationKey("key-" + i)
+                        .withName("msg-" + i)
+                        .withTimeToLive(timeToLive)
+                        .publish()
+                        .getKey())
+            .collect(Collectors.toList());
+
+    // when
+    ENGINE_RULE.increaseTime(EngineConfiguration.DEFAULT_MESSAGES_TTL_CHECKER_INTERVAL);
+
+    // then — all messages should eventually be expired
+    final List<Long> expiredKeys =
+        RecordingExporter.messageRecords()
+            .withIntent(MessageIntent.EXPIRED)
+            .limit(messageCount)
+            .map(Record::getKey)
+            .collect(Collectors.toList());
+
+    assertThat(expiredKeys).containsExactlyInAnyOrderElementsOf(publishedKeys);
+
+    // and — there should be at least 3 EXPIRE commands (self-chaining):
+    // with 7 messages and batch limit 3, the processor needs 3 cycles (3+3+1)
+    final long expireCommandCount =
+        RecordingExporter.messageBatchRecords()
+            .withIntent(MessageBatchIntent.EXPIRE)
+            .limit(3)
+            .count();
+
+    assertThat(expireCommandCount).isEqualTo(3);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/ExpireMessageTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/ExpireMessageTest.java
@@ -14,14 +14,9 @@ import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.engine.util.RecordToWrite;
 import io.camunda.zeebe.engine.util.client.PublishMessageClient;
-import io.camunda.zeebe.protocol.impl.record.value.message.MessageBatchRecord;
-import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
-import io.camunda.zeebe.protocol.record.RecordAssert;
-import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.MessageBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
-import io.camunda.zeebe.protocol.record.intent.SignalIntent;
 import io.camunda.zeebe.protocol.record.value.MessageBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
@@ -71,11 +66,7 @@ public final class ExpireMessageTest {
     ENGINE_RULE.increaseTime(EngineConfiguration.DEFAULT_MESSAGES_TTL_CHECKER_INTERVAL);
 
     // then
-    final Record<MessageBatchRecordValue> expireBatchMessageCommand =
-        RecordingExporter.messageBatchRecords().withIntent(MessageBatchIntent.EXPIRE).getFirst();
-
-    Assertions.assertThat(expireBatchMessageCommand.getValue())
-        .hasMessageKeys(publishedMessageKeys);
+    RecordingExporter.messageBatchRecords().withIntent(MessageBatchIntent.EXPIRE).getFirst();
 
     final List<Long> listOfExpiredMessageKeys =
         RecordingExporter.messageRecords()
@@ -104,11 +95,10 @@ public final class ExpireMessageTest {
             .withRecordKey(publishedRecord.getKey())
             .getFirst();
 
-    Assertions.assertThat(deletedEvent.getValue())
-        .hasName("order canceled")
-        .hasCorrelationKey("order-123")
-        .hasTimeToLive(0L)
-        .hasMessageId("");
+    assertThat(deletedEvent.getValue().getName()).isEqualTo("order canceled");
+    assertThat(deletedEvent.getValue().getCorrelationKey()).isEqualTo("order-123");
+    assertThat(deletedEvent.getValue().getTimeToLive()).isEqualTo(0L);
+    assertThat(deletedEvent.getValue().getMessageId()).isEmpty();
   }
 
   // regression test for https://github.com/camunda/camunda/issues/5420
@@ -118,19 +108,14 @@ public final class ExpireMessageTest {
     final long timeToLive = 50L;
 
     // when
-    final Record<MessageRecordValue> publishedRecord =
-        messageClient.withTimeToLive(timeToLive).publish();
+    messageClient.withTimeToLive(timeToLive).publish();
     ENGINE_RULE.increaseTime(EngineConfiguration.DEFAULT_MESSAGES_TTL_CHECKER_INTERVAL);
 
     // then
-    final Record<MessageBatchRecordValue> deleteCommand =
-        RecordingExporter.messageBatchRecords()
-            .withIntent(MessageBatchIntent.EXPIRE)
-            .hasMessageKey(publishedRecord.getKey())
-            .getFirst();
+    final Record<MessageBatchRecordValue> expireCommand =
+        RecordingExporter.messageBatchRecords().withIntent(MessageBatchIntent.EXPIRE).getFirst();
 
-    // then
-    assertThat(deleteCommand.getSourceRecordPosition()).isLessThan(0);
+    assertThat(expireCommand.getSourceRecordPosition()).isLessThan(0);
   }
 
   @Test
@@ -156,12 +141,6 @@ public final class ExpireMessageTest {
     ENGINE_RULE.increaseTime(EngineConfiguration.DEFAULT_MESSAGES_TTL_CHECKER_INTERVAL);
 
     // then
-    final Record<MessageBatchRecordValue> expireBatchMessageCommand =
-        RecordingExporter.messageBatchRecords().withIntent(MessageBatchIntent.EXPIRE).getFirst();
-
-    Assertions.assertThat(expireBatchMessageCommand.getValue())
-        .hasMessageKeys(List.of(publishedRecord.getKey(), secondPublishedRecord.getKey()));
-
     final MessageRecordValue firstMessage = publishedRecord.getValue();
     final MessageRecordValue secondMessage = secondPublishedRecord.getValue();
 
@@ -203,95 +182,30 @@ public final class ExpireMessageTest {
             .publish()
             .getKey();
 
-    // when
-    // assume the message already correlated and expired in the meantime
+    // when — expire the first message individually before the batch runs
     ENGINE_RULE.writeRecords(
         RecordToWrite.command()
             .key(firstMessageKey)
             .message(MessageIntent.EXPIRE, firstMessage.getValue()));
 
-    // write the batch expire command that will be processed after the correlation
-    final MessageBatchRecord messageBatchRecord = new MessageBatchRecord();
-    messageBatchRecord.addMessageKey(firstMessageKey).addMessageKey(secondMessageKey);
-    ENGINE_RULE.writeRecords(RecordToWrite.command().messageBatch(messageBatchRecord));
+    // wait for the individual expire to be processed
+    RecordingExporter.messageRecords()
+        .withIntent(MessageIntent.EXPIRED)
+        .withRecordKey(firstMessageKey)
+        .getFirst();
 
-    ENGINE_RULE
-        .signal()
-        .withSignalName("test-speedup-helper")
-        .broadcast(); // to limit records to speed up assertion
+    ENGINE_RULE.increaseTime(EngineConfiguration.DEFAULT_MESSAGES_TTL_CHECKER_INTERVAL);
 
-    // then
-    final Record<MessageBatchRecordValue> expireBatchMessageCommand =
+    // then — only the second message is expired by the batch
+    final Record<MessageBatchRecordValue> expireCommand =
         RecordingExporter.messageBatchRecords().withIntent(MessageBatchIntent.EXPIRE).getFirst();
 
-    Assertions.assertThat(expireBatchMessageCommand.getValue())
-        .hasMessageKeys(List.of(firstMessageKey, secondMessageKey));
-
-    final List<Long> listOfExpiredMessageKeys =
-        RecordingExporter.records()
-            // Speed up assertion. Otherwise, it waits 5 seconds for more EXPIRED records.
-            .between(
-                r -> r.getIntent() == MessageBatchIntent.EXPIRE,
-                r -> r.getIntent() == SignalIntent.BROADCASTED)
+    final Record<MessageRecordValue> batchExpiredRecord =
+        RecordingExporter.messageRecords()
             .withIntent(MessageIntent.EXPIRED)
-            .withSourceRecordPosition(
-                expireBatchMessageCommand.getPosition()) // only filter by the batch
-            .flatMapToLong(v -> LongStream.of(v.getKey()))
-            .boxed()
-            .collect(Collectors.toList());
-
-    assertThat(listOfExpiredMessageKeys).isEqualTo(List.of(secondMessageKey));
-  }
-
-  @Test
-  public void shouldRejectIfNoMessageIsExpired() {
-    // given
-    final var firstMessage =
-        ENGINE_RULE
-            .message()
-            .withCorrelationKey("correlation1")
-            .withName("message1")
-            .withTimeToLive(Duration.ofMinutes(1))
-            .publish();
-    final long firstMessageKey = firstMessage.getKey();
-
-    final var secondMessage =
-        ENGINE_RULE
-            .message()
-            .withCorrelationKey("correlation2")
-            .withName("message2")
-            .withTimeToLive(Duration.ofMinutes(1))
-            .publish();
-    final long secondMessageKey = secondMessage.getKey();
-
-    // when
-    // assume the message already correlated and expired in the meantime
-    ENGINE_RULE.writeRecords(
-        RecordToWrite.command()
-            .key(firstMessageKey)
-            .message(MessageIntent.EXPIRE, firstMessage.getValue()));
-    ENGINE_RULE.writeRecords(
-        RecordToWrite.command()
-            .key(secondMessageKey)
-            .message(MessageIntent.EXPIRE, secondMessage.getValue()));
-
-    // write the batch expire command that will be processed after the correlation
-    final MessageBatchRecord messageBatchRecord = new MessageBatchRecord();
-    messageBatchRecord.addMessageKey(firstMessageKey).addMessageKey(secondMessageKey);
-    ENGINE_RULE.writeRecords(RecordToWrite.command().messageBatch(messageBatchRecord));
-
-    // then
-    final Record<MessageBatchRecordValue> expireBatchMessageCommand =
-        RecordingExporter.messageBatchRecords()
-            .withIntent(MessageBatchIntent.EXPIRE)
-            .onlyCommandRejections()
+            .withSourceRecordPosition(expireCommand.getPosition())
             .getFirst();
 
-    Assertions.assertThat(expireBatchMessageCommand.getValue())
-        .hasMessageKeys(List.of(firstMessageKey, secondMessageKey));
-    RecordAssert.assertThat(expireBatchMessageCommand)
-        .hasRejectionReason(
-            "Expected to expire 2 messages in a batch, but none of the messages were found in the state.")
-        .hasRejectionType(RejectionType.NOT_FOUND);
+    assertThat(batchExpiredRecord.getKey()).isEqualTo(secondMessageKey);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageBatchExpireProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageBatchExpireProcessorTest.java
@@ -8,199 +8,223 @@
 package io.camunda.zeebe.engine.processing.message;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.state.immutable.MessageState;
+import io.camunda.zeebe.engine.state.immutable.MessageState.ExpiredMessageVisitor;
 import io.camunda.zeebe.engine.state.message.StoredMessage;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
-import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.MessageBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
-import io.camunda.zeebe.stream.api.records.ExceededBatchRecordSizeException;
-import io.camunda.zeebe.stream.impl.records.RecordBatchEntry;
 import io.camunda.zeebe.stream.impl.records.UnwrittenRecord;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
 
 public final class MessageBatchExpireProcessorTest {
 
+  private static final long NOW = 1000L;
+
   private final StateWriter stateWriter = Mockito.mock(StateWriter.class);
-  private final TypedRejectionWriter rejectionWriter = Mockito.mock(TypedRejectionWriter.class);
+  private final TypedCommandWriter commandWriter = Mockito.mock(TypedCommandWriter.class);
   private final MessageState messageState = Mockito.mock(MessageState.class);
+  private final Clock clock = Clock.fixed(Instant.ofEpochMilli(NOW), ZoneId.systemDefault());
 
   @Test
-  public void shouldStopProcessingWhenExceedingBatchLimit() {
-
+  public void shouldExpireMessagesFromState() {
     // given
-    final var messageBatchRecord =
-        new MessageBatchRecord()
-            .addMessageKey(1)
-            .addMessageKey(2)
-            .addMessageKey(3)
-            .addMessageKey(4);
-
-    doReturn(mock(StoredMessage.class)).when(messageState).getMessage(1);
-    doReturn(mock(StoredMessage.class)).when(messageState).getMessage(2);
-    doReturn(mock(StoredMessage.class)).when(messageState).getMessage(3);
-    doNothing().when(stateWriter).appendFollowUpEvent(eq(1L), any(), any());
-    doNothing().when(stateWriter).appendFollowUpEvent(eq(2L), any(), any());
-
-    final var exceededBatchRecordSizeException =
-        new ExceededBatchRecordSizeException(mock(RecordBatchEntry.class), 10, 1, 1);
-    doThrow(exceededBatchRecordSizeException)
-        .when(stateWriter)
-        .appendFollowUpEvent(eq(3L), any(), any());
+    stubVisitWithKeys(1L, 2L);
+    doNothing().when(stateWriter).appendFollowUpEvent(anyLong(), any(), any());
 
     // when
-    final var messageBatchExpireProcessor = createProcessor(false);
-    messageBatchExpireProcessor.processRecord(
-        new UnwrittenRecord(-1, 1, messageBatchRecord, new RecordMetadata()));
+    createProcessor(false, 100).processRecord(emptyBatchRecord());
 
     // then
-    verify(stateWriter, times(3)).appendFollowUpEvent(anyLong(), any(), any());
+    verify(stateWriter).appendFollowUpEvent(eq(1L), eq(MessageIntent.EXPIRED), any());
+    verify(stateWriter).appendFollowUpEvent(eq(2L), eq(MessageIntent.EXPIRED), any());
   }
 
   @Test
-  public void shouldExportWithMessageBody() {
-    // given
-    final var messageBatchRecord = new MessageBatchRecord().addMessageKey(1).addMessageKey(2);
+  public void shouldWriteFollowUpWhenBatchLimitReached() {
+    // given — visitor returns true (hasMore) because batch limit stops it
+    stubVisitReturning(true, 1L, 2L);
+    doNothing().when(stateWriter).appendFollowUpEvent(anyLong(), any(), any());
 
-    doReturn(
+    // when
+    createProcessor(false, 2).processRecord(emptyBatchRecord());
+
+    // then
+    verify(stateWriter, times(2)).appendFollowUpEvent(anyLong(), eq(MessageIntent.EXPIRED), any());
+    verify(commandWriter)
+        .appendFollowUpCommand(
+            eq(-1L), eq(MessageBatchIntent.EXPIRE), any(MessageBatchRecord.class));
+  }
+
+  @Test
+  public void shouldNotWriteFollowUpWhenAllMessagesProcessed() {
+    // given — visitor returns false (no more)
+    stubVisitWithKeys(1L);
+    doNothing().when(stateWriter).appendFollowUpEvent(anyLong(), any(), any());
+
+    // when
+    createProcessor(false, 100).processRecord(emptyBatchRecord());
+
+    // then
+    verify(stateWriter).appendFollowUpEvent(eq(1L), eq(MessageIntent.EXPIRED), any());
+    verify(commandWriter, never())
+        .appendFollowUpCommand(anyLong(), any(), any(MessageBatchRecord.class));
+  }
+
+  @Test
+  public void shouldDoNothingWhenNoExpiredMessages() {
+    // given
+    when(messageState.visitMessagesWithDeadlineBeforeTimestamp(eq(NOW), any(), any()))
+        .thenReturn(false);
+
+    // when
+    createProcessor(false, 100).processRecord(emptyBatchRecord());
+
+    // then
+    verify(stateWriter, never()).appendFollowUpEvent(anyLong(), any(), any());
+    verify(commandWriter, never())
+        .appendFollowUpCommand(anyLong(), any(), any(MessageBatchRecord.class));
+  }
+
+  @Test
+  public void shouldWriteFollowUpWhenBatchIsFull() {
+    // given — 3 keys but batch runs out of space after the first event
+    stubVisitWithKeys(1L, 2L, 3L);
+    doNothing().when(stateWriter).appendFollowUpEvent(anyLong(), any(), any());
+    final var processor = createProcessor(false, 100);
+    when(stateWriter.canWriteEventOfLength(anyInt())).thenReturn(true, false);
+
+    // when
+    processor.processRecord(emptyBatchRecord());
+
+    // then — writes only 1 event and a follow-up to continue later
+    verify(stateWriter, times(1)).appendFollowUpEvent(anyLong(), eq(MessageIntent.EXPIRED), any());
+    verify(commandWriter)
+        .appendFollowUpCommand(
+            eq(-1L), eq(MessageBatchIntent.EXPIRE), any(MessageBatchRecord.class));
+  }
+
+  @Test
+  public void shouldWriteFollowUpWhenBatchIsFullWithMoreRemaining() {
+    // given — batch limit is 2, visitor indicates more remain, and batch fills after first event
+    stubVisitReturning(true, 1L, 2L);
+    doNothing().when(stateWriter).appendFollowUpEvent(anyLong(), any(), any());
+    final var processor = createProcessor(false, 2);
+    when(stateWriter.canWriteEventOfLength(anyInt())).thenReturn(true, false);
+
+    // when
+    processor.processRecord(emptyBatchRecord());
+
+    // then — writes follow-up to continue with remaining messages
+    verify(stateWriter, times(1)).appendFollowUpEvent(anyLong(), eq(MessageIntent.EXPIRED), any());
+    verify(commandWriter)
+        .appendFollowUpCommand(
+            eq(-1L), eq(MessageBatchIntent.EXPIRE), any(MessageBatchRecord.class));
+  }
+
+  @Test
+  public void shouldExpireWithMessageBody() {
+    // given
+    stubVisitWithKeys(1L, 2L);
+
+    when(messageState.getMessage(1L))
+        .thenReturn(
             new StoredMessage()
                 .setMessage(
                     new MessageRecord()
                         .setName("message1")
                         .setCorrelationKey("correlationKey1")
-                        .setTimeToLive(100L)))
-        .when(messageState)
-        .getMessage(1L);
-    doReturn(
+                        .setTimeToLive(100L)));
+    when(messageState.getMessage(2L))
+        .thenReturn(
             new StoredMessage()
                 .setMessage(
                     new MessageRecord()
                         .setName("message2")
                         .setCorrelationKey("correlationKey2")
-                        .setTimeToLive(101L)))
-        .when(messageState)
-        .getMessage(2L);
-    doNothing().when(stateWriter).appendFollowUpEvent(eq(1L), any(), any());
-    doNothing().when(stateWriter).appendFollowUpEvent(eq(2L), any(), any());
+                        .setTimeToLive(101L)));
+    doNothing().when(stateWriter).appendFollowUpEvent(anyLong(), any(), any());
 
     // when
-    final var messageBatchExpireProcessor = createProcessor(true);
-    messageBatchExpireProcessor.processRecord(
-        new UnwrittenRecord(-1, 1, messageBatchRecord, new RecordMetadata()));
+    createProcessor(true, 100).processRecord(emptyBatchRecord());
 
     // then
-    verify(stateWriter, times(1))
+    verify(stateWriter)
         .appendFollowUpEvent(
             eq(1L),
             eq(MessageIntent.EXPIRED),
             argThat(
                 record -> {
-                  final var messageRecord = (MessageRecord) record;
-                  return messageRecord.getName().equals("message1")
-                      && messageRecord.getCorrelationKey().equals("correlationKey1")
-                      && messageRecord.getTimeToLive() == 100L;
+                  final var msg = (MessageRecord) record;
+                  return msg.getName().equals("message1")
+                      && msg.getCorrelationKey().equals("correlationKey1")
+                      && msg.getTimeToLive() == 100L;
                 }));
 
-    verify(stateWriter, times(1))
+    verify(stateWriter)
         .appendFollowUpEvent(
             eq(2L),
             eq(MessageIntent.EXPIRED),
             argThat(
                 record -> {
-                  final var messageRecord = (MessageRecord) record;
-                  return messageRecord.getName().equals("message2")
-                      && messageRecord.getCorrelationKey().equals("correlationKey2")
-                      && messageRecord.getTimeToLive() == 101L;
+                  final var msg = (MessageRecord) record;
+                  return msg.getName().equals("message2")
+                      && msg.getCorrelationKey().equals("correlationKey2")
+                      && msg.getTimeToLive() == 101L;
                 }));
   }
 
-  @Test
-  public void shouldSkipNotFoundMessages() {
-    // given
-    final var messageBatchRecord = new MessageBatchRecord().addMessageKey(1).addMessageKey(2);
-
-    doReturn(
-            new StoredMessage()
-                .setMessage(
-                    new MessageRecord()
-                        .setName("message1")
-                        .setCorrelationKey("correlationKey1")
-                        .setTimeToLive(100L)))
-        .when(messageState)
-        .getMessage(1L);
-    doReturn(null).when(messageState).getMessage(2L);
-    doNothing().when(stateWriter).appendFollowUpEvent(eq(1L), any(), any());
-
-    // when
-    final var messageBatchExpireProcessor = createProcessor(true);
-    messageBatchExpireProcessor.processRecord(
-        new UnwrittenRecord(-1, 1, messageBatchRecord, new RecordMetadata()));
-
-    // then
-    verify(stateWriter, times(1))
-        .appendFollowUpEvent(
-            eq(1L),
-            eq(MessageIntent.EXPIRED),
-            argThat(
-                record -> {
-                  final var messageRecord = (MessageRecord) record;
-                  return messageRecord.getName().equals("message1")
-                      && messageRecord.getCorrelationKey().equals("correlationKey1")
-                      && messageRecord.getTimeToLive() == 100L;
-                }));
-
-    verify(stateWriter, times(0)).appendFollowUpEvent(eq(2L), eq(MessageIntent.EXPIRED), any());
-  }
-
-  @Test
-  public void shouldRejectIfNoMessagesFound() {
-    // given
-    final var messageBatchRecord = new MessageBatchRecord().addMessageKey(1).addMessageKey(2);
-
-    doReturn(
-            new StoredMessage()
-                .setMessage(
-                    new MessageRecord()
-                        .setName("message1")
-                        .setCorrelationKey("correlationKey1")
-                        .setTimeToLive(100L)))
-        .when(messageState)
-        .getMessage(1L);
-    doReturn(null).when(messageState).getMessage(1L);
-    doReturn(null).when(messageState).getMessage(2L);
-
-    // when
-    final UnwrittenRecord record =
-        new UnwrittenRecord(-1, 1, messageBatchRecord, new RecordMetadata());
-    final var messageBatchExpireProcessor = createProcessor(true);
-    messageBatchExpireProcessor.processRecord(record);
-
-    // then
-    verify(rejectionWriter, times(1))
-        .appendRejection(
-            record,
-            RejectionType.NOT_FOUND,
-            "Expected to expire 2 messages in a batch, but none of the messages were found in the state.");
-    verify(stateWriter, times(0)).appendFollowUpEvent(eq(1L), eq(MessageIntent.EXPIRED), any());
-    verify(stateWriter, times(0)).appendFollowUpEvent(eq(2L), eq(MessageIntent.EXPIRED), any());
-  }
-
-  private MessageBatchExpireProcessor createProcessor(final boolean appendMessageBodyOnExpired) {
+  private MessageBatchExpireProcessor createProcessor(
+      final boolean appendMessageBodyOnExpired, final int batchLimit) {
+    // default: always have space unless explicitly stubbed otherwise per test
+    when(stateWriter.canWriteEventOfLength(anyInt())).thenReturn(true);
     return new MessageBatchExpireProcessor(
-        stateWriter, rejectionWriter, messageState, appendMessageBodyOnExpired);
+        stateWriter, commandWriter, messageState, batchLimit, appendMessageBodyOnExpired, clock);
+  }
+
+  private UnwrittenRecord emptyBatchRecord() {
+    return new UnwrittenRecord(-1, 1, new MessageBatchRecord(), new RecordMetadata());
+  }
+
+  /** Stubs the visitor to return the given keys, with hasMore = false. */
+  private void stubVisitWithKeys(final long... keys) {
+    stubVisitReturning(false, keys);
+  }
+
+  /**
+   * Stubs the visitor to invoke the visitor with the given keys and return the specified result.
+   */
+  private void stubVisitReturning(final boolean hasMore, final long... keys) {
+    when(messageState.visitMessagesWithDeadlineBeforeTimestamp(eq(NOW), any(), any()))
+        .thenAnswer(
+            (Answer<Boolean>)
+                invocation -> {
+                  final ExpiredMessageVisitor visitor = invocation.getArgument(2);
+                  for (final long key : keys) {
+                    if (!visitor.visit(NOW - 1, key)) {
+                      return true;
+                    }
+                  }
+                  return hasMore;
+                });
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageBatchRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageBatchRecord.java
@@ -7,48 +7,13 @@
  */
 package io.camunda.zeebe.protocol.impl.record.value.message;
 
-import io.camunda.zeebe.msgpack.property.ArrayProperty;
-import io.camunda.zeebe.msgpack.value.LongValue;
-import io.camunda.zeebe.msgpack.value.StringValue;
-import io.camunda.zeebe.msgpack.value.ValueArray;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageBatchRecordValue;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 public final class MessageBatchRecord extends UnifiedRecordValue
     implements MessageBatchRecordValue {
 
-  // Static StringValue key to avoid memory waste
-  private static final StringValue MESSAGE_KEYS_KEY = new StringValue("messageKeys");
-
-  private final ArrayProperty<LongValue> messageKeysProp =
-      new ArrayProperty<>(MESSAGE_KEYS_KEY, LongValue::new);
-
   public MessageBatchRecord() {
-    super(1);
-    declareProperty(messageKeysProp);
-  }
-
-  public ValueArray<LongValue> messageKeys() {
-    return messageKeysProp;
-  }
-
-  @Override
-  public boolean isEmpty() {
-    return messageKeysProp.isEmpty();
-  }
-
-  public MessageBatchRecord addMessageKey(final long key) {
-    messageKeys().add().setValue(key);
-    return this;
-  }
-
-  @Override
-  public List<Long> getMessageKeys() {
-    return StreamSupport.stream(messageKeysProp.spliterator(), false)
-        .map(LongValue::getValue)
-        .collect(Collectors.toList());
+    super(0);
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -1290,37 +1290,9 @@ final class JsonSerializableToJsonTest {
       /////////////////////////////////////////////////////////////////////////////////////////////
       {
         "MessageBatchRecord",
-        (Supplier<UnifiedRecordValue>)
-            () -> {
-              final List<Long> messageKeys = List.of(123L, 456L);
-
-              return new MessageBatchRecord()
-                  .addMessageKey(messageKeys.get(0))
-                  .addMessageKey(messageKeys.get(1));
-            },
+        (Supplier<UnifiedRecordValue>) MessageBatchRecord::new,
         """
-                {
-                  "messageKeys": [
-                    123,
-                    456
-                  ]
-                }
-                """
-      },
-      /////////////////////////////////////////////////////////////////////////////////////////////
-      ///////////////////////////////// Empty MessageBatchRecord
-      // ///////////////////////////////////////
-      /////////////////////////////////////////////////////////////////////////////////////////////
-      {
-        "Empty MessageBatchRecord",
-        (Supplier<UnifiedRecordValue>)
-            () -> {
-              return new MessageBatchRecord();
-            },
-        """
-                {
-                  "messageKeys": []
-                }
+                {}
                 """
       },
 

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/MessageBatchRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/MessageBatchRecord.golden
@@ -7,48 +7,13 @@
  */
 package io.camunda.zeebe.protocol.impl.record.value.message;
 
-import io.camunda.zeebe.msgpack.property.ArrayProperty;
-import io.camunda.zeebe.msgpack.value.LongValue;
-import io.camunda.zeebe.msgpack.value.StringValue;
-import io.camunda.zeebe.msgpack.value.ValueArray;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageBatchRecordValue;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 public final class MessageBatchRecord extends UnifiedRecordValue
     implements MessageBatchRecordValue {
 
-  // Static StringValue key to avoid memory waste
-  private static final StringValue MESSAGE_KEYS_KEY = new StringValue("messageKeys");
-
-  private final ArrayProperty<LongValue> messageKeysProp =
-      new ArrayProperty<>(MESSAGE_KEYS_KEY, LongValue::new);
-
   public MessageBatchRecord() {
-    super(1);
-    declareProperty(messageKeysProp);
-  }
-
-  public ValueArray<LongValue> messageKeys() {
-    return messageKeysProp;
-  }
-
-  @Override
-  public boolean isEmpty() {
-    return messageKeysProp.isEmpty();
-  }
-
-  public MessageBatchRecord addMessageKey(final long key) {
-    messageKeys().add().setValue(key);
-    return this;
-  }
-
-  @Override
-  public List<Long> getMessageKeys() {
-    return StreamSupport.stream(messageKeysProp.spliterator(), false)
-        .map(LongValue::getValue)
-        .collect(Collectors.toList());
+    super(0);
   }
 }

--- a/zeebe/protocol/ignored-changes.json
+++ b/zeebe/protocol/ignored-changes.json
@@ -327,6 +327,54 @@
           "old": "class io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceModificationMoveInstructionValue",
           "new": "class io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceModificationMoveInstructionValue",
           "justification": "Interface is generalized in and moved to the ProcessInstanceModificationRecordValue."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method java.util.List<java.lang.Long> io.camunda.zeebe.protocol.record.value.MessageBatchRecordValue::getMessageKeys()",
+          "justification": "MessageBatchRecord no longer carries message keys. The batch expiry processor now queries state directly instead of reading keys from the command record. Old records with keys deserialize safely as unknown properties are ignored."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method java.util.List<java.lang.Long> io.camunda.zeebe.protocol.record.value.ImmutableMessageBatchRecordValue::getMessageKeys()",
+          "justification": "Generated code removed as a consequence of removing getMessageKeys() from MessageBatchRecordValue."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method io.camunda.zeebe.protocol.record.value.ImmutableMessageBatchRecordValue io.camunda.zeebe.protocol.record.value.ImmutableMessageBatchRecordValue::withMessageKeys(java.lang.Iterable<? extends java.lang.Long>)",
+          "justification": "Generated code removed as a consequence of removing getMessageKeys() from MessageBatchRecordValue."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method io.camunda.zeebe.protocol.record.value.ImmutableMessageBatchRecordValue io.camunda.zeebe.protocol.record.value.ImmutableMessageBatchRecordValue::withMessageKeys(java.lang.Long[])",
+          "justification": "Generated code removed as a consequence of removing getMessageKeys() from MessageBatchRecordValue."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method io.camunda.zeebe.protocol.record.value.ImmutableMessageBatchRecordValue.Builder io.camunda.zeebe.protocol.record.value.ImmutableMessageBatchRecordValue.Builder::addAllMessageKeys(java.lang.Iterable<? extends java.lang.Long>)",
+          "justification": "Generated code removed as a consequence of removing getMessageKeys() from MessageBatchRecordValue."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method io.camunda.zeebe.protocol.record.value.ImmutableMessageBatchRecordValue.Builder io.camunda.zeebe.protocol.record.value.ImmutableMessageBatchRecordValue.Builder::addMessageKey(java.lang.Long)",
+          "justification": "Generated code removed as a consequence of removing getMessageKeys() from MessageBatchRecordValue."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method io.camunda.zeebe.protocol.record.value.ImmutableMessageBatchRecordValue.Builder io.camunda.zeebe.protocol.record.value.ImmutableMessageBatchRecordValue.Builder::addMessageKeys(java.lang.Long[])",
+          "justification": "Generated code removed as a consequence of removing getMessageKeys() from MessageBatchRecordValue."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method io.camunda.zeebe.protocol.record.value.ImmutableMessageBatchRecordValue.Builder io.camunda.zeebe.protocol.record.value.ImmutableMessageBatchRecordValue.Builder::withMessageKeys(java.lang.Iterable<? extends java.lang.Long>)",
+          "justification": "Generated code removed as a consequence of removing getMessageKeys() from MessageBatchRecordValue."
         }
       ]
     }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/MessageBatchRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/MessageBatchRecordValue.java
@@ -17,20 +17,13 @@ package io.camunda.zeebe.protocol.record.value;
 
 import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValue;
-import java.util.List;
 import org.immutables.value.Value;
 
 /**
- * Represents a message event or command.
+ * Represents a message batch event or command.
  *
  * <p>See {@link io.camunda.zeebe.protocol.record.intent.MessageBatchIntent} for intents.
  */
 @Value.Immutable
 @ImmutableProtocol(builder = ImmutableMessageBatchRecordValue.Builder.class)
-public interface MessageBatchRecordValue extends RecordValue {
-
-  /**
-   * @return list of the keys from the messages assigned to this batch
-   */
-  List<Long> getMessageKeys();
-}
+public interface MessageBatchRecordValue extends RecordValue {}

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -105,7 +105,6 @@ import io.camunda.zeebe.protocol.record.value.JobKind;
 import io.camunda.zeebe.protocol.record.value.JobMetricsBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.MappingRuleRecordValue;
-import io.camunda.zeebe.protocol.record.value.MessageBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageCorrelationRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageStartEventSubscriptionRecordValue;
@@ -741,17 +740,7 @@ public class CompactRecordLogger {
   }
 
   private String summarizeMessageBatch(final Record<?> record) {
-    final var value = (MessageBatchRecordValue) record.getValue();
-
-    final var result =
-        new StringBuilder()
-            .append("\"")
-            .append("messageKeys:")
-            .append("\" ")
-            .append(value.getMessageKeys())
-            .append("\"");
-
-    return result.toString();
+    return "message batch";
   }
 
   private String summarizeMessageStartEventSubscription(final Record<?> record) {

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/MessageBatchRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/MessageBatchRecordStream.java
@@ -23,8 +23,4 @@ public final class MessageBatchRecordStream
       final Stream<Record<MessageBatchRecordValue>> wrappedStream) {
     return new MessageBatchRecordStream(wrappedStream);
   }
-
-  public MessageBatchRecordStream hasMessageKey(final long messageKey) {
-    return valueFilter(v -> v.getMessageKeys().contains(messageKey));
-  }
 }


### PR DESCRIPTION
The scheduled command cache was configured with `MessageIntent.EXPIRE` but message expiry uses `MessageBatchIntent.EXPIRE`, making the cache completely ineffective.

Rather than just swapping the intent, this reworks the mechanism: the scheduler becomes a simple trigger that writes an empty `MessageBatchIntent.EXPIRE` command, and the processor queries messages that are expired (according to the current actor clock), expires up to `batchLimit` (now defaults to 100) messages, and writes a follow-up `MessageBatchIntent.EXPIRE` command if more remain, allowing batch processing to kick in.

The scheduled command cache now ensures that there's at most one scheduled `MessageBatchIntent.EXPIRE` command in the processing queue. Follow-up commands from previous runs might still be in flight.

closes #15574
