### PR TITLE
poc: multi-instance activity execution listeners

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractMultiInstanceLoopCharacteristicsBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractMultiInstanceLoopCharacteristicsBuilder.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.model.bpmn.instance.CompletionCondition;
 import io.camunda.zeebe.model.bpmn.instance.LoopCardinality;
 import io.camunda.zeebe.model.bpmn.instance.MultiInstanceLoopCharacteristics;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeLoopCharacteristics;
+import java.util.function.Consumer;
 
 /**
  * @author Thorben Lindhauer
@@ -30,11 +31,14 @@ public class AbstractMultiInstanceLoopCharacteristicsBuilder<
         B extends AbstractMultiInstanceLoopCharacteristicsBuilder<B>>
     extends AbstractBaseElementBuilder<B, MultiInstanceLoopCharacteristics> {
 
+  private final ZeebeExecutionListenersBuilderImpl<B> zeebeExecutionListenersBuilder;
+
   protected AbstractMultiInstanceLoopCharacteristicsBuilder(
       final BpmnModelInstance modelInstance,
       final MultiInstanceLoopCharacteristics element,
       final Class<?> selfType) {
     super(modelInstance, element, selfType);
+    zeebeExecutionListenersBuilder = new ZeebeExecutionListenersBuilderImpl<>(myself);
   }
 
   /**
@@ -131,5 +135,26 @@ public class AbstractMultiInstanceLoopCharacteristicsBuilder<
 
   public B zeebeOutputElementExpression(final String outputElementExpression) {
     return zeebeOutputElement(asZeebeExpression(outputElementExpression));
+  }
+
+  public B zeebeStartExecutionListener(final String type) {
+    return zeebeExecutionListenersBuilder.zeebeStartExecutionListener(type);
+  }
+
+  public B zeebeStartExecutionListener(final String type, final String retries) {
+    return zeebeExecutionListenersBuilder.zeebeStartExecutionListener(type, retries);
+  }
+
+  public B zeebeEndExecutionListener(final String type) {
+    return zeebeExecutionListenersBuilder.zeebeEndExecutionListener(type);
+  }
+
+  public B zeebeEndExecutionListener(final String type, final String retries) {
+    return zeebeExecutionListenersBuilder.zeebeEndExecutionListener(type, retries);
+  }
+
+  public B zeebeExecutionListener(
+      final Consumer<ExecutionListenerBuilder> executionListenerBuilderConsumer) {
+    return zeebeExecutionListenersBuilder.zeebeExecutionListener(executionListenerBuilderConsumer);
   }
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ExecutionListenersValidator.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ExecutionListenersValidator.java
@@ -58,7 +58,9 @@ public class ExecutionListenersValidator implements ModelElementValidator<ZeebeE
               BpmnModelConstants.BPMN_ELEMENT_EXCLUSIVE_GATEWAY,
               BpmnModelConstants.BPMN_ELEMENT_INCLUSIVE_GATEWAY,
               BpmnModelConstants.BPMN_ELEMENT_PARALLEL_GATEWAY,
-              BpmnModelConstants.BPMN_ELEMENT_EVENT_BASED_GATEWAY));
+              BpmnModelConstants.BPMN_ELEMENT_EVENT_BASED_GATEWAY,
+              // multi-instance
+              BpmnModelConstants.BPMN_ELEMENT_MULTI_INSTANCE_LOOP_CHARACTERISTICS));
 
   @Override
   public Class<ZeebeExecutionListeners> getElementType() {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/MultiInstanceBodyProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/MultiInstanceBodyProcessor.java
@@ -89,14 +89,19 @@ public final class MultiInstanceBodyProcessor
   @Override
   public Either<Failure, ?> onActivate(
       final ExecutableMultiInstanceBody element, final BpmnElementContext context) {
-    // verify that the input collection variable is present and valid
+    // Subscribe to boundary events so they can interrupt during execution listener processing.
+    // The input collection evaluation is deferred to finalizeActivation() so that variables
+    // produced by start execution listeners on the multi-instance body are available.
+    return eventSubscriptionBehavior.subscribeToEvents(element, context);
+  }
+
+  @Override
+  public Either<Failure, ?> finalizeActivation(
+      final ExecutableMultiInstanceBody element, final BpmnElementContext context) {
+    // Evaluate the input collection after start execution listeners have completed.
+    // Variables produced by those listeners are now available for the inputCollection expression.
     return multiInstanceInputCollectionBehavior
         .initializeInputCollection(element, context)
-        .flatMap(
-            inputCollection ->
-                eventSubscriptionBehavior
-                    .subscribeToEvents(element, context)
-                    .map(ok -> inputCollection))
         .thenDo(inputCollection -> activate(element, context, inputCollection));
   }
 
@@ -113,6 +118,12 @@ public final class MultiInstanceBodyProcessor
 
     compensationSubscriptionBehaviour.createCompensationSubscription(element, context);
 
+    return SUCCESS;
+  }
+
+  @Override
+  public Either<Failure, ?> finalizeCompletion(
+      final ExecutableMultiInstanceBody element, final BpmnElementContext context) {
     return stateTransitionBehavior
         .transitionToCompleted(element, context)
         .thenDo(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/MultiInstanceActivityTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/MultiInstanceActivityTransformer.java
@@ -17,9 +17,11 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableMul
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableProcess;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.ModelElementTransformer;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.TransformContext;
+import io.camunda.zeebe.engine.processing.deployment.model.transformer.zeebe.ExecutionListenerTransformer;
 import io.camunda.zeebe.model.bpmn.instance.Activity;
 import io.camunda.zeebe.model.bpmn.instance.CompletionCondition;
 import io.camunda.zeebe.model.bpmn.instance.MultiInstanceLoopCharacteristics;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListeners;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeLoopCharacteristics;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.BpmnEventType;
@@ -29,6 +31,10 @@ import java.util.Optional;
 import org.agrona.DirectBuffer;
 
 public final class MultiInstanceActivityTransformer implements ModelElementTransformer<Activity> {
+
+  private final ExecutionListenerTransformer executionListenerTransformer =
+      new ExecutionListenerTransformer();
+
   @Override
   public Class<Activity> getType() {
     return Activity.class;
@@ -50,6 +56,7 @@ public final class MultiInstanceActivityTransformer implements ModelElementTrans
           new ExecutableMultiInstanceBody(element.getId(), miLoopCharacteristics, innerActivity);
 
       transformMultiInstanceBody(process, innerActivity, multiInstanceBody);
+      transformExecutionListeners(loopCharacteristics, multiInstanceBody, context);
     }
   }
 
@@ -114,6 +121,21 @@ public final class MultiInstanceActivityTransformer implements ModelElementTrans
 
     // replace the inner element with the body
     process.addFlowElement(multiInstanceBody);
+  }
+
+  private void transformExecutionListeners(
+      final MultiInstanceLoopCharacteristics loopCharacteristics,
+      final ExecutableMultiInstanceBody multiInstanceBody,
+      final TransformContext context) {
+    Optional.ofNullable(
+            loopCharacteristics.getSingleExtensionElement(ZeebeExecutionListeners.class))
+        .ifPresent(
+            listeners ->
+                executionListenerTransformer.transform(
+                    loopCharacteristics,
+                    multiInstanceBody,
+                    listeners.getExecutionListeners(),
+                    context.getExpressionLanguage()));
   }
 
   private static void attachEventsToMultiInstanceBody(


### PR DESCRIPTION
## Description

- support execution listeners in multi instance
- add execution listeners transformer in multi instance
- introduce execution listeners methods in multi instance
- evaluate execution listeners before multi instance element instantiation
   - use already existing lifecycle to add multi-instance execution listeners
execution listeners before multi instance initialization

## Related issues

closes #50446