### PR TITLE
[Backport stable/8.8] fix: resolve flaky UsageMetricRpiTest by waiting for state commit before assertions

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/metrics/UsageMetricRpiTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/metrics/UsageMetricRpiTest.java
@@ -36,9 +36,10 @@ public class UsageMetricRpiTest {
     engine.processInstance().ofBpmnProcessId("process").create();
 
     // then
-    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
-        .filterRootScope()
-        .getFirst();
+    engine.awaitProcessingOf(
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .filterRootScope()
+            .getFirst());
 
     final var bucket = engine.getProcessingState().getUsageMetricState().getActiveBucket();
     assertThat(bucket).isNotNull();
@@ -60,9 +61,10 @@ public class UsageMetricRpiTest {
     engine.message().withName("startMessage").withCorrelationKey("key-1").publish();
 
     // then
-    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
-        .filterRootScope()
-        .getFirst();
+    engine.awaitProcessingOf(
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .filterRootScope()
+            .getFirst());
 
     final var bucket = engine.getProcessingState().getUsageMetricState().getActiveBucket();
     assertThat(bucket).isNotNull();
@@ -84,9 +86,10 @@ public class UsageMetricRpiTest {
     engine.increaseTime(Duration.ofSeconds(2));
 
     // then
-    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
-        .filterRootScope()
-        .getFirst();
+    engine.awaitProcessingOf(
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .filterRootScope()
+            .getFirst());
 
     final var bucket = engine.getProcessingState().getUsageMetricState().getActiveBucket();
     assertThat(bucket).isNotNull();
@@ -108,9 +111,10 @@ public class UsageMetricRpiTest {
     engine.signal().withSignalName("startSignal").broadcast();
 
     // then
-    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
-        .filterRootScope()
-        .getFirst();
+    engine.awaitProcessingOf(
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .filterRootScope()
+            .getFirst());
 
     final var bucket = engine.getProcessingState().getUsageMetricState().getActiveBucket();
     assertThat(bucket).isNotNull();
@@ -141,9 +145,10 @@ public class UsageMetricRpiTest {
     engine.message().withName("waitMessage").withCorrelationKey("key-1").publish();
 
     // then - the process completes, but the RPI count must still be 1
-    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
-        .filterRootScope()
-        .getFirst();
+    engine.awaitProcessingOf(
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+            .filterRootScope()
+            .getFirst());
 
     final var bucket = engine.getProcessingState().getUsageMetricState().getActiveBucket();
     assertThat(bucket).isNotNull();
@@ -171,12 +176,13 @@ public class UsageMetricRpiTest {
     engine.signal().withSignalName("sharedSignal").broadcast();
 
     // then - both process instances should be counted
-    final var instanceCount =
+    final var activatedRecords =
         RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
             .filterRootScope()
             .limit(2)
-            .count();
-    assertThat(instanceCount).isEqualTo(2);
+            .asList();
+    assertThat(activatedRecords).hasSize(2);
+    engine.awaitProcessingOf(activatedRecords.getLast());
 
     final var bucket = engine.getProcessingState().getUsageMetricState().getActiveBucket();
     assertThat(bucket).isNotNull();


### PR DESCRIPTION
# Description
Backport of #50467 to `stable/8.8`.

relates to camunda/camunda#50466