### PR TITLE
[Backport stable/8.9] refactor: replace use-official-docker-images with orchestration-tag and add per-component image tags

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -536,31 +536,30 @@ jobs:
 
           # Append optimize image config if enabled
           if [[ "${{ inputs.enable-optimize }}" == "true" ]]; then
-            # Use dedicated optimize-tag only with official images; otherwise fall back to the built image tag
-            if [[ "${{ inputs.use-official-docker-images }}" == "true" && -n "${{ inputs.optimize-tag }}" ]]; then
-              optimize_tag="${{ inputs.optimize-tag }}"
+            if [[ "${{ inputs.use-official-docker-images }}" == "true" ]]; then
+              # Official images: only override if an explicit optimize-tag is provided; otherwise let Helm chart defaults apply
+              if [[ -n "${{ inputs.optimize-tag }}" ]]; then
+                additional_platform_config+=" \
+                  --set optimize.image.tag=${{ inputs.optimize-tag }}"
+              fi
             else
-              optimize_tag="${image_tag}"
+              # Custom build: use the built image tag with full registry/repo override
+              additional_platform_config+=" \
+                --set optimize.image.registry=${image_registry} \
+                --set optimize.image.repository=${optimize_repo} \
+                --set optimize.image.tag=${image_tag}"
             fi
-            additional_platform_config+=" \
-              --set optimize.image.registry=${image_registry} \
-              --set optimize.image.repository=${optimize_repo} \
-              --set optimize.image.tag=${optimize_tag}"
           fi
 
           # Append identity image config if a dedicated tag is provided (only for official images)
           if [[ "${{ inputs.use-official-docker-images }}" == "true" && -n "${{ inputs.identity-tag }}" ]]; then
             additional_platform_config+=" \
-              --set identity.image.registry=docker.io \
-              --set identity.image.repository=camunda/identity \
               --set identity.image.tag=${{ inputs.identity-tag }}"
           fi
 
           # Append connectors image config if a dedicated tag is provided (only for official images)
           if [[ "${{ inputs.use-official-docker-images }}" == "true" && -n "${{ inputs.connectors-tag }}" ]]; then
             additional_platform_config+=" \
-              --set connectors.image.registry=docker.io \
-              --set connectors.image.repository=camunda/connectors \
               --set connectors.image.tag=${{ inputs.connectors-tag }}"
           fi
 

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -30,15 +30,10 @@ on:
         default: 1
         required: false
       reuse-tag:
-        description: 'Docker image tag, that should be reused for the load test. Allows to skip the docker image build step'
+        description: 'Reuse Tag: Pre-built image tag from the internal registry (registry.camunda.cloud). Skips the docker image build step. Cannot be used together with orchestration-tag.'
         type: string
         default: ""
         required: false
-      use-official-docker-images:
-        description: 'Use official Camunda Docker images from Docker Hub instead of building from source'
-        type: boolean
-        required: false
-        default: false
       scenario:
         description: 'Choose the variant of workload to use for the load test. When not set, it will default to max'
         required: false
@@ -86,18 +81,23 @@ on:
         - postgresql
         - none
         default: elasticsearch
+      orchestration-tag:
+        description: 'Orchestration Tag: Docker image tag for official Camunda images from Docker Hub (docker.io/camunda/camunda). When set, official Docker Hub images are used instead of building from source. Cannot be used together with reuse-tag.'
+        type: string
+        default: ""
+        required: false
       optimize-tag:
-        description: 'Docker image tag for Optimize. If not set, defaults to the Helm chart default image.'
+        description: 'Optimize Tag: Docker image tag for Optimize from Docker Hub (docker.io/camunda/optimize). When set, overrides the optimize image regardless of build mode. If not set, custom builds use the built image from the internal registry; official images use Helm chart defaults.'
         type: string
         default: ""
         required: false
       identity-tag:
