### PR TITLE
fix: Adjust `@RequiresSecondaryStorage` annotation placement

### DIFF
--- a/qa/archunit-tests/src/test/java/io/camunda/zeebe/gateway/rest/RequiresSecondaryStorageAnnotationArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/zeebe/gateway/rest/RequiresSecondaryStorageAnnotationArchTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest;
+
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
+import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * ArchUnit rules that govern correct usage of the {@link RequiresSecondaryStorage} annotation in
+ * gateway REST controllers.
+ *
+ * <p>This class is intentionally separate from {@link RestControllerAnnotationArchTest} to keep
+ * {@link RequiresSecondaryStorage} annotation conventions co-located and distinct from the
+ * gateway-enabled guarding rules enforced by that class.
+ *
+ * <p>Current rules:
+ *
+ * <ul>
+ *   <li>{@link #RULE_HANDLER_MUST_NOT_REPEAT_CLASS_LEVEL_REQUIRES_SECONDARY_STORAGE_ANNOTATION} —
+ *       methods must not carry {@link RequiresSecondaryStorage} when the enclosing class is already
+ *       annotated with it.
+ * </ul>
+ */
+@AnalyzeClasses(
+    packages = "io.camunda.zeebe.gateway.rest",
+    importOptions = ImportOption.DoNotIncludeTests.class)
+public class RequiresSecondaryStorageAnnotationArchTest {
+
+  /**
+   * Methods annotated with {@link RequiresSecondaryStorage} must not reside in a class that is
+   * itself annotated with {@link RequiresSecondaryStorage}.
+   *
+   * <p>Redundant dual annotation is a maintenance hazard: it is unclear whether the class-level
+   * annotation is authoritative (and the method-level copy is noise), or whether the class-level
+   * annotation should be removed and only specific methods should remain annotated.
+   */
+  @ArchTest
+  public static final ArchRule
+      RULE_HANDLER_MUST_NOT_REPEAT_CLASS_LEVEL_REQUIRES_SECONDARY_STORAGE_ANNOTATION =
+          ArchRuleDefinition.classes()
+              .that()
+              .areAnnotatedWith(RequiresSecondaryStorage.class)
+              .should(notHaveMethodsRedundantlyAnnotated())
+              .because(
+                  "redundant @RequiresSecondaryStorage at both class and method level is ambiguous;"
+                      + " either keep only the class-level annotation (if all endpoints require"
+                      + " secondary storage) or keep only the necessary method-level annotations");
+
+  /**
+   * For each class already annotated with {@link RequiresSecondaryStorage}, checks that none of its
+   * methods are themselves annotated with {@link RequiresSecondaryStorage}.
+   */
+  private static ArchCondition<JavaClass> notHaveMethodsRedundantlyAnnotated() {
+    return new ArchCondition<>(
+        "not have methods redundantly annotated with @RequiresSecondaryStorage") {
+      @Override
+      public void check(final JavaClass clazz, final ConditionEvents events) {
+        final List<JavaMethod> redundantMethods =
+            clazz.getMethods().stream()
+                .filter(method -> method.isAnnotatedWith(RequiresSecondaryStorage.class))
+                .toList();
+        if (!redundantMethods.isEmpty()) {
+          events.add(SimpleConditionEvent.violated(clazz, buildMessage(clazz, redundantMethods)));
+        }
+      }
+    };
+  }
+
+  private static String buildMessage(final JavaClass clazz, final List<JavaMethod> methods) {
+    final String methodList =
+        methods.stream()
+            .map(m -> "  - " + m.getFullName().substring(clazz.getName().length() + 1))
+            .collect(Collectors.joining("\n"));
+    return String.format(
+        """
+        Redundant @RequiresSecondaryStorage placement detected.
+
+        Controller : %s
+
+        The following methods are annotated with @RequiresSecondaryStorage,
+        but the enclosing class is already annotated with @RequiresSecondaryStorage:
+        %s
+
+        Choose one of the following fixes:
+        1. If only SOME endpoints require secondary storage:
+           - Remove the class-level @RequiresSecondaryStorage annotation from the controller
+           - Keep @RequiresSecondaryStorage only on the specific handler methods that need it
+        2. If ALL endpoints in the controller require secondary storage:
+           - Keep the class-level @RequiresSecondaryStorage annotation on the controller
+           - Remove the now-redundant method-level @RequiresSecondaryStorage annotation""",
+        clazz.getName(), methodList);
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/BatchOperationController.java
@@ -27,8 +27,19 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-@CamundaRestController
+/**
+ * Batch operations are unavailable when secondary storage is disabled.
+ *
+ * <p>This is an intentional product decision for no-db mode, so the whole controller is guarded
+ * with {@link RequiresSecondaryStorage}.
+ *
+ * <p>Although lifecycle endpoints such as cancel, suspend, and resume do not directly query
+ * secondary storage in their own request path, the batch operation feature depends on secondary
+ * storage overall. Without secondary storage, batch operations cannot be meaningfully created or
+ * used, so all endpoints in this controller are disabled.
+ */
 @RequiresSecondaryStorage
+@CamundaRestController
 @RequestMapping("/v2/batch-operations")
 public class BatchOperationController {
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterVariableController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterVariableController.java
@@ -39,7 +39,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @CamundaRestController
-@RequiresSecondaryStorage
 @RequestMapping("/v2/cluster-variables")
 public class ClusterVariableController {
 
@@ -110,6 +109,7 @@ public class ClusterVariableController {
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::updateTenantClusterVariable);
   }
 
+  @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/search")
   private ResponseEntity<Object> search(
       @RequestBody final ClusterVariableSearchQueryRequest query,
@@ -131,6 +131,7 @@ public class ClusterVariableController {
     }
   }
 
+  @RequiresSecondaryStorage
   @CamundaGetMapping(path = "/global/{name}")
   public ResponseEntity<Object> getGlobalClusterVariable(@PathVariable("name") final String name) {
     return clusterVariableMapper
@@ -138,6 +139,7 @@ public class ClusterVariableController {
         .fold(RestErrorMapper::mapProblemToResponse, this::getGlobalClusterVariable);
   }
 
+  @RequiresSecondaryStorage
   @CamundaGetMapping(path = "/tenants/{tenantId}/{name}")
   public ResponseEntity<Object> getTenantClusterVariable(
       @PathVariable("tenantId") final String tenantId, @PathVariable("name") final String name) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterVariableController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterVariableController.java
@@ -111,7 +111,7 @@ public class ClusterVariableController {
 
   @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/search")
-  private ResponseEntity<Object> search(
+  public ResponseEntity<Object> search(
       @RequestBody final ClusterVariableSearchQueryRequest query,
       @RequestParam(name = "truncateValues", required = false, defaultValue = "true")
           final boolean truncateValues) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceController.java
@@ -33,7 +33,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @CamundaRestController
-@RequiresSecondaryStorage
 @RequestMapping("/v2/decision-instances")
 public class DecisionInstanceController {
 
@@ -47,6 +46,7 @@ public class DecisionInstanceController {
     this.authenticationProvider = authenticationProvider;
   }
 
+  @RequiresSecondaryStorage
   @CamundaPostMapping(path = "/search")
   public ResponseEntity<DecisionInstanceSearchQueryResult> searchDecisionInstances(
       @RequestBody(required = false) final DecisionInstanceSearchQuery query) {
@@ -54,6 +54,7 @@ public class DecisionInstanceController {
         .fold(RestErrorMapper::mapProblemToResponse, this::search);
   }
 
+  @RequiresSecondaryStorage
   @CamundaGetMapping(path = "/{decisionEvaluationInstanceKey}")
   public ResponseEntity<DecisionInstanceGetQueryResult> getDecisionInstanceById(
       @PathVariable final String decisionEvaluationInstanceKey) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionController.java
@@ -39,7 +39,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @CamundaRestController
-@RequiresSecondaryStorage
 @RequestMapping("/v2/process-definitions")
 public class ProcessDefinitionController {
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/system/SystemController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/system/SystemController.java
@@ -28,7 +28,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @CamundaRestController
-@RequiresSecondaryStorage
 @RequestMapping("/v2/system")
 public class SystemController {
 
@@ -45,6 +44,7 @@ public class SystemController {
     this.gatewayRestConfiguration = gatewayRestConfiguration;
   }
 
+  @RequiresSecondaryStorage
   @CamundaGetMapping(path = "/usage-metrics")
   public ResponseEntity<UsageMetricsResponse> getUsageMetrics(
       @RequestParam final String startTime,


### PR DESCRIPTION
## Description

This PR revisits the usage of `@RequiresSecondaryStorage` in the Orchestration Cluster REST API, the core goal is to ensure that only endpoints that are intentionally unavailable without secondary storage are gated with `@RequiresSecondaryStorage`, while broker-only endpoints that can operate on primary storage remain available. And introduces ArchUnit rule to prevent redundant @RequiresSecondaryStorage usage on methods inside already-annotated controllers.

In practice, this means:
- removing class-level `@RequiresSecondaryStorage` from mixed controllers where only some endpoints truly require secondary storage,
- moving the annotation down to the individual read/search handlers that depend on secondary storage,
- keeping class-level annotation only where the entire controller/feature is intentionally disabled in no-db mode,
- and adding clarifying comments in places where the product decision is broader than the direct request-path dependency.

---

### Background

`@RequiresSecondaryStorage` was introduced to return a clear early `403 Forbidden` when a REST endpoint is unavailable without secondary storage, instead of letting the request fail later in deeper service/search layers.

Its intended usage is:

- **controller level** only when **all handler methods** in that controller are unavailable without secondary storage,
- **method level** when only **some endpoints** in the controller are unavailable.

Over time, several controllers evolved and gained write/delete/broker-only endpoints, but the original class-level annotation was not revisited. As a result, some endpoints became falsely disabled in no-db mode even though they only communicate with the Zeebe broker and do not require search-backed reads.

This PR addresses those inconsistencies for the controllers covered here.

---

### What this PR changes

### 1. Reclassifies mixed controllers
For controllers that contain both (e.g. `ClusterVariableController.java`):
- secondary-storage-backed read/search endpoints, and
- broker-only write/delete/command endpoints,

this PR removes the class-level `@RequiresSecondaryStorage` annotation and re-applies it only to the endpoints that should actually be unavailable in no-db mode.

This follows the same approach previously applied in #40200 for `UserController`.

### 2. Preserves controller-level gating where the whole feature is unavailable
For some controllers, the entire feature remains intentionally unavailable when secondary storage is disabled. In these cases, the class-level annotation is preserved.

A notable example is **batch operations** (`BatchOperationController.java`):
- some lifecycle endpoints such as **cancel**, **suspend**, and **resume** primarily send broker commands and do not directly query secondary storage in their own request path,
- however, **batch operations as a feature** depend heavily on secondary storage overall for:
  - creation from filters,
  - item discovery / materialization,
  - initialization,
  - status tracking,
  - and read/search APIs.

Because batch operations are intentionally treated as unavailable in no-db mode, the whole `BatchOperationController` remains guarded with `@RequiresSecondaryStorage`.
Clarification comment was added over it.

### 3. Introduces ArchUnit rule to prevent redundant `@RequiresSecondaryStorage` usage
Added an ArchUnit rule to prevent redundant `@RequiresSecondaryStorage` usage on methods inside already-annotated controllers.

### 4. Cleans up small controller inconsistencies
This PR also fixes small related issues discovered during the audit, such as request-mapped handler visibility inconsistencies where applicable.

---

### Why this change is needed

Without this cleanup, some endpoints that can operate correctly on primary storage alone are rejected in no-db mode simply because they live in a controller that was historically annotated at class level.

That behavior is misleading for users and makes no-db support more restrictive than intended.

This PR makes the behavior more precise:
- **search / secondary-storage-dependent endpoints** continue to return `403 Forbidden`,
- **broker-only endpoints** remain usable where supported,
- and **feature-wide no-db restrictions** stay explicit where they are an intentional product decision.

---

### Notes on `@RequiresSecondaryStorage`

This PR follows the practical interpretation discussed in [#40199](https://github.com/camunda/camunda/issues/34385):

- Use `@RequiresSecondaryStorage` to gate endpoints that are unavailable without secondary storage.
- Use **method-level annotation** for mixed controllers.
- Keep **class-level annotation** only if:
  - every endpoint in the controller is genuinely unavailable without secondary storage, or
  - the whole feature is intentionally disabled in no-db mode.

This means not every annotated endpoint necessarily performs a direct search query itself; some remain annotated because the **feature as a whole is unsupported without secondary storage**.

Batch operations are the main example of that distinction in this PR.

---

### Examples of the distinction

### Should generally be method-level gated
- `GET /...`
- `POST /search`
- other endpoints backed by search clients / secondary-storage reads

#### Should generally stay enabled in no-db mode
- pure broker commands
- create/update/delete endpoints that operate only through primary storage

#### Can still remain class-level gated
- controllers representing a feature that is intentionally unavailable without secondary storage, even if some individual handlers are broker-only in isolation

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #40199
