### PR TITLE
[Backport stable/8.9] feat: add trace logging for entity size in ES bulk request payloads

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
@@ -97,6 +97,7 @@ public class CamundaExporterMetrics implements AutoCloseable {
   private Timer.Sample flushLatencyMeasurement;
   private final Timer archivingDuration;
   private final DistributionSummary bulkSize;
+  private final DistributionSummary bulkEstimatedMemorySize;
   private final Counter bulkOperations;
   private final Timer flushDuration;
   private final Counter failedFlush;
@@ -246,6 +247,13 @@ public class CamundaExporterMetrics implements AutoCloseable {
             .description("How many items were exported in one bulk request")
             .serviceLevelObjectives(10, 100, 1_000, 10_000, 100_000)
             .register(meterRegistry);
+    bulkEstimatedMemorySize =
+        DistributionSummary.builder(meterName("bulk.estimated.memory.size"))
+            .description("Estimated serialized payload size in bytes of a bulk request")
+            .baseUnit("bytes")
+            .serviceLevelObjectives(
+                10_000, 100_000, 1_000_000, 10_000_000, 50_000_000, 100_000_000, 200_000_000)
+            .register(meterRegistry);
     bulkOperations =
         Counter.builder(meterName("bulk.operations"))
             .description(
@@ -302,6 +310,10 @@ public class CamundaExporterMetrics implements AutoCloseable {
 
   public void recordBulkSize(final int bulkSize) {
     this.bulkSize.record(bulkSize);
+  }
+
+  public void recordBulkMemorySize(final long bytes) {
+    bulkEstimatedMemorySize.record(bytes);
   }
 
   public void recordBulkOperations(final int operations) {
@@ -457,6 +469,7 @@ public class CamundaExporterMetrics implements AutoCloseable {
     meterRegistry.remove(archiverReindexedDocs);
     meterRegistry.remove(archivingDuration);
     meterRegistry.remove(bulkSize);
+    meterRegistry.remove(bulkEstimatedMemorySize);
     meterRegistry.remove(bulkOperations);
     meterRegistry.remove(flushDuration);
     meterRegistry.remove(failedFlush);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ElasticsearchBatchRequest.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ElasticsearchBatchRequest.java
@@ -18,6 +18,7 @@ import io.camunda.exporter.errorhandling.Error;
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.utils.ElasticsearchScriptBuilder;
+import io.camunda.exporter.utils.NdJsonSizeUtil;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import java.io.IOException;
 import java.util.LinkedHashMap;
@@ -262,6 +263,24 @@ public class ElasticsearchBatchRequest implements BatchRequest {
         metrics.recordBulkOperations(bulkRequest.operations().size());
       }
     } catch (final IOException | ElasticsearchException ex) {
+      if (LOGGER.isTraceEnabled()) {
+        try {
+          final var payloadSize =
+              NdJsonSizeUtil.measureNdJsonPayloadSize(bulkRequest, esClient._jsonpMapper());
+          LOGGER.trace(
+              "Elasticsearch bulk request FAILED: operations={} serializedPayloadBytes={} error={}",
+              bulkRequest.operations().size(),
+              payloadSize.totalBytes(),
+              ex.getMessage());
+          LOGGER.trace("Breakdown of operations in bulk request, {}", payloadSize.operationSizes());
+        } catch (final Exception measureEx) {
+          LOGGER.trace(
+              "Elasticsearch bulk request FAILED and payload measurement also failed: operations={} error={} measurementError={}",
+              bulkRequest.operations().size(),
+              ex.getMessage(),
+              measureEx.getMessage());
+        }
+      }
       throw new PersistenceException(
           "Error when processing bulk request against Elasticsearch: " + ex.getMessage(), ex);
     }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ElasticsearchBatchRequest.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ElasticsearchBatchRequest.java
@@ -264,8 +264,7 @@ public class ElasticsearchBatchRequest implements BatchRequest {
       }
     } catch (final IOException | ElasticsearchException ex) {
       if (isRequestEntityTooLarge(ex)) {
-        LOGGER.error("The entities in the payload to ES are too large", ex);
-        logPayloadTooLarge(bulkRequest, ex);
+        LOGGER.error("The entities in the payload to ES are too large, cannot write batch", ex);
       } else if (LOGGER.isTraceEnabled()) {
         logBulkFailureTrace(bulkRequest, ex);
       }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ElasticsearchBatchRequest.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ElasticsearchBatchRequest.java
@@ -263,23 +263,11 @@ public class ElasticsearchBatchRequest implements BatchRequest {
         metrics.recordBulkOperations(bulkRequest.operations().size());
       }
     } catch (final IOException | ElasticsearchException ex) {
-      if (LOGGER.isTraceEnabled()) {
-        try {
-          final var payloadSize =
-              NdJsonSizeUtil.measureNdJsonPayloadSize(bulkRequest, esClient._jsonpMapper());
-          LOGGER.trace(
-              "Elasticsearch bulk request FAILED: operations={} serializedPayloadBytes={} error={}",
-              bulkRequest.operations().size(),
-              payloadSize.totalBytes(),
-              ex.getMessage());
-          LOGGER.trace("Breakdown of operations in bulk request, {}", payloadSize.operationSizes());
-        } catch (final Exception measureEx) {
-          LOGGER.trace(
-              "Elasticsearch bulk request FAILED and payload measurement also failed: operations={} error={} measurementError={}",
-              bulkRequest.operations().size(),
-              ex.getMessage(),
-              measureEx.getMessage());
-        }
+      if (isRequestEntityTooLarge(ex)) {
+        LOGGER.error("The entities in the payload to ES are too large", ex);
+        logPayloadTooLarge(bulkRequest, ex);
+      } else if (LOGGER.isTraceEnabled()) {
+        logBulkFailureTrace(bulkRequest, ex);
       }
       throw new PersistenceException(
           "Error when processing bulk request against Elasticsearch: " + ex.getMessage(), ex);
@@ -338,6 +326,31 @@ public class ElasticsearchBatchRequest implements BatchRequest {
             throw new PersistenceException(message);
           }
         });
+  }
+
+  private static boolean isRequestEntityTooLarge(final Exception ex) {
+    final String message = ex.getMessage();
+    return message != null && message.contains("413");
+  }
+
+  private void logBulkFailureTrace(final BulkRequest bulkRequest, final Exception ex) {
+    try {
+      final var payloadSize =
+          NdJsonSizeUtil.measureNdJsonPayloadSize(bulkRequest, esClient._jsonpMapper());
+      LOGGER.trace(
+          "Elasticsearch bulk request FAILED: operations={} serializedPayloadBytes={} error={}",
+          bulkRequest.operations().size(),
+          payloadSize.totalBytes(),
+          ex.getMessage());
+      LOGGER.trace("Breakdown of operations in bulk request: {}", payloadSize.operationSizes());
+    } catch (final Exception measureEx) {
+      LOGGER.trace(
+          "Elasticsearch bulk request FAILED and payload measurement also failed: "
+              + "operations={} error={} measurementError={}",
+          bulkRequest.operations().size(),
+          ex.getMessage(),
+          measureEx.getMessage());
+    }
   }
 
   private record ErrorValues(List<String> indexes, List<String> ids) {}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ExporterBatchWriter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ExporterBatchWriter.java
@@ -112,11 +112,11 @@ public final class ExporterBatchWriter {
         final var entityKey = key.key();
         final var cached = cachedEntities.get(entityKey);
         LOG.trace(
-            "  entity: id={} type={} handler={} initialRecordBytes={}",
+            "  entity: id={} type={} handler={} sourceRecordBytes={}",
             entityKey.entityId(),
             entityKey.entityType().getSimpleName(),
             key.handler().getClass().getSimpleName(),
-            cached != null ? cached.initialRecordBytes() : 0L);
+            cached != null ? cached.sourceRecordBytes() : 0L);
       }
     }
 
@@ -217,7 +217,7 @@ public final class ExporterBatchWriter {
     }
   }
 
