### PR TITLE
[Backport stable/8.9] fix(tasklist): preserve filter search params when navigating away from cancelled task

### DIFF
--- a/tasklist/client/src/common/tasks/removeRefParam.ts
+++ b/tasklist/client/src/common/tasks/removeRefParam.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+function removeRefParam(params: URLSearchParams): string {
+  const result = new URLSearchParams(params);
+  result.delete('ref');
+  return result.toString();
+}
+
+export {removeRefParam};

--- a/tasklist/client/src/v1/TaskDetailsLayout/index.test.tsx
+++ b/tasklist/client/src/v1/TaskDetailsLayout/index.test.tsx
@@ -12,27 +12,30 @@ import {MemoryRouter, Routes, Route} from 'react-router-dom';
 import {
   render,
   screen,
+  waitFor,
   waitForElementToBeRemoved,
   within,
 } from 'common/testing/testing-library';
 import {getMockQueryClient} from 'common/testing/getMockQueryClient';
 import {nodeMockServer} from 'common/testing/nodeMockServer';
+import {LocationLog} from 'common/testing/LocationLog';
 import * as userMocks from 'common/mocks/current-user';
 import * as taskMocks from 'v1/mocks/task';
 import * as processMocks from 'v1/mocks/processes';
 import {Component} from '.';
 
-const getWrapper = (id: string = '0') => {
+const getWrapper = (id: string = '0', search: string = '') => {
   const mockClient = getMockQueryClient();
 
   const Wrapper: React.FC<{
     children?: React.ReactNode;
   }> = ({children}) => (
     <QueryClientProvider client={mockClient}>
-      <MemoryRouter initialEntries={[`/${id}`]}>
+      <MemoryRouter initialEntries={[`/${id}${search}`]}>
         <Routes>
           <Route path="/:id" element={children} />
         </Routes>
+        <LocationLog />
       </MemoryRouter>
     </QueryClientProvider>
   );
@@ -199,5 +202,30 @@ describe('Task Details', () => {
     expect(
       within(nav).getByLabelText(/show associated BPMN process/i),
     ).not.toBeVisible();
+  });
+
+  it('navigates to initial page preserving search params when task is cancelled', async () => {
+    nodeMockServer.use(
+      http.get(
+        '/v1/tasks/:taskId',
+        () =>
+          HttpResponse.json({
+            ...taskMocks.assignedTask(),
+            taskState: 'CANCELED',
+          }),
+        {once: true},
+      ),
+    );
+
+    render(<Component />, {
+      wrapper: getWrapper('0', '?filter=all-open'),
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('pathname')).toHaveTextContent('/');
+      expect(screen.getByTestId('search')).toHaveTextContent(
+        '?filter=all-open',
+      );
+    });
   });
 });

--- a/tasklist/client/src/v1/TaskDetailsLayout/index.tsx
+++ b/tasklist/client/src/v1/TaskDetailsLayout/index.tsx
@@ -26,6 +26,7 @@ import {notificationsStore} from 'common/notifications/notifications.store';
 import {AssignButton} from './AssignButton';
 import {tracking} from 'common/tracking';
 import {decodeTaskOpenedRef} from 'common/tracking/reftags';
+import {removeRefParam} from 'common/tasks/removeRefParam';
 
 type OutletContext = {
   task: Task;
@@ -76,16 +77,24 @@ const TaskDetailsLayout: React.FC = () => {
         subtitle: `${task?.processName} (${task?.processInstanceKey})`,
         isDismissable: true,
       });
-      navigate(pages.initial);
+      navigate({
+        pathname: pages.initial,
+        search: removeRefParam(searchParams),
+      });
     }
