### PR TITLE
test: Make `io.camunda.ConnectorProcessTest.shouldInvokeConnectors` reliable

### DIFF
--- a/testing/camunda-process-test-example/src/test/java/io/camunda/ConnectorProcessTest.java
+++ b/testing/camunda-process-test-example/src/test/java/io/camunda/ConnectorProcessTest.java
@@ -15,6 +15,13 @@
  */
 package io.camunda;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static io.camunda.process.test.api.CamundaAssert.assertThatProcessInstance;
 import static io.camunda.process.test.api.assertions.ElementSelectors.byName;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -29,15 +36,20 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.testcontainers.Testcontainers;
+import org.wiremock.spring.EnableWireMock;
 
+@EnableWireMock
 @SpringBootTest(
     properties = {
       "camunda.process-test.runtime-mode=managed",
       "camunda.process-test.connectors-enabled=true",
-      "camunda.process-test.connectors-secrets.WEATHER_URL=https://api.open-meteo.com/v1/forecast"
+      "camunda.process-test.connectors-secrets.WEATHER_URL=http://host.testcontainers.internal:${wiremock.server.port}/forecast"
     })
 @CamundaSpringProcessTest
 public class ConnectorProcessTest {
@@ -47,8 +59,22 @@ public class ConnectorProcessTest {
 
   private final ObjectMapper objectMapper = new ObjectMapper();
 
+  @Value("${wiremock.server.port}")
+  private int wireMockPort;
+
   @Autowired private CamundaClient client;
   @Autowired private CamundaProcessTestContext processTestContext;
+
+  @BeforeEach
+  void setup() {
+    Testcontainers.exposeHostPorts(wireMockPort);
+
+    // Create a stub for the HTTP endpoint that is invoked by the Connector
+    stubFor(
+        get(urlPathEqualTo("/forecast"))
+            .willReturn(
+                aResponse().withStatus(200).withBodyFile("weather-forecast-response.json")));
+  }
 
   @Test
   void shouldInvokeConnectors() throws Exception {
@@ -94,8 +120,18 @@ public class ConnectorProcessTest {
     // then
     assertThatProcessInstance(processInstance)
         .hasCompletedElements(byName("Receive weather request"), byName("Get weather info"))
-        .hasVariableNames("temperature", "rain", "weather_code")
+        .hasVariable("temperature", 6.2)
+        .hasVariable("rain", 0)
+        .hasVariable("weather_code", 0)
         .isCompleted();
+
+    // Assert that the HTTP endpoint was invoked with the expected parameters
+    verify(
+        getRequestedFor(urlPathEqualTo("/forecast"))
+            .withQueryParam("latitude", equalTo(String.valueOf(weatherInfoRequest.latitude)))
+            .withQueryParam("longitude", equalTo(String.valueOf(weatherInfoRequest.longitude)))
+            .withQueryParam("timezone", equalTo(weatherInfoRequest.timezone))
+            .withQueryParam("current", equalTo("temperature_2m,rain,weather_code")));
   }
 
   record WeatherInfoRequest(String key, double latitude, double longitude, String timezone) {}

--- a/testing/camunda-process-test-example/src/test/resources/__files/weather-forecast-response.json
+++ b/testing/camunda-process-test-example/src/test/resources/__files/weather-forecast-response.json
@@ -1,0 +1,23 @@
+{
+  "latitude": 52.5,
+  "longitude": 13.4,
+  "generationtime_ms": 0.048160552978515625,
+  "utc_offset_seconds": 7200,
+  "timezone": "Europe/Berlin",
+  "timezone_abbreviation": "GMT+2",
+  "elevation": 37.0,
+  "current_units": {
+    "time": "iso8601",
+    "interval": "seconds",
+    "temperature_2m": "°C",
+    "rain": "mm",
+    "weather_code": "wmo code"
+  },
+  "current": {
+    "time": "2026-04-08T10:00",
+    "interval": 900,
+    "temperature_2m": 6.2,
+    "rain": 0.00,
+    "weather_code": 0
+  }
+}


### PR DESCRIPTION
## Description

The test case `io.camunda.ConnectorProcessTest.shouldInvokeConnectors` uses an outgoing REST connector.

This PR replaces the external API with a WireMock stub to make it reliable.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/50530
