### PR TITLE
Delete process instance api test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-delete-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-delete-api.spec.ts
@@ -7,7 +7,11 @@
  */
 
 import {expect, test} from '@playwright/test';
-import {cancelProcessInstance, createInstances, deploy} from '../../../../utils/zeebeClient';
+import {
+  cancelProcessInstance,
+  createInstances,
+  deploy,
+} from '../../../../utils/zeebeClient';
 import {
   assertBadRequest,
   assertForbiddenRequest,
@@ -21,231 +25,287 @@ import {
 } from '../../../../utils/http';
 import {defaultAssertionOptions} from '../../../../utils/constants';
 import {validateResponse} from '../../../../json-body-assertions';
-import { 
-    createUser,
-    grantUserResourceAuthorization,
-    expectBatchState,
+import {
+  createUser,
+  grantUserResourceAuthorization,
+  expectBatchState,
 } from '@requestHelpers';
-import { cleanupUsers } from 'utils/usersCleanup';
+import {cleanupUsers} from 'utils/usersCleanup';
 
 test.describe.parallel('Delete Batch Process Instance API Tests', () => {
-    let processInstanceKeysToDelete: string[] = [];
-    let activeProcessInstanceKeysToDelete: string[] = [];
-    let userWithResourcesAuthorizationToSendRequest: {
-      username: string;
-      name: string;
-      email: string;
-      password: string;
-    } = {} as {
-      username: string;
-      name: string;
-      email: string;
-      password: string;
-    };
+  let processInstanceKeysToDelete: string[] = [];
+  let activeProcessInstanceKeysToDelete: string[] = [];
+  let userWithResourcesAuthorizationToSendRequest: {
+    username: string;
+    name: string;
+    email: string;
+    password: string;
+  } = {} as {
+    username: string;
+    name: string;
+    email: string;
+    password: string;
+  };
 
-    test.beforeAll(async ({request}) => {
-        await test.step('Setup - Deploy process and create instance to delete', async () => {
-            await deploy([
-                './resources/calledProcess.bpmn',
-                './resources/IncidentProcess.bpmn'
-            ]);
-            const createdInstances = await createInstances('CalledProcess', 1, 5);
-            for (const createdInstance of createdInstances) {
-                processInstanceKeysToDelete.push(createdInstance.processInstanceKey);
-            }
+  test.beforeAll(async ({request}) => {
+    await test.step('Setup - Deploy process and create instance to delete', async () => {
+      await deploy([
+        './resources/calledProcess.bpmn',
+        './resources/IncidentProcess.bpmn',
+      ]);
+      const createdInstances = await createInstances('CalledProcess', 1, 5);
+      for (const createdInstance of createdInstances) {
+        processInstanceKeysToDelete.push(createdInstance.processInstanceKey);
+      }
 
-            const createdIncidentInstance = await createInstances('IncidentProcess', 1, 5);
-            for (const createdInstance of createdIncidentInstance) {
-                activeProcessInstanceKeysToDelete.push(createdInstance.processInstanceKey);
-            }
-
-        });
-
-        await test.step('Setup - Create test user with Resource Authorization and user for granting Authorization', async () => {
-            userWithResourcesAuthorizationToSendRequest = await createUser(request);
-            await grantUserResourceAuthorization(
-                request,
-                userWithResourcesAuthorizationToSendRequest,
-            );
-        });
+      const createdIncidentInstance = await createInstances(
+        'IncidentProcess',
+        1,
+        5,
+      );
+      for (const createdInstance of createdIncidentInstance) {
+        activeProcessInstanceKeysToDelete.push(
+          createdInstance.processInstanceKey,
+        );
+      }
     });
 
-    test.afterAll(async ({request}) => {
-        await test.step('Cleanup - Delete test users', async () => {
-            await cleanupUsers(request, [
-                userWithResourcesAuthorizationToSendRequest.username,
-            ]);
-        });
+    await test.step('Setup - Create test user with Resource Authorization and user for granting Authorization', async () => {
+      userWithResourcesAuthorizationToSendRequest = await createUser(request);
+      await grantUserResourceAuthorization(
+        request,
+        userWithResourcesAuthorizationToSendRequest,
+      );
+    });
+  });
 
-        await test.step('Cleanup - Cancel created process instances', async () => {
-            for (const processInstanceKey of activeProcessInstanceKeysToDelete) {
-                await cancelProcessInstance(processInstanceKey);
-            }
-        });
-
-        await test.step('Cleanup - Clean arrays', async () => {
-            processInstanceKeysToDelete = [];
-            activeProcessInstanceKeysToDelete = [];
-        });
+  test.afterAll(async ({request}) => {
+    await test.step('Cleanup - Delete test users', async () => {
+      await cleanupUsers(request, [
+        userWithResourcesAuthorizationToSendRequest.username,
+      ]);
     });
 
-    test('Delete Batch Process Instance, single Process Instance - Success', async ({request}) => {
-        const processInstanceKeyToDelete = processInstanceKeysToDelete[0];
-        let batchOperationKey = '';
-        await test.step('Verify Process Instance Key to Delete has state COMPLETED', async () => {
-            await expect(async () => {
-                const response = await request.get(buildUrl(`/process-instances/${processInstanceKeyToDelete}`), {
-                    headers: jsonHeaders(),
-                });
-                await assertStatusCode(response, 200);
-                await validateResponse({
-                    path: '/process-instances/{processInstanceKey}',
-                    method: 'GET',
-                    status: '200'
-                }, response);
-                const responseBody = await response.json();
-                expect(responseBody.state).toBe('COMPLETED');
-            }).toPass(defaultAssertionOptions);
-        });
-
-        await test.step('Delete the process instance as batch', async () => {
-            const res = await request.post(buildUrl('/process-instances/deletion'), {
-                headers: jsonHeaders(),
-                data: {
-                    filter: {
-                        processInstanceKey: processInstanceKeyToDelete,
-                    },
-                },
-            });
-            await assertStatusCode(res, 200);
-            await validateResponse({
-                    path: '/process-instances/deletion',
-                    method: 'POST',
-                    status: '200'
-            }, res);
-            const json = await res.json();
-            batchOperationKey = json.batchOperationKey;
-            expect(json.batchOperationType).toBe('DELETE_PROCESS_INSTANCE');
-        });
-
-        await test.step('Verify the batch operation is completed', async () => {
-            await expectBatchState(request, batchOperationKey, 'COMPLETED');
-        });
-
-        await test.step('Verify process instance is deleted', async () => {
-            await expect(async () => {
-                const response = await request.get(buildUrl(`/process-instances/${processInstanceKeyToDelete}`), {
-                    headers: jsonHeaders(),
-                });
-                await assertNotFoundRequest(response, `Process Instance with key '${processInstanceKeyToDelete}' not found`);
-            }).toPass(defaultAssertionOptions);
-        });
+    await test.step('Cleanup - Cancel created process instances', async () => {
+      for (const processInstanceKey of activeProcessInstanceKeysToDelete) {
+        await cancelProcessInstance(processInstanceKey);
+      }
     });
 
-    test('Delete Batch Process Instance, multiple Process Instances - Success', async ({request}) => {
-        const processInstancesToDelete = processInstanceKeysToDelete.slice(1);
-        let batchOperationKey = '';
+    await test.step('Cleanup - Clean arrays', async () => {
+      processInstanceKeysToDelete = [];
+      activeProcessInstanceKeysToDelete = [];
+    });
+  });
 
-        await test.step('Verify Process Instance Key to Delete has state COMPLETED', async () => {
-            for (const processInstanceKey of processInstancesToDelete) {
-                await expect(async () => {
-                    const response = await request.get(buildUrl(`/process-instances/${processInstanceKey}`), {
-                        headers: jsonHeaders(),
-                    });
-                    await assertStatusCode(response, 200);
-                    await validateResponse({
-                        path: '/process-instances/{processInstanceKey}',
-                        method: 'GET',
-                        status: '200'
-                    }, response);
-                    const responseBody = await response.json();
-                    expect(responseBody.state).toBe('COMPLETED');
-                }).toPass(defaultAssertionOptions);
-            }
-        });
+  test('Delete Batch Process Instance, single Process Instance - Success', async ({
+    request,
+  }) => {
+    const processInstanceKeyToDelete = processInstanceKeysToDelete[0];
+    let batchOperationKey = '';
 
-        await test.step('Delete the process instances as batch', async () => {
-            const res = await request.post(buildUrl('/process-instances/deletion'), {
-                headers: jsonHeaders(),
-                data: {
-                    filter: {
-                        processInstanceKey: { $in: processInstancesToDelete },
-                    },
-                },
-            });
-            await assertStatusCode(res, 200);
-            await validateResponse({
-                    path: '/process-instances/deletion',
-                    method: 'POST',
-                    status: '200'
-            }, res);
-            const json = await res.json();
-            batchOperationKey = json.batchOperationKey;
-            expect(json.batchOperationType).toBe('DELETE_PROCESS_INSTANCE');
-        });
-
-        test.step('Verify the batch operation is completed', async () => {
-            await expectBatchState(request, batchOperationKey, 'COMPLETED');
-        });
-
-        test.step('Verify process instances are deleted', async () => {
-            for (const processInstanceKey of processInstancesToDelete) {
-                await expect(async () => {
-                    const response = await request.get(buildUrl(`/process-instances/${processInstanceKey}`), {
-                        headers: jsonHeaders(),
-                    });
-                    await assertNotFoundRequest(response, `Process Instance with key '${processInstanceKey}' not found`);
-            }).toPass(defaultAssertionOptions);
-            }
-        });
+    await test.step('Verify Process Instance Key to Delete has state COMPLETED', async () => {
+      await expect(async () => {
+        const response = await request.get(
+          buildUrl(`/process-instances/${processInstanceKeyToDelete}`),
+          {
+            headers: jsonHeaders(),
+          },
+        );
+        await assertStatusCode(response, 200);
+        await validateResponse(
+          {
+            path: '/process-instances/{processInstanceKey}',
+            method: 'GET',
+            status: '200',
+          },
+          response,
+        );
+        const responseBody = await response.json();
+        expect(responseBody.state).toBe('COMPLETED');
+      }).toPass(defaultAssertionOptions);
     });
 
-    test('Delete Batch Process Instance, single Process Instance - Unauthorized', async ({request}) => {
-        const someInstanceKey = '999999999999999';
-        const res = await request.post(buildUrl('/process-instances/deletion'), {
-            headers: {},
-            data: {
-                filter: {
-                    processInstanceKey: someInstanceKey,
-                },
+    await test.step('Delete the process instance as batch', async () => {
+      const res = await request.post(buildUrl('/process-instances/deletion'), {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            processInstanceKey: processInstanceKeyToDelete,
+          },
+        },
+      });
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: '/process-instances/deletion',
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+      const json = await res.json();
+      batchOperationKey = json.batchOperationKey;
+      expect(json.batchOperationType).toBe('DELETE_PROCESS_INSTANCE');
+    });
+
+    await test.step('Verify the batch operation is completed', async () => {
+      await expectBatchState(request, batchOperationKey, 'COMPLETED');
+    });
+
+    await test.step('Verify process instance is deleted', async () => {
+      await expect(async () => {
+        const response = await request.get(
+          buildUrl(`/process-instances/${processInstanceKeyToDelete}`),
+          {
+            headers: jsonHeaders(),
+          },
+        );
+        await assertNotFoundRequest(
+          response,
+          `Process Instance with key '${processInstanceKeyToDelete}' not found`,
+        );
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+
+  test('Delete Batch Process Instance, multiple Process Instances - Success', async ({
+    request,
+  }) => {
+    const processInstancesToDelete = processInstanceKeysToDelete.slice(1);
+    let batchOperationKey = '';
+
+    await test.step('Verify Process Instance Key to Delete has state COMPLETED', async () => {
+      for (const processInstanceKey of processInstancesToDelete) {
+        await expect(async () => {
+          const response = await request.get(
+            buildUrl(`/process-instances/${processInstanceKey}`),
+            {
+              headers: jsonHeaders(),
             },
-        });
-        await assertUnauthorizedRequest(res);
-    });
-
-    test('Delete Batch Process Instance, single Process Instance - Forbidden', async ({request}) => {
-        const someInstanceKey = '999999999999999';
-        const token = encode(`${userWithResourcesAuthorizationToSendRequest.username}:${userWithResourcesAuthorizationToSendRequest.password}`);
-        const res = await request.post(buildUrl('/process-instances/deletion'), {
-            headers: jsonHeaders(token), // ovverrides default demo:demo
-            data: {
-                filter: {
-                    processInstanceKey: someInstanceKey,
-                },
+          );
+          await assertStatusCode(response, 200);
+          await validateResponse(
+            {
+              path: '/process-instances/{processInstanceKey}',
+              method: 'GET',
+              status: '200',
             },
-        });
-        await assertForbiddenRequest(res, 'Insufficient permissions to perform operation \'CREATE_BATCH_OPERATION_DELETE_PROCESS_INSTANCE\'');
+            response,
+          );
+          const responseBody = await response.json();
+          expect(responseBody.state).toBe('COMPLETED');
+        }).toPass(defaultAssertionOptions);
+      }
     });
 
-    test('Delete Batch Process Instance, no filter - Bad Request', async ({request}) => {
-        const res = await request.post(buildUrl('/process-instances/deletion'), {
-                headers: jsonHeaders(),
-                data: {
-                    // No filter or processInstanceKeys provided
-                },
-            });
-        await assertInvalidArgument(res, 400, 'No filter provided.');
+    await test.step('Delete the process instances as batch', async () => {
+      const res = await request.post(buildUrl('/process-instances/deletion'), {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            processInstanceKey: {$in: processInstancesToDelete},
+          },
+        },
+      });
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: '/process-instances/deletion',
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+      const json = await res.json();
+      batchOperationKey = json.batchOperationKey;
+      expect(json.batchOperationType).toBe('DELETE_PROCESS_INSTANCE');
     });
 
-    test('Delete Batch Process Instance, invalid filter - Bad Request', async ({request}) => {
-        const res = await request.post(buildUrl('/process-instances/deletion'), {
-                headers: jsonHeaders(),
-                data: {
-                    filter: {
-                        invalidField: 'invalidValue',
-                    },
-                },
-            });
-        await assertBadRequest(res, 'Request property [filter.invalidField] cannot be parsed');
+    await test.step('Verify the batch operation is completed', async () => {
+      await expectBatchState(request, batchOperationKey, 'COMPLETED');
     });
+
+    await test.step('Verify process instances are deleted', async () => {
+      for (const processInstanceKey of processInstancesToDelete) {
+        await expect(async () => {
+          const response = await request.get(
+            buildUrl(`/process-instances/${processInstanceKey}`),
+            {
+              headers: jsonHeaders(),
+            },
+          );
+          await assertNotFoundRequest(
+            response,
+            `Process Instance with key '${processInstanceKey}' not found`,
+          );
+        }).toPass(defaultAssertionOptions);
+      }
+    });
+  });
+
+  test('Delete Batch Process Instance, single Process Instance - Unauthorized', async ({
+    request,
+  }) => {
+    const someInstanceKey = '999999999999999';
+    const res = await request.post(buildUrl('/process-instances/deletion'), {
+      headers: {},
+      data: {
+        filter: {
+          processInstanceKey: someInstanceKey,
+        },
+      },
+    });
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Delete Batch Process Instance, single Process Instance - Forbidden', async ({
+    request,
+  }) => {
+    const someInstanceKey = '999999999999999';
+    const token = encode(
+      `${userWithResourcesAuthorizationToSendRequest.username}:${userWithResourcesAuthorizationToSendRequest.password}`,
+    );
+    const res = await request.post(buildUrl('/process-instances/deletion'), {
+      headers: jsonHeaders(token), // ovverrides default demo:demo
+      data: {
+        filter: {
+          processInstanceKey: someInstanceKey,
+        },
+      },
+    });
+    await assertForbiddenRequest(
+      res,
+      "Insufficient permissions to perform operation 'CREATE_BATCH_OPERATION_DELETE_PROCESS_INSTANCE'",
+    );
+  });
+
+  test('Delete Batch Process Instance, no filter - Bad Request', async ({
+    request,
+  }) => {
+    const res = await request.post(buildUrl('/process-instances/deletion'), {
+      headers: jsonHeaders(),
+      data: {
+        // No filter or processInstanceKeys provided
+      },
+    });
+    await assertInvalidArgument(res, 400, 'No filter provided.');
+  });
+
+  test('Delete Batch Process Instance, invalid filter - Bad Request', async ({
+    request,
+  }) => {
+    const res = await request.post(buildUrl('/process-instances/deletion'), {
+      headers: jsonHeaders(),
+      data: {
+        filter: {
+          invalidField: 'invalidValue',
+        },
+      },
+    });
+    await assertBadRequest(
+      res,
+      'Request property [filter.invalidField] cannot be parsed',
+    );
+  });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-delete-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-delete-api.spec.ts
@@ -244,6 +244,202 @@ test.describe.parallel('Delete Batch Process Instance API Tests', () => {
     });
   });
 
+  test('Delete Batch Active Single Process Instance - No instance should be deleted', async ({
+    request,
+  }) => {
+    const processInstanceKeyToDelete = activeProcessInstanceKeysToDelete[0];
+    let batchOperationKey = '';
+    await test.step('Verify Process Instance Key to Delete has state ACTIVE', async () => {
+      await expect(async () => {
+        const response = await request.get(
+          buildUrl(`/process-instances/${processInstanceKeyToDelete}`),
+          {
+            headers: jsonHeaders(),
+          },
+        );
+        await assertStatusCode(response, 200);
+        await validateResponse(
+          {
+            path: '/process-instances/{processInstanceKey}',
+            method: 'GET',
+            status: '200',
+          },
+          response,
+        );
+        const responseBody = await response.json();
+        expect(responseBody.state).toBe('ACTIVE');
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Delete the process instance as batch', async () => {
+      const res = await request.post(buildUrl('/process-instances/deletion'), {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            processInstanceKey: processInstanceKeyToDelete,
+          },
+        },
+      });
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: '/process-instances/deletion',
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+      const json = await res.json();
+      batchOperationKey = json.batchOperationKey;
+      expect(json.batchOperationType).toBe('DELETE_PROCESS_INSTANCE');
+    });
+
+    await test.step('Verify the batch operation is completed', async () => {
+      await expect(async () => {
+        const statusRes = await request.get(
+          buildUrl(`/batch-operations/${batchOperationKey}`),
+          {
+            headers: jsonHeaders(),
+          },
+        );
+        await assertStatusCode(statusRes, 200);
+        await validateResponse(
+          {
+            path: '/batch-operations/{batchOperationKey}',
+            method: 'GET',
+            status: '200',
+          },
+          statusRes,
+        );
+        const body = await statusRes.json();
+        expect(body.state).toBe('COMPLETED');
+        expect(body.operationsCompletedCount).toBe(0);
+      }).toPass({
+        intervals: [5_000, 10_000, 15_000, 25_000, 35_000],
+        timeout: 120_000,
+      });
+    });
+
+    await test.step('Verify process instance is still active', async () => {
+      await expect(async () => {
+        const response = await request.get(
+          buildUrl(`/process-instances/${processInstanceKeyToDelete}`),
+          {
+            headers: jsonHeaders(),
+          },
+        );
+        await assertStatusCode(response, 200);
+        await validateResponse({
+          path: '/process-instances/{processInstanceKey}',
+          method: 'GET',
+          status: '200',
+        }, response);
+        const responseBody = await response.json();
+        expect(responseBody.state).toBe('ACTIVE');
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+
+  test('Delete Batch Active Multiple Process Instances - No instance should be deleted', async ({
+    request,
+  }) => {
+    const processInstancesToDelete = activeProcessInstanceKeysToDelete.slice(1);
+    let batchOperationKey = '';
+    await test.step('Verify Process Instance Key to Delete has state ACTIVE', async () => {
+      for (const processInstanceKey of processInstancesToDelete) {
+        await expect(async () => {
+          const response = await request.get(
+            buildUrl(`/process-instances/${processInstanceKey}`),
+            {
+              headers: jsonHeaders(),
+            },
+          );
+          await assertStatusCode(response, 200);
+          await validateResponse(
+            {
+              path: '/process-instances/{processInstanceKey}',
+              method: 'GET',
+              status: '200',
+            },
+            response,
+          );
+          const responseBody = await response.json();
+          expect(responseBody.state).toBe('ACTIVE');
+        }).toPass(defaultAssertionOptions);
+      }
+    });
+
+    await test.step('Delete the process instance as batch', async () => {
+      const res = await request.post(buildUrl('/process-instances/deletion'), {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            processInstanceKey: {$in: processInstancesToDelete},
+          },
+        },
+      });
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: '/process-instances/deletion',
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+      const json = await res.json();
+      batchOperationKey = json.batchOperationKey;
+      expect(json.batchOperationType).toBe('DELETE_PROCESS_INSTANCE');
+    });
+
+    await test.step('Verify the batch operation is completed', async () => {
+      await expect(async () => {
+        const statusRes = await request.get(
+          buildUrl(`/batch-operations/${batchOperationKey}`),
+          {
+            headers: jsonHeaders(),
+          },
+        );
+        await assertStatusCode(statusRes, 200);
+        await validateResponse(
+          {
+            path: '/batch-operations/{batchOperationKey}',
+            method: 'GET',
+            status: '200',
+          },
+          statusRes,
+        );
+        const body = await statusRes.json();
+        expect(body.state).toBe('COMPLETED');
+        expect(body.operationsCompletedCount).toBe(0);
+      }).toPass({
+        intervals: [5_000, 10_000, 15_000, 25_000, 35_000],
+        timeout: 120_000,
+      });
+    });
+
+    await test.step('Verify process instances are still active', async () => {
+      for (const processInstanceKey of processInstancesToDelete) {
+        await expect(async () => {
+          const response = await request.get(
+            buildUrl(`/process-instances/${processInstanceKey}`),
+            {
+              headers: jsonHeaders(),
+            },
+          );
+          await assertStatusCode(response, 200);
+          await validateResponse({
+            path: '/process-instances/{processInstanceKey}',
+            method: 'GET',
+            status: '200',
+          }, response);
+          const responseBody = await response.json();
+          expect(responseBody.state).toBe('ACTIVE');
+      }).toPass(defaultAssertionOptions);
+      }
+    });
+  });
+
   test('Delete Batch Process Instance, single Process Instance - Unauthorized', async ({
     request,
   }) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-delete-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-delete-api.spec.ts
@@ -1,0 +1,251 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect, test} from '@playwright/test';
+import {cancelProcessInstance, createInstances, deploy} from '../../../../utils/zeebeClient';
+import {
+  assertBadRequest,
+  assertForbiddenRequest,
+  assertInvalidArgument,
+  assertNotFoundRequest,
+  assertStatusCode,
+  assertUnauthorizedRequest,
+  buildUrl,
+  encode,
+  jsonHeaders,
+} from '../../../../utils/http';
+import {defaultAssertionOptions} from '../../../../utils/constants';
+import {validateResponse} from '../../../../json-body-assertions';
+import { 
+    createUser,
+    grantUserResourceAuthorization,
+    expectBatchState,
+} from '@requestHelpers';
+import { cleanupUsers } from 'utils/usersCleanup';
+
+test.describe.parallel('Delete Batch Process Instance API Tests', () => {
+    let processInstanceKeysToDelete: string[] = [];
+    let activeProcessInstanceKeysToDelete: string[] = [];
+    let userWithResourcesAuthorizationToSendRequest: {
+      username: string;
+      name: string;
+      email: string;
+      password: string;
+    } = {} as {
+      username: string;
+      name: string;
+      email: string;
+      password: string;
+    };
+
+    test.beforeAll(async ({request}) => {
+        await test.step('Setup - Deploy process and create instance to delete', async () => {
+            await deploy([
+                './resources/calledProcess.bpmn',
+                './resources/IncidentProcess.bpmn'
+            ]);
+            const createdInstances = await createInstances('CalledProcess', 1, 5);
+            for (const createdInstance of createdInstances) {
+                processInstanceKeysToDelete.push(createdInstance.processInstanceKey);
+            }
+
+            const createdIncidentInstance = await createInstances('IncidentProcess', 1, 5);
+            for (const createdInstance of createdIncidentInstance) {
+                activeProcessInstanceKeysToDelete.push(createdInstance.processInstanceKey);
+            }
+
+        });
+
+        await test.step('Setup - Create test user with Resource Authorization and user for granting Authorization', async () => {
+            userWithResourcesAuthorizationToSendRequest = await createUser(request);
+            await grantUserResourceAuthorization(
+                request,
+                userWithResourcesAuthorizationToSendRequest,
+            );
+        });
+    });
+
+    test.afterAll(async ({request}) => {
+        await test.step('Cleanup - Delete test users', async () => {
+            await cleanupUsers(request, [
+                userWithResourcesAuthorizationToSendRequest.username,
+            ]);
+        });
+
+        await test.step('Cleanup - Cancel created process instances', async () => {
+            for (const processInstanceKey of activeProcessInstanceKeysToDelete) {
+                await cancelProcessInstance(processInstanceKey);
+            }
+        });
+
+        await test.step('Cleanup - Clean arrays', async () => {
+            processInstanceKeysToDelete = [];
+            activeProcessInstanceKeysToDelete = [];
+        });
+    });
+
+    test('Delete Batch Process Instance, single Process Instance - Success', async ({request}) => {
+        const processInstanceKeyToDelete = processInstanceKeysToDelete[0];
+        let batchOperationKey = '';
+        await test.step('Verify Process Instance Key to Delete has state COMPLETED', async () => {
+            await expect(async () => {
+                const response = await request.get(buildUrl(`/process-instances/${processInstanceKeyToDelete}`), {
+                    headers: jsonHeaders(),
+                });
+                await assertStatusCode(response, 200);
+                await validateResponse({
+                    path: '/process-instances/{processInstanceKey}',
+                    method: 'GET',
+                    status: '200'
+                }, response);
+                const responseBody = await response.json();
+                expect(responseBody.state).toBe('COMPLETED');
+            }).toPass(defaultAssertionOptions);
+        });
+
+        await test.step('Delete the process instance as batch', async () => {
+            const res = await request.post(buildUrl('/process-instances/deletion'), {
+                headers: jsonHeaders(),
+                data: {
+                    filter: {
+                        processInstanceKey: processInstanceKeyToDelete,
+                    },
+                },
+            });
+            await assertStatusCode(res, 200);
+            await validateResponse({
+                    path: '/process-instances/deletion',
+                    method: 'POST',
+                    status: '200'
+            }, res);
+            const json = await res.json();
+            batchOperationKey = json.batchOperationKey;
+            expect(json.batchOperationType).toBe('DELETE_PROCESS_INSTANCE');
+        });
+
+        await test.step('Verify the batch operation is completed', async () => {
+            await expectBatchState(request, batchOperationKey, 'COMPLETED');
+        });
+
+        await test.step('Verify process instance is deleted', async () => {
+            await expect(async () => {
+                const response = await request.get(buildUrl(`/process-instances/${processInstanceKeyToDelete}`), {
+                    headers: jsonHeaders(),
+                });
+                await assertNotFoundRequest(response, `Process Instance with key '${processInstanceKeyToDelete}' not found`);
+            }).toPass(defaultAssertionOptions);
+        });
+    });
+
+    test('Delete Batch Process Instance, multiple Process Instances - Success', async ({request}) => {
+        const processInstancesToDelete = processInstanceKeysToDelete.slice(1);
+        let batchOperationKey = '';
+
+        await test.step('Verify Process Instance Key to Delete has state COMPLETED', async () => {
+            for (const processInstanceKey of processInstancesToDelete) {
+                await expect(async () => {
+                    const response = await request.get(buildUrl(`/process-instances/${processInstanceKey}`), {
+                        headers: jsonHeaders(),
+                    });
+                    await assertStatusCode(response, 200);
+                    await validateResponse({
+                        path: '/process-instances/{processInstanceKey}',
+                        method: 'GET',
+                        status: '200'
+                    }, response);
+                    const responseBody = await response.json();
+                    expect(responseBody.state).toBe('COMPLETED');
+                }).toPass(defaultAssertionOptions);
+            }
+        });
+
+        await test.step('Delete the process instances as batch', async () => {
+            const res = await request.post(buildUrl('/process-instances/deletion'), {
+                headers: jsonHeaders(),
+                data: {
+                    filter: {
+                        processInstanceKey: { $in: processInstancesToDelete },
+                    },
+                },
+            });
+            await assertStatusCode(res, 200);
+            await validateResponse({
+                    path: '/process-instances/deletion',
+                    method: 'POST',
+                    status: '200'
+            }, res);
+            const json = await res.json();
+            batchOperationKey = json.batchOperationKey;
+            expect(json.batchOperationType).toBe('DELETE_PROCESS_INSTANCE');
+        });
+
+        test.step('Verify the batch operation is completed', async () => {
+            await expectBatchState(request, batchOperationKey, 'COMPLETED');
+        });
+
+        test.step('Verify process instances are deleted', async () => {
+            for (const processInstanceKey of processInstancesToDelete) {
+                await expect(async () => {
+                    const response = await request.get(buildUrl(`/process-instances/${processInstanceKey}`), {
+                        headers: jsonHeaders(),
+                    });
+                    await assertNotFoundRequest(response, `Process Instance with key '${processInstanceKey}' not found`);
+            }).toPass(defaultAssertionOptions);
+            }
+        });
+    });
+
+    test('Delete Batch Process Instance, single Process Instance - Unauthorized', async ({request}) => {
+        const someInstanceKey = '999999999999999';
+        const res = await request.post(buildUrl('/process-instances/deletion'), {
+            headers: {},
+            data: {
+                filter: {
+                    processInstanceKey: someInstanceKey,
+                },
+            },
+        });
+        await assertUnauthorizedRequest(res);
+    });
+
+    test('Delete Batch Process Instance, single Process Instance - Forbidden', async ({request}) => {
+        const someInstanceKey = '999999999999999';
+        const token = encode(`${userWithResourcesAuthorizationToSendRequest.username}:${userWithResourcesAuthorizationToSendRequest.password}`);
+        const res = await request.post(buildUrl('/process-instances/deletion'), {
+            headers: jsonHeaders(token), // ovverrides default demo:demo
+            data: {
+                filter: {
+                    processInstanceKey: someInstanceKey,
+                },
+            },
+        });
+        await assertForbiddenRequest(res, 'Insufficient permissions to perform operation \'CREATE_BATCH_OPERATION_DELETE_PROCESS_INSTANCE\'');
+    });
+
+    test('Delete Batch Process Instance, no filter - Bad Request', async ({request}) => {
+        const res = await request.post(buildUrl('/process-instances/deletion'), {
+                headers: jsonHeaders(),
+                data: {
+                    // No filter or processInstanceKeys provided
+                },
+            });
+        await assertInvalidArgument(res, 400, 'No filter provided.');
+    });
+
+    test('Delete Batch Process Instance, invalid filter - Bad Request', async ({request}) => {
+        const res = await request.post(buildUrl('/process-instances/deletion'), {
+                headers: jsonHeaders(),
+                data: {
+                    filter: {
+                        invalidField: 'invalidValue',
+                    },
+                },
+            });
+        await assertBadRequest(res, 'Request property [filter.invalidField] cannot be parsed');
+    });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-delete-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-create-batch-to-delete-api.spec.ts
@@ -267,7 +267,7 @@ test.describe.parallel('Delete Batch Process Instance API Tests', () => {
       `${userWithResourcesAuthorizationToSendRequest.username}:${userWithResourcesAuthorizationToSendRequest.password}`,
     );
     const res = await request.post(buildUrl('/process-instances/deletion'), {
-      headers: jsonHeaders(token), // ovverrides default demo:demo
+      headers: jsonHeaders(token), // overrides default demo:demo
       data: {
         filter: {
           processInstanceKey: someInstanceKey,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-delete-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-delete-api.spec.ts
@@ -6,13 +6,10 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {expect, request, test} from '@playwright/test';
+import {expect, test} from '@playwright/test';
 import {cancelProcessInstance, createSingleInstance, deploy} from '../../../../utils/zeebeClient';
 import {
-  assertBadRequest,
-  assertConflictRequest,
   assertForbiddenRequest,
-  assertInvalidArgument,
   assertInvalidState,
   assertNotFoundRequest,
   assertStatusCode,
@@ -29,7 +26,7 @@ import {
 } from '@requestHelpers';
 import { cleanupUsers } from 'utils/usersCleanup';
 
-test.describe.parallel('Delete Single Process instance API Tests', () => {
+test.describe.parallel('Delete Single Process Instance API Tests', () => {
     let processInstanceKeyToDelete: string = '';
     let activeProcessInstanceKeyToDelete: string = '';
     let userWithResourcesAuthorizationToSendRequest: {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-delete-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-delete-api.spec.ts
@@ -7,7 +7,11 @@
  */
 
 import {expect, test} from '@playwright/test';
-import {cancelProcessInstance, createSingleInstance, deploy} from '../../../../utils/zeebeClient';
+import {
+  cancelProcessInstance,
+  createSingleInstance,
+  deploy,
+} from '../../../../utils/zeebeClient';
 import {
   assertForbiddenRequest,
   assertInvalidState,
@@ -20,144 +24,189 @@ import {
 } from '../../../../utils/http';
 import {defaultAssertionOptions} from '../../../../utils/constants';
 import {validateResponse} from '../../../../json-body-assertions';
-import { 
-    createUser,
-    grantUserResourceAuthorization 
-} from '@requestHelpers';
-import { cleanupUsers } from 'utils/usersCleanup';
+import {createUser, grantUserResourceAuthorization} from '@requestHelpers';
+import {cleanupUsers} from 'utils/usersCleanup';
 
 test.describe.parallel('Delete Single Process Instance API Tests', () => {
-    let processInstanceKeyToDelete: string = '';
-    let activeProcessInstanceKeyToDelete: string = '';
-    let userWithResourcesAuthorizationToSendRequest: {
-      username: string;
-      name: string;
-      email: string;
-      password: string;
-    } = {} as {
-      username: string;
-      name: string;
-      email: string;
-      password: string;
-    };
+  let processInstanceKeyToDelete: string = '';
+  let activeProcessInstanceKeyToDelete: string = '';
+  let userWithResourcesAuthorizationToSendRequest: {
+    username: string;
+    name: string;
+    email: string;
+    password: string;
+  } = {} as {
+    username: string;
+    name: string;
+    email: string;
+    password: string;
+  };
 
-    test.beforeAll(async ({request}) => {
-        await test.step('Setup - Deploy process and create instance to delete', async () => {
-            await deploy([
-                './resources/calledProcess.bpmn',
-                './resources/IncidentProcess.bpmn'
-            ]);
-            const createdInstance = await createSingleInstance('CalledProcess', 1);
-            processInstanceKeyToDelete = createdInstance.processInstanceKey;
+  test.beforeAll(async ({request}) => {
+    await test.step('Setup - Deploy process and create instance to delete', async () => {
+      await deploy([
+        './resources/calledProcess.bpmn',
+        './resources/IncidentProcess.bpmn',
+      ]);
+      const createdInstance = await createSingleInstance('CalledProcess', 1);
+      processInstanceKeyToDelete = createdInstance.processInstanceKey;
 
-            const createdIncidentInstance = await createSingleInstance('IncidentProcess', 1);
-            activeProcessInstanceKeyToDelete = createdIncidentInstance.processInstanceKey;
-        });
-
-        await test.step('Setup - Create test user with Resource Authorization and user for granting Authorization', async () => {
-            userWithResourcesAuthorizationToSendRequest = await createUser(request);
-            await grantUserResourceAuthorization(
-                request,
-                userWithResourcesAuthorizationToSendRequest,
-            );
-        });
+      const createdIncidentInstance = await createSingleInstance(
+        'IncidentProcess',
+        1,
+      );
+      activeProcessInstanceKeyToDelete =
+        createdIncidentInstance.processInstanceKey;
     });
 
-    test.afterAll(async ({request}) => {
-        await test.step('Cleanup - Delete test users', async () => {
-            await cleanupUsers(request, [
-                userWithResourcesAuthorizationToSendRequest.username,
-            ]);
-        });
+    await test.step('Setup - Create test user with Resource Authorization and user for granting Authorization', async () => {
+      userWithResourcesAuthorizationToSendRequest = await createUser(request);
+      await grantUserResourceAuthorization(
+        request,
+        userWithResourcesAuthorizationToSendRequest,
+      );
+    });
+  });
 
-        await test.step('Cleanup - Cancel created process instances', async () => {
-            await cancelProcessInstance(activeProcessInstanceKeyToDelete);
-        });
+  test.afterAll(async ({request}) => {
+    await test.step('Cleanup - Delete test users', async () => {
+      await cleanupUsers(request, [
+        userWithResourcesAuthorizationToSendRequest.username,
+      ]);
     });
 
-    test('Delete Single Process Instance - Success', async ({request}) => {
-        await test.step('Verify process instance is listed and complete', async () => {
-            await expect(async () => {
-                const response = await request.get(buildUrl(`/process-instances/${processInstanceKeyToDelete}`), {
-                    headers: jsonHeaders(),
-                });
-                await assertStatusCode(response, 200);
-                await validateResponse({
-                    path: '/process-instances/{processInstanceKey}',
-                    method: 'GET',
-                    status: '200'
-                }, response);
-                const responseBody = await response.json();
-                expect(responseBody.state).toBe('COMPLETED');
-            }).toPass(defaultAssertionOptions);
-        });
+    await test.step('Cleanup - Cancel created process instances', async () => {
+      await cancelProcessInstance(activeProcessInstanceKeyToDelete);
+    });
+  });
 
-        await test.step('Delete the process instance', async () => {
-            const response = await request.post(buildUrl(`/process-instances/${processInstanceKeyToDelete}/deletion`), {
-                headers: jsonHeaders(),
-            });
-            await assertStatusCode(response, 204);
-        });
-
-        await test.step('Verify process instance is deleted', async () => {
-            await expect(async () => {
-                const response = await request.get(buildUrl(`/process-instances/${processInstanceKeyToDelete}`), {
-                    headers: jsonHeaders(),
-                });
-                await assertNotFoundRequest(response, `Process Instance with key '${processInstanceKeyToDelete}' not found`);
-            }).toPass(defaultAssertionOptions);
-        });
+  test('Delete Single Process Instance - Success', async ({request}) => {
+    await test.step('Verify process instance is listed and complete', async () => {
+      await expect(async () => {
+        const response = await request.get(
+          buildUrl(`/process-instances/${processInstanceKeyToDelete}`),
+          {
+            headers: jsonHeaders(),
+          },
+        );
+        await assertStatusCode(response, 200);
+        await validateResponse(
+          {
+            path: '/process-instances/{processInstanceKey}',
+            method: 'GET',
+            status: '200',
+          },
+          response,
+        );
+        const responseBody = await response.json();
+        expect(responseBody.state).toBe('COMPLETED');
+      }).toPass(defaultAssertionOptions);
     });
 
-    test('Delete Single Process Instance - Unauthorized', async ({request}) => {
-        const someInstanceKey = '999999999999999';
-        const response = await request.post(buildUrl(`/process-instances/${someInstanceKey}/deletion`), {
-            headers: {},
-        });
-        await assertUnauthorizedRequest(response);
+    await test.step('Delete the process instance', async () => {
+      const response = await request.post(
+        buildUrl(`/process-instances/${processInstanceKeyToDelete}/deletion`),
+        {
+          headers: jsonHeaders(),
+        },
+      );
+      await assertStatusCode(response, 204);
     });
 
-    test('Delete Single Process Instance - Forbidden', async ({request}) => {
-        const someInstanceKey = '999999999999999';
-        const token = encode(`${userWithResourcesAuthorizationToSendRequest.username}:${userWithResourcesAuthorizationToSendRequest.password}`);
-        const response = await request.post(buildUrl(`/process-instances/${processInstanceKeyToDelete}/deletion`), {
-            headers: jsonHeaders(token),
-        });
-        await assertForbiddenRequest(response, 'Insufficient permissions to perform operation \'DELETE_PROCESS_INSTANCE\'');
+    await test.step('Verify process instance is deleted', async () => {
+      await expect(async () => {
+        const response = await request.get(
+          buildUrl(`/process-instances/${processInstanceKeyToDelete}`),
+          {
+            headers: jsonHeaders(),
+          },
+        );
+        await assertNotFoundRequest(
+          response,
+          `Process Instance with key '${processInstanceKeyToDelete}' not found`,
+        );
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+
+  test('Delete Single Process Instance - Unauthorized', async ({request}) => {
+    const someInstanceKey = '999999999999999';
+    const response = await request.post(
+      buildUrl(`/process-instances/${someInstanceKey}/deletion`),
+      {
+        headers: {},
+      },
+    );
+    await assertUnauthorizedRequest(response);
+  });
+
+  test('Delete Single Process Instance - Forbidden', async ({request}) => {
+    const someInstanceKey = '999999999999999';
+    const token = encode(
+      `${userWithResourcesAuthorizationToSendRequest.username}:${userWithResourcesAuthorizationToSendRequest.password}`,
+    );
+    const response = await request.post(
+      buildUrl(`/process-instances/${processInstanceKeyToDelete}/deletion`),
+      {
+        headers: jsonHeaders(token),
+      },
+    );
+    await assertForbiddenRequest(
+      response,
+      "Insufficient permissions to perform operation 'DELETE_PROCESS_INSTANCE'",
+    );
+  });
+
+  test('Delete Single Process Instance - Not Found', async ({request}) => {
+    const someNotExistingInstanceKey = '999999999999999';
+
+    await test.step('Delete the process instance', async () => {
+      const response = await request.post(
+        buildUrl(`/process-instances/${someNotExistingInstanceKey}/deletion`),
+        {
+          headers: jsonHeaders(),
+        },
+      );
+      await assertNotFoundRequest(
+        response,
+        `Process Instance with key '${someNotExistingInstanceKey}' not found`,
+      );
+    });
+  });
+
+  test('Delete Single Process Instance - Conflict', async ({request}) => {
+    await test.step('Verify process instance is listed and active', async () => {
+      await expect(async () => {
+        const response = await request.get(
+          buildUrl(`/process-instances/${activeProcessInstanceKeyToDelete}`),
+          {
+            headers: jsonHeaders(),
+          },
+        );
+        await assertStatusCode(response, 200);
+        await validateResponse(
+          {
+            path: '/process-instances/{processInstanceKey}',
+            method: 'GET',
+            status: '200',
+          },
+          response,
+        );
+        const responseBody = await response.json();
+        expect(responseBody.state).toBe('ACTIVE');
+      }).toPass(defaultAssertionOptions);
     });
 
-    test('Delete Single Process Instance - Not Found', async ({request}) => {
-        const someNotExistingInstanceKey = '999999999999999';
-        await test.step('Delete the process instance', async () => {
-            const response = await request.post(buildUrl(`/process-instances/${someNotExistingInstanceKey}/deletion`), {
-                headers: jsonHeaders(),
-            });
-            await assertNotFoundRequest(response, `Process Instance with key '${someNotExistingInstanceKey}' not found`);
-        });
+    await test.step('Try to delete active process instance', async () => {
+      const response = await request.post(
+        buildUrl(
+          `/process-instances/${activeProcessInstanceKeyToDelete}/deletion`,
+        ),
+        {
+          headers: jsonHeaders(),
+        },
+      );
+      await assertInvalidState(response, 409);
     });
-
-    test('Delete Single Process Instance - Conflict', async ({request}) => {
-        await test.step('Verify process instance is listed and active', async () => {
-            await expect(async () => {
-                const response = await request.get(buildUrl(`/process-instances/${activeProcessInstanceKeyToDelete}`), {
-                    headers: jsonHeaders(),
-                });
-                await assertStatusCode(response, 200);
-                await validateResponse({
-                    path: '/process-instances/{processInstanceKey}',
-                    method: 'GET',
-                    status: '200'
-                }, response);
-                const responseBody = await response.json();
-                expect(responseBody.state).toBe('ACTIVE');
-            }).toPass(defaultAssertionOptions);
-        });
-
-        await test.step('Try to delete active process instance', async () => {
-            const response = await request.post(buildUrl(`/process-instances/${activeProcessInstanceKeyToDelete}/deletion`), {
-                headers: jsonHeaders(),
-            });
-            await assertInvalidState(response, 409);
-        });
-    });
+  });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-delete-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-delete-api.spec.ts
@@ -1,0 +1,166 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect, request, test} from '@playwright/test';
+import {cancelProcessInstance, createSingleInstance, deploy} from '../../../../utils/zeebeClient';
+import {
+  assertBadRequest,
+  assertConflictRequest,
+  assertForbiddenRequest,
+  assertInvalidArgument,
+  assertInvalidState,
+  assertNotFoundRequest,
+  assertStatusCode,
+  assertUnauthorizedRequest,
+  buildUrl,
+  encode,
+  jsonHeaders,
+} from '../../../../utils/http';
+import {defaultAssertionOptions} from '../../../../utils/constants';
+import {validateResponse} from '../../../../json-body-assertions';
+import { 
+    createUser,
+    grantUserResourceAuthorization 
+} from '@requestHelpers';
+import { cleanupUsers } from 'utils/usersCleanup';
+
+test.describe.parallel('Delete Single Process instance API Tests', () => {
+    let processInstanceKeyToDelete: string = '';
+    let activeProcessInstanceKeyToDelete: string = '';
+    let userWithResourcesAuthorizationToSendRequest: {
+      username: string;
+      name: string;
+      email: string;
+      password: string;
+    } = {} as {
+      username: string;
+      name: string;
+      email: string;
+      password: string;
+    };
+
+    test.beforeAll(async ({request}) => {
+        await test.step('Setup - Deploy process and create instance to delete', async () => {
+            await deploy([
+                './resources/calledProcess.bpmn',
+                './resources/IncidentProcess.bpmn'
+            ]);
+            const createdInstance = await createSingleInstance('CalledProcess', 1);
+            processInstanceKeyToDelete = createdInstance.processInstanceKey;
+
+            const createdIncidentInstance = await createSingleInstance('IncidentProcess', 1);
+            activeProcessInstanceKeyToDelete = createdIncidentInstance.processInstanceKey;
+        });
+
+        await test.step('Setup - Create test user with Resource Authorization and user for granting Authorization', async () => {
+            userWithResourcesAuthorizationToSendRequest = await createUser(request);
+            await grantUserResourceAuthorization(
+                request,
+                userWithResourcesAuthorizationToSendRequest,
+            );
+        });
+    });
+
+    test.afterAll(async ({request}) => {
+        await test.step('Cleanup - Delete test users', async () => {
+            await cleanupUsers(request, [
+                userWithResourcesAuthorizationToSendRequest.username,
+            ]);
+        });
+
+        await test.step('Cleanup - Cancel created process instances', async () => {
+            await cancelProcessInstance(activeProcessInstanceKeyToDelete);
+        });
+    });
+
+    test('Delete Single Process Instance - Success', async ({request}) => {
+        await test.step('Verify process instance is listed and complete', async () => {
+            await expect(async () => {
+                const response = await request.get(buildUrl(`/process-instances/${processInstanceKeyToDelete}`), {
+                    headers: jsonHeaders(),
+                });
+                await assertStatusCode(response, 200);
+                await validateResponse({
+                    path: '/process-instances/{processInstanceKey}',
+                    method: 'GET',
+                    status: '200'
+                }, response);
+                const responseBody = await response.json();
+                expect(responseBody.state).toBe('COMPLETED');
+            }).toPass(defaultAssertionOptions);
+        });
+
+        await test.step('Delete the process instance', async () => {
+            const response = await request.post(buildUrl(`/process-instances/${processInstanceKeyToDelete}/deletion`), {
+                headers: jsonHeaders(),
+            });
+            await assertStatusCode(response, 204);
+        });
+
+        await test.step('Verify process instance is deleted', async () => {
+            await expect(async () => {
+                const response = await request.get(buildUrl(`/process-instances/${processInstanceKeyToDelete}`), {
+                    headers: jsonHeaders(),
+                });
+                await assertNotFoundRequest(response, `Process Instance with key '${processInstanceKeyToDelete}' not found`);
+            }).toPass(defaultAssertionOptions);
+        });
+    });
+
+    test('Delete Single Process Instance - Unauthorized', async ({request}) => {
+        const someInstanceKey = '999999999999999';
+        const response = await request.post(buildUrl(`/process-instances/${someInstanceKey}/deletion`), {
+            headers: {},
+        });
+        await assertUnauthorizedRequest(response);
+    });
+
+    test('Delete Single Process Instance - Forbidden', async ({request}) => {
+        const someInstanceKey = '999999999999999';
+        const token = encode(`${userWithResourcesAuthorizationToSendRequest.username}:${userWithResourcesAuthorizationToSendRequest.password}`);
+        const response = await request.post(buildUrl(`/process-instances/${processInstanceKeyToDelete}/deletion`), {
+            headers: jsonHeaders(token),
+        });
+        await assertForbiddenRequest(response, 'Insufficient permissions to perform operation \'DELETE_PROCESS_INSTANCE\'');
+    });
+
+    test('Delete Single Process Instance - Not Found', async ({request}) => {
+        const someNotExistingInstanceKey = '999999999999999';
+        await test.step('Delete the process instance', async () => {
+            const response = await request.post(buildUrl(`/process-instances/${someNotExistingInstanceKey}/deletion`), {
+                headers: jsonHeaders(),
+            });
+            await assertNotFoundRequest(response, `Process Instance with key '${someNotExistingInstanceKey}' not found`);
+        });
+    });
+
+    test('Delete Single Process Instance - Conflict', async ({request}) => {
+        await test.step('Verify process instance is listed and active', async () => {
+            await expect(async () => {
+                const response = await request.get(buildUrl(`/process-instances/${activeProcessInstanceKeyToDelete}`), {
+                    headers: jsonHeaders(),
+                });
+                await assertStatusCode(response, 200);
+                await validateResponse({
+                    path: '/process-instances/{processInstanceKey}',
+                    method: 'GET',
+                    status: '200'
+                }, response);
+                const responseBody = await response.json();
+                expect(responseBody.state).toBe('ACTIVE');
+            }).toPass(defaultAssertionOptions);
+        });
+
+        await test.step('Try to delete active process instance', async () => {
+            const response = await request.post(buildUrl(`/process-instances/${activeProcessInstanceKeyToDelete}/deletion`), {
+                headers: jsonHeaders(),
+            });
+            await assertInvalidState(response, 409);
+        });
+    });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-delete-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-delete-api.spec.ts
@@ -24,7 +24,7 @@ import {
 } from '../../../../utils/http';
 import {defaultAssertionOptions} from '../../../../utils/constants';
 import {validateResponse} from '../../../../json-body-assertions';
-import {createUser, grantUserResourceAuthorization} from '@requestHelpers';
+import {createUser, expectProcessInstanceCanBeFound, grantUserResourceAuthorization} from '@requestHelpers';
 import {cleanupUsers} from 'utils/usersCleanup';
 
 test.describe.parallel('Delete Single Process Instance API Tests', () => {
@@ -57,6 +57,12 @@ test.describe.parallel('Delete Single Process Instance API Tests', () => {
       );
       activeProcessInstanceKeyToDelete =
         createdIncidentInstance.processInstanceKey;
+
+      await expectProcessInstanceCanBeFound(request, processInstanceKeyToDelete);
+      await expectProcessInstanceCanBeFound(
+        request,
+        activeProcessInstanceKeyToDelete,
+      );
     });
 
     await test.step('Setup - Create test user with Resource Authorization and user for granting Authorization', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-delete-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-delete-api.spec.ts
@@ -141,7 +141,7 @@ test.describe.parallel('Delete Single Process Instance API Tests', () => {
   });
 
   test('Delete Single Process Instance - Forbidden', async ({request}) => {
-    const someInstanceKey = '999999999999999';
+    const someInstanceKey = activeProcessInstanceKeyToDelete;
     const token = encode(
       `${userWithResourcesAuthorizationToSendRequest.username}:${userWithResourcesAuthorizationToSendRequest.password}`,
     );

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-delete-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-delete-api.spec.ts
@@ -146,9 +146,9 @@ test.describe.parallel('Delete Single Process Instance API Tests', () => {
       `${userWithResourcesAuthorizationToSendRequest.username}:${userWithResourcesAuthorizationToSendRequest.password}`,
     );
     const response = await request.post(
-      buildUrl(`/process-instances/${processInstanceKeyToDelete}/deletion`),
+      buildUrl(`/process-instances/${someInstanceKey}/deletion`),
       {
-        headers: jsonHeaders(token),
+        headers: jsonHeaders(token), // overrides default demo:demo
       },
     );
     await assertForbiddenRequest(


### PR DESCRIPTION
## Description

This PR introduces test files for Delete process instance [API](https://docs.camunda.io/docs/next/apis-tools/orchestration-cluster-api-rest/specifications/delete-process-instance/) and Delete process instances (batch) [API](https://docs.camunda.io/docs/next/apis-tools/orchestration-cluster-api-rest/specifications/delete-process-instances-batch-operation/). 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

related to [this issue](https://github.com/camunda/team-test-automation/issues/62)

## On demand workflow
[Was green on APIs](https://github.com/camunda/camunda/actions/runs/24231883975)