### PR TITLE
refactor: move rdbms typehandlers to singular package

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/typehandler/EmptyStringSetTypeHandler.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/typehandler/EmptyStringSetTypeHandler.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.db.rdbms.typehandler;
+package io.camunda.db.rdbms.sql.typehandler;
 
 import java.sql.CallableStatement;
 import java.sql.PreparedStatement;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/typehandler/MapByteArrayJsonTypeHandler.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/typehandler/MapByteArrayJsonTypeHandler.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.db.rdbms.typehandler;
+package io.camunda.db.rdbms.sql.typehandler;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/typehandler/NullToEmptyStringTypeHandler.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/typehandler/NullToEmptyStringTypeHandler.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.db.rdbms.typehandler;
+package io.camunda.db.rdbms.sql.typehandler;
 
 import static io.camunda.db.rdbms.read.NullSafeStrings.nullToEmpty;
 

--- a/db/rdbms/src/main/resources/mapper/ClusterVariableMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ClusterVariableMapper.xml
@@ -14,9 +14,9 @@
     <constructor>
       <idArg column="CLUSTER_VARIABLE_ID" javaType="java.lang.String"/>
       <arg column="VAR_NAME" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="VAR_VALUE" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="VAR_FULL_VALUE" javaType="java.lang.String"/>
       <arg column="IS_PREVIEW" javaType="boolean"/>
       <arg column="SCOPE" javaType="io.camunda.search.entities.ClusterVariableScope"/>

--- a/db/rdbms/src/main/resources/mapper/DecisionDefinitionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/DecisionDefinitionMapper.xml
@@ -126,18 +126,18 @@
     <constructor>
       <idArg column="DECISION_DEFINITION_KEY" javaType="java.lang.Long"/>
       <arg column="DECISION_DEFINITION_ID" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="NAME" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="VERSION" javaType="java.lang.Integer"/>
       <arg column="DECISION_REQUIREMENTS_ID" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="DECISION_REQUIREMENTS_KEY" javaType="java.lang.Long"/>
       <arg column="DECISION_REQUIREMENTS_NAME" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="DECISION_REQUIREMENTS_VERSION" javaType="java.lang.Integer"/>
       <arg column="TENANT_ID" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
     </constructor>
   </resultMap>
 

--- a/db/rdbms/src/main/resources/mapper/DecisionInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/DecisionInstanceMapper.xml
@@ -205,18 +205,18 @@
       <arg column="ROOT_PROCESS_INSTANCE_KEY" javaType="java.lang.Long"/>
       <arg column="FLOW_NODE_INSTANCE_KEY" javaType="java.lang.Long"/>
       <arg column="TENANT_ID" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="DECISION_DEFINITION_ID" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="DECISION_DEFINITION_KEY" javaType="java.lang.Long"/>
       <arg column="DECISION_DEFINITION_NAME" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="DECISION_DEFINITION_VERSION" javaType="java.lang.Integer"/>
       <arg column="TYPE"
         javaType="io.camunda.search.entities.DecisionInstanceEntity$DecisionDefinitionType"/>
       <arg column="ROOT_DECISION_DEFINITION_KEY" javaType="java.lang.Long"/>
       <arg column="RESULT" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
       <!-- The list is loaded separately (optional). But we still need a value (NULL) here.
        we use the ObjectTypeHandler because no other typeHandler can map NULL to List -->
       <arg column="EVALUATED_INPUTS" javaType="java.util.List"

--- a/db/rdbms/src/main/resources/mapper/DecisionRequirementsMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/DecisionRequirementsMapper.xml
@@ -99,15 +99,15 @@
     <constructor>
       <idArg column="DECISION_REQUIREMENTS_KEY" javaType="java.lang.Long"/>
       <arg column="DECISION_REQUIREMENTS_ID" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="NAME" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="VERSION" javaType="java.lang.Integer"/>
       <arg column="RESOURCE_NAME" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="XML" javaType="java.lang.String"/>
       <arg column="TENANT_ID" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
     </constructor>
   </resultMap>
 

--- a/db/rdbms/src/main/resources/mapper/FormMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/FormMapper.xml
@@ -16,11 +16,11 @@
     <constructor>
       <idArg column="FORM_KEY" javaType="java.lang.Long"/>
       <arg column="TENANT_ID" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="FORM_ID" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="SCHEMA_XML" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="VERSION" javaType="java.lang.Long"/>
     </constructor>
   </resultMap>

