### PR TITLE
refactor: replace use-official-docker-images with orchestration-tag and add per-component image tags

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -539,31 +539,30 @@ jobs:
 
           # Append optimize image config if enabled
           if [[ "${{ inputs.enable-optimize }}" == "true" ]]; then
-            # Use dedicated optimize-tag only with official images; otherwise fall back to the built image tag
-            if [[ "${{ inputs.use-official-docker-images }}" == "true" && -n "${{ inputs.optimize-tag }}" ]]; then
-              optimize_tag="${{ inputs.optimize-tag }}"
+            if [[ "${{ inputs.use-official-docker-images }}" == "true" ]]; then
+              # Official images: only override if an explicit optimize-tag is provided; otherwise let Helm chart defaults apply
+              if [[ -n "${{ inputs.optimize-tag }}" ]]; then
+                additional_platform_config+=" \
+                  --set optimize.image.tag=${{ inputs.optimize-tag }}"
+              fi
             else
-              optimize_tag="${image_tag}"
+              # Custom build: use the built image tag with full registry/repo override
+              additional_platform_config+=" \
+                --set optimize.image.registry=${image_registry} \
+                --set optimize.image.repository=${optimize_repo} \
+                --set optimize.image.tag=${image_tag}"
             fi
-            additional_platform_config+=" \
-              --set optimize.image.registry=${image_registry} \
-              --set optimize.image.repository=${optimize_repo} \
-              --set optimize.image.tag=${optimize_tag}"
           fi
 
           # Append identity image config if a dedicated tag is provided (only for official images)
           if [[ "${{ inputs.use-official-docker-images }}" == "true" && -n "${{ inputs.identity-tag }}" ]]; then
             additional_platform_config+=" \
-              --set identity.image.registry=docker.io \
-              --set identity.image.repository=camunda/identity \
               --set identity.image.tag=${{ inputs.identity-tag }}"
           fi
 
           # Append connectors image config if a dedicated tag is provided (only for official images)
           if [[ "${{ inputs.use-official-docker-images }}" == "true" && -n "${{ inputs.connectors-tag }}" ]]; then
             additional_platform_config+=" \
-              --set connectors.image.registry=docker.io \
-              --set connectors.image.repository=camunda/connectors \
               --set connectors.image.tag=${{ inputs.connectors-tag }}"
           fi
 

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -33,15 +33,10 @@ on:
         default: 1
         required: false
       reuse-tag:
-        description: 'Docker image tag, that should be reused for the load test. Allows to skip the docker image build step'
+        description: 'Reuse Tag: Pre-built image tag from the internal registry (registry.camunda.cloud). Skips the docker image build step. Cannot be used together with orchestration-tag.'
         type: string
         default: ""
         required: false
-      use-official-docker-images:
-        description: 'Use official Camunda Docker images from Docker Hub instead of building from source'
-        type: boolean
-        required: false
-        default: false
       scenario:
         description: 'Choose the variant of workload to use for the load test. When not set, it will default to max'
         required: false
@@ -89,18 +84,23 @@ on:
         - postgresql
         - none
         default: elasticsearch
+      orchestration-tag:
+        description: 'Orchestration Tag: Docker image tag for official Camunda images from Docker Hub (docker.io/camunda/camunda). When set, official Docker Hub images are used instead of building from source. Cannot be used together with reuse-tag.'
+        type: string
+        default: ""
+        required: false
       optimize-tag:
-        description: 'Docker image tag for Optimize. If not set, defaults to the Helm chart default image.'
+        description: 'Optimize Tag: Docker image tag for Optimize from Docker Hub (docker.io/camunda/optimize). When set, overrides the optimize image regardless of build mode. If not set, custom builds use the built image from the internal registry; official images use Helm chart defaults.'
         type: string
         default: ""
         required: false
       identity-tag:
-        description: 'Docker image tag for Identity. If not set, defaults to the Helm chart default image.'
+        description: 'Identity Tag: Docker image tag for Identity from Docker Hub (docker.io/camunda/identity). If not set, defaults to the Helm chart default image.'
         type: string
         default: ""
         required: false
       connectors-tag:
-        description: 'Docker image tag for Connectors. If not set, defaults to the Helm chart default image.'
+        description: 'Connectors Tag: Docker image tag for Connectors from Docker Hub (docker.io/camunda/connectors). If not set, defaults to the Helm chart default image.'
         type: string
         default: ""
         required: false