-        description: 'Docker image tag for Identity. If not set, defaults to the Helm chart default image.'
+        description: 'Identity Tag: Docker image tag for Identity from Docker Hub (docker.io/camunda/identity). If not set, defaults to the Helm chart default image.'
         type: string
         default: ""
         required: false
       connectors-tag:
-        description: 'Docker image tag for Connectors. If not set, defaults to the Helm chart default image.'
+        description: 'Connectors Tag: Docker image tag for Connectors from Docker Hub (docker.io/camunda/connectors). If not set, defaults to the Helm chart default image.'
         type: string
         default: ""
         required: false
@@ -118,15 +118,10 @@ on:
         default: 1
         required: false
       reuse-tag:
-        description: 'Docker image tag, that should be reused for the load test. Allows to skip the docker image build step'
+        description: 'Reuse Tag: Pre-built image tag from the internal registry (registry.camunda.cloud). Skips the docker image build step. Cannot be used together with orchestration-tag.'
         type: string
         default: ""
         required: false
-      use-official-docker-images:
-        description: 'Use official Camunda Docker images from Docker Hub instead of building from source'
-        type: boolean
-        required: false
-        default: false
       scenario:
         description: 'Choose the variant of workload to use for the load test. Options: custom, latency, realistic, typical, max. If specified, this will override the load-test-load input when not set to "custom".'
         type: string
@@ -172,18 +167,23 @@ on:
         type: string
         required: false
         default: elasticsearch
+      orchestration-tag:
+        description: 'Orchestration Tag: Docker image tag for official Camunda images from Docker Hub (docker.io/camunda/camunda). When set, official Docker Hub images are used instead of building from source. Cannot be used together with reuse-tag.'
+        type: string
+        default: ""
+        required: false
       optimize-tag:
-        description: 'Docker image tag for Optimize. If not set, defaults to the Helm chart default image.'
+        description: 'Optimize Tag: Docker image tag for Optimize from Docker Hub (docker.io/camunda/optimize). When set, overrides the optimize image regardless of build mode. If not set, custom builds use the built image from the internal registry; official images use Helm chart defaults.'
         type: string
         default: ""
         required: false
       identity-tag:
-        description: 'Docker image tag for Identity. If not set, defaults to the Helm chart default image.'
+        description: 'Identity Tag: Docker image tag for Identity from Docker Hub (docker.io/camunda/identity). If not set, defaults to the Helm chart default image.'
         type: string
         default: ""
         required: false
       connectors-tag:
-        description: 'Docker image tag for Connectors. If not set, defaults to the Helm chart default image.'
+        description: 'Connectors Tag: Docker image tag for Connectors from Docker Hub (docker.io/camunda/connectors). If not set, defaults to the Helm chart default image.'
         type: string
         default: ""
         required: false
@@ -209,12 +209,12 @@ jobs:
     timeout-minutes: 5
     permissions: { }
     outputs:
-      image-tag: ${{ inputs.reuse-tag != '' && inputs.reuse-tag || steps.image-tag.outputs.image-tag }}
+      image-tag: ${{ inputs.orchestration-tag != '' && inputs.orchestration-tag || (inputs.reuse-tag != '' && inputs.reuse-tag || steps.image-tag.outputs.image-tag) }}
     steps:
-      - name: Validate official images require explicit tag
-        if: ${{ inputs.use-official-docker-images == true && inputs.reuse-tag == '' }}
+      - name: Validate mutually exclusive inputs
+        if: ${{ inputs.orchestration-tag != '' && inputs.reuse-tag != '' }}
         run: |
-          echo "::error::Invalid input combination: 'use-official-docker-images' is enabled but 'reuse-tag' is empty. Official Camunda Docker images require an explicit tag (e.g., '8.9.0-rc2') to pull from Docker Hub. Either provide a 'reuse-tag' or disable 'use-official-docker-images'."
+          echo "::error::Invalid input combination: 'orchestration-tag' and 'reuse-tag' cannot both be provided. Use 'orchestration-tag' for official Docker Hub images or 'reuse-tag' for reusing pre-built images from the internal registry."
           exit 1
       - uses: actions/checkout@v6
         with:
