### PR TITLE
ci: show load tests inputs in the job summary

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -176,6 +176,27 @@ defaults:
     shell: bash
 
 jobs:
+  show-summary:
+    name: Summarize workflow inputs
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Show summary
+        run: |-
+          INPUTS=$(cat <<EOF | jq . --sort-keys
+          ${{ toJSON(inputs) }}
+          EOF
+          )
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          # Load test configuration
+
+          A load test was created with the following inputs:
+
+          \`\`\`json
+          $INPUTS
+          \`\`\`
+          EOF
+
   calculate-image-tag:
     name: Calculate Image Tag
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Display a summary of the inputs passed to the job to help investigations.
The action could be reused in other jobs, if needed.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/50386
