### PR TITLE
[Backport stable/8.7] refactor: replace use-official-docker-images with orchestration-tag and add per-component image tags

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -83,6 +83,21 @@ on:
         options:
         - elasticsearch
         default: elasticsearch
+      optimize-tag:
+        description: 'Docker image tag for Optimize. If not set, defaults to the Helm chart default image.'
+        type: string
+        default: ""
+        required: false
+      identity-tag:
+        description: 'Docker image tag for Identity. If not set, defaults to the Helm chart default image.'
+        type: string
+        default: ""
+        required: false
+      connectors-tag:
+        description: 'Docker image tag for Connectors. If not set, defaults to the Helm chart default image.'
+        type: string
+        default: ""
+        required: false
   workflow_call:
     inputs:
       ref:
@@ -154,6 +169,21 @@ on:
         type: string
         required: false
         default: elasticsearch
+      optimize-tag:
+        description: 'Docker image tag for Optimize. If not set, defaults to the Helm chart default image.'
+        type: string
+        default: ""
+        required: false
+      identity-tag:
+        description: 'Docker image tag for Identity. If not set, defaults to the Helm chart default image.'
+        type: string
+        default: ""
+        required: false
+      connectors-tag:
+        description: 'Docker image tag for Connectors. If not set, defaults to the Helm chart default image.'
+        type: string
+        default: ""
+        required: false
 
 env:
   CLUSTER: camunda-benchmark-prod  # change this to "camunda-benchmark-dev" when experimenting
@@ -195,6 +225,9 @@ jobs:
         env:
           TAG: ${{ inputs.reuse-tag }}
           ENABLE_OPTIMIZE: ${{ inputs.enable-optimize }}
