### PR TITLE
Job statistics api tests

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/playwright.config.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/playwright.config.ts
@@ -78,6 +78,7 @@ const apiTestIgnore = [
   'tests/api/v2/clock/*.spec.ts',
   'tests/api/v2/usage-metrics/*.spec.ts',
   'tests/api/v2/audit-log/*.spec.ts',
+  'tests/api/v2/job/job-statistics-*.spec.ts',
 ];
 // Projects
 const normalProjects = [
@@ -94,6 +95,7 @@ const normalProjects = [
       'tests/api/v2/clock/*.spec.ts',
       'tests/api/v2/usage-metrics/*.spec.ts',
       'tests/api/v2/audit-log/*.spec.ts',
+      'tests/api/v2/job/job-statistics-*.spec.ts',
     ],
     use: devices['Desktop Chrome'],
     workers: 1,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/expression/expression-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/expression/expression-api-tests.spec.ts
@@ -7,14 +7,9 @@
  */
 
 import {test, expect, APIRequestContext} from '@playwright/test';
-import {
-  assertStatusCode,
-  assertInvalidArgument,
-} from '../../../../utils/http';
+import {assertStatusCode, assertInvalidArgument} from '../../../../utils/http';
 import {validateResponse} from '../../../../json-body-assertions';
-import {evaluateExpression, EXPRESSION_URL} from '@requestHelpers'
-
-
+import {evaluateExpression, EXPRESSION_URL} from '@requestHelpers';
 
 type ExpressionTestCase = {
   description: string;
@@ -199,7 +194,8 @@ const errorTestCases: ExpressionTestCase[] = [
     errorDetail: 'Failed to parse expression',
   },
   {
-    description: 'Should return warning when invalid FEEL syntax (missing else) - Error',
+    description:
+      'Should return warning when invalid FEEL syntax (missing else) - Error',
     expression: '=if x > 5 then "big"',
     variables: {x: 10},
     errorDetail: 'Failed to parse expression',

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-statistics-by-type-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-statistics-by-type-api-tests.spec.ts
@@ -1,0 +1,243 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect, test} from '@playwright/test';
+import {
+  assertBadRequest,
+  assertStatusCode,
+  assertUnauthorizedRequest,
+  buildUrl,
+  encode,
+  jsonHeaders,
+} from '../../../../utils/http';
+import {validateResponse} from '../../../../json-body-assertions';
+import {
+  createUser,
+  grantUserResourceAuthorization,
+  getLast24HoursRange,
+  StatisticsJobItem,
+} from '@requestHelpers';
+import {cleanupUsers} from 'utils/usersCleanup';
+import { defaultAssertionOptions } from 'utils/constants';
+
+test.describe.parallel('Job Statistics By Type API Tests', () => {
+  let userWithResourcesAuthorizationToSendRequest: {
+    username: string;
+    name: string;
+    email: string;
+    password: string;
+  } = {} as {
+    username: string;
+    name: string;
+    email: string;
+    password: string;
+  };
+  const {fromDate, toDate} = getLast24HoursRange();
+
+  test.beforeAll(async ({request}) => {
+    await test.step('Setup - Create test user with Resource Authorization and user for granting Authorization', async () => {
+      userWithResourcesAuthorizationToSendRequest = await createUser(request);
+      await grantUserResourceAuthorization(
+        request,
+        userWithResourcesAuthorizationToSendRequest,
+      );
+    });
+  });
+
+  test.afterAll(async ({request}) => {
+    await test.step('Cleanup - Delete test users', async () => {
+      await cleanupUsers(request, [
+        userWithResourcesAuthorizationToSendRequest.username,
+      ]);
+    });
+  });
+
+  test('Get Job Statistics By Type - success', async ({request}) => {
+    let item: StatisticsJobItem;
+    let jobType: string = 'uninitialized';
+
+    await test.step('General Search', async () => {
+      await expect(async () => {
+        const generalSearchRes = await request.post(
+          buildUrl('/jobs/statistics/by-types'),
+          {
+            headers: jsonHeaders(),
+            data: {
+              filter: {
+                from: fromDate,
+                to: toDate,
+              },
+            },
+          },
+        );
+        await assertStatusCode(generalSearchRes, 200);
+        await validateResponse(
+          {
+            path: '/jobs/statistics/by-types',
+            method: 'POST',
+            status: '200',
+          },
+          generalSearchRes,
+        );
+        const responseBody = await generalSearchRes.json();
+        const items = responseBody.items as StatisticsJobItem[];
+        for (const receivedItem of items) {
+          if (receivedItem.jobType != '') {
+            expect(receivedItem.jobType).toBeDefined();
+            item = receivedItem;
+            jobType = receivedItem.jobType;
+            break;
+          }
+        }
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Search with jobType', async () => {
+      const extendedSearchRes = await request.post(
+        buildUrl('/jobs/statistics/by-types'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              from: fromDate,
+              to: toDate,
+              jobType,
+            },
+          },
+        },
+      );
+
+      await assertStatusCode(extendedSearchRes, 200);
+      await validateResponse(
+        {
+          path: '/jobs/statistics/by-types',
+          method: 'POST',
+          status: '200',
+        },
+        extendedSearchRes,
+      );
+      const extendedResponseBody = await extendedSearchRes.json();
+      const extendedItem = extendedResponseBody.items[0];
+      if (!extendedItem || !extendedItem.jobType) {
+        test.info().annotations.push({ type: 'blocked', description: 'No job statistics data available to verify the response with jobType filter' });
+        return;
+      }
+      
+      expect(extendedItem).toBeDefined();
+      expect(extendedItem.jobType).toBe(jobType);
+      expect(extendedItem.created.count).toBe(item.created.count);
+      expect(extendedItem.completed.count).toBe(item.completed.count);
+      expect(extendedItem.failed.count).toBe(item.failed.count);
+      expect(extendedItem.workers).toBe(item.workers);
+    });
+  });
+
+  test('Get Job Statistics By Type With Wrong Filter Parameter - Bad Request', async ({
+    request,
+  }) => {
+    const res = await request.post(buildUrl('/jobs/statistics/by-types'), {
+      headers: jsonHeaders(),
+      data: {
+        filter: {
+          from: fromDate,
+          to: toDate,
+          type: 'someJobType',
+        },
+      },
+    });
+    await assertBadRequest(
+      res,
+      'Request property [filter.type] cannot be parsed',
+    );
+  });
+
+  test('Get Job Statistics By Type With Missing Required From Filter Parameter - Bad Request', async ({
+    request,
+  }) => {
+    const res = await request.post(buildUrl('/jobs/statistics/by-types'), {
+      headers: jsonHeaders(),
+      data: {
+        filter: {
+          to: toDate,
+          jobType: 'someJobType',
+        },
+      },
+    });
+    await assertBadRequest(res, 'from must not be null');
+  });
+
+  test('Get Job Statistics By Type With Not Existing Job Type - Success Empty Result', async ({
+    request,
+  }) => {
+    const jobType = 'someNotExistingJobType';
+    const res = await request.post(buildUrl('/jobs/statistics/by-types'), {
+      headers: jsonHeaders(),
+      data: {
+        filter: {
+          from: fromDate,
+          to: toDate,
+          jobType,
+        },
+      },
+    });
+    await assertStatusCode(res, 200);
+    await validateResponse(
+      {
+        path: '/jobs/statistics/by-types',
+        method: 'POST',
+        status: '200',
+      },
+      res,
+    );
+    const body = await res.json();
+    expect(body.items.length).toBe(0);
+    expect(body.page.totalItems).toBe(0);
+  });
+
+  test('Get Job Statistics By Type - Unauthorized', async ({request}) => {
+    const res = await request.post(buildUrl('/jobs/statistics/by-types'), {
+      headers: {},
+      data: {
+        filter: {
+          from: fromDate,
+          to: toDate,
+        },
+      },
+    });
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Get Job Statistics By Type - Forbidden, Empty Result, 200', async ({
+    request,
+  }) => {
+    const token = encode(
+      `${userWithResourcesAuthorizationToSendRequest.username}:${userWithResourcesAuthorizationToSendRequest.password}`,
+    );
+    const res = await request.post(buildUrl('/jobs/statistics/by-types'), {
+      headers: jsonHeaders(token), // overrides default demo:demo
+      data: {
+        filter: {
+          from: fromDate,
+          to: toDate,
+        },
+      },
+    });
+    await assertStatusCode(res, 200);
+    await validateResponse(
+      {
+        path: '/jobs/statistics/by-types',
+        method: 'POST',
+        status: '200',
+      },
+      res,
+    );
+    const body = await res.json();
+    expect(body.items.length).toBe(0);
+    expect(body.page.totalItems).toBe(0);
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-statistics-by-worker-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-statistics-by-worker-api-tests.spec.ts
@@ -88,7 +88,7 @@ test.describe.parallel('Job Statistics By Worker API Tests', () => {
       expect(item.failed.count).toBeGreaterThanOrEqual(1);
     }).toPass({
       intervals: [5_000, 10_000, 15_000],
-      timeout: 300_000,
+      timeout: 90_000,
     });
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-statistics-by-worker-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-statistics-by-worker-api-tests.spec.ts
@@ -1,0 +1,183 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect, test} from '@playwright/test';
+import {
+  assertInvalidArgument,
+  assertStatusCode,
+  assertUnauthorizedRequest,
+  buildUrl,
+  encode,
+  jsonHeaders,
+} from '../../../../utils/http';
+import {validateResponse} from '../../../../json-body-assertions';
+import {
+  createUser,
+  grantUserResourceAuthorization,
+  getLast24HoursRange,
+} from '@requestHelpers';
+import {cleanupUsers} from 'utils/usersCleanup';
+
+test.describe.parallel('Job Statistics By Worker API Tests', () => {
+  let userWithResourcesAuthorizationToSendRequest: {
+    username: string;
+    name: string;
+    email: string;
+    password: string;
+  } = {} as {
+    username: string;
+    name: string;
+    email: string;
+    password: string;
+  };
+  const {fromDate, toDate} = getLast24HoursRange();
+  const expectedJobType = 'incidentGenerator';
+
+  test.beforeAll(async ({request}) => {
+    await test.step('Setup - Create test user with Resource Authorization and user for granting Authorization', async () => {
+      userWithResourcesAuthorizationToSendRequest = await createUser(request);
+      await grantUserResourceAuthorization(
+        request,
+        userWithResourcesAuthorizationToSendRequest,
+      );
+    });
+  });
+
+  test.afterAll(async ({request}) => {
+    await test.step('Cleanup - Delete test users', async () => {
+      await cleanupUsers(request, [
+        userWithResourcesAuthorizationToSendRequest.username,
+      ]);
+    });
+  });
+
+  test('Get Job Statistics By Worker - success', async ({request}) => {
+    await expect(async () => {
+      const res = await request.post(buildUrl('/jobs/statistics/by-workers'), {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            from: fromDate,
+            to: toDate,
+            jobType: expectedJobType,
+          },
+        },
+      });
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: '/jobs/statistics/by-workers',
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+
+      const body = await res.json();
+      expect(body.items.length).toBeGreaterThanOrEqual(1);
+      expect(body.page.totalItems).toBeGreaterThanOrEqual(1);
+      const item = body.items[0];
+      expect(item.worker).toBeDefined();
+      expect(item.created.count).toBeGreaterThanOrEqual(0);
+      expect(item.completed.count).toBeGreaterThanOrEqual(0);
+      expect(item.failed.count).toBeGreaterThanOrEqual(1);
+    }).toPass({
+      intervals: [5_000, 10_000, 15_000],
+      timeout: 300_000,
+    });
+  });
+
+  test('Get Job Statistics By Worker with non existing job type - success, empty result', async ({
+    request,
+  }) => {
+    const res = await request.post(buildUrl('/jobs/statistics/by-workers'), {
+      headers: jsonHeaders(),
+      data: {
+        filter: {
+          from: fromDate,
+          to: toDate,
+          jobType: 'someNotExistingJobType',
+        },
+      },
+    });
+    await assertStatusCode(res, 200);
+    await validateResponse(
+      {
+        path: '/jobs/statistics/by-workers',
+        method: 'POST',
+        status: '200',
+      },
+      res,
+    );
+
+    const body = await res.json();
+    expect(body.items.length).toBe(0);
+    expect(body.page.totalItems).toBe(0);
+    expect(body.page.hasMoreTotalItems).toBe(false);
+  });
+
+  test('Get Job Statistics By Worker no jobType parameter - Bad Request', async ({
+    request,
+  }) => {
+    const res = await request.post(buildUrl('/jobs/statistics/by-workers'), {
+      headers: jsonHeaders(),
+      data: {
+        filter: {
+          from: fromDate,
+          to: toDate,
+        },
+      },
+    });
+    await assertInvalidArgument(res, 400, 'No jobType provided.');
+  });
+
+  test('Get Job Statistics By Worker - Unauthorized', async ({request}) => {
+    const res = await request.post(buildUrl('/jobs/statistics/by-workers'), {
+      headers: {},
+      data: {
+        filter: {
+          from: fromDate,
+          to: toDate,
+          jobType: 'someNotExistingJobType',
+        },
+      },
+    });
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Get Job Statistics By Worker  - Forbidden, empty result', async ({
+    request,
+  }) => {
+    const token = encode(
+      `${userWithResourcesAuthorizationToSendRequest.username}:${userWithResourcesAuthorizationToSendRequest.password}`,
+    );
+    const res = await request.post(buildUrl('/jobs/statistics/by-workers'), {
+      headers: jsonHeaders(token), // overrides default demo:demo
+      data: {
+        filter: {
+          from: fromDate,
+          to: toDate,
+          jobType: 'someNotExistingJobType',
+        },
+      },
+    });
+    await assertStatusCode(res, 200);
+    await validateResponse(
+      {
+        path: '/jobs/statistics/by-workers',
+        method: 'POST',
+        status: '200',
+      },
+      res,
+    );
+    const body = await res.json();
+    expect(body.items.length).toBe(0);
+    expect(body.page.totalItems).toBe(0);
+    expect(body.page.hasMoreTotalItems).toBe(false);
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-statistics-error-metrics-job-type-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-statistics-error-metrics-job-type-api-tests.spec.ts
@@ -1,0 +1,171 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect, test} from '@playwright/test';
+import {
+  assertBadRequest,
+  assertInvalidArgument,
+  assertStatusCode,
+  assertUnauthorizedRequest,
+  buildUrl,
+  encode,
+  jsonHeaders,
+} from '../../../../utils/http';
+import {validateResponse} from '../../../../json-body-assertions';
+import {
+  createUser,
+  grantUserResourceAuthorization,
+  getLast24HoursRange,
+  StatisticsJobItem,
+} from '@requestHelpers';
+import {cleanupUsers} from 'utils/usersCleanup';
+
+test.describe.parallel('Get error metrics for a job type API Tests', () => {
+  let userWithResourcesAuthorizationToSendRequest: {
+    username: string;
+    name: string;
+    email: string;
+    password: string;
+  } = {} as {
+    username: string;
+    name: string;
+    email: string;
+    password: string;
+  };
+  const {fromDate, toDate} = getLast24HoursRange();
+
+  test.beforeAll(async ({request}) => {
+    await test.step('Setup - Create test user with Resource Authorization and user for granting Authorization', async () => {
+      userWithResourcesAuthorizationToSendRequest = await createUser(request);
+      await grantUserResourceAuthorization(
+        request,
+        userWithResourcesAuthorizationToSendRequest,
+      );
+    });
+  });
+
+  test.afterAll(async ({request}) => {
+    await test.step('Cleanup - Delete test users', async () => {
+      await cleanupUsers(request, [
+        userWithResourcesAuthorizationToSendRequest.username,
+      ]);
+    });
+  });
+
+  test('Get error metrics for a job type - success', async ({request}) => {
+    let failedItems: string[] = [];
+
+    await test.step('General Search', async () => {
+      const generalSearchRes = await request.post(
+        buildUrl('/jobs/statistics/by-types'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              from: fromDate,
+              to: toDate,
+            },
+          },
+        },
+      );
+      await assertStatusCode(generalSearchRes, 200);
+      await validateResponse(
+        {
+          path: '/jobs/statistics/by-types',
+          method: 'POST',
+          status: '200',
+        },
+        generalSearchRes,
+      );
+      const responseBody = await generalSearchRes.json();
+      const receivedItems: StatisticsJobItem[] = responseBody.items;
+      for (const item of receivedItems) {
+        if (item.failed.count != 0) {
+          failedItems.push(item.jobType);
+        }
+      }
+
+      if (failedItems.length === 0) {
+        test.info().annotations.push({ type: 'blocked', description: 'No failed jobs in the last 24 hours to verify the response with jobType filter' });
+        return;
+      }
+    });
+
+    await test.step('Get error metrics for a job type without error code and without errorMessage', async () => {
+      for (const statisticsJob of failedItems) {
+        const extendedSearchRes = await request.post(
+          buildUrl('/jobs/statistics/errors'),
+          {
+            headers: jsonHeaders(),
+            data: {
+              filter: {
+                from: fromDate,
+                to: toDate,
+                jobType: statisticsJob,
+              },
+            },
+          },
+        );
+        await assertStatusCode(extendedSearchRes, 200);
+        await validateResponse(
+          {
+            path: '/jobs/statistics/errors',
+            method: 'POST',
+            status: '200',
+          },
+          extendedSearchRes,
+        );
+      }
+    });
+  });
+
+  test('Get error metrics for a job type without jobType - Bad Request', async ({
+    request,
+  }) => {
+    const res = await request.post(buildUrl('/jobs/statistics/errors'), {
+      headers: jsonHeaders(),
+      data: {
+        filter: {
+          from: fromDate,
+          to: toDate,
+        },
+      },
+    });
+    await assertInvalidArgument(res, 400, 'No jobType provided.');
+  });
+
+  test('Get error metrics for a job type - Forbidden, empty result', async ({
+    request,
+  }) => {
+    const token = encode(
+      `${userWithResourcesAuthorizationToSendRequest.username}:${userWithResourcesAuthorizationToSendRequest.password}`,
+    );
+    const res = await request.post(buildUrl('/jobs/statistics/errors'), {
+      headers: jsonHeaders(token), // overrides default demo:demo
+      data: {
+        filter: {
+          from: fromDate,
+          to: toDate,
+          jobType: 'meowJobType',
+        },
+      },
+    });
+
+    await assertStatusCode(res, 200);
+    await validateResponse(
+      {
+        path: '/jobs/statistics/errors',
+        method: 'POST',
+        status: '200',
+      },
+      res,
+    );
+    const responseBody = await res.json();
+    expect(responseBody.items.length).toBe(0);
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-statistics-global-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-statistics-global-api-tests.spec.ts
@@ -1,0 +1,186 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect, test} from '@playwright/test';
+import {
+  assertBadRequest,
+  assertStatusCode,
+  assertUnauthorizedRequest,
+  buildUrl,
+  encode,
+  jsonHeaders,
+} from '../../../../utils/http';
+import {validateResponse} from '../../../../json-body-assertions';
+import {
+  createUser,
+  getLast24HoursRange,
+  grantUserResourceAuthorization,
+} from '@requestHelpers';
+import {cleanupUsers} from 'utils/usersCleanup';
+import {defaultAssertionOptions} from 'utils/constants';
+
+test.describe.parallel('Job Statistics Global API Tests', () => {
+  let userWithResourcesAuthorizationToSendRequest: {
+    username: string;
+    name: string;
+    email: string;
+    password: string;
+  } = {} as {
+    username: string;
+    name: string;
+    email: string;
+    password: string;
+  };
+  const {fromDate, toDate} = getLast24HoursRange();
+
+  test.beforeAll(async ({request}) => {
+    await test.step('Setup - Create test user with Resource Authorization and user for granting Authorization', async () => {
+      userWithResourcesAuthorizationToSendRequest = await createUser(request);
+      await grantUserResourceAuthorization(
+        request,
+        userWithResourcesAuthorizationToSendRequest,
+      );
+    });
+  });
+
+  test.afterAll(async ({request}) => {
+    await test.step('Cleanup - Delete test users', async () => {
+      await cleanupUsers(request, [
+        userWithResourcesAuthorizationToSendRequest.username,
+      ]);
+    });
+  });
+
+  test('Get Job Statistics - success', async ({request}) => {
+    await expect(async () => {
+      const res = await request.get(
+        buildUrl('/jobs/statistics/global', undefined, {
+          from: fromDate,
+          to: toDate,
+        }),
+        {
+          headers: jsonHeaders(),
+        },
+      );
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: '/jobs/statistics/global',
+          method: 'GET',
+          status: '200',
+        },
+        res,
+      );
+      const body = await res.json();
+      expect(body.created.count).toBeGreaterThanOrEqual(1);
+      expect(body.completed.count).toBeGreaterThanOrEqual(0);
+      expect(body.failed.count).toBeGreaterThanOrEqual(0);
+      expect(body.isIncomplete).toBe(false);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Get Job Statistics with jobtype - success', async ({request}) => {
+    const jobType = 'someNotExistingJobType';
+    const res = await request.get(
+      buildUrl('/jobs/statistics/global', undefined, {
+        from: fromDate,
+        to: toDate,
+        jobType: jobType,
+      }),
+      {
+        headers: jsonHeaders(),
+      },
+    );
+    await assertStatusCode(res, 200);
+    await validateResponse(
+      {
+        path: '/jobs/statistics/global',
+        method: 'GET',
+        status: '200',
+      },
+      res,
+    );
+    const body = await res.json();
+    expect(body.created.count).toBe(0);
+    expect(body.completed.count).toBe(0);
+    expect(body.failed.count).toBe(0);
+    expect(body.isIncomplete).toBe(false);
+  });
+
+  test('Get Job Statistics no from parameter - Bad Request', async ({
+    request,
+  }) => {
+    const jobType = 'someNotExistingJobType';
+    const res = await request.get(
+      buildUrl('/jobs/statistics/global', undefined, {
+        to: toDate,
+        jobType: jobType,
+      }),
+      {
+        headers: jsonHeaders(),
+      },
+    );
+    await assertBadRequest(res, "Required parameter 'from' is not present.");
+  });
+
+  test('Get Job Statistics no to parameter - Bad Request', async ({
+    request,
+  }) => {
+    const res = await request.get(
+      buildUrl('/jobs/statistics/global', undefined, {from: fromDate}),
+      {
+        headers: jsonHeaders(),
+      },
+    );
+    await assertBadRequest(res, "Required parameter 'to' is not present.");
+  });
+
+  test('Get Job Statistics - Unauthorized', async ({request}) => {
+    const res = await request.get(
+      buildUrl('/jobs/statistics/global', undefined, {
+        from: fromDate,
+        to: toDate,
+      }),
+      {
+        headers: {},
+      },
+    );
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Get Job Statistics - Forbidden, Empty Result, 200', async ({
+    request,
+  }) => {
+    const token = encode(
+      `${userWithResourcesAuthorizationToSendRequest.username}:${userWithResourcesAuthorizationToSendRequest.password}`,
+    );
+    const res = await request.get(
+      buildUrl('/jobs/statistics/global', undefined, {
+        from: fromDate,
+        to: toDate,
+      }),
+      {
+        headers: jsonHeaders(token), // overrides default demo:demo
+      },
+    );
+    await assertStatusCode(res, 200);
+    await validateResponse(
+      {
+        path: '/jobs/statistics/global',
+        method: 'GET',
+        status: '200',
+      },
+      res,
+    );
+    const body = await res.json();
+    expect(body.created.count).toBe(0);
+    expect(body.completed.count).toBe(0);
+    expect(body.failed.count).toBe(0);
+    expect(body.isIncomplete).toBe(false);
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-statistics-time-series-job-type-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-statistics-time-series-job-type-api-tests.spec.ts
@@ -1,0 +1,301 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect, test} from '@playwright/test';
+import {
+  assertInvalidArgument,
+  assertStatusCode,
+  assertUnauthorizedRequest,
+  buildUrl,
+  encode,
+  jsonHeaders,
+} from '../../../../utils/http';
+import {validateResponse} from '../../../../json-body-assertions';
+import {
+  createUser,
+  grantUserResourceAuthorization,
+  getLast24HoursRange,
+  StatisticsJobItem,
+} from '@requestHelpers';
+import {cleanupUsers} from 'utils/usersCleanup';
+
+test.describe
+  .parallel('Get time-series metrics for a job type API Tests', () => {
+  let userWithResourcesAuthorizationToSendRequest: {
+    username: string;
+    name: string;
+    email: string;
+    password: string;
+  } = {} as {
+    username: string;
+    name: string;
+    email: string;
+    password: string;
+  };
+  const {fromDate, toDate} = getLast24HoursRange();
+
+  test.beforeAll(async ({request}) => {
+    await test.step('Setup - Create test user with Resource Authorization and user for granting Authorization', async () => {
+      userWithResourcesAuthorizationToSendRequest = await createUser(request);
+      await grantUserResourceAuthorization(
+        request,
+        userWithResourcesAuthorizationToSendRequest,
+      );
+    });
+  });
+
+  test.afterAll(async ({request}) => {
+    await test.step('Cleanup - Delete test users', async () => {
+      await cleanupUsers(request, [
+        userWithResourcesAuthorizationToSendRequest.username,
+      ]);
+    });
+  });
+
+  test('Get time-series metrics for a job type - success', async ({
+    request,
+  }) => {
+    let item: StatisticsJobItem;
+    let jobType: string = 'uninitialized';
+    const resolution = 'PT1M';
+
+    await test.step('General Search', async () => {
+      const generalSearchRes = await request.post(
+        buildUrl('/jobs/statistics/by-types'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              from: fromDate,
+              to: toDate,
+            },
+          },
+        },
+      );
+      await assertStatusCode(generalSearchRes, 200);
+      await validateResponse(
+        {
+          path: '/jobs/statistics/by-types',
+          method: 'POST',
+          status: '200',
+        },
+        generalSearchRes,
+      );
+      const responseBody = await generalSearchRes.json();
+      const items: StatisticsJobItem[] = responseBody.items;
+      for (const statisticsJob of items) {
+        if (statisticsJob.failed.count > 0) {
+          item = statisticsJob;
+          jobType = item.jobType;
+          break;
+        }
+      }
+
+      if (jobType === 'uninitialized') {
+        test.info().annotations.push({ type: 'blocked', description: 'No job statistics data available to verify the response with jobType filter' });
+        return;
+      }
+    });
+
+    await test.step('Get time-series metrics with jobType', async () => {
+      const extendedSearchRes = await request.post(
+        buildUrl('/jobs/statistics/time-series'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              from: fromDate,
+              to: toDate,
+              jobType,
+              resolution,
+            },
+          },
+        },
+      );
+      await assertStatusCode(extendedSearchRes, 200);
+      await validateResponse(
+        {
+          path: '/jobs/statistics/time-series',
+          method: 'POST',
+          status: '200',
+        },
+        extendedSearchRes,
+      );
+      const extendedResponseBody = await extendedSearchRes.json();
+      const extendedItem = extendedResponseBody.items[0];
+      expect(extendedItem.created.count).toBe(item.created.count);
+      expect(extendedItem.completed.count).toBe(item.completed.count);
+      expect(extendedItem.failed.count).toBe(item.failed.count);
+    });
+  });
+
+  test('Get time-series metrics for a job type - Unauthorized', async ({
+    request,
+  }) => {
+    const res = await request.post(buildUrl('/jobs/statistics/time-series'), {
+      headers: {},
+      data: {
+        filter: {
+          from: fromDate,
+          to: toDate,
+          jobType: 'someNotExistingJobType',
+          resolution: 'PT1M',
+        },
+      },
+    });
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Get time-series metrics for a not existing job type - Success, empty result', async ({
+    request,
+  }) => {
+    const res = await request.post(buildUrl('/jobs/statistics/time-series'), {
+      headers: jsonHeaders(),
+      data: {
+        filter: {
+          from: fromDate,
+          to: toDate,
+          jobType: 'someNotExistingJobType',
+          resolution: 'PT1M',
+        },
+      },
+    });
+    await assertStatusCode(res, 200);
+    await validateResponse(
+      {
+        path: '/jobs/statistics/time-series',
+        method: 'POST',
+        status: '200',
+      },
+      res,
+    );
+    const responseBody = await res.json();
+    expect(responseBody.items.length).toBe(0);
+  });
+
+  test('Get time-series metrics for a job type with no jobtype parameter - Bad Request', async ({
+    request,
+  }) => {
+    const res = await request.post(buildUrl('/jobs/statistics/time-series'), {
+      headers: jsonHeaders(),
+      data: {
+        filter: {
+          from: fromDate,
+          to: toDate,
+          resolution: 'PT1M',
+        },
+      },
+    });
+    await assertInvalidArgument(res, 400, 'No jobType provided.');
+  });
+
+  test('Get time-series metrics for a job type with no resolution parameter - Success', async ({
+    request,
+  }) => {
+    let item: StatisticsJobItem;
+    let jobType: string = 'uninitialized';
+
+    await test.step('General Search', async () => {
+      const generalSearchRes = await request.post(
+        buildUrl('/jobs/statistics/by-types'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              from: fromDate,
+              to: toDate,
+            },
+          },
+        },
+      );
+      await assertStatusCode(generalSearchRes, 200);
+      await validateResponse(
+        {
+          path: '/jobs/statistics/by-types',
+          method: 'POST',
+          status: '200',
+        },
+        generalSearchRes,
+      );
+      const responseBody = await generalSearchRes.json();
+      const items: StatisticsJobItem[] = responseBody.items;
+      for (const statisticsJob of items) {
+        if (statisticsJob.failed.count > 0) {
+          item = statisticsJob;
+          jobType = item.jobType;
+          break;
+        }
+      }
+      
+      if (jobType === 'uninitialized') {
+        test.info().annotations.push({ type: 'blocked', description: 'No job statistics data available to verify the response with jobType filter' });
+        return;
+      }
+    });
+
+    await test.step('Get time-series metrics with jobType', async () => {
+      const extendedSearchRes = await request.post(
+        buildUrl('/jobs/statistics/time-series'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              from: fromDate,
+              to: toDate,
+              jobType,
+            },
+          },
+        },
+      );
+      await assertStatusCode(extendedSearchRes, 200);
+      await validateResponse(
+        {
+          path: '/jobs/statistics/time-series',
+          method: 'POST',
+          status: '200',
+        },
+        extendedSearchRes,
+      );
+      const extendedResponseBody = await extendedSearchRes.json();
+      const extendedItem = extendedResponseBody.items[0];
+      expect(extendedItem.created.count).toBe(item.created.count);
+      expect(extendedItem.completed.count).toBe(item.completed.count);
+      expect(extendedItem.failed.count).toBe(item.failed.count);
+    });
+  });
+
+  test('Get time-series metrics for a job type - Forbidden, empty result', async ({
+    request,
+  }) => {
+    const token = encode(
+      `${userWithResourcesAuthorizationToSendRequest.username}:${userWithResourcesAuthorizationToSendRequest.password}`,
+    );
+    const res = await request.post(buildUrl('/jobs/statistics/time-series'), {
+      headers: jsonHeaders(token), // overrides default demo:demo
+      data: {
+        filter: {
+          from: fromDate,
+          to: toDate,
+          jobType: 'someNotExistingJobType',
+          resolution: 'PT1M',
+        },
+      },
+    });
+    await assertStatusCode(res, 200);
+    await validateResponse(
+      {
+        path: '/jobs/statistics/time-series',
+        method: 'POST',
+        status: '200',
+      },
+      res,
+    );
+    const responseBody = await res.json();
+    expect(responseBody.items.length).toBe(0);
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-worker-statistics-test-setup.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-worker-statistics-test-setup.spec.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test} from '@playwright/test';
+import {createSingleInstance, createWorker, deploy} from 'utils/zeebeClient';
+
+test.describe.parallel('Job Statistics By Worker Setup', () => {
+  const expectedJobType = 'incidentGenerator';
+
+  test('Setup - Create jobs with different workers and types', async () => {
+    await test.step('Setup - Create process with worker', async () => {
+      await deploy(['./resources/incidentGeneratorProcess.bpmn']);
+
+      createWorker(expectedJobType, true, {}, (job) => {
+        const BASE_ERROR_MESSAGE =
+          'This is an error message for testing purposes. This error message is very long to ensure it is truncated in the UI.';
+
+        if (job.variables.incidentType === 'Incident Type A') {
+          return job.fail(`${BASE_ERROR_MESSAGE} Type A`);
+        } else {
+          return job.fail(`${BASE_ERROR_MESSAGE} Type B`);
+        }
+      });
+
+      await createSingleInstance('incidentGeneratorProcess', 1, {
+        incidentType: 'Incident Type A',
+      });
+      await createSingleInstance('incidentGeneratorProcess', 1, {
+        incidentType: 'Incident Type B',
+      });
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
@@ -54,8 +54,12 @@ export {
 } from './authorization-requestHelpers';
 export {assertRoleInResponse} from './role-requestHelpers';
 export {assertClientsInResponse} from './clients-requestHelpers';
-export {setupProcessInstanceForTests} from './job-requestHelpers';
-export {activateJobToObtainAValidJobKey} from './job-requestHelpers';
+export {
+  setupProcessInstanceForTests,
+  activateJobToObtainAValidJobKey,
+  getLast24HoursRange,
+  type StatisticsJobItem
+} from './job-requestHelpers';
 export {
   createGlobalClusterVariable,
   createTenantClusterVariable,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/job-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/job-requestHelpers.ts
@@ -111,3 +111,29 @@ export function setupProcessInstanceForTests(
     },
   };
 }
+
+export function getLast24HoursRange() {
+  const fromDate = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(); // 24 hours ago
+  const toDate = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(); // 24 hours from now
+  return {
+    fromDate,
+    toDate,
+  };
+}
+
+export interface StatisticsJobItem {      
+    jobType: string,
+    created: {
+        count: number,
+        lastUpdatedAt: string
+    },
+    completed: {
+        count: number,
+        lastUpdatedAt: string
+    },
+    failed: {
+        count: number,
+        lastUpdatedAt: string
+    },
+    workers: number,
+};


### PR DESCRIPTION
## Description

Few new test spec files are introduced:

- `job-statistics-by-type-api-tests.spec.ts` 
- `job-statistics-by-worker-api-tests.spec.ts`
- `job-statistics-error-metrics-job-type-api-tests.spec.ts`
- `job-statistics-global-api-tests.spec.ts`
- `job-statistics-time-series-job-type-api-tests.spec.ts`

Some of the tests has built-in return, so if no data is there yet, it will be not checked. This will mark this test as _passed_

The `playwright.config.ts` is updated to ensure the new test files, so they run after all of the tests as part of api-subset

- `job-worker-statistics-test-setup.spec.ts` - is required setup for `job-statistics-by-worker-api-tests.spec.ts` as separated file as it takes a lot of time (3 min < time < 5 min) before data is in ES. With this configuration setup runs with the most of the APIs tests. So when the actual test is running the data is there.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

related to [this issue](https://github.com/camunda/team-test-automation/issues/62)

## On demand workflow
[was all green on APIs](https://github.com/camunda/camunda/actions/runs/24232606445)
