### PR TITLE
feat(clients/java): add addVariable and addVariables methods to command builders

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/command/ActivateAdHocSubProcessActivitiesCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/ActivateAdHocSubProcessActivitiesCommandStep1.java
@@ -24,7 +24,8 @@ public interface ActivateAdHocSubProcessActivitiesCommandStep1 {
 
   /**
    * Create an {@link io.camunda.client.protocol.rest.AdHocSubProcessActivateActivitiesInstruction}
-   * for the given element id.
+   * for the given element id. This starts a new variable accumulation; variables added afterward
+   * apply to this element rather than any previously activated element.
    *
    * @param elementId the id of the element to activate
    * @return the builder for this command
@@ -33,7 +34,8 @@ public interface ActivateAdHocSubProcessActivitiesCommandStep1 {
 
   /**
    * Create an {@link io.camunda.client.protocol.rest.AdHocSubProcessActivateActivitiesInstruction}
-   * for the given element id with variables.
+   * for the given element id with variables. This starts a new variable accumulation initialized
+   * with the provided variables.
    *
    * @param elementId the id of the element to activate
    * @param variables variables to be set when activating the element
@@ -89,5 +91,25 @@ public interface ActivateAdHocSubProcessActivitiesCommandStep1 {
   interface ActivateAdHocSubProcessActivitiesCommandStep2
       extends ActivateAdHocSubProcessActivitiesCommandStep1,
           CommandWithVariables<ActivateAdHocSubProcessActivitiesCommandStep2>,
-          FinalCommandStep<ActivateAdHocSubProcessActivitiesResponse> {}
+          FinalCommandStep<ActivateAdHocSubProcessActivitiesResponse> {
+
+    /**
+     * Adds a single variable to the most recently activated element instance.
+     *
+     * @param key the key of the variable as string
+     * @param value the value of the variable as object
+     * @return the builder for this command
+     */
+    @Override
+    ActivateAdHocSubProcessActivitiesCommandStep2 addVariable(String key, Object value);
+
+    /**
+     * Adds multiple variables to the most recently activated element instance.
+     *
+     * @param variables the variables to add as map
+     * @return the builder for this command
+     */
+    @Override
+    ActivateAdHocSubProcessActivitiesCommandStep2 addVariables(Map<String, Object> variables);
+  }
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/CommandWithVariables.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CommandWithVariables.java
@@ -54,4 +54,26 @@ public interface CommandWithVariables<T> {
    *     to the broker.
    */
   T variable(String key, Object value);
+
+  /**
+   * Adds a single variable to the command. Unlike {@link #variable(String, Object)}, this method
+   * accumulates variables across multiple invocations, allowing you to build the variable map entry
+   * by entry.
+   *
+   * @param key the key of the variable as string
+   * @param value the value of the variable as object
+   * @return the builder for this command. Call {@link #send()} to complete the command and send it
+   *     to the broker.
+   */
+  T addVariable(String key, Object value);
+
+  /**
+   * Adds multiple variables to the command. Unlike {@link #variables(Map)}, this method accumulates
+   * variables across multiple invocations, allowing you to build the variable map incrementally.
+   *
+   * @param variables the variables to add as map
+   * @return the builder for this command. Call {@link #send()} to complete the command and send it
+   *     to the broker.
+   */
+  T addVariables(Map<String, Object> variables);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/CommandWithVariables.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CommandWithVariables.java
@@ -20,27 +20,45 @@ import java.util.Map;
 
 public interface CommandWithVariables<T> {
   /**
-   * @param variables the variables (JSON) as String
+   * Sets the variables from a JSON document, replacing any variables previously set on the command.
+   * An empty document or JSON {@code null} is treated as empty variables. Any other document must
+   * represent a JSON object.
+   *
+   * @param variables the variables JSON document as String
    * @return the builder for this command. Call {@link #send()} to complete the command and send it
    *     to the broker.
+   * @throws IllegalArgumentException if the JSON document represents a non-null value other than an
+   *     object
    */
   T variables(String variables);
 
   /**
+   * Sets the variables from an object, replacing any variables previously set on the command. The
+   * object must serialize to a JSON object.
+   *
    * @param variables the variables as object
    * @return the builder for this command. Call {@link #send()} to complete the command and send it
    *     to the broker.
+   * @throws IllegalArgumentException if the serialized value is not a JSON object
    */
   T variables(Object variables);
 
   /**
-   * @param variables the variables (JSON) as stream
+   * Sets the variables from a JSON document, replacing any variables previously set on the command.
+   * JSON {@code null} is treated as empty variables. Any other document must represent a JSON
+   * object.
+   *
+   * @param variables the variables JSON document as stream
    * @return the builder for this command. Call {@link #send()} to complete the command and send it
    *     to the broker.
+   * @throws IllegalArgumentException if the JSON document represents a non-null value other than an
+   *     object
    */
   T variables(InputStream variables);
 
   /**
+   * Sets the variables from a map, replacing any variables previously set on the command.
+   *
    * @param variables the variables as map
    * @return the builder for this command. Call {@link #send()} to complete the command and send it
    *     to the broker.
@@ -48,10 +66,34 @@ public interface CommandWithVariables<T> {
   T variables(Map<String, Object> variables);
 
   /**
+   * Sets a single variable, replacing any variables previously set on the command.
+   *
    * @param key the key of the variable as string
    * @param value the value of the variable as object
    * @return the builder for this command. Call {@link #send()} to complete the command and send it
    *     to the broker.
    */
   T variable(String key, Object value);
+
+  /**
+   * Adds a single variable to the command. Unlike {@link #variable(String, Object)}, this method
+   * accumulates variables across multiple invocations, allowing you to build the variable map entry
+   * by entry.
+   *
+   * @param key the key of the variable as string
+   * @param value the value of the variable as object
+   * @return the builder for this command. Call {@link #send()} to complete the command and send it
+   *     to the broker.
+   */
+  T addVariable(String key, Object value);
+
+  /**
+   * Adds multiple variables to the command. Unlike {@link #variables(Map)}, this method accumulates
+   * variables across multiple invocations, allowing you to build the variable map incrementally.
+   *
+   * @param variables the variables to add as map
+   * @return the builder for this command. Call {@link #send()} to complete the command and send it
+   *     to the broker.
+   */
+  T addVariables(Map<String, Object> variables);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/CompleteAdHocSubProcessResultStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CompleteAdHocSubProcessResultStep1.java
@@ -90,5 +90,24 @@ public interface CompleteAdHocSubProcessResultStep1 extends CompleteJobResult {
      */
     @Override
     CompleteAdHocSubProcessResultStep1 variable(String key, Object value);
+
+    /**
+     * Adds a single variable to the activated element instance.
+     *
+     * @param key the key of the variable as string
+     * @param value the value of the variable as object
+     * @return the builder for this command.
+     */
+    @Override
+    CompleteAdHocSubProcessResultStep2 addVariable(String key, Object value);
+
+    /**
+     * Adds multiple variables to the activated element instance.
+     *
+     * @param variables the variables document as map
+     * @return the builder for this command.
+     */
+    @Override
+    CompleteAdHocSubProcessResultStep2 addVariables(Map<String, Object> variables);
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/CompleteAdHocSubProcessResultStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CompleteAdHocSubProcessResultStep1.java
@@ -21,7 +21,8 @@ import java.util.Map;
 public interface CompleteAdHocSubProcessResultStep1 extends CompleteJobResult {
 
   /**
-   * Adds an element to activate in the ad-hoc sub-process.
+   * Adds an element to activate in the ad-hoc sub-process. This starts a new variable accumulation;
+   * variables added afterward apply to this element rather than any previously activated element.
    *
    * @return this result
    */
@@ -90,5 +91,24 @@ public interface CompleteAdHocSubProcessResultStep1 extends CompleteJobResult {
      */
     @Override
     CompleteAdHocSubProcessResultStep1 variable(String key, Object value);
+
+    /**
+     * Adds a single variable to the most recently activated element instance.
+     *
+     * @param key the key of the variable as string
+     * @param value the value of the variable as object
+     * @return the builder for this command.
+     */
+    @Override
+    CompleteAdHocSubProcessResultStep2 addVariable(String key, Object value);
+
+    /**
+     * Adds multiple variables to the most recently activated element instance.
+     *
+     * @param variables the variables document as map
+     * @return the builder for this command.
+     */
+    @Override
+    CompleteAdHocSubProcessResultStep2 addVariables(Map<String, Object> variables);
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/CreateProcessInstanceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CreateProcessInstanceCommandStep1.java
@@ -122,6 +122,31 @@ public interface CreateProcessInstanceCommandStep1
     CreateProcessInstanceCommandStep3 variable(String key, Object value);
 
     /**
+     * Add a single initial variable to the process instance. Unlike {@link #variable(String,
+     * Object)}, this method accumulates variables across multiple invocations, allowing you to
+     * build the variable map entry by entry.
+     *
+     * @param key the key of the variable as string
+     * @param value the value of the variable as object
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    @Override
+    CreateProcessInstanceCommandStep3 addVariable(String key, Object value);
+
+    /**
+     * Add multiple initial variables to the process instance. Unlike {@link #variables(Map)}, this
+     * method accumulates variables across multiple invocations, allowing you to build the variable
+     * map incrementally.
+     *
+     * @param variables the variables to add as map
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    @Override
+    CreateProcessInstanceCommandStep3 addVariables(Map<String, Object> variables);
+
+    /**
      * Overrides the default start position of the process. Calling this method will make the
      * process start at the given {@code elementId}, if possible. This method can be called more
      * than once to simultaneously start at different elements in different branches of the process.

--- a/clients/java/src/main/java/io/camunda/client/impl/command/ActivateAdHocSubProcessActivitiesCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/ActivateAdHocSubProcessActivitiesCommandImpl.java
@@ -59,6 +59,7 @@ public final class ActivateAdHocSubProcessActivitiesCommandImpl
 
   @Override
   public ActivateAdHocSubProcessActivitiesCommandStep2 activateElement(final String elementId) {
+    resetAccumulatedVariables();
     latestActivateElement = new AdHocSubProcessActivateActivityReference().elementId(elementId);
     httpRequestObject.addElementsItem(latestActivateElement);
     return this;
@@ -68,6 +69,9 @@ public final class ActivateAdHocSubProcessActivitiesCommandImpl
   public ActivateAdHocSubProcessActivitiesCommandStep2 activateElement(
       final String elementId, final Map<String, Object> variables) {
     activateElement(elementId);
+    if (variables != null) {
+      seedAccumulatedVariables(variables);
+    }
     latestActivateElement.setVariables(variables);
     return this;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/ActivateAdHocSubProcessActivitiesCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/ActivateAdHocSubProcessActivitiesCommandImpl.java
@@ -59,6 +59,7 @@ public final class ActivateAdHocSubProcessActivitiesCommandImpl
 
   @Override
   public ActivateAdHocSubProcessActivitiesCommandStep2 activateElement(final String elementId) {
+    resetAccumulatedVariables();
     latestActivateElement = new AdHocSubProcessActivateActivityReference().elementId(elementId);
     httpRequestObject.addElementsItem(latestActivateElement);
     return this;
@@ -68,6 +69,9 @@ public final class ActivateAdHocSubProcessActivitiesCommandImpl
   public ActivateAdHocSubProcessActivitiesCommandStep2 activateElement(
       final String elementId, final Map<String, Object> variables) {
     activateElement(elementId);
+    if (variables != null) {
+      replaceAccumulatedVariables(variables);
+    }
     latestActivateElement.setVariables(variables);
     return this;
   }
@@ -102,6 +106,9 @@ public final class ActivateAdHocSubProcessActivitiesCommandImpl
   @Override
   protected ActivateAdHocSubProcessActivitiesCommandStep2 setVariablesInternal(
       final String variables) {
+    if (latestActivateElement == null) {
+      throw new IllegalStateException("An element must be activated before setting variables");
+    }
     latestActivateElement.setVariables(jsonMapper.fromJsonAsMap(variables));
     return this;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/ArgumentUtil.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/ArgumentUtil.java
@@ -18,9 +18,12 @@ package io.camunda.client.impl.command;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Predicate;
 
 public final class ArgumentUtil {
+
+  private static final int MAX_VALUE_LENGTH = 500;
 
   public static void ensureNotNull(final String property, final Object value) {
     if (value == null) {
@@ -82,10 +85,28 @@ public final class ArgumentUtil {
     ensureNotEmpty(property, value);
   }
 
+  @SuppressWarnings("unchecked")
+  public static Map<String, Object> ensureJsonObject(final String property, final Object value) {
+    if (!(value instanceof Map<?, ?>)) {
+      throw new IllegalArgumentException(
+          String.format(
+              "%s must be a JSON object, but was: %s",
+              property, abbreviate(String.valueOf(value))));
+    }
+    return (Map<String, Object>) value;
+  }
+
   private static <T> void ensureNotEmpty(
       final String property, final T value, final Predicate<T> isEmptyPredicate) {
     if (isEmptyPredicate.test(value)) {
       throw new IllegalArgumentException(property + " must not be empty");
     }
+  }
+
+  private static String abbreviate(final String value) {
+    if (value.length() <= MAX_VALUE_LENGTH) {
+      return value;
+    }
+    return value.substring(0, MAX_VALUE_LENGTH - 3) + "...";
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/BroadcastSignalCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/BroadcastSignalCommandImpl.java
@@ -72,13 +72,6 @@ public final class BroadcastSignalCommandImpl
   @Override
   protected BroadcastSignalCommandImpl setVariablesInternal(final String variables) {
     grpcRequestObjectBuilder.setVariables(variables);
-    // This check is mandatory. Without it, gRPC requests can fail unnecessarily.
-    // gRPC and REST handle setting variables differently:
-    // - For gRPC commands, we only check if the JSON is valid and forward it to the engine.
-    //    The engine checks if the provided String can be transformed into a Map, if not it
-    //    throws an error.
-    // - For REST commands, users have to provide a valid JSON Object String.
-    //    Otherwise, the client throws an exception already.
     if (useRest) {
       httpRequestObject.setVariables(objectMapper.fromJsonAsMap(variables));
     }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CommandWithVariables.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CommandWithVariables.java
@@ -17,12 +17,13 @@ package io.camunda.client.impl.command;
 
 import io.camunda.client.api.JsonMapper;
 import java.io.InputStream;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 public abstract class CommandWithVariables<T> {
 
   protected final JsonMapper objectMapper;
+  private final Map<String, Object> accumulatedVariables = new HashMap<>();
 
   public CommandWithVariables(final JsonMapper jsonMapper) {
     objectMapper = jsonMapper;
@@ -30,27 +31,75 @@ public abstract class CommandWithVariables<T> {
 
   public T variables(final InputStream variables) {
     ArgumentUtil.ensureNotNull("variables", variables);
-    return setVariablesInternal(objectMapper.validateJson("variables", variables));
+    final String validatedVariables = objectMapper.validateJson("variables", variables);
+    seedAccumulatedVariables(validatedVariables);
+    return setVariablesInternal(validatedVariables);
   }
 
   public T variables(final String variables) {
     ArgumentUtil.ensureNotNull("variables", variables);
-    return setVariablesInternal(objectMapper.validateJson("variables", variables));
+    final String validatedVariables = objectMapper.validateJson("variables", variables);
+    seedAccumulatedVariables(validatedVariables);
+    return setVariablesInternal(validatedVariables);
   }
 
   public T variables(final Map<String, Object> variables) {
     ArgumentUtil.ensureNotNull("variables", variables);
-    return variables((Object) variables);
+    final String serializedVariables = objectMapper.toJson(variables);
+    seedAccumulatedVariables(variables);
+    return setVariablesInternal(serializedVariables);
   }
 
   public T variables(final Object variables) {
     ArgumentUtil.ensureNotNull("variables", variables);
-    return setVariablesInternal(objectMapper.toJson(variables));
+    final String serializedVariables = objectMapper.toJson(variables);
+    seedAccumulatedVariables(serializedVariables);
+    return setVariablesInternal(serializedVariables);
   }
 
   public T variable(final String key, final Object value) {
     ArgumentUtil.ensureNotNull("key", key);
-    return variables(Collections.singletonMap(key, value));
+    accumulatedVariables.clear();
+    accumulatedVariables.put(key, value);
+    return setVariablesInternal(objectMapper.toJson(accumulatedVariables));
+  }
+
+  public T addVariable(final String key, final Object value) {
+    ArgumentUtil.ensureNotNull("key", key);
+    accumulatedVariables.put(key, value);
+    return setVariablesInternal(objectMapper.toJson(accumulatedVariables));
+  }
+
+  public T addVariables(final Map<String, Object> variables) {
+    ArgumentUtil.ensureNotNull("variables", variables);
+    accumulatedVariables.putAll(variables);
+    return setVariablesInternal(objectMapper.toJson(accumulatedVariables));
+  }
+
+  private void seedAccumulatedVariables(final String variables) {
+    accumulatedVariables.clear();
+    if (variables == null || variables.trim().isEmpty()) {
+      return;
+    }
+    final Object parsedVariables = objectMapper.fromJson(variables, Object.class);
+    if (parsedVariables instanceof Map) {
+      final Map<?, ?> variablesMap = (Map<?, ?>) parsedVariables;
+      for (final Map.Entry<?, ?> entry : variablesMap.entrySet()) {
+        final Object key = entry.getKey();
+        if (key instanceof String) {
+          accumulatedVariables.put((String) key, entry.getValue());
+        }
+      }
+    }
+  }
+
+  protected void resetAccumulatedVariables() {
+    accumulatedVariables.clear();
+  }
+
+  protected void seedAccumulatedVariables(final Map<String, Object> variables) {
+    accumulatedVariables.clear();
+    accumulatedVariables.putAll(variables);
   }
 
   protected abstract T setVariablesInternal(String variables);

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CommandWithVariables.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CommandWithVariables.java
@@ -18,11 +18,13 @@ package io.camunda.client.impl.command;
 import io.camunda.client.api.JsonMapper;
 import java.io.InputStream;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 public abstract class CommandWithVariables<T> {
 
   protected final JsonMapper objectMapper;
+  private final Map<String, Object> accumulatedVariables = new HashMap<>();
 
   public CommandWithVariables(final JsonMapper jsonMapper) {
     objectMapper = jsonMapper;
@@ -30,27 +32,73 @@ public abstract class CommandWithVariables<T> {
 
   public T variables(final InputStream variables) {
     ArgumentUtil.ensureNotNull("variables", variables);
-    return setVariablesInternal(objectMapper.validateJson("variables", variables));
+    final String validatedVariables = objectMapper.validateJson("variables", variables);
+    replaceAccumulatedVariables(validatedVariables);
+    return setVariablesInternal(validatedVariables);
   }
 
   public T variables(final String variables) {
     ArgumentUtil.ensureNotNull("variables", variables);
-    return setVariablesInternal(objectMapper.validateJson("variables", variables));
+    final String validatedVariables = objectMapper.validateJson("variables", variables);
+    replaceAccumulatedVariables(validatedVariables);
+    return setVariablesInternal(validatedVariables);
   }
 
   public T variables(final Map<String, Object> variables) {
     ArgumentUtil.ensureNotNull("variables", variables);
-    return variables((Object) variables);
+    final String serializedVariables = objectMapper.toJson(variables);
+    replaceAccumulatedVariables(variables);
+    return setVariablesInternal(serializedVariables);
   }
 
   public T variables(final Object variables) {
     ArgumentUtil.ensureNotNull("variables", variables);
-    return setVariablesInternal(objectMapper.toJson(variables));
+    final String serializedVariables = objectMapper.toJson(variables);
+    final Object transformedVariables = objectMapper.transform(variables, Object.class);
+    replaceAccumulatedVariables(ArgumentUtil.ensureJsonObject("variables", transformedVariables));
+    return setVariablesInternal(serializedVariables);
   }
 
   public T variable(final String key, final Object value) {
     ArgumentUtil.ensureNotNull("key", key);
-    return variables(Collections.singletonMap(key, value));
+    accumulatedVariables.clear();
+    accumulatedVariables.put(key, value);
+    return setVariablesInternal(objectMapper.toJson(accumulatedVariables));
+  }
+
+  public T addVariable(final String key, final Object value) {
+    ArgumentUtil.ensureNotNull("key", key);
+    accumulatedVariables.put(key, value);
+    return setVariablesInternal(objectMapper.toJson(accumulatedVariables));
+  }
+
+  public T addVariables(final Map<String, Object> variables) {
+    ArgumentUtil.ensureNotNull("variables", variables);
+    accumulatedVariables.putAll(variables);
+    return setVariablesInternal(objectMapper.toJson(accumulatedVariables));
+  }
+
+  private void replaceAccumulatedVariables(final String variables) {
+    if (variables == null || variables.trim().isEmpty()) {
+      replaceAccumulatedVariables(Collections.emptyMap());
+      return;
+    }
+
+    final Object parsedVariables = objectMapper.fromJson(variables, Object.class);
+    if (parsedVariables == null) {
+      replaceAccumulatedVariables(Collections.emptyMap());
+      return;
+    }
+    replaceAccumulatedVariables(ArgumentUtil.ensureJsonObject("variables", parsedVariables));
+  }
+
+  protected final void resetAccumulatedVariables() {
+    accumulatedVariables.clear();
+  }
+
+  protected final void replaceAccumulatedVariables(final Map<String, Object> variables) {
+    accumulatedVariables.clear();
+    accumulatedVariables.putAll(variables);
   }
 
   protected abstract T setVariablesInternal(String variables);

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CompleteAdHocSubProcessJobResultImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CompleteAdHocSubProcessJobResultImpl.java
@@ -21,6 +21,7 @@ import io.camunda.client.api.command.CompleteAdHocSubProcessResultStep1.Complete
 import io.camunda.client.api.command.enums.JobResultType;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class CompleteAdHocSubProcessJobResultImpl
     extends CommandWithVariables<CompleteAdHocSubProcessResultStep2>
@@ -47,6 +48,7 @@ public class CompleteAdHocSubProcessJobResultImpl
   @Override
   public CompleteAdHocSubProcessResultStep2 activateElement(final String elementId) {
     ArgumentUtil.ensureNotNull("elementId", elementId);
+    resetAccumulatedVariables();
     latestActivateElement = new ActivateElement().setElementId(elementId);
     activateElements.add(latestActivateElement);
     return this;
@@ -64,6 +66,16 @@ public class CompleteAdHocSubProcessJobResultImpl
       final boolean cancelRemainingInstances) {
     this.cancelRemainingInstances = cancelRemainingInstances;
     return this;
+  }
+
+  @Override
+  public CompleteAdHocSubProcessResultStep2 addVariable(final String key, final Object value) {
+    return super.addVariable(key, value);
+  }
+
+  @Override
+  public CompleteAdHocSubProcessResultStep2 addVariables(final Map<String, Object> variables) {
+    return super.addVariables(variables);
   }
 
   public boolean isCompletionConditionFulfilled() {

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CompleteAdHocSubProcessJobResultImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CompleteAdHocSubProcessJobResultImpl.java
@@ -19,8 +19,10 @@ import io.camunda.client.api.JsonMapper;
 import io.camunda.client.api.command.CompleteAdHocSubProcessResultStep1;
 import io.camunda.client.api.command.CompleteAdHocSubProcessResultStep1.CompleteAdHocSubProcessResultStep2;
 import io.camunda.client.api.command.enums.JobResultType;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class CompleteAdHocSubProcessJobResultImpl
     extends CommandWithVariables<CompleteAdHocSubProcessResultStep2>
@@ -47,6 +49,7 @@ public class CompleteAdHocSubProcessJobResultImpl
   @Override
   public CompleteAdHocSubProcessResultStep2 activateElement(final String elementId) {
     ArgumentUtil.ensureNotNull("elementId", elementId);
+    resetAccumulatedVariables();
     latestActivateElement = new ActivateElement().setElementId(elementId);
     activateElements.add(latestActivateElement);
     return this;
@@ -72,6 +75,31 @@ public class CompleteAdHocSubProcessJobResultImpl
 
   public boolean isCancelRemainingInstances() {
     return cancelRemainingInstances;
+  }
+
+  @Override
+  public CompleteAdHocSubProcessResultStep2 variables(final String variables) {
+    return super.variables(variables);
+  }
+
+  @Override
+  public CompleteAdHocSubProcessResultStep2 variables(final InputStream variables) {
+    return super.variables(variables);
+  }
+
+  @Override
+  public CompleteAdHocSubProcessResultStep2 variables(final Map<String, Object> variables) {
+    return super.variables(variables);
+  }
+
+  @Override
+  public CompleteAdHocSubProcessResultStep2 variables(final Object variables) {
+    return super.variables(variables);
+  }
+
+  @Override
+  public CompleteAdHocSubProcessResultStep2 variable(final String key, final Object value) {
+    return super.variable(key, value);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CompleteJobCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CompleteJobCommandImpl.java
@@ -311,13 +311,6 @@ public final class CompleteJobCommandImpl extends CommandWithVariables<CompleteJ
   @Override
   protected CompleteJobCommandStep1 setVariablesInternal(final String variables) {
     grpcRequestObjectBuilder.setVariables(variables);
-    // This check is mandatory. Without it, gRPC requests can fail unnecessarily.
-    // gRPC and REST handle setting variables differently:
-    // - For gRPC commands, we only check if the JSON is valid and forward it to the engine.
-    //    The engine checks if the provided String can be transformed into a Map, if not it
-    //    throws an error.
-    // - For REST commands, users have to provide a valid JSON Object String.
-    //    Otherwise, the client throws an exception already.
     if (useRest) {
       httpRequestObject.setVariables(jsonMapper.fromJsonAsMap(variables));
     }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateProcessInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateProcessInstanceCommandImpl.java
@@ -52,7 +52,7 @@ import java.util.function.Predicate;
 import org.apache.hc.client5.http.config.RequestConfig;
 
 public final class CreateProcessInstanceCommandImpl
-    extends CommandWithVariables<CreateProcessInstanceCommandImpl>
+    extends CommandWithVariables<CreateProcessInstanceCommandStep3>
     implements CreateProcessInstanceCommandStep1,
         CreateProcessInstanceCommandStep2,
         CreateProcessInstanceCommandStep3 {

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateProcessInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateProcessInstanceCommandImpl.java
@@ -93,13 +93,6 @@ public final class CreateProcessInstanceCommandImpl
   @Override
   protected CreateProcessInstanceCommandImpl setVariablesInternal(final String variables) {
     grpcRequestObjectBuilder.setVariables(variables);
-    // This check is mandatory. Without it, gRPC requests can fail unnecessarily.
-    // gRPC and REST handle setting variables differently:
-    // - For gRPC commands, we only check if the JSON is valid and forward it to the engine.
-    //    The engine checks if the provided String can be transformed into a Map, if not it
-    //    throws an error.
-    // - For REST commands, users have to provide a valid JSON Object String.
-    //    Otherwise, the client throws an exception already.
     if (useRest) {
       httpRequestObject.setVariables(jsonMapper.fromJsonAsMap(variables));
     }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/EvaluateConditionalCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/EvaluateConditionalCommandImpl.java
@@ -73,13 +73,6 @@ public final class EvaluateConditionalCommandImpl
   @Override
   protected EvaluateConditionalCommandStep2 setVariablesInternal(final String variables) {
     grpcRequestObjectBuilder.setVariables(variables);
-    // This check is mandatory. Without it, gRPC requests can fail unnecessarily.
-    // gRPC and REST handle setting variables differently:
-    // - For gRPC commands, we only check if the JSON is valid and forward it to the engine.
-    //    The engine checks if the provided String can be transformed into a Map, if not it
-    //    throws an error.
-    // - For REST commands, users have to provide a valid JSON Object String.
-    //    Otherwise, the client throws an exception already.
     if (useRest) {
       httpRequestObject.setVariables(objectMapper.fromJsonAsMap(variables));
     }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/EvaluateDecisionCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/EvaluateDecisionCommandImpl.java
@@ -76,13 +76,6 @@ public class EvaluateDecisionCommandImpl extends CommandWithVariables<EvaluateDe
   @Override
   protected EvaluateDecisionCommandImpl setVariablesInternal(final String variables) {
     grpcRequestObjectBuilder.setVariables(variables);
-    // This check is mandatory. Without it, gRPC requests can fail unnecessarily.
-    // gRPC and REST handle setting variables differently:
-    // - For gRPC commands, we only check if the JSON is valid and forward it to the engine.
-    //    The engine checks if the provided String can be transformed into a Map, if not it
-    //    throws an error.
-    // - For REST commands, users have to provide a valid JSON Object String.
-    //    Otherwise, the client throws an exception already.
     if (useRest) {
       httpRequestObject.setVariables(jsonMapper.fromJsonAsMap(variables));
     }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/FailJobCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/FailJobCommandImpl.java
@@ -105,13 +105,6 @@ public final class FailJobCommandImpl extends CommandWithVariables<FailJobComman
   @Override
   public FailJobCommandStep2 setVariablesInternal(final String variables) {
     grpcRequestObjectBuilder.setVariables(variables);
-    // This check is mandatory. Without it, gRPC requests can fail unnecessarily.
-    // gRPC and REST handle setting variables differently:
-    // - For gRPC commands, we only check if the JSON is valid and forward it to the engine.
-    //    The engine checks if the provided String can be transformed into a Map, if not it
-    //    throws an error.
-    // - For REST commands, users have to provide a valid JSON Object String.
-    //    Otherwise, the client throws an exception already.
     if (useRest) {
       httpRequestObject.setVariables(objectMapper.fromJsonAsMap(variables));
     }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/PublishMessageCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/PublishMessageCommandImpl.java
@@ -73,13 +73,6 @@ public final class PublishMessageCommandImpl extends CommandWithVariables<Publis
   @Override
   protected PublishMessageCommandImpl setVariablesInternal(final String variables) {
     grpcRequestObjectBuilder.setVariables(variables);
-    // This check is mandatory. Without it, gRPC requests can fail unnecessarily.
-    // gRPC and REST handle setting variables differently:
-    // - For gRPC commands, we only check if the JSON is valid and forward it to the engine.
-    //    The engine checks if the provided String can be transformed into a Map, if not it
-    //    throws an error.
-    // - For REST commands, users have to provide a valid JSON Object String.
-    //    Otherwise, the client throws an exception already.
     if (useRest) {
       httpRequestObject.setVariables(objectMapper.fromJsonAsMap(variables));
     }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/SetVariablesCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/SetVariablesCommandImpl.java
@@ -132,13 +132,6 @@ public final class SetVariablesCommandImpl extends CommandWithVariables<SetVaria
   @Override
   public SetVariablesCommandStep2 setVariablesInternal(final String variables) {
     grpcRequestObjectBuilder.setVariables(variables);
-    // This check is mandatory. Without it, gRPC requests can fail unnecessarily.
-    // gRPC and REST handle setting variables differently:
-    // - For gRPC commands, we only check if the JSON is valid and forward it to the engine.
-    //    The engine checks if the provided String can be transformed into a Map, if not it
-    //    throws an error.
-    // - For REST commands, users have to provide a valid JSON Object String.
-    //    Otherwise, the client throws an exception already.
     if (useRest) {
       httpRequestObject.setVariables(objectMapper.fromJsonAsMap(variables));
     }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/ThrowErrorCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/ThrowErrorCommandImpl.java
@@ -98,13 +98,6 @@ public final class ThrowErrorCommandImpl extends CommandWithVariables<ThrowError
   @Override
   public ThrowErrorCommandStep2 setVariablesInternal(final String variables) {
     grpcRequestObjectBuilder.setVariables(variables);
-    // This check is mandatory. Without it, gRPC requests can fail unnecessarily.
-    // gRPC and REST handle setting variables differently:
-    // - For gRPC commands, we only check if the JSON is valid and forward it to the engine.
-    //    The engine checks if the provided String can be transformed into a Map, if not it
-    //    throws an error.
-    // - For REST commands, users have to provide a valid JSON Object String.
-    //    Otherwise, the client throws an exception already.
     if (useRest) {
       httpRequestObject.setVariables(objectMapper.fromJsonAsMap(variables));
     }

--- a/clients/java/src/test/java/io/camunda/client/adhocsubprocess/AdHocSubProcessActivityActivationTest.java
+++ b/clients/java/src/test/java/io/camunda/client/adhocsubprocess/AdHocSubProcessActivityActivationTest.java
@@ -115,6 +115,31 @@ public class AdHocSubProcessActivityActivationTest extends ClientRestTest {
             tuple("G", Collections.singletonMap("G", "gValue")));
   }
 
+  @Test
+  void shouldScopeAddedVariablesToLatestActivatedElement() {
+    client
+        .newActivateAdHocSubProcessActivitiesCommand(AD_HOC_SUBPROCESS_INSTANCE_KEY)
+        .activateElement("A")
+        .addVariable("A", "aValue")
+        .activateElement("B")
+        .addVariable("B", "bValue")
+        .activateElement("C", mapOf(entry("C", "cValue")))
+        .addVariable("C2", "cValue2")
+        .send()
+        .join();
+
+    final AdHocSubProcessActivateActivitiesInstruction request =
+        gatewayService.getLastRequest(AdHocSubProcessActivateActivitiesInstruction.class);
+    assertThat(request.getElements())
+        .extracting(
+            AdHocSubProcessActivateActivityReference::getElementId,
+            AdHocSubProcessActivateActivityReference::getVariables)
+        .containsExactly(
+            tuple("A", Collections.singletonMap("A", "aValue")),
+            tuple("B", Collections.singletonMap("B", "bValue")),
+            tuple("C", mapOf(Arrays.asList(entry("C", "cValue"), entry("C2", "cValue2")))));
+  }
+
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   void shouldSetCancelRemainingInstances(final boolean cancelRemainingInstances) {

--- a/clients/java/src/test/java/io/camunda/client/adhocsubprocess/AdHocSubProcessActivityActivationTest.java
+++ b/clients/java/src/test/java/io/camunda/client/adhocsubprocess/AdHocSubProcessActivityActivationTest.java
@@ -34,10 +34,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -115,6 +117,31 @@ public class AdHocSubProcessActivityActivationTest extends ClientRestTest {
             tuple("G", Collections.singletonMap("G", "gValue")));
   }
 
+  @Test
+  void shouldScopeAddedVariablesToLatestActivatedElement() {
+    client
+        .newActivateAdHocSubProcessActivitiesCommand(AD_HOC_SUBPROCESS_INSTANCE_KEY)
+        .activateElement("A")
+        .addVariable("A", "aValue")
+        .activateElement("B")
+        .addVariable("B", "bValue")
+        .activateElement("C", mapOf(entry("C", "cValue")))
+        .addVariable("C2", "cValue2")
+        .send()
+        .join();
+
+    final AdHocSubProcessActivateActivitiesInstruction request =
+        gatewayService.getLastRequest(AdHocSubProcessActivateActivitiesInstruction.class);
+    assertThat(request.getElements())
+        .extracting(
+            AdHocSubProcessActivateActivityReference::getElementId,
+            AdHocSubProcessActivateActivityReference::getVariables)
+        .containsExactly(
+            tuple("A", Collections.singletonMap("A", "aValue")),
+            tuple("B", Collections.singletonMap("B", "bValue")),
+            tuple("C", mapOf(Arrays.asList(entry("C", "cValue"), entry("C2", "cValue2")))));
+  }
+
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   void shouldSetCancelRemainingInstances(final boolean cancelRemainingInstances) {
@@ -141,6 +168,23 @@ public class AdHocSubProcessActivityActivationTest extends ClientRestTest {
     final AdHocSubProcessActivateActivitiesInstruction request =
         gatewayService.getLastRequest(AdHocSubProcessActivateActivitiesInstruction.class);
     assertThat(request.getCancelRemainingInstances()).isFalse();
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("variableSetters")
+  void shouldRejectSettingVariablesBeforeActivatingElement(
+      final String description,
+      final Consumer<ActivateAdHocSubProcessActivitiesCommandStep2> setVariables) {
+    // given
+    final ActivateAdHocSubProcessActivitiesCommandStep2 command =
+        client
+            .newActivateAdHocSubProcessActivitiesCommand(AD_HOC_SUBPROCESS_INSTANCE_KEY)
+            .cancelRemainingInstances(true);
+
+    // when / then
+    assertThatThrownBy(() -> setVariables.accept(command))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("An element must be activated before setting variables");
   }
 
   @ParameterizedTest
@@ -173,6 +217,40 @@ public class AdHocSubProcessActivityActivationTest extends ClientRestTest {
         command -> command.activateElement("A").activateElement("B").activateElement("C"),
         command -> command.activateElements("A", "B", "C"),
         command -> command.activateElements(Arrays.asList("A", "B", "C")));
+  }
+
+  static Stream<Arguments> variableSetters() {
+    return Stream.of(
+        Arguments.of(
+            "variables JSON",
+            (Consumer<ActivateAdHocSubProcessActivitiesCommandStep2>)
+                command -> command.variables("{}")),
+        Arguments.of(
+            "variables stream",
+            (Consumer<ActivateAdHocSubProcessActivitiesCommandStep2>)
+                command ->
+                    command.variables(
+                        new ByteArrayInputStream("{}".getBytes(StandardCharsets.UTF_8)))),
+        Arguments.of(
+            "variables map",
+            (Consumer<ActivateAdHocSubProcessActivitiesCommandStep2>)
+                command -> command.variables(Collections.emptyMap())),
+        Arguments.of(
+            "variables object",
+            (Consumer<ActivateAdHocSubProcessActivitiesCommandStep2>)
+                command -> command.variables((Object) Collections.emptyMap())),
+        Arguments.of(
+            "variable",
+            (Consumer<ActivateAdHocSubProcessActivitiesCommandStep2>)
+                command -> command.variable("key", "value")),
+        Arguments.of(
+            "addVariable",
+            (Consumer<ActivateAdHocSubProcessActivitiesCommandStep2>)
+                command -> command.addVariable("key", "value")),
+        Arguments.of(
+            "addVariables",
+            (Consumer<ActivateAdHocSubProcessActivitiesCommandStep2>)
+                command -> command.addVariables(Collections.singletonMap("key", "value"))));
   }
 
   private static Map<String, Object> mapOf(final Entry<String, Object> entry) {

--- a/clients/java/src/test/java/io/camunda/client/impl/command/CommandWithVariablesTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/command/CommandWithVariablesTest.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.entry;
+
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.impl.CamundaObjectMapper;
+import java.io.ByteArrayInputStream;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class CommandWithVariablesTest {
+
+  private final TestCommand command = new TestCommand(new CamundaObjectMapper());
+
+  @Test
+  void shouldAccumulateVariablesAcrossAddMethods() {
+    // given
+    final Map<String, Object> additionalVariables = new HashMap<>();
+    additionalVariables.put("second", 2);
+    additionalVariables.put("third", 3);
+
+    // when
+    command.addVariable("first", 1).addVariables(additionalVariables);
+
+    // then
+    assertThat(command.getVariables())
+        .containsOnly(entry("first", 1), entry("second", 2), entry("third", 3));
+  }
+
+  @Test
+  void shouldReplaceExistingValueWhenAddingVariableWithSameName() {
+    // when
+    command.addVariable("variable", "old").addVariable("variable", "new");
+
+    // then
+    assertThat(command.getVariables()).containsOnly(entry("variable", "new"));
+  }
+
+  @Test
+  void shouldPreserveDecimalPrecisionWhenAddingVariableAfterVariablesObject() {
+    // given
+    final String preciseValue = "0.123456789012345678901234567890";
+    final PreciseVariablesDocument variables =
+        new PreciseVariablesDocument(new BigDecimal(preciseValue));
+
+    // when
+    command.variables(variables).addVariable("added", true);
+
+    // then
+    assertThat(command.getSerializedVariables()).contains("\"amount\":" + preciseValue);
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("replacingVariableSetters")
+  void shouldReplaceAccumulatedVariables(
+      final String description, final Consumer<TestCommand> replaceVariables) {
+    // given
+    command.addVariable("discarded", "value");
+
+    // when
+    replaceVariables.accept(command);
+    command.addVariable("added", "value");
+
+    // then
+    assertThat(command.getVariables())
+        .containsOnly(entry("replacement", "value"), entry("added", "value"));
+  }
+
+  @Test
+  void shouldResetAccumulatedVariablesForEmptyJson() {
+    // given
+    command.addVariable("discarded", "value");
+
+    // when
+    command.variables("").addVariable("added", "value");
+
+    // then
+    assertThat(command.getVariables()).containsOnly(entry("added", "value"));
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("nullVariableSetters")
+  void shouldForwardJsonNullAndResetAccumulatedVariables(
+      final String description, final Consumer<TestCommand> setVariables) {
+    // given
+    command.addVariable("discarded", "value");
+
+    // when
+    setVariables.accept(command);
+
+    // then
+    assertThat(command.getSerializedVariables()).isEqualTo("null");
+
+    command.addVariable("added", "value");
+    assertThat(command.getVariables()).containsOnly(entry("added", "value"));
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("nonObjectVariableSetters")
+  void shouldRejectVariablesThatAreNotAJsonObjectWithoutChangingAccumulatedVariables(
+      final String description,
+      final Consumer<TestCommand> setVariables,
+      final String expectedValue) {
+    // given
+    command.addVariable("existing", "value");
+
+    // when / then
+    assertThatThrownBy(() -> setVariables.accept(command))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("variables must be a JSON object, but was: " + expectedValue);
+
+    command.addVariable("added", "value");
+    assertThat(command.getVariables())
+        .containsOnly(entry("existing", "value"), entry("added", "value"));
+  }
+
+  @Test
+  void shouldTruncateRejectedJsonValueInErrorMessage() {
+    // given
+    final String largeValue = String.join("", Collections.nCopies(600, "a"));
+
+    // when / then
+    assertThatThrownBy(() -> command.variables("[\"" + largeValue + "\"]"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("variables must be a JSON object, but was: [")
+        .hasMessageEndingWith("...")
+        .hasMessageNotContaining(largeValue);
+  }
+
+  private static Stream<Arguments> nonObjectVariableSetters() {
+    return Stream.of(
+        Arguments.of(
+            "JSON string",
+            (Consumer<TestCommand>) command -> command.variables("[1,2,3]"),
+            "[1, 2, 3]"),
+        Arguments.of(
+            "JSON stream",
+            (Consumer<TestCommand>)
+                command ->
+                    command.variables(
+                        new ByteArrayInputStream("[1,2,3]".getBytes(StandardCharsets.UTF_8))),
+            "[1, 2, 3]"),
+        Arguments.of(
+            "object",
+            (Consumer<TestCommand>) command -> command.variables(Arrays.asList(1, 2, 3)),
+            "[1, 2, 3]"));
+  }
+
+  private static Stream<Arguments> nullVariableSetters() {
+    return Stream.of(
+        Arguments.of("JSON string", (Consumer<TestCommand>) command -> command.variables("null")),
+        Arguments.of(
+            "JSON stream",
+            (Consumer<TestCommand>)
+                command ->
+                    command.variables(
+                        new ByteArrayInputStream("null".getBytes(StandardCharsets.UTF_8)))));
+  }
+
+  private static Stream<Arguments> replacingVariableSetters() {
+    return Stream.of(
+        Arguments.of(
+            "single variable",
+            (Consumer<TestCommand>) command -> command.variable("replacement", "value")),
+        Arguments.of(
+            "variables map",
+            (Consumer<TestCommand>)
+                command -> command.variables(Collections.singletonMap("replacement", "value"))),
+        Arguments.of(
+            "variables JSON",
+            (Consumer<TestCommand>) command -> command.variables("{\"replacement\":\"value\"}")),
+        Arguments.of(
+            "variables stream",
+            (Consumer<TestCommand>)
+                command ->
+                    command.variables(
+                        new ByteArrayInputStream(
+                            "{\"replacement\":\"value\"}".getBytes(StandardCharsets.UTF_8)))),
+        Arguments.of(
+            "variables object",
+            (Consumer<TestCommand>) command -> command.variables(new VariablesDocument())));
+  }
+
+  private static final class TestCommand extends CommandWithVariables<TestCommand> {
+
+    private String serializedVariables;
+
+    private TestCommand(final JsonMapper jsonMapper) {
+      super(jsonMapper);
+    }
+
+    @Override
+    protected TestCommand setVariablesInternal(final String variables) {
+      serializedVariables = variables;
+      return this;
+    }
+
+    private Map<String, Object> getVariables() {
+      return objectMapper.fromJsonAsMap(serializedVariables);
+    }
+
+    private String getSerializedVariables() {
+      return serializedVariables;
+    }
+  }
+
+  private static final class VariablesDocument {
+
+    public String getReplacement() {
+      return "value";
+    }
+  }
+
+  private static final class PreciseVariablesDocument {
+
+    private final BigDecimal amount;
+
+    private PreciseVariablesDocument(final BigDecimal amount) {
+      this.amount = amount;
+    }
+
+    public BigDecimal getAmount() {
+      return amount;
+    }
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/impl/command/CompleteAdHocSubProcessJobResultImplTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/command/CompleteAdHocSubProcessJobResultImplTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import io.camunda.client.api.command.CompleteAdHocSubProcessResultStep1;
+import io.camunda.client.api.command.CompleteAdHocSubProcessResultStep1.CompleteAdHocSubProcessResultStep2;
+import io.camunda.client.impl.CamundaObjectMapper;
+import io.camunda.client.util.JsonUtil;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+class CompleteAdHocSubProcessJobResultImplTest {
+
+  @Test
+  void shouldScopeAddedVariablesToLatestActivatedElement() {
+    // given
+    final CompleteAdHocSubProcessJobResultImpl result =
+        new CompleteAdHocSubProcessJobResultImpl(new CamundaObjectMapper());
+    final CompleteAdHocSubProcessResultStep1 publicResult = result;
+
+    // when
+    publicResult
+        .activateElement("first")
+        .addVariable("first", 1)
+        .addVariable("second", 2)
+        .activateElement("second")
+        .addVariables(Collections.singletonMap("third", 3))
+        .activateElement("third");
+
+    // then
+    assertThat(result.getActivateElements())
+        .extracting(CompleteAdHocSubProcessJobResultImpl.ActivateElement::getElementId)
+        .containsExactly("first", "second", "third");
+    assertThat(JsonUtil.fromJsonAsMap(result.getActivateElements().get(0).getVariables()))
+        .containsOnly(entry("first", 1), entry("second", 2));
+    assertThat(JsonUtil.fromJsonAsMap(result.getActivateElements().get(1).getVariables()))
+        .containsOnly(entry("third", 3));
+    assertThat(result.getActivateElements().get(2).getVariables()).isNull();
+  }
+
+  @Test
+  void shouldAccumulateVariablesAfterEverySeedMethod() {
+    // given
+    final CompleteAdHocSubProcessJobResultImpl result =
+        new CompleteAdHocSubProcessJobResultImpl(new CamundaObjectMapper());
+    final CompleteAdHocSubProcessResultStep1 publicResult = result;
+
+    // when
+    final CompleteAdHocSubProcessResultStep2 jsonElement = publicResult.activateElement("json");
+    jsonElement.variables("{\"seed\":1}");
+    jsonElement.addVariable("added", 2);
+
+    final CompleteAdHocSubProcessResultStep2 streamElement = publicResult.activateElement("stream");
+    streamElement.variables(
+        new ByteArrayInputStream("{\"seed\":1}".getBytes(StandardCharsets.UTF_8)));
+    streamElement.addVariable("added", 2);
+
+    final CompleteAdHocSubProcessResultStep2 mapElement = publicResult.activateElement("map");
+    mapElement.variables(Collections.singletonMap("seed", 1));
+    mapElement.addVariable("added", 2);
+
+    final CompleteAdHocSubProcessResultStep2 objectElement = publicResult.activateElement("object");
+    objectElement.variables(new VariablesDocument());
+    objectElement.addVariable("added", 2);
+
+    final CompleteAdHocSubProcessResultStep2 variableElement =
+        publicResult.activateElement("variable");
+    variableElement.variable("seed", 1);
+    variableElement.addVariable("added", 2);
+
+    // then
+    assertThat(result.getActivateElements())
+        .allSatisfy(
+            element ->
+                assertThat(JsonUtil.fromJsonAsMap(element.getVariables()))
+                    .containsOnly(entry("seed", 1), entry("added", 2)));
+  }
+
+  private static final class VariablesDocument {
+
+    public int getSeed() {
+      return 1;
+    }
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/job/CompleteJobTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/CompleteJobTest.java
@@ -767,6 +767,53 @@ public final class CompleteJobTest extends ClientTest {
   }
 
   @Test
+  public void shouldScopeAddedVariablesToLatestAdHocSubProcessElement() {
+    // given
+    final ActivatedJob job = Mockito.mock(ActivatedJob.class);
+    Mockito.when(job.getKey()).thenReturn(12L);
+    final String elementId1 = "elementId1";
+    final String elementId2 = "elementId2";
+    final String elementId3 = "elementId3";
+
+    // when
+    client
+        .newCompleteCommand(job)
+        .withResult(
+            r ->
+                r.forAdHocSubProcess()
+                    .activateElement(elementId1)
+                    .addVariable("key", "value")
+                    .addVariable("key2", "value2")
+                    .activateElement(elementId2)
+                    .addVariable("anotherKey", "anotherValue")
+                    .addVariables(Collections.singletonMap("anotherKey2", "anotherValue2"))
+                    .activateElement(elementId3))
+        .send()
+        .join();
+
+    // then
+    final CompleteJobRequest request = gatewayService.getLastRequest();
+
+    assertThat(request.getJobKey()).isEqualTo(job.getKey());
+    assertThat(request.getResult().getType()).isEqualTo(AD_HOC_SUB_PROCESS_DISCRIMINATOR);
+    assertThat(request.getResult().getActivateElementsCount()).isEqualTo(3);
+    assertThat(request.getResult().getActivateElements(0).getElementId()).isEqualTo(elementId1);
+    assertThat(JsonUtil.fromJsonAsMap(request.getResult().getActivateElements(0).getVariables()))
+        .containsEntry("key", "value")
+        .containsEntry("key2", "value2")
+        .hasSize(2);
+    assertThat(request.getResult().getActivateElements(1).getElementId()).isEqualTo(elementId2);
+    assertThat(JsonUtil.fromJsonAsMap(request.getResult().getActivateElements(1).getVariables()))
+        .containsEntry("anotherKey", "anotherValue")
+        .containsEntry("anotherKey2", "anotherValue2")
+        .hasSize(2);
+    assertThat(request.getResult().getActivateElements(2).getElementId()).isEqualTo(elementId3);
+    assertThat(request.getResult().getActivateElements(2).getVariables()).isEmpty();
+    assertThat(request.getResult().getIsCompletionConditionFulfilled()).isFalse();
+    assertThat(request.getResult().getIsCancelRemainingInstances()).isFalse();
+  }
+
+  @Test
   public void shouldCompleteAdHocSubProcessWithCompletionConditionFulfilled() {
     // given
     final ActivatedJob job = Mockito.mock(ActivatedJob.class);

--- a/clients/java/src/test/java/io/camunda/client/process/CorrelateMessageTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/CorrelateMessageTest.java
@@ -18,7 +18,6 @@ package io.camunda.client.process;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import io.camunda.client.api.command.InternalClientException;
 import io.camunda.client.protocol.rest.MessageCorrelationRequest;
 import io.camunda.client.protocol.rest.MessageCorrelationResult;
 import io.camunda.client.util.ClientRestTest;
@@ -125,8 +124,7 @@ final class CorrelateMessageTest extends ClientRestTest {
                     .withoutCorrelationKey()
                     .tenantId(tenantId)
                     .variables(variables))
-        .isInstanceOf(InternalClientException.class)
-        .hasMessageContaining(
-            String.format("Failed to deserialize json '%s' to 'Map<String, Object>'", variables));
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("variables must be a JSON object, but was: []");
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/process/CreateProcessInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/CreateProcessInstanceTest.java
@@ -173,6 +173,175 @@ public final class CreateProcessInstanceTest extends ClientTest {
         .containsOnly(entry("foo", "bar"));
   }
 
+  // Verifies repeated addVariable calls accumulate entries.
+  @Test
+  public void shouldCreateProcessInstanceWithMultipleAddVariableCalls() {
+    // when
+    client
+        .newCreateInstanceCommand()
+        .processDefinitionKey(123)
+        .addVariable("key1", "value1")
+        .addVariable("key2", "value2")
+        .send()
+        .join();
+
+    // then
+    final CreateProcessInstanceRequest request = gatewayService.getLastRequest();
+    Assertions.assertThat(JsonUtil.fromJsonAsMap(request.getVariables()))
+        .containsOnly(entry("key1", "value1"), entry("key2", "value2"));
+  }
+
+  // Verifies addVariables and addVariable can be mixed and still accumulate.
+  @Test
+  public void shouldAccumulateAddVariableWithAddVariablesMap() {
+    // given
+    final java.util.Map<String, Object> variables = new java.util.HashMap<>();
+    variables.put("key1", "value1");
+
+    // when
+    client
+        .newCreateInstanceCommand()
+        .processDefinitionKey(123)
+        .addVariables(variables)
+        .addVariable("key2", "value2")
+        .send()
+        .join();
+
+    // then
+    final CreateProcessInstanceRequest request = gatewayService.getLastRequest();
+    Assertions.assertThat(JsonUtil.fromJsonAsMap(request.getVariables()))
+        .containsOnly(entry("key1", "value1"), entry("key2", "value2"));
+  }
+
+  // Verifies map-based reset works the same with addVariables as with addVariable.
+  @Test
+  public void shouldResetAccumulatedVariablesWhenCallingVariablesMapAndAddVariables() {
+    // given
+    final java.util.Map<String, Object> replacementVariables = new java.util.HashMap<>();
+    replacementVariables.put("key2", "value2");
+    final java.util.Map<String, Object> additionalVariables = new java.util.HashMap<>();
+    additionalVariables.put("key3", "value3");
+
+    // when
+    client
+        .newCreateInstanceCommand()
+        .processDefinitionKey(123)
+        .addVariable("key1", "value1")
+        .variables(replacementVariables)
+        .addVariables(additionalVariables)
+        .send()
+        .join();
+
+    // then
+    final CreateProcessInstanceRequest request = gatewayService.getLastRequest();
+    Assertions.assertThat(JsonUtil.fromJsonAsMap(request.getVariables()))
+        .containsOnly(entry("key2", "value2"), entry("key3", "value3"));
+  }
+
+  // Verifies single-variable reset clears prior additive state before continuing accumulation.
+  @Test
+  public void shouldResetAccumulatedVariablesWhenCallingVariable() {
+    // when
+    client
+        .newCreateInstanceCommand()
+        .processDefinitionKey(123)
+        .addVariable("key1", "value1")
+        .variable("key2", "value2")
+        .addVariable("key3", "value3")
+        .send()
+        .join();
+
+    // then
+    final CreateProcessInstanceRequest request = gatewayService.getLastRequest();
+    Assertions.assertThat(JsonUtil.fromJsonAsMap(request.getVariables()))
+        .containsOnly(entry("key2", "value2"), entry("key3", "value3"));
+  }
+
+  // Verifies addVariables pre-state is cleared by string reset before continuing accumulation.
+  @Test
+  public void shouldSeedAccumulationWhenCallingVariablesStringAfterAddVariables() {
+    // when
+    client
+        .newCreateInstanceCommand()
+        .processDefinitionKey(123)
+        .addVariables(Collections.singletonMap("key1", "value1"))
+        .variables("{\"key2\":\"value2\"}")
+        .addVariable("key3", "value3")
+        .send()
+        .join();
+
+    // then
+    final CreateProcessInstanceRequest request = gatewayService.getLastRequest();
+    Assertions.assertThat(JsonUtil.fromJsonAsMap(request.getVariables()))
+        .containsOnly(entry("key2", "value2"), entry("key3", "value3"));
+  }
+
+  // Verifies addVariables pre-state is cleared by InputStream reset before continuing accumulation.
+  @Test
+  public void shouldSeedAccumulationWhenCallingVariablesInputStreamAfterAddVariables() {
+    // given
+    final String variables = "{\"key2\":\"value2\"}";
+    final InputStream inputStream =
+        new ByteArrayInputStream(variables.getBytes(StandardCharsets.UTF_8));
+
+    // when
+    client
+        .newCreateInstanceCommand()
+        .processDefinitionKey(123)
+        .addVariables(Collections.singletonMap("key1", "value1"))
+        .variables(inputStream)
+        .addVariable("key3", "value3")
+        .send()
+        .join();
+
+    // then
+    final CreateProcessInstanceRequest request = gatewayService.getLastRequest();
+    Assertions.assertThat(JsonUtil.fromJsonAsMap(request.getVariables()))
+        .containsOnly(entry("key2", "value2"), entry("key3", "value3"));
+  }
+
+  // Verifies addVariables pre-state is cleared by object reset before continuing accumulation.
+  @Test
+  public void shouldSeedAccumulationWhenCallingVariablesObjectAfterAddVariables() {
+    // when
+    client
+        .newCreateInstanceCommand()
+        .processDefinitionKey(123)
+        .addVariables(Collections.singletonMap("key1", "value1"))
+        .variables(new VariableDocument())
+        .addVariable("key3", "value3")
+        .send()
+        .join();
+
+    // then
+    final CreateProcessInstanceRequest request = gatewayService.getLastRequest();
+    Assertions.assertThat(JsonUtil.fromJsonAsMap(request.getVariables()))
+        .containsOnly(entry("foo", "bar"), entry("key3", "value3"));
+  }
+
+  // Verifies string reset also composes correctly with addVariables after reset.
+  @Test
+  public void shouldSeedAccumulationWhenCallingVariablesStringAndAddVariablesAfterAddVariable() {
+    // given
+    final java.util.Map<String, Object> additionalVariables = new java.util.HashMap<>();
+    additionalVariables.put("key3", "value3");
+
+    // when
+    client
+        .newCreateInstanceCommand()
+        .processDefinitionKey(123)
+        .addVariable("key1", "value1")
+        .variables("{\"key2\":\"value2\"}")
+        .addVariables(additionalVariables)
+        .send()
+        .join();
+
+    // then
+    final CreateProcessInstanceRequest request = gatewayService.getLastRequest();
+    Assertions.assertThat(JsonUtil.fromJsonAsMap(request.getVariables()))
+        .containsOnly(entry("key2", "value2"), entry("key3", "value3"));
+  }
+
   @Test
   public void shouldRaiseAnErrorIfRequestFails() {
     // given

--- a/clients/java/src/test/java/io/camunda/client/process/SetVariablesTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/SetVariablesTest.java
@@ -107,7 +107,7 @@ public final class SetVariablesTest extends ClientTest {
         SetVariablesRequest.class, () -> new ClientException("Invalid request"));
 
     // when
-    assertThatThrownBy(() -> client.newSetVariablesCommand(123).variables("[]").send().join())
+    assertThatThrownBy(() -> client.newSetVariablesCommand(123).variables("{}").send().join())
         .isInstanceOf(ClientException.class)
         .hasMessageContaining("Invalid request");
   }

--- a/clients/java/src/test/java/io/camunda/client/process/rest/CreateProcessInstanceRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/rest/CreateProcessInstanceRestTest.java
@@ -195,6 +195,28 @@ public class CreateProcessInstanceRestTest extends ClientRestTest {
   }
 
   @Test
+  void shouldAddVariablesIncrementally() {
+    // given
+    gatewayService.onCreateProcessInstanceRequest(DUMMY_RESPONSE);
+
+    // when
+    client
+        .newCreateInstanceCommand()
+        .processDefinitionKey(123)
+        .addVariable("first", 1)
+        .addVariable("second", 2)
+        .addVariables(Collections.singletonMap("third", 3))
+        .send()
+        .join();
+
+    // then
+    final ProcessInstanceCreationInstruction request =
+        gatewayService.getLastRequest(ProcessInstanceCreationInstruction.class);
+    assertThat(request.getVariables())
+        .containsOnly(entry("first", 1), entry("second", 2), entry("third", 3));
+  }
+
+  @Test
   public void shouldRaiseAnErrorIfRequestFails() {
     // given
     gatewayService.errorOnRequest(

--- a/clients/java/src/test/java/io/camunda/client/process/rest/SetVariablesRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/rest/SetVariablesRestTest.java
@@ -18,7 +18,6 @@ package io.camunda.client.process.rest;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
 
-import io.camunda.client.api.command.ClientException;
 import io.camunda.client.protocol.rest.SetVariableRequest;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.StringUtil;
@@ -85,11 +84,11 @@ public class SetVariablesRestTest extends ClientRestTest {
   }
 
   @Test
-  public void shouldRaiseExceptionOnError() {
-    // when
-    assertThatThrownBy(() -> client.newSetVariablesCommand(123).variables("[]").send().join())
-        .isInstanceOf(ClientException.class)
-        .hasMessageContaining("Failed to deserialize json '[]' to 'Map<String, Object>'");
+  void shouldRejectVariablesThatAreNotJsonObject() {
+    // when / then
+    assertThatThrownBy(() -> client.newSetVariablesCommand(123).variables("[]"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("variables must be a JSON object, but was: []");
   }
 
   static class Document {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CompleteJobTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CompleteJobTest.java
@@ -102,19 +102,11 @@ public final class CompleteJobTest {
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
-  public void shouldRejectIfVariablesAreInvalid(final boolean useRest, final TestInfo testInfo) {
-    // given
-    final String jobType = "job-" + testInfo.getDisplayName();
-    final var jobKey = resourcesHelper.createSingleJob(jobType);
-
-    // when
-    if (useRest) {
-      assertThatThrownBy(() -> getCommand(client, useRest, jobKey).variables("[]").send().join())
-          .hasMessageContaining("Failed to deserialize json '[]' to 'Map<String, Object>'");
-    } else {
-      assertThatThrownBy(() -> getCommand(client, useRest, jobKey).variables("[]").send().join())
-          .hasMessageContaining("Expected variables to be valid msgpack, but it could not be read");
-    }
+  public void shouldRejectIfVariablesAreInvalid(final boolean useRest) {
+    // when / then
+    assertThatThrownBy(() -> getCommand(client, useRest, 1L).variables("[]"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("variables must be a JSON object, but was: []");
   }
 
   @ParameterizedTest

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CreateProcessInstanceTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CreateProcessInstanceTest.java
@@ -378,33 +378,16 @@ public final class CreateProcessInstanceTest {
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
-  public void shouldRejectCompleteJobIfVariablesAreInvalid(
-      final boolean useRest, final TestInfo testInfo) {
-    // given
-    deployProcesses(testInfo, useRest);
-
-    // when
-    if (useRest) {
-      assertThatThrownBy(
-              () ->
-                  getCommand(client, useRest)
-                      .bpmnProcessId(processId)
-                      .latestVersion()
-                      .variables("[]")
-                      .send()
-                      .join())
-          .hasMessageContaining("Failed to deserialize json '[]' to 'Map<String, Object>'");
-    } else {
-      assertThatThrownBy(
-              () ->
-                  getCommand(client, useRest)
-                      .bpmnProcessId(processId)
-                      .latestVersion()
-                      .variables("[]")
-                      .send()
-                      .join())
-          .hasMessageContaining("Expected variables to be valid msgpack, but it could not be read");
-    }
+  public void shouldRejectIfVariablesAreInvalid(final boolean useRest) {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                getCommand(client, useRest)
+                    .bpmnProcessId("process")
+                    .latestVersion()
+                    .variables("[]"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("variables must be a JSON object, but was: []");
   }
 
   @ParameterizedTest

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/SetVariablesTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/SetVariablesTest.java
@@ -103,20 +103,10 @@ public final class SetVariablesTest {
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   public void shouldRejectIfVariablesAreInvalid(final boolean useRest) {
-    // given
-    final long processInstanceKey = resourcesHelper.createProcessInstance(processDefinitionKey);
-
-    // then
-    if (useRest) {
-      assertThatThrownBy(
-              () -> getCommand(client, useRest, processInstanceKey).variables("[]").send().join())
-          .hasMessageContaining("Failed to deserialize json '[]' to 'Map<String, Object>");
-    } else {
-      assertThatThrownBy(
-              () -> getCommand(client, useRest, processInstanceKey).variables("[]").send().join())
-          .hasMessageContaining(
-              "Property 'variables' is invalid: Expected document to be a root level object, but was 'ARRAY'");
-    }
+    // when / then
+    assertThatThrownBy(() -> getCommand(client, useRest, 1L).variables("[]"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("variables must be a JSON object, but was: []");
   }
 
   @ParameterizedTest


### PR DESCRIPTION
## Description

The existing `variable()` method replaces all previously set variables on each call. This makes it impossible to build variables one by one using the builder pattern.

This adds two methods to `CommandWithVariables`:

- `addVariable(key, value)` adds one variable while retaining variables added earlier.
- `addVariables(map)` adds multiple variables while retaining variables added earlier.

The existing replacement semantics remain unchanged: `variable(...)` and `variables(...)` replace the current variable document, while the new methods accumulate values.

To keep the accumulated state consistent, `variables(String)`, `variables(InputStream)`, and `variables(Object)` now fail fast with `IllegalArgumentException` when the supplied value is valid JSON but does not represent an object, such as an array. Validation happens before the accumulated state is changed.

For ad-hoc subprocess commands, accumulated variables are scoped to the latest activated element and do not leak into the next element.

## Related issues

Closes #15352

## How I tested this

- Covered accumulation, replacement, mixed method usage, duplicate keys, empty input, and invalid non-object JSON in the shared command contract.
- Covered REST request mapping for incremental process-instance variables.
- Covered variable isolation for both ad-hoc subprocess command paths.
- Ran the Java client module: 2,098 tests, 0 failures, 0 errors.
- Ran formatting checks and verified that the full repository compiles.