### PR TITLE
ci: skip ConnectorProcessTest for CPT < 8.8.20 in compatibility tests

### DIFF
--- a/.github/workflows/camunda-process-test-compatibility.yml
+++ b/.github/workflows/camunda-process-test-compatibility.yml
@@ -467,6 +467,7 @@ jobs:
         run: |
           CLIENT_VERSION="${{ matrix.client }}"
           EXTRA_PROPS=""
+          EXCLUDED_TESTS=()
           if [[ "$CLIENT_VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
             MAJOR="${BASH_REMATCH[1]}"
             MINOR="${BASH_REMATCH[2]}"
@@ -478,13 +479,31 @@ jobs:
               EXTRA_PROPS+=" -Dapi.version=1.44"
               echo "CPT version $CLIENT_VERSION < 8.8.5 - adding Docker API version override"
             fi
-            # For CPT versions <= 8.8.7, skip CamundaSpringProcessMultiTenancyTestListenerIT
+            # For CPT versions <= 8.8.11, skip CamundaSpringProcessMultiTenancyTestListenerIT
             if (( MAJOR < 8 )) || \
                (( MAJOR == 8 && MINOR < 8 )) || \
                (( MAJOR == 8 && MINOR == 8 && PATCH <= 11 )); then
-              EXTRA_PROPS+=" -Dit.test=!CamundaSpringProcessMultiTenancyTestListenerIT -Dfailsafe.failIfNoSpecifiedTests=false"
+              EXCLUDED_TESTS+=("CamundaSpringProcessMultiTenancyTestListenerIT")
               echo "CPT version $CLIENT_VERSION <= 8.8.11 - excluding CamundaSpringProcessMultiTenancyTestListenerIT"
             fi
+            # For CPT versions < 8.8.20, skip ConnectorProcessTest.
+            # These versions lack the CAMUNDA_CONNECTOR_SECRETPROVIDER_ENVIRONMENT_PREFIX
+            # env var (empty prefix) that the SNAPSHOT connectors runtime now requires.
+            # Without it, the connector container cannot resolve secrets and the
+            # ConnectorProcessTest fails. The fix was introduced in 8.8.20.
+            if (( MAJOR < 8 )) || \
+               (( MAJOR == 8 && MINOR < 8 )) || \
+               (( MAJOR == 8 && MINOR == 8 && PATCH < 20 )); then
+              EXCLUDED_TESTS+=("ConnectorProcessTest")
+              echo "CPT version $CLIENT_VERSION < 8.8.20 - excluding ConnectorProcessTest (missing secret prefix support)"
+            fi
+          fi
+          # Build the -Dit.test exclusion string from the array
+          if (( ${#EXCLUDED_TESTS[@]} > 0 )); then
+            EXCLUSION_PATTERN=$(printf "!%s+" "${EXCLUDED_TESTS[@]}")
+            # Remove trailing +
+            EXCLUSION_PATTERN="${EXCLUSION_PATTERN%+}"
+            EXTRA_PROPS+=" -Dit.test=${EXCLUSION_PATTERN} -Dfailsafe.failIfNoSpecifiedTests=false"
           fi
           echo "extra-props=${EXTRA_PROPS}" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Description

CPT versions before 8.8.20 lack the
CAMUNDA_CONNECTOR_SECRETPROVIDER_ENVIRONMENT_PREFIX env var (empty prefix) that the SNAPSHOT connectors runtime now requires. Without it, the connector container cannot resolve secrets and ConnectorProcessTest fails.

Also refactors the test exclusion logic to use an array-based approach, properly combining multiple -Dit.test exclusions when both this and the existing CamundaSpringProcessMultiTenancyTestListenerIT skip apply.

## Related issues

related to https://camunda.slack.com/archives/C0A2AGG2Q2E/p1775532417000729
