### PR TITLE
[Backport stable/8.9] fix: graceful schema initialization and add readiness check

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/search/SchemaReadinessCheck.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SchemaReadinessCheck.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.search;
+
+import io.camunda.search.schema.SchemaManagerContainer;
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.boot.health.contributor.HealthIndicator;
+
+public class SchemaReadinessCheck implements HealthIndicator {
+
+  public static final String SCHEMA_READINESS_CHECK = "schemaReadinessCheck";
+  private final SchemaManagerContainer schemaManagerContainer;
+
+  public SchemaReadinessCheck(final SchemaManagerContainer schemaManagerContainer) {
+    this.schemaManagerContainer = schemaManagerContainer;
+  }
+
+  @Override
+  public Health health() {
+    return (schemaManagerContainer.isInitialized() ? Health.up() : Health.down()).build();
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/search/SchemaReadinessCheckConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SchemaReadinessCheckConfiguration.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.search;
+
+import io.camunda.application.commons.condition.ConditionalOnAnyHttpGatewayEnabled;
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
+import io.camunda.configuration.conditions.ConditionalOnSecondaryStorageType;
+import io.camunda.search.schema.SchemaManagerContainer;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnAnyHttpGatewayEnabled
+@ConditionalOnSecondaryStorageType({
+  SecondaryStorageType.elasticsearch,
+  SecondaryStorageType.opensearch
+})
+public class SchemaReadinessCheckConfiguration {
+
+  @Bean
+  @Qualifier(SchemaReadinessCheck.SCHEMA_READINESS_CHECK)
+  public SchemaReadinessCheck schemaReadinessCheck(
+      final SchemaManagerContainer schemaManagerContainer) {
+    return new SchemaReadinessCheck(schemaManagerContainer);
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchEngineSchemaInitializer.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchEngineSchemaInitializer.java
@@ -13,6 +13,7 @@ import io.camunda.search.schema.SchemaManagerContainer;
 import io.camunda.search.schema.config.SearchEngineConfiguration;
 import io.camunda.search.schema.metrics.SchemaManagerMetrics;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
+import io.camunda.zeebe.util.VisibleForTesting;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
@@ -56,7 +57,8 @@ public class SearchEngineSchemaInitializer implements InitializingBean, SchemaMa
     }
   }
 
-  private void synchronousSchemaInitialization(
+  @VisibleForTesting
+  void synchronousSchemaInitialization(
       final CompletableFuture<Void> future, final ExecutorService executor) throws Exception {
     try {
       future.get();
@@ -66,11 +68,15 @@ public class SearchEngineSchemaInitializer implements InitializingBean, SchemaMa
           "Schema initialization task was interrupted. Shutdown signal is caught={}",
           isShutdown.get(),
           ie);
-      Thread.currentThread().interrupt();
+      if (!isShutdown.get()) {
+        // Only re-interrupt if this is not a shutdown-triggered interrupt.
+        // During shutdown, we must let Spring finish context refresh so that
+        // Broker can perform a graceful shutdown.
+        Thread.currentThread().interrupt();
+      }
     } catch (final Exception e) {
       if (isShutdown.get()) {
         LOGGER.debug("Schema initialization interrupted with shutdown.", e);
-        Thread.currentThread().interrupt();
         return;
       }
       throw e;
@@ -79,7 +85,8 @@ public class SearchEngineSchemaInitializer implements InitializingBean, SchemaMa
     }
   }
 
-  private void asyncSchemaInitialization(
+  @VisibleForTesting
+  void asyncSchemaInitialization(
       final CompletableFuture<Void> future, final ExecutorService executor) {
     future.whenCompleteAsync(
         (result, error) -> {

--- a/dist/src/main/java/io/camunda/application/initializers/HealthConfigurationInitializer.java
+++ b/dist/src/main/java/io/camunda/application/initializers/HealthConfigurationInitializer.java
@@ -8,6 +8,7 @@
 package io.camunda.application.initializers;
 
 import io.camunda.application.Profile;
+import io.camunda.application.commons.search.SchemaReadinessCheck;
 import io.camunda.spring.utils.DatabaseTypeUtils;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -132,8 +133,8 @@ public class HealthConfigurationInitializer
     final var healthIndicators = new ArrayList<String>();
 
     if (activeProfiles.contains(Profile.BROKER.getId())) {
-      healthIndicators.add("brokerReady");
-      healthIndicators.add("nodeIdProviderReady");
+      healthIndicators.add(INDICATOR_BROKER_READY);
+      healthIndicators.add(INDICATOR_NODE_ID_PROVIDER_READY);
     }
 
     if (activeProfiles.contains(Profile.GATEWAY.getId())) {
@@ -161,12 +162,18 @@ public class HealthConfigurationInitializer
     }
 
     if (secondaryStorageEnabled) {
-      if (Profile.getWebappProfiles().stream()
-          .map(Profile::getId)
-          .anyMatch(activeProfiles::contains)) {
+      final boolean isWebappProfile =
+          Profile.getWebappProfiles().stream().anyMatch(p -> activeProfiles.contains(p.getId()));
+      if (isWebappProfile) {
         healthIndicators.add(INDICATOR_SPRING_READINESS_STATE);
       }
       if (DatabaseTypeUtils.isRdbmsDisabled(env)) {
+        if (isAnyHttpGatewayEnabled(env)
+            && (isWebappProfile
+                || activeProfiles.contains(Profile.GATEWAY.getId())
+                || activeProfiles.contains(Profile.BROKER.getId()))) {
+          healthIndicators.add(SchemaReadinessCheck.SCHEMA_READINESS_CHECK);
+        }
         if (activeProfiles.contains(Profile.OPERATE.getId())) {
           healthIndicators.add("indicesCheck");
         }
@@ -177,5 +184,15 @@ public class HealthConfigurationInitializer
     }
 
     return healthIndicators;
+  }
+
+  /**
+   * Same condition as {@link
+   * io.camunda.application.commons.condition.ConditionalOnAnyHttpGatewayEnabled}
+   */
+  private boolean isAnyHttpGatewayEnabled(final Environment env) {
+    return env.getProperty("zeebe.broker.gateway.enable", Boolean.class, true)
+        && (env.getProperty("camunda.rest.enabled", Boolean.class, true)
+            || env.getProperty("camunda.mcp.enabled", Boolean.class, false));
   }
 }

--- a/dist/src/test/java/io/camunda/application/StartCamundaDockerIT.java
+++ b/dist/src/test/java/io/camunda/application/StartCamundaDockerIT.java
@@ -56,6 +56,7 @@ public class StartCamundaDockerIT extends AbstractCamundaDockerIT {
                 "nodeIdProvider":{"status":"UP"},
                 "nodeIdProviderReady":{"status":"UP"},
                 "readinessState": {"status": "UP"},
+                "schemaReadinessCheck":{"status":"UP"},
                 "searchEngineCheck": {"status": "UP"}
               },
               "groups": ["liveness", "readiness", "startup", "status"]
@@ -74,6 +75,7 @@ public class StartCamundaDockerIT extends AbstractCamundaDockerIT {
                 "indicesCheck": {"status": "UP"},
                 "nodeIdProviderReady": {"status": "UP"},
                 "readinessState": {"status": "UP"},
+                "schemaReadinessCheck":{"status":"UP"},
                 "searchEngineCheck": {"status": "UP"}
               }
             }

--- a/dist/src/test/java/io/camunda/application/commons/search/SearchEngineSchemaInitializerTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/search/SearchEngineSchemaInitializerTest.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.search;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.lang.reflect.Field;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class SearchEngineSchemaInitializerTest {
+
+  private SearchEngineSchemaInitializer createInitializer() {
+    return new SearchEngineSchemaInitializer(null, new SimpleMeterRegistry(), true);
+  }
+
+  /** Sets the private {@code isShutdown} flag on the initializer via reflection. */
+  private static void setShutdown(
+      final SearchEngineSchemaInitializer initializer, final boolean value) {
+    try {
+      final Field field = SearchEngineSchemaInitializer.class.getDeclaredField("isShutdown");
+      field.setAccessible(true);
+      ((AtomicBoolean) field.get(initializer)).set(value);
+    } catch (final ReflectiveOperationException e) {
+      throw new RuntimeException("Failed to set isShutdown via reflection", e);
+    }
+  }
+
+  @Nested
+  class SynchronousInitialization {
+
+    private ExecutorService executor;
+
+    @AfterEach
+    void tearDown() {
+      if (executor != null && !executor.isShutdown()) {
+        executor.shutdownNow();
+      }
+      // Clear interrupt flag to avoid leaking to other tests
+      Thread.interrupted();
+    }
+
+    @Test
+    void shouldCompleteSuccessfully() throws Exception {
+      // given
+      final var initializer = createInitializer();
+      executor = Executors.newSingleThreadExecutor();
+      final var future = CompletableFuture.completedFuture((Void) null);
+
+      // when
+      initializer.synchronousSchemaInitialization(future, executor);
+
+      // then — no exception thrown, executor is closed
+      assertThat(executor.isShutdown()).isTrue();
+    }
+
+    @Test
+    void shouldNotInterruptThreadOnShutdownTriggeredInterrupt() throws Exception {
+      // given — simulate shutdown-triggered interrupt
+      final var initializer = createInitializer();
+      executor = Executors.newSingleThreadExecutor();
+      setShutdown(initializer, true);
+
+      // Use an incomplete future so that future.get() blocks and sees the interrupt flag
+      final var blockingFuture = new CompletableFuture<Void>();
+
+      // when — interrupt the thread so future.get() throws InterruptedException
+      Thread.currentThread().interrupt();
+      initializer.synchronousSchemaInitialization(blockingFuture, executor);
+
+      // then — thread should NOT be interrupted (shutdown swallows the interrupt)
+      assertThat(Thread.currentThread().isInterrupted()).isFalse();
+      assertThat(executor.isShutdown()).isTrue();
+    }
+
+    @Test
+    void shouldReInterruptThreadOnNonShutdownInterrupt() throws Exception {
+      // given — NOT a shutdown, something else interrupted
+      final var initializer = createInitializer();
+      executor = Executors.newSingleThreadExecutor();
+      // isShutdown remains false (default)
+
+      final var blockingFuture = new CompletableFuture<Void>();
+
+      // when — interrupt the current thread so future.get() throws InterruptedException
+      Thread.currentThread().interrupt();
+      initializer.synchronousSchemaInitialization(blockingFuture, executor);
+
+      // then — thread should be re-interrupted
+      assertThat(Thread.currentThread().isInterrupted()).isTrue();
+      assertThat(executor.isShutdown()).isTrue();
+    }
+
+    @Test
+    void shouldSuppressExceptionDuringShutdown() {
+      // given — shutdown is in progress and the future fails with a non-interrupt exception.
+      // CompletableFuture.get() wraps the cause in ExecutionException, which falls into
+      // the catch(Exception) block where isShutdown=true causes a silent return.
+      final var initializer = createInitializer();
+      executor = Executors.newSingleThreadExecutor();
+      setShutdown(initializer, true);
+
+      final var future = new CompletableFuture<Void>();
+      future.completeExceptionally(new RuntimeException("ES connection failed"));
+
+      // when/then — should not throw, exception is suppressed during shutdown
+      assertThatNoException()
+          .isThrownBy(() -> initializer.synchronousSchemaInitialization(future, executor));
+      assertThat(executor.isShutdown()).isTrue();
+    }
+
+    @Test
+    void shouldPropagateExceptionWhenNotShutdown() {
+      // given — NOT a shutdown, the future fails with a real error.
+      // CompletableFuture.get() wraps the cause in ExecutionException.
+      final var initializer = createInitializer();
+      executor = Executors.newSingleThreadExecutor();
+      // isShutdown remains false
+
+      final var cause = new RuntimeException("ES connection refused");
+      final var future = new CompletableFuture<Void>();
+      future.completeExceptionally(cause);
+
+      // when/then — ExecutionException wrapping the cause should propagate
+      assertThatThrownBy(() -> initializer.synchronousSchemaInitialization(future, executor))
+          .isInstanceOf(ExecutionException.class)
+          .hasCause(cause);
+      assertThat(executor.isShutdown()).isTrue();
+    }
+
+    @Test
+    void shouldAlwaysCloseExecutorEvenOnException() {
+      // given
+      final var initializer = createInitializer();
+      executor = Executors.newSingleThreadExecutor();
+
+      final var future = new CompletableFuture<Void>();
+      future.completeExceptionally(new RuntimeException("schema init failed"));
+
+      // when
+      try {
+        initializer.synchronousSchemaInitialization(future, executor);
+      } catch (final Exception ignored) {
+        // expected
+      }
+
+      // then — executor must be closed regardless
+      assertThat(executor.isShutdown()).isTrue();
+    }
+
+    @Test
+    void shouldAlwaysCloseExecutorOnInterrupt() throws Exception {
+      // given
+      final var initializer = createInitializer();
+      executor = Executors.newSingleThreadExecutor();
+
+      final var blockingFuture = new CompletableFuture<Void>();
+      Thread.currentThread().interrupt();
+
+      // when
+      initializer.synchronousSchemaInitialization(blockingFuture, executor);
+
+      // then — executor must be closed regardless
+      assertThat(executor.isShutdown()).isTrue();
+    }
+  }
+
+  @Nested
+  class AsynchronousInitialization {
+
+    @Test
+    void shouldCloseExecutorOnSuccess() throws Exception {
+      // given
+      final var initializer = createInitializer();
+      final var executor = Executors.newSingleThreadExecutor();
+      final var future = CompletableFuture.completedFuture((Void) null);
+
+      // when
+      initializer.asyncSchemaInitialization(future, executor);
+
+      // then — wait a bit for the whenCompleteAsync callback to run
+      executor.awaitTermination(2, TimeUnit.SECONDS);
+      assertThat(executor.isShutdown()).isTrue();
+    }
+
+    @Test
+    void shouldCloseExecutorOnFailure() throws Exception {
+      // given
+      final var initializer = createInitializer();
+      final var executor = Executors.newSingleThreadExecutor();
+      final var future = new CompletableFuture<Void>();
+      future.completeExceptionally(new RuntimeException("ES unavailable"));
+
+      // when
+      initializer.asyncSchemaInitialization(future, executor);
+
+      // then — wait a bit for the whenCompleteAsync callback to run
+      executor.awaitTermination(2, TimeUnit.SECONDS);
+      assertThat(executor.isShutdown()).isTrue();
+    }
+  }
+}

--- a/dist/src/test/java/io/camunda/application/initializers/HealthConfigurationInitializerTest.java
+++ b/dist/src/test/java/io/camunda/application/initializers/HealthConfigurationInitializerTest.java
@@ -45,6 +45,17 @@ class HealthConfigurationInitializerTest {
     when(environment.getProperty("camunda.data.secondary-storage.type")).thenReturn("none");
   }
 
+  private void withEmbeddedGateway(final boolean enabled) {
+    when(environment.getProperty("zeebe.broker.gateway.enable", Boolean.class, true))
+        .thenReturn(enabled);
+  }
+
+  private void withHttpGatewayEnabled() {
+    withEmbeddedGateway(true);
+    when(environment.getProperty("camunda.rest.enabled", Boolean.class, true)).thenReturn(true);
+    when(environment.getProperty("camunda.mcp.enabled", Boolean.class, false)).thenReturn(false);
+  }
+
   @Nested
   class LivenessGroup {
 
@@ -153,6 +164,7 @@ class HealthConfigurationInitializerTest {
     void shouldIncludeReadinessStateForAnyWebappProfile(final String profile) {
       // given — Identity is a webapp profile, should get readinessState
       withElasticsearchSecondaryStorage();
+      withHttpGatewayEnabled();
       final var profiles = List.of(profile);
 
       // when
@@ -160,13 +172,14 @@ class HealthConfigurationInitializerTest {
           initializer.collectReadinessGroupHealthIndicators(profiles, environment);
 
       // then
-      assertThat(indicators).contains("readinessState");
+      assertThat(indicators).contains("readinessState", "schemaReadinessCheck");
     }
 
     @Test
     void shouldNotDuplicateReadinessStateForMultipleWebappProfiles() {
       // given
       withElasticsearchSecondaryStorage();
+      withHttpGatewayEnabled();
       final var profiles = Profile.getWebappProfiles().stream().map(Profile::getId).toList();
 
       // when
@@ -175,12 +188,15 @@ class HealthConfigurationInitializerTest {
 
       // then — readinessState should appear exactly once
       assertThat(indicators.stream().filter("readinessState"::equals)).hasSize(1);
+      // then — schemaReadinessCheck should appear exactly once
+      assertThat(indicators.stream().filter("schemaReadinessCheck"::equals)).hasSize(1);
     }
 
     @Test
     void shouldIncludeIndicesCheckForOperateWithES() {
       // given
       withElasticsearchSecondaryStorage();
+      withHttpGatewayEnabled();
       final var profiles = List.of(Profile.OPERATE.getId());
 
       // when
@@ -188,13 +204,14 @@ class HealthConfigurationInitializerTest {
           initializer.collectReadinessGroupHealthIndicators(profiles, environment);
 
       // then
-      assertThat(indicators).contains("readinessState", "indicesCheck");
+      assertThat(indicators).contains("readinessState", "indicesCheck", "schemaReadinessCheck");
     }
 
     @Test
     void shouldIncludeSearchEngineCheckForTasklistWithES() {
       // given
       withElasticsearchSecondaryStorage();
+      withHttpGatewayEnabled();
       final var profiles = List.of(Profile.TASKLIST.getId());
 
       // when
@@ -202,7 +219,8 @@ class HealthConfigurationInitializerTest {
           initializer.collectReadinessGroupHealthIndicators(profiles, environment);
 
       // then
-      assertThat(indicators).contains("readinessState", "searchEngineCheck");
+      assertThat(indicators)
+          .contains("readinessState", "searchEngineCheck", "schemaReadinessCheck");
     }
 
     @Test
@@ -218,7 +236,7 @@ class HealthConfigurationInitializerTest {
       // then
       assertThat(indicators)
           .contains("readinessState")
-          .doesNotContain("indicesCheck", "searchEngineCheck");
+          .doesNotContain("indicesCheck", "searchEngineCheck", "schemaReadinessCheck");
     }
 
     @Test
@@ -233,6 +251,131 @@ class HealthConfigurationInitializerTest {
 
       // then
       assertThat(indicators).isEmpty();
+    }
+
+    @Test
+    void shouldIncludeSchemaReadinessCheckForGatewayWithES() {
+      // given
+      withElasticsearchSecondaryStorage();
+      withHttpGatewayEnabled();
+      final var profiles = List.of(Profile.GATEWAY.getId());
+
+      // when
+      final var indicators =
+          initializer.collectReadinessGroupHealthIndicators(profiles, environment);
+
+      // then
+      assertThat(indicators).contains("gatewayStarted", "schemaReadinessCheck");
+    }
+
+    @Test
+    void shouldIncludeSchemaReadinessCheckForBrokerWithEmbeddedGatewayEnabled() {
+      // given
+      withElasticsearchSecondaryStorage();
+      withHttpGatewayEnabled();
+      final var profiles = List.of(Profile.BROKER.getId());
+
+      // when
+      final var indicators =
+          initializer.collectReadinessGroupHealthIndicators(profiles, environment);
+
+      // then
+      assertThat(indicators).contains("brokerReady", "nodeIdProviderReady", "schemaReadinessCheck");
+    }
+
+    @Test
+    void shouldNotIncludeSchemaReadinessCheckForBrokerWithEmbeddedGatewayDisabled() {
+      // given
+      withElasticsearchSecondaryStorage();
+      withEmbeddedGateway(false);
+      final var profiles = List.of(Profile.BROKER.getId());
+
+      // when
+      final var indicators =
+          initializer.collectReadinessGroupHealthIndicators(profiles, environment);
+
+      // then
+      assertThat(indicators)
+          .contains("brokerReady", "nodeIdProviderReady")
+          .doesNotContain("schemaReadinessCheck");
+    }
+
+    @Test
+    void shouldNotIncludeSchemaReadinessCheckWithNoSecondaryStorage() {
+      // given
+      withNoSecondaryStorage();
+      final var profiles = List.of(Profile.GATEWAY.getId());
+
+      // when
+      final var indicators =
+          initializer.collectReadinessGroupHealthIndicators(profiles, environment);
+
+      // then
+      assertThat(indicators).contains("gatewayStarted").doesNotContain("schemaReadinessCheck");
+    }
+
+    @Test
+    void shouldNotIncludeSchemaReadinessCheckWithRdbms() {
+      // given
+      withRdbmsSecondaryStorage();
+      final var profiles = List.of(Profile.GATEWAY.getId());
+
+      // when
+      final var indicators =
+          initializer.collectReadinessGroupHealthIndicators(profiles, environment);
+
+      // then
+      assertThat(indicators).contains("gatewayStarted").doesNotContain("schemaReadinessCheck");
+    }
+
+    @Test
+    void shouldIncludeSchemaReadinessCheckForBrokerWithGatewayProfileAndES() {
+      // given — broker + gateway profiles with ES secondary storage and gateway enabled
+      withElasticsearchSecondaryStorage();
+      withHttpGatewayEnabled();
+      final var profiles = List.of(Profile.BROKER.getId(), Profile.GATEWAY.getId());
+
+      // when
+      final var indicators =
+          initializer.collectReadinessGroupHealthIndicators(profiles, environment);
+
+      // then — schemaReadinessCheck should be included because gateway is enabled
+      assertThat(indicators)
+          .contains("brokerReady", "nodeIdProviderReady", "gatewayStarted", "schemaReadinessCheck");
+    }
+
+    @Test
+    void shouldIncludeSchemaReadinessCheckForBrokerWithGatewayProfileAndEmbeddedGatewayDisabled() {
+      // given — broker + gateway profiles, embedded gateway disabled but gateway profile active
+      withElasticsearchSecondaryStorage();
+      withEmbeddedGateway(false);
+      when(environment.getProperty("camunda.rest.enabled", Boolean.class, true)).thenReturn(true);
+      when(environment.getProperty("camunda.mcp.enabled", Boolean.class, false)).thenReturn(false);
+      final var profiles = List.of(Profile.BROKER.getId(), Profile.GATEWAY.getId());
+
+      // when
+      final var indicators =
+          initializer.collectReadinessGroupHealthIndicators(profiles, environment);
+
+      // then — schemaReadinessCheck NOT included because isAnyHttpGatewayEnabled is false
+      assertThat(indicators)
+          .contains("brokerReady", "nodeIdProviderReady", "gatewayStarted")
+          .doesNotContain("schemaReadinessCheck");
+    }
+
+    @Test
+    void shouldNotIncludeSchemaReadinessCheckWithoutRelevantProfile() {
+      // given — ES storage and gateway enabled, but no broker/gateway/webapp profile
+      withElasticsearchSecondaryStorage();
+      withHttpGatewayEnabled();
+      final var profiles = List.of(Profile.RESTORE.getId());
+
+      // when
+      final var indicators =
+          initializer.collectReadinessGroupHealthIndicators(profiles, environment);
+
+      // then — no schemaReadinessCheck because no relevant profile is active
+      assertThat(indicators).doesNotContain("schemaReadinessCheck");
     }
   }
 }


### PR DESCRIPTION
# Description
Backport of #48939 to `stable/8.9`.

relates to camunda/camunda#48718 #43266