### PR TITLE
feat: deploy versioned load test images for stable branches

### DIFF
--- a/.github/workflows/ci-zeebe.yml
+++ b/.github/workflows/ci-zeebe.yml
@@ -468,20 +468,30 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           user_description: "team-distributed-systems"
 
+  # Dynamically generate the concurrency group for load test image deployment
+  utils-get-concurrency-group-for-load-test:
+    uses: ./.github/workflows/generate-concurrency-group.yml
+    secrets: inherit
+    permissions:
+      contents: read
+    with:
+      base_group_name: deploy-load-test-images
+
   deploy-load-test-images:
     name: Deploy load test images
     timeout-minutes: 5
-    needs: [ test-summary ]
+    needs: [ test-summary, utils-get-snapshot-docker-tag, utils-get-concurrency-group-for-load-test ]
     runs-on: ubuntu-latest
-    if: github.repository == 'camunda/camunda' && github.ref == 'refs/heads/main'
+    if: github.repository == 'camunda/camunda' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/'))
     concurrency:
-      group: deploy-load-test-images
+      group: ${{ needs.utils-get-concurrency-group-for-load-test.outputs.concurrency_group_name }}
       cancel-in-progress: false
     permissions:
       contents: 'read'
       id-token: 'write'
     env:
       IMAGE_REPOSITORY: registry.camunda.cloud/team-zeebe
+      IMAGE_TAG: ${{ needs.utils-get-snapshot-docker-tag.outputs.snapshot_tag != '' && needs.utils-get-snapshot-docker-tag.outputs.snapshot_tag || needs.utils-get-snapshot-docker-tag.outputs.version_tag }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-build
@@ -493,9 +503,9 @@ jobs:
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
       - run: ./mvnw -B -D skipTests -D skipChecks -pl load-tests/load-tester -am install
       - name: Build Starter Image
-        run: ./mvnw -pl load-tests/load-tester jib:build -P starter -D image="${{ env.IMAGE_REPOSITORY }}/starter:SNAPSHOT"
+        run: ./mvnw -pl load-tests/load-tester jib:build -P starter -D image="${{ env.IMAGE_REPOSITORY }}/starter:${{ env.IMAGE_TAG }}"
       - name: Build Worker Image
-        run: ./mvnw -pl load-tests/load-tester jib:build -P worker -D image="${{ env.IMAGE_REPOSITORY }}/worker:SNAPSHOT"
+        run: ./mvnw -pl load-tests/load-tester jib:build -P worker -D image="${{ env.IMAGE_REPOSITORY }}/worker:${{ env.IMAGE_TAG }}"
       - name: Observe build status
         if: always()
         continue-on-error: true


### PR DESCRIPTION
## Description

The `deploy-load-test-images` job in `ci-zeebe.yml` currently only runs on `main` and pushes starter/worker images with a hardcoded `SNAPSHOT` tag. This means stable branches (e.g., `stable/8.8`, `stable/8.9`) do not get their own load test images when PRs are merged.

This change:
- Extends `deploy-load-test-images` to also run on `stable/*` branches
- Derives the image tag using the new split `generate-snapshot-docker-tag.yml` reusable workflow (from #50455):
  - `snapshot_tag` is `SNAPSHOT` on `main` and empty on `stable/*`
  - `version_tag` is `8.8-SNAPSHOT` on `stable/8.8`, etc.
  - Uses the recommended `snapshot_tag != '' && snapshot_tag || version_tag` pattern to resolve the correct tag
- Adds per-branch concurrency groups via the new `generate-concurrency-group.yml` reusable workflow with `base_group_name: deploy-load-test-images`, so deployments on different branches don't cancel or block each other (consistent with how `deploy-docker-snapshot` and other jobs use the same utility)

### Image tags after this change

| Branch | Starter image tag | Worker image tag |
|---|---|---|
| `main` | `starter:SNAPSHOT` | `worker:SNAPSHOT` |
| `stable/8.8` | `starter:8.8-SNAPSHOT` | `worker:8.8-SNAPSHOT` |
| `stable/8.9` | `starter:8.9-SNAPSHOT` | `worker:8.9-SNAPSHOT` |

### Note
This change needs to be backported to each `stable/*` branch where versioned load test images are desired, since each branch runs its own copy of the workflow files.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues
#50881