### PR TITLE
refactor: remove element state and element placeholder types

### DIFF
--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/index.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/index.tsx
@@ -72,13 +72,13 @@ function convertToVirtualElementInstance(params: {
 
   return elementInstancePlaceholders.map((elementInstancePlaceholder) => {
     const businessObject =
-      businessObjects[elementInstancePlaceholder.flowNodeId];
+      businessObjects[elementInstancePlaceholder.elementId];
     return {
       isVirtual: true,
-      elementId: elementInstancePlaceholder.flowNodeId,
+      elementId: elementInstancePlaceholder.elementId,
       elementName: businessObject?.name,
       type: businessObject?.$type,
-      elementInstanceKey: elementInstancePlaceholder.id,
+      elementInstanceKey: elementInstancePlaceholder.elementInstanceKey,
     };
   });
 }

--- a/operate/client/src/modules/bpmn-js/overlayTypes.ts
+++ b/operate/client/src/modules/bpmn-js/overlayTypes.ts
@@ -7,7 +7,9 @@
  */
 
 import type {OverlayPosition} from 'bpmn-js/lib/NavigatedViewer';
-type ElementState = 'active' | 'incidents' | 'canceled' | 'completed';
+import type {ProcessDefinitionStatistic} from '@camunda/camunda-api-zod-schemas/8.10';
+
+type ElementState = keyof Omit<ProcessDefinitionStatistic, 'elementId'>;
 
 type OverlayData = {
   payload?: unknown;

--- a/operate/client/src/modules/stores/instanceHistoryModification.ts
+++ b/operate/client/src/modules/stores/instanceHistoryModification.ts
@@ -7,19 +7,14 @@
  */
 
 import {makeAutoObservable} from 'mobx';
-import type {ProcessInstanceState} from '@camunda/camunda-api-zod-schemas/8.10';
+import type {ElementInstance} from '@camunda/camunda-api-zod-schemas/8.10';
 import type {ElementModification} from './modifications';
 
-type ElementInstancePlaceholder = {
-  id: string;
-  type: string;
-  state?: ProcessInstanceState;
-  flowNodeId: string;
-  startDate: string;
-  endDate: null | string;
-  treePath: string;
-  sortValues: [string, string] | [];
-  isPlaceholder?: boolean;
+type ElementInstancePlaceholder = Pick<
+  ElementInstance,
+  'elementId' | 'elementInstanceKey'
+> & {
+  isPlaceholder: true;
 };
 
 type ModificationPlaceholder = {
@@ -44,12 +39,14 @@ class InstanceHistoryModification {
     makeAutoObservable(this);
   }
 
-  addExpandedElementInstanceIds = (id: ElementInstancePlaceholder['id']) => {
+  addExpandedElementInstanceIds = (
+    id: ElementInstancePlaceholder['elementInstanceKey'],
+  ) => {
     this.state.expandedElementInstanceIds.push(id);
   };
 
   removeFromExpandedElementInstanceIds = (
-    id: ElementInstancePlaceholder['id'],
+    id: ElementInstancePlaceholder['elementInstanceKey'],
   ) => {
     this.state.expandedElementInstanceIds =
       this.state.expandedElementInstanceIds.filter(

--- a/operate/client/src/modules/utils/instanceHistoryModification.test.ts
+++ b/operate/client/src/modules/utils/instanceHistoryModification.test.ts
@@ -42,11 +42,14 @@ const businessObjects: BusinessObjects = {
   },
 };
 
+const startEventScopeId = generateUniqueID();
+const endEvent1ScopeIds = [generateUniqueID(), generateUniqueID()];
+
 const startEventModification: ElementModification = {
   type: 'token',
   payload: {
     operation: 'ADD_TOKEN',
-    scopeId: generateUniqueID(),
+    scopeId: startEventScopeId,
     element: {id: 'startEvent_1', name: 'Start Event 1'},
     affectedTokenCount: 1,
     visibleAffectedTokenCount: 1,
@@ -62,7 +65,7 @@ const endEvent1Modification: ElementModification = {
     element: {id: 'startEvent_1', name: 'Start Event 1'},
     affectedTokenCount: 2,
     visibleAffectedTokenCount: 2,
-    scopeIds: [generateUniqueID(), generateUniqueID()],
+    scopeIds: endEvent1ScopeIds,
     parentScopeIds: {},
   },
 };
@@ -77,6 +80,8 @@ const endEvent2Modification: ElementModification = {
   },
 };
 
+const subprocessScopeIds = [generateUniqueID()];
+
 const subprocessModification: ElementModification = {
   type: 'token',
   payload: {
@@ -85,7 +90,7 @@ const subprocessModification: ElementModification = {
     element: {id: 'subprocess_1', name: 'Sub Process 1'},
     affectedTokenCount: 5,
     visibleAffectedTokenCount: 5,
-    scopeIds: [generateUniqueID()],
+    scopeIds: subprocessScopeIds,
     parentScopeIds: {},
   },
 };
@@ -109,13 +114,8 @@ describe('stores/instanceHistoryModification', () => {
       getVisibleChildPlaceholders('id', 'process_1', businessObjects),
     ).toEqual([
       {
-        flowNodeId: 'startEvent_1',
-        type: 'bpmn:StartEvent',
-        id: expect.any(String),
-        endDate: null,
-        sortValues: [],
-        startDate: '',
-        treePath: '',
+        elementId: 'startEvent_1',
+        elementInstanceKey: startEventScopeId,
         isPlaceholder: true,
       },
     ]);
@@ -124,23 +124,13 @@ describe('stores/instanceHistoryModification', () => {
       getVisibleChildPlaceholders('id', 'subprocess_1', businessObjects),
     ).toEqual([
       {
-        flowNodeId: 'endEvent_1',
-        type: 'bpmn:EndEvent',
-        id: expect.any(String),
-        endDate: null,
-        sortValues: [],
-        startDate: '',
-        treePath: '',
+        elementId: 'endEvent_1',
+        elementInstanceKey: endEvent1ScopeIds[0],
         isPlaceholder: true,
       },
       {
-        flowNodeId: 'endEvent_1',
-        type: 'bpmn:EndEvent',
-        id: expect.any(String),
-        endDate: null,
-        sortValues: [],
-        startDate: '',
-        treePath: '',
+        elementId: 'endEvent_1',
+        elementInstanceKey: endEvent1ScopeIds[1],
         isPlaceholder: true,
       },
     ]);
@@ -159,23 +149,13 @@ describe('stores/instanceHistoryModification', () => {
       getVisibleChildPlaceholders('id', 'subprocess_1', businessObjects),
     ).toEqual([
       {
-        flowNodeId: 'endEvent_1',
-        type: 'bpmn:EndEvent',
-        id: expect.any(String),
-        endDate: null,
-        sortValues: [],
-        startDate: '',
-        treePath: '',
+        elementId: 'endEvent_1',
+        elementInstanceKey: endEvent1ScopeIds[0],
         isPlaceholder: true,
       },
       {
-        flowNodeId: 'endEvent_1',
-        type: 'bpmn:EndEvent',
-        id: expect.any(String),
-        endDate: null,
-        sortValues: [],
-        startDate: '',
-        treePath: '',
+        elementId: 'endEvent_1',
+        elementInstanceKey: endEvent1ScopeIds[1],
         isPlaceholder: true,
       },
     ]);
@@ -188,13 +168,8 @@ describe('stores/instanceHistoryModification', () => {
       getVisibleChildPlaceholders('id', 'process_1', businessObjects),
     ).toEqual([
       {
-        flowNodeId: 'startEvent_1',
-        type: 'bpmn:StartEvent',
-        id: expect.any(String),
-        endDate: null,
-        sortValues: [],
-        startDate: '',
-        treePath: '',
+        elementId: 'startEvent_1',
+        elementInstanceKey: startEventScopeId,
         isPlaceholder: true,
       },
     ]);
@@ -213,13 +188,8 @@ describe('stores/instanceHistoryModification', () => {
       getVisibleChildPlaceholders('id', 'subprocess_1', businessObjects),
     ).toEqual([
       {
-        flowNodeId: 'endEvent_1',
-        type: 'bpmn:EndEvent',
-        id: expect.any(String),
-        endDate: null,
-        sortValues: [],
-        startDate: '',
-        treePath: '',
+        elementId: 'endEvent_1',
+        elementInstanceKey: subprocessScopeIds[0],
         isPlaceholder: true,
       },
     ]);

--- a/operate/client/src/modules/utils/instanceHistoryModification.ts
+++ b/operate/client/src/modules/utils/instanceHistoryModification.ts
@@ -10,7 +10,6 @@ import type {
   BusinessObject,
   BusinessObjects,
 } from 'bpmn-js/lib/NavigatedViewer';
-import {isMultiInstance} from 'modules/bpmn-js/utils/isMultiInstance';
 import {
   instanceHistoryModificationStore,
   type ModificationPlaceholder,
@@ -63,13 +62,8 @@ const generateParentPlaceholders = (
     ),
     {
       elementInstancePlaceholder: {
-        flowNodeId: element.id,
-        id: scopeId,
-        type: 'SUB_PROCESS',
-        startDate: '',
-        endDate: null,
-        sortValues: [],
-        treePath: '',
+        elementId: element.id,
+        elementInstanceKey: scopeId,
         isPlaceholder: true,
       },
       operation: modificationPayload.operation,
@@ -137,13 +131,8 @@ const createModificationPlaceholders = ({
 
   return getScopeIds(modificationPayload).map((scopeId) => ({
     elementInstancePlaceholder: {
-      flowNodeId: element.id,
-      id: scopeId,
-      type: isMultiInstance(element) ? 'MULTI_INSTANCE_BODY' : element.$type,
-      startDate: '',
-      endDate: null,
-      sortValues: [],
-      treePath: '',
+      elementId: element.id,
+      elementInstanceKey: scopeId,
       isPlaceholder: true,
     },
     operation: modificationPayload.operation,


### PR DESCRIPTION
## Description

- `ElementInstancePlaceholder` now derived from `ElementInstance` via `Pick`
> [!NOTE]
> Some reasoning on fields update
> - `treePath`, `sortValues`, `startDate`, `endDate`, `state` were removed because they were always set to empty/null defaults and seem like they were never read anywhere
> - `type` was removed because consumers use `businessObject.$type` instead, and the values like `bpmn:StartEvent` don't match `ElementInstanceType` enum like `START_EVENT`                                                                                              
 > - `isPlaceholder: true` should act as a discriminant since every creatio always sets it to true   


- `ElementState` now derived from `ProcessDefinitionStatistic`
> [!NOTE]
> These values are literally the numeric field names of `ProcessDefinitionStatistic` from the API. The code already uses `ElementState` as keys to index into statistic objects. So extracting them from the schema shpould make them stay in sync


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #50160 