--- a/db/rdbms/src/main/resources/mapper/IncidentMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/IncidentMapper.xml
@@ -161,20 +161,20 @@
       <idArg column="INCIDENT_KEY" javaType="java.lang.Long"/>
       <arg column="PROCESS_DEFINITION_KEY" javaType="java.lang.Long"/>
       <arg column="PROCESS_DEFINITION_ID" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="PROCESS_INSTANCE_KEY" javaType="java.lang.Long"/>
       <arg column="ROOT_PROCESS_INSTANCE_KEY" javaType="java.lang.Long"/>
       <arg column="ERROR_TYPE" javaType="io.camunda.search.entities.IncidentEntity$ErrorType"/>
       <arg column="ERROR_MESSAGE" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="FLOW_NODE_ID" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="FLOW_NODE_INSTANCE_KEY" javaType="java.lang.Long"/>
       <arg column="CREATION_DATE" javaType="java.time.OffsetDateTime" />
       <arg column="STATE" javaType="io.camunda.search.entities.IncidentEntity$IncidentState"/>
       <arg column="JOB_KEY" javaType="java.lang.Long"/>
       <arg column="TENANT_ID" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
     </constructor>
 
   </resultMap>

--- a/db/rdbms/src/main/resources/mapper/MappingRuleMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/MappingRuleMapper.xml
@@ -15,14 +15,14 @@
   <resultMap id="searchResultMap" type="io.camunda.search.entities.MappingRuleEntity">
     <constructor>
       <idArg column="MAPPING_RULE_ID" javaType="string"
-        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="MAPPING_RULE_KEY" javaType="long"/>
       <arg column="CLAIM_NAME" javaType="string"
-        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="CLAIM_VALUE" javaType="string"
-        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="NAME" javaType="string"
-        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
     </constructor>
   </resultMap>
 

