### PR TITLE
revert: Revert BACKPORT_ACTION_PAT migration (#50333)

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -14,9 +14,9 @@ jobs:
     name: Create backport PRs
     runs-on: ubuntu-latest
     # Only run when pull request is merged
-    # or when a comment starting with `/backport` is created by someone other than a bot:
-    # - https://github.com/backport-action bot user (user id: 97796249)
-    # - Monorepo DevOps Automation GitHub App bot user (user id: 248077375)
+    # or when a comment starting with `/backport` is created by someone other than the
+    # https://github.com/backport-action bot user (user id: 97796249). Note that if you use your
+    # own PAT as `github_token`, that you should replace this id with yours.
     if: >
       (
         github.event_name == 'pull_request' &&
@@ -25,34 +25,18 @@ jobs:
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
         github.event.comment.user.id != 97796249 &&
-        github.event.comment.user.id != 248077375 &&
         startsWith(github.event.comment.body, '/backport')
       )
-    # No GITHUB_TOKEN permissions needed; all GitHub operations use the
-    # Monorepo DevOps Automation GitHub App token generated in the first step.
-    permissions: {}
     steps:
-      - name: Generate GitHub token
-        id: github-token
-        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@fc4fa13813cbc1835129967f10a12f24aa7a393c # main
-        with:
-          github-app-id-vault-key: MONOREPO_DEVOPS_AUTOMATION_APP_ID
-          github-app-id-vault-path: secret/data/products/camunda/ci/camunda
-          github-app-private-key-vault-key: MONOREPO_DEVOPS_AUTOMATION_APP_PRIVATE_KEY
-          github-app-private-key-vault-path: secret/data/products/camunda/ci/camunda
-          vault-auth-method: approle
-          vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
-          vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-          vault-url: ${{ secrets.VAULT_ADDR }}
       - uses: actions/checkout@v6
         with:
           # Token for git actions, e.g. git push
-          token: ${{ steps.github-token.outputs.token }}
+          token: ${{ secrets.BACKPORT_ACTION_PAT }}
       - name: Create backport PRs
         uses: korthout/backport-action@v4
         with:
           # Token to authenticate requests to GitHub
-          github_token: ${{ steps.github-token.outputs.token }}
+          github_token: ${{ secrets.BACKPORT_ACTION_PAT }}
 
           # Template used as description in the pull requests created by this action.
           # Placeholders can be used to define variable values.


### PR DESCRIPTION
Reverts #50333.

The `korthut/backport-action` is not compatible with GitHub App tokens when backporting commits that touch `.github/workflows/` files.

Root cause: the action authenticates by embedding the token into the git remote URL as `https://x-access-token:<TOKEN>@github.com/...`. Classic PATs with the `workflow` OAuth scope work fine. However, GitHub App tokens use a permission-based model (not OAuth scopes), and when pushing files under `.github/workflows/`, GitHub checks for the `workflow` OAuth scope — which has no equivalent for App tokens at the git push level. The action does not implement the additional handshake required to satisfy this check, so the push is rejected.

Restoring `BACKPORT_ACTION_PAT` (classic PAT with `workflow` scope) until either:
- `korthut/backport-action` adds explicit GitHub App token support, or
- we migrate to a different backport action that handles App tokens natively (e.g. `sorenlouv/backport`)