### PR TITLE
fix: improve logging around web session failure

### DIFF
--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -113,6 +113,10 @@
       <artifactId>camunda-search-client</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.github.resilience4j</groupId>
+      <artifactId>resilience4j-retry</artifactId>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -117,6 +117,10 @@
       <artifactId>resilience4j-retry</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.github.resilience4j</groupId>
+      <artifactId>resilience4j-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/authentication/src/main/java/io/camunda/authentication/session/WebSessionRepository.java
+++ b/authentication/src/main/java/io/camunda/authentication/session/WebSessionRepository.java
@@ -125,12 +125,11 @@ public class WebSessionRepository implements SessionRepository<WebSession> {
     if (webSession.isChanged()) {
       LOGGER.debug("Web Session {} changed, save in storage.", webSession);
       final var entity = webSessionMapper.toPersistentWebSession(webSession);
-      upsertWithRetry(webSession, entity);
+      upsertWithRetry(entity);
     }
   }
 
-  private void upsertWithRetry(
-      final WebSession webSession, final PersistentWebSessionEntity entity) {
+  private void upsertWithRetry(final PersistentWebSessionEntity entity) {
     try {
       Retry.decorateRunnable(
               UPSERT_RETRY, () -> persistentWebSessionClient.upsertPersistentWebSession(entity))

--- a/authentication/src/main/java/io/camunda/authentication/session/WebSessionRepository.java
+++ b/authentication/src/main/java/io/camunda/authentication/session/WebSessionRepository.java
@@ -10,6 +10,9 @@ package io.camunda.authentication.session;
 import io.camunda.search.clients.PersistentWebSessionClient;
 import io.camunda.search.entities.PersistentWebSessionEntity;
 import io.camunda.search.exception.CamundaSearchException;
+import io.github.resilience4j.core.IntervalFunction;
+import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.retry.RetryConfig;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Optional;
 import java.util.UUID;
@@ -21,6 +24,17 @@ public class WebSessionRepository implements SessionRepository<WebSession> {
 
   public static final Logger LOGGER = LoggerFactory.getLogger(WebSessionRepository.class);
   private static final String POLLING_HEADER = "x-is-polling";
+  private static final int MAX_RETRY_ATTEMPTS = 3;
+  private static final long INITIAL_RETRY_DELAY_MS = 100;
+
+  private static final Retry UPSERT_RETRY =
+      Retry.of(
+          "web-session-upsert",
+          RetryConfig.custom()
+              .maxAttempts(MAX_RETRY_ATTEMPTS)
+              .intervalFunction(IntervalFunction.ofExponentialBackoff(INITIAL_RETRY_DELAY_MS, 2))
+              .retryExceptions(RuntimeException.class)
+              .build());
 
   private final PersistentWebSessionClient persistentWebSessionClient;
   private final WebSessionMapper webSessionMapper;
@@ -101,23 +115,41 @@ public class WebSessionRepository implements SessionRepository<WebSession> {
     if (webSession.isChanged()) {
       LOGGER.debug("Web Session {} changed, save in storage.", webSession);
       final var entity = webSessionMapper.toPersistentWebSession(webSession);
-      try {
-        persistentWebSessionClient.upsertPersistentWebSession(entity);
-      } catch (final CamundaSearchException e) {
-        LOGGER.warn(
-            "Failed to save web session [{}] to persistent storage: {} (reason: {})",
-            webSession.getId(),
-            e.getMessage(),
-            e.getReason(),
-            e);
-      } catch (final RuntimeException e) {
-        LOGGER.warn(
-            "Failed to save web session [{}] to persistent storage: {}",
-            webSession.getId(),
-            e.getMessage(),
-            e);
-      }
+      upsertWithRetry(webSession, entity);
     }
+  }
+
+  private void upsertWithRetry(
+      final WebSession webSession, final PersistentWebSessionEntity entity) {
+    final var redactedId = redactSessionId(webSession.getId());
+    try {
+      Retry.decorateRunnable(
+              UPSERT_RETRY,
+              () -> persistentWebSessionClient.upsertPersistentWebSession(entity))
+          .run();
+    } catch (final CamundaSearchException e) {
+      LOGGER.warn(
+          "Failed to save web session [{}] to persistent storage after {} attempts: {} (reason: {})",
+          redactedId,
+          MAX_RETRY_ATTEMPTS,
+          e.getMessage(),
+          e.getReason(),
+          e);
+    } catch (final RuntimeException e) {
+      LOGGER.warn(
+          "Failed to save web session [{}] to persistent storage after {} attempts: {}",
+          redactedId,
+          MAX_RETRY_ATTEMPTS,
+          e.getMessage(),
+          e);
+    }
+  }
+
+  private static String redactSessionId(final String sessionId) {
+    if (sessionId == null || sessionId.length() <= 8) {
+      return "***";
+    }
+    return sessionId.substring(0, 8) + "...";
   }
 
   private Optional<WebSession> toWebSession(

--- a/authentication/src/main/java/io/camunda/authentication/session/WebSessionRepository.java
+++ b/authentication/src/main/java/io/camunda/authentication/session/WebSessionRepository.java
@@ -36,16 +36,6 @@ public class WebSessionRepository implements SessionRepository<WebSession> {
               .retryOnException(WebSessionRepository::isTransientFailure)
               .build());
 
-  private static boolean isTransientFailure(final Throwable throwable) {
-    if (throwable instanceof final CamundaSearchException cse) {
-      return switch (cse.getReason()) {
-        case CONNECTION_FAILED, SEARCH_CLIENT_FAILED, SEARCH_SERVER_FAILED, UNKNOWN -> true;
-        default -> false;
-      };
-    }
-    return throwable instanceof RuntimeException;
-  }
-
   private final PersistentWebSessionClient persistentWebSessionClient;
   private final WebSessionMapper webSessionMapper;
   private final HttpServletRequest request;
@@ -57,6 +47,16 @@ public class WebSessionRepository implements SessionRepository<WebSession> {
     this.persistentWebSessionClient = persistentWebSessionClient;
     this.webSessionMapper = webSessionMapper;
     this.request = request;
+  }
+
+  private static boolean isTransientFailure(final Throwable throwable) {
+    if (throwable instanceof final CamundaSearchException cse) {
+      return switch (cse.getReason()) {
+        case CONNECTION_FAILED, SEARCH_CLIENT_FAILED, SEARCH_SERVER_FAILED, UNKNOWN -> true;
+        default -> false;
+      };
+    }
+    return throwable instanceof RuntimeException;
   }
 
   @Override

--- a/authentication/src/main/java/io/camunda/authentication/session/WebSessionRepository.java
+++ b/authentication/src/main/java/io/camunda/authentication/session/WebSessionRepository.java
@@ -110,6 +110,12 @@ public class WebSessionRepository implements SessionRepository<WebSession> {
             e.getMessage(),
             e.getReason(),
             e);
+      } catch (final RuntimeException e) {
+        LOGGER.warn(
+            "Failed to save web session [{}] to persistent storage: {}",
+            webSession.getId(),
+            e.getMessage(),
+            e);
       }
     }
   }

--- a/authentication/src/main/java/io/camunda/authentication/session/WebSessionRepository.java
+++ b/authentication/src/main/java/io/camunda/authentication/session/WebSessionRepository.java
@@ -9,6 +9,7 @@ package io.camunda.authentication.session;
 
 import io.camunda.search.clients.PersistentWebSessionClient;
 import io.camunda.search.entities.PersistentWebSessionEntity;
+import io.camunda.search.exception.CamundaSearchException;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Optional;
 import java.util.UUID;
@@ -99,9 +100,17 @@ public class WebSessionRepository implements SessionRepository<WebSession> {
   private void saveWebSessionIfChanged(final WebSession webSession) {
     if (webSession.isChanged()) {
       LOGGER.debug("Web Session {} changed, save in storage.", webSession);
-      Optional.of(webSession)
-          .map(webSessionMapper::toPersistentWebSession)
-          .ifPresent(persistentWebSessionClient::upsertPersistentWebSession);
+      final var entity = webSessionMapper.toPersistentWebSession(webSession);
+      try {
+        persistentWebSessionClient.upsertPersistentWebSession(entity);
+      } catch (final CamundaSearchException e) {
+        LOGGER.warn(
+            "Failed to save web session [{}] to persistent storage: {} (reason: {})",
+            webSession.getId(),
+            e.getMessage(),
+            e.getReason(),
+            e);
+      }
     }
   }
 

--- a/authentication/src/main/java/io/camunda/authentication/session/WebSessionRepository.java
+++ b/authentication/src/main/java/io/camunda/authentication/session/WebSessionRepository.java
@@ -10,6 +10,7 @@ package io.camunda.authentication.session;
 import io.camunda.search.clients.PersistentWebSessionClient;
 import io.camunda.search.entities.PersistentWebSessionEntity;
 import io.camunda.search.exception.CamundaSearchException;
+import io.camunda.search.exception.CamundaSearchException.Reason;
 import io.github.resilience4j.core.IntervalFunction;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
@@ -33,8 +34,15 @@ public class WebSessionRepository implements SessionRepository<WebSession> {
           RetryConfig.custom()
               .maxAttempts(MAX_RETRY_ATTEMPTS)
               .intervalFunction(IntervalFunction.ofExponentialBackoff(INITIAL_RETRY_DELAY_MS, 2))
-              .retryExceptions(RuntimeException.class)
+              .retryOnException(WebSessionRepository::isTransientFailure)
               .build());
+
+  private static boolean isTransientFailure(final Throwable throwable) {
+    if (throwable instanceof final CamundaSearchException cse) {
+      return cse.getReason() != Reason.INVALID_ARGUMENT && cse.getReason() != Reason.FORBIDDEN;
+    }
+    return throwable instanceof RuntimeException;
+  }
 
   private final PersistentWebSessionClient persistentWebSessionClient;
   private final WebSessionMapper webSessionMapper;
@@ -121,35 +129,24 @@ public class WebSessionRepository implements SessionRepository<WebSession> {
 
   private void upsertWithRetry(
       final WebSession webSession, final PersistentWebSessionEntity entity) {
-    final var redactedId = redactSessionId(webSession.getId());
     try {
       Retry.decorateRunnable(
-              UPSERT_RETRY,
-              () -> persistentWebSessionClient.upsertPersistentWebSession(entity))
+              UPSERT_RETRY, () -> persistentWebSessionClient.upsertPersistentWebSession(entity))
           .run();
     } catch (final CamundaSearchException e) {
       LOGGER.warn(
-          "Failed to save web session [{}] to persistent storage after {} attempts: {} (reason: {})",
-          redactedId,
+          "Failed to save web session to persistent storage after {} attempts: {} (reason: {})",
           MAX_RETRY_ATTEMPTS,
           e.getMessage(),
           e.getReason(),
           e);
     } catch (final RuntimeException e) {
       LOGGER.warn(
-          "Failed to save web session [{}] to persistent storage after {} attempts: {}",
-          redactedId,
+          "Failed to save web session to persistent storage after {} attempts: {}",
           MAX_RETRY_ATTEMPTS,
           e.getMessage(),
           e);
     }
-  }
-
-  private static String redactSessionId(final String sessionId) {
-    if (sessionId == null || sessionId.length() <= 8) {
-      return "***";
-    }
-    return sessionId.substring(0, 8) + "...";
   }
 
   private Optional<WebSession> toWebSession(

--- a/authentication/src/main/java/io/camunda/authentication/session/WebSessionRepository.java
+++ b/authentication/src/main/java/io/camunda/authentication/session/WebSessionRepository.java
@@ -10,7 +10,6 @@ package io.camunda.authentication.session;
 import io.camunda.search.clients.PersistentWebSessionClient;
 import io.camunda.search.entities.PersistentWebSessionEntity;
 import io.camunda.search.exception.CamundaSearchException;
-import io.camunda.search.exception.CamundaSearchException.Reason;
 import io.github.resilience4j.core.IntervalFunction;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
@@ -39,7 +38,10 @@ public class WebSessionRepository implements SessionRepository<WebSession> {
 
   private static boolean isTransientFailure(final Throwable throwable) {
     if (throwable instanceof final CamundaSearchException cse) {
-      return cse.getReason() != Reason.INVALID_ARGUMENT && cse.getReason() != Reason.FORBIDDEN;
+      return switch (cse.getReason()) {
+        case CONNECTION_FAILED, SEARCH_CLIENT_FAILED, SEARCH_SERVER_FAILED, UNKNOWN -> true;
+        default -> false;
+      };
     }
     return throwable instanceof RuntimeException;
   }

--- a/authentication/src/test/java/io/camunda/authentication/session/WebSessionRepositoryTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/session/WebSessionRepositoryTest.java
@@ -189,6 +189,43 @@ class WebSessionRepositoryTest {
     assertThatNoException().isThrownBy(() -> repository.save(webSession));
   }
 
+  @Test
+  void shouldNotPropagateRuntimeExceptionWhenUpsertFails() {
+    // given
+    final PersistentWebSessionClient failingClient =
+        new PersistentWebSessionClient() {
+          @Override
+          public PersistentWebSessionEntity getPersistentWebSession(final String sessionId) {
+            return null;
+          }
+
+          @Override
+          public void upsertPersistentWebSession(
+              final PersistentWebSessionEntity persistentWebSessionEntity) {
+            throw new RuntimeException("Connection refused");
+          }
+
+          @Override
+          public void deletePersistentWebSession(final String sessionId) {}
+
+          @Override
+          public SearchQueryResult<PersistentWebSessionEntity> getAllPersistentWebSessions() {
+            return SearchQueryResult.of(b -> b.items(new ArrayList<>()));
+          }
+        };
+    final var repository =
+        new WebSessionRepository(
+            failingClient,
+            new WebSessionMapper(
+                new SpringBasedWebSessionAttributeConverter(new GenericConversionService())),
+            null);
+    final var webSession = repository.createSession();
+    webSession.setLastAccessedTime(Instant.now());
+
+    // when / then
+    assertThatNoException().isThrownBy(() -> repository.save(webSession));
+  }
+
   static final class PersistentWebSessionClientStub implements PersistentWebSessionClient {
 
     private final Map<String, PersistentWebSessionEntity> persistentWebSessions;

--- a/authentication/src/test/java/io/camunda/authentication/session/WebSessionRepositoryTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/session/WebSessionRepositoryTest.java
@@ -8,10 +8,12 @@
 package io.camunda.authentication.session;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import io.camunda.authentication.session.WebSessionMapper.SpringBasedWebSessionAttributeConverter;
 import io.camunda.search.clients.PersistentWebSessionClient;
 import io.camunda.search.entities.PersistentWebSessionEntity;
+import io.camunda.search.exception.CamundaSearchException;
 import io.camunda.search.query.SearchQueryResult;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -148,6 +150,43 @@ class WebSessionRepositoryTest {
 
     // then
     assertThat(persistentWebSessionClient.getAllPersistentWebSessions().items()).isEmpty();
+  }
+
+  @Test
+  void shouldNotPropagateExceptionWhenUpsertFails() {
+    // given
+    final PersistentWebSessionClient failingClient =
+        new PersistentWebSessionClient() {
+          @Override
+          public PersistentWebSessionEntity getPersistentWebSession(final String sessionId) {
+            return null;
+          }
+
+          @Override
+          public void upsertPersistentWebSession(
+              final PersistentWebSessionEntity persistentWebSessionEntity) {
+            throw new CamundaSearchException("Failed to execute index request");
+          }
+
+          @Override
+          public void deletePersistentWebSession(final String sessionId) {}
+
+          @Override
+          public SearchQueryResult<PersistentWebSessionEntity> getAllPersistentWebSessions() {
+            return SearchQueryResult.of(b -> b.items(new ArrayList<>()));
+          }
+        };
+    final var repository =
+        new WebSessionRepository(
+            failingClient,
+            new WebSessionMapper(
+                new SpringBasedWebSessionAttributeConverter(new GenericConversionService())),
+            null);
+    final var webSession = repository.createSession();
+    webSession.setLastAccessedTime(Instant.now());
+
+    // when / then
+    assertThatNoException().isThrownBy(() -> repository.save(webSession));
   }
 
   static final class PersistentWebSessionClientStub implements PersistentWebSessionClient {

--- a/authentication/src/test/java/io/camunda/authentication/session/WebSessionRepositoryTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/session/WebSessionRepositoryTest.java
@@ -19,8 +19,14 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.core.convert.support.GenericConversionService;
 import org.springframework.session.MapSession;
 
@@ -152,50 +158,23 @@ class WebSessionRepositoryTest {
     assertThat(persistentWebSessionClient.getAllPersistentWebSessions().items()).isEmpty();
   }
 
-  @Test
-  void shouldNotPropagateExceptionWhenUpsertFailsAfterRetries() {
-    // given
-    final var upsertAttempts = new java.util.concurrent.atomic.AtomicInteger(0);
-    final PersistentWebSessionClient failingClient =
-        new PersistentWebSessionClient() {
-          @Override
-          public PersistentWebSessionEntity getPersistentWebSession(final String sessionId) {
-            return null;
-          }
-
-          @Override
-          public void upsertPersistentWebSession(
-              final PersistentWebSessionEntity persistentWebSessionEntity) {
-            upsertAttempts.incrementAndGet();
-            throw new CamundaSearchException("Failed to execute index request");
-          }
-
-          @Override
-          public void deletePersistentWebSession(final String sessionId) {}
-
-          @Override
-          public SearchQueryResult<PersistentWebSessionEntity> getAllPersistentWebSessions() {
-            return SearchQueryResult.of(b -> b.items(new ArrayList<>()));
-          }
-        };
-    final var repository =
-        new WebSessionRepository(
-            failingClient,
-            new WebSessionMapper(
-                new SpringBasedWebSessionAttributeConverter(new GenericConversionService())),
-            null);
-    final var webSession = repository.createSession();
-    webSession.setLastAccessedTime(Instant.now());
-
-    // when / then
-    assertThatNoException().isThrownBy(() -> repository.save(webSession));
-    assertThat(upsertAttempts.get()).isEqualTo(3);
+  static Stream<Arguments> upsertExceptionProvider() {
+    return Stream.of(
+        Arguments.of(
+            "CamundaSearchException",
+            (Supplier<RuntimeException>)
+                () -> new CamundaSearchException("Failed to execute index request")),
+        Arguments.of(
+            "RuntimeException",
+            (Supplier<RuntimeException>) () -> new RuntimeException("Connection refused")));
   }
 
-  @Test
-  void shouldNotPropagateRuntimeExceptionWhenUpsertFailsAfterRetries() {
+  @ParameterizedTest(name = "should not propagate {0} when upsert fails after retries")
+  @MethodSource("upsertExceptionProvider")
+  void shouldNotPropagateExceptionWhenUpsertFailsAfterRetries(
+      final String exceptionName, final Supplier<RuntimeException> exceptionSupplier) {
     // given
-    final var upsertAttempts = new java.util.concurrent.atomic.AtomicInteger(0);
+    final var upsertAttempts = new AtomicInteger(0);
     final PersistentWebSessionClient failingClient =
         new PersistentWebSessionClient() {
           @Override
@@ -207,7 +186,7 @@ class WebSessionRepositoryTest {
           public void upsertPersistentWebSession(
               final PersistentWebSessionEntity persistentWebSessionEntity) {
             upsertAttempts.incrementAndGet();
-            throw new RuntimeException("Connection refused");
+            throw exceptionSupplier.get();
           }
 
           @Override
@@ -235,7 +214,7 @@ class WebSessionRepositoryTest {
   @Test
   void shouldSucceedOnRetryAfterTransientFailure() {
     // given
-    final var upsertAttempts = new java.util.concurrent.atomic.AtomicInteger(0);
+    final var upsertAttempts = new AtomicInteger(0);
     final var savedEntities = new HashMap<String, PersistentWebSessionEntity>();
     final PersistentWebSessionClient transientFailureClient =
         new PersistentWebSessionClient() {

--- a/authentication/src/test/java/io/camunda/authentication/session/WebSessionRepositoryTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/session/WebSessionRepositoryTest.java
@@ -14,6 +14,7 @@ import io.camunda.authentication.session.WebSessionMapper.SpringBasedWebSessionA
 import io.camunda.search.clients.PersistentWebSessionClient;
 import io.camunda.search.entities.PersistentWebSessionEntity;
 import io.camunda.search.exception.CamundaSearchException;
+import io.camunda.search.exception.CamundaSearchException.Reason;
 import io.camunda.search.query.SearchQueryResult;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -209,6 +210,46 @@ class WebSessionRepositoryTest {
     // when / then
     assertThatNoException().isThrownBy(() -> repository.save(webSession));
     assertThat(upsertAttempts.get()).isEqualTo(3);
+  }
+
+  @Test
+  void shouldNotRetryNonTransientCamundaSearchException() {
+    // given
+    final var upsertAttempts = new AtomicInteger(0);
+    final PersistentWebSessionClient failingClient =
+        new PersistentWebSessionClient() {
+          @Override
+          public PersistentWebSessionEntity getPersistentWebSession(final String sessionId) {
+            return null;
+          }
+
+          @Override
+          public void upsertPersistentWebSession(
+              final PersistentWebSessionEntity persistentWebSessionEntity) {
+            upsertAttempts.incrementAndGet();
+            throw new CamundaSearchException("Invalid argument", Reason.INVALID_ARGUMENT);
+          }
+
+          @Override
+          public void deletePersistentWebSession(final String sessionId) {}
+
+          @Override
+          public SearchQueryResult<PersistentWebSessionEntity> getAllPersistentWebSessions() {
+            return SearchQueryResult.of(b -> b.items(new ArrayList<>()));
+          }
+        };
+    final var repository =
+        new WebSessionRepository(
+            failingClient,
+            new WebSessionMapper(
+                new SpringBasedWebSessionAttributeConverter(new GenericConversionService())),
+            null);
+    final var webSession = repository.createSession();
+    webSession.setLastAccessedTime(Instant.now());
+
+    // when / then
+    assertThatNoException().isThrownBy(() -> repository.save(webSession));
+    assertThat(upsertAttempts.get()).isEqualTo(1);
   }
 
   @Test

--- a/authentication/src/test/java/io/camunda/authentication/session/WebSessionRepositoryTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/session/WebSessionRepositoryTest.java
@@ -153,8 +153,9 @@ class WebSessionRepositoryTest {
   }
 
   @Test
-  void shouldNotPropagateExceptionWhenUpsertFails() {
+  void shouldNotPropagateExceptionWhenUpsertFailsAfterRetries() {
     // given
+    final var upsertAttempts = new java.util.concurrent.atomic.AtomicInteger(0);
     final PersistentWebSessionClient failingClient =
         new PersistentWebSessionClient() {
           @Override
@@ -165,6 +166,7 @@ class WebSessionRepositoryTest {
           @Override
           public void upsertPersistentWebSession(
               final PersistentWebSessionEntity persistentWebSessionEntity) {
+            upsertAttempts.incrementAndGet();
             throw new CamundaSearchException("Failed to execute index request");
           }
 
@@ -187,11 +189,13 @@ class WebSessionRepositoryTest {
 
     // when / then
     assertThatNoException().isThrownBy(() -> repository.save(webSession));
+    assertThat(upsertAttempts.get()).isEqualTo(3);
   }
 
   @Test
-  void shouldNotPropagateRuntimeExceptionWhenUpsertFails() {
+  void shouldNotPropagateRuntimeExceptionWhenUpsertFailsAfterRetries() {
     // given
+    final var upsertAttempts = new java.util.concurrent.atomic.AtomicInteger(0);
     final PersistentWebSessionClient failingClient =
         new PersistentWebSessionClient() {
           @Override
@@ -202,6 +206,7 @@ class WebSessionRepositoryTest {
           @Override
           public void upsertPersistentWebSession(
               final PersistentWebSessionEntity persistentWebSessionEntity) {
+            upsertAttempts.incrementAndGet();
             throw new RuntimeException("Connection refused");
           }
 
@@ -224,6 +229,53 @@ class WebSessionRepositoryTest {
 
     // when / then
     assertThatNoException().isThrownBy(() -> repository.save(webSession));
+    assertThat(upsertAttempts.get()).isEqualTo(3);
+  }
+
+  @Test
+  void shouldSucceedOnRetryAfterTransientFailure() {
+    // given
+    final var upsertAttempts = new java.util.concurrent.atomic.AtomicInteger(0);
+    final var savedEntities = new HashMap<String, PersistentWebSessionEntity>();
+    final PersistentWebSessionClient transientFailureClient =
+        new PersistentWebSessionClient() {
+          @Override
+          public PersistentWebSessionEntity getPersistentWebSession(final String sessionId) {
+            return savedEntities.get(sessionId);
+          }
+
+          @Override
+          public void upsertPersistentWebSession(
+              final PersistentWebSessionEntity persistentWebSessionEntity) {
+            if (upsertAttempts.incrementAndGet() < 3) {
+              throw new RuntimeException("Connection refused");
+            }
+            savedEntities.put(persistentWebSessionEntity.id(), persistentWebSessionEntity);
+          }
+
+          @Override
+          public void deletePersistentWebSession(final String sessionId) {}
+
+          @Override
+          public SearchQueryResult<PersistentWebSessionEntity> getAllPersistentWebSessions() {
+            return SearchQueryResult.of(b -> b.items(new ArrayList<>(savedEntities.values())));
+          }
+        };
+    final var repository =
+        new WebSessionRepository(
+            transientFailureClient,
+            new WebSessionMapper(
+                new SpringBasedWebSessionAttributeConverter(new GenericConversionService())),
+            null);
+    final var webSession = repository.createSession();
+    webSession.setLastAccessedTime(Instant.now());
+
+    // when
+    repository.save(webSession);
+
+    // then
+    assertThat(upsertAttempts.get()).isEqualTo(3);
+    assertThat(transientFailureClient.getPersistentWebSession(webSession.getId())).isNotNull();
   }
 
   static final class PersistentWebSessionClientStub implements PersistentWebSessionClient {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR improves the logging around the web session repository, ultimately it catches the exception that may be thrown from storage and logs a more meaningful output.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #39705
