### PR TITLE
fix: simplify useTasks v1 query to fix refetch with paginated data

### DIFF
--- a/tasklist/client/src/v1/api/useTasks.query.ts
+++ b/tasklist/client/src/v1/api/useTasks.query.ts
@@ -6,11 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {
-  type InfiniteData,
-  type UseInfiniteQueryOptions,
-  useInfiniteQuery,
-} from '@tanstack/react-query';
+import {useInfiniteQuery, type InfiniteData} from '@tanstack/react-query';
 import {api} from 'v1/api';
 import {type RequestError, request} from 'common/api/request';
 import type {Task} from 'v1/api/types';
@@ -39,18 +35,7 @@ function getQueryKey(keys: unknown[]) {
 
 function useTasks(
   filters: TaskFilters,
-  options?: Partial<
-    Pick<
-      UseInfiniteQueryOptions<
-        Task[],
-        RequestError | Error,
-        InfiniteData<Task[], PageParam | undefined>,
-        unknown[],
-        PageParam | undefined
-      >,
-      'refetchInterval'
-    >
-  >,
+  options?: {refetchInterval?: number | false},
 ) {
   const {refetchInterval} = options ?? {};
   const {data: currentUser} = useCurrentUser();

--- a/tasklist/client/src/v1/api/useTasks.query.ts
+++ b/tasklist/client/src/v1/api/useTasks.query.ts
@@ -10,14 +10,12 @@ import {
   type InfiniteData,
   type UseInfiniteQueryOptions,
   useInfiniteQuery,
-  useQueryClient,
 } from '@tanstack/react-query';
 import {api} from 'v1/api';
 import {type RequestError, request} from 'common/api/request';
 import type {Task} from 'v1/api/types';
 import {getQueryVariables} from 'v1/api/getQueryVariables';
 import type {TaskFilters} from 'v1/features/tasks/filters/useTaskFilters';
-import chunk from 'lodash/chunk';
 import {useCurrentUser} from 'common/api/useCurrentUser.query';
 
 const POLLING_INTERVAL = 5000;
@@ -25,15 +23,13 @@ const MAX_TASKS_DISPLAYED = 200;
 const MAX_TASKS_PER_REQUEST = 50;
 const MAX_PAGE_COUNT = Math.ceil(MAX_TASKS_DISPLAYED / MAX_TASKS_PER_REQUEST);
 
-type PageParam = {
-  pageParam?:
-    | {
-        searchBefore: [string, string];
-      }
-    | {
-        searchAfter: [string, string];
-      };
-};
+type PageParam =
+  | {
+      searchBefore: [string, string];
+    }
+  | {
+      searchAfter: [string, string];
+    };
 
 const USE_TASKS_QUERY_KEY = 'tasks';
 
@@ -45,7 +41,13 @@ function useTasks(
   filters: TaskFilters,
   options?: Partial<
     Pick<
-      UseInfiniteQueryOptions<Task[], RequestError | Error>,
+      UseInfiniteQueryOptions<
+        Task[],
+        RequestError | Error,
+        InfiniteData<Task[], PageParam | undefined>,
+        unknown[],
+        PageParam | undefined
+      >,
       'refetchInterval'
     >
   >,
@@ -56,12 +58,17 @@ function useTasks(
     assignee: currentUser?.username,
     pageSize: MAX_TASKS_PER_REQUEST,
   });
-  const client = useQueryClient();
-  const result = useInfiniteQuery<Task[], RequestError | Error>({
+  const result = useInfiniteQuery<
+    Task[],
+    RequestError | Error,
+    InfiniteData<Task[], PageParam | undefined>,
+    unknown[],
+    PageParam | undefined
+  >({
     queryKey: getQueryKey(Object.values(payload)),
     queryFn: async ({pageParam}) => {
       const {response, error} = await request(
-        api.searchTasks({...payload, ...(pageParam as PageParam)}),
+        api.searchTasks({...payload, ...pageParam}),
       );
 
       if (response !== null) {
@@ -71,6 +78,7 @@ function useTasks(
       throw error;
     },
     initialPageParam: undefined,
+    maxPages: MAX_PAGE_COUNT,
     placeholderData: (previousData) => previousData,
     refetchInterval: refetchInterval ?? POLLING_INTERVAL,
     getNextPageParam: (lastPage) => {
@@ -107,36 +115,8 @@ function useTasks(
     }
 
     const {data} = await result.fetchPreviousPage();
-    function calculatePreviousTasksData(
-      data?: InfiniteData<Task[]>,
-    ): InfiniteData<Task[]> | undefined {
-      const tasks = data?.pages.flat() ?? [];
-      if (data === undefined || tasks.length <= MAX_TASKS_DISPLAYED) {
-        return data;
-      }
-      const trimmedTasks = tasks.slice(0, MAX_TASKS_DISPLAYED + 1);
-      const lastTask = trimmedTasks.pop();
 
-      return {
-        pages: chunk(trimmedTasks, MAX_TASKS_PER_REQUEST),
-        pageParams: [
-          ...data.pageParams.slice(0, MAX_PAGE_COUNT - 1),
-          {
-            searchBefore: lastTask!.sortValues,
-          },
-        ],
-      };
-    }
-    const newData = calculatePreviousTasksData(data);
-
-    client.setQueryData<InfiniteData<Task[]>>(
-      getQueryKey(Object.values(payload)),
-      () => {
-        return newData;
-      },
-    );
-
-    return newData?.pages[0] ?? [];
+    return data?.pages[0] ?? [];
   }
 
   async function fetchNextTasks() {
@@ -145,37 +125,8 @@ function useTasks(
     }
 
     const {data} = await result.fetchNextPage();
-    function calculateNextTasksData(
-      data?: InfiniteData<Task[]>,
-    ): InfiniteData<Task[]> | undefined {
-      const tasks = data?.pages.flat() ?? [];
-      if (data === undefined || tasks.length <= MAX_TASKS_DISPLAYED) {
-        return data;
-      }
-      const [firstTask, ...trimmedTasks] = tasks.slice(
-        -(MAX_TASKS_DISPLAYED + 1),
-      );
 
-      return {
-        pages: chunk(trimmedTasks, MAX_TASKS_PER_REQUEST),
-        pageParams: [
-          {
-            searchAfter: firstTask.sortValues,
-          },
-          ...data.pageParams.slice(-(MAX_PAGE_COUNT - 1)),
-        ],
-      };
-    }
-    const newData = calculateNextTasksData(data);
-
-    client.setQueryData<InfiniteData<Task[]>>(
-      getQueryKey(Object.values(payload)),
-      () => {
-        return newData;
-      },
-    );
-
-    return newData === undefined ? [] : newData.pages[newData.pages.length - 1];
+    return data === undefined ? [] : data.pages[data.pages.length - 1];
   }
 
   return Object.assign(result, {


### PR DESCRIPTION
## Description

This PR fixes a bug in Tasklist V1 where the pagination breaks on refetch. To reproduce the bug:
1. Checkout the target branch: tasklist/44583-v1-fix-stuck-scrolling
1. Have more than 250 tasks in your V1 Tasklist (more than 4 paginations can load)
1. Scroll down beyond loading for pages
1. Scroll back up and wait for a background-refetch
1. Observe that only a few tasks remain and the list can no longer be scrolled beyond those tasks

This PR removes the manual chunking logic and fully relies on Tanstack Query for pagination. This seems to work fine. I captured a network-trace of scrolling down and up through many tasks with background-refetch and had "GPT-5.4 xHigh" analyze it for any inconsistencies in the data and pagination. It reported no anomalies. My conclusion is that the manual chunking is not needed.

Here's a little loop for creating a bunch of tasks for local testing that can be pasted into the browser console. Note: It needs an fresh CSRF token extracted from a recent "start process request".
```ts
for (let i = 0; i < 400; i++) {
  const res = await fetch(
    'http://localhost:3000/v1/internal/processes/RequestAnnualLeave/start?tenantId=%3Cdefault%3E',
    {
      headers: {
        'content-type': 'application/json',
        'x-csrf-token': '<insert-fresh-csrf-token>',
      },
      body: '{"variables":[]}',
      method: 'PATCH',
      mode: 'cors',
      credentials: 'include',
    },
  );
  if (res.ok) console.log('Process started');
  else console.log('Failed');
  await new Promise((res) => setTimeout(res, 100));
}
```

## Checklist

- [ ] Note that this PR is [stacked on a backend fix](https://github.com/camunda/camunda/pull/50377) that enabled backward pagination without throwing exceptions in the API.

## Related issues

closes #44583
