### PR TITLE
feat(zeebe): add component health details to broker health indicator

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/broker/health/BrokerStatusHealthIndicator.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/health/BrokerStatusHealthIndicator.java
@@ -7,8 +7,12 @@
  */
 package io.camunda.zeebe.broker.health;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
-import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
+import io.camunda.zeebe.broker.system.management.HealthTree;
+import io.camunda.zeebe.util.health.HealthReport;
+import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.health.contributor.Health;
 import org.springframework.boot.health.contributor.HealthIndicator;
@@ -17,24 +21,39 @@ import org.springframework.stereotype.Component;
 @Component
 public final class BrokerStatusHealthIndicator implements HealthIndicator {
 
-  private static final Health HEALTHY = Health.up().build();
-  private static final Health UNHEALTHY = Health.down().build();
+  private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
 
   private final SpringBrokerBridge brokerBridge;
+  private final ObjectMapper objectMapper;
 
   @Autowired
-  public BrokerStatusHealthIndicator(final SpringBrokerBridge brokerBridge) {
+  public BrokerStatusHealthIndicator(
+      final SpringBrokerBridge brokerBridge, final ObjectMapper objectMapper) {
     this.brokerBridge = brokerBridge;
+    this.objectMapper = objectMapper;
   }
 
   @Override
   public Health health() {
-    final var isHealthy =
-        brokerBridge
-            .getBrokerHealthCheckService()
-            .map(BrokerHealthCheckService::isBrokerHealthy)
-            .orElse(false);
+    final var optionalService = brokerBridge.getBrokerHealthCheckService();
+    if (optionalService.isEmpty()) {
+      return Health.down().build();
+    }
 
-    return isHealthy ? HEALTHY : UNHEALTHY;
+    final var service = optionalService.get();
+    final var isHealthy = service.isBrokerHealthy();
+    final var builder = isHealthy ? Health.up() : Health.down();
+
+    final var healthReport = service.getHealthReport();
+    addComponentTreeDetails(builder, healthReport);
+
+    return builder.build();
+  }
+
+  private void addComponentTreeDetails(final Health.Builder builder, final HealthReport report) {
+    for (final var entry : report.children().entrySet()) {
+      final var tree = HealthTree.fromHealthReport(entry.getKey(), entry.getValue());
+      builder.withDetail(entry.getKey(), objectMapper.convertValue(tree, MAP_TYPE));
+    }
   }
 }

--- a/dist/src/main/java/io/camunda/zeebe/broker/health/BrokerStatusHealthIndicator.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/health/BrokerStatusHealthIndicator.java
@@ -51,9 +51,9 @@ public final class BrokerStatusHealthIndicator implements HealthIndicator {
   }
 
   private void addComponentTreeDetails(final Health.Builder builder, final HealthReport report) {
-    for (final var entry : report.children().entrySet()) {
-      final var tree = HealthTree.fromHealthReport(entry.getKey(), entry.getValue());
-      builder.withDetail(entry.getKey(), objectMapper.convertValue(tree, MAP_TYPE));
+    final var componentTree = HealthTree.fromHealthReport(report);
+    for (final var child : componentTree.children()) {
+      builder.withDetail(child.id(), objectMapper.convertValue(child, MAP_TYPE));
     }
   }
 }

--- a/dist/src/test/java/io/camunda/application/StartCamundaDockerIT.java
+++ b/dist/src/test/java/io/camunda/application/StartCamundaDockerIT.java
@@ -50,7 +50,55 @@ public class StartCamundaDockerIT extends AbstractCamundaDockerIT {
               "components": {
                 "brokerReady": {"status": "UP"},
                 "brokerStartup": {"status": "UP"},
-                "brokerStatus": {"status": "UP"},
+                "brokerStatus": {
+                  "status": "UP",
+                  "details": {
+                    "Partition-default-1": {
+                      "id": "Partition-default-1",
+                      "name": "Partition-default-1",
+                      "status": "HEALTHY",
+                      "componentsState": "HEALTHY",
+                      "children": [
+                        {
+                          "id": "SnapshotDirector-1",
+                          "name": "SnapshotDirector-1",
+                          "status": "HEALTHY",
+                          "children": []
+                        },
+                        {
+                          "id": "ZeebePartitionHealth-1",
+                          "name": "ZeebePartitionHealth-1",
+                          "status": "HEALTHY",
+                          "children": []
+                        },
+                        {
+                          "id": "StreamProcessor-1",
+                          "name": "StreamProcessor-1",
+                          "status": "HEALTHY",
+                          "children": []
+                        },
+                        {
+                          "id": "Exporter-1",
+                          "name": "Exporter-1",
+                          "status": "HEALTHY",
+                          "children": []
+                        },
+                        {
+                          "id": "MigrationSnapshotDirector",
+                          "name": "MigrationSnapshotDirector",
+                          "status": "HEALTHY",
+                          "children": []
+                        },
+                        {
+                          "id": "RaftPartition-1",
+                          "name": "RaftPartition-1",
+                          "status": "HEALTHY",
+                          "children": []
+                        }
+                      ]
+                    }
+                  }
+                },
                 "indicesCheck": {"status": "UP"},
                 "livenessState": {"status": "UP"},
                 "nodeIdProvider":{"status":"UP"},

--- a/dist/src/test/java/io/camunda/zeebe/broker/health/BrokerStatusHealthIndicatorTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/broker/health/BrokerStatusHealthIndicatorTest.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.health;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.google.common.collect.ImmutableMap;
+import io.camunda.zeebe.broker.SpringBrokerBridge;
+import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
+import io.camunda.zeebe.util.health.HealthIssue;
+import io.camunda.zeebe.util.health.HealthReport;
+import io.camunda.zeebe.util.health.HealthStatus;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.boot.health.contributor.Status;
+
+final class BrokerStatusHealthIndicatorTest {
+
+  private SpringBrokerBridge brokerBridge;
+  private BrokerHealthCheckService healthCheckService;
+  private BrokerStatusHealthIndicator indicator;
+
+  @BeforeEach
+  void setUp() {
+    brokerBridge = mock(SpringBrokerBridge.class);
+    healthCheckService = mock(BrokerHealthCheckService.class);
+    when(brokerBridge.getBrokerHealthCheckService()).thenReturn(Optional.of(healthCheckService));
+    final var objectMapper = JsonMapper.builder().findAndAddModules().build();
+    indicator = new BrokerStatusHealthIndicator(brokerBridge, objectMapper);
+  }
+
+  @Test
+  void shouldReportUpWhenBrokerIsHealthy() {
+    when(healthCheckService.isBrokerHealthy()).thenReturn(true);
+    when(healthCheckService.getHealthReport())
+        .thenReturn(new HealthReport("Broker-0", HealthStatus.HEALTHY, null, ImmutableMap.of()));
+
+    final Health health = indicator.health();
+
+    assertThat(health.getStatus()).isEqualTo(Status.UP);
+  }
+
+  @Test
+  void shouldReportDownWhenBrokerIsUnhealthy() {
+    when(healthCheckService.isBrokerHealthy()).thenReturn(false);
+    when(healthCheckService.getHealthReport())
+        .thenReturn(new HealthReport("Broker-0", HealthStatus.UNHEALTHY, null, ImmutableMap.of()));
+
+    final Health health = indicator.health();
+
+    assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+  }
+
+  @Test
+  void shouldReportDownWhenServiceUnavailable() {
+    when(brokerBridge.getBrokerHealthCheckService()).thenReturn(Optional.empty());
+
+    final Health health = indicator.health();
+
+    assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+    assertThat(health.getDetails()).isEmpty();
+  }
+
+  @Test
+  void shouldIncludeComponentTreeInDetails() {
+    final var raftReport =
+        new HealthReport("Raft-1", HealthStatus.HEALTHY, null, ImmutableMap.of());
+    final var streamProcessorReport =
+        new HealthReport("StreamProcessor-1", HealthStatus.HEALTHY, null, ImmutableMap.of());
+    final var partitionReport =
+        new HealthReport(
+            "Partition-1",
+            HealthStatus.HEALTHY,
+            null,
+            ImmutableMap.of("Raft-1", raftReport, "StreamProcessor-1", streamProcessorReport));
+
+    final var brokerReport =
+        new HealthReport(
+            "Broker-0",
+            HealthStatus.HEALTHY,
+            null,
+            ImmutableMap.of("Partition-1", partitionReport));
+
+    when(healthCheckService.isBrokerHealthy()).thenReturn(true);
+    when(healthCheckService.getHealthReport()).thenReturn(brokerReport);
+
+    final Health health = indicator.health();
+
+    assertThat(health.getStatus()).isEqualTo(Status.UP);
+    assertThat(health.getDetails())
+        .containsEntry(
+            "Partition-1",
+            Map.of(
+                "id",
+                "Partition-1",
+                "name",
+                "Partition-1",
+                "status",
+                "HEALTHY",
+                "componentsState",
+                "HEALTHY",
+                "children",
+                List.of(
+                    Map.of(
+                        "id",
+                        "Raft-1",
+                        "name",
+                        "Raft-1",
+                        "status",
+                        "HEALTHY",
+                        "children",
+                        List.of()),
+                    Map.of(
+                        "id",
+                        "StreamProcessor-1",
+                        "name",
+                        "StreamProcessor-1",
+                        "status",
+                        "HEALTHY",
+                        "children",
+                        List.of()))));
+  }
+
+  @Test
+  void shouldIncludeIssueDetailsForUnhealthyComponent() {
+    final var since = Instant.parse("2026-04-05T12:00:00Z");
+    final var unhealthyChild =
+        new HealthReport(
+            "StreamProcessor-1",
+            HealthStatus.UNHEALTHY,
+            HealthIssue.of("Processing is stuck", since),
+            ImmutableMap.of());
+
+    final var brokerReport =
+        new HealthReport(
+            "Broker-0",
+            HealthStatus.UNHEALTHY,
+            null,
+            ImmutableMap.of("StreamProcessor-1", unhealthyChild));
+
+    when(healthCheckService.isBrokerHealthy()).thenReturn(false);
+    when(healthCheckService.getHealthReport()).thenReturn(brokerReport);
+
+    final Health health = indicator.health();
+
+    assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+    assertThat(health.getDetails())
+        .containsEntry(
+            "StreamProcessor-1",
+            Map.of(
+                "id",
+                "StreamProcessor-1",
+                "name",
+                "StreamProcessor-1",
+                "status",
+                "UNHEALTHY",
+                "message",
+                "Processing is stuck",
+                "since",
+                "2026-04-05T12:00:00.000Z",
+                "children",
+                List.of()));
+  }
+
+  @Test
+  void shouldIncludeThrowableMessageInIssue() {
+    final var since = Instant.parse("2026-04-05T12:00:00Z");
+    final var exception = new RuntimeException("Disk full");
+    final var deadChild =
+        new HealthReport(
+            "Log-1", HealthStatus.DEAD, HealthIssue.of(exception, since), ImmutableMap.of());
+
+    final var brokerReport =
+        new HealthReport("Broker-0", HealthStatus.DEAD, null, ImmutableMap.of("Log-1", deadChild));
+
+    when(healthCheckService.isBrokerHealthy()).thenReturn(false);
+    when(healthCheckService.getHealthReport()).thenReturn(brokerReport);
+
+    final Health health = indicator.health();
+
+    assertThat(health.getDetails())
+        .containsEntry(
+            "Log-1",
+            Map.of(
+                "id",
+                "Log-1",
+                "name",
+                "Log-1",
+                "status",
+                "DEAD",
+                "message",
+                "Disk full",
+                "since",
+                "2026-04-05T12:00:00.000Z",
+                "children",
+                List.of()));
+  }
+
+  @Test
+  void shouldHandleEmptyComponentTree() {
+    when(healthCheckService.isBrokerHealthy()).thenReturn(true);
+    when(healthCheckService.getHealthReport())
+        .thenReturn(new HealthReport("Broker-0", HealthStatus.HEALTHY, null, ImmutableMap.of()));
+
+    final Health health = indicator.health();
+
+    assertThat(health.getStatus()).isEqualTo(Status.UP);
+    assertThat(health.getDetails()).isEmpty();
+  }
+}

--- a/dist/src/test/java/io/camunda/zeebe/broker/health/BrokerStatusHealthIndicatorTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/broker/health/BrokerStatusHealthIndicatorTest.java
@@ -14,7 +14,7 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.google.common.collect.ImmutableMap;
+
 import io.camunda.zeebe.broker.SpringBrokerBridge;
 import io.camunda.zeebe.broker.system.management.HealthTree;
 import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
@@ -51,7 +51,7 @@ final class BrokerStatusHealthIndicatorTest {
   void shouldReportUpWhenBrokerIsHealthy() {
     when(healthCheckService.isBrokerHealthy()).thenReturn(true);
     when(healthCheckService.getHealthReport())
-        .thenReturn(new HealthReport("Broker-0", HealthStatus.HEALTHY, null, ImmutableMap.of()));
+        .thenReturn(new HealthReport("Broker-0", HealthStatus.HEALTHY, null, Map.of()));
 
     final Health health = indicator.health();
 
@@ -62,7 +62,7 @@ final class BrokerStatusHealthIndicatorTest {
   void shouldReportDownWhenBrokerIsUnhealthy() {
     when(healthCheckService.isBrokerHealthy()).thenReturn(false);
     when(healthCheckService.getHealthReport())
-        .thenReturn(new HealthReport("Broker-0", HealthStatus.UNHEALTHY, null, ImmutableMap.of()));
+        .thenReturn(new HealthReport("Broker-0", HealthStatus.UNHEALTHY, null, Map.of()));
 
     final Health health = indicator.health();
 
@@ -82,22 +82,22 @@ final class BrokerStatusHealthIndicatorTest {
   @Test
   void shouldIncludeComponentTreeInDetails() {
     final var raftReport =
-        new HealthReport("Raft-1", HealthStatus.HEALTHY, null, ImmutableMap.of());
+        new HealthReport("Raft-1", HealthStatus.HEALTHY, null, Map.of());
     final var streamProcessorReport =
-        new HealthReport("StreamProcessor-1", HealthStatus.HEALTHY, null, ImmutableMap.of());
+        new HealthReport("StreamProcessor-1", HealthStatus.HEALTHY, null, Map.of());
     final var partitionReport =
         new HealthReport(
             "Partition-1",
             HealthStatus.HEALTHY,
             null,
-            ImmutableMap.of("Raft-1", raftReport, "StreamProcessor-1", streamProcessorReport));
+            Map.of("Raft-1", raftReport, "StreamProcessor-1", streamProcessorReport));
 
     final var brokerReport =
         new HealthReport(
             "Broker-0",
             HealthStatus.HEALTHY,
             null,
-            ImmutableMap.of("Partition-1", partitionReport));
+            Map.of("Partition-1", partitionReport));
 
     when(healthCheckService.isBrokerHealthy()).thenReturn(true);
     when(healthCheckService.getHealthReport()).thenReturn(brokerReport);
@@ -120,14 +120,14 @@ final class BrokerStatusHealthIndicatorTest {
             "StreamProcessor-1",
             HealthStatus.UNHEALTHY,
             HealthIssue.of("Processing is stuck", since),
-            ImmutableMap.of());
+            Map.of());
 
     final var brokerReport =
         new HealthReport(
             "Broker-0",
             HealthStatus.UNHEALTHY,
             null,
-            ImmutableMap.of("StreamProcessor-1", unhealthyChild));
+            Map.of("StreamProcessor-1", unhealthyChild));
 
     when(healthCheckService.isBrokerHealthy()).thenReturn(false);
     when(healthCheckService.getHealthReport()).thenReturn(brokerReport);
@@ -149,10 +149,10 @@ final class BrokerStatusHealthIndicatorTest {
     final var exception = new RuntimeException("Disk full");
     final var deadChild =
         new HealthReport(
-            "Log-1", HealthStatus.DEAD, HealthIssue.of(exception, since), ImmutableMap.of());
+            "Log-1", HealthStatus.DEAD, HealthIssue.of(exception, since), Map.of());
 
     final var brokerReport =
-        new HealthReport("Broker-0", HealthStatus.DEAD, null, ImmutableMap.of("Log-1", deadChild));
+        new HealthReport("Broker-0", HealthStatus.DEAD, null, Map.of("Log-1", deadChild));
 
     when(healthCheckService.isBrokerHealthy()).thenReturn(false);
     when(healthCheckService.getHealthReport()).thenReturn(brokerReport);
@@ -169,7 +169,7 @@ final class BrokerStatusHealthIndicatorTest {
   void shouldHandleEmptyComponentTree() {
     when(healthCheckService.isBrokerHealthy()).thenReturn(true);
     when(healthCheckService.getHealthReport())
-        .thenReturn(new HealthReport("Broker-0", HealthStatus.HEALTHY, null, ImmutableMap.of()));
+        .thenReturn(new HealthReport("Broker-0", HealthStatus.HEALTHY, null, Map.of()));
 
     final Health health = indicator.health();
 

--- a/dist/src/test/java/io/camunda/zeebe/broker/health/BrokerStatusHealthIndicatorTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/broker/health/BrokerStatusHealthIndicatorTest.java
@@ -14,7 +14,7 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
-
+import com.google.common.collect.ImmutableMap;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
 import io.camunda.zeebe.broker.system.management.HealthTree;
 import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
@@ -22,7 +22,6 @@ import io.camunda.zeebe.util.health.HealthIssue;
 import io.camunda.zeebe.util.health.HealthReport;
 import io.camunda.zeebe.util.health.HealthStatus;
 import java.time.Instant;
-import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -51,7 +50,7 @@ final class BrokerStatusHealthIndicatorTest {
   void shouldReportUpWhenBrokerIsHealthy() {
     when(healthCheckService.isBrokerHealthy()).thenReturn(true);
     when(healthCheckService.getHealthReport())
-        .thenReturn(new HealthReport("Broker-0", HealthStatus.HEALTHY, null, Map.of()));
+        .thenReturn(new HealthReport("Broker-0", HealthStatus.HEALTHY, null, ImmutableMap.of()));
 
     final Health health = indicator.health();
 
@@ -62,7 +61,7 @@ final class BrokerStatusHealthIndicatorTest {
   void shouldReportDownWhenBrokerIsUnhealthy() {
     when(healthCheckService.isBrokerHealthy()).thenReturn(false);
     when(healthCheckService.getHealthReport())
-        .thenReturn(new HealthReport("Broker-0", HealthStatus.UNHEALTHY, null, Map.of()));
+        .thenReturn(new HealthReport("Broker-0", HealthStatus.UNHEALTHY, null, ImmutableMap.of()));
 
     final Health health = indicator.health();
 
@@ -82,22 +81,22 @@ final class BrokerStatusHealthIndicatorTest {
   @Test
   void shouldIncludeComponentTreeInDetails() {
     final var raftReport =
-        new HealthReport("Raft-1", HealthStatus.HEALTHY, null, Map.of());
+        new HealthReport("Raft-1", HealthStatus.HEALTHY, null, ImmutableMap.of());
     final var streamProcessorReport =
-        new HealthReport("StreamProcessor-1", HealthStatus.HEALTHY, null, Map.of());
+        new HealthReport("StreamProcessor-1", HealthStatus.HEALTHY, null, ImmutableMap.of());
     final var partitionReport =
         new HealthReport(
             "Partition-1",
             HealthStatus.HEALTHY,
             null,
-            Map.of("Raft-1", raftReport, "StreamProcessor-1", streamProcessorReport));
+            ImmutableMap.of("Raft-1", raftReport, "StreamProcessor-1", streamProcessorReport));
 
     final var brokerReport =
         new HealthReport(
             "Broker-0",
             HealthStatus.HEALTHY,
             null,
-            Map.of("Partition-1", partitionReport));
+            ImmutableMap.of("Partition-1", partitionReport));
 
     when(healthCheckService.isBrokerHealthy()).thenReturn(true);
     when(healthCheckService.getHealthReport()).thenReturn(brokerReport);
@@ -120,14 +119,14 @@ final class BrokerStatusHealthIndicatorTest {
             "StreamProcessor-1",
             HealthStatus.UNHEALTHY,
             HealthIssue.of("Processing is stuck", since),
-            Map.of());
+            ImmutableMap.of());
 
     final var brokerReport =
         new HealthReport(
             "Broker-0",
             HealthStatus.UNHEALTHY,
             null,
-            Map.of("StreamProcessor-1", unhealthyChild));
+            ImmutableMap.of("StreamProcessor-1", unhealthyChild));
 
     when(healthCheckService.isBrokerHealthy()).thenReturn(false);
     when(healthCheckService.getHealthReport()).thenReturn(brokerReport);
@@ -149,10 +148,10 @@ final class BrokerStatusHealthIndicatorTest {
     final var exception = new RuntimeException("Disk full");
     final var deadChild =
         new HealthReport(
-            "Log-1", HealthStatus.DEAD, HealthIssue.of(exception, since), Map.of());
+            "Log-1", HealthStatus.DEAD, HealthIssue.of(exception, since), ImmutableMap.of());
 
     final var brokerReport =
-        new HealthReport("Broker-0", HealthStatus.DEAD, null, Map.of("Log-1", deadChild));
+        new HealthReport("Broker-0", HealthStatus.DEAD, null, ImmutableMap.of("Log-1", deadChild));
 
     when(healthCheckService.isBrokerHealthy()).thenReturn(false);
     when(healthCheckService.getHealthReport()).thenReturn(brokerReport);
@@ -169,7 +168,7 @@ final class BrokerStatusHealthIndicatorTest {
   void shouldHandleEmptyComponentTree() {
     when(healthCheckService.isBrokerHealthy()).thenReturn(true);
     when(healthCheckService.getHealthReport())
-        .thenReturn(new HealthReport("Broker-0", HealthStatus.HEALTHY, null, Map.of()));
+        .thenReturn(new HealthReport("Broker-0", HealthStatus.HEALTHY, null, ImmutableMap.of()));
 
     final Health health = indicator.health();
 

--- a/dist/src/test/java/io/camunda/zeebe/broker/health/BrokerStatusHealthIndicatorTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/broker/health/BrokerStatusHealthIndicatorTest.java
@@ -11,15 +11,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.google.common.collect.ImmutableMap;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
+import io.camunda.zeebe.broker.system.management.HealthTree;
 import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
 import io.camunda.zeebe.util.health.HealthIssue;
 import io.camunda.zeebe.util.health.HealthReport;
 import io.camunda.zeebe.util.health.HealthStatus;
 import java.time.Instant;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,6 +31,9 @@ import org.springframework.boot.health.contributor.Status;
 
 final class BrokerStatusHealthIndicatorTest {
 
+  private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
+
+  private ObjectMapper objectMapper;
   private SpringBrokerBridge brokerBridge;
   private BrokerHealthCheckService healthCheckService;
   private BrokerStatusHealthIndicator indicator;
@@ -38,7 +43,7 @@ final class BrokerStatusHealthIndicatorTest {
     brokerBridge = mock(SpringBrokerBridge.class);
     healthCheckService = mock(BrokerHealthCheckService.class);
     when(brokerBridge.getBrokerHealthCheckService()).thenReturn(Optional.of(healthCheckService));
-    final var objectMapper = JsonMapper.builder().findAndAddModules().build();
+    objectMapper = JsonMapper.builder().findAndAddModules().build();
     indicator = new BrokerStatusHealthIndicator(brokerBridge, objectMapper);
   }
 
@@ -99,39 +104,12 @@ final class BrokerStatusHealthIndicatorTest {
 
     final Health health = indicator.health();
 
+    final var expectedPartitionDetail =
+        objectMapper.convertValue(
+            HealthTree.fromHealthReport("Partition-1", partitionReport), MAP_TYPE);
+
     assertThat(health.getStatus()).isEqualTo(Status.UP);
-    assertThat(health.getDetails())
-        .containsEntry(
-            "Partition-1",
-            Map.of(
-                "id",
-                "Partition-1",
-                "name",
-                "Partition-1",
-                "status",
-                "HEALTHY",
-                "componentsState",
-                "HEALTHY",
-                "children",
-                List.of(
-                    Map.of(
-                        "id",
-                        "Raft-1",
-                        "name",
-                        "Raft-1",
-                        "status",
-                        "HEALTHY",
-                        "children",
-                        List.of()),
-                    Map.of(
-                        "id",
-                        "StreamProcessor-1",
-                        "name",
-                        "StreamProcessor-1",
-                        "status",
-                        "HEALTHY",
-                        "children",
-                        List.of()))));
+    assertThat(health.getDetails()).containsEntry("Partition-1", expectedPartitionDetail);
   }
 
   @Test
@@ -156,23 +134,13 @@ final class BrokerStatusHealthIndicatorTest {
 
     final Health health = indicator.health();
 
+    final var expectedStreamProcessorDetail =
+        objectMapper.convertValue(
+            HealthTree.fromHealthReport("StreamProcessor-1", unhealthyChild), MAP_TYPE);
+
     assertThat(health.getStatus()).isEqualTo(Status.DOWN);
     assertThat(health.getDetails())
-        .containsEntry(
-            "StreamProcessor-1",
-            Map.of(
-                "id",
-                "StreamProcessor-1",
-                "name",
-                "StreamProcessor-1",
-                "status",
-                "UNHEALTHY",
-                "message",
-                "Processing is stuck",
-                "since",
-                "2026-04-05T12:00:00.000Z",
-                "children",
-                List.of()));
+        .containsEntry("StreamProcessor-1", expectedStreamProcessorDetail);
   }
 
   @Test
@@ -191,22 +159,10 @@ final class BrokerStatusHealthIndicatorTest {
 
     final Health health = indicator.health();
 
-    assertThat(health.getDetails())
-        .containsEntry(
-            "Log-1",
-            Map.of(
-                "id",
-                "Log-1",
-                "name",
-                "Log-1",
-                "status",
-                "DEAD",
-                "message",
-                "Disk full",
-                "since",
-                "2026-04-05T12:00:00.000Z",
-                "children",
-                List.of()));
+    final var expectedLogDetail =
+        objectMapper.convertValue(HealthTree.fromHealthReport("Log-1", deadChild), MAP_TYPE);
+
+    assertThat(health.getDetails()).containsEntry("Log-1", expectedLogDetail);
   }
 
   @Test

--- a/dist/src/test/java/io/camunda/zeebe/broker/health/BrokerStatusHealthIndicatorTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/broker/health/BrokerStatusHealthIndicatorTest.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.util.health.HealthIssue;
 import io.camunda.zeebe.util.health.HealthReport;
 import io.camunda.zeebe.util.health.HealthStatus;
 import java.time.Instant;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/dist/src/test/java/io/camunda/zeebe/broker/health/BrokerStatusHealthIndicatorTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/broker/health/BrokerStatusHealthIndicatorTest.java
@@ -14,13 +14,12 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.google.common.collect.ImmutableMap;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
 import io.camunda.zeebe.broker.system.management.HealthTree;
 import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
-import io.camunda.zeebe.util.health.HealthIssue;
+import io.camunda.zeebe.util.health.FailureListener;
+import io.camunda.zeebe.util.health.HealthMonitorable;
 import io.camunda.zeebe.util.health.HealthReport;
-import io.camunda.zeebe.util.health.HealthStatus;
 import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
@@ -50,8 +49,7 @@ final class BrokerStatusHealthIndicatorTest {
   @Test
   void shouldReportUpWhenBrokerIsHealthy() {
     when(healthCheckService.isBrokerHealthy()).thenReturn(true);
-    when(healthCheckService.getHealthReport())
-        .thenReturn(new HealthReport("Broker-0", HealthStatus.HEALTHY, null, ImmutableMap.of()));
+    when(healthCheckService.getHealthReport()).thenReturn(healthyReport("Broker-0"));
 
     final Health health = indicator.health();
 
@@ -61,8 +59,7 @@ final class BrokerStatusHealthIndicatorTest {
   @Test
   void shouldReportDownWhenBrokerIsUnhealthy() {
     when(healthCheckService.isBrokerHealthy()).thenReturn(false);
-    when(healthCheckService.getHealthReport())
-        .thenReturn(new HealthReport("Broker-0", HealthStatus.UNHEALTHY, null, ImmutableMap.of()));
+    when(healthCheckService.getHealthReport()).thenReturn(unhealthyReport("Broker-0"));
 
     final Health health = indicator.health();
 
@@ -81,23 +78,14 @@ final class BrokerStatusHealthIndicatorTest {
 
   @Test
   void shouldIncludeComponentTreeInDetails() {
-    final var raftReport =
-        new HealthReport("Raft-1", HealthStatus.HEALTHY, null, ImmutableMap.of());
-    final var streamProcessorReport =
-        new HealthReport("StreamProcessor-1", HealthStatus.HEALTHY, null, ImmutableMap.of());
+    final var raftReport = healthyReport("Raft-1");
+    final var streamProcessorReport = healthyReport("StreamProcessor-1");
     final var partitionReport =
-        new HealthReport(
+        reportFromChildren(
             "Partition-1",
-            HealthStatus.HEALTHY,
-            null,
-            ImmutableMap.of("Raft-1", raftReport, "StreamProcessor-1", streamProcessorReport));
+            Map.of("Raft-1", raftReport, "StreamProcessor-1", streamProcessorReport));
 
-    final var brokerReport =
-        new HealthReport(
-            "Broker-0",
-            HealthStatus.HEALTHY,
-            null,
-            ImmutableMap.of("Partition-1", partitionReport));
+    final var brokerReport = reportFromChildren("Broker-0", Map.of("Partition-1", partitionReport));
 
     when(healthCheckService.isBrokerHealthy()).thenReturn(true);
     when(healthCheckService.getHealthReport()).thenReturn(brokerReport);
@@ -116,18 +104,10 @@ final class BrokerStatusHealthIndicatorTest {
   void shouldIncludeIssueDetailsForUnhealthyComponent() {
     final var since = Instant.parse("2026-04-05T12:00:00Z");
     final var unhealthyChild =
-        new HealthReport(
-            "StreamProcessor-1",
-            HealthStatus.UNHEALTHY,
-            HealthIssue.of("Processing is stuck", since),
-            ImmutableMap.of());
+        unhealthyReport("StreamProcessor-1").withMessage("Processing is stuck", since);
 
     final var brokerReport =
-        new HealthReport(
-            "Broker-0",
-            HealthStatus.UNHEALTHY,
-            null,
-            ImmutableMap.of("StreamProcessor-1", unhealthyChild));
+        reportFromChildren("Broker-0", Map.of("StreamProcessor-1", unhealthyChild));
 
     when(healthCheckService.isBrokerHealthy()).thenReturn(false);
     when(healthCheckService.getHealthReport()).thenReturn(brokerReport);
@@ -147,12 +127,9 @@ final class BrokerStatusHealthIndicatorTest {
   void shouldIncludeThrowableMessageInIssue() {
     final var since = Instant.parse("2026-04-05T12:00:00Z");
     final var exception = new RuntimeException("Disk full");
-    final var deadChild =
-        new HealthReport(
-            "Log-1", HealthStatus.DEAD, HealthIssue.of(exception, since), ImmutableMap.of());
+    final var deadChild = HealthReport.dead(component("Log-1")).withIssue(exception, since);
 
-    final var brokerReport =
-        new HealthReport("Broker-0", HealthStatus.DEAD, null, ImmutableMap.of("Log-1", deadChild));
+    final var brokerReport = reportFromChildren("Broker-0", Map.of("Log-1", deadChild));
 
     when(healthCheckService.isBrokerHealthy()).thenReturn(false);
     when(healthCheckService.getHealthReport()).thenReturn(brokerReport);
@@ -168,12 +145,43 @@ final class BrokerStatusHealthIndicatorTest {
   @Test
   void shouldHandleEmptyComponentTree() {
     when(healthCheckService.isBrokerHealthy()).thenReturn(true);
-    when(healthCheckService.getHealthReport())
-        .thenReturn(new HealthReport("Broker-0", HealthStatus.HEALTHY, null, ImmutableMap.of()));
+    when(healthCheckService.getHealthReport()).thenReturn(healthyReport("Broker-0"));
 
     final Health health = indicator.health();
 
     assertThat(health.getStatus()).isEqualTo(Status.UP);
     assertThat(health.getDetails()).isEmpty();
+  }
+
+  private static HealthReport healthyReport(final String componentName) {
+    return HealthReport.healthy(component(componentName));
+  }
+
+  private static HealthReport unhealthyReport(final String componentName) {
+    return HealthReport.unhealthy(component(componentName));
+  }
+
+  private static HealthReport reportFromChildren(
+      final String componentName, final Map<String, HealthReport> children) {
+    return HealthReport.fromChildrenStatus(componentName, children)
+        .orElseGet(() -> healthyReport(componentName));
+  }
+
+  private static HealthMonitorable component(final String componentName) {
+    return new TestHealthMonitorable(componentName);
+  }
+
+  private record TestHealthMonitorable(String componentName) implements HealthMonitorable {
+
+    @Override
+    public HealthReport getHealthReport() {
+      return HealthReport.healthy(this);
+    }
+
+    @Override
+    public void addFailureListener(final FailureListener failureListener) {}
+
+    @Override
+    public void removeFailureListener(final FailureListener failureListener) {}
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.health.CriticalComponentsHealthMonitor;
 import io.camunda.zeebe.util.health.HealthMonitor;
 import io.camunda.zeebe.util.health.HealthMonitorable;
+import io.camunda.zeebe.util.health.HealthReport;
 import io.camunda.zeebe.util.health.HealthStatus;
 import java.util.Collection;
 import java.util.Map;
@@ -227,6 +228,10 @@ public final class BrokerHealthCheckService extends Actor implements PartitionRa
 
   public boolean isBrokerHealthy() {
     return !actor.isClosed() && getBrokerHealth() == HealthStatus.HEALTHY;
+  }
+
+  public HealthReport getHealthReport() {
+    return healthMonitor.getHealthReport();
   }
 
   private HealthStatus getBrokerHealth() {


### PR DESCRIPTION
## Description

The `BrokerStatusHealthIndicator` currently reports only `UP` or `DOWN` without any details, making it difficult to diagnose broker health issues without digging through logs or metrics.

This change exposes the `CriticalComponentsHealthMonitor` component tree as nested map details in the Spring Boot health actuator endpoint.

### Before
```json
{
  "status": "UP",
  "components": {
    "brokerStatus": {
      "status": "UP"
    }
  }
}
```

### After
```json
{
  "status": "DOWN",
  "components": {
    "brokerStatus": {
      "status": "DOWN",
      "details": {
        "Partition-1": {
          "id": "Partition-1",
          "name": "Partition-1",
          "status": "UNHEALTHY",
          "componentsState": "UNHEALTHY",
          "children": [
            {
              "id": "Raft-1",
              "name": "Raft-1",
              "status": "HEALTHY",
              "children": []
            },
            {
              "id": "StreamProcessor-1",
              "name": "StreamProcessor-1",
              "status": "UNHEALTHY",
              "message": "Processing is stuck",
              "since": "2026-04-05T12:00:00.000Z",
              "children": []
            }
          ]
        }
      }
    }
  }
}
```

## Changes

- `BrokerHealthCheckService`: added `getHealthReport()` to expose the full `HealthReport` from the `CriticalComponentsHealthMonitor`. This reads a `volatile` field, so it is safe to call from the Spring health endpoint thread.
- `BrokerStatusHealthIndicator`: builds the actuator health response from `HealthTree`, so the Spring Boot health component keeps its `UP` or `DOWN` status and adds the component tree under `details`.
- `BrokerStatusHealthIndicatorTest`: covers healthy, unhealthy, service-unavailable, nested component tree, issue with message, issue with throwable, and empty tree scenarios.
- `StartCamundaDockerIT`: updates the expected all-in-one `/actuator/health` payload to include `brokerStatus.details`.

## Related issues

closes #33382