--- a/db/rdbms/src/main/resources/mapper/PersistentWebSessionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/PersistentWebSessionMapper.xml
@@ -27,7 +27,7 @@
                     CAST(#{creationTime} AS BIGINT)                        AS CREATION_TIME,
                     CAST(#{lastAccessedTime} AS BIGINT)                    AS LAST_ACCESSED_TIME,
                     CAST(#{maxInactiveIntervalInSeconds} AS BIGINT)        AS MAX_INACTIVE_INTERVAL_IN_SECONDS,
-                    CAST(#{attributes, typeHandler=io.camunda.db.rdbms.typehandler.MapByteArrayJsonTypeHandler} AS BINARY LARGE OBJECT) AS ATTRIBUTES
+                    CAST(#{attributes, typeHandler=io.camunda.db.rdbms.sql.typehandler.MapByteArrayJsonTypeHandler} AS BINARY LARGE OBJECT) AS ATTRIBUTES
       ) source
       ON (target.SESSION_ID = source.SESSION_ID)
       WHEN MATCHED THEN
@@ -50,30 +50,30 @@
   </insert>
   <insert id="upsert" parameterType="io.camunda.search.entities.PersistentWebSessionEntity" databaseId="postgresql">
       INSERT INTO ${prefix}WEB_SESSION (SESSION_ID, CREATION_TIME, LAST_ACCESSED_TIME, MAX_INACTIVE_INTERVAL_IN_SECONDS, ATTRIBUTES)
-      VALUES (#{id}, #{creationTime}, #{lastAccessedTime}, #{maxInactiveIntervalInSeconds}, #{attributes, typeHandler=io.camunda.db.rdbms.typehandler.MapByteArrayJsonTypeHandler})
+      VALUES (#{id}, #{creationTime}, #{lastAccessedTime}, #{maxInactiveIntervalInSeconds}, #{attributes, typeHandler=io.camunda.db.rdbms.sql.typehandler.MapByteArrayJsonTypeHandler})
       ON CONFLICT (SESSION_ID) DO UPDATE SET
         CREATION_TIME = #{creationTime},
         LAST_ACCESSED_TIME = #{lastAccessedTime},
         MAX_INACTIVE_INTERVAL_IN_SECONDS = #{maxInactiveIntervalInSeconds},
-        ATTRIBUTES = #{attributes, typeHandler=io.camunda.db.rdbms.typehandler.MapByteArrayJsonTypeHandler}
+        ATTRIBUTES = #{attributes, typeHandler=io.camunda.db.rdbms.sql.typehandler.MapByteArrayJsonTypeHandler}
   </insert>
   <insert id="upsert" parameterType="io.camunda.search.entities.PersistentWebSessionEntity" databaseId="mysql">
       INSERT INTO ${prefix}WEB_SESSION (SESSION_ID, CREATION_TIME, LAST_ACCESSED_TIME, MAX_INACTIVE_INTERVAL_IN_SECONDS, ATTRIBUTES)
-      VALUES (#{id}, #{creationTime}, #{lastAccessedTime}, #{maxInactiveIntervalInSeconds}, #{attributes, typeHandler=io.camunda.db.rdbms.typehandler.MapByteArrayJsonTypeHandler})
+      VALUES (#{id}, #{creationTime}, #{lastAccessedTime}, #{maxInactiveIntervalInSeconds}, #{attributes, typeHandler=io.camunda.db.rdbms.sql.typehandler.MapByteArrayJsonTypeHandler})
       ON DUPLICATE KEY UPDATE
         CREATION_TIME = #{creationTime},
         LAST_ACCESSED_TIME = #{lastAccessedTime},
         MAX_INACTIVE_INTERVAL_IN_SECONDS = #{maxInactiveIntervalInSeconds},
-        ATTRIBUTES = #{attributes, typeHandler=io.camunda.db.rdbms.typehandler.MapByteArrayJsonTypeHandler}
+        ATTRIBUTES = #{attributes, typeHandler=io.camunda.db.rdbms.sql.typehandler.MapByteArrayJsonTypeHandler}
   </insert>
   <insert id="upsert" parameterType="io.camunda.search.entities.PersistentWebSessionEntity" databaseId="mariadb">
     INSERT INTO ${prefix}WEB_SESSION (SESSION_ID, CREATION_TIME, LAST_ACCESSED_TIME, MAX_INACTIVE_INTERVAL_IN_SECONDS, ATTRIBUTES)
-    VALUES (#{id}, #{creationTime}, #{lastAccessedTime}, #{maxInactiveIntervalInSeconds}, #{attributes, typeHandler=io.camunda.db.rdbms.typehandler.MapByteArrayJsonTypeHandler})
+    VALUES (#{id}, #{creationTime}, #{lastAccessedTime}, #{maxInactiveIntervalInSeconds}, #{attributes, typeHandler=io.camunda.db.rdbms.sql.typehandler.MapByteArrayJsonTypeHandler})
     ON DUPLICATE KEY UPDATE
       CREATION_TIME = #{creationTime},
       LAST_ACCESSED_TIME = #{lastAccessedTime},
       MAX_INACTIVE_INTERVAL_IN_SECONDS = #{maxInactiveIntervalInSeconds},
-      ATTRIBUTES = #{attributes, typeHandler=io.camunda.db.rdbms.typehandler.MapByteArrayJsonTypeHandler}
+      ATTRIBUTES = #{attributes, typeHandler=io.camunda.db.rdbms.sql.typehandler.MapByteArrayJsonTypeHandler}
   </insert>
   <insert id="upsert" parameterType="io.camunda.search.entities.PersistentWebSessionEntity" databaseId="mssql">
     MERGE INTO ${prefix}WEB_SESSION AS target
@@ -84,10 +84,10 @@
         CREATION_TIME = #{creationTime},
         LAST_ACCESSED_TIME = #{lastAccessedTime},
         MAX_INACTIVE_INTERVAL_IN_SECONDS = #{maxInactiveIntervalInSeconds},
-        ATTRIBUTES = #{attributes, typeHandler=io.camunda.db.rdbms.typehandler.MapByteArrayJsonTypeHandler}
+        ATTRIBUTES = #{attributes, typeHandler=io.camunda.db.rdbms.sql.typehandler.MapByteArrayJsonTypeHandler}
     WHEN NOT MATCHED THEN
       INSERT (SESSION_ID, CREATION_TIME, LAST_ACCESSED_TIME, MAX_INACTIVE_INTERVAL_IN_SECONDS, ATTRIBUTES)
-      VALUES (#{id}, #{creationTime}, #{lastAccessedTime}, #{maxInactiveIntervalInSeconds}, #{attributes, typeHandler=io.camunda.db.rdbms.typehandler.MapByteArrayJsonTypeHandler});
+      VALUES (#{id}, #{creationTime}, #{lastAccessedTime}, #{maxInactiveIntervalInSeconds}, #{attributes, typeHandler=io.camunda.db.rdbms.sql.typehandler.MapByteArrayJsonTypeHandler});
   </insert>
   <insert id="upsert" parameterType="io.camunda.search.entities.PersistentWebSessionEntity" databaseId="oracle">
     MERGE INTO ${prefix}WEB_SESSION target
@@ -95,7 +95,7 @@
                     #{creationTime}              AS CREATION_TIME,
                     #{lastAccessedTime}          AS LAST_ACCESSED_TIME,
                     #{maxInactiveIntervalInSeconds} AS MAX_INACTIVE_INTERVAL_IN_SECONDS,
-                    #{attributes, typeHandler=io.camunda.db.rdbms.typehandler.MapByteArrayJsonTypeHandler} AS ATTRIBUTES
+                    #{attributes, typeHandler=io.camunda.db.rdbms.sql.typehandler.MapByteArrayJsonTypeHandler} AS ATTRIBUTES
              FROM dual) source
       ON (target.SESSION_ID = source.SESSION_ID)
       WHEN MATCHED THEN
@@ -128,7 +128,7 @@
       <arg column="CREATION_TIME" javaType="java.lang.Long"/>
       <arg column="LAST_ACCESSED_TIME" javaType="java.lang.Long"/>
       <arg column="MAX_INACTIVE_INTERVAL_IN_SECONDS" javaType="java.lang.Long"/>
-      <arg column="ATTRIBUTES" javaType="java.util.Map" typeHandler="io.camunda.db.rdbms.typehandler.MapByteArrayJsonTypeHandler"/>
+      <arg column="ATTRIBUTES" javaType="java.util.Map" typeHandler="io.camunda.db.rdbms.sql.typehandler.MapByteArrayJsonTypeHandler"/>
     </constructor>
   </resultMap>
 

--- a/db/rdbms/src/main/resources/mapper/ProcessDefinitionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessDefinitionMapper.xml
@@ -131,14 +131,14 @@
       <idArg column="PROCESS_DEFINITION_KEY" javaType="java.lang.Long"/>
       <arg column="NAME" javaType="java.lang.String"/>
       <arg column="PROCESS_DEFINITION_ID" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="BPMN_XML" javaType="java.lang.String"/>
       <arg column="RESOURCE_NAME" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="VERSION" javaType="java.lang.Integer"/>
       <arg column="VERSION_TAG" javaType="java.lang.String"/>
       <arg column="TENANT_ID" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="FORM_ID" javaType="java.lang.String"/>
     </constructor>
   </resultMap>

--- a/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
@@ -365,7 +365,7 @@
       <idArg column="PROCESS_INSTANCE_KEY" javaType="java.lang.Long"/>
       <arg column="ROOT_PROCESS_INSTANCE_KEY" javaType="java.lang.Long"/>
       <arg column="PROCESS_DEFINITION_ID" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="PROCESS_DEFINITION_NAME" javaType="java.lang.String"/>
       <arg column="PROCESS_DEFINITION_VERSION" javaType="java.lang.Integer"/>
       <arg column="PROCESS_DEFINITION_VERSION_TAG" javaType="java.lang.String"/>
@@ -377,7 +377,7 @@
       <arg column="STATE" javaType="io.camunda.search.entities.ProcessInstanceEntity$ProcessInstanceState"/>
       <arg column="HAS_INCIDENT" javaType="java.lang.Boolean"/>
       <arg column="TENANT_ID" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="TREE_PATH" javaType="java.lang.String"/>
       <arg column="BUSINESS_ID" javaType="java.lang.String"/>
     </constructor>

--- a/db/rdbms/src/main/resources/mapper/UserMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/UserMapper.xml
@@ -90,7 +90,7 @@
     <constructor>
       <idArg column="USER_KEY" javaType="java.lang.Long"/>
       <arg column="USERNAME" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="NAME" javaType="java.lang.String"/>
       <arg column="EMAIL" javaType="java.lang.String"/>
       <arg column="PASSWORD" javaType="java.lang.String"/>

--- a/db/rdbms/src/main/resources/mapper/VariableMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/VariableMapper.xml
@@ -130,18 +130,18 @@
     <constructor>
       <idArg column="VAR_KEY" javaType="java.lang.Long"/>
       <arg column="VAR_NAME" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="VAR_VALUE" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="VAR_FULL_VALUE" javaType="java.lang.String"/>
       <arg column="IS_PREVIEW" javaType="java.lang.Boolean"/>
       <arg column="SCOPE_KEY" javaType="java.lang.Long"/>
       <arg column="PROCESS_INSTANCE_KEY" javaType="java.lang.Long"/>
       <arg column="ROOT_PROCESS_INSTANCE_KEY" javaType="java.lang.Long"/>
       <arg column="PROCESS_DEFINITION_ID" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
       <arg column="TENANT_ID" javaType="java.lang.String"
-        typeHandler="io.camunda.db.rdbms.typehandler.NullToEmptyStringTypeHandler"/>
+        typeHandler="io.camunda.db.rdbms.sql.typehandler.NullToEmptyStringTypeHandler"/>
     </constructor>
   </resultMap>
 

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/sql/typehandler/MapByteArrayJsonTypeHandlerTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/sql/typehandler/MapByteArrayJsonTypeHandlerTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.db.rdbms.typehandler;
+package io.camunda.db.rdbms.sql.typehandler;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/sql/typehandler/NullToEmptyStringTypeHandlerTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/sql/typehandler/NullToEmptyStringTypeHandlerTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.db.rdbms.typehandler;
+package io.camunda.db.rdbms.sql.typehandler;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;


### PR DESCRIPTION
## Description

Moves all RDBMS MyBatis typehandlers to `io.camunda.db.rdbms.sql.typehandler`

## Related issues

closes #50355 
