### PR TITLE
test: add parallel user task migration e2e coverage

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessMigrationModePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessMigrationModePage.ts
@@ -106,4 +106,24 @@ export class OperateProcessMigrationModePage {
       await expect(this.page.getByLabel(label)).toHaveValue(targetValue);
     }
   }
+
+  async verifySummaryNotification({
+    instanceCount,
+    sourceBpmnProcessId,
+    sourceVersion,
+    targetBpmnProcessId,
+    targetVersion,
+  }: {
+    instanceCount: number;
+    sourceBpmnProcessId: string;
+    sourceVersion: string;
+    targetBpmnProcessId: string;
+    targetVersion: string;
+  }): Promise<void> {
+    const instanceWord =
+      instanceCount === 1 ? 'process instance' : 'process instances';
+    await expect(this.summaryNotification).toContainText(
+      `You are about to migrate ${instanceCount} ${instanceWord} from the process definition: ${sourceBpmnProcessId} - version ${sourceVersion} to the process definition: ${targetBpmnProcessId} - version ${targetVersion}`,
+    );
+  }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskDetailsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskDetailsPage.ts
@@ -418,9 +418,7 @@ class TaskDetailsPage {
     await this.clickUnassignButton();
 
     // Assign to the logged-in user and verify assignment
-    await expect(this.assignToMeButton).toBeVisible({timeout: 15000});
-    await this.assignToMeButton.click();
-    await expect(this.assignedToMeText).toBeVisible({timeout: 15000});
+    await this.clickAssignToMeButton();
 
     // Complete the task, wait for the banner to appear, then disappear
     await expect(this.completeTaskButton).toBeEnabled({timeout: 15000});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskDetailsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskDetailsPage.ts
@@ -412,6 +412,22 @@ class TaskDetailsPage {
   getHistoryTableAssignCellCount(): Promise<number> {
     return this.historyTableAssignCell.count();
   }
+
+  async unassignReassignToMeAndComplete(): Promise<void> {
+    // Unassign from the current assignee
+    await this.clickUnassignButton();
+
+    // Assign to the logged-in user and verify assignment
+    await expect(this.assignToMeButton).toBeVisible({timeout: 15000});
+    await this.assignToMeButton.click();
+    await expect(this.assignedToMeText).toBeVisible({timeout: 15000});
+
+    // Complete the task, wait for the banner to appear, then disappear
+    await expect(this.completeTaskButton).toBeEnabled({timeout: 15000});
+    await this.clickCompleteTaskButton();
+    await expect(this.taskCompletedBanner).toBeVisible();
+    await expect(this.taskCompletedBanner).toBeHidden();
+  }
 }
 
 export {TaskDetailsPage};

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskDetailsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskDetailsPage.ts
@@ -426,7 +426,7 @@ class TaskDetailsPage {
     await expect(this.completeTaskButton).toBeEnabled({timeout: 15000});
     await this.clickCompleteTaskButton();
     await expect(this.taskCompletedBanner).toBeVisible();
-    await expect(this.taskCompletedBanner).toBeHidden();
+    await expect(this.taskCompletedBanner).toBeHidden({timeout: 15000});
   }
 }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskPanelPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskPanelPage.ts