@@ -224,9 +224,9 @@ jobs:
         run: |
           echo "image-tag=${{ inputs.name }}-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
       - name: Validate Docker image tags exist
-        if: ${{ inputs.use-official-docker-images == true && inputs.reuse-tag != '' }}
+        if: ${{ inputs.orchestration-tag != '' || inputs.optimize-tag != '' || inputs.identity-tag != '' || inputs.connectors-tag != '' }}
         env:
-          TAG: ${{ inputs.reuse-tag }}
+          ORCHESTRATION_TAG: ${{ inputs.orchestration-tag }}
           ENABLE_OPTIMIZE: ${{ inputs.enable-optimize }}
           OPTIMIZE_TAG: ${{ inputs.optimize-tag }}
           IDENTITY_TAG: ${{ inputs.identity-tag }}
@@ -265,7 +265,9 @@ jobs:
             done
           }
 
-          validate_image "camunda/camunda:${TAG}" || exit 1
+          if [[ -n "${ORCHESTRATION_TAG}" ]]; then
+            validate_image "camunda/camunda:${ORCHESTRATION_TAG}" || exit 1
+          fi
 
           if [[ "${ENABLE_OPTIMIZE}" == "true" && -n "${OPTIMIZE_TAG}" ]]; then
             validate_image "camunda/optimize:${OPTIMIZE_TAG}" || exit 1
@@ -343,7 +345,7 @@ jobs:
   build-camunda-image:
     name: Build Camunda
     needs: calculate-image-tag