@@ -121,15 +121,10 @@ on:
         default: 1
         required: false
       reuse-tag:
-        description: 'Docker image tag, that should be reused for the load test. Allows to skip the docker image build step'
+        description: 'Reuse Tag: Pre-built image tag from the internal registry (registry.camunda.cloud). Skips the docker image build step. Cannot be used together with orchestration-tag.'
         type: string
         default: ""
         required: false
-      use-official-docker-images:
-        description: 'Use official Camunda Docker images from Docker Hub instead of building from source'
-        type: boolean
-        required: false
-        default: false
       scenario:
         description: 'Choose the variant of workload to use for the load test. Options: custom, latency, realistic, typical, max. If specified, this will override the load-test-load input when not set to "custom".'
         type: string
@@ -175,18 +170,23 @@ on:
         type: string
         required: false
         default: elasticsearch
+      orchestration-tag:
+        description: 'Orchestration Tag: Docker image tag for official Camunda images from Docker Hub (docker.io/camunda/camunda). When set, official Docker Hub images are used instead of building from source. Cannot be used together with reuse-tag.'
+        type: string
+        default: ""
+        required: false
       optimize-tag:
-        description: 'Docker image tag for Optimize. If not set, defaults to the Helm chart default image.'
+        description: 'Optimize Tag: Docker image tag for Optimize from Docker Hub (docker.io/camunda/optimize). When set, overrides the optimize image regardless of build mode. If not set, custom builds use the built image from the internal registry; official images use Helm chart defaults.'
         type: string
         default: ""
         required: false
       identity-tag:
-        description: 'Docker image tag for Identity. If not set, defaults to the Helm chart default image.'
+        description: 'Identity Tag: Docker image tag for Identity from Docker Hub (docker.io/camunda/identity). If not set, defaults to the Helm chart default image.'
         type: string
         default: ""
         required: false
       connectors-tag:
-        description: 'Docker image tag for Connectors. If not set, defaults to the Helm chart default image.'
+        description: 'Connectors Tag: Docker image tag for Connectors from Docker Hub (docker.io/camunda/connectors). If not set, defaults to the Helm chart default image.'
         type: string
         default: ""
         required: false
@@ -212,12 +212,12 @@ jobs:
     timeout-minutes: 5
     permissions: { }
     outputs:
-      image-tag: ${{ inputs.reuse-tag != '' && inputs.reuse-tag || steps.image-tag.outputs.image-tag }}
+      image-tag: ${{ inputs.orchestration-tag != '' && inputs.orchestration-tag || (inputs.reuse-tag != '' && inputs.reuse-tag || steps.image-tag.outputs.image-tag) }}
     steps:
-      - name: Validate official images require explicit tag
-        if: ${{ inputs.use-official-docker-images == true && inputs.reuse-tag == '' }}
+      - name: Validate mutually exclusive inputs
+        if: ${{ inputs.orchestration-tag != '' && inputs.reuse-tag != '' }}
         run: |
-          echo "::error::Invalid input combination: 'use-official-docker-images' is enabled but 'reuse-tag' is empty. Official Camunda Docker images require an explicit tag (e.g., '8.9.0-rc2') to pull from Docker Hub. Either provide a 'reuse-tag' or disable 'use-official-docker-images'."
+          echo "::error::Invalid input combination: 'orchestration-tag' and 'reuse-tag' cannot both be provided. Use 'orchestration-tag' for official Docker Hub images or 'reuse-tag' for reusing pre-built images from the internal registry."
           exit 1
       - uses: actions/checkout@v6
         with:
@@ -227,9 +227,9 @@ jobs:
         run: |
           echo "image-tag=${{ inputs.name }}-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
       - name: Validate Docker image tags exist
-        if: ${{ inputs.use-official-docker-images == true && inputs.reuse-tag != '' }}
+        if: ${{ inputs.orchestration-tag != '' || inputs.optimize-tag != '' || inputs.identity-tag != '' || inputs.connectors-tag != '' }}
         env:
-          TAG: ${{ inputs.reuse-tag }}
+          ORCHESTRATION_TAG: ${{ inputs.orchestration-tag }}
           ENABLE_OPTIMIZE: ${{ inputs.enable-optimize }}
           OPTIMIZE_TAG: ${{ inputs.optimize-tag }}
           IDENTITY_TAG: ${{ inputs.identity-tag }}
@@ -268,7 +268,9 @@ jobs:
             done
           }
 
