### PR TITLE
refactor: remove unnecessary CompletableFuture wrapping in archiver batch methods

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -136,10 +136,8 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
     return client
         .search(searchRequest, ProcessInstanceForListViewEntity.class)
         .whenCompleteAsync((ignored, error) -> metrics.measureArchiverSearch(timer), executor)
-        .thenComposeAsync(
-            (response) ->
-                createProcessInstanceBatch(
-                    response, ListViewTemplate.END_DATE, listViewTemplateDescriptor),
+        .thenApplyAsync(
+            (response) -> createProcessInstanceBatch(response, ListViewTemplate.END_DATE),
             executor);
   }
 
@@ -151,7 +149,7 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
     return client
         .search(searchRequest, Object.class)
         .whenCompleteAsync((ignored, error) -> metrics.measureArchiverSearch(timer), executor)
-        .thenComposeAsync(
+        .thenApplyAsync(
             (response) -> createBasicBatch(response, BatchOperationTemplate.END_DATE), executor);
   }
 
@@ -167,7 +165,7 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
     return client
         .search(searchRequest, Object.class)
         .whenCompleteAsync((ignored, error) -> metrics.measureArchiverSearch(timer), executor)
-        .thenComposeAsync(
+        .thenApplyAsync(
             response ->
                 createBasicBatch(
                     response,
@@ -188,7 +186,7 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
     return client
         .search(searchRequest, Object.class)
         .whenCompleteAsync((ignored, error) -> metrics.measureArchiverSearch(timer), executor)
-        .thenComposeAsync(
+        .thenApplyAsync(
             response ->
                 createBasicBatch(
                     response,
@@ -205,7 +203,7 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
     return client
         .search(searchRequest, Object.class)
         .whenCompleteAsync((ignored, error) -> metrics.measureArchiverSearch(timer), executor)
-        .thenComposeAsync(
+        .thenApplyAsync(
             response -> createBasicBatch(response, JobMetricsBatchTemplate.END_TIME), executor);
   }
 
@@ -217,7 +215,7 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
     return client
         .search(searchRequest, Object.class)
         .whenCompleteAsync((ignored, error) -> metrics.measureArchiverSearch(timer), executor)
-        .thenComposeAsync(
+        .thenApplyAsync(
             response -> createBasicBatch(response, DecisionInstanceTemplate.EVALUATION_DATE),
             executor);
   }
@@ -429,30 +427,18 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
     return client.indices().putSettings(settingsRequest);
   }
 
-  private CompletableFuture<ProcessInstanceArchiveBatch> createProcessInstanceBatch(
-      final SearchResponse<ProcessInstanceForListViewEntity> response,
-      final String field,
-      final IndexTemplateDescriptor templateDescriptor) {
-    return createProcessInstanceBatch(
-        response, field, templateDescriptor, config.getRolloverInterval());
-  }
-
-  private CompletableFuture<ProcessInstanceArchiveBatch> createProcessInstanceBatch(
-      final SearchResponse<ProcessInstanceForListViewEntity> response,
-      final String field,
-      final IndexTemplateDescriptor templateDescriptor,
-      final String rolloverInterval) {
+  private ProcessInstanceArchiveBatch createProcessInstanceBatch(
+      final SearchResponse<ProcessInstanceForListViewEntity> response, final String field) {
     final var hits = response.hits().hits();
     if (hits.isEmpty()) {
-      return CompletableFuture.completedFuture(
-          new ProcessInstanceArchiveBatch(null, List.of(), List.of()));
+      return new ProcessInstanceArchiveBatch(null, List.of(), List.of());
     }
 
     final String endDate = hits.getFirst().fields().get(field).toJson().asJsonArray().getString(0);
 
     final String date =
         DateOfArchivedDocumentsUtil.getBucketStart(
-            endDate, rolloverInterval, config.getElsRolloverDateFormat());
+            endDate, config.getRolloverInterval(), config.getElsRolloverDateFormat());
 
     final var batchHits =
         hits.stream()
@@ -476,20 +462,19 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
       }
     }
 
-    return CompletableFuture.completedFuture(
-        new ProcessInstanceArchiveBatch(date, processInstanceKeys, rootProcessInstanceKeys));
+    return new ProcessInstanceArchiveBatch(date, processInstanceKeys, rootProcessInstanceKeys);
   }
 
-  private <T> CompletableFuture<BasicArchiveBatch> createBasicBatch(
+  private <T> BasicArchiveBatch createBasicBatch(
       final SearchResponse<T> response, final String field) {
     return createBasicBatch(response, field, config.getRolloverInterval());
   }
 
-  private <T> CompletableFuture<BasicArchiveBatch> createBasicBatch(
+  private <T> BasicArchiveBatch createBasicBatch(
       final SearchResponse<T> response, final String field, final String rolloverInterval) {
     final List<Hit<T>> hits = response.hits().hits();
     if (hits.isEmpty()) {
-      return CompletableFuture.completedFuture(new BasicArchiveBatch(null, List.of()));
+      return new BasicArchiveBatch(null, List.of());
     }
 
     final String endDate = hits.getFirst().fields().get(field).toJson().asJsonArray().getString(0);
@@ -505,7 +490,7 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
             .toList();
 
     final List<String> ids = batchHits.stream().map(Hit::id).toList();
-    return CompletableFuture.completedFuture(new BasicArchiveBatch(date, ids));
+    return new BasicArchiveBatch(date, ids);
   }
 
   private TermsQuery buildIdTermsQuery(final String idFieldName, final List<String> idValues) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -143,10 +143,8 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
     final var timer = Timer.start();
     return sendRequestAsync(() -> client.search(request, ProcessInstanceForListViewEntity.class))
         .whenCompleteAsync((ignored, error) -> metrics.measureArchiverSearch(timer), executor)
-        .thenComposeAsync(
-            (response) ->
-                createProcessInstanceBatch(
-                    response, ListViewTemplate.END_DATE, listViewTemplateDescriptor),
+        .thenApplyAsync(
+            (response) -> createProcessInstanceBatch(response, ListViewTemplate.END_DATE),
             executor);
   }
 
@@ -157,7 +155,7 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
     final var timer = Timer.start();
     return sendRequestAsync(() -> client.search(searchRequest, Object.class))
         .whenCompleteAsync((ignored, error) -> metrics.measureArchiverSearch(timer), executor)
-        .thenComposeAsync(
+        .thenApplyAsync(
             (response) ->
                 createBasicBatch(
                     response, BatchOperationTemplate.END_DATE, batchOperationTemplateDescriptor),
@@ -175,7 +173,7 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
     final var timer = Timer.start();
     return sendRequestAsync(() -> client.search(searchRequest, Object.class))
         .whenCompleteAsync((ignored, error) -> metrics.measureArchiverSearch(timer), executor)
-        .thenComposeAsync(
+        .thenApplyAsync(
             response ->
                 createBasicBatch(
                     response,
@@ -196,7 +194,7 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
     final var timer = Timer.start();
     return sendRequestAsync(() -> client.search(searchRequest, Object.class))
         .whenCompleteAsync((ignored, error) -> metrics.measureArchiverSearch(timer), executor)
-        .thenComposeAsync(
+        .thenApplyAsync(
             response ->
                 createBasicBatch(
                     response,
@@ -213,7 +211,7 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
     final var timer = Timer.start();
     return sendRequestAsync(() -> client.search(searchRequest, Object.class))
         .whenCompleteAsync((ignored, error) -> metrics.measureArchiverSearch(timer), executor)
-        .thenComposeAsync(
+        .thenApplyAsync(
             response ->
                 createBasicBatch(
                     response, JobMetricsBatchTemplate.END_TIME, jobMetricsBatchTemplateDescriptor),
@@ -227,7 +225,7 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
     final var timer = Timer.start();
     return sendRequestAsync(() -> client.search(searchRequest, Object.class))
         .whenCompleteAsync((ignored, error) -> metrics.measureArchiverSearch(timer), executor)
-        .thenComposeAsync(
+        .thenApplyAsync(
             response ->
                 createBasicBatch(
                     response,
@@ -631,23 +629,11 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
         .toQuery();
   }
 
-  private CompletableFuture<ProcessInstanceArchiveBatch> createProcessInstanceBatch(
-      final SearchResponse<ProcessInstanceForListViewEntity> response,
-      final String field,
-      final IndexTemplateDescriptor templateDescriptor) {
-    return createProcessInstanceBatch(
-        response, field, templateDescriptor, config.getRolloverInterval());
-  }
-
-  private CompletableFuture<ProcessInstanceArchiveBatch> createProcessInstanceBatch(
-      final SearchResponse<ProcessInstanceForListViewEntity> response,
-      final String endDateField,
-      final IndexTemplateDescriptor templateDescriptor,
-      final String rolloverInterval) {
+  private ProcessInstanceArchiveBatch createProcessInstanceBatch(
+      final SearchResponse<ProcessInstanceForListViewEntity> response, final String endDateField) {
     final var hits = response.hits().hits();
     if (hits.isEmpty()) {
-      return CompletableFuture.completedFuture(
-          new ProcessInstanceArchiveBatch(null, List.of(), List.of()));
+      return new ProcessInstanceArchiveBatch(null, List.of(), List.of());
     }
 
     final String endDate =
@@ -655,7 +641,7 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
 
     final String date =
         DateOfArchivedDocumentsUtil.getBucketStart(
-            endDate, rolloverInterval, config.getElsRolloverDateFormat());
+            endDate, config.getRolloverInterval(), config.getElsRolloverDateFormat());
 
     final var batchHits =
         hits.stream()
@@ -685,25 +671,24 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
       }
     }
 
-    return CompletableFuture.completedFuture(
-        new ProcessInstanceArchiveBatch(date, processInstanceKeys, rootProcessInstanceKeys));
+    return new ProcessInstanceArchiveBatch(date, processInstanceKeys, rootProcessInstanceKeys);
   }
 
-  private <T> CompletableFuture<BasicArchiveBatch> createBasicBatch(
+  private <T> BasicArchiveBatch createBasicBatch(
       final SearchResponse<T> response,
       final String field,
       final IndexTemplateDescriptor templateDescriptor) {
     return createBasicBatch(response, field, templateDescriptor, config.getRolloverInterval());
   }
 
-  private <T> CompletableFuture<BasicArchiveBatch> createBasicBatch(
+  private <T> BasicArchiveBatch createBasicBatch(
       final SearchResponse<T> response,
       final String endDateField,
       final IndexTemplateDescriptor templateDescriptor,
       final String rolloverInterval) {
     final var hits = response.hits().hits();
     if (hits.isEmpty()) {
-      return CompletableFuture.completedFuture(new BasicArchiveBatch(null, List.of()));
+      return new BasicArchiveBatch(null, List.of());
     }
 
     final String endDate =
@@ -726,7 +711,7 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
             .toList();
 
     final List<String> ids = batchHits.stream().map(Hit::id).toList();
-    return CompletableFuture.completedFuture(new BasicArchiveBatch(date, ids));
+    return new BasicArchiveBatch(date, ids);
   }
 
   private TermsQuery buildIdTermsQuery(final String idFieldName, final List<String> idValues) {


### PR DESCRIPTION
## Summary

- `createProcessInstanceBatch` and `createBasicBatch` in both `ElasticsearchArchiverRepository` and `OpenSearchArchiverRepository` were previously wrapping their results in `CompletableFuture.completedFuture()`, which was needed when these methods performed async calls to Elasticsearch/OpenSearch. Since that is no longer the case after https://github.com/camunda/camunda/pull/48762, the `CompletableFuture` wrapping is unnecessary overhead.
- These methods now return their batch results directly, and callers use `thenApplyAsync` instead of `thenComposeAsync`.