### PR TITLE
test: replace mutable state and hard-coded delays in e2e tests

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operation-items-search-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operation-items-search-api.spec.ts
@@ -60,29 +60,19 @@ test.describe.parallel('Batch Operation Items Search API Tests', () => {
   test('Search Batch Operation Items - by itemKey [incident key] - Success', async ({
     request,
   }) => {
-    const localState: Record<string, unknown> = {};
-    await createSingleIncidentProcessInstance(localState, request);
-    const incidentKeys = localState['incidentKeys'] as string[];
+    const {processInstanceKey, incidentKeys} =
+      await createSingleIncidentProcessInstance({}, request);
     const incidentKey = incidentKeys[0];
-    const processInstanceKeyToResolveIncident =
-      localState.processInstanceKey as string;
-    processInstanceKeys.push(processInstanceKeyToResolveIncident);
+
+    expect(incidentKey).toBeDefined();
+    processInstanceKeys.push(processInstanceKey);
 
     await test.step('Verify that the process instance has incidents', async () => {
-      await verifyIncidentsForProcessInstance(
-        request,
-        processInstanceKeyToResolveIncident,
-        1,
-      );
+      await verifyIncidentsForProcessInstance(request, processInstanceKey, 1);
     });
 
-    await sleep(10000);
-
     await test.step('Poll process instance can be found', async () => {
-      await expectProcessInstanceCanBeFound(
-        request,
-        processInstanceKeyToResolveIncident,
-      );
+      await expectProcessInstanceCanBeFound(request, processInstanceKey);
     });
 
     await test.step('Create Batch Operation to Resolve Incidents', async () => {
@@ -93,7 +83,7 @@ test.describe.parallel('Batch Operation Items Search API Tests', () => {
             headers: jsonHeaders(),
             data: {
               filter: {
-                processInstanceKey: localState.processInstanceKey,
+                processInstanceKey,
               },
             },
           },
@@ -146,9 +136,7 @@ test.describe.parallel('Batch Operation Items Search API Tests', () => {
             expect(item.itemKey).toBe(incidentKey);
             expect(item.operationType).toBe('RESOLVE_INCIDENT');
             expect(item.state).toBeDefined();
-            expect(item.processInstanceKey).toBe(
-              processInstanceKeyToResolveIncident,
-            );
+            expect(item.processInstanceKey).toBe(processInstanceKey);
           }).toPass(defaultAssertionOptions);
         },
         onFailure: async () => {},

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/incident-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/incident-requestHelpers.ts
@@ -144,22 +144,27 @@ export async function createTwoDifferentIncidentsInOneProcess(
 }
 
 export async function createSingleIncidentProcessInstance(
-  localState: Record<string, unknown>,
+  localState: Record<string, unknown> = {},
   request: APIRequestContext,
 ) {
-  await test.step('Create process instance with single incidents', async () => {
-    const instance = await createSingleInstance('singleIncidentProcess', 1);
-    localState['processInstanceKey'] = instance.processInstanceKey;
-  });
-
-  await test.step('Search incident to get incidentKey', async () => {
-    const incidents = await searchIncidentByPIK(request, {
-      processInstanceKey: localState['processInstanceKey'] as string,
+  const processInstanceKey =
+    await test.step('Create process instance with single incidents', async () => {
+      const instance = await createSingleInstance('singleIncidentProcess', 1);
+      localState['processInstanceKey'] = instance.processInstanceKey; // mutation left for backward-compatibility
+      return instance.processInstanceKey;
     });
-    localState['incidentKeys'] = incidents.map(
-      (incident) => incident.incidentKey,
-    );
-  });
+
+  const incidentKeys =
+    await test.step('Search incident to get incidentKey', async () => {
+      const incidents = await searchIncidentByPIK(request, {
+        processInstanceKey,
+      });
+      const incidentKeys = incidents.map((incident) => incident.incidentKey);
+      localState['incidentKeys'] = incidentKeys; // mutation left for backward-compatibility
+      return incidentKeys;
+    });
+  // explicit object return removes parameter mutation and makes behaviour explicit and discoverable
+  return {processInstanceKey, incidentKeys};
 }
 
 /**

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/process-instance-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/process-instance-requestHelpers.ts
@@ -216,7 +216,10 @@ export async function expectProcessInstanceCanBeFound(
     const json = await statusRes.json();
     expect(json.processInstanceKey).toBe(processInstanceKey);
   }).toPass({
-    intervals: [5_000, 10_000, 15_000, 25_000, 35_000],
+    intervals: [
+      1_000, 2_000, 3_000, 4_000, 5_000, 6_000, 7_000, 8_000, 9_000, 10_000,
+      15_000, 25_000, 35_000,
+    ],
     timeout: 180_000,
   });
 }


### PR DESCRIPTION
## Description

Addresses structural issues in the e2e test suite that cause flakiness and make tests harder to understand.

Closes #50442

### Changes

1. **`createSingleIncidentProcessInstance` returns explicit values** — Instead of mutating a `Record<string, unknown>` parameter (which hides the function's outputs), the function now returns `{processInstanceKey, incidentKeys}` directly. Backward-compatible mutation is retained for other callers.

2. **Removed `sleep(10000)`** — The batch operation items search test used a hard-coded 10-second sleep before polling. The subsequent `expectProcessInstanceCanBeFound` already polls, so the sleep just adds unnecessary waiting time.

3. **More granular polling intervals** — `expectProcessInstanceCanBeFound` previously polled at 5s, 10s, 15s, 25s, 35s intervals. Now polls at 1s, 2s, 3s, ..., 10s, 15s, 25s, 35s — so tests succeed as soon as data is available rather than waiting in large fixed increments.

### Testing

- All 919 e2e tests pass (0 failures)
- The previously-flaky batch operation items search test passes reliably