### PR TITLE
fix: align OpenSearch load test config with Elasticsearch settings

### DIFF
--- a/load-tests/camunda-platform-values-opensearch.yaml
+++ b/load-tests/camunda-platform-values-opensearch.yaml
@@ -46,17 +46,21 @@ masterService: "opensearch"
 
 majorVersion: "2.19.0"
 
+replicas: 3
+
 config:
   opensearch.yml: |
     cluster.name: opensearch
     network.host: 0.0.0.0
     plugins.security.disabled: true
+    # Disable deprecation logging to avoid filling up the logs with warnings about deprecated features that we might be using in our tests
+    logger.org.opensearch.deprecation: "OFF"
 
 extraEnvs:
   - name: OPENSEARCH_INITIAL_ADMIN_PASSWORD
     value: "yourStrongPassword123!"
 
-opensearchJavaOpts: "-Xms1024m -Xmx1024m"
+opensearchJavaOpts: "-Xms3g -Xmx3g"
 
 sysctlInit:
   enabled: true
@@ -64,24 +68,24 @@ sysctlVmMaxMapCount: 262144
 
 resources:
   requests:
-    cpu: 3000m
-    memory: 4Gi
+    cpu: 7000m
+    memory: 8Gi
   limits:
-    cpu: 3000m
-    memory: 10Gi
+    cpu: 7000m
+    memory: 8Gi
 
 persistence:
   enabled: true
-  size: 128Gi
+  size: 512Gi
   storageClass: "ssd"
 
 nodeSelector:
-  component: benchmark-n2-standard-4
+  component: benchmark-n2-standard-8
 
 tolerations:
   - key: nodepool
     operator: Equal
-    value: n2-standard-4
+    value: n2-standard-8
     effect: NoSchedule
 
 antiAffinity: "hard"


### PR DESCRIPTION
## Summary

The OpenSearch load test configuration was significantly under-provisioned compared to the Elasticsearch configuration, making cross-storage benchmarking results incomparable.

This PR aligns the OpenSearch values (`camunda-platform-values-opensearch.yaml`) with the Elasticsearch settings in `camunda-platform-values.yaml`:

| Setting | Before (OpenSearch) | After (OpenSearch) | Elasticsearch |
|---|---|---|---|
| `replicas` | not set (default 3) | `3` (explicit) | `3` |
| Heap | 1g | 3g | 3g |
| CPU requests/limits | 3000m | 7000m | 7000m |
| Memory requests/limits | 4Gi/10Gi | 8Gi/8Gi | 8Gi/8Gi |
| Disk | 128Gi | 512Gi | 512Gi |
| Node pool | `n2-standard-4` | `n2-standard-8` | `n2-standard-8` |
| Deprecation logging | not set | `OFF` | `OFF` |

Closes the conversation: https://camunda.slack.com/archives/C013MEVQ4M9/p1775513252496279

## Test plan

- [x] Deploy a load test with `secondary-storage-type: opensearch` and verify OpenSearch pods are scheduled on `n2-standard-8` nodes
- [x] Verify OpenSearch cluster has 3 replicas with correct resource allocation
- [ ] Compare OpenSearch and Elasticsearch load test performance under the same scenario

## Success Run:
[Run](https://github.com/camunda/camunda/actions/runs/24072906062)
[Zeebe](https://dashboard.benchmark.camunda.cloud/d/zeebe-dashboard/zeebe?orgId=1&from=2026-04-07T09:16:43.490Z&to=2026-04-07T10:19:49.507Z&timezone=browser&var-DS_PROMETHEUS=prometheus&var-cluster=$__all&var-namespace=c8-pg-opensearch-ld&var-pod=$__all&var-partition=$__all&var-memory_state=committed&refresh=auto) 

> Notes: The Opensearch is not performing at par with E.S. in realistic load test