### PR TITLE
48109 es + os exporter config implementations

### DIFF
--- a/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/DefaultRecordFilterTest.java
+++ b/zeebe/exporter-filter/src/test/java/io/camunda/zeebe/exporter/filter/DefaultRecordFilterTest.java
@@ -353,6 +353,42 @@ final class DefaultRecordFilterTest {
         .isTrue();
   }
 
+  @Test
+  void shouldApplyScopeAndGlobalFiltersIndependently() {
+    // given: global name inclusion for "allowed", local type inclusion for NUMBER
+    final var configuration =
+        new TestConfiguration()
+            .withIndexedRecordType(RecordType.EVENT)
+            .withIndexedValueType(ValueType.VARIABLE);
+
+    configuration
+        .filterIndexConfig()
+        .withVariableNameInclusionExact(List.of("allowed"))
+        .withLocalVariableValueTypeInclusion(List.of("NUMBER"));
+
+    final var filter = new DefaultRecordFilter(configuration);
+
+    // root variable named "allowed" → passes global name filter, no local type rule applies
+    assertThat(filter.acceptRecord(scopedVariableRecord("allowed", "\"text\"", 100L, 100L)))
+        .as("Root variable 'allowed' should pass global name filter")
+        .isTrue();
+
+    // root variable named "other" → rejected by global name filter
+    assertThat(filter.acceptRecord(scopedVariableRecord("other", "\"text\"", 100L, 100L)))
+        .as("Root variable 'other' should be rejected by global name filter")
+        .isFalse();
+
+    // local variable named "allowed" with NUMBER value → passes both filters
+    assertThat(filter.acceptRecord(scopedVariableRecord("allowed", "42", 100L, 200L)))
+        .as("Local variable 'allowed' with NUMBER type should pass both filters")
+        .isTrue();
+
+    // local variable named "allowed" with STRING value → rejected by local type filter
+    assertThat(filter.acceptRecord(scopedVariableRecord("allowed", "\"text\"", 100L, 200L)))
+        .as("Local variable 'allowed' with STRING type should be rejected by local type filter")
+        .isFalse();
+  }
+
   // ---------------------------------------------------------------------------
   // helpers
   // ---------------------------------------------------------------------------