+          OPTIMIZE_TAG: ${{ inputs.optimize-tag }}
+          IDENTITY_TAG: ${{ inputs.identity-tag }}
+          CONNECTORS_TAG: ${{ inputs.connectors-tag }}
         run: |
           validate_image() {
             local image="$1"
@@ -231,8 +264,16 @@ jobs:
 
           validate_image "camunda/camunda:${TAG}" || exit 1
 
-          if [[ "${ENABLE_OPTIMIZE}" == "true" ]]; then
-            validate_image "camunda/optimize:${TAG}" || exit 1
+          if [[ "${ENABLE_OPTIMIZE}" == "true" && -n "${OPTIMIZE_TAG}" ]]; then
+            validate_image "camunda/optimize:${OPTIMIZE_TAG}" || exit 1
+          fi
+
+          if [[ -n "${IDENTITY_TAG}" ]]; then
+            validate_image "camunda/identity:${IDENTITY_TAG}" || exit 1
+          fi
+
+          if [[ -n "${CONNECTORS_TAG}" ]]; then
+            validate_image "camunda/connectors:${CONNECTORS_TAG}" || exit 1
           fi
 
   calculate-scenario-config:
@@ -441,6 +482,7 @@ jobs:
           image_tag="${{ needs.calculate-image-tag.outputs.image-tag }}"
           image_registry="${{ inputs.use-official-docker-images && 'docker.io' || 'registry.camunda.cloud' }}"
           zeebe_repo="${{ inputs.use-official-docker-images && 'camunda/zeebe' || 'team-zeebe/zeebe' }}"
+          optimize_repo="${{ inputs.use-official-docker-images && 'camunda/optimize' || 'team-zeebe/optimize' }}"
 
           additional_platform_config="--set global.image.tag=${image_tag} \
             --set zeebe.image.registry=${image_registry} \
@@ -449,6 +491,36 @@ jobs:
             --set zeebeGateway.image.registry=${image_registry} \
             --set zeebeGateway.image.repository=${zeebe_repo} \
             --set zeebeGateway.image.tag=${image_tag}"
+
+          # Append optimize image config if enabled
+          if [[ "${{ inputs.enable-optimize }}" == "true" ]]; then
+            # Use dedicated optimize-tag only with official images; otherwise fall back to the built image tag
+            if [[ "${{ inputs.use-official-docker-images }}" == "true" && -n "${{ inputs.optimize-tag }}" ]]; then
+              optimize_tag="${{ inputs.optimize-tag }}"
+            else
+              optimize_tag="${image_tag}"
+            fi
+            additional_platform_config+=" \
+              --set optimize.image.registry=${image_registry} \
+              --set optimize.image.repository=${optimize_repo} \
+              --set optimize.image.tag=${optimize_tag}"
+          fi
+
+          # Append identity image config if a dedicated tag is provided (only for official images)
+          if [[ "${{ inputs.use-official-docker-images }}" == "true" && -n "${{ inputs.identity-tag }}" ]]; then
+            additional_platform_config+=" \
+              --set identity.image.registry=docker.io \
+              --set identity.image.repository=camunda/identity \
+              --set identity.image.tag=${{ inputs.identity-tag }}"
+          fi
+
+          # Append connectors image config if a dedicated tag is provided (only for official images)
+          if [[ "${{ inputs.use-official-docker-images }}" == "true" && -n "${{ inputs.connectors-tag }}" ]]; then
+            additional_platform_config+=" \
+              --set connectors.image.registry=docker.io \
+              --set connectors.image.repository=camunda/connectors \
+              --set connectors.image.tag=${{ inputs.connectors-tag }}"
+          fi
 
           # Append user-provided helm values if present
           if [[ -n "${{ inputs.platform-helm-values }}" ]]; then

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -495,7 +495,7 @@ jobs:
           # Append optimize image config if enabled
           if [[ "${{ inputs.enable-optimize }}" == "true" ]]; then
             if [[ "${{ inputs.use-official-docker-images }}" == "true" ]]; then
-              # Official images: only override if an explicit optimize-tag is provided; otherwise let Helm chart defaults apply
+              # Official images: only override if an explicit optimize-tag is provided; otherwise no image override is set
               if [[ -n "${{ inputs.optimize-tag }}" ]]; then
                 additional_platform_config+=" \
                   --set optimize.image.tag=${{ inputs.optimize-tag }}"

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -30,15 +30,10 @@ on:
         default: 1
         required: false
       reuse-tag:
-        description: 'Docker image tag, that should be reused for the load test. Allows to skip the docker image build step'
+        description: 'Reuse Tag: Pre-built image tag from the internal registry (registry.camunda.cloud). Skips the docker image build step. Cannot be used together with orchestration-tag.'
         type: string
         default: ""
         required: false
-      use-official-docker-images:
-        description: 'Use official Camunda Docker images from Docker Hub instead of building from source'
-        type: boolean
-        required: false
-        default: false
       scenario:
         description: 'Choose the variant of workload to use for the load test.'
         required: false
@@ -83,18 +78,23 @@ on:
         options:
         - elasticsearch
         default: elasticsearch
+      orchestration-tag:
+        description: 'Orchestration Tag: Docker image tag for official Camunda images from Docker Hub (docker.io/camunda/camunda). When set, official Docker Hub images are used instead of building from source. Cannot be used together with reuse-tag.'
+        type: string
+        default: ""
+        required: false
       optimize-tag:
-        description: 'Docker image tag for Optimize. If not set, defaults to the Helm chart default image.'
+        description: 'Optimize Tag: Docker image tag for Optimize from Docker Hub (docker.io/camunda/optimize). When set, overrides the optimize image regardless of build mode. If not set, custom builds use the built image from the internal registry; official images use Helm chart defaults.'
         type: string
         default: ""
         required: false
       identity-tag:
-        description: 'Docker image tag for Identity. If not set, defaults to the Helm chart default image.'
+        description: 'Identity Tag: Docker image tag for Identity from Docker Hub (docker.io/camunda/identity). If not set, defaults to the Helm chart default image.'
         type: string
         default: ""
         required: false
       connectors-tag:
-        description: 'Docker image tag for Connectors. If not set, defaults to the Helm chart default image.'
+        description: 'Connectors Tag: Docker image tag for Connectors from Docker Hub (docker.io/camunda/connectors). If not set, defaults to the Helm chart default image.'
         type: string
         default: ""
         required: false
@@ -115,15 +115,10 @@ on:
         default: 1
         required: false
       reuse-tag:
-        description: 'Docker image tag, that should be reused for the load test. Allows to skip the docker image build step'
+        description: 'Reuse Tag: Pre-built image tag from the internal registry (registry.camunda.cloud). Skips the docker image build step. Cannot be used together with orchestration-tag.'
         type: string
         default: ""
         required: false
-      use-official-docker-images:
-        description: 'Use official Camunda Docker images from Docker Hub instead of building from source'
-        type: boolean
-        required: false
-        default: false
       scenario:
         description: 'Choose the variant of workload to use for the load test. Options: custom, latency, realistic, typical, max. If specified, this will override the load-test-load input when not set to "custom".'
         type: string
@@ -169,18 +164,23 @@ on:
         type: string
         required: false
         default: elasticsearch
+      orchestration-tag:
+        description: 'Orchestration Tag: Docker image tag for official Camunda images from Docker Hub (docker.io/camunda/camunda). When set, official Docker Hub images are used instead of building from source. Cannot be used together with reuse-tag.'
+        type: string
+        default: ""
+        required: false
       optimize-tag:
-        description: 'Docker image tag for Optimize. If not set, defaults to the Helm chart default image.'
+        description: 'Optimize Tag: Docker image tag for Optimize from Docker Hub (docker.io/camunda/optimize). When set, overrides the optimize image regardless of build mode. If not set, custom builds use the built image from the internal registry; official images use Helm chart defaults.'
         type: string
         default: ""
         required: false
       identity-tag:
-        description: 'Docker image tag for Identity. If not set, defaults to the Helm chart default image.'
+        description: 'Identity Tag: Docker image tag for Identity from Docker Hub (docker.io/camunda/identity). If not set, defaults to the Helm chart default image.'
         type: string
         default: ""
         required: false
       connectors-tag:
-        description: 'Docker image tag for Connectors. If not set, defaults to the Helm chart default image.'
+        description: 'Connectors Tag: Docker image tag for Connectors from Docker Hub (docker.io/camunda/connectors). If not set, defaults to the Helm chart default image.'
         type: string
         default: ""
         required: false
@@ -206,12 +206,12 @@ jobs:
     timeout-minutes: 5
     permissions: { }
     outputs:
-      image-tag: ${{ inputs.reuse-tag != '' && inputs.reuse-tag || steps.image-tag.outputs.image-tag }}
+      image-tag: ${{ inputs.orchestration-tag != '' && inputs.orchestration-tag || (inputs.reuse-tag != '' && inputs.reuse-tag || steps.image-tag.outputs.image-tag) }}
     steps:
-      - name: Validate official images require explicit tag
-        if: ${{ inputs.use-official-docker-images == true && inputs.reuse-tag == '' }}
+      - name: Validate mutually exclusive inputs
+        if: ${{ inputs.orchestration-tag != '' && inputs.reuse-tag != '' }}
         run: |
-          echo "::error::Invalid input combination: 'use-official-docker-images' is enabled but 'reuse-tag' is empty. Official Camunda Docker images require an explicit tag (e.g., '8.9.0-rc2') to pull from Docker Hub. Either provide a 'reuse-tag' or disable 'use-official-docker-images'."
+          echo "::error::Invalid input combination: 'orchestration-tag' and 'reuse-tag' cannot both be provided. Use 'orchestration-tag' for official Docker Hub images or 'reuse-tag' for reusing pre-built images from the internal registry."
           exit 1
       - uses: actions/checkout@v6
         with:
@@ -221,9 +221,9 @@ jobs:
         run: |
           echo "image-tag=${{ inputs.name }}-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
       - name: Validate Docker image tags exist
-        if: ${{ inputs.use-official-docker-images == true && inputs.reuse-tag != '' }}
+        if: ${{ inputs.orchestration-tag != '' || inputs.optimize-tag != '' || inputs.identity-tag != '' || inputs.connectors-tag != '' }}
         env:
-          TAG: ${{ inputs.reuse-tag }}
+          ORCHESTRATION_TAG: ${{ inputs.orchestration-tag }}
           ENABLE_OPTIMIZE: ${{ inputs.enable-optimize }}
           OPTIMIZE_TAG: ${{ inputs.optimize-tag }}
           IDENTITY_TAG: ${{ inputs.identity-tag }}
@@ -262,7 +262,9 @@ jobs:
             done
           }
 
