### PR TITLE
fix: keep migration view open when request fails

### DIFF
--- a/operate/client/e2e-playwright/docs-screenshots/process-instance-migration.spec.ts
+++ b/operate/client/e2e-playwright/docs-screenshots/process-instance-migration.spec.ts
@@ -250,6 +250,9 @@ test.describe('process instance migration', () => {
 
     await migrationView.confirmMigration();
 
+    await expect(migrationView.step1Header).toBeHidden();
+    await expect(migrationView.step2Header).toBeHidden();
+
     await processesPage.diagram.moveCanvasHorizontally(-200);
 
     await expect(

--- a/operate/client/e2e-playwright/mocks/processes.mocks.ts
+++ b/operate/client/e2e-playwright/mocks/processes.mocks.ts
@@ -211,6 +211,16 @@ function mockResponses({
       });
     }
 
+    if (route.request().url().includes('/v2/process-instances/migration')) {
+      return route.fulfill({
+        status: 200,
+        json: {
+          batchOperationKey: '1234567890',
+          batchOperationType: 'MIGRATE_PROCESS_INSTANCE',
+        },
+      });
+    }
+
     route.continue();
   };
 }

--- a/operate/client/e2e-playwright/pages/Processes/MigrationView.ts
+++ b/operate/client/e2e-playwright/pages/Processes/MigrationView.ts
@@ -17,6 +17,8 @@ export class MigrationView {
   readonly confirmButton: Locator;
   readonly summaryNotification: Locator;
   readonly migrationConfirmationModal: Locator;
+  readonly step1Header: Locator;
+  readonly step2Header: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -42,6 +44,9 @@ export class MigrationView {
     });
 
     this.summaryNotification = page.getByRole('main').getByRole('status');