--- a/zeebe/exporters/elasticsearch-exporter/pom.xml
+++ b/zeebe/exporters/elasticsearch-exporter/pom.xml
@@ -206,6 +206,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-broker</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -271,6 +271,33 @@ public class ElasticsearchExporterConfiguration implements FilterConfiguration {
     // optimize mode
     private boolean optimizeModeEnabled = false;
 
+    // export local variables flag
+    private boolean exportLocalVariablesEnabled = true;
+
+    // local variable name filters
+    private List<String> localVariableNameInclusionExact = new ArrayList<>();
+    private List<String> localVariableNameInclusionStartWith = new ArrayList<>();
+    private List<String> localVariableNameInclusionEndWith = new ArrayList<>();
+    private List<String> localVariableNameExclusionExact = new ArrayList<>();
+    private List<String> localVariableNameExclusionStartWith = new ArrayList<>();
+    private List<String> localVariableNameExclusionEndWith = new ArrayList<>();
+
+    // local variable value type filters
+    private List<String> localVariableValueTypeInclusion = new ArrayList<>();
+    private List<String> localVariableValueTypeExclusion = new ArrayList<>();
+
+    // root variable name filters
+    private List<String> rootVariableNameInclusionExact = new ArrayList<>();
+    private List<String> rootVariableNameInclusionStartWith = new ArrayList<>();
+    private List<String> rootVariableNameInclusionEndWith = new ArrayList<>();
+    private List<String> rootVariableNameExclusionExact = new ArrayList<>();
+    private List<String> rootVariableNameExclusionStartWith = new ArrayList<>();
+    private List<String> rootVariableNameExclusionEndWith = new ArrayList<>();
+
+    // root variable value type filters
+    private List<String> rootVariableValueTypeInclusion = new ArrayList<>();
+    private List<String> rootVariableValueTypeExclusion = new ArrayList<>();
+
     // BPMN process id filters
     private List<String> bpmnProcessIdInclusion = new ArrayList<>();
     private List<String> bpmnProcessIdExclusion = new ArrayList<>();
@@ -301,7 +328,7 @@ public class ElasticsearchExporterConfiguration implements FilterConfiguration {
 
     @Override
     public List<String> getVariableNameInclusionExact() {
-      return variableNameInclusionExact;
+      return List.copyOf(variableNameInclusionExact);
     }
 
     @Override
@@ -339,6 +366,165 @@ public class ElasticsearchExporterConfiguration implements FilterConfiguration {
       return List.copyOf(variableValueTypeExclusion);
     }
 
+    public void setVariableValueTypeExclusion(final List<String> variableValueTypeExclusion) {
+      this.variableValueTypeExclusion = variableValueTypeExclusion;
+    }
+
+    @Override
+    public List<String> getRootVariableNameInclusionExact() {
+      return List.copyOf(rootVariableNameInclusionExact);
+    }
+
+    public void setRootVariableNameInclusionExact(
+        final List<String> rootVariableNameInclusionExact) {
+      this.rootVariableNameInclusionExact = rootVariableNameInclusionExact;
+    }
+
+    @Override
+    public List<String> getRootVariableNameInclusionStartWith() {
+      return List.copyOf(rootVariableNameInclusionStartWith);
+    }
+
+    public void setRootVariableNameInclusionStartWith(
+        final List<String> rootVariableNameInclusionStartWith) {
+      this.rootVariableNameInclusionStartWith = rootVariableNameInclusionStartWith;
+    }
+
+    @Override
+    public List<String> getRootVariableNameInclusionEndWith() {
+      return List.copyOf(rootVariableNameInclusionEndWith);
+    }
+
+    public void setRootVariableNameInclusionEndWith(
+        final List<String> rootVariableNameInclusionEndWith) {
+      this.rootVariableNameInclusionEndWith = rootVariableNameInclusionEndWith;
+    }
+
+    @Override
+    public List<String> getRootVariableNameExclusionExact() {
+      return List.copyOf(rootVariableNameExclusionExact);
+    }
+
+    public void setRootVariableNameExclusionExact(
+        final List<String> rootVariableNameExclusionExact) {
+      this.rootVariableNameExclusionExact = rootVariableNameExclusionExact;
+    }
+
+    @Override
+    public List<String> getRootVariableNameExclusionStartWith() {
+      return List.copyOf(rootVariableNameExclusionStartWith);
+    }
+
+    public void setRootVariableNameExclusionStartWith(
+        final List<String> rootVariableNameExclusionStartWith) {
+      this.rootVariableNameExclusionStartWith = rootVariableNameExclusionStartWith;
+    }
+
+    @Override
+    public List<String> getRootVariableNameExclusionEndWith() {
+      return List.copyOf(rootVariableNameExclusionEndWith);
+    }
+
+    public void setRootVariableNameExclusionEndWith(
+        final List<String> rootVariableNameExclusionEndWith) {
+      this.rootVariableNameExclusionEndWith = rootVariableNameExclusionEndWith;
+    }
+
+    @Override
+    public List<String> getRootVariableValueTypeInclusion() {
+      return List.copyOf(rootVariableValueTypeInclusion);
+    }
+
+    public void setRootVariableValueTypeInclusion(
+        final List<String> rootVariableValueTypeInclusion) {
+      this.rootVariableValueTypeInclusion = rootVariableValueTypeInclusion;
+    }
+
+    @Override
+    public List<String> getRootVariableValueTypeExclusion() {
+      return List.copyOf(rootVariableValueTypeExclusion);
+    }
+
+    @Override
+    public List<String> getLocalVariableNameInclusionExact() {
+      return List.copyOf(localVariableNameInclusionExact);
+    }
+
+    public void setLocalVariableNameInclusionExact(
+        final List<String> localVariableNameInclusionExact) {
+      this.localVariableNameInclusionExact = localVariableNameInclusionExact;
+    }
+
+    @Override
+    public List<String> getLocalVariableNameInclusionStartWith() {
+      return List.copyOf(localVariableNameInclusionStartWith);
+    }
+
+    public void setLocalVariableNameInclusionStartWith(
+        final List<String> localVariableNameInclusionStartWith) {
+      this.localVariableNameInclusionStartWith = localVariableNameInclusionStartWith;
+    }
+
+    @Override
+    public List<String> getLocalVariableNameInclusionEndWith() {
+      return List.copyOf(localVariableNameInclusionEndWith);
+    }
+
+    public void setLocalVariableNameInclusionEndWith(
+        final List<String> localVariableNameInclusionEndWith) {
+      this.localVariableNameInclusionEndWith = localVariableNameInclusionEndWith;
+    }
+
+    @Override
+    public List<String> getLocalVariableNameExclusionExact() {
+      return List.copyOf(localVariableNameExclusionExact);
+    }
+
+    public void setLocalVariableNameExclusionExact(
+        final List<String> localVariableNameExclusionExact) {
+      this.localVariableNameExclusionExact = localVariableNameExclusionExact;
+    }
+
+    @Override
+    public List<String> getLocalVariableNameExclusionStartWith() {
+      return List.copyOf(localVariableNameExclusionStartWith);
+    }
+
+    public void setLocalVariableNameExclusionStartWith(
+        final List<String> localVariableNameExclusionStartWith) {
+      this.localVariableNameExclusionStartWith = localVariableNameExclusionStartWith;
+    }
+
+    @Override
+    public List<String> getLocalVariableNameExclusionEndWith() {
+      return List.copyOf(localVariableNameExclusionEndWith);
+    }
+
+    public void setLocalVariableNameExclusionEndWith(
+        final List<String> localVariableNameExclusionEndWith) {
+      this.localVariableNameExclusionEndWith = localVariableNameExclusionEndWith;
+    }
+
+    @Override
+    public List<String> getLocalVariableValueTypeInclusion() {
+      return List.copyOf(localVariableValueTypeInclusion);
+    }
+
+    public void setLocalVariableValueTypeInclusion(
+        final List<String> localVariableValueTypeInclusion) {
+      this.localVariableValueTypeInclusion = localVariableValueTypeInclusion;
+    }
+
+    @Override
+    public List<String> getLocalVariableValueTypeExclusion() {
+      return List.copyOf(localVariableValueTypeExclusion);
+    }
+
+    @Override
+    public boolean isExportLocalVariablesEnabled() {
+      return exportLocalVariablesEnabled;
+    }
+
     @Override
     public List<String> getBpmnProcessIdInclusion() {
       return List.copyOf(bpmnProcessIdInclusion);
@@ -366,8 +552,18 @@ public class ElasticsearchExporterConfiguration implements FilterConfiguration {
       this.bpmnProcessIdInclusion = bpmnProcessIdInclusion;
     }
 
-    public void setVariableValueTypeExclusion(final List<String> variableValueTypeExclusion) {
-      this.variableValueTypeExclusion = variableValueTypeExclusion;
+    public void setExportLocalVariablesEnabled(final boolean exportLocalVariablesEnabled) {
+      this.exportLocalVariablesEnabled = exportLocalVariablesEnabled;
+    }
+
+    public void setLocalVariableValueTypeExclusion(
+        final List<String> localVariableValueTypeExclusion) {
+      this.localVariableValueTypeExclusion = localVariableValueTypeExclusion;
+    }
+
+    public void setRootVariableValueTypeExclusion(
+        final List<String> rootVariableValueTypeExclusion) {
+      this.rootVariableValueTypeExclusion = rootVariableValueTypeExclusion;
     }
 
     public void setVariableValueTypeInclusion(final List<String> variableValueTypeInclusion) {
@@ -513,6 +709,40 @@ public class ElasticsearchExporterConfiguration implements FilterConfiguration {
           + variableValueTypeExclusion
           + ", optimizeModeEnabled="
           + optimizeModeEnabled
+          + ", exportLocalVariablesEnabled="
+          + exportLocalVariablesEnabled
+          + ", localVariableNameInclusionExact="
+          + localVariableNameInclusionExact
+          + ", localVariableNameInclusionStartWith="
+          + localVariableNameInclusionStartWith
+          + ", localVariableNameInclusionEndWith="
+          + localVariableNameInclusionEndWith
+          + ", localVariableNameExclusionExact="
+          + localVariableNameExclusionExact
+          + ", localVariableNameExclusionStartWith="
+          + localVariableNameExclusionStartWith
+          + ", localVariableNameExclusionEndWith="
+          + localVariableNameExclusionEndWith
+          + ", localVariableValueTypeInclusion="
+          + localVariableValueTypeInclusion
+          + ", localVariableValueTypeExclusion="
+          + localVariableValueTypeExclusion
+          + ", rootVariableNameInclusionExact="
+          + rootVariableNameInclusionExact
+          + ", rootVariableNameInclusionStartWith="
+          + rootVariableNameInclusionStartWith
+          + ", rootVariableNameInclusionEndWith="
+          + rootVariableNameInclusionEndWith
+          + ", rootVariableNameExclusionExact="
+          + rootVariableNameExclusionExact
+          + ", rootVariableNameExclusionStartWith="
+          + rootVariableNameExclusionStartWith
+          + ", rootVariableNameExclusionEndWith="
+          + rootVariableNameExclusionEndWith
+          + ", rootVariableValueTypeInclusion="
+          + rootVariableValueTypeInclusion
+          + ", rootVariableValueTypeExclusion="
+          + rootVariableValueTypeExclusion
           + ", bpmnProcessIdInclusion="
           + bpmnProcessIdInclusion
           + ", bpmnProcessIdExclusion="

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchIndexConfigurationTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchIndexConfigurationTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.broker.exporter.context.ExporterConfiguration;
+import io.camunda.zeebe.exporter.ElasticsearchExporterConfiguration.IndexConfiguration;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that the new scope-based variable filter fields on {@link IndexConfiguration} are
+ * correctly wired: setters update the backing fields and getters return the expected values. Tests
+ * also verify round-trip deserialization via {@link ExporterConfiguration#MAPPER}, which is the
+ * exact mapper the Zeebe broker uses to instantiate exporter configuration at runtime.
+ */
+final class ElasticsearchIndexConfigurationTest {
+
+  // ---------------------------------------------------------------------------
+  // exportLocalVariablesEnabled
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldDefaultExportLocalVariablesEnabledToTrue() {
+    assertThat(new IndexConfiguration().isExportLocalVariablesEnabled()).isTrue();
+  }
+
+  @Test
+  void shouldRoundTripExportLocalVariablesEnabled() {
+    // given
+    final var args = Map.<String, Object>of("exportLocalVariablesEnabled", false);
+
+    // when
+    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+
+    // then
+    assertThat(config.isExportLocalVariablesEnabled()).isFalse();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Local variable name filters
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldRoundTripLocalVariableNameInclusionExact() {
+    // given
+    final var args =
+        Map.<String, Object>of("localVariableNameInclusionExact", List.of("localVar", "other"));
+
+    // when
+    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+
+    // then
+    assertThat(config.getLocalVariableNameInclusionExact()).containsExactly("localVar", "other");
+  }
+
+  @Test
+  void shouldRoundTripLocalVariableNameExclusionStartWith() {
+    // given
+    final var args =
+        Map.<String, Object>of("localVariableNameExclusionStartWith", List.of("debug_", "tmp_"));
+
+    // when
+    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+
+    // then
+    assertThat(config.getLocalVariableNameExclusionStartWith()).containsExactly("debug_", "tmp_");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Root variable name filters
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldRoundTripRootVariableNameInclusionExact() {
+    // given
+    final var args = Map.<String, Object>of("rootVariableNameInclusionExact", List.of("rootVar"));
+
+    // when
+    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+
+    // then
+    assertThat(config.getRootVariableNameInclusionExact()).containsExactly("rootVar");
+  }
+
+  @Test
+  void shouldRoundTripRootVariableNameExclusionEndWith() {
+    // given
+    final var args = Map.<String, Object>of("rootVariableNameExclusionEndWith", List.of("_secret"));
+
+    // when
+    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+
+    // then
+    assertThat(config.getRootVariableNameExclusionEndWith()).containsExactly("_secret");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Scope variable value type filters
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldRoundTripLocalAndRootVariableValueTypeFilters() {
+    // given
+    final var args =
+        Map.<String, Object>of(
+            "localVariableValueTypeInclusion", List.of("NUMBER", "STRING"),
+            "rootVariableValueTypeExclusion", List.of("BOOLEAN"));
+
+    // when
+    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+
+    // then
+    assertThat(config.getLocalVariableValueTypeInclusion()).containsExactly("NUMBER", "STRING");
+    assertThat(config.getRootVariableValueTypeExclusion()).containsExactly("BOOLEAN");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Defaults (all new list fields default to empty)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldDefaultAllNewListFieldsToEmpty() {
+    final var config = new IndexConfiguration();
+
+    assertThat(config.getLocalVariableNameInclusionExact()).isEmpty();
+    assertThat(config.getLocalVariableNameInclusionStartWith()).isEmpty();
+    assertThat(config.getLocalVariableNameInclusionEndWith()).isEmpty();
+    assertThat(config.getLocalVariableNameExclusionExact()).isEmpty();
+    assertThat(config.getLocalVariableNameExclusionStartWith()).isEmpty();
+    assertThat(config.getLocalVariableNameExclusionEndWith()).isEmpty();
+    assertThat(config.getLocalVariableValueTypeInclusion()).isEmpty();
+    assertThat(config.getLocalVariableValueTypeExclusion()).isEmpty();
+    assertThat(config.getRootVariableNameInclusionExact()).isEmpty();
+    assertThat(config.getRootVariableNameInclusionStartWith()).isEmpty();
+    assertThat(config.getRootVariableNameInclusionEndWith()).isEmpty();
+    assertThat(config.getRootVariableNameExclusionExact()).isEmpty();
+    assertThat(config.getRootVariableNameExclusionStartWith()).isEmpty();
+    assertThat(config.getRootVariableNameExclusionEndWith()).isEmpty();
+    assertThat(config.getRootVariableValueTypeInclusion()).isEmpty();
+    assertThat(config.getRootVariableValueTypeExclusion()).isEmpty();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Spring indexed-list format (map with numeric string keys)
+  // ExporterConfigurationListDeserializer handles this at runtime when lists are
+  // configured via Spring Boot properties: e.g. index.localVariableNameInclusionExact[0]=foo
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldDeserializeSpringIndexedListForLocalVariableNameInclusionExact() {
+    // given — Spring Boot encodes list[0]=a, list[1]=b as a Map {"0": "a", "1": "b"}
+    final var args =
+        Map.<String, Object>of(
+            "localVariableNameInclusionExact", Map.of("0", "localVar", "1", "other"));
+
+    // when
+    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+
+    // then
+    assertThat(config.getLocalVariableNameInclusionExact()).containsExactly("localVar", "other");
+  }
+
+  @Test
+  void shouldDeserializeSpringIndexedListForRootVariableNameExclusionExact() {
+    // given
+    final var args =
+        Map.<String, Object>of(
+            "rootVariableNameExclusionExact", Map.of("0", "_secret", "1", "_internal"));
+
+    // when
+    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+
+    // then
+    assertThat(config.getRootVariableNameExclusionExact()).containsExactly("_secret", "_internal");
+  }
+
+  @Test
+  void shouldDeserializeSpringIndexedListForLocalVariableValueTypeInclusion() {
+    // given
+    final var args =
+        Map.<String, Object>of(
+            "localVariableValueTypeInclusion", Map.of("0", "NUMBER", "1", "STRING"));
+
+    // when
+    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+
+    // then
+    assertThat(config.getLocalVariableValueTypeInclusion()).containsExactly("NUMBER", "STRING");
+  }
+}

--- a/zeebe/exporters/opensearch-exporter/pom.xml
+++ b/zeebe/exporters/opensearch-exporter/pom.xml
@@ -255,6 +255,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-broker</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
@@ -300,6 +300,33 @@ public class OpensearchExporterConfiguration implements FilterConfiguration {
     // optimize mode
     private boolean optimizeModeEnabled = false;
 
+    // export local variables flag
+    private boolean exportLocalVariablesEnabled = true;
+
+    // local variable name filters
+    private List<String> localVariableNameInclusionExact = new ArrayList<>();
+    private List<String> localVariableNameInclusionStartWith = new ArrayList<>();
+    private List<String> localVariableNameInclusionEndWith = new ArrayList<>();
+    private List<String> localVariableNameExclusionExact = new ArrayList<>();
+    private List<String> localVariableNameExclusionStartWith = new ArrayList<>();
+    private List<String> localVariableNameExclusionEndWith = new ArrayList<>();
+
+    // local variable value type filters
+    private List<String> localVariableValueTypeInclusion = new ArrayList<>();
+    private List<String> localVariableValueTypeExclusion = new ArrayList<>();
+
+    // root variable name filters
+    private List<String> rootVariableNameInclusionExact = new ArrayList<>();
+    private List<String> rootVariableNameInclusionStartWith = new ArrayList<>();
+    private List<String> rootVariableNameInclusionEndWith = new ArrayList<>();
+    private List<String> rootVariableNameExclusionExact = new ArrayList<>();
+    private List<String> rootVariableNameExclusionStartWith = new ArrayList<>();
+    private List<String> rootVariableNameExclusionEndWith = new ArrayList<>();
+
+    // root variable value type filters
+    private List<String> rootVariableValueTypeInclusion = new ArrayList<>();
+    private List<String> rootVariableValueTypeExclusion = new ArrayList<>();
+
     // BPMN process id filters
     private List<String> bpmnProcessIdInclusion = new ArrayList<>();
     private List<String> bpmnProcessIdExclusion = new ArrayList<>();
@@ -330,7 +357,7 @@ public class OpensearchExporterConfiguration implements FilterConfiguration {
 
     @Override
     public List<String> getVariableNameInclusionExact() {
-      return variableNameInclusionExact;
+      return List.copyOf(variableNameInclusionExact);
     }
 
     @Override
@@ -368,6 +395,165 @@ public class OpensearchExporterConfiguration implements FilterConfiguration {
       return List.copyOf(variableValueTypeExclusion);
     }
 
+    public void setVariableValueTypeExclusion(final List<String> variableValueTypeExclusion) {
+      this.variableValueTypeExclusion = variableValueTypeExclusion;
+    }
+
+    @Override
+    public List<String> getRootVariableNameInclusionExact() {
+      return List.copyOf(rootVariableNameInclusionExact);
+    }
+
+    public void setRootVariableNameInclusionExact(
+        final List<String> rootVariableNameInclusionExact) {
+      this.rootVariableNameInclusionExact = rootVariableNameInclusionExact;
+    }
+
+    @Override
+    public List<String> getRootVariableNameInclusionStartWith() {
+      return List.copyOf(rootVariableNameInclusionStartWith);
+    }
+
+    public void setRootVariableNameInclusionStartWith(
+        final List<String> rootVariableNameInclusionStartWith) {
+      this.rootVariableNameInclusionStartWith = rootVariableNameInclusionStartWith;
+    }
+
+    @Override
+    public List<String> getRootVariableNameInclusionEndWith() {
+      return List.copyOf(rootVariableNameInclusionEndWith);
+    }
+
+    public void setRootVariableNameInclusionEndWith(
+        final List<String> rootVariableNameInclusionEndWith) {
+      this.rootVariableNameInclusionEndWith = rootVariableNameInclusionEndWith;
+    }
+
+    @Override
+    public List<String> getRootVariableNameExclusionExact() {
+      return List.copyOf(rootVariableNameExclusionExact);
+    }
+
+    public void setRootVariableNameExclusionExact(
+        final List<String> rootVariableNameExclusionExact) {
+      this.rootVariableNameExclusionExact = rootVariableNameExclusionExact;
+    }
+
+    @Override
+    public List<String> getRootVariableNameExclusionStartWith() {
+      return List.copyOf(rootVariableNameExclusionStartWith);
+    }
+
+    public void setRootVariableNameExclusionStartWith(
+        final List<String> rootVariableNameExclusionStartWith) {
+      this.rootVariableNameExclusionStartWith = rootVariableNameExclusionStartWith;
+    }
+
+    @Override
+    public List<String> getRootVariableNameExclusionEndWith() {
+      return List.copyOf(rootVariableNameExclusionEndWith);
+    }
+
+    public void setRootVariableNameExclusionEndWith(
+        final List<String> rootVariableNameExclusionEndWith) {
+      this.rootVariableNameExclusionEndWith = rootVariableNameExclusionEndWith;
+    }
+
+    @Override
+    public List<String> getRootVariableValueTypeInclusion() {
+      return List.copyOf(rootVariableValueTypeInclusion);
+    }
+
+    public void setRootVariableValueTypeInclusion(
+        final List<String> rootVariableValueTypeInclusion) {
+      this.rootVariableValueTypeInclusion = rootVariableValueTypeInclusion;
+    }
+
+    @Override
+    public List<String> getRootVariableValueTypeExclusion() {
+      return List.copyOf(rootVariableValueTypeExclusion);
+    }
+
+    @Override
+    public List<String> getLocalVariableNameInclusionExact() {
+      return List.copyOf(localVariableNameInclusionExact);
+    }
+
+    public void setLocalVariableNameInclusionExact(
+        final List<String> localVariableNameInclusionExact) {
+      this.localVariableNameInclusionExact = localVariableNameInclusionExact;
+    }
+
+    @Override
+    public List<String> getLocalVariableNameInclusionStartWith() {
+      return List.copyOf(localVariableNameInclusionStartWith);
+    }
+
+    public void setLocalVariableNameInclusionStartWith(
+        final List<String> localVariableNameInclusionStartWith) {
+      this.localVariableNameInclusionStartWith = localVariableNameInclusionStartWith;
+    }
+
+    @Override
+    public List<String> getLocalVariableNameInclusionEndWith() {
+      return List.copyOf(localVariableNameInclusionEndWith);
+    }
+
+    public void setLocalVariableNameInclusionEndWith(
+        final List<String> localVariableNameInclusionEndWith) {
+      this.localVariableNameInclusionEndWith = localVariableNameInclusionEndWith;
+    }
+
+    @Override
+    public List<String> getLocalVariableNameExclusionExact() {
+      return List.copyOf(localVariableNameExclusionExact);
+    }
+
+    public void setLocalVariableNameExclusionExact(
+        final List<String> localVariableNameExclusionExact) {
+      this.localVariableNameExclusionExact = localVariableNameExclusionExact;
+    }
+
+    @Override
+    public List<String> getLocalVariableNameExclusionStartWith() {
+      return List.copyOf(localVariableNameExclusionStartWith);
+    }
+
+    public void setLocalVariableNameExclusionStartWith(
+        final List<String> localVariableNameExclusionStartWith) {
+      this.localVariableNameExclusionStartWith = localVariableNameExclusionStartWith;
+    }
+
+    @Override
+    public List<String> getLocalVariableNameExclusionEndWith() {
+      return List.copyOf(localVariableNameExclusionEndWith);
+    }
+
+    public void setLocalVariableNameExclusionEndWith(
+        final List<String> localVariableNameExclusionEndWith) {
+      this.localVariableNameExclusionEndWith = localVariableNameExclusionEndWith;
+    }
+
+    @Override
+    public List<String> getLocalVariableValueTypeInclusion() {
+      return List.copyOf(localVariableValueTypeInclusion);
+    }
+
+    public void setLocalVariableValueTypeInclusion(
+        final List<String> localVariableValueTypeInclusion) {
+      this.localVariableValueTypeInclusion = localVariableValueTypeInclusion;
+    }
+
+    @Override
+    public List<String> getLocalVariableValueTypeExclusion() {
+      return List.copyOf(localVariableValueTypeExclusion);
+    }
+
+    @Override
+    public boolean isExportLocalVariablesEnabled() {
+      return exportLocalVariablesEnabled;
+    }
+
     @Override
     public List<String> getBpmnProcessIdInclusion() {
       return List.copyOf(bpmnProcessIdInclusion);
@@ -395,8 +581,18 @@ public class OpensearchExporterConfiguration implements FilterConfiguration {
       this.bpmnProcessIdInclusion = bpmnProcessIdInclusion;
     }
 
-    public void setVariableValueTypeExclusion(final List<String> variableValueTypeExclusion) {
-      this.variableValueTypeExclusion = variableValueTypeExclusion;
+    public void setExportLocalVariablesEnabled(final boolean exportLocalVariablesEnabled) {
+      this.exportLocalVariablesEnabled = exportLocalVariablesEnabled;
+    }
+
+    public void setLocalVariableValueTypeExclusion(
+        final List<String> localVariableValueTypeExclusion) {
+      this.localVariableValueTypeExclusion = localVariableValueTypeExclusion;
+    }
+
+    public void setRootVariableValueTypeExclusion(
+        final List<String> rootVariableValueTypeExclusion) {
+      this.rootVariableValueTypeExclusion = rootVariableValueTypeExclusion;
     }
 
     public void setVariableValueTypeInclusion(final List<String> variableValueTypeInclusion) {
@@ -540,6 +736,40 @@ public class OpensearchExporterConfiguration implements FilterConfiguration {
           + variableValueTypeExclusion
           + ", optimizeModeEnabled="
           + optimizeModeEnabled
+          + ", exportLocalVariablesEnabled="
+          + exportLocalVariablesEnabled
+          + ", localVariableNameInclusionExact="
+          + localVariableNameInclusionExact
+          + ", localVariableNameInclusionStartWith="
+          + localVariableNameInclusionStartWith
+          + ", localVariableNameInclusionEndWith="
+          + localVariableNameInclusionEndWith
+          + ", localVariableNameExclusionExact="
+          + localVariableNameExclusionExact
+          + ", localVariableNameExclusionStartWith="
+          + localVariableNameExclusionStartWith
+          + ", localVariableNameExclusionEndWith="
+          + localVariableNameExclusionEndWith
+          + ", localVariableValueTypeInclusion="
+          + localVariableValueTypeInclusion
+          + ", localVariableValueTypeExclusion="
+          + localVariableValueTypeExclusion
+          + ", rootVariableNameInclusionExact="
+          + rootVariableNameInclusionExact
+          + ", rootVariableNameInclusionStartWith="
+          + rootVariableNameInclusionStartWith
+          + ", rootVariableNameInclusionEndWith="
+          + rootVariableNameInclusionEndWith
+          + ", rootVariableNameExclusionExact="
+          + rootVariableNameExclusionExact
+          + ", rootVariableNameExclusionStartWith="
+          + rootVariableNameExclusionStartWith
+          + ", rootVariableNameExclusionEndWith="
+          + rootVariableNameExclusionEndWith
+          + ", rootVariableValueTypeInclusion="
+          + rootVariableValueTypeInclusion
+          + ", rootVariableValueTypeExclusion="
+          + rootVariableValueTypeExclusion
           + ", bpmnProcessIdInclusion="
           + bpmnProcessIdInclusion
           + ", bpmnProcessIdExclusion="

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchIndexConfigurationTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchIndexConfigurationTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.opensearch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.broker.exporter.context.ExporterConfiguration;
+import io.camunda.zeebe.exporter.opensearch.OpensearchExporterConfiguration.IndexConfiguration;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that the new scope-based variable filter fields on {@link IndexConfiguration} are
+ * correctly wired: setters update the backing fields and getters return the expected values. Tests
+ * also verify round-trip deserialization via {@link ExporterConfiguration#MAPPER}, which is the
+ * exact mapper the Zeebe broker uses to instantiate exporter configuration at runtime.
+ */
+final class OpensearchIndexConfigurationTest {
+
+  // ---------------------------------------------------------------------------
+  // exportLocalVariablesEnabled
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldDefaultExportLocalVariablesEnabledToTrue() {
+    assertThat(new IndexConfiguration().isExportLocalVariablesEnabled()).isTrue();
+  }
+
+  @Test
+  void shouldRoundTripExportLocalVariablesEnabled() {
+    // given
+    final var args = Map.<String, Object>of("exportLocalVariablesEnabled", false);
+
+    // when
+    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+
+    // then
+    assertThat(config.isExportLocalVariablesEnabled()).isFalse();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Local variable name filters
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldRoundTripLocalVariableNameInclusionExact() {
+    // given
+    final var args =
+        Map.<String, Object>of("localVariableNameInclusionExact", List.of("localVar", "other"));
+
+    // when
+    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+
+    // then
+    assertThat(config.getLocalVariableNameInclusionExact()).containsExactly("localVar", "other");
+  }
+
+  @Test
+  void shouldRoundTripLocalVariableNameExclusionStartWith() {
+    // given
+    final var args =
+        Map.<String, Object>of("localVariableNameExclusionStartWith", List.of("debug_", "tmp_"));
+
+    // when
+    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+
+    // then
+    assertThat(config.getLocalVariableNameExclusionStartWith()).containsExactly("debug_", "tmp_");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Root variable name filters
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldRoundTripRootVariableNameInclusionExact() {
+    // given
+    final var args = Map.<String, Object>of("rootVariableNameInclusionExact", List.of("rootVar"));
+
+    // when
+    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+
+    // then
+    assertThat(config.getRootVariableNameInclusionExact()).containsExactly("rootVar");
+  }
+
+  @Test
+  void shouldRoundTripRootVariableNameExclusionEndWith() {
+    // given
+    final var args = Map.<String, Object>of("rootVariableNameExclusionEndWith", List.of("_secret"));
+
+    // when
+    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+
+    // then
+    assertThat(config.getRootVariableNameExclusionEndWith()).containsExactly("_secret");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Scope variable value type filters
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldRoundTripLocalAndRootVariableValueTypeFilters() {
+    // given
+    final var args =
+        Map.<String, Object>of(
+            "localVariableValueTypeInclusion", List.of("NUMBER", "STRING"),
+            "rootVariableValueTypeExclusion", List.of("BOOLEAN"));
+
+    // when
+    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+
+    // then
+    assertThat(config.getLocalVariableValueTypeInclusion()).containsExactly("NUMBER", "STRING");
+    assertThat(config.getRootVariableValueTypeExclusion()).containsExactly("BOOLEAN");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Defaults (all new list fields default to empty)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldDefaultAllNewListFieldsToEmpty() {
+    final var config = new IndexConfiguration();
+
+    assertThat(config.getLocalVariableNameInclusionExact()).isEmpty();
+    assertThat(config.getLocalVariableNameInclusionStartWith()).isEmpty();
+    assertThat(config.getLocalVariableNameInclusionEndWith()).isEmpty();
+    assertThat(config.getLocalVariableNameExclusionExact()).isEmpty();
+    assertThat(config.getLocalVariableNameExclusionStartWith()).isEmpty();
+    assertThat(config.getLocalVariableNameExclusionEndWith()).isEmpty();
+    assertThat(config.getLocalVariableValueTypeInclusion()).isEmpty();
+    assertThat(config.getLocalVariableValueTypeExclusion()).isEmpty();
+    assertThat(config.getRootVariableNameInclusionExact()).isEmpty();
+    assertThat(config.getRootVariableNameInclusionStartWith()).isEmpty();
+    assertThat(config.getRootVariableNameInclusionEndWith()).isEmpty();
+    assertThat(config.getRootVariableNameExclusionExact()).isEmpty();
+    assertThat(config.getRootVariableNameExclusionStartWith()).isEmpty();
+    assertThat(config.getRootVariableNameExclusionEndWith()).isEmpty();
+    assertThat(config.getRootVariableValueTypeInclusion()).isEmpty();
+    assertThat(config.getRootVariableValueTypeExclusion()).isEmpty();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Spring indexed-list format (map with numeric string keys)
+  // ExporterConfigurationListDeserializer handles this at runtime when lists are
+  // configured via Spring Boot properties: e.g. index.localVariableNameInclusionExact[0]=foo
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldDeserializeSpringIndexedListForLocalVariableNameInclusionExact() {
+    // given — Spring Boot encodes list[0]=a, list[1]=b as a Map {"0": "a", "1": "b"}
+    final var args =
+        Map.<String, Object>of(
+            "localVariableNameInclusionExact", Map.of("0", "localVar", "1", "other"));
+
+    // when
+    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+
+    // then
+    assertThat(config.getLocalVariableNameInclusionExact()).containsExactly("localVar", "other");
+  }
+
+  @Test
+  void shouldDeserializeSpringIndexedListForRootVariableNameExclusionExact() {
+    // given
+    final var args =
+        Map.<String, Object>of(
+            "rootVariableNameExclusionExact", Map.of("0", "_secret", "1", "_internal"));
+
+    // when
+    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+
+    // then
+    assertThat(config.getRootVariableNameExclusionExact()).containsExactly("_secret", "_internal");
+  }
+
+  @Test
+  void shouldDeserializeSpringIndexedListForLocalVariableValueTypeInclusion() {
+    // given
+    final var args =
+        Map.<String, Object>of(
+            "localVariableValueTypeInclusion", Map.of("0", "NUMBER", "1", "STRING"));
+
+    // when
+    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+
+    // then
+    assertThat(config.getLocalVariableValueTypeInclusion()).containsExactly("NUMBER", "STRING");
+  }
+}


### PR DESCRIPTION
## Description

 - Wires the FilterConfiguration variable filter fields into OpensearchExporterConfiguration and ElasticsearchExporterConfiguration: local/root variable name inclusion/exclusion (exact, prefix, suffix), local/root variable value type inclusion/exclusion, and the exportLocalVariables flag.                        
  - Both exporter configurations now fully satisfy the FilterConfiguration contract consumed by DefaultRecordFilter, making the new filtering options configurable via the standard exporter YAML config.                                                                                                         
  - Adds shouldApplyScopeAndGlobalFiltersIndependently to DefaultRecordFilterTest, confirming that a global name inclusion and a local value-type inclusion applied together still evaluate each variable against the right filter set depending on whether it is root- or locally-scoped.

## Related issues

closes https://github.com/camunda/camunda/issues/48109
Relates to https://github.com/camunda/camunda/issues/46267