### PR TITLE
[Backport stable/8.9] fix: batch getMappings requests to avoid exceeding URL limit

### DIFF
--- a/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.util.migration.VersionCompatibilityCheck.CheckResult.Com
 import io.camunda.zeebe.util.migration.VersionCompatibilityCheck.CheckResult.Incompatible;
 import io.camunda.zeebe.util.migration.VersionCompatibilityCheck.CheckResult.Indeterminate;
 import io.camunda.zeebe.util.retry.RetryDecorator;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -47,6 +48,10 @@ import org.slf4j.LoggerFactory;
 public class SchemaManager implements CloseableSilently {
 
   public static final int INDEX_CREATION_TIMEOUT_SECONDS = 60;
+
+  /** Maximum length of a comma-delimited index-pattern string passed in a URL request. */
+  static final int MAX_INDEX_PATTERN_REQUEST_LENGTH = 4096;
+
   private static final Logger LOG = LoggerFactory.getLogger(SchemaManager.class);
   private final SearchEngineClient searchEngineClient;
   private final Collection<IndexDescriptor> allIndexDescriptors;
@@ -427,16 +432,41 @@ public class SchemaManager implements CloseableSilently {
         indexTemplateDescriptors.stream()
             .map(IndexDescriptor::getFullQualifiedName)
             .collect(Collectors.toSet());
-    final String indexPatterns =
-        indexTemplateDescriptors.stream()
-            .map(IndexTemplateDescriptor::getIndexPattern)
-            .collect(Collectors.joining(","));
+    final var indexPatterns =
+        indexTemplateDescriptors.stream().map(IndexTemplateDescriptor::getIndexPattern).toList();
     final var archivedIndices =
-        searchEngineClient.getMappings(indexPatterns, MappingSource.INDEX).keySet().stream()
+        batchIndexPatterns(indexPatterns).stream()
+            .flatMap(
+                batch ->
+                    searchEngineClient.getMappings(batch, MappingSource.INDEX).keySet().stream())
             .filter(index -> !liveIndices.contains(index))
             .toList();
     archivedIndices.forEach(searchEngineClient::deleteIndex);
     LOG.debug("Deleted archived indices '{}'", archivedIndices);
+  }
+
+  /**
+   * Splits the given list of index patterns into batches where each batch's comma-joined length
+   * does not exceed the maximum URL-safe request size of 4096 characters.
+   */
+  static List<String> batchIndexPatterns(final List<String> indexPatterns) {
+    final List<String> batches = new ArrayList<>();
+    final StringBuilder current = new StringBuilder();
+    for (final String pattern : indexPatterns) {
+      if (!current.isEmpty()
+          && current.length() + 1 + pattern.length() > MAX_INDEX_PATTERN_REQUEST_LENGTH) {
+        batches.add(current.toString());
+        current.setLength(0);
+      }
+      if (!current.isEmpty()) {
+        current.append(",");
+      }
+      current.append(pattern);
+    }
+    if (!current.isEmpty()) {
+      batches.add(current.toString());
+    }
+    return batches;
   }
 
   private IndexConfiguration getIndexSettingsFromConfig(final String indexName) {

--- a/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
@@ -29,7 +29,6 @@ import io.camunda.zeebe.util.migration.VersionCompatibilityCheck.CheckResult.Com
 import io.camunda.zeebe.util.migration.VersionCompatibilityCheck.CheckResult.Incompatible;
 import io.camunda.zeebe.util.migration.VersionCompatibilityCheck.CheckResult.Indeterminate;
 import io.camunda.zeebe.util.retry.RetryDecorator;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -48,10 +47,6 @@ import org.slf4j.LoggerFactory;
 public class SchemaManager implements CloseableSilently {
 
   public static final int INDEX_CREATION_TIMEOUT_SECONDS = 60;
-
-  /** Maximum length of a comma-delimited index-pattern string passed in a URL request. */
-  static final int MAX_INDEX_PATTERN_REQUEST_LENGTH = 4096;
-
   private static final Logger LOG = LoggerFactory.getLogger(SchemaManager.class);
   private final SearchEngineClient searchEngineClient;
   private final Collection<IndexDescriptor> allIndexDescriptors;
@@ -432,41 +427,16 @@ public class SchemaManager implements CloseableSilently {
         indexTemplateDescriptors.stream()
             .map(IndexDescriptor::getFullQualifiedName)
             .collect(Collectors.toSet());
-    final var indexPatterns =
-        indexTemplateDescriptors.stream().map(IndexTemplateDescriptor::getIndexPattern).toList();
+    final String indexPatterns =
+        indexTemplateDescriptors.stream()
+            .map(IndexTemplateDescriptor::getIndexPattern)
+            .collect(Collectors.joining(","));
     final var archivedIndices =
-        batchIndexPatterns(indexPatterns).stream()
-            .flatMap(
-                batch ->
-                    searchEngineClient.getMappings(batch, MappingSource.INDEX).keySet().stream())
+        searchEngineClient.getMappings(indexPatterns, MappingSource.INDEX).keySet().stream()
             .filter(index -> !liveIndices.contains(index))
             .toList();
     archivedIndices.forEach(searchEngineClient::deleteIndex);
     LOG.debug("Deleted archived indices '{}'", archivedIndices);
-  }
-
-  /**
-   * Splits the given list of index patterns into batches where each batch's comma-joined length
-   * does not exceed the maximum URL-safe request size of 4096 characters.
-   */
-  static List<String> batchIndexPatterns(final List<String> indexPatterns) {
-    final List<String> batches = new ArrayList<>();
-    final StringBuilder current = new StringBuilder();
-    for (final String pattern : indexPatterns) {
-      if (!current.isEmpty()
-          && current.length() + 1 + pattern.length() > MAX_INDEX_PATTERN_REQUEST_LENGTH) {
-        batches.add(current.toString());
-        current.setLength(0);
-      }
-      if (!current.isEmpty()) {
-        current.append(",");
-      }
-      current.append(pattern);
-    }
-    if (!current.isEmpty()) {
-      batches.add(current.toString());
-    }
-    return batches;
   }
 
   private IndexConfiguration getIndexSettingsFromConfig(final String indexName) {

--- a/schema-manager/src/main/java/io/camunda/search/schema/elasticsearch/ElasticsearchEngineClient.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/elasticsearch/ElasticsearchEngineClient.java
@@ -54,6 +54,7 @@ import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -165,9 +166,12 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
   public Map<String, IndexMapping> getMappings(
       final String namePattern, final MappingSource mappingSource) {
     try {
-      final Map<String, TypeMapping> mappings = getCurrentMappings(mappingSource, namePattern);
+      final Map<String, TypeMapping> allMappings = new HashMap<>();
+      for (final String batch : SearchEngineClientUtils.batchPatterns(namePattern)) {
+        allMappings.putAll(getCurrentMappings(mappingSource, batch));
+      }
 
-      return mappings.entrySet().stream()
+      return allMappings.entrySet().stream()
           .collect(
               Collectors.toMap(
                   Entry::getKey,

--- a/schema-manager/src/main/java/io/camunda/search/schema/opensearch/OpensearchEngineClient.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/opensearch/OpensearchEngineClient.java
@@ -31,6 +31,7 @@ import io.camunda.zeebe.util.VisibleForTesting;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -181,8 +182,11 @@ public class OpensearchEngineClient implements SearchEngineClient {
   public Map<String, IndexMapping> getMappings(
       final String namePattern, final MappingSource mappingSource) {
     try {
-      final Map<String, TypeMapping> mappings = getCurrentMappings(mappingSource, namePattern);
-      return mappings.entrySet().stream()
+      final Map<String, TypeMapping> allMappings = new HashMap<>();
+      for (final String batch : SearchEngineClientUtils.batchPatterns(namePattern)) {
+        allMappings.putAll(getCurrentMappings(mappingSource, batch));
+      }
+      return allMappings.entrySet().stream()
           .collect(
               Collectors.toMap(
                   Entry::getKey,

--- a/schema-manager/src/main/java/io/camunda/search/schema/utils/SearchEngineClientUtils.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/utils/SearchEngineClientUtils.java
@@ -14,6 +14,8 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -22,6 +24,13 @@ import java.util.stream.Collectors;
 import org.apache.commons.io.IOUtils;
 
 public class SearchEngineClientUtils {
+
+  /**
+   * Maximum length of a comma-delimited index-pattern string passed in a URL request. Requests
+   * exceeding this limit may be rejected by the search engine.
+   */
+  public static final int MAX_INDEX_PATTERN_REQUEST_LENGTH = 4096;
+
   private final ObjectMapper objectMapper;
 
   public SearchEngineClientUtils(final ObjectMapper objectMapper) {
@@ -36,6 +45,38 @@ public class SearchEngineClientUtils {
 
   public static <T, U> U convertValue(final T fromValue, final Function<T, U> converter) {
     return fromValue != null ? converter.apply(fromValue) : null;
+  }
+
+  /**
+   * Splits a comma-separated index-pattern string into batches where each batch's length does not
+   * exceed {@link #MAX_INDEX_PATTERN_REQUEST_LENGTH}. A single pattern that is itself longer than
+   * the limit is placed in its own batch.
+   *
+   * @param namePattern comma-separated index patterns, e.g. {@code "index-a*,index-b*"}
+   * @return ordered list of comma-joined batches
+   */
+  public static List<String> batchPatterns(final String namePattern) {
+    if (namePattern == null || namePattern.isEmpty()) {
+      return Collections.emptyList();
+    }
+    final String[] patterns = namePattern.split(",");
+    final List<String> batches = new ArrayList<>();
+    final StringBuilder current = new StringBuilder();
+    for (final String pattern : patterns) {
+      if (current.length() > 0
+          && current.length() + 1 + pattern.length() > MAX_INDEX_PATTERN_REQUEST_LENGTH) {
+        batches.add(current.toString());
+        current.setLength(0);
+      }
+      if (current.length() > 0) {
+        current.append(",");
+      }
+      current.append(pattern);
+    }
+    if (current.length() > 0) {
+      batches.add(current.toString());
+    }
+    return batches;
   }
 
   public <T> T mapToSettings(

--- a/schema-manager/src/main/java/io/camunda/search/schema/utils/SearchEngineClientUtils.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/utils/SearchEngineClientUtils.java
@@ -22,8 +22,12 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SearchEngineClientUtils {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SearchEngineClientUtils.class);
 
   /**
    * Maximum length of a comma-delimited index-pattern string passed in a URL request. Requests
@@ -52,6 +56,11 @@ public class SearchEngineClientUtils {
    * exceed {@link #MAX_INDEX_PATTERN_REQUEST_LENGTH}. A single pattern that is itself longer than
    * the limit is placed in its own batch.
    *
+   * <p><b>Note:</b> If the pattern contains exclusion entries (segments starting with {@code -},
+   * e.g. {@code "index-a*,-index-a"}), batching is skipped entirely because splitting at a batch
+   * boundary could separate an include pattern from its paired exclusion, producing incorrect query
+   * results. In that case a warning is logged and the original pattern is returned as-is.
+   *
    * @param namePattern comma-separated index patterns, e.g. {@code "index-a*,index-b*"}
    * @return ordered list of comma-joined batches
    */
@@ -60,6 +69,15 @@ public class SearchEngineClientUtils {
       return Collections.emptyList();
     }
     final String[] patterns = namePattern.split(",");
+    for (final String pattern : patterns) {
+      if (pattern.startsWith("-")) {
+        LOG.warn(
+            "Index pattern [{}] contains exclusion entries; skipping batching to preserve "
+                + "exclusion semantics. The full pattern will be sent in a single request.",
+            namePattern);
+        return Collections.singletonList(namePattern);
+      }
+    }
     final List<String> batches = new ArrayList<>();
     final StringBuilder current = new StringBuilder();
     for (final String pattern : patterns) {

--- a/schema-manager/src/main/java/io/camunda/search/schema/utils/SearchEngineClientUtils.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/utils/SearchEngineClientUtils.java
@@ -27,14 +27,14 @@ import org.slf4j.LoggerFactory;
 
 public class SearchEngineClientUtils {
 
-  private static final Logger LOG = LoggerFactory.getLogger(SearchEngineClientUtils.class);
-
   /**
    * Maximum length of a comma-delimited index-pattern string passed in a URL request. Requests
-   * exceeding this limit may be rejected by the search engine.
+   * exceeding this limit may be rejected by the search engine. ES/OS limit this to 4096, but we use
+   * a lower value to be conservative
    */
-  public static final int MAX_INDEX_PATTERN_REQUEST_LENGTH = 4096;
+  public static final int MAX_INDEX_PATTERN_REQUEST_LENGTH = 3500;
 
+  private static final Logger LOG = LoggerFactory.getLogger(SearchEngineClientUtils.class);
   private final ObjectMapper objectMapper;
 
   public SearchEngineClientUtils(final ObjectMapper objectMapper) {

--- a/schema-manager/src/main/java/io/camunda/search/schema/utils/SearchEngineClientUtils.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/utils/SearchEngineClientUtils.java
@@ -71,7 +71,7 @@ public class SearchEngineClientUtils {
     final String[] patterns = namePattern.split(",");
     for (final String pattern : patterns) {
       if (pattern.startsWith("-")) {
-        LOG.warn(
+        LOG.debug(
             "Index pattern [{}] contains exclusion entries; skipping batching to preserve "
                 + "exclusion semantics. The full pattern will be sent in a single request.",
             namePattern);

--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerTest.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerTest.java
@@ -10,11 +10,9 @@ package io.camunda.search.schema;
 import static io.camunda.search.schema.SchemaMetadataStore.SCHEMA_VERSION_METADATA_ID;
 import static io.camunda.webapps.schema.descriptors.index.MetadataIndex.ID;
 import static io.camunda.webapps.schema.descriptors.index.MetadataIndex.VALUE;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -342,63 +340,6 @@ class SchemaManagerTest {
   }
 
   @Nested
-  class BatchIndexPatternsTest {
-
-    @Test
-    void shouldReturnSingleBatchWhenPatternsWithinLimit() {
-      // given
-      final var patterns = List.of("index-a*", "index-b*", "index-c*");
-
-      // when
-      final var batches = SchemaManager.batchIndexPatterns(patterns);
-
-      // then
-      assertThat(batches).hasSize(1);
-      assertThat(batches.get(0)).isEqualTo("index-a*,index-b*,index-c*");
-    }
-
-    @Test
-    void shouldReturnEmptyListWhenNoPatternsGiven() {
-      // when
-      final var batches = SchemaManager.batchIndexPatterns(List.of());
-
-      // then
-      assertThat(batches).isEmpty();
-    }
-
-    @Test
-    void shouldSplitIntoBatchesWhenPatternsExceedMaxLength() {
-      // given
-      // Create patterns that together exceed the max request length
-      final var longPattern = "a".repeat(2000) + "*";
-      final var patterns = List.of(longPattern, longPattern, longPattern);
-
-      // when
-      final var batches = SchemaManager.batchIndexPatterns(patterns);
-
-      // then
-      assertThat(batches).hasSizeGreaterThan(1);
-      // Each batch must not exceed the configured max length
-      batches.forEach(
-          batch ->
-              assertThat(batch.length())
-                  .isLessThanOrEqualTo(SchemaManager.MAX_INDEX_PATTERN_REQUEST_LENGTH));
-      // All patterns must appear across batches
-      final var allPatterns = batches.stream().flatMap(b -> Stream.of(b.split(","))).toList();
-      assertThat(allPatterns).containsExactlyInAnyOrderElementsOf(patterns);
-    }
-
-    @Test
-    void shouldPutEachOversizedPatternInItsOwnBatch() {
-      // A single pattern longer than the limit should still be included alone
-      final var largePattern = "x".repeat(SchemaManager.MAX_INDEX_PATTERN_REQUEST_LENGTH) + "*";
-      final var batches = SchemaManager.batchIndexPatterns(List.of(largePattern));
-      assertThat(batches).hasSize(1);
-      assertThat(batches.get(0)).isEqualTo(largePattern);
-    }
-  }
-
-  @Nested
   class DeleteArchivedIndicesTest {
 
     @Test
@@ -429,43 +370,6 @@ class SchemaManagerTest {
       // then
       verify(searchEngineClient, never()).deleteIndex(liveIndexName);
       verify(searchEngineClient).deleteIndex(archivedIndexName);
-    }
-
-    @Test
-    void shouldBatchGetMappingsCallsWhenIndexPatternsExceedMaxLength() {
-      // given
-      // Build many template descriptors whose combined index patterns exceed 4096 chars
-      final List<IndexTemplateDescriptor> manyTemplates =
-          Stream.iterate(0, i -> i + 1)
-              .limit(5)
-              .map(
-                  i ->
-                      (IndexTemplateDescriptor)
-                          new TestTemplateDescriptor(
-                              config.connect().getIndexPrefix(),
-                              true,
-                              "a".repeat(1000) + "_template_" + i,
-                              "mappings.json"))
-              .toList();
-
-      schemaManager =
-          new SchemaManager(
-              searchEngineClient,
-              indexDescriptors,
-              manyTemplates,
-              config,
-              mock(IndexSchemaValidator.class),
-              "8.8.0",
-              null);
-
-      when(searchEngineClient.getMappings(anyString(), any())).thenReturn(Map.of());
-
-      // when
-      schemaManager.deleteArchivedIndices();
-
-      // then
-      // Combined pattern length exceeds 4096, so getMappings must be called more than once
-      verify(searchEngineClient, atLeast(2)).getMappings(anyString(), any());
     }
   }
 }

--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerTest.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerTest.java
@@ -10,9 +10,11 @@ package io.camunda.search.schema;
 import static io.camunda.search.schema.SchemaMetadataStore.SCHEMA_VERSION_METADATA_ID;
 import static io.camunda.webapps.schema.descriptors.index.MetadataIndex.ID;
 import static io.camunda.webapps.schema.descriptors.index.MetadataIndex.VALUE;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -28,11 +30,13 @@ import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.index.MetadataIndex;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -335,5 +339,133 @@ class SchemaManagerTest {
     when(searchEngineClient.getDocument(
             metadataIndex.getFullQualifiedName(), SCHEMA_VERSION_METADATA_ID))
         .thenReturn(versionDoc);
+  }
+
+  @Nested
+  class BatchIndexPatternsTest {
+
+    @Test
+    void shouldReturnSingleBatchWhenPatternsWithinLimit() {
+      // given
+      final var patterns = List.of("index-a*", "index-b*", "index-c*");
+
+      // when
+      final var batches = SchemaManager.batchIndexPatterns(patterns);
+
+      // then
+      assertThat(batches).hasSize(1);
+      assertThat(batches.get(0)).isEqualTo("index-a*,index-b*,index-c*");
+    }
+
+    @Test
+    void shouldReturnEmptyListWhenNoPatternsGiven() {
+      // when
+      final var batches = SchemaManager.batchIndexPatterns(List.of());
+
+      // then
+      assertThat(batches).isEmpty();
+    }
+
+    @Test
+    void shouldSplitIntoBatchesWhenPatternsExceedMaxLength() {
+      // given
+      // Create patterns that together exceed the max request length
+      final var longPattern = "a".repeat(2000) + "*";
+      final var patterns = List.of(longPattern, longPattern, longPattern);
+
+      // when
+      final var batches = SchemaManager.batchIndexPatterns(patterns);
+
+      // then
+      assertThat(batches).hasSizeGreaterThan(1);
+      // Each batch must not exceed the configured max length
+      batches.forEach(
+          batch ->
+              assertThat(batch.length())
+                  .isLessThanOrEqualTo(SchemaManager.MAX_INDEX_PATTERN_REQUEST_LENGTH));
+      // All patterns must appear across batches
+      final var allPatterns = batches.stream().flatMap(b -> Stream.of(b.split(","))).toList();
+      assertThat(allPatterns).containsExactlyInAnyOrderElementsOf(patterns);
+    }
+
+    @Test
+    void shouldPutEachOversizedPatternInItsOwnBatch() {
+      // A single pattern longer than the limit should still be included alone
+      final var largePattern = "x".repeat(SchemaManager.MAX_INDEX_PATTERN_REQUEST_LENGTH) + "*";
+      final var batches = SchemaManager.batchIndexPatterns(List.of(largePattern));
+      assertThat(batches).hasSize(1);
+      assertThat(batches.get(0)).isEqualTo(largePattern);
+    }
+  }
+
+  @Nested
+  class DeleteArchivedIndicesTest {
+
+    @Test
+    void shouldDeleteArchivedIndicesNotMatchingLiveIndices() {
+      // given
+      schemaManager =
+          new SchemaManager(
+              searchEngineClient,
+              indexDescriptors,
+              templateDescriptors,
+              config,
+              mock(IndexSchemaValidator.class),
+              "8.8.0",
+              null);
+
+      final var liveIndexName = testTemplateDescriptor.getFullQualifiedName();
+      final var archivedIndexName = liveIndexName + "_2024-01-01";
+      final var dummyMapping =
+          new IndexMapping.Builder().indexName(liveIndexName).dynamic("strict").build();
+      final Map<String, IndexMapping> mappings = new HashMap<>();
+      mappings.put(liveIndexName, dummyMapping);
+      mappings.put(archivedIndexName, dummyMapping);
+      when(searchEngineClient.getMappings(anyString(), any())).thenReturn(mappings);
+
+      // when
+      schemaManager.deleteArchivedIndices();
+
+      // then
+      verify(searchEngineClient, never()).deleteIndex(liveIndexName);
+      verify(searchEngineClient).deleteIndex(archivedIndexName);
+    }
+
+    @Test
+    void shouldBatchGetMappingsCallsWhenIndexPatternsExceedMaxLength() {
+      // given
+      // Build many template descriptors whose combined index patterns exceed 4096 chars
+      final List<IndexTemplateDescriptor> manyTemplates =
+          Stream.iterate(0, i -> i + 1)
+              .limit(5)
+              .map(
+                  i ->
+                      (IndexTemplateDescriptor)
+                          new TestTemplateDescriptor(
+                              config.connect().getIndexPrefix(),
+                              true,
+                              "a".repeat(1000) + "_template_" + i,
+                              "mappings.json"))
+              .toList();
+
+      schemaManager =
+          new SchemaManager(
+              searchEngineClient,
+              indexDescriptors,
+              manyTemplates,
+              config,
+              mock(IndexSchemaValidator.class),
+              "8.8.0",
+              null);
+
+      when(searchEngineClient.getMappings(anyString(), any())).thenReturn(Map.of());
+
+      // when
+      schemaManager.deleteArchivedIndices();
+
+      // then
+      // Combined pattern length exceeds 4096, so getMappings must be called more than once
+      verify(searchEngineClient, atLeast(2)).getMappings(anyString(), any());
+    }
   }
 }

--- a/schema-manager/src/test/java/io/camunda/search/schema/utils/SearchEngineClientUtilsTest.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/utils/SearchEngineClientUtilsTest.java
@@ -78,4 +78,17 @@ class SearchEngineClientUtilsTest {
     assertThat(batches).hasSize(1);
     assertThat(batches.get(0)).isEqualTo(largePattern);
   }
+
+  @Test
+  void shouldSkipBatchingWhenPatternContainsExclusionEntries() {
+    // given – the exclusion pattern must not be split away from its include
+    final var namePattern = "index-a*,-index-a,index-b*,-index-b";
+
+    // when
+    final var batches = SearchEngineClientUtils.batchPatterns(namePattern);
+
+    // then – returned as-is so exclusion semantics are preserved
+    assertThat(batches).hasSize(1);
+    assertThat(batches.get(0)).isEqualTo(namePattern);
+  }
 }

--- a/schema-manager/src/test/java/io/camunda/search/schema/utils/SearchEngineClientUtilsTest.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/utils/SearchEngineClientUtilsTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.schema.utils;
+
+import static io.camunda.search.schema.utils.SearchEngineClientUtils.MAX_INDEX_PATTERN_REQUEST_LENGTH;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+class SearchEngineClientUtilsTest {
+
+  @Test
+  void shouldReturnSingleBatchWhenPatternWithinLimit() {
+    // given
+    final var namePattern = "index-a*,index-b*,index-c*";
+
+    // when
+    final var batches = SearchEngineClientUtils.batchPatterns(namePattern);
+
+    // then
+    assertThat(batches).hasSize(1);
+    assertThat(batches.get(0)).isEqualTo(namePattern);
+  }
+
+  @Test
+  void shouldReturnEmptyListWhenNullPatternGiven() {
+    // when
+    final var batches = SearchEngineClientUtils.batchPatterns(null);
+
+    // then
+    assertThat(batches).isEmpty();
+  }
+
+  @Test
+  void shouldReturnEmptyListWhenEmptyPatternGiven() {
+    // when
+    final var batches = SearchEngineClientUtils.batchPatterns("");
+
+    // then
+    assertThat(batches).isEmpty();
+  }
+
+  @Test
+  void shouldSplitIntoBatchesWhenPatternExceedsMaxLength() {
+    // given – create patterns that together exceed the max request length
+    final var longPart = "a".repeat(2000);
+    final var namePattern = longPart + "*," + longPart + "*," + longPart + "*";
+
+    // when
+    final var batches = SearchEngineClientUtils.batchPatterns(namePattern);
+
+    // then
+    assertThat(batches).hasSizeGreaterThan(1);
+    // Each batch must not exceed the configured max length
+    batches.forEach(
+        batch -> assertThat(batch.length()).isLessThanOrEqualTo(MAX_INDEX_PATTERN_REQUEST_LENGTH));
+    // All patterns must appear across batches
+    final var allPatterns = batches.stream().flatMap(b -> Stream.of(b.split(","))).toList();
+    assertThat(allPatterns).containsExactlyInAnyOrderElementsOf(List.of(namePattern.split(",")));
+  }
+
+  @Test
+  void shouldPutOversizedSinglePatternInItsOwnBatch() {
+    // given – a single pattern that is itself longer than the limit
+    final var largePattern = "x".repeat(MAX_INDEX_PATTERN_REQUEST_LENGTH) + "*";
+
+    // when
+    final var batches = SearchEngineClientUtils.batchPatterns(largePattern);
+
+    // then
+    assertThat(batches).hasSize(1);
+    assertThat(batches.get(0)).isEqualTo(largePattern);
+  }
+}


### PR DESCRIPTION
# Description
Backport of #47024 to `stable/8.9`.

relates to camunda/camunda#47023