### PR TITLE
ci: use vault secret for distro ci app

### DIFF
--- a/.github/workflows/c8run-closed-issue.yaml
+++ b/.github/workflows/c8run-closed-issue.yaml
@@ -40,13 +40,26 @@ jobs:
               echo "match=true" >> "$GITHUB_OUTPUT"
             fi
 
+        - name: Import Secrets
+          id: secrets
+          uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+          with:
+            url: ${{ secrets.VAULT_ADDR }}
+            method: approle
+            roleId: ${{ secrets.VAULT_ROLE_ID }}
+            secretId: ${{ secrets.VAULT_SECRET_ID }}
+            secrets: |
+              secret/data/products/distribution/ci GH_APP_ID_DISTRO_CI;
+              secret/data/products/distribution/ci GH_APP_PRIVATE_KEY_DISTRO_CI;
+            exportEnv: true
+
         - name: Generate GitHub token
           if: ${{ steps.vars.outputs.match == 'true' }}
           uses: tibdex/github-app-token@v2
           id: generate-github-token
           with:
-            app_id: ${{ secrets.GH_APP_ID_DISTRO_CI }}
-            private_key: ${{ secrets.GH_APP_PRIVATE_KEY_DISTRO_CI }}
+            app_id: ${{ env.GH_APP_ID_DISTRO_CI }}
+            private_key: ${{ env.GH_APP_PRIVATE_KEY_DISTRO_CI }}
 
         - name: Update Closed At field
           if: ${{ steps.vars.outputs.match == 'true' }}


### PR DESCRIPTION
## Description

We're rotating a lot of secrets, and moving more and more to Vault. This PR uses the Vault reference for the "closed issue" action which is used to apply date labels to track when issues are closed.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
