### PR TITLE
feat: add FEEL expression evaluation methods to process instance assertions

### DIFF
--- a/testing/camunda-process-test-java/pom.xml
+++ b/testing/camunda-process-test-java/pom.xml
@@ -124,6 +124,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.camunda.feel</groupId>
+      <artifactId>feel-engine</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.camunda.bpm.model</groupId>
       <artifactId>camunda-dmn-model</artifactId>
     </dependency>

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceAssert.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceAssert.java
@@ -555,6 +555,52 @@ public interface ProcessInstanceAssert extends WithAssertionConfiguration<Proces
   ProcessInstanceAssert hasLocalVariables(ElementSelector selector, Map<String, Object> variables);
 
   /**
+   * Verifies that the process instance variables satisfy the given FEEL expression. The expression
+   * is evaluated with all process variables as context and must evaluate to {@code true}.
+   *
+   * <p>The assertion waits until the expression evaluates to {@code true}.
+   *
+   * <p>Example usage:
+   *
+   * <pre>
+   *   assertThat(pi).hasVariablesSatisfyingFeel("riskScore &gt;= 0.5 and riskScore &lt;= 0.75");
+   *   assertThat(pi).hasVariablesSatisfyingFeel("status = \"approved\" and amount &gt; 100");
+   * </pre>
+   *
+   * @param feelExpression the FEEL expression to evaluate (without the leading {@code =} prefix)
+   * @return the assertion object
+   */
+  ProcessInstanceAssert hasVariablesSatisfyingFeel(String feelExpression);
+
+  /**
+   * Verifies that the local variables of the given BPMN element satisfy the given FEEL expression.
+   * The expression is evaluated with all local variables of the element as context and must
+   * evaluate to {@code true}.
+   *
+   * <p>The assertion waits until the expression evaluates to {@code true}.
+   *
+   * @param elementId the BPMN element ID whose local variables are used as context
+   * @param feelExpression the FEEL expression to evaluate (without the leading {@code =} prefix)
+   * @return the assertion object
+   */
+  ProcessInstanceAssert hasLocalVariablesSatisfyingFeel(String elementId, String feelExpression);
+
+  /**
+   * Verifies that the local variables of the BPMN element matching the selector satisfy the given
+   * FEEL expression. The expression is evaluated with all local variables of the element as context
+   * and must evaluate to {@code true}.
+   *
+   * <p>The assertion waits until the expression evaluates to {@code true}.
+   *
+   * @param selector the selector for the BPMN element
+   * @param feelExpression the FEEL expression to evaluate (without the leading {@code =} prefix)
+   * @return the assertion object
+   * @see ElementSelectors
+   */
+  ProcessInstanceAssert hasLocalVariablesSatisfyingFeel(
+      ElementSelector selector, String feelExpression);
+
+  /**
    * Verifies that the process instance has no active incidents. The verification fails if there is
    * any active incident.
    *

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/FeelExpressionEvaluator.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/FeelExpressionEvaluator.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import org.camunda.feel.api.EvaluationResult;
 import org.camunda.feel.api.FeelEngineApi;
 import org.camunda.feel.api.FeelEngineBuilder;
+import org.camunda.feel.api.ParseResult;
 
 /** Evaluates FEEL expressions against a map of variables. */
 class FeelExpressionEvaluator {
@@ -32,24 +33,53 @@ class FeelExpressionEvaluator {
   }
 
   /**
+   * Validates a FEEL expression by attempting to parse it. Call this before entering a retry loop
+   * to fail fast on non-recoverable syntax errors.
+   *
+   * @param expression the FEEL expression (without the leading {@code =} prefix)
+   * @throws IllegalArgumentException if the expression is null, blank, starts with {@code =}, or
+   *     contains a syntax error
+   */
+  void validate(final String expression) {
+    final String normalized = normalizeExpression(expression);
+    final ParseResult parseResult = feelEngine.parseExpression(normalized);
+    if (!parseResult.isSuccess()) {
+      throw new IllegalArgumentException(
+          "FEEL expression '"
+              + expression
+              + "' is not a valid FEEL expression: "
+              + parseResult.failure().message());
+    }
+  }
+
+  /**
    * Evaluates a FEEL expression with the given variables as context.
    *
    * @param expression the FEEL expression (without the leading {@code =} prefix)
    * @param variables the context variables available to the expression
    * @return the evaluation result
-   * @throws IllegalArgumentException if the expression starts with {@code =}
+   * @throws IllegalArgumentException if the expression is null, blank, or starts with {@code =}
    */
   EvaluationResult evaluate(final String expression, final Map<String, Object> variables) {
-    if (expression != null && expression.startsWith("=")) {
+    final String normalized = normalizeExpression(expression);
+    return feelEngine.evaluateExpression(normalized, variables);
+  }
+
+  private String normalizeExpression(final String expression) {
+    final String normalized = expression != null ? expression.trim() : "";
+    if (normalized.isEmpty()) {
+      throw new IllegalArgumentException("FEEL expression must not be null or blank.");
+    }
+    if (normalized.startsWith("=")) {
       throw new IllegalArgumentException(
           "FEEL expression must not start with '='. "
               + "The '=' prefix is a Camunda expression language marker and is not part of the FEEL expression itself. "
               + "Please provide the expression without the leading '=', e.g., \""
-              + expression.substring(1).trim()
+              + normalized.substring(1).trim()
               + "\" instead of \""
-              + expression
+              + normalized
               + "\".");
     }
-    return feelEngine.evaluateExpression(expression, variables);
+    return normalized;
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/FeelExpressionEvaluator.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/FeelExpressionEvaluator.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.assertions;
+
+import java.util.Map;
+import org.camunda.feel.api.EvaluationResult;
+import org.camunda.feel.api.FeelEngineApi;
+import org.camunda.feel.api.FeelEngineBuilder;
+
+/** Evaluates FEEL expressions against a map of variables. */
+class FeelExpressionEvaluator {
+
+  static final FeelExpressionEvaluator INSTANCE = new FeelExpressionEvaluator();
+
+  private final FeelEngineApi feelEngine;
+
+  FeelExpressionEvaluator() {
+    feelEngine = FeelEngineBuilder.forJava().build();
+  }
+
+  /**
+   * Evaluates a FEEL expression with the given variables as context.
+   *
+   * @param expression the FEEL expression (without the leading {@code =} prefix)
+   * @param variables the context variables available to the expression
+   * @return the evaluation result
+   * @throws IllegalArgumentException if the expression starts with {@code =}
+   */
+  EvaluationResult evaluate(final String expression, final Map<String, Object> variables) {
+    if (expression != null && expression.startsWith("=")) {
+      throw new IllegalArgumentException(
+          "FEEL expression must not start with '='. "
+              + "The '=' prefix is a Camunda expression language marker and is not part of the FEEL expression itself. "
+              + "Please provide the expression without the leading '=', e.g., \""
+              + expression.substring(1).trim()
+              + "\" instead of \""
+              + expression
+              + "\".");
+    }
+    return feelEngine.evaluateExpression(expression, variables);
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
@@ -428,6 +428,28 @@ public class ProcessInstanceAssertj
   }
 
   @Override
+  public ProcessInstanceAssert hasVariablesSatisfyingFeel(final String feelExpression) {
+    variableAssertj.hasVariablesSatisfyingFeel(getProcessInstanceKey(), feelExpression);
+    return this;
+  }
+
+  @Override
+  public ProcessInstanceAssert hasLocalVariablesSatisfyingFeel(
+      final String elementId, final String feelExpression) {
+    variableAssertj.hasLocalVariablesSatisfyingFeel(
+        getProcessInstanceKey(), elementSelector.apply(elementId), feelExpression);
+    return this;
+  }
+
+  @Override
+  public ProcessInstanceAssert hasLocalVariablesSatisfyingFeel(
+      final ElementSelector selector, final String feelExpression) {
+    variableAssertj.hasLocalVariablesSatisfyingFeel(
+        getProcessInstanceKey(), selector, feelExpression);
+    return this;
+  }
+
+  @Override
   public ProcessInstanceAssert hasNoActiveIncidents() {
     incidentAssertj.hasNoActiveIncidents(getProcessInstanceKey());
     return this;

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/VariableAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/VariableAssertj.java
@@ -332,6 +332,7 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
 
   public void hasVariablesSatisfyingFeel(
       final long processInstanceKey, final String feelExpression) {
+    FeelExpressionEvaluator.INSTANCE.validate(feelExpression);
     awaitBehavior
         .get()
         .untilAsserted(
@@ -344,6 +345,7 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
 
   public void hasLocalVariablesSatisfyingFeel(
       final long processInstanceKey, final ElementSelector selector, final String feelExpression) {
+    FeelExpressionEvaluator.INSTANCE.validate(feelExpression);
     withLocalVariableAssertion(
         processInstanceKey,
         selector,

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/VariableAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/VariableAssertj.java
@@ -42,6 +42,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.ThrowingConsumer;
+import org.camunda.feel.api.EvaluationResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -325,6 +326,61 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
                       jsonMapper.toJsonNode(actualValues))
                   .containsAllEntriesOf(expectedValues);
             });
+  }
+
+  // --- FEEL expression evaluation methods ---
+
+  public void hasVariablesSatisfyingFeel(
+      final long processInstanceKey, final String feelExpression) {
+    awaitBehavior
+        .get()
+        .untilAsserted(
+            () -> {
+              final Map<String, Object> variables =
+                  toObjectMap(getGlobalProcessInstanceVariables(processInstanceKey));
+              evaluateFeelExpression(feelExpression, variables);
+            });
+  }
+
+  public void hasLocalVariablesSatisfyingFeel(
+      final long processInstanceKey, final ElementSelector selector, final String feelExpression) {
+    withLocalVariableAssertion(
+        processInstanceKey,
+        selector,
+        instance -> {
+          final Map<String, Object> variables =
+              toObjectMap(
+                  getLocalProcessInstanceVariables(
+                      processInstanceKey, instance.getElementInstanceKey()));
+          evaluateFeelExpression(feelExpression, variables);
+        });
+  }
+
+  private void evaluateFeelExpression(
+      final String feelExpression, final Map<String, Object> variables) {
+    final EvaluationResult result =
+        FeelExpressionEvaluator.INSTANCE.evaluate(feelExpression, variables);
+
+    if (result.isFailure()) {
+      fail(
+          "%s: FEEL expression '%s' failed to evaluate: %s",
+          actual, feelExpression, result.failure().message());
+    }
+
+    final Object value = result.result();
+    assertThat(value)
+        .withFailMessage(
+            "%s: FEEL expression '%s' should evaluate to true but was '%s'.",
+            actual, feelExpression, value)
+        .isEqualTo(Boolean.TRUE);
+  }
+
+  private Map<String, Object> toObjectMap(final Map<String, String> variables) {
+    return variables.entrySet().stream()
+        .collect(
+            HashMap::new,
+            (m, e) -> m.put(e.getKey(), jsonMapper.readJson(e.getValue(), Object.class)),
+            HashMap::putAll);
   }
 
   private void withLocalVariableAssertion(

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testCases/instructions/AssertVariablesInstructionHandler.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testCases/instructions/AssertVariablesInstructionHandler.java
@@ -64,6 +64,19 @@ public class AssertVariablesInstructionHandler
         processInstanceAssert.hasVariables(instruction.getVariables());
       }
     }
+
+    // Assert variables using a FEEL expression
+    instruction
+        .getFeelExpression()
+        .ifPresent(
+            feelExpression -> {
+              if (elementSelector.isPresent()) {
+                processInstanceAssert.hasLocalVariablesSatisfyingFeel(
+                    elementSelector.get(), feelExpression);
+              } else {
+                processInstanceAssert.hasVariablesSatisfyingFeel(feelExpression);
+              }
+            });
   }
 
   @Override

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
@@ -1190,4 +1190,151 @@ public class ProcessInstanceAssertTest {
               "Process instance [key: 1] should have at least one correlated message [message-name: 'expected', correlation-key: 'correlation-key'], but found none.");
     }
   }
+
+  @Nested
+  class HasVariablesSatisfyingFeel {
+
+    @BeforeEach
+    void configureMocks() {
+      when(camundaDataSource.findProcessInstances(any()))
+          .thenReturn(
+              Collections.singletonList(newActiveProcessInstance(PROCESS_INSTANCE_KEY).build()));
+    }
+
+    @Test
+    void shouldDelegateToVariableAssertj() {
+      // given
+      final Variable variable =
+          VariableBuilder.newVariable("score", "0.7")
+              .setProcessInstanceKey(PROCESS_INSTANCE_KEY)
+              .build();
+      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+          .thenReturn(Collections.singletonList(variable));
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // when / then
+      assertThatProcessInstance(processInstanceEvent)
+          .hasVariablesSatisfyingFeel("score >= 0.5 and score <= 1.0");
+
+      verify(camundaDataSource).findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
+    }
+
+    @Test
+    void shouldSupportMethodChaining() {
+      // given
+      final Variable variable =
+          VariableBuilder.newVariable("score", "0.7")
+              .setProcessInstanceKey(PROCESS_INSTANCE_KEY)
+              .build();
+      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+          .thenReturn(Collections.singletonList(variable));
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // when / then
+      assertThatProcessInstance(processInstanceEvent)
+          .isActive()
+          .hasVariablesSatisfyingFeel("score >= 0.5")
+          .hasVariablesSatisfyingFeel("score <= 1.0");
+    }
+
+    @Test
+    void shouldDelegateLocalVariablesToVariableAssertj() {
+      // given
+      final String elementId = "myTask";
+      final ElementInstance elementInstance =
+          ElementInstanceBuilder.newActiveElementInstance(elementId, PROCESS_INSTANCE_KEY)
+              .setElementInstanceKey(10L)
+              .build();
+      final Variable variable =
+          VariableBuilder.newVariable("score", "0.7")
+              .setProcessInstanceKey(PROCESS_INSTANCE_KEY)
+              .build();
+      when(camundaDataSource.findElementInstances(any()))
+          .thenReturn(Collections.singletonList(elementInstance));
+      when(camundaDataSource.findVariables(any())).thenReturn(Collections.singletonList(variable));
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // when / then — both String and ElementSelector variants
+      assertThatProcessInstance(processInstanceEvent)
+          .hasLocalVariablesSatisfyingFeel(elementId, "score >= 0.5")
+          .hasLocalVariablesSatisfyingFeel(
+              io.camunda.process.test.api.assertions.ElementSelectors.byId(elementId),
+              "score >= 0.5");
+    }
+
+    @Test
+    @CamundaAssertExpectFailure
+    void shouldFailForLocalVariablesWhenFeelExpressionEvaluatesToFalse() {
+      // given
+      final String elementId = "myTask";
+      final ElementInstance elementInstance =
+          ElementInstanceBuilder.newActiveElementInstance(elementId, PROCESS_INSTANCE_KEY)
+              .setElementInstanceKey(10L)
+              .build();
+      final Variable variable =
+          VariableBuilder.newVariable("score", "0.3")
+              .setProcessInstanceKey(PROCESS_INSTANCE_KEY)
+              .build();
+      when(camundaDataSource.findElementInstances(any()))
+          .thenReturn(Collections.singletonList(elementInstance));
+      when(camundaDataSource.findVariables(any())).thenReturn(Collections.singletonList(variable));
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // when / then
+      Assertions.assertThatThrownBy(
+              () ->
+                  assertThatProcessInstance(processInstanceEvent)
+                      .hasLocalVariablesSatisfyingFeel(elementId, "score >= 0.5"))
+          .hasMessageContaining("FEEL expression 'score >= 0.5'")
+          .hasMessageContaining("should evaluate to true but was 'false'");
+    }
+
+    @Test
+    void shouldThrowIllegalArgumentExceptionWhenLocalExpressionStartsWithEquals() {
+      // given
+      final String elementId = "myTask";
+      final ElementInstance elementInstance =
+          ElementInstanceBuilder.newActiveElementInstance(elementId, PROCESS_INSTANCE_KEY)
+              .setElementInstanceKey(10L)
+              .build();
+      final Variable variable =
+          VariableBuilder.newVariable("score", "0.7")
+              .setProcessInstanceKey(PROCESS_INSTANCE_KEY)
+              .build();
+      when(camundaDataSource.findElementInstances(any()))
+          .thenReturn(Collections.singletonList(elementInstance));
+      when(camundaDataSource.findVariables(any())).thenReturn(Collections.singletonList(variable));
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // when / then
+      Assertions.assertThatThrownBy(
+              () ->
+                  assertThatProcessInstance(processInstanceEvent)
+                      .hasLocalVariablesSatisfyingFeel(elementId, "= score >= 0.5"))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("FEEL expression must not start with '='")
+          .hasMessageContaining("score >= 0.5");
+    }
+
+    @Test
+    void shouldThrowIllegalArgumentExceptionWhenExpressionStartsWithEquals() {
+      // given
+      final Variable variable =
+          VariableBuilder.newVariable("score", "0.7")
+              .setProcessInstanceKey(PROCESS_INSTANCE_KEY)
+              .build();
+      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+          .thenReturn(Collections.singletonList(variable));
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // when / then
+      Assertions.assertThatThrownBy(
+              () ->
+                  assertThatProcessInstance(processInstanceEvent)
+                      .hasVariablesSatisfyingFeel("= score >= 0.5"))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("FEEL expression must not start with '='")
+          .hasMessageContaining("score >= 0.5");
+    }
+  }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
@@ -1293,17 +1293,6 @@ public class ProcessInstanceAssertTest {
     void shouldThrowIllegalArgumentExceptionWhenLocalExpressionStartsWithEquals() {
       // given
       final String elementId = "myTask";
-      final ElementInstance elementInstance =
-          ElementInstanceBuilder.newActiveElementInstance(elementId, PROCESS_INSTANCE_KEY)
-              .setElementInstanceKey(10L)
-              .build();
-      final Variable variable =
-          VariableBuilder.newVariable("score", "0.7")
-              .setProcessInstanceKey(PROCESS_INSTANCE_KEY)
-              .build();
-      when(camundaDataSource.findElementInstances(any()))
-          .thenReturn(Collections.singletonList(elementInstance));
-      when(camundaDataSource.findVariables(any())).thenReturn(Collections.singletonList(variable));
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
       // when / then
@@ -1319,12 +1308,6 @@ public class ProcessInstanceAssertTest {
     @Test
     void shouldThrowIllegalArgumentExceptionWhenExpressionStartsWithEquals() {
       // given
-      final Variable variable =
-          VariableBuilder.newVariable("score", "0.7")
-              .setProcessInstanceKey(PROCESS_INSTANCE_KEY)
-              .build();
-      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
-          .thenReturn(Collections.singletonList(variable));
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
       // when / then

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertTest.java
@@ -1093,4 +1093,167 @@ public class VariableAssertTest {
       verify(camundaDataSource, times(2)).findVariables(any());
     }
   }
+
+  @Nested
+  class HasVariablesSatisfyingFeel {
+
+    @Test
+    void shouldPassWhenFeelExpressionEvaluatesToTrue() {
+      // given
+      final Variable variable = newVariable("riskScore", "0.6");
+      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+          .thenReturn(Collections.singletonList(variable));
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // when / then
+      CamundaAssert.assertThatProcessInstance(processInstanceEvent)
+          .hasVariablesSatisfyingFeel("riskScore >= 0.5 and riskScore <= 0.75");
+    }
+
+    @Test
+    void shouldPassWithComplexFeelExpression() {
+      // given
+      final Variable scoreVar = newVariable("riskScore", "0.6");
+      final Variable statusVar = newVariable("status", "\"approved\"");
+      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+          .thenReturn(Arrays.asList(scoreVar, statusVar));
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // when / then
+      CamundaAssert.assertThatProcessInstance(processInstanceEvent)
+          .hasVariablesSatisfyingFeel("riskScore >= 0.5 and status = \"approved\"");
+    }
+
+    @Test
+    @CamundaAssertExpectFailure
+    void shouldFailWhenFeelExpressionEvaluatesToFalse() {
+      // given
+      final Variable variable = newVariable("riskScore", "0.3");
+      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+          .thenReturn(Collections.singletonList(variable));
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // when / then
+      Assertions.assertThatThrownBy(
+              () ->
+                  CamundaAssert.assertThatProcessInstance(processInstanceEvent)
+                      .hasVariablesSatisfyingFeel("riskScore >= 0.5 and riskScore <= 0.75"))
+          .hasMessageContaining("FEEL expression 'riskScore >= 0.5 and riskScore <= 0.75'")
+          .hasMessageContaining("should evaluate to true but was 'false'");
+    }
+
+    @Test
+    @CamundaAssertExpectFailure
+    void shouldFailWithUsefulMessageWhenFeelExpressionIsInvalid() {
+      // given
+      final Variable variable = newVariable("riskScore", "0.6");
+      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+          .thenReturn(Collections.singletonList(variable));
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // when / then
+      Assertions.assertThatThrownBy(
+              () ->
+                  CamundaAssert.assertThatProcessInstance(processInstanceEvent)
+                      .hasVariablesSatisfyingFeel("this is not valid FEEL %%%"))
+          .hasMessageContaining("FEEL expression 'this is not valid FEEL %%%'")
+          .hasMessageContaining("failed to evaluate");
+    }
+
+    @Test
+    void shouldThrowIllegalArgumentExceptionWhenExpressionStartsWithEquals() {
+      // given
+      final Variable variable = newVariable("riskScore", "0.6");
+      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+          .thenReturn(Collections.singletonList(variable));
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // when / then
+      Assertions.assertThatThrownBy(
+              () ->
+                  CamundaAssert.assertThatProcessInstance(processInstanceEvent)
+                      .hasVariablesSatisfyingFeel("= riskScore >= 0.5"))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("FEEL expression must not start with '='")
+          .hasMessageContaining("riskScore >= 0.5");
+    }
+
+    @Test
+    void shouldWaitUntilFeelExpressionEvaluatesToTrue() {
+      // given
+      final Variable lowScore = newVariable("riskScore", "0.3");
+      final Variable highScore = newVariable("riskScore", "0.6");
+      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+          .thenReturn(Collections.singletonList(lowScore))
+          .thenReturn(Collections.singletonList(highScore));
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // when / then
+      CamundaAssert.assertThatProcessInstance(processInstanceEvent)
+          .hasVariablesSatisfyingFeel("riskScore >= 0.5");
+
+      verify(camundaDataSource, times(2))
+          .findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
+    }
+
+    @Test
+    void shouldPassWhenFeelExpressionUsesIntegerComparison() {
+      // given
+      final Variable variable = newVariable("count", "5");
+      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+          .thenReturn(Collections.singletonList(variable));
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // when / then
+      CamundaAssert.assertThatProcessInstance(processInstanceEvent)
+          .hasVariablesSatisfyingFeel("count > 3");
+    }
+
+    @Test
+    void shouldPassForLocalVariablesWithFeelExpression() {
+      // given
+      final String elementId = "element-id";
+      final ElementInstance elementInstance =
+          ElementInstanceBuilder.newActiveElementInstance(elementId, PROCESS_INSTANCE_KEY)
+              .setElementInstanceKey(10L)
+              .build();
+      final Variable variable = newVariable("score", "0.7");
+
+      when(camundaDataSource.findElementInstances(any()))
+          .thenReturn(Collections.singletonList(elementInstance));
+      when(camundaDataSource.findVariables(any())).thenReturn(Collections.singletonList(variable));
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // when / then
+      CamundaAssert.assertThatProcessInstance(processInstanceEvent)
+          .hasLocalVariablesSatisfyingFeel(
+              ElementSelectors.byId(elementId), "score >= 0.5 and score <= 1.0")
+          .hasLocalVariablesSatisfyingFeel(elementId, "score >= 0.5 and score <= 1.0");
+    }
+
+    @Test
+    @CamundaAssertExpectFailure
+    void shouldFailForLocalVariablesWhenFeelExpressionEvaluatesToFalse() {
+      // given
+      final String elementId = "element-id";
+      final ElementInstance elementInstance =
+          ElementInstanceBuilder.newActiveElementInstance(elementId, PROCESS_INSTANCE_KEY)
+              .setElementInstanceKey(10L)
+              .build();
+      final Variable variable = newVariable("score", "0.3");
+
+      when(camundaDataSource.findElementInstances(any()))
+          .thenReturn(Collections.singletonList(elementInstance));
+      when(camundaDataSource.findVariables(any())).thenReturn(Collections.singletonList(variable));
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // when / then
+      Assertions.assertThatThrownBy(
+              () ->
+                  CamundaAssert.assertThatProcessInstance(processInstanceEvent)
+                      .hasLocalVariablesSatisfyingFeel(elementId, "score >= 0.5"))
+          .hasMessageContaining("FEEL expression 'score >= 0.5'")
+          .hasMessageContaining("should evaluate to true but was 'false'");
+    }
+  }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertTest.java
@@ -1143,12 +1143,8 @@ public class VariableAssertTest {
     }
 
     @Test
-    @CamundaAssertExpectFailure
     void shouldFailWithUsefulMessageWhenFeelExpressionIsInvalid() {
       // given
-      final Variable variable = newVariable("riskScore", "0.6");
-      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
-          .thenReturn(Collections.singletonList(variable));
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
       // when / then
@@ -1156,16 +1152,14 @@ public class VariableAssertTest {
               () ->
                   CamundaAssert.assertThatProcessInstance(processInstanceEvent)
                       .hasVariablesSatisfyingFeel("this is not valid FEEL %%%"))
+          .isInstanceOf(IllegalArgumentException.class)
           .hasMessageContaining("FEEL expression 'this is not valid FEEL %%%'")
-          .hasMessageContaining("failed to evaluate");
+          .hasMessageContaining("is not a valid FEEL expression");
     }
 
     @Test
     void shouldThrowIllegalArgumentExceptionWhenExpressionStartsWithEquals() {
       // given
-      final Variable variable = newVariable("riskScore", "0.6");
-      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
-          .thenReturn(Collections.singletonList(variable));
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
       // when / then

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertTest.java
@@ -1158,6 +1158,28 @@ public class VariableAssertTest {
     }
 
     @Test
+    @CamundaAssertExpectFailure
+    void shouldFailWithUsefulMessageWhenFeelExpressionEvaluationFails() {
+      // given
+      // assert() is a FEEL built-in that returns a runtime evaluation failure when its condition
+      // is false; this tests the isFailure() branch in evaluateFeelExpression()
+      final Variable variable = newVariable("score", "0.7");
+      when(camundaDataSource.findGlobalVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+          .thenReturn(Collections.singletonList(variable));
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // when / then
+      Assertions.assertThatThrownBy(
+              () ->
+                  CamundaAssert.assertThatProcessInstance(processInstanceEvent)
+                      .hasVariablesSatisfyingFeel(
+                          "assert(score > 100, \"score must be greater than 100\")"))
+          .hasMessageContaining(
+              "FEEL expression 'assert(score > 100, \"score must be greater than 100\")'")
+          .hasMessageContaining("failed to evaluate");
+    }
+
+    @Test
     void shouldThrowIllegalArgumentExceptionWhenExpressionStartsWithEquals() {
       // given
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/testCases/AssertVariablesInstructionTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/testCases/AssertVariablesInstructionTest.java
@@ -221,4 +221,57 @@ public class AssertVariablesInstructionTest {
 
     verifyNoMoreInteractions(camundaClient, processTestContext, processInstanceAssert);
   }
+
+  @Test
+  void shouldAssertVariablesWithFeelExpression() {
+    // given
+    final AssertVariablesInstruction instruction =
+        ImmutableAssertVariablesInstruction.builder()
+            .processInstanceSelector(
+                ImmutableProcessInstanceSelector.builder()
+                    .processDefinitionId(PROCESS_DEFINITION_ID)
+                    .build())
+            .feelExpression("score >= 0.5 and score <= 1.0")
+            .build();
+
+    // when
+    instructionHandler.execute(instruction, processTestContext, camundaClient, assertionFacade);
+
+    // then
+    verify(assertionFacade).assertThatProcessInstance(any());
+
+    final ProcessInstanceAssert processInstanceAssert =
+        assertionFacade.assertThatProcessInstance(any());
+    verify(processInstanceAssert).hasVariablesSatisfyingFeel("score >= 0.5 and score <= 1.0");
+
+    verifyNoMoreInteractions(camundaClient, processTestContext, processInstanceAssert);
+  }
+
+  @Test
+  void shouldAssertLocalVariablesWithFeelExpression() {
+    // given
+    final AssertVariablesInstruction instruction =
+        ImmutableAssertVariablesInstruction.builder()
+            .processInstanceSelector(
+                ImmutableProcessInstanceSelector.builder()
+                    .processDefinitionId(PROCESS_DEFINITION_ID)
+                    .build())
+            .elementSelector(ImmutableElementSelector.builder().elementId(ELEMENT_ID).build())
+            .feelExpression("score >= 0.5 and score <= 1.0")
+            .build();
+
+    // when
+    instructionHandler.execute(instruction, processTestContext, camundaClient, assertionFacade);
+
+    // then
+    verify(assertionFacade).assertThatProcessInstance(any());
+
+    final ProcessInstanceAssert processInstanceAssert =
+        assertionFacade.assertThatProcessInstance(any());
+    verify(processInstanceAssert)
+        .hasLocalVariablesSatisfyingFeel(
+            any(ElementSelector.class), eq("score >= 0.5 and score <= 1.0"));
+
+    verifyNoMoreInteractions(camundaClient, processTestContext, processInstanceAssert);
+  }
 }

--- a/testing/camunda-process-test-json-test-cases/src/main/java/io/camunda/process/test/api/testCases/instructions/AssertVariablesInstruction.java
+++ b/testing/camunda-process-test-json-test-cases/src/main/java/io/camunda/process/test/api/testCases/instructions/AssertVariablesInstruction.java
@@ -63,4 +63,12 @@ public interface AssertVariablesInstruction extends TestCaseInstruction {
    * @return the expected variables or empty if not asserted
    */
   Map<String, Object> getVariables();
+
+  /**
+   * A FEEL expression to evaluate against the variables. Optional. When combined with an element
+   * selector, the expression is evaluated against the local variables of that element.
+   *
+   * @return the FEEL expression or empty if not asserted
+   */
+  Optional<String> getFeelExpression();
 }

--- a/testing/camunda-process-test-json-test-cases/src/main/resources/schema/cpt-test-cases/schema.json
+++ b/testing/camunda-process-test-json-test-cases/src/main/resources/schema/cpt-test-cases/schema.json
@@ -1086,7 +1086,7 @@
           "description": "A FEEL expression to evaluate against the variables. When combined with elementSelector, evaluates against the local variables of that element. Optional.",
           "type": "string",
           "minLength": 1,
-          "pattern": "^[^=].*$"
+          "pattern": "^(?=\\s*\\S)(?!\\s*=).+"
         }
       },
       "required": [

--- a/testing/camunda-process-test-json-test-cases/src/main/resources/schema/cpt-test-cases/schema.json
+++ b/testing/camunda-process-test-json-test-cases/src/main/resources/schema/cpt-test-cases/schema.json
@@ -1081,6 +1081,10 @@
           "description": "The expected variables with their values. Optional.",
           "type": "object",
           "additionalProperties": true
+        },
+        "feelExpression": {
+          "description": "A FEEL expression to evaluate against the variables. When combined with elementSelector, evaluates against the local variables of that element. Optional.",
+          "type": "string"
         }
       },
       "required": [

--- a/testing/camunda-process-test-json-test-cases/src/main/resources/schema/cpt-test-cases/schema.json
+++ b/testing/camunda-process-test-json-test-cases/src/main/resources/schema/cpt-test-cases/schema.json
@@ -1084,7 +1084,9 @@
         },
         "feelExpression": {
           "description": "A FEEL expression to evaluate against the variables. When combined with elementSelector, evaluates against the local variables of that element. Optional.",
-          "type": "string"
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[^=].*$"
         }
       },
       "required": [

--- a/testing/camunda-process-test-json-test-cases/src/test/java/io/camunda/process/test/testCases/PojoCompatibilityTest.java
+++ b/testing/camunda-process-test-json-test-cases/src/test/java/io/camunda/process/test/testCases/PojoCompatibilityTest.java
@@ -519,6 +519,27 @@ public class PojoCompatibilityTest {
                     .putVariables("x", 3)
                     .putVariables("y", "okay")
                     .build())),
+        Arguments.of(
+            "assert variables: with FEEL expression",
+            singleTestCase(
+                ImmutableAssertVariablesInstruction.builder()
+                    .processInstanceSelector(
+                        ImmutableProcessInstanceSelector.builder()
+                            .processDefinitionId("my-process")
+                            .build())
+                    .feelExpression("score >= 0.5 and score <= 1.0")
+                    .build())),
+        Arguments.of(
+            "assert variables: with local FEEL expression",
+            singleTestCase(
+                ImmutableAssertVariablesInstruction.builder()
+                    .processInstanceSelector(
+                        ImmutableProcessInstanceSelector.builder()
+                            .processDefinitionId("my-process")
+                            .build())
+                    .elementSelector(ImmutableElementSelector.builder().elementId("task_A").build())
+                    .feelExpression("score >= 0.5 and score <= 1.0")
+                    .build())),
         // ===== ASSERT_PROCESS_INSTANCE_MESSAGE_SUBSCRIPTION =====
         Arguments.of(
             "assert process instance message subscription: minimal",


### PR DESCRIPTION
## Description

This pull request adds support for asserting that process instance variables and local variables satisfy FEEL (Friendly Enough Expression Language) expressions in process tests. This enables more expressive and powerful assertions on process data, improving test readability and maintainability. The changes include new assertion methods, the integration of the FEEL engine, and comprehensive test coverage.

**New FEEL assertion support:**

* Added new assertion methods to `ProcessInstanceAssert` for checking that process variables and local variables satisfy a given FEEL expression, including support for both element IDs and selectors.
* Implemented the FEEL expression evaluation logic in a new utility class `FeelExpressionEvaluator`, which integrates the `feel-engine` dependency and provides robust validation for FEEL expressions:
  * Input normalization (trimming) before validation and evaluation.
  * Null/blank expressions are rejected with a clear `IllegalArgumentException`.
  * Leading whitespace before `=` (e.g. `" = a"`) is correctly detected and rejected.
  * A `validate()` method pre-parses expressions via `feelEngine.parseExpression()` to fail fast on syntax errors before entering the Awaitility retry loop, avoiding the default 10s timeout for non-recoverable errors.
* Extended `VariableAssertj` to evaluate FEEL expressions against process/global and local variables: `validate()` is now called before `untilAsserted()` so that syntactically invalid expressions throw `IllegalArgumentException` immediately rather than being retried until timeout.
* Added `minLength: 1` and `pattern: "^[^=].*$"` constraints to the `feelExpression` field in the JSON test-cases schema, aligning schema validation with the runtime constraints enforced by `FeelExpressionEvaluator`.

**Test enhancements:**

* Added comprehensive unit tests for the new FEEL assertion methods, covering success, failure, invalid expressions, and method chaining, in both `ProcessInstanceAssertTest` and `VariableAssertTest`.
* Added a test that triggers a runtime evaluation failure via the FEEL `assert()` built-in (e.g. `assert(score > 100, "...")`), covering the `EvaluationResult.isFailure()` code path in `evaluateFeelExpression()`.
* Updated tests for invalid expressions to assert fast-fail `IllegalArgumentException` behavior (no longer annotated with `@CamundaAssertExpectFailure`).
* Removed unnecessary variable stubs from equals-prefix tests since validation fires before any variable fetching.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).