### PR TITLE
fix: Global job metrics API documentation

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/job-metrics.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/job-metrics.yaml
@@ -9,7 +9,7 @@ paths:
       operationId: getGlobalJobStatistics
       summary: Global job statistics
       description: |
-        Returns global aggregated counts for jobs. Optionally filter by the creation time window and/or jobType.
+        Returns global aggregated counts for jobs. Filter by the creation time window (required) and optionally by jobType.
       parameters:
         - name: from
           in: query


### PR DESCRIPTION
## Description

[Discussion](https://camunda.slack.com/archives/C08MRKHJ0CD/p1775137765883719)

This pull request updates the documentation for the global job statistics endpoint to clarify the filtering requirements. Specifically, it now states that filtering by the creation time window is required, and filtering by job type is optional.

- **Documentation Update:**
  - Clarified in `job-metrics.yaml` that the creation time window filter is required and the job type filter is optional for the global job statistics endpoint.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

