### PR TITLE
fix: skip cancelled/failed runs when looking up previous cache artifact

### DIFF
--- a/.github/workflows/zeebe-version-compatibility.yml
+++ b/.github/workflows/zeebe-version-compatibility.yml
@@ -40,11 +40,12 @@ jobs:
         id: get-last-run-id
         run: |
           runs=$(gh api /repos/${{ github.repository }}/actions/workflows/zeebe-version-compatibility.yml/runs)
-          last_run_id=$(echo "$runs" | jq 'first(.workflow_runs[] | select(.status=="completed").id)')
+          last_run_id=$(echo "$runs" | jq -r 'first(.workflow_runs[] | select(.status=="completed" and .conclusion=="success").id) // empty')
           echo "last_run_id=$last_run_id" >> "$GITHUB_OUTPUT"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Download previous report
+        if: steps.get-last-run-id.outputs.last_run_id != ''
         uses: actions/download-artifact@v8
         continue-on-error: true
         with:


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

skip cancelled/failed runs when looking up previous cache artifact

## Related issues

related to https://camunda.slack.com/archives/C013MEVQ4M9/p1775129762232329
