### PR TITLE
deps: update zeebe and identity versions

### DIFF
--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -14,8 +14,8 @@
     <camunda.maven.artifacts.version>7.22.0</camunda.maven.artifacts.version>
 
     <!-- We use this version to compile but run IT against containers with zeebe.docker.version -->
-    <zeebe.version>8.7.24</zeebe.version>
-    <identity.version>8.7.16</identity.version>
+    <zeebe.version>8.7.26</zeebe.version>
+    <identity.version>8.7.17</identity.version>
     <!-- We use this for the Zeebe test container version only -->
     <zeebe.docker.version>${zeebe.version}</zeebe.docker.version>
 


### PR DESCRIPTION
## Description

Zeebe updated to `8.7.26`
Identity `8.7.17`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
