### PR TITLE
test: skip flaky date range test

### DIFF
--- a/operate/client/src/modules/components/DateRangeField/index.test.tsx
+++ b/operate/client/src/modules/components/DateRangeField/index.test.tsx
@@ -77,7 +77,8 @@ describe('Date Range Field', () => {
     );
   });
 
-  it('should set default values', async () => {
+  // TODO: un-skip after fixed with https://github.com/camunda/camunda/issues/50378
+  it.skip('should set default values', async () => {
     const {user} = render(<MockDateRangeField />, {
       wrapper: getWrapper({
         startDateAfter: '2021-02-03T12:34:56',

--- a/operate/client/src/modules/components/DateRangeField/index.test.tsx
+++ b/operate/client/src/modules/components/DateRangeField/index.test.tsx
@@ -78,7 +78,7 @@ describe('Date Range Field', () => {
   });
 
   // TODO: un-skip after fixed with https://github.com/camunda/camunda/issues/50378
-  it.skip('should set default values', async () => {
+  it.todo('should set default values', async () => {
     const {user} = render(<MockDateRangeField />, {
       wrapper: getWrapper({
         startDateAfter: '2021-02-03T12:34:56',


### PR DESCRIPTION
## Description

We discovered a flaky Operate FE test, which blocked the stable/8.8 merge queue, see incident: https://camunda.slack.com/archives/C0AQ1BH7WBZ

This PR skips the test. It needs to be fixed with https://github.com/camunda/camunda/issues/50378

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

related to #50378
