### PR TITLE
feat(identity): reflect selected resource type in URL on Authorizations page

### DIFF
--- a/identity/client/src/pages/authorizations/List.tsx
+++ b/identity/client/src/pages/authorizations/List.tsx
@@ -6,8 +6,8 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { FC, useState, useMemo, useCallback } from "react";
-import { useSearchParams } from "react-router-dom";
+import { FC, useMemo, useCallback, useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
 import { TabsVertical, Tab, TabPanels } from "@carbon/react";
 import useTranslate from "src/utility/localization";
 import { usePaginatedApi } from "src/utility/api";
@@ -26,20 +26,33 @@ import {
 } from "./components";
 import AuthorizationList from "./AuthorizationsList";
 import { isTenantsApiEnabled } from "src/configuration";
+import { Paths } from "src/components/global/routePaths";
 import type { ResourceType } from "@camunda/camunda-api-zod-schemas/8.10";
 
 const List: FC = () => {
   const { t } = useTranslate("authorizations");
+  const navigate = useNavigate();
+  const { id } = useParams<{ id?: string }>();
   const authorizationTabs = isTenantsApiEnabled
     ? ALL_RESOURCE_TYPES
     : RESOURCE_TYPES_WITHOUT_TENANT;
 
-  const [searchParams, setSearchParams] = useSearchParams();
-
   const [activeTab, setActiveTab] = useState<ResourceType>(() => {
-    const param = searchParams.get("resourceType") as ResourceType;
-    return param && authorizationTabs.includes(param) ? param : authorizationTabs[0];
+    return authorizationTabs.find((tab) => tab === id) ?? authorizationTabs[0];
   });
+
+  useEffect(() => {
+    const routeTab = authorizationTabs.find((tab) => tab === id);
+    const nextActiveTab = routeTab ?? authorizationTabs[0];
+
+    setActiveTab(nextActiveTab);
+
+    if (!routeTab) {
+      void navigate(`${Paths.authorizations()}/${nextActiveTab}`, {
+        replace: true,
+      });
+    }
+  }, [authorizationTabs, id, navigate]);
 
   const {
     data,
@@ -82,12 +95,12 @@ const List: FC = () => {
       <TabsTitle>{t("resourceType")}</TabsTitle>
       <TabsContainer>
         <TabsVertical
-          defaultSelectedIndex={authorizationTabs.indexOf(activeTab)}
+          selectedIndex={authorizationTabs.indexOf(activeTab)}
           onChange={(tab: { selectedIndex: number }) => {
             const newTab = authorizationTabs[tab.selectedIndex];
             resetPagination();
             setActiveTab(newTab);
-            setSearchParams({ resourceType: newTab }, { replace: true });
+            void navigate(`${Paths.authorizations()}/${newTab}`);
           }}
         >
           <CustomTabListVertical aria-label={t("authorizationType")}>

--- a/identity/client/src/pages/authorizations/List.tsx
+++ b/identity/client/src/pages/authorizations/List.tsx
@@ -7,6 +7,7 @@
  */
 
 import { FC, useState, useMemo, useCallback } from "react";
+import { useSearchParams } from "react-router-dom";
 import { TabsVertical, Tab, TabPanels } from "@carbon/react";
 import useTranslate from "src/utility/localization";
 import { usePaginatedApi } from "src/utility/api";
@@ -33,9 +34,12 @@ const List: FC = () => {
     ? ALL_RESOURCE_TYPES
     : RESOURCE_TYPES_WITHOUT_TENANT;
 
-  const [activeTab, setActiveTab] = useState<ResourceType>(
-    authorizationTabs[0],
-  );
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const [activeTab, setActiveTab] = useState<ResourceType>(() => {
+    const param = searchParams.get("resourceType") as ResourceType;
+    return param && authorizationTabs.includes(param) ? param : authorizationTabs[0];
+  });
 
   const {
     data,
@@ -78,9 +82,12 @@ const List: FC = () => {
       <TabsTitle>{t("resourceType")}</TabsTitle>
       <TabsContainer>
         <TabsVertical
+          defaultSelectedIndex={authorizationTabs.indexOf(activeTab)}
           onChange={(tab: { selectedIndex: number }) => {
+            const newTab = authorizationTabs[tab.selectedIndex];
             resetPagination();
-            setActiveTab(authorizationTabs[tab.selectedIndex]);
+            setActiveTab(newTab);
+            setSearchParams({ resourceType: newTab }, { replace: true });
           }}
         >
           <CustomTabListVertical aria-label={t("authorizationType")}>

--- a/identity/client/src/pages/authorizations/index.tsx
+++ b/identity/client/src/pages/authorizations/index.tsx
@@ -11,7 +11,10 @@ import Lazy from "src/components/router/Lazy";
 import PageRoutes from "src/components/router/PageRoutes";
 
 const Authorizations: FC = () => (
-  <PageRoutes indexElement={<Lazy load={() => import("./List")} />} />
+  <PageRoutes
+    indexElement={<Lazy load={() => import("./List")} />}
+    detailElement={<Lazy load={() => import("./List")} />}
+  />
 );
 
 export default Authorizations;


### PR DESCRIPTION
## Description

The Authorizations page shows resource types in a vertical tab list on the left. Clicking a tab shows its authorizations on the right. But the selected tab was only kept in local React state, so reloading the page always reset back to the first resource type.

This adds URL query param support so the selected tab is preserved in the URL:
```
/authorizations?resourceType=DECISION
```

**Before:** Click "Decision" → URL stays as `/authorizations` → reload resets to first tab

**After:** Click "Decision" → URL becomes `/authorizations?resourceType=DECISION` → reload stays on Decision

Direct navigation also works — pasting a URL with `?resourceType=DOCUMENT` opens the correct tab.

## Changes

Only one file changed: `identity/client/src/pages/authorizations/List.tsx`

- Added `useSearchParams` from React Router to read and write the URL query param
- On mount, reads the `resourceType` query param to initialize the active tab (falls back to first tab if param is missing or invalid)
- On tab click, updates both local state (so Carbon switches panels immediately) and the URL query param
- Used `defaultSelectedIndex` on `TabsVertical` so the correct tab is highlighted on page load
- Used `{ replace: true }` in `setSearchParams` so tab clicks don't pollute browser history

## Related issues

Closes #36866

## How I tested this

- Clicked different resource types — URL updates with `?resourceType=...` and content changes correctly
- Reloaded the page — correct tab is still selected
- Navigated directly to `/authorizations?resourceType=DOCUMENT` — lands on the right tab
- Navigated to `/authorizations?resourceType=INVALID` — falls back to first tab correctly
- TypeScript check — zero errors