-          validate_image "camunda/camunda:${TAG}" || exit 1
+          if [[ -n "${ORCHESTRATION_TAG}" ]]; then
+            validate_image "camunda/camunda:${ORCHESTRATION_TAG}" || exit 1
+          fi
 
           if [[ "${ENABLE_OPTIMIZE}" == "true" && -n "${OPTIMIZE_TAG}" ]]; then
             validate_image "camunda/optimize:${OPTIMIZE_TAG}" || exit 1
@@ -337,7 +339,7 @@ jobs:
   build-zeebe-image:
     name: Build Zeebe Docker image
     needs: calculate-image-tag
-    if: ${{ inputs.reuse-tag == '' }}
+    if: ${{ inputs.reuse-tag == '' && inputs.orchestration-tag == '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -381,7 +383,7 @@ jobs:
 
   build-load-test-images:
     name: Build Starter and Worker
-    if: ${{ inputs.reuse-tag == '' || inputs.use-official-docker-images == true }}
+    if: ${{ inputs.reuse-tag == '' || inputs.orchestration-tag != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: calculate-image-tag
@@ -478,11 +480,12 @@ jobs:
           load_test_config="$load_test_config ${{ needs.calculate-scenario-config.outputs.load-test-load }}"
           load_test_config="$load_test_config ${{ inputs.load-test-load }}"
 
-          # Build platform configuration matching stable/8.7 helm chart keys
+          # Resolve image registry/repository: Docker Hub when orchestration-tag is set, internal registry otherwise
+          # optimize_repo is only consumed in the custom build path where orchestration-tag is empty
           image_tag="${{ needs.calculate-image-tag.outputs.image-tag }}"
-          image_registry="${{ inputs.use-official-docker-images && 'docker.io' || 'registry.camunda.cloud' }}"
-          zeebe_repo="${{ inputs.use-official-docker-images && 'camunda/zeebe' || 'team-zeebe/zeebe' }}"
-          optimize_repo="${{ inputs.use-official-docker-images && 'camunda/optimize' || 'team-zeebe/optimize' }}"
+          image_registry="${{ inputs.orchestration-tag != '' && 'docker.io' || 'registry.camunda.cloud' }}"
+          zeebe_repo="${{ inputs.orchestration-tag != '' && 'camunda/zeebe' || 'team-zeebe/zeebe' }}"
+          optimize_repo="${{ inputs.orchestration-tag != '' && 'camunda/optimize' || 'team-zeebe/optimize' }}"
 
           additional_platform_config="--set global.image.tag=${image_tag} \
             --set zeebe.image.registry=${image_registry} \
@@ -492,16 +495,14 @@ jobs:
             --set zeebeGateway.image.repository=${zeebe_repo} \
             --set zeebeGateway.image.tag=${image_tag}"
 
-          # Append optimize image config if enabled
+          # Append optimize image config: optimize-tag wins if set, otherwise custom builds use internal registry
           if [[ "${{ inputs.enable-optimize }}" == "true" ]]; then
-            if [[ "${{ inputs.use-official-docker-images }}" == "true" ]]; then
-              # Official images: only override if an explicit optimize-tag is provided; otherwise no image override is set
-              if [[ -n "${{ inputs.optimize-tag }}" ]]; then
-                additional_platform_config+=" \
-                  --set optimize.image.tag=${{ inputs.optimize-tag }}"
-              fi
-            else
-              # Custom build: use the built image tag with full registry/repo override
+            if [[ -n "${{ inputs.optimize-tag }}" ]]; then
+              # Explicit optimize tag provided: use it directly (Docker Hub image)
+              additional_platform_config+=" \
+                --set optimize.image.tag=${{ inputs.optimize-tag }}"
+            elif [[ -z "${{ inputs.orchestration-tag }}" ]]; then
+              # Custom build without explicit optimize tag: use the built image from internal registry
               additional_platform_config+=" \
                 --set optimize.image.registry=${image_registry} \
                 --set optimize.image.repository=${optimize_repo} \
@@ -509,14 +510,14 @@ jobs:
             fi
           fi
 
-          # Append identity image config if a dedicated tag is provided (only for official images)
-          if [[ "${{ inputs.use-official-docker-images }}" == "true" && -n "${{ inputs.identity-tag }}" ]]; then
+          # Append identity image config if a dedicated tag is provided
+          if [[ -n "${{ inputs.identity-tag }}" ]]; then
             additional_platform_config+=" \
               --set identity.image.tag=${{ inputs.identity-tag }}"
           fi
 
-          # Append connectors image config if a dedicated tag is provided (only for official images)
-          if [[ "${{ inputs.use-official-docker-images }}" == "true" && -n "${{ inputs.connectors-tag }}" ]]; then
+          # Append connectors image config if a dedicated tag is provided
+          if [[ -n "${{ inputs.connectors-tag }}" ]]; then
             additional_platform_config+=" \
               --set connectors.image.tag=${{ inputs.connectors-tag }}"
           fi

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -494,31 +494,30 @@ jobs:
 
           # Append optimize image config if enabled
           if [[ "${{ inputs.enable-optimize }}" == "true" ]]; then
-            # Use dedicated optimize-tag only with official images; otherwise fall back to the built image tag
-            if [[ "${{ inputs.use-official-docker-images }}" == "true" && -n "${{ inputs.optimize-tag }}" ]]; then
-              optimize_tag="${{ inputs.optimize-tag }}"
+            if [[ "${{ inputs.use-official-docker-images }}" == "true" ]]; then
+              # Official images: only override if an explicit optimize-tag is provided; otherwise let Helm chart defaults apply
+              if [[ -n "${{ inputs.optimize-tag }}" ]]; then
+                additional_platform_config+=" \
+                  --set optimize.image.tag=${{ inputs.optimize-tag }}"
+              fi
             else
-              optimize_tag="${image_tag}"
+              # Custom build: use the built image tag with full registry/repo override
+              additional_platform_config+=" \
+                --set optimize.image.registry=${image_registry} \
+                --set optimize.image.repository=${optimize_repo} \
+                --set optimize.image.tag=${image_tag}"
             fi
-            additional_platform_config+=" \
-              --set optimize.image.registry=${image_registry} \
-              --set optimize.image.repository=${optimize_repo} \
-              --set optimize.image.tag=${optimize_tag}"
           fi
 
           # Append identity image config if a dedicated tag is provided (only for official images)
           if [[ "${{ inputs.use-official-docker-images }}" == "true" && -n "${{ inputs.identity-tag }}" ]]; then
             additional_platform_config+=" \
-              --set identity.image.registry=docker.io \
-              --set identity.image.repository=camunda/identity \
               --set identity.image.tag=${{ inputs.identity-tag }}"
           fi
 
           # Append connectors image config if a dedicated tag is provided (only for official images)
           if [[ "${{ inputs.use-official-docker-images }}" == "true" && -n "${{ inputs.connectors-tag }}" ]]; then
             additional_platform_config+=" \
-              --set connectors.image.registry=docker.io \
-              --set connectors.image.repository=camunda/connectors \
               --set connectors.image.tag=${{ inputs.connectors-tag }}"
           fi
 

--- a/.github/workflows/camunda-release-load-test.yaml
+++ b/.github/workflows/camunda-release-load-test.yaml
@@ -1,10 +1,11 @@
 # description: Creates a load test for official release images. Abstraction layer between
 #              the release process and the load test infrastructure, with a simple public API
-#              accepting name, tag, and optional per-component image tags as inputs.
+#              accepting required name and tag inputs plus optional per-component
+#              tag overrides: optimize-tag, identity-tag, and connectors-tag.
 #              Uses official Docker images with scenario: realistic.
 # called-by: camunda-scheduled-release-load-tests.yml (daily schedule),
 #            release BPMN process (workflow_dispatch via GitHub API)
-# calls: camunda-load-test.yml (use-official-docker-images: true, scenario: realistic)
+# calls: camunda-load-test.yml (orchestration-tag: <tag>, scenario: realistic)
 # note: Verification and namespace cleanup are handled externally by the scheduled workflow
 #       via camunda-verify-and-cleanup-load-test.yml, not by this workflow.
 # type: CI
@@ -107,9 +108,8 @@ jobs:
     with:
       name: ${{ needs.sanitize-inputs.outputs.sanitized-name }}
       ref: stable/8.7
-      reuse-tag: ${{ needs.sanitize-inputs.outputs.test-tag }}
+      orchestration-tag: ${{ inputs.tag }}
       ttl: 60
-      use-official-docker-images: true
       scenario: 'realistic'
       optimize-tag: ${{ inputs.optimize-tag }}
       identity-tag: ${{ inputs.identity-tag }}

--- a/.github/workflows/camunda-release-load-test.yaml
+++ b/.github/workflows/camunda-release-load-test.yaml
@@ -1,7 +1,12 @@
-# description: Create a Camunda load test for a given release.
-#              Abstraction layer of the actual load test creation process, to define a clear API between release process and the load test workflows.
-#              Public API - accepting inputs for test name and tag.
-#              Called by: camunda-scheduled-release-load-tests.yml (daily schedule)
+# description: Creates a load test for official release images. Abstraction layer between
+#              the release process and the load test infrastructure, with a simple public API
+#              accepting name, tag, and optional per-component image tags as inputs.
+#              Uses official Docker images with scenario: realistic.
+# called-by: camunda-scheduled-release-load-tests.yml (daily schedule),
+#            release BPMN process (workflow_dispatch via GitHub API)
+# calls: camunda-load-test.yml (use-official-docker-images: true, scenario: realistic)
+# note: Verification and namespace cleanup are handled externally by the scheduled workflow
+#       via camunda-verify-and-cleanup-load-test.yml, not by this workflow.
 # type: CI
 # owner @camunda/reliability-testing
 name: Camunda Release load test workflow

--- a/.github/workflows/camunda-release-load-test.yaml
+++ b/.github/workflows/camunda-release-load-test.yaml
@@ -16,6 +16,21 @@ on:
         description: 'Specifies the tag that should be used for the release load test'
         type: string
         required: true
+      optimize-tag:
+        description: 'Docker image tag for Optimize. If not set, defaults to the Helm chart default image.'
+        type: string
+        default: ""
+        required: false
+      identity-tag:
+        description: 'Docker image tag for Identity. If not set, defaults to the Helm chart default image.'
+        type: string
+        default: ""
+        required: false
+      connectors-tag:
+        description: 'Docker image tag for Connectors. If not set, defaults to the Helm chart default image.'
+        type: string
+        default: ""
+        required: false
   workflow_call:
     inputs:
       name:
@@ -26,6 +41,21 @@ on:
         description: 'Specifies the tag that should be used for the release load test'
         type: string
         required: true
+      optimize-tag:
+        description: 'Docker image tag for Optimize. If not set, defaults to the Helm chart default image.'
+        type: string
+        default: ""
+        required: false
+      identity-tag:
+        description: 'Docker image tag for Identity. If not set, defaults to the Helm chart default image.'
+        type: string
+        default: ""
+        required: false
+      connectors-tag:
+        description: 'Docker image tag for Connectors. If not set, defaults to the Helm chart default image.'
+        type: string
+        default: ""
+        required: false
 
 defaults:
   run:
@@ -76,6 +106,9 @@ jobs:
       ttl: 60
       use-official-docker-images: true
       scenario: 'realistic'
+      optimize-tag: ${{ inputs.optimize-tag }}
+      identity-tag: ${{ inputs.identity-tag }}
+      connectors-tag: ${{ inputs.connectors-tag }}
 
   notify-on-failure:
     name: Notify on failure


### PR DESCRIPTION
# Description
Backport of #50417 to `stable/8.7`.

relates to #50323