### PR TITLE
[Backport stable/8.9] feat: migrate SLACK_CAMUNDA_EX_CI_WEBHOOK from repo secret to Vault

### DIFF
--- a/.github/workflows/camunda-client-compatibility-test.yml
+++ b/.github/workflows/camunda-client-compatibility-test.yml
@@ -447,13 +447,22 @@ jobs:
     permissions: {}
     steps:
       - uses: actions/checkout@v6
-      - name: Notify failure
-        uses: slackapi/slack-github-action@v2.1.1
-        if: env.SLACK_CAMUNDA_EX_CI_WEBHOOK != ''
-        env:
-          SLACK_CAMUNDA_EX_CI_WEBHOOK: ${{ secrets.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@79632e33d6953d190b940ffa440bf97821cabd80
         with:
-          webhook: ${{ secrets.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_CAMUNDA_EX_CI_WEBHOOK;
+      - name: Notify failure
+        uses: slackapi/slack-github-action@v3.0.1
+        if: steps.secrets.outputs.SLACK_CAMUNDA_EX_CI_WEBHOOK != ''
+        with:
+          webhook: ${{ steps.secrets.outputs.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
           webhook-type: incoming-webhook
           payload: |
            {

--- a/.github/workflows/camunda-process-test-compatibility.yml
+++ b/.github/workflows/camunda-process-test-compatibility.yml
@@ -571,13 +571,22 @@ jobs:
     permissions: {}
     steps:
       - uses: actions/checkout@v6
-      - name: Notify failure
-        uses: slackapi/slack-github-action@v2.1.1
-        if: env.SLACK_CAMUNDA_EX_CI_WEBHOOK != ''
-        env:
-          SLACK_CAMUNDA_EX_CI_WEBHOOK: ${{ secrets.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@79632e33d6953d190b940ffa440bf97821cabd80
         with:
-          webhook: ${{ secrets.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_CAMUNDA_EX_CI_WEBHOOK;
+      - name: Notify failure
+        uses: slackapi/slack-github-action@v3.0.1
+        if: steps.secrets.outputs.SLACK_CAMUNDA_EX_CI_WEBHOOK != ''
+        with:
+          webhook: ${{ steps.secrets.outputs.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
           webhook-type: incoming-webhook
           payload: |
            {

--- a/.github/workflows/camunda-spring-boot-starter-compatibility-test.yml
+++ b/.github/workflows/camunda-spring-boot-starter-compatibility-test.yml
@@ -444,13 +444,22 @@ jobs:
     permissions: {}
     steps:
       - uses: actions/checkout@v6
-      - name: Notify failure
-        uses: slackapi/slack-github-action@v2.1.1
-        if: env.SLACK_CAMUNDA_EX_CI_WEBHOOK != ''
-        env:
-          SLACK_CAMUNDA_EX_CI_WEBHOOK: ${{ secrets.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@79632e33d6953d190b940ffa440bf97821cabd80
         with:
-          webhook: ${{ secrets.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_CAMUNDA_EX_CI_WEBHOOK;
+      - name: Notify failure
+        uses: slackapi/slack-github-action@v3.0.1
+        if: steps.secrets.outputs.SLACK_CAMUNDA_EX_CI_WEBHOOK != ''
+        with:
+          webhook: ${{ steps.secrets.outputs.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
           webhook-type: incoming-webhook
           payload: |
            {

--- a/.github/workflows/camunda8-getting-started-bundle.yaml
+++ b/.github/workflows/camunda8-getting-started-bundle.yaml
@@ -884,7 +884,20 @@ jobs:
     if: always() && (needs.build-bundle.result == 'failure' || needs.test-bundle.result == 'failure' || needs.upload-to-release.result == 'failure')
     permissions: {}
     steps:
+      - uses: actions/checkout@v6
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@79632e33d6953d190b940ffa440bf97821cabd80
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_CAMUNDA_EX_CI_WEBHOOK;
       - name: Send failure notification to Slack
+        if: steps.secrets.outputs.SLACK_CAMUNDA_EX_CI_WEBHOOK != ''
         run: |
           WORKFLOW_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           BLOCKS=$(cat <<EOF
@@ -902,7 +915,7 @@ jobs:
           
           PAYLOAD=$(jq -n --argjson blocks "$BLOCKS" '{blocks: $blocks}')
           
-          curl -X POST "${{ secrets.SLACK_CAMUNDA_EX_CI_WEBHOOK }}" \
+          curl -X POST "${{ steps.secrets.outputs.SLACK_CAMUNDA_EX_CI_WEBHOOK }}" \
             -H "Content-Type: application/json" \
             -d "$PAYLOAD"
 


### PR DESCRIPTION
# Description
Backport of #50257 to `stable/8.9`.

relates to camunda/camunda#50234 camunda/camunda#18211