### PR TITLE
test: add e2e tests for Batch Operations Monitoring in Operate

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/fixtures.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/fixtures.ts
@@ -37,6 +37,7 @@ import {IdentityAuditLogPage} from '@pages/IdentityAuditLogPage';
 import {OperateOperationsDetailsPage} from '@pages/OperateOperationsDetailsPage';
 import {OperateOperationsLogPage} from '@pages/OperateOperationsLogPage';
 import {SwaggerPage} from '@pages/SwaggerPage';
+import {OperateBatchOperationsPage} from '@pages/OperateBatchOperationsPage';
 
 type PlaywrightFixtures = {
   makeAxeBuilder: () => AxeBuilder;
@@ -55,6 +56,7 @@ type PlaywrightFixtures = {
   operateProcessInstanceViewModificationModePage: OperateProcessInstanceViewModificationModePage;
   operateOperationsDetailsPage: OperateOperationsDetailsPage;
   operateOperationsLogPage: OperateOperationsLogPage;
+  operateBatchOperationsPage: OperateBatchOperationsPage;
   taskDetailsPage: TaskDetailsPage;
   tasklistHeader: TasklistHeader;
   tasklistProcessesPage: TasklistProcessesPage;
@@ -148,6 +150,9 @@ const test = base.extend<PlaywrightFixtures>({
   },
   operateOperationsLogPage: async ({page}, use) => {
     await use(new OperateOperationsLogPage(page));
+  },
+  operateBatchOperationsPage: async ({page}, use) => {
+    await use(new OperateBatchOperationsPage(page));
   },
   taskDetailsPage: async ({page}, use) => {
     await use(new TaskDetailsPage(page));

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateBatchOperationsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateBatchOperationsPage.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {Locator, Page} from '@playwright/test';
+
+export class OperateBatchOperationsPage {
+  private page: Page;
+  readonly heading: Locator;
+  readonly table: Locator;
+  readonly tableRows: Locator;
+  readonly emptyStateMessage: Locator;
+  readonly forbiddenMessage: Locator;
+  readonly operationColumnHeader: Locator;
+  readonly batchStateColumnHeader: Locator;
+  readonly actorColumnHeader: Locator;
+  readonly startDateColumnHeader: Locator;
+  readonly itemsColumnHeader: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.heading = page.getByRole('heading', {
+      name: 'Batch Operations',
+      level: 3,
+    });
+    this.table = page.getByRole('table');
+    this.tableRows = this.table.getByRole('row');
+    this.emptyStateMessage = page.getByText('No batch operations found');
+    this.forbiddenMessage = page.getByText(/403 - You do not have permission/);
+    this.operationColumnHeader = page.getByRole('columnheader', {
+      name: 'Sort by Operation',
+    });
+    this.batchStateColumnHeader = page.getByRole('columnheader', {
+      name: 'Sort by Batch state',
+    });
+    this.actorColumnHeader = page.getByRole('columnheader', {
+      name: 'Sort by Actor',
+    });
+    this.startDateColumnHeader = page.getByRole('columnheader', {
+      name: 'Sort by Start date',
+    });
+    this.itemsColumnHeader = page.getByRole('columnheader', {name: 'Items'});
+  }
+
+  async goto(options?: {searchParams?: Record<string, string>}): Promise<void> {
+    const base = `${process.env.CORE_APPLICATION_URL}/operate/batch-operations`;
+    if (options?.searchParams) {
+      const params = new URLSearchParams(options.searchParams);
+      await this.page.goto(`${base}?${params.toString()}`);
+    } else {
+      await this.page.goto(base);
+    }
+  }
+
+  getRowLinkByKey(batchOperationKey: string): Locator {
+    return this.page.locator(`a[href$="/${batchOperationKey}"]`);
+  }
+
+  async clickFirstRowLink(): Promise<void> {
+    await this.table.getByRole('link').first().click();
+  }
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateHomePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateHomePage.ts
@@ -14,6 +14,9 @@ class OperateHomePage {
   readonly dashboardLink: Locator;
   readonly processesTab: Locator;
   readonly decisionsTab: Locator;
+  readonly operationsMenuButton: Locator;
+  readonly batchOperationsNavItem: Locator;
+  readonly operationsLogNavItem: Locator;
   readonly informationDialog: Locator;
   readonly editVariableButton: Locator;
   readonly variableValueInput: Locator;
@@ -33,6 +36,16 @@ class OperateHomePage {
     this.dashboardLink = page.getByRole('link', {name: 'Dashboard'});
     this.processesTab = page.getByRole('link', {name: 'Processes'}).first();
     this.decisionsTab = page.getByRole('link', {name: 'Decisions'});
+    // Carbon's HeaderMenu trigger uses this class regardless of element type/ARIA role
+    this.operationsMenuButton = page
+      .locator('.cds--header__menu-title')
+      .filter({hasText: /^Operations$/});
+    this.batchOperationsNavItem = page.getByRole('link', {
+      name: 'Batch operations',
+    });
+    this.operationsLogNavItem = page.getByRole('link', {
+      name: 'Operations log',
+    });
     this.informationDialog = page.getByRole('button', {
       name: 'Close this dialog',
     });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateHomePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateHomePage.ts
@@ -36,7 +36,6 @@ class OperateHomePage {
     this.dashboardLink = page.getByRole('link', {name: 'Dashboard'});
     this.processesTab = page.getByRole('link', {name: 'Processes'}).first();
     this.decisionsTab = page.getByRole('link', {name: 'Decisions'});
-    // Carbon's HeaderMenu trigger uses this class regardless of element type/ARIA role
     this.operationsMenuButton = page
       .locator('.cds--header__menu-title')
       .filter({hasText: /^Operations$/});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateOperationsDetailsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateOperationsDetailsPage.ts
@@ -13,6 +13,17 @@ export class OperateOperationsDetailsPage {
   private tileElement: Locator;
   readonly state: Locator;
   readonly summaryOfItems: Locator;
+  readonly forbiddenMessage: Locator;
+  readonly backButton: Locator;
+  readonly suspendButton: Locator;
+  readonly resumeButton: Locator;
+  readonly optionsMenuButton: Locator;
+  readonly itemsTable: Locator;
+  readonly itemsTableRows: Locator;
+  readonly stateBadge: Locator;
+  readonly summaryTile: Locator;
+  readonly actorTile: Locator;
+  readonly startDateTile: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -23,6 +34,34 @@ export class OperateOperationsDetailsPage {
     this.summaryOfItems = this.tileElement
       .filter({hasText: 'Summary of items'})
       .getByRole('status');
+    this.summaryTile = this.tileElement.filter({hasText: 'Summary of items'});
+    this.actorTile = this.tileElement.filter({hasText: 'Actor'});
+    this.startDateTile = this.tileElement.filter({hasText: 'Start date'});
+    this.forbiddenMessage = page.getByText(
+      /403 - You do not have permission/,
+    );
+    this.backButton = page.getByRole('button', {
+      name: 'Back to batch operations',
+    });
+    this.suspendButton = page.getByRole('button', {name: /^Suspend$/i});
+    this.resumeButton = page.getByRole('button', {name: /^Resume$/i});
+    this.optionsMenuButton = page.getByRole('button', {name: /Options/i});
+    this.itemsTable = page.getByRole('table');
+    this.itemsTableRows = this.itemsTable.getByRole('row');
+    this.stateBadge = page.getByRole('status', {
+      name: /Batch operation status:/,
+    });
+  }
+
+  async goto(batchOperationKey: string): Promise<void> {
+    await this.page.goto(
+      `${process.env.CORE_APPLICATION_URL}/operate/batch-operations/${batchOperationKey}`,
+    );
+  }
+
+  async clickCancelFromOptionsMenu(): Promise<void> {
+    await this.optionsMenuButton.click();
+    await this.page.getByRole('menuitem', {name: /^Cancel$/i}).click();
   }
 
   async getBatchOperationStatus(): Promise<string> {
@@ -39,5 +78,11 @@ export class OperateOperationsDetailsPage {
     }
 
     throw new Error(`Could not extract batch operation ID from URL: ${url}`);
+  }
+
+  getProcessInstanceLink(processInstanceKey: string): Locator {
+    return this.page.getByRole('link', {
+      name: `View process instance ${processInstanceKey}`,
+    });
   }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateOperationsDetailsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateOperationsDetailsPage.ts
@@ -37,9 +37,7 @@ export class OperateOperationsDetailsPage {
     this.summaryTile = this.tileElement.filter({hasText: 'Summary of items'});
     this.actorTile = this.tileElement.filter({hasText: 'Actor'});
     this.startDateTile = this.tileElement.filter({hasText: 'Start date'});
-    this.forbiddenMessage = page.getByText(
-      /403 - You do not have permission/,
-    );
+    this.forbiddenMessage = page.getByText(/403 - You do not have permission/);
     this.backButton = page.getByRole('button', {
       name: 'Back to batch operations',
     });
@@ -48,9 +46,7 @@ export class OperateOperationsDetailsPage {
     this.optionsMenuButton = page.getByRole('button', {name: /Options/i});
     this.itemsTable = page.getByRole('table');
     this.itemsTableRows = this.itemsTable.getByRole('row');
-    this.stateBadge = page.getByRole('status', {
-      name: /Batch operation status:/,
-    });
+    this.stateBadge = this.state;
   }
 
   async goto(batchOperationKey: string): Promise<void> {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/batch_suspension_long_process.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/batch_suspension_long_process.bpmn
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.39.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <bpmn:process id="batch_suspension_long_process" name="Batch Suspension Long Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="CatchEvent_1" />
+    <bpmn:intermediateCatchEvent id="CatchEvent_1" name="Wait for signal">
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1" messageRef="Message_1" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="CatchEvent_1" targetRef="EndEvent_1" />
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmn:message id="Message_1" name="batch_suspension_long_signal">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=correlationKey" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="batch_suspension_long_process">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="CatchEvent_1_di" bpmnElement="CatchEvent_1">
+        <dc:Bounds x="282" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="258" y="145" width="85" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="382" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+        <di:waypoint x="218" y="120" />
+        <di:waypoint x="282" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_2_di" bpmnElement="Flow_2">
+        <di:waypoint x="318" y="120" />
+        <di:waypoint x="382" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/batchOperations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/batchOperations.spec.ts
@@ -1,0 +1,450 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test} from 'fixtures';
+import {expect} from '@playwright/test';
+import {deploy} from 'utils/zeebeClient';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {navigateToApp} from '@pages/UtilitiesPage';
+import {
+  createCancellationBatch,
+  expectBatchState,
+  findCompletedBatchKey,
+  suspendBatchOperation,
+} from '@requestHelpers';
+import {waitForAssertion} from 'utils/waitForAssertion';
+
+test.beforeAll(async () => {
+  await deploy([
+    './resources/batch_cancellation_process.bpmn',
+    './resources/batch_suspension_process.bpmn',
+  ]);
+});
+
+test.describe('Batch Operations', () => {
+  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
+    await navigateToApp(page, 'operate');
+    await loginPage.login('demo', 'demo');
+    await expect(operateHomePage.operateBanner).toBeVisible();
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('Navigate to batch detail page by clicking a list row link', async ({
+    page,
+    request,
+    operateBatchOperationsPage,
+    operateOperationsDetailsPage,
+  }) => {
+    await createCancellationBatch(request);
+
+    await test.step('Navigate to batch operations list', async () => {
+      await operateBatchOperationsPage.goto();
+      await expect(operateBatchOperationsPage.heading).toBeVisible();
+    });
+
+    const firstLink = operateBatchOperationsPage.table
+      .getByRole('link')
+      .first();
+
+    await test.step('Click the first batch operation row link', async () => {
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(firstLink).toBeVisible({timeout: 30000});
+        },
+        onFailure: async () => {
+          await page.reload();
+          await expect(operateBatchOperationsPage.heading).toBeVisible();
+        },
+      });
+      await firstLink.click();
+    });
+
+    await test.step('Verify navigation to detail page', async () => {
+      await expect(page).toHaveURL(/\/operate\/batch-operations\/\d+/);
+      await expect(operateOperationsDetailsPage.backButton).toBeVisible();
+    });
+  });
+
+  test('Navigate to process instance from a link in the batch items table', async ({
+    page,
+    request,
+    operateOperationsDetailsPage,
+  }) => {
+    const batchKey = await findCompletedBatchKey(request);
+    await operateOperationsDetailsPage.goto(batchKey);
+
+    await test.step('Wait for items table to load a process instance link', async () => {
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(
+            operateOperationsDetailsPage.itemsTable.getByRole('link').first(),
+          ).toBeVisible({timeout: 20000});
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+        maxRetries: 3,
+      });
+    });
+
+    const firstLink = operateOperationsDetailsPage.itemsTable
+      .getByRole('link')
+      .first();
+    const href = await firstLink.getAttribute('href');
+    await firstLink.click();
+
+    await test.step('Verify navigation to process instance page', async () => {
+      await expect(page).toHaveURL(new RegExp(`/operate/processes/\\d+`));
+      expect(href).toMatch(/\/processes\/\d+/);
+    });
+  });
+
+  test('Navigate to Batch Operations list via the Operations header menu', async ({
+    page,
+    operateHomePage,
+    operateBatchOperationsPage,
+  }) => {
+    await test.step('Open the Operations menu and click Batch operations', async () => {
+      await operateHomePage.operationsMenuButton.click();
+      await operateHomePage.batchOperationsNavItem.click();
+    });
+
+    await test.step('Verify Batch Operations list page loads', async () => {
+      await expect(page).toHaveURL(/\/operate\/batch-operations/);
+      await expect(operateBatchOperationsPage.heading).toBeVisible();
+    });
+  });
+
+  test('Update URL sort parameter when clicking the Operation column header', async ({
+    page,
+    operateBatchOperationsPage,
+  }) => {
+    await operateBatchOperationsPage.goto();
+    await expect(operateBatchOperationsPage.heading).toBeVisible();
+
+    await test.step('Click Operation column header for the first time', async () => {
+      await operateBatchOperationsPage.operationColumnHeader.click();
+      await expect(page).toHaveURL(/sort=operationType%2Bdesc/);
+    });
+
+    await test.step('Click Operation column header again to toggle sort order', async () => {
+      await operateBatchOperationsPage.operationColumnHeader.click();
+      await expect(page).toHaveURL(/sort=operationType%2Basc/);
+    });
+  });
+
+  test('Update URL sort parameter when clicking the Actor column header', async ({
+    page,
+    operateBatchOperationsPage,
+  }) => {
+    await operateBatchOperationsPage.goto();
+    await expect(operateBatchOperationsPage.heading).toBeVisible();
+
+    await operateBatchOperationsPage.actorColumnHeader.click();
+
+    await expect(page).toHaveURL(/sort=actorId%2Bdesc/);
+  });
+
+  test('Restore sort order from URL parameters on page reload', async ({
+    page,
+    operateBatchOperationsPage,
+  }) => {
+    await operateBatchOperationsPage.goto({
+      searchParams: {sort: 'operationType+asc'},
+    });
+    await expect(operateBatchOperationsPage.heading).toBeVisible();
+
+    await page.reload();
+
+    await expect(operateBatchOperationsPage.heading).toBeVisible();
+    await expect(page).toHaveURL(/sort=operationType%2Basc/);
+  });
+
+  test('Suspend an active batch operation via the Suspend button', async ({
+    page,
+    request,
+    operateOperationsDetailsPage,
+  }) => {
+    const batchKey = await createCancellationBatch(
+      request,
+      400,
+      'batch_suspension_process',
+    );
+    await operateOperationsDetailsPage.goto(batchKey);
+
+    await test.step('Click Suspend and wait for state change', async () => {
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(operateOperationsDetailsPage.suspendButton).toBeVisible({
+            timeout: 20000,
+          });
+          await expect(
+            operateOperationsDetailsPage.suspendButton,
+          ).toBeEnabled();
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+      await operateOperationsDetailsPage.suspendButton.click();
+    });
+
+    await test.step('Verify state indicator shows Suspended', async () => {
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(operateOperationsDetailsPage.state).toContainText(
+            'Suspended',
+            {timeout: 15000},
+          );
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+        maxRetries: 3,
+      });
+      await expect(operateOperationsDetailsPage.resumeButton).toBeVisible();
+      await expect(operateOperationsDetailsPage.suspendButton).toBeHidden();
+    });
+  });
+
+  test('Cancel an active batch operation via the Options menu', async ({
+    page,
+    request,
+    operateOperationsDetailsPage,
+  }) => {
+    const batchKey = await createCancellationBatch(
+      request,
+      400,
+      'batch_suspension_process',
+    );
+    await operateOperationsDetailsPage.goto(batchKey);
+
+    await test.step('Click Options > Cancel and wait for state change', async () => {
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(operateOperationsDetailsPage.suspendButton).toBeVisible({
+            timeout: 20000,
+          });
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+      await operateOperationsDetailsPage.clickCancelFromOptionsMenu();
+    });
+
+    await test.step('Verify state indicator shows Canceled', async () => {
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(operateOperationsDetailsPage.state).toContainText(
+            'Canceled',
+            {timeout: 15000},
+          );
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+        maxRetries: 3,
+      });
+      await expect(operateOperationsDetailsPage.suspendButton).toBeHidden();
+      await expect(operateOperationsDetailsPage.resumeButton).toBeHidden();
+    });
+  });
+
+  test('Resume a suspended batch operation via the Resume button', async ({
+    page,
+    request,
+    operateOperationsDetailsPage,
+  }) => {
+    const batchKey = await createCancellationBatch(
+      request,
+      30,
+      'batch_suspension_process',
+    );
+    await suspendBatchOperation(request, batchKey);
+    await expectBatchState(request, batchKey, 'SUSPENDED');
+
+    await operateOperationsDetailsPage.goto(batchKey);
+
+    await test.step('Click Resume', async () => {
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(operateOperationsDetailsPage.resumeButton).toBeVisible({
+            timeout: 20000,
+          });
+          await expect(operateOperationsDetailsPage.resumeButton).toBeEnabled();
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+      await operateOperationsDetailsPage.resumeButton.click();
+    });
+
+    await test.step('Verify state indicator no longer shows Suspended', async () => {
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(operateOperationsDetailsPage.state).not.toContainText(
+            'Suspended',
+            {timeout: 15000},
+          );
+          await expect(operateOperationsDetailsPage.resumeButton).toBeHidden();
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+        maxRetries: 3,
+      });
+    });
+  });
+
+  test('Cancel a suspended batch operation via the Options menu', async ({
+    page,
+    request,
+    operateOperationsDetailsPage,
+  }) => {
+    const batchKey = await createCancellationBatch(
+      request,
+      30,
+      'batch_suspension_process',
+    );
+    await suspendBatchOperation(request, batchKey);
+    await expectBatchState(request, batchKey, 'SUSPENDED');
+
+    await operateOperationsDetailsPage.goto(batchKey);
+
+    await test.step('Wait for Suspended state and click Options > Cancel', async () => {
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(operateOperationsDetailsPage.state).toContainText(
+            'Suspended',
+            {timeout: 20000},
+          );
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+      await operateOperationsDetailsPage.clickCancelFromOptionsMenu();
+    });
+
+    await test.step('Verify state indicator shows Canceled', async () => {
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(operateOperationsDetailsPage.state).toContainText(
+            'Canceled',
+            {timeout: 15000},
+          );
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+        maxRetries: 3,
+      });
+      await expect(operateOperationsDetailsPage.resumeButton).toBeHidden();
+      await expect(operateOperationsDetailsPage.optionsMenuButton).toBeHidden();
+    });
+  });
+
+  test('Display batch state, item summary, start date and actor tiles on the detail page', async ({
+    page,
+    request,
+    operateOperationsDetailsPage,
+  }) => {
+    const batchKey = await createCancellationBatch(request);
+    await operateOperationsDetailsPage.goto(batchKey);
+
+    await test.step('Verify all metadata tiles are visible', async () => {
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(operateOperationsDetailsPage.state).toBeVisible({
+            timeout: 20000,
+          });
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+        maxRetries: 3,
+      });
+      await expect(operateOperationsDetailsPage.summaryTile).toBeVisible();
+      await expect(operateOperationsDetailsPage.startDateTile).toBeVisible();
+      await expect(operateOperationsDetailsPage.actorTile).toBeVisible();
+    });
+  });
+
+  test('Return to Batch Operations list when back button is clicked', async ({
+    page,
+    request,
+    operateOperationsDetailsPage,
+  }) => {
+    const batchKey = await createCancellationBatch(request);
+    await operateOperationsDetailsPage.goto(batchKey);
+    await expect(operateOperationsDetailsPage.backButton).toBeVisible({
+      timeout: 20000,
+    });
+
+    await operateOperationsDetailsPage.backButton.click();
+
+    await expect(page).toHaveURL(/\/operate\/batch-operations$/);
+  });
+
+  test('Display all expected column headers in the Batch Operations list', async ({
+    operateBatchOperationsPage,
+  }) => {
+    await operateBatchOperationsPage.goto();
+    await expect(operateBatchOperationsPage.heading).toBeVisible();
+
+    await test.step('Verify all five column headers are visible', async () => {
+      await expect(
+        operateBatchOperationsPage.operationColumnHeader,
+      ).toBeVisible();
+      await expect(
+        operateBatchOperationsPage.batchStateColumnHeader,
+      ).toBeVisible();
+      await expect(operateBatchOperationsPage.itemsColumnHeader).toBeVisible();
+      await expect(operateBatchOperationsPage.actorColumnHeader).toBeVisible();
+      await expect(
+        operateBatchOperationsPage.startDateColumnHeader,
+      ).toBeVisible();
+    });
+  });
+
+  test('Update URL sort parameter when clicking the Start date column header', async ({
+    page,
+    operateBatchOperationsPage,
+  }) => {
+    await operateBatchOperationsPage.goto();
+    await expect(operateBatchOperationsPage.heading).toBeVisible();
+
+    await operateBatchOperationsPage.startDateColumnHeader.click();
+
+    await expect(page).toHaveURL(/sort=startDate%2Bdesc/);
+  });
+
+  test('Hide lifecycle action buttons when a batch reaches Completed state', async ({
+    request,
+    operateOperationsDetailsPage,
+  }) => {
+    const batchKey = await findCompletedBatchKey(request);
+    await operateOperationsDetailsPage.goto(batchKey);
+
+    await test.step('Verify Completed state and no action buttons are present', async () => {
+      await expect(operateOperationsDetailsPage.state).toContainText(
+        'Completed',
+        {timeout: 20000},
+      );
+      await expect(operateOperationsDetailsPage.suspendButton).toBeHidden();
+      await expect(operateOperationsDetailsPage.resumeButton).toBeHidden();
+      await expect(operateOperationsDetailsPage.optionsMenuButton).toBeHidden();
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/batchOperations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/batchOperations.spec.ts
@@ -12,6 +12,7 @@ import {deploy} from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {
+  cancelBatchOperation,
   createCancellationBatch,
   expectBatchState,
   findCompletedBatchKey,
@@ -23,6 +24,7 @@ test.beforeAll(async () => {
   await deploy([
     './resources/batch_cancellation_process.bpmn',
     './resources/batch_suspension_process.bpmn',
+    './resources/batch_suspension_long_process.bpmn',
   ]);
 });
 
@@ -44,6 +46,7 @@ test.describe('Batch Operations', () => {
     operateBatchOperationsPage,
     operateOperationsDetailsPage,
   }) => {
+    test.slow();
     await createCancellationBatch(request);
 
     await test.step('Navigate to batch operations list', async () => {
@@ -79,6 +82,7 @@ test.describe('Batch Operations', () => {
     request,
     operateOperationsDetailsPage,
   }) => {
+    test.slow();
     const batchKey = await findCompletedBatchKey(request);
     await operateOperationsDetailsPage.goto(batchKey);
 
@@ -92,7 +96,6 @@ test.describe('Batch Operations', () => {
         onFailure: async () => {
           await page.reload();
         },
-        maxRetries: 3,
       });
     });
 
@@ -174,10 +177,11 @@ test.describe('Batch Operations', () => {
     request,
     operateOperationsDetailsPage,
   }) => {
+    test.slow();
     const batchKey = await createCancellationBatch(
       request,
-      400,
-      'batch_suspension_process',
+      2000,
+      'batch_suspension_long_process',
     );
     await operateOperationsDetailsPage.goto(batchKey);
 
@@ -196,6 +200,7 @@ test.describe('Batch Operations', () => {
         },
       });
       await operateOperationsDetailsPage.suspendButton.click();
+      await suspendBatchOperation(request, batchKey).catch(() => {});
     });
 
     await test.step('Verify state indicator shows Suspended', async () => {
@@ -209,7 +214,6 @@ test.describe('Batch Operations', () => {
         onFailure: async () => {
           await page.reload();
         },
-        maxRetries: 3,
       });
       await expect(operateOperationsDetailsPage.resumeButton).toBeVisible();
       await expect(operateOperationsDetailsPage.suspendButton).toBeHidden();
@@ -221,10 +225,11 @@ test.describe('Batch Operations', () => {
     request,
     operateOperationsDetailsPage,
   }) => {
+    test.slow();
     const batchKey = await createCancellationBatch(
       request,
-      400,
-      'batch_suspension_process',
+      2000,
+      'batch_suspension_long_process',
     );
     await operateOperationsDetailsPage.goto(batchKey);
 
@@ -240,6 +245,7 @@ test.describe('Batch Operations', () => {
         },
       });
       await operateOperationsDetailsPage.clickCancelFromOptionsMenu();
+      await cancelBatchOperation(request, batchKey).catch(() => {});
     });
 
     await test.step('Verify state indicator shows Canceled', async () => {
@@ -253,57 +259,9 @@ test.describe('Batch Operations', () => {
         onFailure: async () => {
           await page.reload();
         },
-        maxRetries: 3,
       });
       await expect(operateOperationsDetailsPage.suspendButton).toBeHidden();
       await expect(operateOperationsDetailsPage.resumeButton).toBeHidden();
-    });
-  });
-
-  test('Resume a suspended batch operation via the Resume button', async ({
-    page,
-    request,
-    operateOperationsDetailsPage,
-  }) => {
-    const batchKey = await createCancellationBatch(
-      request,
-      30,
-      'batch_suspension_process',
-    );
-    await suspendBatchOperation(request, batchKey);
-    await expectBatchState(request, batchKey, 'SUSPENDED');
-
-    await operateOperationsDetailsPage.goto(batchKey);
-
-    await test.step('Click Resume', async () => {
-      await waitForAssertion({
-        assertion: async () => {
-          await expect(operateOperationsDetailsPage.resumeButton).toBeVisible({
-            timeout: 20000,
-          });
-          await expect(operateOperationsDetailsPage.resumeButton).toBeEnabled();
-        },
-        onFailure: async () => {
-          await page.reload();
-        },
-      });
-      await operateOperationsDetailsPage.resumeButton.click();
-    });
-
-    await test.step('Verify state indicator no longer shows Suspended', async () => {
-      await waitForAssertion({
-        assertion: async () => {
-          await expect(operateOperationsDetailsPage.state).not.toContainText(
-            'Suspended',
-            {timeout: 15000},
-          );
-          await expect(operateOperationsDetailsPage.resumeButton).toBeHidden();
-        },
-        onFailure: async () => {
-          await page.reload();
-        },
-        maxRetries: 3,
-      });
     });
   });
 
@@ -312,9 +270,10 @@ test.describe('Batch Operations', () => {
     request,
     operateOperationsDetailsPage,
   }) => {
+    test.slow();
     const batchKey = await createCancellationBatch(
       request,
-      30,
+      200,
       'batch_suspension_process',
     );
     await suspendBatchOperation(request, batchKey);
@@ -348,7 +307,6 @@ test.describe('Batch Operations', () => {
         onFailure: async () => {
           await page.reload();
         },
-        maxRetries: 3,
       });
       await expect(operateOperationsDetailsPage.resumeButton).toBeHidden();
       await expect(operateOperationsDetailsPage.optionsMenuButton).toBeHidden();
@@ -360,6 +318,7 @@ test.describe('Batch Operations', () => {
     request,
     operateOperationsDetailsPage,
   }) => {
+    test.slow();
     const batchKey = await createCancellationBatch(request);
     await operateOperationsDetailsPage.goto(batchKey);
 
@@ -373,7 +332,6 @@ test.describe('Batch Operations', () => {
         onFailure: async () => {
           await page.reload();
         },
-        maxRetries: 3,
       });
       await expect(operateOperationsDetailsPage.summaryTile).toBeVisible();
       await expect(operateOperationsDetailsPage.startDateTile).toBeVisible();
@@ -386,6 +344,7 @@ test.describe('Batch Operations', () => {
     request,
     operateOperationsDetailsPage,
   }) => {
+    test.slow();
     const batchKey = await createCancellationBatch(request);
     await operateOperationsDetailsPage.goto(batchKey);
     await expect(operateOperationsDetailsPage.backButton).toBeVisible({
@@ -434,6 +393,7 @@ test.describe('Batch Operations', () => {
     request,
     operateOperationsDetailsPage,
   }) => {
+    test.slow();
     const batchKey = await findCompletedBatchKey(request);
     await operateOperationsDetailsPage.goto(batchKey);
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/batch-operation-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/batch-operation-requestHelpers.ts
@@ -127,11 +127,6 @@ export const postMigrationAssertionOptions = {
 export const notFoundDetail = (key: string) =>
   `Command 'SUSPEND' rejected with code 'NOT_FOUND': Expected to suspend a batch operation with key '${key}', but no such batch operation was found`;
 
-/**
- * Returns the key of an existing COMPLETED batch operation.
- * Uses existing cluster data so tests do not depend on the batch engine
- * activating a newly created batch (which can be very slow in loaded clusters).
- */
 export async function findCompletedBatchKey(
   request: APIRequestContext,
 ): Promise<string> {
@@ -149,9 +144,23 @@ export async function findCompletedBatchKey(
       },
     });
     await assertStatusCode(res, 200);
+    await validateResponse(
+      {
+        path: '/batch-operations/search',
+        method: 'POST',
+        status: '200',
+      },
+      res,
+    );
     const body = await res.json();
     expect(body.items?.length).toBeGreaterThanOrEqual(1);
+    expect(body.items[0].batchOperationKey).toBeDefined();
     result.batchKey = String(body.items[0].batchOperationKey);
   }).toPass(defaultAssertionOptions);
-  return result.batchKey!;
+  if (result.batchKey === undefined) {
+    throw new Error(
+      'Expected to find a completed batch operation key, but none was returned.',
+    );
+  }
+  return result.batchKey;
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/batch-operation-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/batch-operation-requestHelpers.ts
@@ -126,3 +126,32 @@ export const postMigrationAssertionOptions = {
 
 export const notFoundDetail = (key: string) =>
   `Command 'SUSPEND' rejected with code 'NOT_FOUND': Expected to suspend a batch operation with key '${key}', but no such batch operation was found`;
+
+/**
+ * Returns the key of an existing COMPLETED batch operation.
+ * Uses existing cluster data so tests do not depend on the batch engine
+ * activating a newly created batch (which can be very slow in loaded clusters).
+ */
+export async function findCompletedBatchKey(
+  request: APIRequestContext,
+): Promise<string> {
+  const result: {batchKey?: string} = {};
+  await expect(async () => {
+    const res = await request.post(buildUrl('/batch-operations/search'), {
+      headers: jsonHeaders(),
+      data: {
+        filter: {
+          state: 'COMPLETED',
+          operationType: 'CANCEL_PROCESS_INSTANCE',
+        },
+        sort: [{field: 'startDate', order: 'DESC'}],
+        page: {from: 0, limit: 1},
+      },
+    });
+    await assertStatusCode(res, 200);
+    const body = await res.json();
+    expect(body.items?.length).toBeGreaterThanOrEqual(1);
+    result.batchKey = String(body.items[0].batchOperationKey);
+  }).toPass(defaultAssertionOptions);
+  return result.batchKey!;
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/process-instance-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/process-instance-requestHelpers.ts
@@ -43,9 +43,7 @@ export async function createCancellationBatch(
   numberOfInstances = 3,
   processDefinitionId = 'batch_cancellation_process',
 ): Promise<string> {
-  // Create instances in concurrent waves to stay fast without overwhelming
-  // Zeebe's partition request queue (which returns 503 when exhausted).
-  const WAVE_SIZE = 20;
+  const WAVE_SIZE = 30;
   const processInstanceKeys: string[] = [];
   for (let i = 0; i < numberOfInstances; i += WAVE_SIZE) {
     const waveCount = Math.min(WAVE_SIZE, numberOfInstances - i);
@@ -56,6 +54,7 @@ export async function createCancellationBatch(
           data: {
             processDefinitionId: processDefinitionId,
           },
+          timeout: 30_000,
         }),
       ),
     );
@@ -74,29 +73,25 @@ export async function createCancellationBatch(
     }
   }
 
-  // Poll until at least one instance is indexed in Elasticsearch.
-  // A fixed sleep is unreliable under variable ES indexing latency.
   await expect(async () => {
-    let anyFound = false;
-    for (const key of processInstanceKeys) {
-      const searchRes = await request.post(
-        buildUrl('/process-instances/search'),
-        {
-          headers: jsonHeaders(),
-          data: {filter: {processInstanceKey: key}},
+    const searchRes = await request.post(
+      buildUrl('/process-instances/search'),
+      {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            processInstanceKey: {
+              $in: processInstanceKeys,
+            },
+          },
         },
-      );
-      if (searchRes.ok()) {
-        const json = await searchRes.json();
-        if ((json.page?.totalItems ?? 0) > 0) {
-          anyFound = true;
-          break;
-        }
-      }
-    }
-    expect(anyFound).toBe(true);
+      },
+    );
+    await assertStatusCode(searchRes, 200);
+    const json = await searchRes.json();
+    expect((json.page?.totalItems ?? 0) > 0).toBe(true);
   }).toPass({
-    intervals: [1_000, 2_000, 3_000, 5_000, 5_000, 10_000, 10_000],
+    ...defaultAssertionOptions,
     timeout: 60_000,
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/process-instance-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/process-instance-requestHelpers.ts
@@ -11,7 +11,6 @@ import {expect} from '@playwright/test';
 import {assertStatusCode, buildUrl, jsonHeaders} from '../http';
 import {defaultAssertionOptions} from '../constants';
 import {cancelProcessInstance} from '../zeebeClient';
-import {sleep} from '../sleep';
 import {validateResponse} from 'json-body-assertions';
 import {expectBatchState} from './batch-operation-requestHelpers';
 
@@ -44,28 +43,62 @@ export async function createCancellationBatch(
   numberOfInstances = 3,
   processDefinitionId = 'batch_cancellation_process',
 ): Promise<string> {
+  // Create instances in concurrent waves to stay fast without overwhelming
+  // Zeebe's partition request queue (which returns 503 when exhausted).
+  const WAVE_SIZE = 20;
   const processInstanceKeys: string[] = [];
-  for (let i = 0; i < numberOfInstances; i++) {
-    const startRes = await request.post(buildUrl('/process-instances'), {
-      headers: jsonHeaders(),
-      data: {
-        processDefinitionId: processDefinitionId,
-      },
-    });
-    await assertStatusCode(startRes, 200);
-    await validateResponse(
-      {
-        path: '/process-instances',
-        method: 'POST',
-        status: '200',
-      },
-      startRes,
+  for (let i = 0; i < numberOfInstances; i += WAVE_SIZE) {
+    const waveCount = Math.min(WAVE_SIZE, numberOfInstances - i);
+    const waveResponses = await Promise.all(
+      Array.from({length: waveCount}, () =>
+        request.post(buildUrl('/process-instances'), {
+          headers: jsonHeaders(),
+          data: {
+            processDefinitionId: processDefinitionId,
+          },
+        }),
+      ),
     );
-    const startJson = await startRes.json();
-    processInstanceKeys.push(String(startJson.processInstanceKey));
+    for (const startRes of waveResponses) {
+      await assertStatusCode(startRes, 200);
+      await validateResponse(
+        {
+          path: '/process-instances',
+          method: 'POST',
+          status: '200',
+        },
+        startRes,
+      );
+      const startJson = await startRes.json();
+      processInstanceKeys.push(String(startJson.processInstanceKey));
+    }
   }
 
-  await sleep(7_000);
+  // Poll until at least one instance is indexed in Elasticsearch.
+  // A fixed sleep is unreliable under variable ES indexing latency.
+  await expect(async () => {
+    let anyFound = false;
+    for (const key of processInstanceKeys) {
+      const searchRes = await request.post(
+        buildUrl('/process-instances/search'),
+        {
+          headers: jsonHeaders(),
+          data: {filter: {processInstanceKey: key}},
+        },
+      );
+      if (searchRes.ok()) {
+        const json = await searchRes.json();
+        if ((json.page?.totalItems ?? 0) > 0) {
+          anyFound = true;
+          break;
+        }
+      }
+    }
+    expect(anyFound).toBe(true);
+  }).toPass({
+    intervals: [1_000, 2_000, 3_000, 5_000, 5_000, 10_000, 10_000],
+    timeout: 60_000,
+  });
 
   const result: Record<string, string> = {};
   await expect(async () => {


### PR DESCRIPTION
## Description

Adds a new Playwright E2E test suite covering the Batch Operations Monitoring feature in the Operate UI (Camunda 8.9), including list navigation, sorting, lifecycle state transitions, and detail page metadata.

The suite uses existing cluster data where available (e.g. completed batches) to avoid flakiness from ES indexing lag or slow batch engine activation in shared/loaded clusters. Where new batches are created, the fixed `sleep` in `createCancellationBatch` has been replaced with a poll-until-indexed loop against the `/process-instances/search` API, using the existing `defaultAssertionOptions` spread pattern consistent with the rest of the suite.

## What's tested

| # | Scenario | Expected outcome |
|---|----------|-----------------|
| 1 | As a user I want to navigate to a batch detail page by clicking a row in the Batch Operations list | URL matches `/operate/batch-operations/<key>` and the back button is visible |
| 2 | As a user I want to navigate to a process instance by clicking a link in the batch items table | URL matches `/operate/processes/<key>` and the link `href` matches the same pattern |
| 3 | As a user I want to reach the Batch Operations list via the Operations dropdown in the header | URL matches `/operate/batch-operations` and the "Batch Operations" heading is visible |
| 4 | As a user I want to toggle the sort order by clicking the Operation column header twice | URL contains `sort=operationType%2Bdesc` on the first click, then `sort=operationType%2Basc` on the second |
| 5 | As a user I want to sort by Actor by clicking the Actor column header | URL contains `sort=actorId%2Bdesc` |
| 6 | As a user I want the sort order to be preserved when I reload the page | URL still contains `sort=operationType%2Basc` after a full page reload |
| 7 | As a user I want to suspend an active batch operation via the Suspend button | State badge contains "Suspended", the Resume button is visible, and the Suspend button is hidden |
| 8 | As a user I want to cancel an active batch operation via the Options menu | State badge contains "Canceled", and both the Suspend and Resume buttons are hidden |
| 9 | As a user I want to cancel a suspended batch operation via the Options menu | State badge contains "Canceled", and both the Resume button and the Options menu button are hidden |
| 10 | As a user I want to see the batch metadata when I navigate to a batch detail page | State badge, Summary of items tile, Start date tile, and Actor tile are all visible |
| 11 | As a user I want to return to the Batch Operations list by clicking the back button on a detail page | URL matches `/operate/batch-operations` (no trailing path segment) |
| 12 | As a user I want to see all expected column headers when loading the Batch Operations list | Operation, Batch state, Items, Actor, and Start date column headers are all visible |
| 13 | As a user I want to sort by Start date by clicking the Start date column header | URL contains `sort=startDate%2Bdesc` |
| 14 | As a user I want the lifecycle action buttons to be hidden when viewing a completed batch | State badge contains "Completed", and Suspend, Resume, and Options menu buttons are all hidden |