### PR TITLE
Enable bizId uniqueness enforcement for standalone app in nightly run

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
@@ -529,7 +529,7 @@ jobs:
           export CAMUNDA_DATA_AUDITLOG_CLIENT_EXCLUDES_0="PROCESS_INSTANCE"
 
           # Business ID uniqueness enforcement toggle
-          CAMUNDA_PROCESSINSTANCECREATION_BUSINESSIDUNIQUENESSENABLED="true"
+          export CAMUNDA_PROCESSINSTANCECREATION_BUSINESSIDUNIQUENESSENABLED="true"
 
           dev-dist/bin/camunda > dev-dist/camunda.log 2>&1 &
           echo $! > dev-dist/camunda.pid

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml
@@ -528,6 +528,9 @@ jobs:
           export CAMUNDA_DATA_AUDITLOG_CLIENT_CATEGORIES_0="ADMIN"
           export CAMUNDA_DATA_AUDITLOG_CLIENT_EXCLUDES_0="PROCESS_INSTANCE"
 
+          # Business ID uniqueness enforcement toggle
+          CAMUNDA_PROCESSINSTANCECREATION_BUSINESSIDUNIQUENESSENABLED="true"
+
           dev-dist/bin/camunda > dev-dist/camunda.log 2>&1 &
           echo $! > dev-dist/camunda.pid
 


### PR DESCRIPTION
This pull request introduces a configuration change to the orchestration cluster E2E nightly test workflow. The main update is the addition of an environment variable to enable enforcement of business ID uniqueness for process instance creation.

Configuration update:

* Added the `CAMUNDA_PROCESSINSTANCECREATION_BUSINESSIDUNIQUENESSENABLED` environment variable (set to `"true"`) to enforce business ID uniqueness during process instance creation in the test workflow (`.github/workflows/c8-orchestration-cluster-e2e-tests-nightly.yml`).