@@ -16,6 +16,7 @@ export type TaskCard = {
 
 class TaskPanelPage {
   readonly availableTasks: Locator;
+  readonly taskCards: Locator;
   readonly collapseSidePanelButton: Locator;
   readonly expandSidePanelButton: Locator;
   private page: Page;
@@ -26,6 +27,7 @@ class TaskPanelPage {
   constructor(page: Page) {
     this.page = page;
     this.availableTasks = page.getByTitle('Available tasks');
+    this.taskCards = this.availableTasks.locator('article');
     this.collapseSidePanelButton = page.locator(
       'button[aria-controls="task-nav-bar"][aria-expanded="true"]',
     );
@@ -48,7 +50,7 @@ class TaskPanelPage {
     // V1: displays process name ("User registration")
     // V2: always displays process ID ("user_registration") regardless of task name
 
-    // Mapping of processes names to process IDs for V2 mode compatibility
+    // Mapping of process names to process IDs for V2 mode compatibility
     const processNameToIdMapping: Record<string, string> = {
       'User registration': 'user_registration',
       'Some user activity': 'usertask_to_be_completed', // Process ID from BPMN
@@ -162,41 +164,40 @@ class TaskPanelPage {
     return this.page.goto(`/tasklist/${taskKey}`);
   }
 
+  private getTaskCards(task: TaskCard): Locator {
+    let taskCards = this.taskCards.filter({
+      has: this.page.getByText(task.name, {exact: true}),
+    });
+
+    if (task.assignee) {
+      taskCards = taskCards.filter({
+        has: this.page.getByText(task.assignee, {exact: true}),
+      });
+    }
+
+    return taskCards;
+  }
+
   async assertTaskCardsPresent(
     tasks: TaskCard[],
     options: {expectedCount?: number} = {},
   ): Promise<void> {
     const {expectedCount} = options;
+
     for (const task of tasks) {
-      const taskName = this.availableTasks.getByText(task.name, {exact: true});
-      const assignee = task.assignee
-        ? this.availableTasks.getByText(task.assignee, {exact: true})
-        : null;
+      const taskCards = this.getTaskCards(task);
 
       if (expectedCount === undefined) {
-        await expect(taskName.first()).toBeVisible();
-        if (assignee) {
-          await expect(assignee.first()).toBeVisible();
-        }
+        await expect(taskCards.first()).toBeVisible();
       } else {
-        await expect(taskName).toHaveCount(expectedCount);
-        if (assignee) {
-          await expect(assignee).toHaveCount(expectedCount);
-        }
+        await expect(taskCards).toHaveCount(expectedCount);
       }
     }
   }
 
   async assertTaskCardsAbsent(tasks: TaskCard[]): Promise<void> {
     for (const task of tasks) {
-      await expect(
-        this.availableTasks.getByText(task.name, {exact: true}),
-      ).toHaveCount(0);
-      if (task.assignee) {
-        await expect(
-          this.availableTasks.getByText(task.assignee, {exact: true}),
-        ).toHaveCount(0);
-      }
+      await expect(this.getTaskCards(task)).toHaveCount(0);
     }
   }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskPanelPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskPanelPage.ts
@@ -6,9 +6,13 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {Page, Locator} from '@playwright/test';
+import {Page, Locator, expect} from '@playwright/test';
 import {waitForAssertion} from 'utils/waitForAssertion';
-import {expect} from '@playwright/test';
+
+export type TaskCard = {
+  readonly name: string;
+  readonly assignee?: string;
+};
 
 class TaskPanelPage {
   readonly availableTasks: Locator;
@@ -156,6 +160,44 @@ class TaskPanelPage {
 
   goToTaskDetails(taskKey: string) {
     return this.page.goto(`/tasklist/${taskKey}`);
+  }
+
+  async assertTaskCardsPresent(
+    tasks: TaskCard[],
+    options: {expectedCount?: number} = {},
+  ): Promise<void> {
+    const {expectedCount} = options;
+    for (const task of tasks) {
+      const taskName = this.availableTasks.getByText(task.name, {exact: true});
+      const assignee = task.assignee
+        ? this.availableTasks.getByText(task.assignee, {exact: true})
+        : null;
+
+      if (expectedCount === undefined) {
+        await expect(taskName.first()).toBeVisible();
+        if (assignee) {
+          await expect(assignee.first()).toBeVisible();
+        }
+      } else {
+        await expect(taskName).toHaveCount(expectedCount);
+        if (assignee) {
+          await expect(assignee).toHaveCount(expectedCount);
+        }
+      }
+    }
+  }
+
+  async assertTaskCardsAbsent(tasks: TaskCard[]): Promise<void> {
+    for (const task of tasks) {
+      await expect(
+        this.availableTasks.getByText(task.name, {exact: true}),
+      ).toHaveCount(0);
+      if (task.assignee) {
+        await expect(
+          this.availableTasks.getByText(task.assignee, {exact: true}),
+        ).toHaveCount(0);
+      }
+    }
   }
 }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/TasklistHeader.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/TasklistHeader.ts
@@ -22,7 +22,9 @@ class TasklistHeader {
     this.languageSelector = page.getByRole('combobox', {name: 'Language'});
     this.processesTab = page.getByRole('link', {name: 'Processes'});
     this.logoutButton = page.getByRole('button', {name: 'Log out'});
-    this.tasksTab = page.getByRole('link', {name: 'Tasks'});
+    this.tasksTab = page
+      .getByRole('navigation')
+      .getByRole('link', {name: 'Tasks', exact: true});
   }
 
   async logout() {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/job-worker-id-form.form
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/job-worker-id-form.form
@@ -1,0 +1,44 @@
+{
+  "executionPlatform": "Camunda Cloud",
+  "executionPlatformVersion": "8.8.0",
+  "exporter": {
+    "name": "Camunda Web Modeler",
+    "version": "5159060"
+  },
+  "schemaVersion": 19,
+  "id": "jw-1",
+  "components": [
+    {
+      "text": "# Camunda Form",
+      "type": "text",
+      "layout": {
+        "row": "Row_0zyslyh",
+        "columns": null
+      },
+      "id": "Field_1emp0qu"
+    },
+    {
+      "label": "Text field",
+      "type": "textfield",
+      "layout": {
+        "row": "Row_1lz0r8m",
+        "columns": null
+      },
+      "id": "Field_1dg6fm9",
+      "key": "textfield_6bfdi",
+      "defaultValue": "Insert anything"
+    },
+    {
+      "label": "Text area",
+      "type": "textarea",
+      "layout": {
+        "row": "Row_1jqthqh",
+        "columns": null
+      },
+      "id": "Field_0z6lnhc",
+      "key": "textarea_71e1gb"
+    }
+  ],
+  "type": "default"
+}
+

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/parallel_tasks_jw_v1.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/parallel_tasks_jw_v1.bpmn
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.39.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="parallel_tasks_jw" name="parallel_tasks_jw" isExecutable="true">
+    <bpmn:extensionElements>
+      <zeebe:userTaskForm id="UserTaskForm_17m39d0">{
+  "components": [
+    {
+      "label": "Field 1",
+      "type": "textfield",
+      "id": "Field_1k7p6w3",
+      "key": "field1"
+    },
+    {
+      "label": "Field 2",
+      "type": "textfield",
+      "id": "Field_1x9y8z7",
+      "key": "field2"
+    }
+  ],
+  "type": "default",
+  "schemaVersion": 15
+}</zeebe:userTaskForm>
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1882wip</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1882wip" sourceRef="StartEvent_1" targetRef="Activity_0tyhy6d" />
+    <bpmn:manualTask id="Activity_0tyhy6d">
+      <bpmn:incoming>Flow_1882wip</bpmn:incoming>
+      <bpmn:outgoing>Flow_1bke4l3</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:sequenceFlow id="Flow_1bke4l3" sourceRef="Activity_0tyhy6d" targetRef="Gateway_1ca266m" />
+    <bpmn:parallelGateway id="Gateway_1ca266m">
+      <bpmn:incoming>Flow_1bke4l3</bpmn:incoming>
+      <bpmn:outgoing>Flow_0ucchi9</bpmn:outgoing>
+      <bpmn:outgoing>Flow_00xa2mh</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1igi516</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_0ucchi9" sourceRef="Gateway_1ca266m" targetRef="embedded" />
+    <bpmn:sequenceFlow id="Flow_00xa2mh" sourceRef="Gateway_1ca266m" targetRef="camunda_form" />
+    <bpmn:sequenceFlow id="Flow_1igi516" sourceRef="Gateway_1ca266m" targetRef="external_form" />
+    <bpmn:userTask id="embedded" name="Embedded" implementation="##unspecified">
+      <bpmn:extensionElements>
+        <zeebe:assignmentDefinition assignee="test1" />
+        <zeebe:formDefinition formKey="camunda-forms:bpmn:UserTaskForm_17m39d0" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0ucchi9</bpmn:incoming>
+      <bpmn:outgoing>Flow_1xrn06f</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="camunda_form" name="camunda form" implementation="##unspecified">
+      <bpmn:extensionElements>
+        <zeebe:assignmentDefinition assignee="test2" />
+        <zeebe:formDefinition formId="jw-1" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_00xa2mh</bpmn:incoming>
+      <bpmn:outgoing>Flow_0mbwee0</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="external_form" name="external form" implementation="##unspecified">
+      <bpmn:extensionElements>
+        <zeebe:assignmentDefinition assignee="test3" />
+        <zeebe:formDefinition formKey="https://test.io" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1igi516</bpmn:incoming>
+      <bpmn:outgoing>Flow_0ej2vpk</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_1xrn06f" sourceRef="embedded" targetRef="Gateway_0i0jjyq" />
+    <bpmn:sequenceFlow id="Flow_0mbwee0" sourceRef="camunda_form" targetRef="Gateway_0i0jjyq" />
+    <bpmn:sequenceFlow id="Flow_0ej2vpk" sourceRef="external_form" targetRef="Gateway_0i0jjyq" />
+    <bpmn:parallelGateway id="Gateway_0i0jjyq">
+      <bpmn:incoming>Flow_1xrn06f</bpmn:incoming>
+      <bpmn:incoming>Flow_0mbwee0</bpmn:incoming>
+      <bpmn:incoming>Flow_0ej2vpk</bpmn:incoming>
+      <bpmn:outgoing>Flow_06mpbxg</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_06mpbxg" sourceRef="Gateway_0i0jjyq" targetRef="result" />
+    <bpmn:manualTask id="result" name="Result">
+      <bpmn:incoming>Flow_06mpbxg</bpmn:incoming>
+      <bpmn:outgoing>Flow_1euzc7n</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:sequenceFlow id="Flow_1euzc7n" sourceRef="result" targetRef="Event_0rfla9q" />
+    <bpmn:endEvent id="Event_0rfla9q">
+      <bpmn:incoming>Flow_1euzc7n</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="parallel_tasks_jw">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="-68" y="52" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0tyhy6d_di" bpmnElement="Activity_0tyhy6d">
+        <dc:Bounds x="30" y="30" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1ca266m_di" bpmnElement="Gateway_1ca266m">
+        <dc:Bounds x="200" y="45" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="embedded_di" bpmnElement="embedded">
+        <dc:Bounds x="325" y="-120" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="camunda_form_di" bpmnElement="camunda_form">
+        <dc:Bounds x="325" y="30" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="external_form_di" bpmnElement="external_form">
+        <dc:Bounds x="325" y="170" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0i0jjyq_di" bpmnElement="Gateway_0i0jjyq">
+        <dc:Bounds x="500" y="45" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="result_di" bpmnElement="result">
+        <dc:Bounds x="625" y="30" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0rfla9q_di" bpmnElement="Event_0rfla9q">
+        <dc:Bounds x="807" y="52" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1882wip_di" bpmnElement="Flow_1882wip">
+        <di:waypoint x="-32" y="70" />
+        <di:waypoint x="30" y="70" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1bke4l3_di" bpmnElement="Flow_1bke4l3">
+        <di:waypoint x="130" y="70" />
+        <di:waypoint x="200" y="70" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ucchi9_di" bpmnElement="Flow_0ucchi9">
+        <di:waypoint x="225" y="45" />
+        <di:waypoint x="225" y="-80" />
+        <di:waypoint x="325" y="-80" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_00xa2mh_di" bpmnElement="Flow_00xa2mh">
+        <di:waypoint x="250" y="70" />
+        <di:waypoint x="325" y="70" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1igi516_di" bpmnElement="Flow_1igi516">
+        <di:waypoint x="225" y="95" />
+        <di:waypoint x="225" y="210" />
+        <di:waypoint x="325" y="210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1xrn06f_di" bpmnElement="Flow_1xrn06f">
+        <di:waypoint x="425" y="-80" />
+        <di:waypoint x="525" y="-80" />
+        <di:waypoint x="525" y="45" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0mbwee0_di" bpmnElement="Flow_0mbwee0">
+        <di:waypoint x="425" y="70" />
+        <di:waypoint x="500" y="70" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ej2vpk_di" bpmnElement="Flow_0ej2vpk">
+        <di:waypoint x="425" y="210" />
+        <di:waypoint x="525" y="210" />
+        <di:waypoint x="525" y="95" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_06mpbxg_di" bpmnElement="Flow_06mpbxg">
+        <di:waypoint x="550" y="70" />
+        <di:waypoint x="625" y="70" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1euzc7n_di" bpmnElement="Flow_1euzc7n">
+        <di:waypoint x="725" y="70" />
+        <di:waypoint x="807" y="70" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>
+

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/parallel_tasks_jw_v2.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/parallel_tasks_jw_v2.bpmn
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_2" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.39.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="parallel_tasks_jw" name="parallel_tasks_jw" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1882wip</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1882wip" sourceRef="StartEvent_1" targetRef="Activity_0ual8cm" />
+    <bpmn:manualTask id="Activity_0ual8cm">
+      <bpmn:incoming>Flow_1882wip</bpmn:incoming>
+      <bpmn:outgoing>Flow_17e29uf</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:sequenceFlow id="Flow_17e29uf" sourceRef="Activity_0ual8cm" targetRef="Gateway_1ca266m" />
+    <bpmn:parallelGateway id="Gateway_1ca266m">
+      <bpmn:incoming>Flow_17e29uf</bpmn:incoming>
+      <bpmn:outgoing>Flow_0ucchi9</bpmn:outgoing>
+      <bpmn:outgoing>Flow_00xa2mh</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1igi516</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_0ucchi9" sourceRef="Gateway_1ca266m" targetRef="embedded" />
+    <bpmn:sequenceFlow id="Flow_00xa2mh" sourceRef="Gateway_1ca266m" targetRef="camunda_form" />
+    <bpmn:sequenceFlow id="Flow_1igi516" sourceRef="Gateway_1ca266m" targetRef="external_form" />
+    <bpmn:userTask id="embedded" name="Embedded new" implementation="##unspecified">
+      <bpmn:extensionElements>
+        <zeebe:assignmentDefinition assignee="test111" />
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0ucchi9</bpmn:incoming>
+      <bpmn:outgoing>Flow_1xrn06f</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="camunda_form" name="camunda form new" implementation="##unspecified">
+      <bpmn:extensionElements>
+        <zeebe:assignmentDefinition assignee="test222" />
+        <zeebe:priorityDefinition priority="100" />
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_00xa2mh</bpmn:incoming>
+      <bpmn:outgoing>Flow_0mbwee0</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="external_form" name="external form new" implementation="##unspecified">
+      <bpmn:extensionElements>
+        <zeebe:assignmentDefinition assignee="test333" />
+        <zeebe:priorityDefinition priority="100" />
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1igi516</bpmn:incoming>
+      <bpmn:outgoing>Flow_0ej2vpk</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_1xrn06f" sourceRef="embedded" targetRef="Gateway_0i0jjyq" />
+    <bpmn:sequenceFlow id="Flow_0mbwee0" sourceRef="camunda_form" targetRef="Gateway_0i0jjyq" />
+    <bpmn:sequenceFlow id="Flow_0ej2vpk" sourceRef="external_form" targetRef="Gateway_0i0jjyq" />
+    <bpmn:parallelGateway id="Gateway_0i0jjyq">
+      <bpmn:incoming>Flow_1xrn06f</bpmn:incoming>
+      <bpmn:incoming>Flow_0mbwee0</bpmn:incoming>
+      <bpmn:incoming>Flow_0ej2vpk</bpmn:incoming>
+      <bpmn:outgoing>Flow_06mpbxg</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_06mpbxg" sourceRef="Gateway_0i0jjyq" targetRef="result" />
+    <bpmn:manualTask id="result" name="Result">
+      <bpmn:incoming>Flow_06mpbxg</bpmn:incoming>
+      <bpmn:outgoing>Flow_1euzc7n</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:sequenceFlow id="Flow_1euzc7n" sourceRef="result" targetRef="Event_0rfla9q" />
+    <bpmn:endEvent id="Event_0rfla9q">
+      <bpmn:incoming>Flow_1euzc7n</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_2">
+    <bpmndi:BPMNPlane id="BPMNPlane_2" bpmnElement="parallel_tasks_jw">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="-48" y="52" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0ual8cm_di" bpmnElement="Activity_0ual8cm">
+        <dc:Bounds x="30" y="30" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1ca266m_di" bpmnElement="Gateway_1ca266m">
+        <dc:Bounds x="200" y="45" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="embedded_new_di" bpmnElement="embedded">
+        <dc:Bounds x="325" y="-120" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="camunda_form_di" bpmnElement="camunda_form">
+        <dc:Bounds x="325" y="30" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="external_form_di" bpmnElement="external_form">
+        <dc:Bounds x="325" y="170" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0i0jjyq_di" bpmnElement="Gateway_0i0jjyq">
+        <dc:Bounds x="500" y="45" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="result_di" bpmnElement="result">
+        <dc:Bounds x="625" y="30" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0rfla9q_di" bpmnElement="Event_0rfla9q">
+        <dc:Bounds x="807" y="52" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1882wip_di" bpmnElement="Flow_1882wip">
+        <di:waypoint x="-12" y="70" />
+        <di:waypoint x="30" y="70" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_17e29uf_di" bpmnElement="Flow_17e29uf">
+        <di:waypoint x="130" y="70" />
+        <di:waypoint x="200" y="70" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ucchi9_di" bpmnElement="Flow_0ucchi9">
+        <di:waypoint x="225" y="45" />
+        <di:waypoint x="225" y="-80" />
+        <di:waypoint x="325" y="-80" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_00xa2mh_di" bpmnElement="Flow_00xa2mh">
+        <di:waypoint x="250" y="70" />
+        <di:waypoint x="325" y="70" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1igi516_di" bpmnElement="Flow_1igi516">
+        <di:waypoint x="225" y="95" />
+        <di:waypoint x="225" y="210" />
+        <di:waypoint x="325" y="210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1xrn06f_di" bpmnElement="Flow_1xrn06f">
+        <di:waypoint x="425" y="-80" />
+        <di:waypoint x="525" y="-80" />
+        <di:waypoint x="525" y="45" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0mbwee0_di" bpmnElement="Flow_0mbwee0">
+        <di:waypoint x="425" y="70" />
+        <di:waypoint x="500" y="70" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ej2vpk_di" bpmnElement="Flow_0ej2vpk">
+        <di:waypoint x="425" y="210" />
+        <di:waypoint x="525" y="210" />
+        <di:waypoint x="525" y="95" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_06mpbxg_di" bpmnElement="Flow_06mpbxg">
+        <di:waypoint x="550" y="70" />
+        <di:waypoint x="625" y="70" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1euzc7n_di" bpmnElement="Flow_1euzc7n">
+        <di:waypoint x="725" y="70" />
+        <di:waypoint x="807" y="70" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>
+

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -22,7 +22,7 @@ import {
   DeployResourceResponse,
 } from '@camunda8/sdk/dist/c8/lib/C8Dto';
 import type {TaskCard} from '@pages/TaskPanelPage';
-import {parseUserTasksFromFile} from 'utils/bpmn';
+import {parseAssignedTasksFromFile} from 'utils/bpmn';
 
 const PROCESS_INSTANCE_COUNT = 10;
 const AUTO_MIGRATION_INSTANCE_COUNT = 6;
@@ -51,13 +51,13 @@ let processes: CreateProcessInstanceResponse[][] = [];
 let parallelProcesses: CreateProcessInstanceResponse[] = [];
 
 // Task cards parsed from BPMN fixtures — single source of truth for task names and assignees.
-const sourceTaskCards: TaskCard[] = parseUserTasksFromFile(
+const sourceTaskCards: TaskCard[] = parseAssignedTasksFromFile(
   './resources/parallel_tasks_jw_v1.bpmn',
-).filter((task) => task.name && task.assignee);
+);
 
-const targetTaskCards: TaskCard[] = parseUserTasksFromFile(
+const targetTaskCards: TaskCard[] = parseAssignedTasksFromFile(
   './resources/parallel_tasks_jw_v2.bpmn',
-).filter((task) => task.name && task.assignee);
+);
 
 test.describe.serial('Process Instance Migration', () => {
   test.beforeAll(async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -21,7 +21,7 @@ import {
   CreateProcessInstanceResponse,
   DeployResourceResponse,
 } from '@camunda8/sdk/dist/c8/lib/C8Dto';
-import {TaskCard} from '@pages/TaskPanelPage';
+import type {TaskCard} from '@pages/TaskPanelPage';
 import {parseUserTasksFromFile} from 'utils/bpmn';
 
 const PROCESS_INSTANCE_COUNT = 10;

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -59,86 +59,49 @@ const targetTaskCards: TaskCard[] = parseUserTasksFromFile(
   './resources/parallel_tasks_jw_v2.bpmn',
 ).filter((task) => task.name && task.assignee);
 
-test.beforeAll(async () => {
-  const parallelV1Deploy: DeployResourceResponse = await deploy([
-    './resources/parallel_tasks_jw_v1.bpmn',
-    './resources/job-worker-id-form.form',
-  ]);
-  const parallelProcessV1: ProcessDeployment = {
-    bpmnProcessId: parallelV1Deploy.processes[0].processDefinitionId,
-    version: parallelV1Deploy.processes[0].processDefinitionVersion,
-  };
-
-  parallelProcesses = await createInstances(
-    parallelProcessV1.bpmnProcessId,
-    parallelProcessV1.version,
-    PARALLEL_INSTANCE_COUNT,
-  );
-
-  // Redeploying with the same bpmnProcessId — Zeebe auto-increments the version to V2.
-  const parallelV2Deploy: DeployResourceResponse = await deploy([
-    './resources/parallel_tasks_jw_v2.bpmn',
-  ]);
-  const parallelProcessV2: ProcessDeployment = {
-    bpmnProcessId: parallelV2Deploy.processes[0].processDefinitionId,
-    version: parallelV2Deploy.processes[0].processDefinitionVersion,
-  };
-
-  testParallelProcesses = {parallelProcessV1, parallelProcessV2};
-
-  await deploy(['./resources/orderProcessMigration_v_1.bpmn']);
-  const processV1: ProcessDeployment = {
-    bpmnProcessId: 'orderProcessMigration',
-    version: 1,
-  };
-
-  processes = await Promise.all(
-    [...new Array(PROCESS_INSTANCE_COUNT)].map((_, index) =>
-      createInstances(processV1.bpmnProcessId, processV1.version, 1, {
-        key1: 'myFirstCorrelationKey',
-        key2: 'mySecondCorrelationKey',
-        key3: `myCorrelationKey${index}`,
-      }),
-    ),
-  );
-
-  const newProcessMigrationV2: DeployResourceResponse = await deploy([
-    './resources/orderProcessMigration_v_2.bpmn',
-  ]);
-  const processV2: ProcessDeployment = {
-    bpmnProcessId: 'orderProcessMigration',
-    version: newProcessMigrationV2.processes[0].processDefinitionVersion,
-  };
-  const newProcessMigrationV3: DeployResourceResponse = await deploy([
-    './resources/orderProcessMigration_v_3.bpmn',
-  ]);
-  expect(processV2.version).toBeGreaterThan(processV1.version);
-
-  const processV3: ProcessDeployment = {
-    bpmnProcessId: 'newOrderProcessMigration',
-    version: newProcessMigrationV3.processes[0].processDefinitionVersion,
-  };
-
-  testProcesses = {
-    processV1,
-    processV2,
-    processV3,
-  };
-  await sleep(2000);
-});
-
-test.afterAll(async () => {
-  for (const process of parallelProcesses) {
-    await cancelProcessInstance(process.processInstanceKey as string);
-  }
-  for (const process of processes) {
-    for (const instance of process) {
-      await cancelProcessInstance(instance.processInstanceKey as string);
-    }
-  }
-});
-
 test.describe.serial('Process Instance Migration', () => {
+  test.beforeAll(async () => {
+    await deploy(['./resources/orderProcessMigration_v_1.bpmn']);
+    const processV1: ProcessDeployment = {
+      bpmnProcessId: 'orderProcessMigration',
+      version: 1,
+    };
+
+    processes = await Promise.all(
+      [...new Array(PROCESS_INSTANCE_COUNT)].map((_, index) =>
+        createInstances(processV1.bpmnProcessId, processV1.version, 1, {
+          key1: 'myFirstCorrelationKey',
+          key2: 'mySecondCorrelationKey',
+          key3: `myCorrelationKey${index}`,
+        }),
+      ),
+    );
+
+    const newProcessMigrationV2: DeployResourceResponse = await deploy([
+      './resources/orderProcessMigration_v_2.bpmn',
+    ]);
+    const processV2: ProcessDeployment = {
+      bpmnProcessId: 'orderProcessMigration',
+      version: newProcessMigrationV2.processes[0].processDefinitionVersion,
+    };
+    const newProcessMigrationV3: DeployResourceResponse = await deploy([
+      './resources/orderProcessMigration_v_3.bpmn',
+    ]);
+    expect(processV2.version).toBeGreaterThan(processV1.version);
+
+    const processV3: ProcessDeployment = {
+      bpmnProcessId: 'newOrderProcessMigration',
+      version: newProcessMigrationV3.processes[0].processDefinitionVersion,
+    };
+
+    testProcesses = {
+      processV1,
+      processV2,
+      processV3,
+    };
+    await sleep(2000);
+  });
+
   test.beforeEach(async ({page, loginPage, operateHomePage}) => {
     await navigateToApp(page, 'operate');
     await loginPage.login('demo', 'demo');
@@ -149,6 +112,14 @@ test.describe.serial('Process Instance Migration', () => {
   test.afterEach(async ({page}, testInfo) => {
     await captureScreenshot(page, testInfo);
     await captureFailureVideo(page, testInfo);
+  });
+
+  test.afterAll(async () => {
+    for (const process of processes) {
+      for (const instance of process) {
+        await cancelProcessInstance(instance.processInstanceKey as string);
+      }
+    }
   });
 
   test('Auto mapping migration', async ({
@@ -166,9 +137,10 @@ test.describe.serial('Process Instance Migration', () => {
     await test.step('Filter by process name and version', async () => {
       await operateFiltersPanelPage.selectProcess(sourceBpmnProcessId);
 
-      // Wait for the version dropdown to be populated before selecting
+      // Wait for the process to be selected and version dropdown to be populated
       await sleep(1000);
 
+      // Ensure we're selecting the correct source version (version 1)
       await operateFiltersPanelPage.selectVersion(sourceVersion);
 
       await expect
@@ -776,6 +748,51 @@ test.describe.serial('Process Instance Migration', () => {
       );
     });
   });
+});
+
+test.describe('Parallel job-based user task migration', () => {
+  test.beforeAll(async () => {
+    const parallelV1Deploy: DeployResourceResponse = await deploy([
+      './resources/parallel_tasks_jw_v1.bpmn',
+      './resources/job-worker-id-form.form',
+    ]);
+    const parallelProcessV1: ProcessDeployment = {
+      bpmnProcessId: parallelV1Deploy.processes[0].processDefinitionId,
+      version: parallelV1Deploy.processes[0].processDefinitionVersion,
+    };
+
+    parallelProcesses = await createInstances(
+      parallelProcessV1.bpmnProcessId,
+      parallelProcessV1.version,
+      PARALLEL_INSTANCE_COUNT,
+    );
+
+    // Redeploying with the same bpmnProcessId — Zeebe auto-increments the version to V2.
+    const parallelV2Deploy: DeployResourceResponse = await deploy([
+      './resources/parallel_tasks_jw_v2.bpmn',
+    ]);
+    const parallelProcessV2: ProcessDeployment = {
+      bpmnProcessId: parallelV2Deploy.processes[0].processDefinitionId,
+      version: parallelV2Deploy.processes[0].processDefinitionVersion,
+    };
+
+    expect(parallelProcessV2.version).toBeGreaterThan(
+      parallelProcessV1.version,
+    );
+
+    testParallelProcesses = {parallelProcessV1, parallelProcessV2};
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test.afterAll(async () => {
+    await Promise.all(
+      parallelProcesses.map((p) => cancelProcessInstance(p.processInstanceKey)),
+    );
+  });
 
   test('Migrate parallel job-based user tasks to Camunda user tasks', async ({
     page,
@@ -800,11 +817,13 @@ test.describe.serial('Process Instance Migration', () => {
 
     // Create V2 instances (Camunda user tasks) so Tasklist has tasks to assert on
     // before migration — V1 job-based tasks are not visible in Tasklist.
-    await createInstances(
+    const v2Instances = await createInstances(
       testParallelProcesses.parallelProcessV2.bpmnProcessId,
       testParallelProcesses.parallelProcessV2.version,
       PARALLEL_INSTANCE_COUNT,
     );
+    // Track V2 instances so afterAll cancels them on test failure.
+    parallelProcesses.push(...v2Instances);
 
     await test.step('Verify Tasklist tasks before migration', async () => {
       await navigateToApp(page, 'tasklist');
@@ -812,15 +831,21 @@ test.describe.serial('Process Instance Migration', () => {
       await tasklistHeader.clickTasksTab();
       await taskPanelPage.filterBy('All open tasks');
 
-      // Wait for task cards to be indexed in Tasklist
-      await sleep(20000);
-
-      // V2 instances have Camunda user tasks visible in Tasklist;
-      // V1 instances have job-based tasks which are not shown.
-      await taskPanelPage.assertTaskCardsPresent(targetTaskCards, {
-        expectedCount: PARALLEL_INSTANCE_COUNT,
+      // Poll until Camunda user tasks from V2 instances are indexed in Tasklist.
+      await waitForAssertion({
+        assertion: async () => {
+          // V2 instances have Camunda user tasks visible in Tasklist;
+          // V1 instances have job-based tasks which are not shown.
+          await taskPanelPage.assertTaskCardsPresent(targetTaskCards, {
+            expectedCount: PARALLEL_INSTANCE_COUNT,
+          });
+          await taskPanelPage.assertTaskCardsAbsent(sourceTaskCards);
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+        maxRetries: 10,
       });
-      await taskPanelPage.assertTaskCardsAbsent(sourceTaskCards);
     });
 
     await test.step('Filter by source process and version 1', async () => {
@@ -828,7 +853,10 @@ test.describe.serial('Process Instance Migration', () => {
       await loginPage.login('demo', 'demo');
       await operateHomePage.clickProcessesTab();
       await operateFiltersPanelPage.selectProcess(bpmnProcessId);
+
+      // Wait for the version dropdown to be fully populated after process selection.
       await sleep(1000);
+
       await operateFiltersPanelPage.selectVersion(sourceVersion);
       await expect(operateProcessesPage.resultsText.first()).toBeVisible({
         timeout: 30000,
@@ -861,7 +889,9 @@ test.describe.serial('Process Instance Migration', () => {
         'Embedded',
         'Embedded new',
       );
+    });
 
+    await test.step('Verify auto-mapped flow nodes', async () => {
       await operateProcessMigrationModePage.verifyFlowNodeMappings([
         {
           label: /target element for camunda form/i,
@@ -890,11 +920,17 @@ test.describe.serial('Process Instance Migration', () => {
         'MIGRATE',
       );
       await operateProcessMigrationModePage.clickMigrationConfirmationButton();
-      await sleep(2000);
     });
 
     await test.step('Verify migrated instances appear in Operate at version 2', async () => {
+      await navigateToApp(page, 'operate');
+      await loginPage.login('demo', 'demo');
+      await operateHomePage.clickProcessesTab();
       await operateFiltersPanelPage.selectProcess(bpmnProcessId);
+
+      // Wait for the version dropdown to be fully populated after process selection.
+      await sleep(1000);
+
       await operateFiltersPanelPage.selectVersion(targetVersion);
 
       await waitForAssertion({
@@ -921,11 +957,17 @@ test.describe.serial('Process Instance Migration', () => {
       await tasklistHeader.clickTasksTab();
       await taskPanelPage.filterBy('All open tasks');
 
-      // Wait for migrated Camunda user tasks to be indexed in Tasklist
-      await sleep(20000);
-
-      await taskPanelPage.assertTaskCardsPresent(targetTaskCards, {
-        expectedCount: totalV2InstanceCount,
+      // Poll until migrated Camunda user tasks are indexed in Tasklist.
+      await waitForAssertion({
+        assertion: async () => {
+          await taskPanelPage.assertTaskCardsPresent(targetTaskCards, {
+            expectedCount: totalV2InstanceCount,
+          });
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+        maxRetries: 10,
       });
     });
 
@@ -956,6 +998,10 @@ test.describe.serial('Process Instance Migration', () => {
       await loginPage.login('demo', 'demo');
       await operateHomePage.clickProcessesTab();
       await operateFiltersPanelPage.selectProcess(bpmnProcessId);
+
+      // Wait for the version dropdown to be fully populated after process selection.
+      await sleep(1000);
+
       await operateFiltersPanelPage.selectVersion(targetVersion);
       await operateFiltersPanelPage.clickCompletedInstancesCheckbox();
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -21,10 +21,13 @@ import {
   CreateProcessInstanceResponse,
   DeployResourceResponse,
 } from '@camunda8/sdk/dist/c8/lib/C8Dto';
+import {TaskCard} from '@pages/TaskPanelPage';
+import {parseUserTasksFromFile} from 'utils/bpmn';
 
 const PROCESS_INSTANCE_COUNT = 10;
 const AUTO_MIGRATION_INSTANCE_COUNT = 6;
 const MANUAL_MIGRATION_INSTANCE_COUNT = 3;
+const PARALLEL_INSTANCE_COUNT = 1;
 
 type ProcessDeployment = {
   readonly bpmnProcessId: string;
@@ -37,10 +40,52 @@ type TestProcesses = {
   readonly processV3: ProcessDeployment;
 };
 
+type TestParallelProcesses = {
+  readonly parallelProcessV1: ProcessDeployment;
+  readonly parallelProcessV2: ProcessDeployment;
+};
+
 let testProcesses: TestProcesses;
+let testParallelProcesses: TestParallelProcesses;
 let processes: CreateProcessInstanceResponse[][] = [];
+let parallelProcesses: CreateProcessInstanceResponse[] = [];
+
+// Task cards parsed from BPMN fixtures — single source of truth for task names and assignees.
+const sourceTaskCards: TaskCard[] = parseUserTasksFromFile(
+  './resources/parallel_tasks_jw_v1.bpmn',
+).filter((task) => task.name && task.assignee);
+
+const targetTaskCards: TaskCard[] = parseUserTasksFromFile(
+  './resources/parallel_tasks_jw_v2.bpmn',
+).filter((task) => task.name && task.assignee);
 
 test.beforeAll(async () => {
+  const parallelV1Deploy: DeployResourceResponse = await deploy([
+    './resources/parallel_tasks_jw_v1.bpmn',
+    './resources/job-worker-id-form.form',
+  ]);
+  const parallelProcessV1: ProcessDeployment = {
+    bpmnProcessId: parallelV1Deploy.processes[0].processDefinitionId,
+    version: parallelV1Deploy.processes[0].processDefinitionVersion,
+  };
+
+  parallelProcesses = await createInstances(
+    parallelProcessV1.bpmnProcessId,
+    parallelProcessV1.version,
+    PARALLEL_INSTANCE_COUNT,
+  );
+
+  // Redeploying with the same bpmnProcessId — Zeebe auto-increments the version to V2.
+  const parallelV2Deploy: DeployResourceResponse = await deploy([
+    './resources/parallel_tasks_jw_v2.bpmn',
+  ]);
+  const parallelProcessV2: ProcessDeployment = {
+    bpmnProcessId: parallelV2Deploy.processes[0].processDefinitionId,
+    version: parallelV2Deploy.processes[0].processDefinitionVersion,
+  };
+
+  testParallelProcesses = {parallelProcessV1, parallelProcessV2};
+
   await deploy(['./resources/orderProcessMigration_v_1.bpmn']);
   const processV1: ProcessDeployment = {
     bpmnProcessId: 'orderProcessMigration',
@@ -83,6 +128,9 @@ test.beforeAll(async () => {
 });
 
 test.afterAll(async () => {
+  for (const process of parallelProcesses) {
+    await cancelProcessInstance(process.processInstanceKey as string);
+  }
   for (const process of processes) {
     for (const instance of process) {
       await cancelProcessInstance(instance.processInstanceKey as string);
@@ -118,10 +166,9 @@ test.describe.serial('Process Instance Migration', () => {
     await test.step('Filter by process name and version', async () => {
       await operateFiltersPanelPage.selectProcess(sourceBpmnProcessId);
 
-      // Wait for the process to be selected and version dropdown to be populated
+      // Wait for the version dropdown to be populated before selecting
       await sleep(1000);
 
-      // Ensure we're selecting the correct source version (version 1)
       await operateFiltersPanelPage.selectVersion(sourceVersion);
 
       await expect
@@ -343,9 +390,6 @@ test.describe.serial('Process Instance Migration', () => {
     });
 
     await test.step('Verify TaskF instances', async () => {
-      await operateFiltersPanelPage.selectProcess(targetBpmnProcessId);
-      await operateFiltersPanelPage.selectVersion(targetVersion);
-
       await page.goto(
         `operate/processes?active=true&incidents=true&processDefinitionId=${targetBpmnProcessId}&processDefinitionVersion=${targetVersion}&elementId=TaskF`,
       );
@@ -374,9 +418,6 @@ test.describe.serial('Process Instance Migration', () => {
     const tasksToVerify = ['TaskI', 'TaskJ', 'TaskK'];
     for (const taskId of tasksToVerify) {
       await test.step(`Verify ${taskId} instances`, async () => {
-        await operateFiltersPanelPage.selectProcess(targetBpmnProcessId);
-        await operateFiltersPanelPage.selectVersion(targetVersion);
-
         await page.goto(
           `operate/processes?active=true&incidents=true&processDefinitionId=${targetBpmnProcessId}&processDefinitionVersion=${targetVersion}&elementId=${taskId}`,
         );
@@ -406,9 +447,6 @@ test.describe.serial('Process Instance Migration', () => {
     const tasksToVerify = ['AIAgentTask', 'AIAgentsubprocess'];
     for (const taskId of tasksToVerify) {
       await test.step(`Verify ${taskId} instances`, async () => {
-        await operateFiltersPanelPage.selectProcess(targetBpmnProcessId);
-        await operateFiltersPanelPage.selectVersion(targetVersion);
-
         await page.goto(
           `operate/processes?active=true&incidents=true&processDefinitionId=${targetBpmnProcessId}&processDefinitionVersion=${targetVersion}&elementId=${taskId}`,
         );
@@ -603,11 +641,13 @@ test.describe.serial('Process Instance Migration', () => {
 
     await test.step('Proceed to summary and verify migration details', async () => {
       await operateProcessMigrationModePage.clickNextButton();
-      await expect(
-        operateProcessMigrationModePage.summaryNotification,
-      ).toContainText(
-        `You are about to migrate 3 process instances from the process definition: ${sourceBpmnProcessId} - version ${sourceVersion} to the process definition: ${targetBpmnProcessId} - version ${targetVersion}`,
-      );
+      await operateProcessMigrationModePage.verifySummaryNotification({
+        instanceCount: MANUAL_MIGRATION_INSTANCE_COUNT,
+        sourceBpmnProcessId,
+        sourceVersion,
+        targetBpmnProcessId,
+        targetVersion,
+      });
     });
 
     await test.step('Confirm migration and type MIGRATE', async () => {
@@ -734,6 +774,203 @@ test.describe.serial('Process Instance Migration', () => {
         ['Extract value error.'],
         'ExclusiveGateway2',
       );
+    });
+  });
+
+  test('Migrate parallel job-based user tasks to Camunda user tasks', async ({
+    page,
+    operateHomePage,
+    operateFiltersPanelPage,
+    operateProcessesPage,
+    operateProcessMigrationModePage,
+    tasklistHeader,
+    taskPanelPage,
+    taskDetailsPage,
+    loginPage,
+  }) => {
+    test.slow();
+
+    const sourceVersion =
+      testParallelProcesses.parallelProcessV1.version.toString();
+    const targetVersion =
+      testParallelProcesses.parallelProcessV2.version.toString();
+    const bpmnProcessId = testParallelProcesses.parallelProcessV1.bpmnProcessId;
+    // totalV2InstanceCount = original V2 instances + migrated V1→V2 instances
+    const totalV2InstanceCount = 2 * PARALLEL_INSTANCE_COUNT;
+
+    // Create V2 instances (Camunda user tasks) so Tasklist has tasks to assert on
+    // before migration — V1 job-based tasks are not visible in Tasklist.
+    await createInstances(
+      testParallelProcesses.parallelProcessV2.bpmnProcessId,
+      testParallelProcesses.parallelProcessV2.version,
+      PARALLEL_INSTANCE_COUNT,
+    );
+
+    await test.step('Verify Tasklist tasks before migration', async () => {
+      await navigateToApp(page, 'tasklist');
+      await loginPage.login('demo', 'demo');
+      await tasklistHeader.clickTasksTab();
+      await taskPanelPage.filterBy('All open tasks');
+
+      // Wait for task cards to be indexed in Tasklist
+      await sleep(20000);
+
+      // V2 instances have Camunda user tasks visible in Tasklist;
+      // V1 instances have job-based tasks which are not shown.
+      await taskPanelPage.assertTaskCardsPresent(targetTaskCards, {
+        expectedCount: PARALLEL_INSTANCE_COUNT,
+      });
+      await taskPanelPage.assertTaskCardsAbsent(sourceTaskCards);
+    });
+
+    await test.step('Filter by source process and version 1', async () => {
+      await navigateToApp(page, 'operate');
+      await loginPage.login('demo', 'demo');
+      await operateHomePage.clickProcessesTab();
+      await operateFiltersPanelPage.selectProcess(bpmnProcessId);
+      await sleep(1000);
+      await operateFiltersPanelPage.selectVersion(sourceVersion);
+      await expect(operateProcessesPage.resultsText.first()).toBeVisible({
+        timeout: 30000,
+      });
+    });
+
+    await test.step(`Select ${PARALLEL_INSTANCE_COUNT} instance(s) and start migration`, async () => {
+      await operateProcessesPage.selectProcessInstances(
+        PARALLEL_INSTANCE_COUNT,
+      );
+      await operateProcessesPage.startMigration();
+    });
+
+    await test.step('Select target version 2 (same process)', async () => {
+      await expect(
+        operateProcessMigrationModePage.targetProcessCombobox,
+      ).toHaveValue(bpmnProcessId);
+
+      await operateProcessMigrationModePage.targetVersionDropdown.click();
+      await operateProcessMigrationModePage
+        .getOptionByName(targetVersion)
+        .click();
+      await expect(
+        operateProcessMigrationModePage.targetVersionDropdown,
+      ).toHaveText(targetVersion, {useInnerText: true});
+    });
+
+    await test.step('Map renamed flow node: Embedded → Embedded new', async () => {
+      await operateProcessMigrationModePage.mapFlowNode(
+        'Embedded',
+        'Embedded new',
+      );
+
+      await operateProcessMigrationModePage.verifyFlowNodeMappings([
+        {
+          label: /target element for camunda form/i,
+          targetValue: 'camunda_form',
+        },
+        {
+          label: /target element for external form/i,
+          targetValue: 'external_form',
+        },
+      ]);
+    });
+
+    await test.step('Review summary and confirm migration', async () => {
+      await operateProcessMigrationModePage.clickNextButton();
+
+      await operateProcessMigrationModePage.verifySummaryNotification({
+        instanceCount: PARALLEL_INSTANCE_COUNT,
+        sourceBpmnProcessId: bpmnProcessId,
+        sourceVersion,
+        targetBpmnProcessId: bpmnProcessId,
+        targetVersion,
+      });
+
+      await operateProcessMigrationModePage.clickConfirmButton();
+      await operateProcessMigrationModePage.fillMigrationConfirmation(
+        'MIGRATE',
+      );
+      await operateProcessMigrationModePage.clickMigrationConfirmationButton();
+      await sleep(2000);
+    });
+
+    await test.step('Verify migrated instances appear in Operate at version 2', async () => {
+      await operateFiltersPanelPage.selectProcess(bpmnProcessId);
+      await operateFiltersPanelPage.selectVersion(targetVersion);
+
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(
+            page.getByText(`${totalV2InstanceCount} results`),
+          ).toBeVisible({
+            timeout: 3000,
+          });
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+
+      await expect(
+        operateProcessesPage.versionCells(targetVersion),
+      ).toHaveCount(totalV2InstanceCount, {timeout: 30000});
+    });
+
+    await test.step('Navigate to Tasklist and verify migrated Camunda user task cards with assignees', async () => {
+      await navigateToApp(page, 'tasklist');
+      await loginPage.login('demo', 'demo');
+      await tasklistHeader.clickTasksTab();
+      await taskPanelPage.filterBy('All open tasks');
+
+      // Wait for migrated Camunda user tasks to be indexed in Tasklist
+      await sleep(20000);
+
+      await taskPanelPage.assertTaskCardsPresent(targetTaskCards, {
+        expectedCount: totalV2InstanceCount,
+      });
+    });
+
+    await test.step('Open each task, unassign, assign to self, and complete', async () => {
+      const taskNames = targetTaskCards.map((task) => task.name);
+
+      for (const taskName of taskNames) {
+        for (let i = 0; i < totalV2InstanceCount; i++) {
+          // Always click .nth(0) — the completed task disappears so the next one shifts up
+          await taskPanelPage.availableTasks
+            .getByText(taskName, {exact: true})
+            .nth(0)
+            .click();
+
+          await taskDetailsPage.unassignReassignToMeAndComplete();
+        }
+      }
+
+      // After all tasks complete, the result (manualTask) auto-fires and all instances end.
+      await taskPanelPage.filterBy('All open tasks');
+      await expect(
+        taskPanelPage.availableTasks.getByText(bpmnProcessId),
+      ).toHaveCount(0);
+    });
+
+    await test.step(`Verify ${totalV2InstanceCount} process instance(s) are completed in Operate`, async () => {
+      await navigateToApp(page, 'operate');
+      await loginPage.login('demo', 'demo');
+      await operateHomePage.clickProcessesTab();
+      await operateFiltersPanelPage.selectProcess(bpmnProcessId);
+      await operateFiltersPanelPage.selectVersion(targetVersion);
+      await operateFiltersPanelPage.clickCompletedInstancesCheckbox();
+
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(
+            page.getByText(`${totalV2InstanceCount} results`),
+          ).toBeVisible({
+            timeout: 3000,
+          });
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
     });
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/bpmn.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/bpmn.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import * as fs from 'fs';
+
+export type UserTaskDefinition = {
+  readonly id: string;
+  readonly name: string;
+  readonly assignee?: string;
+  readonly isCamundaUserTask: boolean;
+};
+
+// Minimal parser tailored to the BPMN test fixtures to avoid extra dependencies.
+export function parseUserTasksFromFile(filePath: string): UserTaskDefinition[] {
+  const xml = fs.readFileSync(filePath, 'utf-8');
+  return parseUserTasksFromXml(xml);
+}
+
+export function parseUserTasksFromXml(xml: string): UserTaskDefinition[] {
+  const userTaskBlocks =
+    xml.match(/<bpmn:userTask\b[^>]*>[\s\S]*?<\/bpmn:userTask>/g) || [];
+
+  return userTaskBlocks.map((block) => {
+    const openingTagMatch = block.match(/<bpmn:userTask\b([^>]*)>/);
+    const openingTag = openingTagMatch?.[1] ?? '';
+
+    const id = extractAttribute(openingTag, 'id') ?? '';
+    const name = extractAttribute(openingTag, 'name') ?? '';
+    const assignee = extractAttribute(block, 'assignee');
+    const isCamundaUserTask = /<zeebe:userTask\b/.test(block);
+
+    return {id, name, assignee, isCamundaUserTask};
+  });
+}
+
+function extractAttribute(
+  source: string,
+  attribute: string,
+): string | undefined {
+  const match = source.match(new RegExp(`${attribute}="([^"]+)"`));
+  return match?.[1];
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/bpmn.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/bpmn.ts
@@ -16,10 +16,6 @@ export type UserTaskDefinition = {
 };
 
 // Minimal parser tailored to the BPMN test fixtures to avoid extra dependencies.
-export function parseUserTasksFromFile(filePath: string): UserTaskDefinition[] {
-  const xml = fs.readFileSync(filePath, 'utf-8');
-  return parseUserTasksFromXml(xml);
-}
 
 export function parseUserTasksFromXml(xml: string): UserTaskDefinition[] {
   const userTaskBlocks = xml.match(
@@ -27,7 +23,9 @@ export function parseUserTasksFromXml(xml: string): UserTaskDefinition[] {
   );
 
   if (!userTaskBlocks || userTaskBlocks.length === 0) {
-    throw new Error('Expected at least one <bpmn:userTask> element in BPMN XML');
+    throw new Error(
+      'Expected at least one <bpmn:userTask> element in BPMN XML',
+    );
   }
 
   return userTaskBlocks.map((block, index) => {
@@ -67,4 +65,23 @@ function extractAttribute(
 ): string | undefined {
   const match = source.match(new RegExp(`${attribute}="([^"]+)"`));
   return match?.[1];
+}
+
+/**
+ * Parses user tasks from a BPMN file and returns only tasks that have an assignee defined.
+ * Throws if any task is missing an assignee, making fixture misconfiguration a hard error.
+ */
+export function parseAssignedTasksFromFile(
+  filePath: string,
+): Array<{name: string; assignee: string}> {
+  const xml = fs.readFileSync(filePath, 'utf-8');
+  return parseUserTasksFromXml(xml).map((task) => {
+    if (!task.assignee?.trim()) {
+      throw new Error(
+        `Expected user task "${task.id}" (${task.name}) in BPMN fixture "${filePath}" to define an assignee`,
+      );
+    }
+
+    return {name: task.name, assignee: task.assignee};
+  });
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/bpmn.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/bpmn.ts
@@ -22,15 +22,38 @@ export function parseUserTasksFromFile(filePath: string): UserTaskDefinition[] {
 }
 
 export function parseUserTasksFromXml(xml: string): UserTaskDefinition[] {
-  const userTaskBlocks =
-    xml.match(/<bpmn:userTask\b[^>]*>[\s\S]*?<\/bpmn:userTask>/g) || [];
+  const userTaskBlocks = xml.match(
+    /<bpmn:userTask\b[^>]*>[\s\S]*?<\/bpmn:userTask>/g,
+  );
 
-  return userTaskBlocks.map((block) => {
+  if (!userTaskBlocks || userTaskBlocks.length === 0) {
+    throw new Error('Expected at least one <bpmn:userTask> element in BPMN XML');
+  }
+
+  return userTaskBlocks.map((block, index) => {
     const openingTagMatch = block.match(/<bpmn:userTask\b([^>]*)>/);
-    const openingTag = openingTagMatch?.[1] ?? '';
 
-    const id = extractAttribute(openingTag, 'id') ?? '';
-    const name = extractAttribute(openingTag, 'name') ?? '';
+    if (!openingTagMatch) {
+      throw new Error(
+        `Failed to parse opening tag for <bpmn:userTask> at index ${index}`,
+      );
+    }
+
+    const openingTag = openingTagMatch[1];
+    const id = extractAttribute(openingTag, 'id');
+    const name = extractAttribute(openingTag, 'name');
+
+    if (!id) {
+      throw new Error(
+        `Missing required "id" attribute for <bpmn:userTask> at index ${index}`,
+      );
+    }
+
+    if (!name) {
+      throw new Error(
+        `Missing required "name" attribute for <bpmn:userTask> with id "${id}"`,
+      );
+    }
     const assignee = extractAttribute(block, 'assignee');
     const isCamundaUserTask = /<zeebe:userTask\b/.test(block);
 


### PR DESCRIPTION
## Description

Add E2E coverage for migrating parallel job-based user tasks to Camunda user tasks and refactor the migration spec so the serial Operate flow and the new parallel Tasklist/Operate flow have isolated setup, cleanup, and failure diagnostics.

## Changes

- added a new parallel user task migration E2E test
- added BPMN fixtures and form resources for the scenario
- added `utils/bpmn.ts` to parse task metadata from BPMN files
- extended page objects/helpers needed by the new flow
- isolated setup/cleanup for the serial and parallel migration suites
- added failure artifact capture to the parallel suite

## Why

This adds coverage for a migration path that was not tested before and makes the migration spec easier to maintain and debug.

## Validation


```
cd /Users/yuliia.korsun/Repos/camunda/qa/c8-orchestration-cluster-e2e-test-suite
npx eslint tests/operate/processInstanceMigration.spec.ts
npx playwright test tests/operate/processInstanceMigration.spec.ts --list
```



## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/product-hub/issues/3251
