### PR TITLE
[Backport stable/8.7] feat: migrate SLACK_WEBHOOK_URL to Vault in Zeebe CI workflows

### DIFF
--- a/.github/workflows/critical-issue.yml
+++ b/.github/workflows/critical-issue.yml
@@ -15,10 +15,23 @@ jobs:
         !contains(join(github.event.issue.labels.*.name, ', '), 'component/')
       )
     steps:
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@79632e33d6953d190b940ffa440bf97821cabd80
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_ZEEBOT_ZEEBE_CI_WEBHOOK_URL;
       - id: slack-notify
         name: Send slack notification
         uses: slackapi/slack-github-action@v1.27.1
         with:
+          webhook: ${{ steps.secrets.outputs.SLACK_ZEEBOT_ZEEBE_CI_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           # For posting a rich message using Block Kit
           payload: |
             {

--- a/.github/workflows/zeebe-qa-testbench.yaml
+++ b/.github/workflows/zeebe-qa-testbench.yaml
@@ -64,11 +64,22 @@ jobs:
     needs: [ qa ]
     if: failure()
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@79632e33d6953d190b940ffa440bf97821cabd80
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_ZEEBOT_ZEEBE_CI_WEBHOOK_URL;
       - id: slack-notify
         uses: slackapi/slack-github-action@v2.1.1
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook: ${{ steps.secrets.outputs.SLACK_ZEEBOT_ZEEBE_CI_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
             {

--- a/.github/workflows/zeebe-version-compatibility.yml
+++ b/.github/workflows/zeebe-version-compatibility.yml
@@ -127,10 +127,23 @@ jobs:
     needs: [released-versions, current-snapshot]
     if: failure()
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@79632e33d6953d190b940ffa440bf97821cabd80
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_ZEEBOT_ZEEBE_CI_WEBHOOK_URL;
       - id: slack-notify
         uses: slackapi/slack-github-action@v1.27.1
         with:
+          webhook: ${{ steps.secrets.outputs.SLACK_ZEEBOT_ZEEBE_CI_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           # For posting a rich message using Block Kit
           payload: |
             {


### PR DESCRIPTION
# Description
Backport of #50358 to `stable/8.7`.

relates to camunda/camunda#50242 #18211