-          validate_image "camunda/camunda:${TAG}" || exit 1
+          if [[ -n "${ORCHESTRATION_TAG}" ]]; then
+            validate_image "camunda/camunda:${ORCHESTRATION_TAG}" || exit 1
+          fi
 
           if [[ "${ENABLE_OPTIMIZE}" == "true" && -n "${OPTIMIZE_TAG}" ]]; then
             validate_image "camunda/optimize:${OPTIMIZE_TAG}" || exit 1
@@ -346,7 +348,7 @@ jobs:
   build-camunda-image:
     name: Build Camunda
     needs: calculate-image-tag
-    if: ${{ inputs.reuse-tag == '' }}
+    if: ${{ inputs.reuse-tag == '' && inputs.orchestration-tag == '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -428,7 +430,7 @@ jobs:
 
   build-load-test-images:
     name: Build Starter and Worker
-    if: ${{ inputs.reuse-tag == '' || inputs.use-official-docker-images == true }}
+    if: ${{ inputs.reuse-tag == '' || inputs.orchestration-tag != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: calculate-image-tag
@@ -525,10 +527,11 @@ jobs:
           load_test_config="$load_test_config ${{ needs.calculate-scenario-config.outputs.load-test-load }}"
           load_test_config="$load_test_config ${{ inputs.load-test-load }}"
 
-          # Resolve image registry/repository based on whether official images are used
-          image_registry="${{ inputs.use-official-docker-images && 'docker.io' || 'registry.camunda.cloud' }}"
-          camunda_repo="${{ inputs.use-official-docker-images && 'camunda/camunda' || 'team-zeebe/camunda' }}"
-          optimize_repo="${{ inputs.use-official-docker-images && 'camunda/optimize' || 'team-zeebe/optimize' }}"
+          # Resolve image registry/repository: Docker Hub when orchestration-tag is set, internal registry otherwise
+          # optimize_repo is only consumed in the custom build path where orchestration-tag is empty
+          image_registry="${{ inputs.orchestration-tag != '' && 'docker.io' || 'registry.camunda.cloud' }}"
+          camunda_repo="${{ inputs.orchestration-tag != '' && 'camunda/camunda' || 'team-zeebe/camunda' }}"
+          optimize_repo="${{ inputs.orchestration-tag != '' && 'camunda/optimize' || 'team-zeebe/optimize' }}"
           image_tag="${{ needs.calculate-image-tag.outputs.image-tag }}"
 
           # Build platform configuration
@@ -537,16 +540,14 @@ jobs:
             --set orchestration.image.repository=${camunda_repo} \
             --set orchestration.image.tag=${image_tag}"
 
-          # Append optimize image config if enabled
+          # Append optimize image config: optimize-tag wins if set, otherwise custom builds use internal registry
           if [[ "${{ inputs.enable-optimize }}" == "true" ]]; then
-            if [[ "${{ inputs.use-official-docker-images }}" == "true" ]]; then
-              # Official images: only override if an explicit optimize-tag is provided; otherwise no image override is set
-              if [[ -n "${{ inputs.optimize-tag }}" ]]; then
-                additional_platform_config+=" \
-                  --set optimize.image.tag=${{ inputs.optimize-tag }}"
-              fi
-            else
-              # Custom build: use the built image tag with full registry/repo override
+            if [[ -n "${{ inputs.optimize-tag }}" ]]; then
+              # Explicit optimize tag provided: use it directly (Docker Hub image)
+              additional_platform_config+=" \
+                --set optimize.image.tag=${{ inputs.optimize-tag }}"
+            elif [[ -z "${{ inputs.orchestration-tag }}" ]]; then
+              # Custom build without explicit optimize tag: use the built image from internal registry
               additional_platform_config+=" \
                 --set optimize.image.registry=${image_registry} \
                 --set optimize.image.repository=${optimize_repo} \
@@ -554,14 +555,14 @@ jobs:
             fi
           fi
 
-          # Append identity image config if a dedicated tag is provided (only for official images)
-          if [[ "${{ inputs.use-official-docker-images }}" == "true" && -n "${{ inputs.identity-tag }}" ]]; then
+          # Append identity image config if a dedicated tag is provided
+          if [[ -n "${{ inputs.identity-tag }}" ]]; then
             additional_platform_config+=" \
               --set identity.image.tag=${{ inputs.identity-tag }}"
           fi
 
-          # Append connectors image config if a dedicated tag is provided (only for official images)
-          if [[ "${{ inputs.use-official-docker-images }}" == "true" && -n "${{ inputs.connectors-tag }}" ]]; then
+          # Append connectors image config if a dedicated tag is provided
+          if [[ -n "${{ inputs.connectors-tag }}" ]]; then
             additional_platform_config+=" \
               --set connectors.image.tag=${{ inputs.connectors-tag }}"
           fi

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -540,7 +540,7 @@ jobs:
           # Append optimize image config if enabled
           if [[ "${{ inputs.enable-optimize }}" == "true" ]]; then
             if [[ "${{ inputs.use-official-docker-images }}" == "true" ]]; then
-              # Official images: only override if an explicit optimize-tag is provided; otherwise let Helm chart defaults apply
+              # Official images: only override if an explicit optimize-tag is provided; otherwise no image override is set
               if [[ -n "${{ inputs.optimize-tag }}" ]]; then
                 additional_platform_config+=" \
                   --set optimize.image.tag=${{ inputs.optimize-tag }}"

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -89,6 +89,21 @@ on:
         - postgresql
         - none
         default: elasticsearch
+      optimize-tag:
+        description: 'Docker image tag for Optimize. If not set, defaults to the Helm chart default image.'
+        type: string
+        default: ""
+        required: false
+      identity-tag:
+        description: 'Docker image tag for Identity. If not set, defaults to the Helm chart default image.'
+        type: string
+        default: ""
+        required: false
+      connectors-tag:
+        description: 'Docker image tag for Connectors. If not set, defaults to the Helm chart default image.'
+        type: string
+        default: ""
+        required: false
   workflow_call:
     inputs:
       ref:
@@ -160,6 +175,21 @@ on:
         type: string
         required: false
         default: elasticsearch
+      optimize-tag:
+        description: 'Docker image tag for Optimize. If not set, defaults to the Helm chart default image.'
+        type: string
+        default: ""
+        required: false
+      identity-tag:
+        description: 'Docker image tag for Identity. If not set, defaults to the Helm chart default image.'
+        type: string
+        default: ""
+        required: false
+      connectors-tag:
+        description: 'Docker image tag for Connectors. If not set, defaults to the Helm chart default image.'
+        type: string
+        default: ""
+        required: false
 
 env:
   CLUSTER: camunda-benchmark-prod  # change this to "camunda-benchmark-dev" when experimenting
@@ -201,6 +231,9 @@ jobs:
         env:
           TAG: ${{ inputs.reuse-tag }}
           ENABLE_OPTIMIZE: ${{ inputs.enable-optimize }}
+          OPTIMIZE_TAG: ${{ inputs.optimize-tag }}
+          IDENTITY_TAG: ${{ inputs.identity-tag }}
+          CONNECTORS_TAG: ${{ inputs.connectors-tag }}
         run: |
           validate_image() {
             local image="$1"
@@ -237,8 +270,16 @@ jobs:
 
           validate_image "camunda/camunda:${TAG}" || exit 1
 
-          if [[ "${ENABLE_OPTIMIZE}" == "true" ]]; then
-            validate_image "camunda/optimize:${TAG}" || exit 1
+          if [[ "${ENABLE_OPTIMIZE}" == "true" && -n "${OPTIMIZE_TAG}" ]]; then
+            validate_image "camunda/optimize:${OPTIMIZE_TAG}" || exit 1
+          fi
+
+          if [[ -n "${IDENTITY_TAG}" ]]; then
+            validate_image "camunda/identity:${IDENTITY_TAG}" || exit 1
+          fi
+
+          if [[ -n "${CONNECTORS_TAG}" ]]; then
+            validate_image "camunda/connectors:${CONNECTORS_TAG}" || exit 1
           fi
 
   calculate-scenario-config:
@@ -498,10 +539,32 @@ jobs:
 
           # Append optimize image config if enabled
           if [[ "${{ inputs.enable-optimize }}" == "true" ]]; then
+            # Use dedicated optimize-tag only with official images; otherwise fall back to the built image tag
+            if [[ "${{ inputs.use-official-docker-images }}" == "true" && -n "${{ inputs.optimize-tag }}" ]]; then
+              optimize_tag="${{ inputs.optimize-tag }}"
+            else
+              optimize_tag="${image_tag}"
+            fi
             additional_platform_config+=" \
               --set optimize.image.registry=${image_registry} \
               --set optimize.image.repository=${optimize_repo} \
-              --set optimize.image.tag=${image_tag}"
+              --set optimize.image.tag=${optimize_tag}"
+          fi
+
+          # Append identity image config if a dedicated tag is provided (only for official images)
+          if [[ "${{ inputs.use-official-docker-images }}" == "true" && -n "${{ inputs.identity-tag }}" ]]; then
+            additional_platform_config+=" \
+              --set identity.image.registry=docker.io \
+              --set identity.image.repository=camunda/identity \
+              --set identity.image.tag=${{ inputs.identity-tag }}"
+          fi
+
+          # Append connectors image config if a dedicated tag is provided (only for official images)
+          if [[ "${{ inputs.use-official-docker-images }}" == "true" && -n "${{ inputs.connectors-tag }}" ]]; then
+            additional_platform_config+=" \
+              --set connectors.image.registry=docker.io \
+              --set connectors.image.repository=camunda/connectors \
+              --set connectors.image.tag=${{ inputs.connectors-tag }}"
           fi
 
           # Append user-provided helm values if present

--- a/.github/workflows/camunda-release-load-test.yaml
+++ b/.github/workflows/camunda-release-load-test.yaml
@@ -1,6 +1,7 @@
 # description: Creates a load test for official release images. Abstraction layer between
 #              the release process and the load test infrastructure, with a simple public API
-#              accepting only name and tag as inputs. Uses official Docker images with scenario: realistic.
+#              accepting name, tag, and optional per-component image tags as inputs.
+#              Uses official Docker images with scenario: realistic.
 # called-by: camunda-scheduled-release-load-tests.yml (daily schedule),
 #            release BPMN process (workflow_dispatch via GitHub API)
 # calls: camunda-load-test.yml (use-official-docker-images: true, scenario: realistic)

--- a/.github/workflows/camunda-release-load-test.yaml
+++ b/.github/workflows/camunda-release-load-test.yaml
@@ -20,6 +20,21 @@ on:
         description: 'Specifies the tag that should be used for the release load test'
         type: string
         required: true
+      optimize-tag:
+        description: 'Docker image tag for Optimize. If not set, defaults to the Helm chart default image.'
+        type: string
+        default: ""
+        required: false
+      identity-tag:
+        description: 'Docker image tag for Identity. If not set, defaults to the Helm chart default image.'
+        type: string
+        default: ""
+        required: false
+      connectors-tag:
+        description: 'Docker image tag for Connectors. If not set, defaults to the Helm chart default image.'
+        type: string
+        default: ""
+        required: false
   workflow_call:
     inputs:
       name:
@@ -30,6 +45,21 @@ on:
         description: 'Specifies the tag that should be used for the release load test'
         type: string
         required: true
+      optimize-tag:
+        description: 'Docker image tag for Optimize. If not set, defaults to the Helm chart default image.'
+        type: string
+        default: ""
+        required: false
+      identity-tag:
+        description: 'Docker image tag for Identity. If not set, defaults to the Helm chart default image.'
+        type: string
+        default: ""
+        required: false
+      connectors-tag:
+        description: 'Docker image tag for Connectors. If not set, defaults to the Helm chart default image.'
+        type: string
+        default: ""
+        required: false
 
 defaults:
   run:
@@ -68,6 +98,9 @@ jobs:
       ttl: 60
       use-official-docker-images: true
       scenario: 'realistic'
+      optimize-tag: ${{ inputs.optimize-tag }}
+      identity-tag: ${{ inputs.identity-tag }}
+      connectors-tag: ${{ inputs.connectors-tag }}
 
   notify-on-failure:
     name: Notify on failure

--- a/.github/workflows/camunda-release-load-test.yaml
+++ b/.github/workflows/camunda-release-load-test.yaml
@@ -1,10 +1,11 @@
 # description: Creates a load test for official release images. Abstraction layer between
 #              the release process and the load test infrastructure, with a simple public API
-#              accepting name, tag, and optional per-component image tags as inputs.
+#              accepting required name and tag inputs plus optional per-component
+#              tag overrides: optimize-tag, identity-tag, and connectors-tag.
 #              Uses official Docker images with scenario: realistic.
 # called-by: camunda-scheduled-release-load-tests.yml (daily schedule),
 #            release BPMN process (workflow_dispatch via GitHub API)
-# calls: camunda-load-test.yml (use-official-docker-images: true, scenario: realistic)
+# calls: camunda-load-test.yml (orchestration-tag: <tag>, scenario: realistic)
 # note: Verification and namespace cleanup are handled externally by the scheduled workflow
 #       via camunda-verify-and-cleanup-load-test.yml, not by this workflow.
 # type: CI
@@ -95,9 +96,8 @@ jobs:
     with:
       name: ${{ needs.sanitize-inputs.outputs.sanitized-name }}
       ref: main
-      reuse-tag: ${{ inputs.tag }}
+      orchestration-tag: ${{ inputs.tag }}
       ttl: 60
-      use-official-docker-images: true
       scenario: 'realistic'
       optimize-tag: ${{ inputs.optimize-tag }}
       identity-tag: ${{ inputs.identity-tag }}

--- a/docs/testing/reliability-testing.md
+++ b/docs/testing/reliability-testing.md
@@ -212,7 +212,7 @@ graph TD
     end
 
     subgraph "Implementation — camunda-load-test.yml"
-        LOAD["Create load test cluster<br/>• use-official-docker-images: true<br/>• scenario: realistic<br/>• ttl: 60 days"]
+        LOAD["Create load test cluster<br/>• orchestration-tag: &lt;tag&gt;<br/>• scenario: realistic<br/>• ttl: 60 days"]
     end
 
     BPMN -->|"workflow_dispatch<br/>name + tag"| API

--- a/docs/testing/reliability-testing.md
+++ b/docs/testing/reliability-testing.md
@@ -257,7 +257,10 @@ An example payload looks like this:
     "ref": workflow_ref_name,
     "inputs": {
       "name": benchmark_name,
-      "tag": release_tag
+      "tag": release_tag,
+      "optimize-tag": "optional, Docker Hub tag for Optimize",
+      "identity-tag": "optional, Docker Hub tag for Identity",
+      "connectors-tag": "optional, Docker Hub tag for Connectors"
     }
 }
 ```

--- a/docs/testing/reliability-testing.md
+++ b/docs/testing/reliability-testing.md
@@ -195,7 +195,7 @@ For every [supported/maintained](https://confluence.camunda.com/pages/viewpage.a
 
 ##### Architecture
 
-The release load test workflow acts as an abstraction layer between the release process and the underlying load test infrastructure, with a simple public API accepting only `name` and `tag` as inputs.
+The release load test workflow acts as an abstraction layer between the release process and the underlying load test infrastructure, with a simple public API accepting `name` and `tag` as required inputs, plus optional per-component image tag overrides (`optimize-tag`, `identity-tag`, `connectors-tag`).
 
 ```mermaid
 graph TD
@@ -206,7 +206,7 @@ graph TD
 
     subgraph "Abstraction Layer — camunda-release-load-test.yaml"
         direction TB
-        API["Public API<br/>inputs: name, tag"]
+        API["Public API<br/>inputs: name, tag<br/>optional: optimize-tag, identity-tag, connectors-tag"]
         SANITIZE["Sanitize inputs"]
         API --> SANITIZE
     end
@@ -230,7 +230,7 @@ graph TD
 
 This decoupling provides several benefits:
 
-* **Clear API**: The release process only needs to provide a test name and tag — implementation details (official images, realistic scenario, TTL) are encapsulated in the release load test workflow
+* **Clear API**: The release process only needs to provide a test name and tag (with optional per-component image tags) — implementation details (official images, realistic scenario, TTL) are encapsulated in the release load test workflow
 * **Independent evolution**: Changes to load test infrastructure (helm values, Makefiles, scripts) don't require changes to the release process BPMN
 * **Per-branch workflows**: Each stable branch has its own copy of the release load test workflow (via backports), ensuring the correct infrastructure files are used for each version
 * **Daily smoke tests**: The [scheduled release load test workflow](https://github.com/camunda/camunda/blob/main/.github/workflows/camunda-scheduled-release-load-tests.yml) validates daily that release load tests can be created for all active stable branches

--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -70,7 +70,7 @@ graph TD
     DAILY -- "scenario: max" --> CORE
     WEEKLY -- "4 parallel calls:<br/>typical, realistic,<br/>rdbms-realistic, latency" --> CORE
     ROLLING -- "latest release tag<br/>custom helm values" --> CORE
-    RELEASE -- "scenario: realistic<br/>official Docker images" --> CORE
+    RELEASE -- "scenario: realistic<br/>orchestration-tag" --> CORE
     PR -- "scenario: max" --> CORE
     PR -- "after 15min wait" --> PROFILE
     ADHOC --> CORE


### PR DESCRIPTION
## Summary

Closes #50323

The `camunda-schedule-release-load-test.yml` workflow fails when using official Docker images because it assumes all component images share the same Docker Hub tag.

> For example, when a release load test is triggered with an image tag (8.8.17) for camunda, the same image tag is not available for optimize, causing validation to fail.

Run: https://github.com/camunda/camunda/actions/runs/23884234430

## Changes

### Replace `use-official-docker-images` with `orchestration-tag`

The boolean `use-official-docker-images` flag (always paired with `reuse-tag`) is replaced by a single `orchestration-tag` string input. When set, it signals "use official Docker Hub images with this tag" — combining the signal and the tag in one input. `reuse-tag` remains available for reusing pre-built images from the internal registry.

A validation step ensures `orchestration-tag` and `reuse-tag` cannot be provided together.

### Add per-component Docker image tag inputs

Three new optional inputs for both `camunda-load-test.yml` and `camunda-release-load-test.yaml`:

- **`optimize-tag`** — Docker image tag for Optimize
- **`identity-tag`** — Docker image tag for Identity
- **`connectors-tag`** — Docker image tag for Connectors

### Behavior

- When `orchestration-tag` is set, official Docker Hub images are used (`docker.io/camunda/camunda:<orchestration-tag>`).
- Per-component tags (`optimize-tag`, `identity-tag`, `connectors-tag`) can be provided **independently of `orchestration-tag`** — they work in both official and custom build modes. This allows mixing a custom-built orchestration image with an official component image (e.g., `reuse-tag` + `optimize-tag`).
- When `optimize-tag` is set, it overrides the optimize image regardless of build mode (Docker Hub image). When not set, custom builds use the built image from the internal registry; official images use Helm chart defaults.
- `identity-tag` and `connectors-tag` override just the tag when provided (Helm chart defaults handle registry/repo). These components are never built from source.
- Docker image validation runs whenever any tag input is provided: `orchestration-tag`, `optimize-tag`, `identity-tag`, or `connectors-tag`. Each component is validated independently.

### Files changed

- `.github/workflows/camunda-load-test.yml` — replaced `use-official-docker-images` with `orchestration-tag`, new per-component inputs, scoped validation, per-component image overrides in deploy step
- `.github/workflows/camunda-release-load-test.yaml` — uses `orchestration-tag` instead of `reuse-tag` + `use-official-docker-images`, passes per-component tags
- `docs/testing/reliability-testing.md` — updated architecture docs, Mermaid diagram, and example payload
- `load-tests/README.md` — updated Mermaid diagram

## Test plan

- [x] Trigger `camunda-release-load-test` with `optimize-tag`, `identity-tag`, and `connectors-tag` set — verify images are validated and deployed with the correct per-component tags
- [x] Trigger without the new inputs — verify default Helm chart images are used (no overrides applied)
- [x] Trigger with only `reuse-tag` (no `orchestration-tag`) — verify built images from internal registry are used
- [x] Verify the Docker image validation step only checks images whose tags are explicitly provided
- [x] Verify that passing both `reuse-tag` and `orchestration-tag` fails with a clear error

# Success Runs
- **Normal load test with the image built from scratch** https://github.com/camunda/camunda/actions/runs/24064975195
- **Orchestration tag passed and Optimize enabled** https://github.com/camunda/camunda/actions/runs/24065230470: Optimize defaults to the `platform-helm-values`, and the starter and worker images are built.
- **Orchestration tag passed, Optimize enabled, and Optimize tag also passed** https://github.com/camunda/camunda/actions/runs/24065268656: The Optimize tag is set to the value provided in the input, and the starter and worker images are built.
- **Orchestration tag passed and Optimize disabled** https://github.com/camunda/camunda/actions/runs/24065287883: Optimize is not deployed, and the starter and worker images are built.
- **Reuse the tag from the first normal load test** https://github.com/camunda/camunda/actions/runs/24065314422
- **Reuse tag without Optimize** https://github.com/camunda/camunda/actions/runs/24065336729

### Expected Failure Run
- **Passing both `reuse-tag` and `orchestration-tag`** https://github.com/camunda/camunda/actions/runs/24065353005: The run fails because `orchestration-tag` and `reuse-tag` cannot be provided together.