### PR TITLE
feat: add task headers for execution listeners to modeling API

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ExecutionListenerBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ExecutionListenerBuilder.java
@@ -17,8 +17,10 @@ package io.camunda.zeebe.model.bpmn.builder;
 
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListener;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListenerEventType;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeHeader;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskHeaders;
 
-public class ExecutionListenerBuilder {
+public class ExecutionListenerBuilder implements BuilderWithTaskHeaders<ExecutionListenerBuilder> {
   private final ZeebeExecutionListener element;
   private final AbstractBaseElementBuilder<?, ?> elementBuilder;
 
@@ -57,5 +59,20 @@ public class ExecutionListenerBuilder {
 
   public ExecutionListenerBuilder retriesExpression(final String retriesExpression) {
     return retries(elementBuilder.asZeebeExpression(retriesExpression));
+  }
+
+  @Override
+  public ExecutionListenerBuilder zeebeTaskHeader(final String key, final String value) {
+    ZeebeTaskHeaders taskHeaders = element.getTaskHeaders();
+    if (taskHeaders == null) {
+      taskHeaders = elementBuilder.createInstance(ZeebeTaskHeaders.class);
+      element.setTaskHeaders(taskHeaders);
+    }
+
+    final ZeebeHeader header = elementBuilder.createChild(taskHeaders, ZeebeHeader.class);
+    header.setKey(key);
+    header.setValue(value);
+
+    return this;
   }
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeExecutionListenerImpl.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeExecutionListenerImpl.java
@@ -20,10 +20,12 @@ import io.camunda.zeebe.model.bpmn.impl.ZeebeConstants;
 import io.camunda.zeebe.model.bpmn.impl.instance.BpmnModelElementInstanceImpl;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListener;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListenerEventType;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskHeaders;
 import org.camunda.bpm.model.xml.ModelBuilder;
 import org.camunda.bpm.model.xml.impl.instance.ModelTypeInstanceContext;
 import org.camunda.bpm.model.xml.type.ModelElementTypeBuilder;
 import org.camunda.bpm.model.xml.type.attribute.Attribute;
+import org.camunda.bpm.model.xml.type.child.ChildElement;
 
 public class ZeebeExecutionListenerImpl extends BpmnModelElementInstanceImpl
     implements ZeebeExecutionListener {
@@ -31,6 +33,7 @@ public class ZeebeExecutionListenerImpl extends BpmnModelElementInstanceImpl
   protected static Attribute<ZeebeExecutionListenerEventType> eventTypeAttribute;
   protected static Attribute<String> typeAttribute;
   protected static Attribute<String> retriesAttribute;
+  protected static ChildElement<ZeebeTaskHeaders> taskHeadersChild;
 
   public ZeebeExecutionListenerImpl(final ModelTypeInstanceContext instanceContext) {
     super(instanceContext);
@@ -66,6 +69,16 @@ public class ZeebeExecutionListenerImpl extends BpmnModelElementInstanceImpl
     retriesAttribute.setValue(this, retries);
   }
 
+  @Override
+  public ZeebeTaskHeaders getTaskHeaders() {
+    return taskHeadersChild.getChild(this);
+  }
+
+  @Override
+  public void setTaskHeaders(final ZeebeTaskHeaders taskHeaders) {
+    taskHeadersChild.setChild(this, taskHeaders);
+  }
+
   public static void registerType(final ModelBuilder modelBuilder) {
     final ModelElementTypeBuilder typeBuilder =
         modelBuilder
@@ -94,6 +107,8 @@ public class ZeebeExecutionListenerImpl extends BpmnModelElementInstanceImpl
             .defaultValue(ZeebeExecutionListener.DEFAULT_RETRIES)
             .namespace(BpmnModelConstants.ZEEBE_NS)
             .build();
+
+    taskHeadersChild = typeBuilder.sequence().element(ZeebeTaskHeaders.class).build();
 
     typeBuilder.build();
   }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeExecutionListener.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeExecutionListener.java
@@ -32,4 +32,8 @@ public interface ZeebeExecutionListener extends BpmnModelElementInstance {
   String getRetries();
 
   void setRetries(String retries);
+
+  ZeebeTaskHeaders getTaskHeaders();
+
+  void setTaskHeaders(ZeebeTaskHeaders taskHeaders);
 }

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/AdHocSubProcessBuilderTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/AdHocSubProcessBuilderTest.java
@@ -25,9 +25,12 @@ import io.camunda.zeebe.model.bpmn.instance.CompletionCondition;
 import io.camunda.zeebe.model.bpmn.instance.ExtensionElements;
 import io.camunda.zeebe.model.bpmn.instance.FlowElement;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAdHoc;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListener;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListeners;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeHeader;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskHeaders;
+import java.util.Collection;
 import org.camunda.bpm.model.xml.instance.ModelElementInstance;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -254,6 +257,35 @@ class AdHocSubProcessBuilderTest {
   }
 
   @Test
+  void shouldSetExecutionListenerTaskHeaders() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .adHocSubProcess(
+                "ad-hoc",
+                adHocSubProcess ->
+                    adHocSubProcess.zeebeExecutionListener(
+                        listener ->
+                            listener
+                                .start()
+                                .type("el_start_type")
+                                .zeebeTaskHeader("aKey", "aValue")
+                                .zeebeTaskHeader("bKey", "bValue")))
+            .endEvent()
+            .done();
+
+    // when/then
+    assertThat(getExecutionListeners(process.getModelElementById("ad-hoc")))
+        .singleElement()
+        .satisfies(
+            listener ->
+                assertThat(listener.getTaskHeaders().getHeaders())
+                    .extracting(ZeebeHeader::getKey, ZeebeHeader::getValue)
+                    .containsExactly(tuple("aKey", "aValue"), tuple("bKey", "bValue")));
+  }
+
+  @Test
   void shouldSetOutputCollectionAndElement() {
     // given
     final String outputElementExpression = "result";
@@ -280,5 +312,13 @@ class AdHocSubProcessBuilderTest {
         .first()
         .extracting(ZeebeAdHoc::getOutputElement, ZeebeAdHoc::getOutputCollection)
         .containsExactly("=" + outputElementExpression, outputCollection);
+  }
+
+  private Collection<ZeebeExecutionListener> getExecutionListeners(
+      final ModelElementInstance elementInstance) {
+    return elementInstance
+        .getUniqueChildElementByType(ExtensionElements.class)
+        .getUniqueChildElementByType(ZeebeExecutionListeners.class)
+        .getChildElementsByType(ZeebeExecutionListener.class);
   }
 }

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/CallActivityBuilderTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/CallActivityBuilderTest.java
@@ -16,12 +16,17 @@
 package io.camunda.zeebe.model.bpmn.builder;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.ExtensionElements;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledElement;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListener;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListeners;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeHeader;
+import java.util.Collection;
 import org.camunda.bpm.model.xml.instance.ModelElementInstance;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -148,5 +153,41 @@ public class CallActivityBuilderTest {
         .hasSize(1)
         .extracting(ZeebeCalledElement::getVersionTag)
         .containsExactly("v1");
+  }
+
+  @Test
+  void shouldSetExecutionListenerHeaders() {
+    // when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .callActivity(
+                "callActivity",
+                c ->
+                    c.zeebeExecutionListener(
+                        listener ->
+                            listener
+                                .end()
+                                .type("el_end_type")
+                                .zeebeTaskHeader("aKey", "aValue")
+                                .zeebeTaskHeader("bKey", "bValue")))
+            .done();
+
+    // then
+    assertThat(getExecutionListeners(instance.getModelElementById("callActivity")))
+        .singleElement()
+        .satisfies(
+            listener ->
+                assertThat(listener.getTaskHeaders().getHeaders())
+                    .extracting(ZeebeHeader::getKey, ZeebeHeader::getValue)
+                    .containsExactly(tuple("aKey", "aValue"), tuple("bKey", "bValue")));
+  }
+
+  private Collection<ZeebeExecutionListener> getExecutionListeners(
+      final ModelElementInstance elementInstance) {
+    return elementInstance
+        .getUniqueChildElementByType(ExtensionElements.class)
+        .getUniqueChildElementByType(ZeebeExecutionListeners.class)
+        .getChildElementsByType(ZeebeExecutionListener.class);
   }
 }

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/ServiceTaskBuilderTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/ServiceTaskBuilderTest.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.ExtensionElements;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListener;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListeners;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeHeader;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskDefinition;
 import java.util.Collection;
 import org.camunda.bpm.model.xml.instance.ModelElementInstance;
@@ -91,6 +92,35 @@ public class ServiceTaskBuilderTest {
             tuple(start, "el_start_type_2", "2"),
             tuple(end, "el_end_type_1", "5"),
             tuple(end, "el_end_type_2", ZeebeExecutionListener.DEFAULT_RETRIES));
+  }
+
+  @Test
+  void shouldDefineExecutionListenerTaskHeadersForServiceTask() {
+    // when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask(
+                "task",
+                task ->
+                    task.zeebeJobType("service_task_type")
+                        .zeebeExecutionListener(
+                            listener ->
+                                listener
+                                    .start()
+                                    .type("el_start_type")
+                                    .zeebeTaskHeader("aKey", "aValue")
+                                    .zeebeTaskHeader("bKey", "bValue")))
+            .done();
+
+    // then
+    assertThat(getExecutionListeners(instance.getModelElementById("task")))
+        .singleElement()
+        .satisfies(
+            listener ->
+                assertThat(listener.getTaskHeaders().getHeaders())
+                    .extracting(ZeebeHeader::getKey, ZeebeHeader::getValue)
+                    .containsExactly(tuple("aKey", "aValue"), tuple("bKey", "bValue")));
   }
 
   private Collection<ZeebeExecutionListener> getExecutionListeners(

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeExecutionListenerTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeExecutionListenerTest.java
@@ -30,7 +30,8 @@ public class ZeebeExecutionListenerTest extends BpmnModelElementInstanceTest {
 
   @Override
   public Collection<ChildElementAssumption> getChildElementAssumptions() {
-    return Collections.emptyList();
+    return Collections.singletonList(
+        new ChildElementAssumption(BpmnModelConstants.ZEEBE_NS, ZeebeTaskHeaders.class, 0, 1));
   }
 
   @Override

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeExecutionListenersTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeExecutionListenersTest.java
@@ -22,7 +22,6 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants;
 import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstanceTest;
 import io.camunda.zeebe.model.bpmn.instance.ExtensionElements;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import org.camunda.bpm.model.xml.instance.ModelElementInstance;
@@ -37,7 +36,7 @@ public class ZeebeExecutionListenersTest extends BpmnModelElementInstanceTest {
 
   @Override
   public Collection<ChildElementAssumption> getChildElementAssumptions() {
-    return Arrays.asList(
+    return Collections.singletonList(
         new ChildElementAssumption(BpmnModelConstants.ZEEBE_NS, ZeebeExecutionListener.class));
   }
 
@@ -71,6 +70,28 @@ public class ZeebeExecutionListenersTest extends BpmnModelElementInstanceTest {
                 ZeebeExecutionListenerEventType.end,
                 "task_end_el_2",
                 ZeebeExecutionListener.DEFAULT_RETRIES));
+
+    final ZeebeExecutionListener startListenerWithHeaders =
+        executionListeners.stream()
+            .filter(l -> "task_start_el_1".equals(l.getType()))
+            .findFirst()
+            .orElseThrow(
+                () ->
+                    new AssertionError("Expected execution listener with type 'task_start_el_1'"));
+    final ZeebeExecutionListener endListenerWithHeaders =
+        executionListeners.stream()
+            .filter(l -> "task_end_el_1".equals(l.getType()))
+            .findFirst()
+            .orElseThrow(
+                () -> new AssertionError("Expected execution listener with type 'task_end_el_1'"));
+    assertThat(startListenerWithHeaders.getTaskHeaders()).isNotNull();
+    assertThat(startListenerWithHeaders.getTaskHeaders().getHeaders())
+        .extracting(ZeebeHeader::getKey, ZeebeHeader::getValue)
+        .containsExactly(tuple("aKey", "aValue"), tuple("bKey", "bValue"));
+    assertThat(endListenerWithHeaders.getTaskHeaders()).isNotNull();
+    assertThat(endListenerWithHeaders.getTaskHeaders().getHeaders())
+        .extracting(ZeebeHeader::getKey, ZeebeHeader::getValue)
+        .containsExactly(tuple("cKey", "cValue"));
   }
 
   private Collection<ZeebeExecutionListener> getExecutionListeners(

--- a/zeebe/bpmn-model/src/test/resources/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeExecutionListenersTest.bpmn
+++ b/zeebe/bpmn-model/src/test/resources/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeExecutionListenersTest.bpmn
@@ -12,9 +12,18 @@
     <bpmn:serviceTask id="service_task">
       <bpmn:extensionElements>
         <zeebe:executionListeners>
-          <zeebe:executionListener eventType="start" type="task_start_el_1" retries="4" />
+          <zeebe:executionListener eventType="start" type="task_start_el_1" retries="4">
+            <zeebe:taskHeaders>
+              <zeebe:header key="aKey" value="aValue" />
+              <zeebe:header key="bKey" value="bValue" />
+            </zeebe:taskHeaders>
+          </zeebe:executionListener>
           <zeebe:executionListener eventType="start" type="task_start_el_2" retries="8" />
-          <zeebe:executionListener eventType="end" type="task_end_el_1" retries="5" />
+          <zeebe:executionListener eventType="end" type="task_end_el_1" retries="5">
+            <zeebe:taskHeaders>
+              <zeebe:header key="cKey" value="cValue" />
+            </zeebe:taskHeaders>
+          </zeebe:executionListener>
           <zeebe:executionListener eventType="end" type="task_end_el_2" />
         </zeebe:executionListeners>
         <zeebe:taskDefinition type="task_type" retries="8" />

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/zeebe/FakeZeebeExecutionListener.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/zeebe/FakeZeebeExecutionListener.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.model.bpmn.builder.AbstractBaseElementBuilder;
 import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstance;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListener;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListenerEventType;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskHeaders;
 import java.util.Collection;
 import java.util.List;
 import org.camunda.bpm.model.xml.ModelInstance;
@@ -28,6 +29,7 @@ public final class FakeZeebeExecutionListener implements ZeebeExecutionListener 
   private final String eventType;
   private final String type;
   private final String retries;
+  private ZeebeTaskHeaders taskHeaders;
 
   public FakeZeebeExecutionListener(
       final String eventType, final String type, final String retries) {
@@ -194,4 +196,14 @@ public final class FakeZeebeExecutionListener implements ZeebeExecutionListener 
 
   @Override
   public void setRetries(final String retries) {}
+
+  @Override
+  public ZeebeTaskHeaders getTaskHeaders() {
+    return taskHeaders;
+  }
+
+  @Override
+  public void setTaskHeaders(final ZeebeTaskHeaders taskHeaders) {
+    this.taskHeaders = taskHeaders;
+  }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Add execution listener task headers to the modeling API.

They can be defined on any type of task that allows for ELs, so I added test cases for some of the existing builder type tests to not only cover service tasks all the time.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/49762
