### PR TITLE
feat: remove Zeebe Process Tests (ZPT) from monorepo

### DIFF
--- a/docs/zeebe/developer_handbook.md
+++ b/docs/zeebe/developer_handbook.md
@@ -21,7 +21,7 @@ Generally, you'll need to do the following things:
 2. [Implement this `RecordValue` in the `protocol-impl` module](#implement-a-new-recordvalue-in-protocol-impl).
 3. Support this `RecordValue` in [Exporters and test setups](#support-a-recordvalue-in-exporters-and-test-setups).
 4. [Extend the official exporter documentation](#extend-official-documentation).
-5. [Support the new `ValueType` in Zeebe Process Test (ZPT)](#extend-zeebe-process-test).
+5. [Support the new `ValueType` in Camunda Process Test (CPT)](#extend-camunda-process-test).
 6. [Ensure that the new `ValueType` is processed](#add-valuetype-to-supported-types).
 7. Add support for it to the [CompactRecordLogger](/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java).
 
@@ -98,9 +98,9 @@ Our Exporter configurations are documented in the [official docs](https://github
 In the previous steps we've extended the configuration of the Elasticsearch and OpenSearch exporters.
 These configurations options need to be added to the official documentation.
 
-### Extend Zeebe Process Test
+### Extend Camunda Process Test
 
-The [Zeebe Process Test (ZPT)](https://github.com/camunda/camunda-process-test/) library allows you to unit test your Camunda Platform 8 BPMN processes.
+The [Camunda Process Test (CPT)](https://github.com/camunda/camunda-process-test/) library allows you to unit test your Camunda Platform 8 BPMN processes.
 The [RecordStreamLogger](https://github.com/camunda/camunda-process-test/blob/main/filters/src/main/java/io/camunda/zeebe/process/test/filters/logger/RecordStreamLogger.java) class
 defines how the supported `ValueType`'s records are logged in tests.
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -139,7 +139,6 @@
     <version.jnr-ffi>2.2.18</version.jnr-ffi>
     <version.jnr-posix>3.1.21</version.jnr-posix>
     <version.jnr-constants>0.10.4</version.jnr-constants>
-    <version.zpt>8.8.20</version.zpt>
     <version.feign>13.11</version.feign>
     <version.google-sdk>26.79.0</version.google-sdk>
     <version.azure-sdk>1.3.3</version.azure-sdk>
@@ -1011,20 +1010,6 @@
         <groupId>io.camunda</groupId>
         <artifactId>camunda-process-test-json-test-cases</artifactId>
         <version>${project.version}</version>
-      </dependency>
-
-      <!-- sibling projects -->
-
-      <dependency>
-        <groupId>io.camunda</groupId>
-        <artifactId>zeebe-process-test-assertions</artifactId>
-        <version>${version.zpt}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.camunda</groupId>
-        <artifactId>zeebe-process-test-filters</artifactId>
-        <version>${version.zpt}</version>
       </dependency>
 
       <!-- Third party dependencies -->


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Removes ZPT dependencies from the monorepo as part of the V1 API removal.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #49652
