### PR TITLE
[Backport stable/8.8] fix: replace load test secret placeholder on redeploy

### DIFF
--- a/zeebe/benchmarks/setup/default/createCredsLoadTest.sh
+++ b/zeebe/benchmarks/setup/default/createCredsLoadTest.sh
@@ -14,8 +14,9 @@ NS="${1:-__NAMESPACE__}"
 # for the sed replacement and skip creation.
 if kubectl -n "$NS" get secret camunda-credentials &>/dev/null; then
   echo "Secret 'camunda-credentials' already exists in namespace '$NS'. Skipping creation."
+  echo "Reading existing orchestration secret from 'camunda-credentials' in namespace '$NS'."
   ORCHESTRATION_SECRET=$(kubectl -n "$NS" get secret camunda-credentials -o jsonpath='{.data.orchestration-security-authentication-oidc-secret}' | base64 -d)
-  echo "Replacing __SECRET__ in load-test-values.yaml with existing orchestration secret."
+  echo "Done Replacing __SECRET__ in load-test-values.yaml with existing orchestration secret."
   sed_inplace "s/__SECRET__/${ORCHESTRATION_SECRET}/g" load-test-values.yaml
   exit 0
 fi

--- a/zeebe/benchmarks/setup/default/createCredsLoadTest.sh
+++ b/zeebe/benchmarks/setup/default/createCredsLoadTest.sh
@@ -15,6 +15,7 @@ NS="${1:-__NAMESPACE__}"
 if kubectl -n "$NS" get secret camunda-credentials &>/dev/null; then
   echo "Secret 'camunda-credentials' already exists in namespace '$NS'. Skipping creation."
   ORCHESTRATION_SECRET=$(kubectl -n "$NS" get secret camunda-credentials -o jsonpath='{.data.orchestration-security-authentication-oidc-secret}' | base64 -d)
+  echo "Replacing __SECRET__ in load-test-values.yaml with existing orchestration secret."
   sed_inplace "s/__SECRET__/${ORCHESTRATION_SECRET}/g" load-test-values.yaml
   exit 0
 fi

--- a/zeebe/benchmarks/setup/default/createCredsLoadTest.sh
+++ b/zeebe/benchmarks/setup/default/createCredsLoadTest.sh
@@ -10,9 +10,12 @@ set -euo pipefail
 # Usage: ./createCredsLoadTest.sh [namespace]
 NS="${1:-__NAMESPACE__}"
 
-# Check if the secret already exists; if so, skip creation.
+# Check if the secret already exists; if so, retrieve the existing orchestration secret
+# for the sed replacement and skip creation.
 if kubectl -n "$NS" get secret camunda-credentials &>/dev/null; then
   echo "Secret 'camunda-credentials' already exists in namespace '$NS'. Skipping creation."
+  ORCHESTRATION_SECRET=$(kubectl -n "$NS" get secret camunda-credentials -o jsonpath='{.data.orchestration-security-authentication-oidc-secret}' | base64 -d)
+  sed_inplace "s/__SECRET__/${ORCHESTRATION_SECRET}/g" load-test-values.yaml
   exit 0
 fi
 


### PR DESCRIPTION
# Description
Backport of #50338 to `stable/8.8`.

relates to 