-  private record CachedEntity(ExporterEntity entity, long initialRecordBytes) {}
+  private record CachedEntity(ExporterEntity entity, long sourceRecordBytes) {}
 
   private record EntityIdAndEntityType(String entityId, Class<?> entityType) {}
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ExporterBatchWriter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ExporterBatchWriter.java
@@ -131,6 +131,7 @@ public final class ExporterBatchWriter {
     }
 
     batchRequest.execute(customErrorHandler);
+    metrics.recordBulkMemorySize(totalMemoryEstimate);
     observeRecordTimestamps();
     reset();
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ExporterBatchWriter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ExporterBatchWriter.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
 public final class ExporterBatchWriter {
   private static final Logger LOG = LoggerFactory.getLogger(ExporterBatchWriter.class);
   private boolean warnAboutMessageSizeEstimation = false;
-  private final Map<EntityIdAndEntityType, ExporterEntity> cachedEntities = new HashMap<>();
+  private final Map<EntityIdAndEntityType, CachedEntity> cachedEntities = new HashMap<>();
   private final Map<EntityIdTypeAndHandler, ExporterEntity> cachedEntitiesToFlush =
       new LinkedHashMap<>();
   private final Map<Long, Long> cachedRecordTimestamps = new HashMap<>();
@@ -77,10 +77,14 @@ public final class ExporterBatchWriter {
     final var cacheKey = new EntityIdAndEntityType(id, handler.getEntityType());
 
     totalMemoryEstimate += length;
-    final ExporterEntity entity =
-        cachedEntities.computeIfAbsent(cacheKey, (k) -> handler.createNewEntity(id));
+    final var cached =
+        cachedEntities.computeIfAbsent(
+            cacheKey,
+            (k) -> {
+              return new CachedEntity(handler.createNewEntity(id), length);
+            });
 
-    handler.updateEntity(record, entity);
+    handler.updateEntity(record, cached.entity());
     cachedRecordTimestamps.put(record.getPosition(), record.getTimestamp());
 
     // we store all handlers for an entity to make sure not to miss any flushes.
@@ -88,12 +92,32 @@ public final class ExporterBatchWriter {
     // in cases where we have bugs with writing to the same index + id, but with a different
     // entity, this helps avoid race conditions that make that behavior non-deterministic.
     // which would otherwise make spotting and fixing such bugs harder.
-    cachedEntitiesToFlush.put(new EntityIdTypeAndHandler(cacheKey, handler), entity);
+    cachedEntitiesToFlush.put(new EntityIdTypeAndHandler(cacheKey, handler), cached.entity());
   }
 
   public void flush(final BatchRequest batchRequest) throws PersistenceException {
     if (cachedEntities.isEmpty()) {
       return;
+    }
+
+    if (LOG.isTraceEnabled()) {
+      LOG.trace(
+          "Flushing batch: totalMemoryEstimation={} bytes ({} MB), cachedEntities={}, entitiesToFlush={}",
+          totalMemoryEstimate,
+          getBatchMemoryEstimateInMb(),
+          cachedEntities.size(),
+          cachedEntitiesToFlush.size());
+      for (final var entry : cachedEntitiesToFlush.entrySet()) {
+        final var key = entry.getKey();
+        final var entityKey = key.key();
+        final var cached = cachedEntities.get(entityKey);
+        LOG.trace(
+            "  entity: id={} type={} handler={} initialRecordBytes={}",
+            entityKey.entityId(),
+            entityKey.entityType().getSimpleName(),
+            key.handler().getClass().getSimpleName(),
+            cached != null ? cached.initialRecordBytes() : 0L);
+      }
     }
 
     // some handlers modify the same entity (e.g. list view flow node instances are
@@ -191,6 +215,8 @@ public final class ExporterBatchWriter {
       return this;
     }
   }
+
+  private record CachedEntity(ExporterEntity entity, long initialRecordBytes) {}
 
   private record EntityIdAndEntityType(String entityId, Class<?> entityType) {}
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/NdJsonSizeUtil.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/NdJsonSizeUtil.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.utils;
+
+import co.elastic.clients.elasticsearch.core.BulkRequest;
+import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
+import co.elastic.clients.json.JsonpMapper;
+import co.elastic.clients.json.NdJsonpSerializable;
+import jakarta.json.stream.JsonGenerator;
+import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Utility for measuring the serialized NDJSON payload size of Elasticsearch bulk requests. This
+ * replicates the wire-format serialization performed by the ES transport layer so that the exporter
+ * can log the actual payload size before sending it.
+ */
+public final class NdJsonSizeUtil {
+
+  private NdJsonSizeUtil() {
+    // utility class
+  }
+
+  /**
+   * Serializes a {@link BulkRequest} to NDJSON and returns a {@link PayloadSizeResult} containing
+   * the total byte size and the size of each individual operation. This is the same wire format
+   * that the Elasticsearch client sends over HTTP.
+   *
+   * @param bulkRequest the bulk request to measure
+   * @param mapper the {@link JsonpMapper} from the Elasticsearch client ({@code
+   *     esClient._jsonpMapper()})
+   * @return a result containing total size and per-operation breakdown
+   */
+  public static PayloadSizeResult measureNdJsonPayloadSize(
+      final BulkRequest bulkRequest, final JsonpMapper mapper) {
+    final List<BulkOperation> operations = bulkRequest.operations();
+    final List<OperationSize> operationSizes = new ArrayList<>(operations.size());
+    long totalBytes = 0;
+
+    for (final BulkOperation operation : operations) {
+      final long operationBytes = measureSingleNdJsonSerializable(operation, mapper);
+      operationSizes.add(OperationSize.of(operation, operationBytes));
+      totalBytes += operationBytes;
+    }
+
+    return new PayloadSizeResult(totalBytes, Collections.unmodifiableList(operationSizes));
+  }
+
+  /**
+   * Serializes a single {@link NdJsonpSerializable} value to NDJSON and returns its byte size.
+   * Useful for measuring individual operations or other NDJSON-serializable objects.
+   */
+  private static long measureSingleNdJsonSerializable(
+      final NdJsonpSerializable value, final JsonpMapper mapper) {
+    final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    writeNdJson(value, baos, mapper);
+    return baos.size();
+  }
+
+  private static void writeNdJson(
+      final NdJsonpSerializable value, final ByteArrayOutputStream baos, final JsonpMapper mapper) {
+    final Iterator<?> values = value._serializables();
+    while (values.hasNext()) {
+      final Object item = values.next();
+      if (item == null) {
+        continue;
+      }
+      if (item instanceof NdJsonpSerializable && item != value) {
+        writeNdJson((NdJsonpSerializable) item, baos, mapper);
+      } else {
+        final JsonGenerator generator = mapper.jsonProvider().createGenerator(baos);
+        try {
+          mapper.serialize(item, generator);
+        } finally {
+          generator.close();
+        }
+        baos.write('\n');
+      }
+    }
+  }
+
+  /** The result of measuring a bulk request's NDJSON payload size. */
+  public record PayloadSizeResult(long totalBytes, List<OperationSize> operationSizes) {}
+
+  /** The measured NDJSON size of a single bulk operation. */
+  record OperationSize(String kind, String index, String id, long bytes) {
+
+    static OperationSize of(final BulkOperation operation, final long bytes) {
+      final String kind = operation._kind().jsonValue();
+      final String index;
+      final String id;
+
+      switch (operation._kind()) {
+        case Index -> {
+          index = operation.index().index();
+          id = operation.index().id();
+        }
+        case Create -> {
+          index = operation.create().index();
+          id = operation.create().id();
+        }
+        case Update -> {
+          index = operation.update().index();
+          id = operation.update().id();
+        }
+        case Delete -> {
+          index = operation.delete().index();
+          id = operation.delete().id();
+        }
+        default -> {
+          index = null;
+          id = null;
+        }
+      }
+      return new OperationSize(kind, index, id, bytes);
+    }
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ElasticsearchPayloadSizeIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ElasticsearchPayloadSizeIT.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.store;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.Refresh;
+import co.elastic.clients.elasticsearch.core.BulkRequest;
+import io.camunda.exporter.utils.ElasticsearchScriptBuilder;
+import io.camunda.exporter.utils.NdJsonSizeUtil;
+import io.camunda.search.connect.configuration.ConnectConfiguration;
+import io.camunda.search.connect.es.ElasticsearchConnector;
+import io.camunda.webapps.schema.entities.ExporterEntity;
+import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
+import java.io.IOException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Integration test that validates the accuracy of our NDJSON payload size measurement in {@link
+ * NdJsonSizeUtil#measureNdJsonPayloadSize} against Elasticsearch's default {@code
+ * http.max_content_length} of 100MB.
+ *
+ * <p>Payloads under 100MB should be accepted; payloads over 100MB should be rejected. This confirms
+ * that our measurement accurately predicts whether ES will accept or reject a given bulk request.
+ */
+@Testcontainers
+class ElasticsearchPayloadSizeIT {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchPayloadSizeIT.class);
+  private static final String TEST_INDEX = "payload-size-test";
+
+  /** ~1MB string used as the payload for each entity. */
+  private static final String ONE_MB_PAYLOAD = "x".repeat(1024 * 1024);
+
+  /** 100MB — the default ES http.max_content_length */
+  private static final long ES_MAX_CONTENT_LENGTH_BYTES = 100L * 1024 * 1024;
+
+  @Container
+  private static final ElasticsearchContainer ES_CONTAINER =
+      TestSearchContainers.createDefeaultElasticsearchContainer();
+
+  private static ElasticsearchClient esClient;
+
+  @BeforeAll
+  static void setUp() throws IOException {
+    final var config = new ConnectConfiguration();
+    config.setUrl("http://" + ES_CONTAINER.getHost() + ":" + ES_CONTAINER.getMappedPort(9200));
+    esClient = new ElasticsearchConnector(config).createClient();
+
+    esClient.indices().create(c -> c.index(TEST_INDEX));
+    LOG.info(
+        "Created index '{}' on ES at {}:{}",
+        TEST_INDEX,
+        ES_CONTAINER.getHost(),
+        ES_CONTAINER.getMappedPort(9200));
+  }
+
+  @AfterAll
+  static void tearDown() {
+    if (esClient != null) {
+      try {
+        esClient.indices().delete(d -> d.index(TEST_INDEX));
+      } catch (final IOException e) {
+        LOG.warn("Failed to delete test index", e);
+      }
+      try {
+        esClient._transport().close();
+      } catch (final IOException ex) {
+        LOG.warn("Failed to close Elasticsearch transport", ex);
+      }
+    }
+  }
+
+  /**
+   * Validates that our NDJSON payload size measurement accurately predicts whether Elasticsearch
+   * will accept or reject a bulk request based on its default 100MB {@code
+   * http.max_content_length}.
+   */
+  @ParameterizedTest(name = "shouldHandlePayloadOf{0}MbCorrectly")
+  @ValueSource(ints = {50, 60, 70, 80, 90, 110})
+  void shouldAcceptOrRejectBasedOnPayloadSize(final int targetMB) throws Exception {
+    // given
+    final BulkRequest bulkRequest = buildBulkRequest(targetMB);
+    final long payloadBytes =
+        NdJsonSizeUtil.measureNdJsonPayloadSize(bulkRequest, esClient._jsonpMapper()).totalBytes();
+
+    // when/then
+    if (payloadBytes < ES_MAX_CONTENT_LENGTH_BYTES) {
+      esClient.bulk(bulkRequest);
+    } else {
+      assertThatThrownBy(() -> esClient.bulk(bulkRequest))
+          .hasMessageContaining("413 Request Entity Too Large");
+    }
+  }
+
+  private BulkRequest buildBulkRequest(final int targetMB) {
+    final var bulkRequestBuilder = new BulkRequest.Builder().refresh(Refresh.True);
+    final var batchRequest =
+        new ElasticsearchBatchRequest(
+            esClient, bulkRequestBuilder, new ElasticsearchScriptBuilder());
+
+    for (int i = 0; i < targetMB; i++) {
+      final var entity = new LargeEntity("test" + "-" + targetMB + "-" + i, ONE_MB_PAYLOAD);
+      batchRequest.addWithId(TEST_INDEX, entity.getId(), entity);
+    }
+    return bulkRequestBuilder.build();
+  }
+
+  static class LargeEntity implements ExporterEntity<LargeEntity> {
+    private String id;
+    private String payload;
+
+    LargeEntity(final String id, final String payload) {
+      this.id = id;
+      this.payload = payload;
+    }
+
+    @Override
+    public String getId() {
+      return id;
+    }
+
+    @Override
+    public LargeEntity setId(final String id) {
+      this.id = id;
+      return this;
+    }
+
+    public String getPayload() {
+      return payload;
+    }
+
+    public LargeEntity setPayload(final String payload) {
+      this.payload = payload;
+      return this;
+    }
+  }
+}


### PR DESCRIPTION
# Description
Backport of #49964 to `stable/8.9`.

relates to #49962