### PR TITLE
[Backport stable/8.9] fix: Global job metrics API documentation

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/job-metrics.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/job-metrics.yaml
@@ -9,7 +9,7 @@ paths:
       operationId: getGlobalJobStatistics
       summary: Global job statistics
       description: |
-        Returns global aggregated counts for jobs. Optionally filter by the creation time window and/or jobType.
+        Returns global aggregated counts for jobs. Filter by the creation time window (required) and optionally by jobType.
       parameters:
         - name: from
           in: query


### PR DESCRIPTION
# Description
Backport of #50392 to `stable/8.9`.

relates to 