-    if: ${{ inputs.reuse-tag == '' }}
+    if: ${{ inputs.reuse-tag == '' && inputs.orchestration-tag == '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -425,7 +427,7 @@ jobs:
 
   build-load-test-images:
     name: Build Starter and Worker
-    if: ${{ inputs.reuse-tag == '' || inputs.use-official-docker-images == true }}
+    if: ${{ inputs.reuse-tag == '' || inputs.orchestration-tag != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: calculate-image-tag
@@ -522,10 +524,11 @@ jobs:
           load_test_config="$load_test_config ${{ needs.calculate-scenario-config.outputs.load-test-load }}"
           load_test_config="$load_test_config ${{ inputs.load-test-load }}"
 
-          # Resolve image registry/repository based on whether official images are used
-          image_registry="${{ inputs.use-official-docker-images && 'docker.io' || 'registry.camunda.cloud' }}"
-          camunda_repo="${{ inputs.use-official-docker-images && 'camunda/camunda' || 'team-zeebe/camunda' }}"
-          optimize_repo="${{ inputs.use-official-docker-images && 'camunda/optimize' || 'team-zeebe/optimize' }}"
+          # Resolve image registry/repository: Docker Hub when orchestration-tag is set, internal registry otherwise
+          # optimize_repo is only consumed in the custom build path where orchestration-tag is empty
+          image_registry="${{ inputs.orchestration-tag != '' && 'docker.io' || 'registry.camunda.cloud' }}"
+          camunda_repo="${{ inputs.orchestration-tag != '' && 'camunda/camunda' || 'team-zeebe/camunda' }}"
+          optimize_repo="${{ inputs.orchestration-tag != '' && 'camunda/optimize' || 'team-zeebe/optimize' }}"
           image_tag="${{ needs.calculate-image-tag.outputs.image-tag }}"
 
           # Build platform configuration
@@ -534,16 +537,14 @@ jobs:
             --set orchestration.image.repository=${camunda_repo} \
             --set orchestration.image.tag=${image_tag}"
 
-          # Append optimize image config if enabled
+          # Append optimize image config: optimize-tag wins if set, otherwise custom builds use internal registry
           if [[ "${{ inputs.enable-optimize }}" == "true" ]]; then
-            if [[ "${{ inputs.use-official-docker-images }}" == "true" ]]; then
-              # Official images: only override if an explicit optimize-tag is provided; otherwise no image override is set
-              if [[ -n "${{ inputs.optimize-tag }}" ]]; then
-                additional_platform_config+=" \
-                  --set optimize.image.tag=${{ inputs.optimize-tag }}"
-              fi
-            else
-              # Custom build: use the built image tag with full registry/repo override
+            if [[ -n "${{ inputs.optimize-tag }}" ]]; then
+              # Explicit optimize tag provided: use it directly (Docker Hub image)
+              additional_platform_config+=" \
+                --set optimize.image.tag=${{ inputs.optimize-tag }}"
+            elif [[ -z "${{ inputs.orchestration-tag }}" ]]; then
+              # Custom build without explicit optimize tag: use the built image from internal registry
               additional_platform_config+=" \
                 --set optimize.image.registry=${image_registry} \
                 --set optimize.image.repository=${optimize_repo} \
@@ -551,14 +552,14 @@ jobs:
             fi
           fi
 
-          # Append identity image config if a dedicated tag is provided (only for official images)
-          if [[ "${{ inputs.use-official-docker-images }}" == "true" && -n "${{ inputs.identity-tag }}" ]]; then
+          # Append identity image config if a dedicated tag is provided
+          if [[ -n "${{ inputs.identity-tag }}" ]]; then
             additional_platform_config+=" \
               --set identity.image.tag=${{ inputs.identity-tag }}"
           fi
 
-          # Append connectors image config if a dedicated tag is provided (only for official images)
-          if [[ "${{ inputs.use-official-docker-images }}" == "true" && -n "${{ inputs.connectors-tag }}" ]]; then
+          # Append connectors image config if a dedicated tag is provided
+          if [[ -n "${{ inputs.connectors-tag }}" ]]; then
             additional_platform_config+=" \
               --set connectors.image.tag=${{ inputs.connectors-tag }}"
           fi

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -86,6 +86,21 @@ on:
         - postgresql
         - none
         default: elasticsearch
+      optimize-tag:
+        description: 'Docker image tag for Optimize. If not set, defaults to the Helm chart default image.'
+        type: string
+        default: ""
+        required: false
+      identity-tag:
+        description: 'Docker image tag for Identity. If not set, defaults to the Helm chart default image.'
+        type: string
+        default: ""
+        required: false
+      connectors-tag:
+        description: 'Docker image tag for Connectors. If not set, defaults to the Helm chart default image.'
+        type: string
+        default: ""
+        required: false
   workflow_call:
     inputs:
       ref:
@@ -157,6 +172,21 @@ on:
         type: string
         required: false
         default: elasticsearch
+      optimize-tag:
+        description: 'Docker image tag for Optimize. If not set, defaults to the Helm chart default image.'
+        type: string
+        default: ""
+        required: false
+      identity-tag:
+        description: 'Docker image tag for Identity. If not set, defaults to the Helm chart default image.'
+        type: string
+        default: ""
+        required: false
+      connectors-tag:
+        description: 'Docker image tag for Connectors. If not set, defaults to the Helm chart default image.'
+        type: string
+        default: ""
+        required: false
 
 env:
   CLUSTER: camunda-benchmark-prod  # change this to "camunda-benchmark-dev" when experimenting
@@ -198,6 +228,9 @@ jobs:
         env:
           TAG: ${{ inputs.reuse-tag }}
           ENABLE_OPTIMIZE: ${{ inputs.enable-optimize }}
+          OPTIMIZE_TAG: ${{ inputs.optimize-tag }}
+          IDENTITY_TAG: ${{ inputs.identity-tag }}
+          CONNECTORS_TAG: ${{ inputs.connectors-tag }}
         run: |
           validate_image() {
             local image="$1"
@@ -234,8 +267,16 @@ jobs:
 
           validate_image "camunda/camunda:${TAG}" || exit 1
 
-          if [[ "${ENABLE_OPTIMIZE}" == "true" ]]; then
-            validate_image "camunda/optimize:${TAG}" || exit 1
+          if [[ "${ENABLE_OPTIMIZE}" == "true" && -n "${OPTIMIZE_TAG}" ]]; then
+            validate_image "camunda/optimize:${OPTIMIZE_TAG}" || exit 1
+          fi
+
+          if [[ -n "${IDENTITY_TAG}" ]]; then
+            validate_image "camunda/identity:${IDENTITY_TAG}" || exit 1
+          fi
+
+          if [[ -n "${CONNECTORS_TAG}" ]]; then
+            validate_image "camunda/connectors:${CONNECTORS_TAG}" || exit 1
           fi
 
   calculate-scenario-config:
@@ -495,10 +536,32 @@ jobs:
 
           # Append optimize image config if enabled
           if [[ "${{ inputs.enable-optimize }}" == "true" ]]; then
+            # Use dedicated optimize-tag only with official images; otherwise fall back to the built image tag
+            if [[ "${{ inputs.use-official-docker-images }}" == "true" && -n "${{ inputs.optimize-tag }}" ]]; then
+              optimize_tag="${{ inputs.optimize-tag }}"
+            else
+              optimize_tag="${image_tag}"
+            fi
             additional_platform_config+=" \
               --set optimize.image.registry=${image_registry} \
               --set optimize.image.repository=${optimize_repo} \
-              --set optimize.image.tag=${image_tag}"
+              --set optimize.image.tag=${optimize_tag}"
+          fi
+
+          # Append identity image config if a dedicated tag is provided (only for official images)
+          if [[ "${{ inputs.use-official-docker-images }}" == "true" && -n "${{ inputs.identity-tag }}" ]]; then
+            additional_platform_config+=" \
+              --set identity.image.registry=docker.io \
+              --set identity.image.repository=camunda/identity \
+              --set identity.image.tag=${{ inputs.identity-tag }}"
+          fi
+
+          # Append connectors image config if a dedicated tag is provided (only for official images)
+          if [[ "${{ inputs.use-official-docker-images }}" == "true" && -n "${{ inputs.connectors-tag }}" ]]; then
+            additional_platform_config+=" \
+              --set connectors.image.registry=docker.io \
+              --set connectors.image.repository=camunda/connectors \
+              --set connectors.image.tag=${{ inputs.connectors-tag }}"
           fi
 
           # Append user-provided helm values if present

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -537,7 +537,7 @@ jobs:
           # Append optimize image config if enabled
           if [[ "${{ inputs.enable-optimize }}" == "true" ]]; then
             if [[ "${{ inputs.use-official-docker-images }}" == "true" ]]; then
-              # Official images: only override if an explicit optimize-tag is provided; otherwise let Helm chart defaults apply
+              # Official images: only override if an explicit optimize-tag is provided; otherwise no image override is set
               if [[ -n "${{ inputs.optimize-tag }}" ]]; then
                 additional_platform_config+=" \
                   --set optimize.image.tag=${{ inputs.optimize-tag }}"

--- a/.github/workflows/camunda-release-load-test.yaml
+++ b/.github/workflows/camunda-release-load-test.yaml
@@ -1,7 +1,12 @@
-# description: Create a Camunda load test for a given release.
-#              Abstraction layer of the actual load test creation process, to define a clear API between release process and the load test workflows.
-#              Public API - accepting inputs for test name and tag.
-#              Called by: camunda-scheduled-release-load-tests.yml (daily schedule)
+# description: Creates a load test for official release images. Abstraction layer between
+#              the release process and the load test infrastructure, with a simple public API
+#              accepting name, tag, and optional per-component image tags as inputs.
+#              Uses official Docker images with scenario: realistic.
+# called-by: camunda-scheduled-release-load-tests.yml (daily schedule),
+#            release BPMN process (workflow_dispatch via GitHub API)
+# calls: camunda-load-test.yml (use-official-docker-images: true, scenario: realistic)
+# note: Verification and namespace cleanup are handled externally by the scheduled workflow
+#       via camunda-verify-and-cleanup-load-test.yml, not by this workflow.
 # type: CI
 # owner @camunda/reliability-testing
 name: Camunda Release load test workflow

--- a/.github/workflows/camunda-release-load-test.yaml
+++ b/.github/workflows/camunda-release-load-test.yaml
@@ -16,6 +16,21 @@ on:
         description: 'Specifies the tag that should be used for the release load test'
         type: string
         required: true
+      optimize-tag:
+        description: 'Docker image tag for Optimize. If not set, defaults to the Helm chart default image.'
+        type: string
+        default: ""
+        required: false
+      identity-tag:
+        description: 'Docker image tag for Identity. If not set, defaults to the Helm chart default image.'
+        type: string
+        default: ""
+        required: false
+      connectors-tag:
+        description: 'Docker image tag for Connectors. If not set, defaults to the Helm chart default image.'
+        type: string
+        default: ""
+        required: false
   workflow_call:
     inputs:
       name:
@@ -26,6 +41,21 @@ on:
         description: 'Specifies the tag that should be used for the release load test'
         type: string
         required: true
+      optimize-tag:
+        description: 'Docker image tag for Optimize. If not set, defaults to the Helm chart default image.'
+        type: string
+        default: ""
+        required: false
+      identity-tag:
+        description: 'Docker image tag for Identity. If not set, defaults to the Helm chart default image.'
+        type: string
+        default: ""
+        required: false
+      connectors-tag:
+        description: 'Docker image tag for Connectors. If not set, defaults to the Helm chart default image.'
+        type: string
+        default: ""
+        required: false
 
 defaults:
   run:
@@ -76,6 +106,9 @@ jobs:
       ttl: 60
       use-official-docker-images: true
       scenario: 'realistic'
+      optimize-tag: ${{ inputs.optimize-tag }}
+      identity-tag: ${{ inputs.identity-tag }}
+      connectors-tag: ${{ inputs.connectors-tag }}
 
   notify-on-failure:
     name: Notify on failure

--- a/.github/workflows/camunda-release-load-test.yaml
+++ b/.github/workflows/camunda-release-load-test.yaml
@@ -1,10 +1,11 @@
 # description: Creates a load test for official release images. Abstraction layer between
 #              the release process and the load test infrastructure, with a simple public API
-#              accepting name, tag, and optional per-component image tags as inputs.
+#              accepting required name and tag inputs plus optional per-component
+#              tag overrides: optimize-tag, identity-tag, and connectors-tag.
 #              Uses official Docker images with scenario: realistic.
 # called-by: camunda-scheduled-release-load-tests.yml (daily schedule),
 #            release BPMN process (workflow_dispatch via GitHub API)
-# calls: camunda-load-test.yml (use-official-docker-images: true, scenario: realistic)
+# calls: camunda-load-test.yml (orchestration-tag: <tag>, scenario: realistic)
 # note: Verification and namespace cleanup are handled externally by the scheduled workflow
 #       via camunda-verify-and-cleanup-load-test.yml, not by this workflow.
 # type: CI
@@ -107,9 +108,8 @@ jobs:
     with:
       name: ${{ needs.sanitize-inputs.outputs.sanitized-name }}
       ref: stable/8.9
-      reuse-tag: ${{ needs.sanitize-inputs.outputs.test-tag }}
+      orchestration-tag: ${{ inputs.tag }}
       ttl: 60
-      use-official-docker-images: true
       scenario: 'realistic'
       optimize-tag: ${{ inputs.optimize-tag }}
       identity-tag: ${{ inputs.identity-tag }}

--- a/docs/testing/reliability-testing.md
+++ b/docs/testing/reliability-testing.md
@@ -194,6 +194,48 @@ As of today (16 Jun 2025), we have load tests running:
 * One rolling release test, which is always updated
   * Release-rolling
 
+##### Architecture
+
+The release load test workflow acts as an abstraction layer between the release process and the underlying load test infrastructure, with a simple public API accepting `name` and `tag` as required inputs, plus optional per-component image tag overrides (`optimize-tag`, `identity-tag`, `connectors-tag`).
+
+```mermaid
+graph TD
+    subgraph "Callers"
+        BPMN["Release Process<br/>(BPMN)"]
+        SCHEDULE["Scheduled Smoke Tests<br/>(daily 04:00 UTC)"]
+    end
+
+    subgraph "Abstraction Layer — camunda-release-load-test.yaml"
+        direction TB
+        API["Public API<br/>inputs: name, tag<br/>optional: optimize-tag, identity-tag, connectors-tag"]
+        SANITIZE["Sanitize inputs"]
+        API --> SANITIZE
+    end
+
+    subgraph "Implementation — camunda-load-test.yml"
+        LOAD["Create load test cluster<br/>• use-official-docker-images: true<br/>• scenario: realistic<br/>• ttl: 60 days"]
+    end
+
+    BPMN -->|"workflow_dispatch<br/>name + tag"| API
+    SCHEDULE -->|"workflow_call @stable/8.x<br/>name + tag"| API
+    SANITIZE --> LOAD
+
+    subgraph "Verification — camunda-verify-and-cleanup-load-test.yml"
+        VERIFY["await-load-test action<br/>• pod readiness<br/>• gateway connectivity"]
+        CLEANUP["Delete namespace"]
+        VERIFY --> CLEANUP
+    end
+
+    SCHEDULE -->|"after load test"| VERIFY
+```
+
+This decoupling provides several benefits:
+
+* **Clear API**: The release process only needs to provide a test name and tag (with optional per-component image tags) — implementation details (official images, realistic scenario, TTL) are encapsulated in the release load test workflow
+* **Independent evolution**: Changes to load test infrastructure (helm values, Makefiles, scripts) don't require changes to the release process BPMN
+* **Per-branch workflows**: Each stable branch has its own copy of the release load test workflow (via backports), ensuring the correct infrastructure files are used for each version
+* **Daily smoke tests**: The [scheduled release load test workflow](https://github.com/camunda/camunda/blob/main/.github/workflows/camunda-scheduled-release-load-tests.yml) validates daily that release load tests can be created for all active stable branches
+
 ##### Setup and integration
 
 The release load tests are created as part of the [release process](https://github.com/camunda/zeebe-engineering-processes/blob/main/src/main/resources/release/setup_benchmark.bpmn#L7-L18).

--- a/docs/testing/reliability-testing.md
+++ b/docs/testing/reliability-testing.md
@@ -213,7 +213,7 @@ graph TD
     end
 
     subgraph "Implementation — camunda-load-test.yml"
-        LOAD["Create load test cluster<br/>• use-official-docker-images: true<br/>• scenario: realistic<br/>• ttl: 60 days"]
+        LOAD["Create load test cluster<br/>• orchestration-tag: &lt;tag&gt;<br/>• scenario: realistic<br/>• ttl: 60 days"]
     end
 
     BPMN -->|"workflow_dispatch<br/>name + tag"| API

--- a/docs/testing/reliability-testing.md
+++ b/docs/testing/reliability-testing.md
@@ -258,8 +258,10 @@ An example payload looks like this:
     "ref": workflow_ref_name,
     "inputs": {
       "name": benchmark_name,
-      "ref": zeebe_ref_name,
-      "stable-vms": stable_vms
+      "tag": release_tag,
+      "optimize-tag": "optional, Docker Hub tag for Optimize",
+      "identity-tag": "optional, Docker Hub tag for Identity",
+      "connectors-tag": "optional, Docker Hub tag for Connectors"
     }
 }
 ```

--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -13,3 +13,81 @@ More details can also be found in our [reliability testing documentation](../doc
 * [Run a load test](setup/README.md)
 * [Change the Project](project/README.md)
 
+### Via GitHub Actions (recommended)
+
+Trigger the [Camunda load test workflow](https://github.com/camunda/camunda/actions/workflows/camunda-load-test.yml) via the UI. Select a branch, name your test, and choose a scenario.
+
+### Via Makefile (manual)
+
+```bash
+cd load-tests/setup
+./newLoadTest.sh <name> <storage-type> <ttl-days> <enable-optimize>
+cd <name>
+make install
+```
+
+See the [setup README](setup/README.md) for full details.
+
+## Workflow Overview
+
+All automated load tests flow through `camunda-load-test.yml`, which builds images and deploys via the same Makefiles used for manual deployments.
+
+```mermaid
+graph TD
+    subgraph "Scheduled Triggers"
+        SCHEDULED["camunda-scheduled-release-<br/>load-tests.yml<br/><i>Daily 04:00 UTC</i>"]
+        DAILY["camunda-daily-load-tests.yml<br/><i>Daily 04:00 UTC</i>"]
+        WEEKLY["camunda-weekly-load-tests.yml<br/><i>Monday 01:00 UTC</i>"]
+        ROLLING["zeebe-update-long-running-<br/>migrating-benchmark.yaml<br/><i>Monday 00:00 UTC</i>"]
+        CLEANUP["camunda-load-test-clean-up.yml<br/><i>Daily 04:00 UTC</i>"]
+    end
+
+    subgraph "Event Triggers"
+        PR["camunda-pr-load-test.yaml<br/><i>PR label: benchmark</i>"]
+        ADHOC["Manual workflow_dispatch"]
+    end
+
+    subgraph "Reusable Workflows"
+        RELEASE["camunda-release-load-test.yaml<br/><i>workflow_call</i>"]
+        CORE["camunda-load-test.yml<br/><i>workflow_call + workflow_dispatch</i>"]
+        VERIFY["camunda-verify-and-cleanup-<br/>load-test.yml<br/><i>workflow_call</i>"]
+        PROFILE["profile-load-test.yml<br/><i>workflow_call + workflow_dispatch</i>"]
+    end
+
+    subgraph "Deployment Layer"
+        MAKEFILE["load-tests/setup/<br/><b>Makefile</b><br/><i>make install / make clean</i>"]
+    end
+
+    subgraph "Infrastructure"
+        GKE["GKE Cluster<br/>camunda-benchmark-prod"]
+    end
+
+    SCHEDULED -- "one job per stable branch<br/>+ main, official images" --> RELEASE
+    SCHEDULED -- "verify + delete namespace" --> VERIFY
+    DAILY -- "scenario: max" --> CORE
+    WEEKLY -- "4 parallel calls:<br/>typical, realistic,<br/>rdbms-realistic, latency" --> CORE
+    ROLLING -- "latest release tag<br/>custom helm values" --> CORE
+    RELEASE -- "scenario: realistic<br/>orchestration-tag" --> CORE
+    PR -- "scenario: max" --> CORE
+    PR -- "after 15min wait" --> PROFILE
+    ADHOC --> CORE
+    ADHOC --> RELEASE
+
+    CORE -- "newLoadTest.sh + make install" --> MAKEFILE
+    MAKEFILE -- "Helm install" --> GKE
+    PROFILE -- "async-profiler" --> GKE
+    VERIFY -- "kubectl wait + delete" --> GKE
+    CLEANUP -- "kubectl delete expired ns" --> GKE
+```
+
+### Schedule
+
+|       Time       |                       Workflow                       | Frequency |
+|------------------|------------------------------------------------------|-----------|
+| 00:00 UTC Monday | `zeebe-update-long-running-migrating-benchmark.yaml` | Weekly    |
+| 01:00 UTC Monday | `camunda-weekly-load-tests.yml`                      | Weekly    |
+| 04:00 UTC        | `camunda-scheduled-release-load-tests.yml`           | Daily     |
+| 04:00 UTC        | `camunda-daily-load-tests.yml`                       | Daily     |
+| 04:00 UTC        | `camunda-load-test-clean-up.yml`                     | Daily     |
+
+For detailed inputs, triggers, and job definitions, see each workflow's header comments in [`.github/workflows/`](../.github/workflows/). For branch-specific path differences, see [directory structure history](docs/directory-structure.md).


### PR DESCRIPTION
# Description
Backport of #50417 to `stable/8.9`.

relates to #50323