### PR TITLE
[Backport stable/8.6] fix: align OpenSearch load test config with Elasticsearch settings

### DIFF
--- a/load-tests/camunda-platform-values-opensearch.yaml
+++ b/load-tests/camunda-platform-values-opensearch.yaml
@@ -1,0 +1,96 @@
+########################################################################################
+################################################### Global cluster configuration
+########################################################################################
+global:
+  elasticsearch:
+    enabled: false
+
+  opensearch:
+    enabled: true
+    url:
+      protocol: http
+      host: "opensearch"
+      port: 9200
+
+########################################################################################
+################################################### Orchestration cluster configuration
+########################################################################################
+orchestration:
+  # We need to explicitly set the secondary storage type to OpenSearch
+  # overriding the default value of elasticsearch
+  data:
+    secondaryStorage:
+      type: opensearch
+
+#################################################################################################
+################################################### Disable Elasticsearch when using OpenSearch
+#################################################################################################
+elasticsearch:
+  enabled: false
+
+###########################################################################
+#######
+#     # #####  ###### #    #  ####  ######   ##   #####   ####  #    #
+#     # #    # #      ##   # #      #       #  #  #    # #    # #    #
+#     # #####  #####  # #  #  ####  #####  #    # #    # #      ######
+#     # #      #      #  # #      # #      ###### #####  #      #    #
+#     # #      #      #   ## #    # #      #    # #   #  #    # #    #
+####### #      ###### #    #  ####  ###### #    # #    #  ####  #    #
+###########################################################################
+
+# Override values for https://github.com/opensearch-project/helm-charts
+
+clusterName: "opensearch"
+nameOverride: "opensearch"
+masterService: "opensearch"
+
+majorVersion: "2.19.0"
+
+replicas: 3
+
+config:
+  opensearch.yml: |
+    cluster.name: opensearch
+    network.host: 0.0.0.0
+    plugins.security.disabled: true
+    # Disable deprecation logging to avoid filling up the logs with warnings about deprecated features that we might be using in our tests
+    logger.org.opensearch.deprecation: "OFF"
+
+extraEnvs:
+  - name: OPENSEARCH_INITIAL_ADMIN_PASSWORD
+    value: "yourStrongPassword123!"
+
+opensearchJavaOpts: "-Xms3g -Xmx3g"
+
+sysctlInit:
+  enabled: true
+sysctlVmMaxMapCount: 262144
+
+resources:
+  requests:
+    cpu: 7000m
+    memory: 8Gi
+  limits:
+    cpu: 7000m
+    memory: 8Gi
+
+persistence:
+  enabled: true
+  size: 512Gi
+  storageClass: "ssd"
+
+nodeSelector:
+  component: benchmark-n2-standard-8
+
+tolerations:
+  - key: nodepool
+    operator: Equal
+    value: n2-standard-8
+    effect: NoSchedule
+
+antiAffinity: "hard"
+
+protocol: http
+
+securityConfig:
+  enabled: false


### PR DESCRIPTION
# Description
Backport of #50463 to `stable/8.6`.

relates to 