### PR TITLE
[Backport stable/8.9] fix: operate limit entity type filter options excluding identity values

### DIFF
--- a/operate/client/src/App/OperationsLog/Filters/index.tsx
+++ b/operate/client/src/App/OperationsLog/Filters/index.tsx
@@ -27,14 +27,12 @@ import {TenantField} from 'modules/components/TenantField';
 import {getFilters} from 'modules/utils/filter/getProcessInstanceFilters';
 import {
   AUDIT_LOG_FILTER_FIELDS,
+  AUDIT_LOG_ENTITY_TYPE_FILTER_VALUES,
+  AUDIT_LOG_OPERATION_TYPE_FILTER_VALUES,
   type OperationsLogFilterField,
   type OperationsLogFilters,
 } from '../auditLogFilters';
-import {
-  auditLogEntityTypeSchema,
-  auditLogOperationTypeSchema,
-  auditLogResultSchema,
-} from '@camunda/camunda-api-zod-schemas/8.9';
+import {auditLogResultSchema} from '@camunda/camunda-api-zod-schemas/8.9';
 import {spaceAndCapitalize} from 'modules/utils/spaceAndCapitalize';
 import {DateRangeField} from 'modules/components/DateRangeField';
 import {useState} from 'react';
@@ -148,12 +146,12 @@ const Filters: React.FC = observer(() => {
                       <FilterMultiselect
                         name="operationType"
                         titleText="Operation type"
-                        items={auditLogOperationTypeSchema.options}
+                        items={AUDIT_LOG_OPERATION_TYPE_FILTER_VALUES}
                       />
                       <FilterMultiselect
                         name="entityType"
                         titleText="Entity type"
-                        items={auditLogEntityTypeSchema.options}
+                        items={AUDIT_LOG_ENTITY_TYPE_FILTER_VALUES}
                       />
                       <Field name="result">
                         {({input}) => (

--- a/operate/client/src/App/OperationsLog/auditLogFilters.ts
+++ b/operate/client/src/App/OperationsLog/auditLogFilters.ts
@@ -6,6 +6,11 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import type {
+  AuditLogEntityType,
+  AuditLogOperationType,
+} from '@camunda/camunda-api-zod-schemas/8.9';
+
 type OperationsLogFilterField =
   | 'processDefinitionId'
   | 'processDefinitionVersion'
@@ -44,5 +49,37 @@ const AUDIT_LOG_FILTER_FIELDS: (keyof OperationsLogFilters)[] = [
   'tenantId',
 ];
 
+const AUDIT_LOG_ENTITY_TYPE_FILTER_VALUES: AuditLogEntityType[] = [
+  'USER_TASK',
+  'BATCH',
+  'RESOURCE',
+  'CLIENT',
+  'DECISION',
+  'INCIDENT',
+  'JOB',
+  'PROCESS_INSTANCE',
+  'VARIABLE',
+];
+
+const AUDIT_LOG_OPERATION_TYPE_FILTER_VALUES: AuditLogOperationType[] = [
+  'CREATE',
+  'UPDATE',
+  'DELETE',
+  'COMPLETE',
+  'EVALUATE',
+  'ASSIGN',
+  'CANCEL',
+  'MIGRATE',
+  'MODIFY',
+  'RESOLVE',
+  'RESUME',
+  'SUSPEND',
+  'UNASSIGN',
+];
+
 export type {OperationsLogFilters, OperationsLogFilterField};
-export {AUDIT_LOG_FILTER_FIELDS};
+export {
+  AUDIT_LOG_FILTER_FIELDS,
+  AUDIT_LOG_ENTITY_TYPE_FILTER_VALUES,
+  AUDIT_LOG_OPERATION_TYPE_FILTER_VALUES,
+};


### PR DESCRIPTION
# Description
Backport of #50465 to `stable/8.9`.

relates to #50305