-  }, [navigate, task?.processInstanceKey, task?.processName, taskState, t]);
+  }, [
+    navigate,
+    searchParams,
+    task?.processInstanceKey,
+    task?.processName,
+    taskState,
+    t,
+  ]);
 
   useEffect(() => {
-    const search = new URLSearchParams(searchParams);
-    const ref = search.get('ref');
-    if (search.has('ref')) {
-      search.delete('ref');
-      setSearchParams(search, {replace: true});
+    const ref = searchParams.get('ref');
+    if (searchParams.has('ref')) {
+      setSearchParams(removeRefParam(searchParams), {replace: true});
     }
 
     const taskOpenedRef = decodeTaskOpenedRef(ref);

--- a/tasklist/client/src/v2/TaskDetailsLayout/index.test.tsx
+++ b/tasklist/client/src/v2/TaskDetailsLayout/index.test.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {HttpResponse, http} from 'msw';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {MemoryRouter, Routes, Route} from 'react-router-dom';
+import {render, screen, waitFor} from 'common/testing/testing-library';
+import {getMockQueryClient} from 'common/testing/getMockQueryClient';
+import {nodeMockServer} from 'common/testing/nodeMockServer';
+import {LocationLog} from 'common/testing/LocationLog';
+import * as userMocks from 'common/mocks/current-user';
+import * as taskMocks from 'v2/mocks/task';
+import {Component} from '.';
+
+const getWrapper = (id: string = '0', search: string = '') => {
+  const mockClient = getMockQueryClient();
+
+  const Wrapper: React.FC<{
+    children?: React.ReactNode;
+  }> = ({children}) => (
+    <QueryClientProvider client={mockClient}>
+      <MemoryRouter initialEntries={[`/${id}${search}`]}>
+        <Routes>
+          <Route path="/:id" element={children} />
+        </Routes>
+        <LocationLog />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+
+  return Wrapper;
+};
+
+describe('Task Details', () => {
+  beforeEach(() => {
+    nodeMockServer.use(
+      http.get(
+        '/v2/authentication/me',
+        () => HttpResponse.json(userMocks.currentUser),
+        {once: true},
+      ),
+    );
+  });
+
+  it('navigates to initial page preserving search params when task is cancelled', async () => {
+    nodeMockServer.use(
+      http.get(
+        '/v2/user-tasks/:userTaskKey',
+        () => HttpResponse.json(taskMocks.assignedTask({state: 'CANCELED'})),
+        {once: true},
+      ),
+    );
+
+    render(<Component />, {
+      wrapper: getWrapper('0', '?filter=all-open'),
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('pathname')).toHaveTextContent('/');
+      expect(screen.getByTestId('search')).toHaveTextContent(
+        '?filter=all-open',
+      );
+    });
+  });
+});

--- a/tasklist/client/src/v2/TaskDetailsLayout/index.tsx
+++ b/tasklist/client/src/v2/TaskDetailsLayout/index.tsx
@@ -26,6 +26,7 @@ import {tracking} from 'common/tracking';
 import {decodeTaskOpenedRef} from 'common/tracking/reftags';
 import {AssignButton} from './AssignButton';
 import {removeSortParam} from 'common/tasks/removeSortParam';
+import {removeRefParam} from 'common/tasks/removeRefParam';
 
 type OutletContext = {
   task: UserTask;
@@ -73,10 +74,14 @@ const TaskDetailsLayout: React.FC = () => {
         subtitle: `${task?.processName ?? task?.processDefinitionId} (${task?.processInstanceKey})`,
         isDismissable: true,
       });
-      navigate(pages.initial);
+      navigate({
+        pathname: pages.initial,
+        search: removeRefParam(searchParams),
+      });
     }
   }, [
     navigate,
+    searchParams,
     task?.processInstanceKey,
     task?.processName,
     task?.state,
@@ -85,11 +90,9 @@ const TaskDetailsLayout: React.FC = () => {
   ]);
 
   useEffect(() => {
-    const search = new URLSearchParams(searchParams);
-    const ref = search.get('ref');
-    if (search.has('ref')) {
-      search.delete('ref');
-      setSearchParams(search, {replace: true});
+    const ref = searchParams.get('ref');
+    if (searchParams.has('ref')) {
+      setSearchParams(removeRefParam(searchParams), {replace: true});
     }
 
     const taskOpenedRef = decodeTaskOpenedRef(ref);


### PR DESCRIPTION
# Description
Backport of #50256 to `stable/8.9`.

relates to camunda/camunda#43889