+
+    this.step1Header = page.getByText('Migration step 1 - mapping elements');
+    this.step2Header = page.getByText('Migration step 2 - confirm');
   }
 
   async selectTargetProcess(option: string) {

--- a/operate/client/src/App/Processes/MigrationView/Footer/index.test.tsx
+++ b/operate/client/src/App/Processes/MigrationView/Footer/index.test.tsx
@@ -259,7 +259,7 @@ describe('Footer', () => {
     vi.useRealTimers();
   });
 
-  it('should show auth warning and keep migration active when migration creation is forbidden', async () => {
+  it('should show an auth warning and keep the migration view open when batch migration creation is forbidden', async () => {
     mockMigrateProcessInstancesBatchOperation().withServerError(403);
 
     processInstanceMigrationStore.setBatchOperationQuery({
@@ -295,6 +295,53 @@ describe('Footer', () => {
       kind: 'warning',
       title: "You don't have permission to perform this operation",
       subtitle: 'Please contact the administrator if you need access.',
+      isDismissable: true,
+    });
+    expect(tracking.track).toHaveBeenCalledWith({
+      eventName: 'process-instance-migration-confirmed',
+    });
+    expect(tracking.track).not.toHaveBeenCalledWith({
+      eventName: 'batch-operation',
+      operationType: 'MIGRATE_PROCESS_INSTANCE',
+    });
+  });
+
+  it('should show an error and keep the migration view open when batch migration creation fails', async () => {
+    mockMigrateProcessInstancesBatchOperation().withServerError(500);
+
+    processInstanceMigrationStore.setBatchOperationQuery({
+      ids: ['1', '2'],
+    });
+    processInstanceMigrationStore.setTargetProcessDefinition(
+      createProcessDefinition({processDefinitionKey: 'target-process-key'}),
+    );
+    processInstanceMigrationStore.setSourceProcessDefinition(
+      createProcessDefinition({processDefinitionKey: 'source-process-key'}),
+    );
+
+    const {user} = render(<Footer />, {wrapper: Wrapper});
+
+    await user.click(screen.getByRole('button', {name: /map element/i}));
+    await user.click(screen.getByRole('button', {name: /next/i}));
+    await user.click(screen.getByRole('button', {name: /confirm/i}));
+
+    const withinModal = within(screen.getByRole('dialog'));
+    await user.type(withinModal.getByRole('textbox'), 'MIGRATE');
+    await user.click(withinModal.getByRole('button', {name: /confirm/i}));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Migrating...')).not.toBeInTheDocument();
+    });
+
+    expect(processInstanceMigrationStore.isEnabled).toBe(true);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(screen.getByTestId('pathname')).toHaveTextContent('/');
+    expect(screen.getByTestId('search')).toBeEmptyDOMElement();
+
+    expect(notificationsStore.displayNotification).toHaveBeenCalledWith({
+      kind: 'error',
+      title: 'Operation could not be created',
+      subtitle: undefined,
       isDismissable: true,
     });
     expect(tracking.track).toHaveBeenCalledWith({

--- a/operate/client/src/App/Processes/MigrationView/Footer/index.test.tsx
+++ b/operate/client/src/App/Processes/MigrationView/Footer/index.test.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {act, render, screen, within} from 'modules/testing-library';
+import {act, render, screen, waitFor, within} from 'modules/testing-library';
 import {Footer} from './index';
 import {processInstanceMigrationStore} from 'modules/stores/processInstanceMigration';
 import {useEffect} from 'react';
@@ -19,6 +19,7 @@ import {mockQueryBatchOperations} from 'modules/mocks/api/v2/batchOperations/que
 import {panelStatesStore} from 'modules/stores/panelStates';
 import {notificationsStore} from 'modules/stores/notifications';
 import {createProcessDefinition} from 'modules/testUtils';
+import {LocationLog} from 'modules/utils/LocationLog';
 
 type Props = {
   children?: React.ReactNode;
@@ -54,6 +55,7 @@ const Wrapper = ({children}: Props) => {
         >
           map element
         </button>
+        <LocationLog />
       </MemoryRouter>
     </QueryClientProvider>
   );
@@ -197,6 +199,10 @@ describe('Footer', () => {
 
   it('should perform migration batch operation successfully and expand operations panel', async () => {
     vi.useFakeTimers({shouldAdvanceTime: true});
+    mockMigrateProcessInstancesBatchOperation().withDelay({
+      batchOperationKey: 'migrate-operation-123',
+      batchOperationType: 'MIGRATE_PROCESS_INSTANCE',
+    });
 
     processInstanceMigrationStore.setBatchOperationQuery({
       ids: ['1', '2'],
@@ -218,7 +224,23 @@ describe('Footer', () => {
     await user.type(withinModal.getByRole('textbox'), 'MIGRATE');
     await user.click(withinModal.getByRole('button', {name: /confirm/i}));
 
+    expect(processInstanceMigrationStore.isEnabled).toBe(true);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(screen.getByText('Migrating...')).toBeInTheDocument();
+    expect(screen.getByTestId('pathname')).toHaveTextContent('/');
+    expect(screen.getByTestId('search')).toBeEmptyDOMElement();
+
     vi.runOnlyPendingTimers();
+
+    await waitFor(() => {
+      expect(screen.queryByText('Migrating...')).not.toBeInTheDocument();
+    });
+
+    expect(processInstanceMigrationStore.isEnabled).toBe(false);
+    expect(screen.getByTestId('pathname')).toHaveTextContent('/processes');
+    expect(screen.getByTestId('search')).toHaveTextContent(
+      '?active=true&incidents=true&processDefinitionId=bigVarProcess&processDefinitionVersion=1',
+    );
 
     expect(tracking.track).toHaveBeenCalledWith({
       eventName: 'batch-operation',
@@ -235,5 +257,52 @@ describe('Footer', () => {
     );
 
     vi.useRealTimers();
+  });
+
+  it('should show auth warning and keep migration active when migration creation is forbidden', async () => {
+    mockMigrateProcessInstancesBatchOperation().withServerError(403);
+
+    processInstanceMigrationStore.setBatchOperationQuery({
+      ids: ['1', '2'],
+    });
+    processInstanceMigrationStore.setTargetProcessDefinition(
+      createProcessDefinition({processDefinitionKey: 'target-process-key'}),
+    );
+    processInstanceMigrationStore.setSourceProcessDefinition(
+      createProcessDefinition({processDefinitionKey: 'source-process-key'}),
+    );
+
+    const {user} = render(<Footer />, {wrapper: Wrapper});
+
+    await user.click(screen.getByRole('button', {name: /map element/i}));
+    await user.click(screen.getByRole('button', {name: /next/i}));
+    await user.click(screen.getByRole('button', {name: /confirm/i}));
+
+    const withinModal = within(screen.getByRole('dialog'));
+    await user.type(withinModal.getByRole('textbox'), 'MIGRATE');
+    await user.click(withinModal.getByRole('button', {name: /confirm/i}));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Migrating...')).not.toBeInTheDocument();
+    });
+
+    expect(processInstanceMigrationStore.isEnabled).toBe(true);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(screen.getByTestId('pathname')).toHaveTextContent('/');
+    expect(screen.getByTestId('search')).toBeEmptyDOMElement();
+
+    expect(notificationsStore.displayNotification).toHaveBeenCalledWith({
+      kind: 'warning',
+      title: "You don't have permission to perform this operation",
+      subtitle: 'Please contact the administrator if you need access.',
+      isDismissable: true,
+    });
+    expect(tracking.track).toHaveBeenCalledWith({
+      eventName: 'process-instance-migration-confirmed',
+    });
+    expect(tracking.track).not.toHaveBeenCalledWith({
+      eventName: 'batch-operation',
+      operationType: 'MIGRATE_PROCESS_INSTANCE',
+    });
   });
 });

--- a/operate/client/src/App/Processes/MigrationView/Footer/index.tsx
+++ b/operate/client/src/App/Processes/MigrationView/Footer/index.tsx
@@ -11,6 +11,7 @@ import {observer} from 'mobx-react';
 import {processInstanceMigrationStore} from 'modules/stores/processInstanceMigration';
 import {Container} from './styled';
 import {ModalStateManager} from 'modules/components/ModalStateManager';
+import {AsyncActionTrigger} from 'modules/components/AsyncActionTrigger';
 import {useNavigate, useSearchParams} from 'react-router-dom';
 import {Locations} from 'modules/Routes';
 import {tracking} from 'modules/tracking';
@@ -25,7 +26,11 @@ const Footer: React.FC = observer(() => {
   const [searchParams] = useSearchParams();
   const displaySuccessNotification = useBatchOperationSuccessNotification();
   const navigate = useNavigate();
-  const {mutate: migrateProcess} = useMigrateProcessInstancesBatchOperation({
+  const {
+    mutate: migrateProcess,
+    reset: resetMigrate,
+    status: migrateStatus,
+  } = useMigrateProcessInstancesBatchOperation({
     onSuccess: ({batchOperationKey, batchOperationType}) => {
       displaySuccessNotification(batchOperationType, batchOperationKey);
       tracking.track({
@@ -37,6 +42,7 @@ const Footer: React.FC = observer(() => {
       return handleOperationError(error.response?.status);
     },
   });
+  const isMigratePending = migrateStatus === 'pending';
 
   return (
     <Container orientation="horizontal" gap={5}>
@@ -45,6 +51,7 @@ const Footer: React.FC = observer(() => {
           <Button
             kind="secondary"
             size="sm"
+            disabled={isMigratePending}
             onClick={() => {
               setOpen(true);
             }}
@@ -98,6 +105,7 @@ const Footer: React.FC = observer(() => {
           <Button
             kind="secondary"
             size="sm"
+            disabled={isMigratePending}
             onClick={() =>
               processInstanceMigrationStore.setCurrentStep('elementMapping')
             }
@@ -107,15 +115,21 @@ const Footer: React.FC = observer(() => {
 
           <ModalStateManager
             renderLauncher={({setOpen}) => (
-              <Button
-                aria-label="Confirm"
-                size="sm"
-                onClick={() => {
-                  setOpen(true);
-                }}
+              <AsyncActionTrigger
+                status={migrateStatus}
+                pendingLabel="Migrating..."
+                onReset={resetMigrate}
               >
-                Confirm
-              </Button>
+                <Button
+                  aria-label="Confirm"
+                  size="sm"
+                  onClick={() => {
+                    setOpen(true);
+                  }}
+                >
+                  Confirm
+                </Button>
+              </AsyncActionTrigger>
             )}
           >
             {({open, setOpen}) => (
@@ -162,36 +176,41 @@ const Footer: React.FC = observer(() => {
                       sourceProcessDefinition?.processDefinitionKey,
                   });
 
-                  migrateProcess({
-                    ...requestBody,
-                    migrationPlan: {
-                      targetProcessDefinitionKey:
-                        targetProcessDefinition.processDefinitionKey,
-                      mappingInstructions: Object.entries(elementMapping).map(
-                        ([sourceElementId, targetElementId]) => ({
-                          sourceElementId,
-                          targetElementId,
-                        }),
-                      ),
-                    },
-                  });
-
-                  processInstanceMigrationStore.disable();
-                  processInstancesSelectionStore.reset();
-
                   tracking.track({
                     eventName: 'process-instance-migration-confirmed',
                   });
 
-                  navigate(
-                    Locations.processes({
-                      active: true,
-                      incidents: true,
-                      processDefinitionId:
-                        targetProcessDefinition.processDefinitionId,
-                      processDefinitionVersion:
-                        targetProcessDefinition.version.toString(),
-                    }),
+                  setOpen(false);
+                  migrateProcess(
+                    {
+                      ...requestBody,
+                      migrationPlan: {
+                        targetProcessDefinitionKey:
+                          targetProcessDefinition.processDefinitionKey,
+                        mappingInstructions: Object.entries(elementMapping).map(
+                          ([sourceElementId, targetElementId]) => ({
+                            sourceElementId,
+                            targetElementId,
+                          }),
+                        ),
+                      },
+                    },
+                    {
+                      onSuccess: () => {
+                        processInstanceMigrationStore.disable();
+                        processInstancesSelectionStore.reset();
+                        navigate(
+                          Locations.processes({
+                            active: true,
+                            incidents: true,
+                            processDefinitionId:
+                              targetProcessDefinition.processDefinitionId,
+                            processDefinitionVersion:
+                              targetProcessDefinition.version.toString(),
+                          }),
+                        );
+                      },
+                    },
                   );
                 }}
               />


### PR DESCRIPTION
## Description

This PR updates the migration view to keep the view open when creating the migration batch operation fails. 

> [!NOTE]
> The related bug reported that no error message is shown. However, error messages are shown in 8.9 - users are just always navigated away from migration mode (https://github.com/camunda/camunda/issues/39075#issuecomment-4199999364). Keeping them there has been a suggestion to further improve the bug fix, but has not be confirmed as a wanted fix yet.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates #39075
