### PR TITLE
fix: task search v1 does not work with backwards pagination

### DIFF
--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskStoreElasticSearch.java
@@ -359,7 +359,7 @@ public class TaskStoreElasticSearch implements TaskStore {
                 TaskSearchView.createFrom(
                     hit.source(), hit.sort().stream().map(FieldValue::_get).toArray()))
         .filter(Objects::nonNull)
-        .toList();
+        .collect(Collectors.toCollection(ArrayList::new));
   }
 
   /**

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskStoreOpenSearch.java
@@ -447,7 +447,7 @@ public class TaskStoreOpenSearch implements TaskStore {
             sh ->
                 TaskSearchView.createFrom(
                     sh.source(), sh.sort().stream().map(FieldValue::_get).toArray()))
-        .toList();
+        .collect(Collectors.toCollection(ArrayList::new));
   }
 
   private List<String> getTasksContainsVarNameAndValue(

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskControllerIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskControllerIT.java
@@ -191,6 +191,18 @@ public class TaskControllerIT extends TasklistZeebeIntegrationTest {
         .taskIsCreated(flowNodeBpmnId);
   }
 
+  private List<TaskSearchResponse> executeSearchRequest(final TaskSearchRequest searchRequest)
+      throws Exception {
+    final var result =
+        mockMvcHelper.doRequest(post(TasklistURIs.TASKS_URL_V1.concat("/search")), searchRequest);
+
+    assertThat(result).hasOkHttpStatus().hasApplicationJsonContentType();
+
+    return objectMapper
+        .readerForListOf(TaskSearchResponse.class)
+        .readValue(result.getContentAsString());
+  }
+
   @Nested
   class SearchTaskTests {
     @Test
@@ -221,6 +233,49 @@ public class TaskControllerIT extends TasklistZeebeIntegrationTest {
                 assertThat(task.getTaskState()).isEqualTo(TaskState.CREATED);
                 assertThat(task.getAssignee()).isNull();
               });
+    }
+
+    @Test
+    public void searchTasksWithPagination() throws Exception {
+      // given
+      createTask("Process_1_" + UUID.randomUUID(), "Task_1_" + UUID.randomUUID(), 1);
+      createTask("Process_2_" + UUID.randomUUID(), "Task_2_" + UUID.randomUUID(), 1);
+      createTask("Process_3_" + UUID.randomUUID(), "Task_3_" + UUID.randomUUID(), 1);
+
+      // when
+      final var initialPageResult =
+          executeSearchRequest(new TaskSearchRequest().setState(TaskState.CREATED).setPageSize(2));
+
+      final var nextPagePagination =
+          initialPageResult.get(initialPageResult.size() - 1).getSortValues();
+      final var nextPageResult =
+          executeSearchRequest(
+              new TaskSearchRequest()
+                  .setState(TaskState.CREATED)
+                  .setPageSize(2)
+                  .setSearchAfter(nextPagePagination));
+
+      final var previousPagePagination = nextPageResult.get(0).getSortValues();
+      final var previousPageResult =
+          executeSearchRequest(
+              new TaskSearchRequest()
+                  .setState(TaskState.CREATED)
+                  .setPageSize(2)
+                  .setSearchBefore(previousPagePagination));
+
+      // then
+      assertThat(initialPageResult).hasSize(2);
+      assertThat(nextPageResult).hasSize(1);
+      assertThat(previousPageResult).hasSize(2);
+
+      final var initialPageTaskIds =
+          initialPageResult.stream().map(TaskSearchResponse::getId).toList();
+      final var nextPageTaskIds = nextPageResult.stream().map(TaskSearchResponse::getId).toList();
+      final var previousPageTaskIds =
+          previousPageResult.stream().map(TaskSearchResponse::getId).toList();
+      assertThat(nextPageTaskIds).doesNotContainAnyElementsOf(initialPageTaskIds);
+      assertThat(previousPageTaskIds).doesNotContainAnyElementsOf(nextPageTaskIds);
+      assertThat(previousPageTaskIds).containsExactlyElementsOf(initialPageTaskIds);
     }
 
     @Test

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/dto/TaskQueryDTO.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/dto/TaskQueryDTO.java
@@ -447,7 +447,6 @@ public class TaskQueryDTO {
         .setSearchAfter(searchAfter)
         .setSearchAfterOrEqual(searchAfterOrEqual)
         .setSearchBefore(searchBefore)
-        .setSearchBefore(searchBefore)
         .setSearchBeforeOrEqual(searchBeforeOrEqual)
         .setFollowUpDate(followUpDate)
         .setDueDate(dueDate)


### PR DESCRIPTION
## Description

> [!NOTE]
> **Disclaimer:** These **changes are completely AI generated** with multiple AI self-reviews. I have no experience with the Camunda backend code and can't really judge its quality. I have given it a "review"... The changes itself look reasonable and I can confirm with `curl` that they work. They tests look a bit more questionable... So please feel free to improve them to align with Camunda's best-practices and conventions.

Calling the v1 task search with backwards pagination (`searchBefore`) returns a generic 500 error response. Calling the endpoint with `searchAfter` works fine. It looks like the ES/OS `TaskStore` throw an error in Java 21 because they try to reverse an immutable list. Reversing is done to fulfill `searchBefore` requests in `TaskStore.queryTasks()`. This PR makes the list mutable so reversing them does not fail.

```bash
curl 'http://localhost:8080/v1/tasks/search' \
-H 'Content-Type: application/json' \
-H 'Authorization: Basic ZGVtbzpkZW1v' \
-d '{
    "sort": [
        {
            "field": "creationTime",
            "order": "DESC"
        }
    ],
    "pageSize": 50,
    "searchBefore": [
        "1775119572867",
        "2251799813688785"
    ],
    "state": "CREATED"
}'
```


## Observations for 8.8

The bug reports only 8.9 as effected. I just tried it on 8.8 with **ElasticSearch** and it indeed seems to work.

Looking at the code: 8.8 is quite a bit different with different implementations between ES and OS. Both use Java 21. The ES implementation calls [`Stream.collect(Collectors.toList())`](https://github.com/camunda/camunda/blob/stable/8.8/tasklist/common/src/main/java/io/camunda/tasklist/util/CollectionUtil.java#L91). The OS implementation calls [`Stream.toList()`](https://github.com/camunda/camunda/blob/stable/8.8/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskStoreOpenSearch.java#L448). At least the OS implementation in 8.8 seems to have the problem as well.

- [ ] How should this be best handled? Only adjust the OS implementation in 8.8, or should ES be improved as well?

## Checklist

- [ ] Some frontend changes will be required in a followup PR to fully fix the related bug. Otherwise, pagination no longer works once scrolled back up and a periodic background refetch triggers.
  - Follow-up => https://github.com/camunda/camunda/pull/50482

## Related issues

relates #44583
