### PR TITLE
Validate cluster API parameters.

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -33,6 +33,7 @@ import io.camunda.zeebe.management.cluster.MessageCorrelationHashMod;
 import io.camunda.zeebe.management.cluster.RequestHandlingActivePartitions;
 import io.camunda.zeebe.management.cluster.RequestHandlingAllPartitions;
 import io.camunda.zeebe.management.cluster.RoutingState;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -45,7 +46,9 @@ import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -55,6 +58,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 @Component
 @RestControllerEndpoint(id = "cluster")
 public class ClusterEndpoint {
+  private static final Set<String> ALLOWED_QUERY_PARAMETERS =
+      Set.of("dryRun", "force", "replicationFactor");
+
   private final ClusterConfigurationManagementRequestSender requestSender;
 
   @Autowired
@@ -75,6 +81,26 @@ public class ClusterEndpoint {
     final var errorResponse = new Error();
     errorResponse.setMessage(message);
     return ResponseEntity.status(400).body(errorResponse);
+  }
+
+  @ModelAttribute
+  public void validateRequestParameters(final HttpServletRequest request) {
+    final var unknownParameters =
+        request.getParameterMap().keySet().stream()
+            .filter(parameter -> !ALLOWED_QUERY_PARAMETERS.contains(parameter))
+            .sorted()
+            .toList();
+
+    if (!unknownParameters.isEmpty()) {
+      throw new UnknownRequestParameterException(
+          "Unsupported query parameter(s): " + String.join(", ", unknownParameters));
+    }
+  }
+
+  @ExceptionHandler(UnknownRequestParameterException.class)
+  public ResponseEntity<Error> handleUnknownRequestParameter(
+      final UnknownRequestParameterException error) {
+    return invalidRequest(error.getMessage());
   }
 
   @PostMapping(path = "/{resource}/{id}")
@@ -428,6 +454,12 @@ public class ClusterEndpoint {
   }
 
   public record PartitionAddRequest(int priority) {}
+
+  private static final class UnknownRequestParameterException extends RuntimeException {
+    private UnknownRequestParameterException(final String message) {
+      super(message);
+    }
+  }
 
   public enum Resource {
     brokers,

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterEndpointTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.shared.management;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+final class ClusterEndpointTest {
+
+  @Test
+  void shouldAllowKnownQueryParameters() {
+    // given
+    final var endpoint = createEndpoint();
+    final var request = mock(HttpServletRequest.class);
+    when(request.getParameterMap())
+        .thenReturn(
+            Map.of(
+                "dryRun", new String[] {"true"},
+                "force", new String[] {"false"},
+                "replicationFactor", new String[] {"3"}));
+
+    // when - then
+    assertThatCode(() -> endpoint.validateRequestParameters(request)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldRejectUnknownQueryParameter() {
+    // given
+    final var endpoint = createEndpoint();
+    final var request = mock(HttpServletRequest.class);
+    when(request.getParameterMap())
+        .thenReturn(Map.of("dryRun", new String[] {"true"}, "unknown", new String[] {"x"}));
+
+    // when - then
+    assertThatThrownBy(() -> endpoint.validateRequestParameters(request))
+        .hasMessage("Unsupported query parameter(s): unknown");
+  }
+
+  @Test
+  void shouldRejectAndSortMultipleUnknownQueryParameters() {
+    // given
+    final var endpoint = createEndpoint();
+    final var request = mock(HttpServletRequest.class);
+    when(request.getParameterMap())
+        .thenReturn(Map.of("x", new String[] {"1"}, "y", new String[] {"2"}));
+
+    // when - then
+    assertThatThrownBy(() -> endpoint.validateRequestParameters(request))
+        .hasMessage("Unsupported query parameter(s): x, y");
+  }
+
+  private ClusterEndpoint createEndpoint() {
+    return new ClusterEndpoint(mock(ClusterConfigurationManagementRequestSender.class));
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeCoordinatorImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeCoordinatorImpl.java
@@ -156,6 +156,10 @@ public class ConfigurationChangeCoordinatorImpl implements ConfigurationChangeCo
           // Validation was successful. If it's not a dry-run, apply the changes.
           final ActorFuture<ClusterConfiguration> applyFuture = executor.createFuture();
           if (dryRun) {
+            LOG.debug(
+                "Dry run for configuration change request validated "
+                    + "successfully. The resulting cluster configuration would be: {}",
+                simulatedFinalTopology);
             applyFuture.complete(currentClusterConfiguration.startConfigurationChange(operations));
           } else {
             applyTopologyChange(

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ClusterEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ClusterEndpointIT.java
@@ -19,6 +19,11 @@ import io.camunda.zeebe.management.cluster.Operation.OperationEnum;
 import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import io.camunda.zeebe.qa.util.topology.ClusterActuatorAssert;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse.BodyHandlers;
 import java.util.List;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.awaitility.Awaitility;
@@ -30,6 +35,7 @@ import org.junit.jupiter.api.Timeout;
 final class ClusterEndpointIT {
   private static final int BROKER_COUNT = 2;
   private static final int PARTITION_COUNT = 2;
+  private static final String SCALE_BROKERS_REQUEST_BODY = "[1,2]";
 
   @Test
   void shouldQueryCurrentClusterTopology() {
@@ -220,6 +226,21 @@ final class ClusterEndpointIT {
     }
   }
 
+  @Test
+  void shouldFailRequestWhenHavingTypoInParameter() throws IOException, InterruptedException {
+    try (final var cluster = createCluster(1)) {
+      // given
+      cluster.awaitCompleteTopology();
+
+      // when
+      final var response = sendBrokerScaleRequest(cluster, URI.create("/brokers?dry-run=true"));
+
+      // then
+      assertThat(response.statusCode()).isEqualTo(400);
+      assertThat(response.body()).contains("Unsupported query parameter(s): dry-run");
+    }
+  }
+
   private static void movePartition(final ClusterActuator actuator) {
     final var plannedJoin = actuator.joinPartition(0, 2, 1);
     Awaitility.await()
@@ -230,6 +251,22 @@ final class ClusterEndpointIT {
         .untilAsserted(() -> ClusterActuatorAssert.assertThat(actuator).hasAppliedChanges(leave));
   }
 
+  private static java.net.http.HttpResponse<String> sendBrokerScaleRequest(
+      final TestCluster cluster, final URI pathAndQuery) throws IOException, InterruptedException {
+    final var baseClusterEndpoint = cluster.availableGateway().actuatorUri("cluster");
+    final var request =
+        HttpRequest.newBuilder()
+            .uri(URI.create(baseClusterEndpoint + pathAndQuery.toString()))
+            .header("Content-Type", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString(SCALE_BROKERS_REQUEST_BODY))
+            .build();
+
+    try (final var httpClient = HttpClient.newHttpClient()) {
+      return httpClient.send(request, BodyHandlers.ofString());
+    }
+  }
+
+  @SuppressWarnings("resource")
   private static TestCluster createCluster(final int replicationFactor) {
     return TestCluster.builder()
         .withEmbeddedGateway(true)


### PR DESCRIPTION
## Description

This PR adds parameter validation to the /cluster endpoint, namely preventing any cluster changes from occurring if some of the parameters do not exist, or in case of typos. 

This concern was raised in the incident [#inc-support-32165-purge-dry-run-deletes-the-production-cluster](https://camunda.slack.com/archives/C0AQ5STV464), where we noticed that the purge commands in the docs were using kebab-case for the dry-run command, which would execute the purge command.

Additionally this PR also adds a simple debug log when simulating the request.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/50163
