### PR TITLE
feat: migrate SLACK_WEBHOOK_URL to Vault in Zeebe CI workflows

### DIFF
--- a/.github/workflows/critical-issue.yml
+++ b/.github/workflows/critical-issue.yml
@@ -16,11 +16,22 @@ jobs:
         !contains(join(github.event.issue.labels.*.name, ', '), 'component/')
       )
     steps:
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@79632e33d6953d190b940ffa440bf97821cabd80
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_ZEEBOT_ZEEBE_CI_WEBHOOK_URL;
       - id: slack-notify
         name: Send slack notification
         uses: slackapi/slack-github-action@v3.0.1
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook: ${{ steps.secrets.outputs.SLACK_ZEEBOT_ZEEBE_CI_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           # For posting a rich message using Block Kit
           payload: |

--- a/.github/workflows/zeebe-qa-testbench.yaml
+++ b/.github/workflows/zeebe-qa-testbench.yaml
@@ -69,10 +69,21 @@ jobs:
     if: failure()
     steps:
       - uses: actions/checkout@v6
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@79632e33d6953d190b940ffa440bf97821cabd80
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_ZEEBOT_ZEEBE_CI_WEBHOOK_URL;
       - id: slack-notify
         uses: slackapi/slack-github-action@v3.0.1
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook: ${{ steps.secrets.outputs.SLACK_ZEEBOT_ZEEBE_CI_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
             {

--- a/.github/workflows/zeebe-version-compatibility.yml
+++ b/.github/workflows/zeebe-version-compatibility.yml
@@ -155,10 +155,21 @@ jobs:
     if: failure()
     steps:
       - uses: actions/checkout@v6
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@79632e33d6953d190b940ffa440bf97821cabd80
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_ZEEBOT_ZEEBE_CI_WEBHOOK_URL;
       - id: slack-notify
         uses: slackapi/slack-github-action@v3.0.1
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook: ${{ steps.secrets.outputs.SLACK_ZEEBOT_ZEEBE_CI_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           # For posting a rich message using Block Kit
           payload: |


### PR DESCRIPTION
## Summary

Migrates the `SLACK_WEBHOOK_URL` repository secret to HashiCorp Vault in three Zeebe CI workflows. The secret is stored in Vault as `SLACK_ZEEBOT_ZEEBE_CI_WEBHOOK_URL` and fetched at runtime using `hashicorp/vault-action`.

## Changes

**`.github/workflows/critical-issue.yml`**:
- Added `Import Secrets` step to fetch `SLACK_ZEEBOT_ZEEBE_CI_WEBHOOK_URL` from Vault before the Slack notification step
- Updated `webhook:` to use `steps.secrets.outputs.SLACK_ZEEBOT_ZEEBE_CI_WEBHOOK_URL`

**`.github/workflows/zeebe-qa-testbench.yaml`**:
- Added `Import Secrets` step in the `notify` job to fetch `SLACK_ZEEBOT_ZEEBE_CI_WEBHOOK_URL` from Vault
- Updated `webhook:` to use `steps.secrets.outputs.SLACK_ZEEBOT_ZEEBE_CI_WEBHOOK_URL`

**`.github/workflows/zeebe-version-compatibility.yml`**:
- Added `Import Secrets` step in the `notify` job to fetch `SLACK_ZEEBOT_ZEEBE_CI_WEBHOOK_URL` from Vault
- Updated `webhook:` to use `steps.secrets.outputs.SLACK_ZEEBOT_ZEEBE_CI_WEBHOOK_URL`

**Vault path:** `secret/data/products/camunda/ci/github-actions`
**Vault key:** `SLACK_ZEEBOT_ZEEBE_CI_WEBHOOK_URL`

> **Note:** The `SLACK_WEBHOOK_URL` repository secret can be deleted once this PR is merged and verified.


## Secret tested on cli
<img width="1626" height="51" alt="image" src="https://github.com/user-attachments/assets/36ee0f9d-b82e-4f05-933b-3daf7e685367" />


## Related
https://github.com/camunda/camunda/issues/50242
Part of #18211 (migrate repository secrets to Vault)
