### PR TITLE
feat: add infinite scrolling to task variables

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/usertask_with_many_variables.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/usertask_with_many_variables.bpmn
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_many_vars" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.30.0">
+  <bpmn:process id="usertask_with_many_variables" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Start">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="UserTask_1" />
+    <bpmn:userTask id="UserTask_1" name="Task with many variables">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="UserTask_1" targetRef="EndEvent_1" />
+    <bpmn:endEvent id="EndEvent_1" name="End">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="usertask_with_many_variables">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="156" y="103" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="UserTask_1_di" bpmnElement="UserTask_1">
+        <dc:Bounds x="280" y="81" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="472" y="103" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+        <di:waypoint x="192" y="121" />
+        <di:waypoint x="280" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_2_di" bpmnElement="Flow_2">
+        <di:waypoint x="380" y="121" />
+        <di:waypoint x="472" y="121" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/variables.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/variables.spec.ts
@@ -12,11 +12,16 @@ import {deploy, createInstances} from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {navigateToApp} from '@pages/UtilitiesPage';
 
+const MANY_VARIABLES = Object.fromEntries(
+  Array.from({length: 60}, (_, i) => [`variable_${i}`, `value_${i}`]),
+);
+
 test.beforeAll(async () => {
   await deploy([
     './resources/usertask_with_variables.bpmn',
     './resources/usertask_with_variables2.bpmn',
     './resources/usertask_without_variables.bpmn',
+    './resources/usertask_with_many_variables.bpmn',
   ]);
   await createInstances('usertask_without_variables', 1, 1);
   await createInstances('usertask_with_variables', 1, 3, {
@@ -25,6 +30,7 @@ test.beforeAll(async () => {
   await createInstances('usertask_with_variables2', 1, 1, {
     testData: 'something',
   });
+  await createInstances('usertask_with_many_variables', 1, 1, MANY_VARIABLES);
 });
 
 test.describe('variables page', () => {
@@ -165,6 +171,35 @@ test.describe('variables page', () => {
     await expect(
       taskDetailsPage.variablesTable.getByText('newVariableValue'),
     ).toBeHidden();
+  });
+
+  test('loads all variables via infinite scroll pagination', async ({
+    page,
+    taskPanelPage,
+    taskDetailsPage,
+  }) => {
+    await taskPanelPage.filterBy('Unassigned');
+    await expect(async () => {
+      await expect(
+        taskPanelPage.availableTasks.getByText('usertask_with_many_variables'),
+      ).toBeVisible();
+    }).toPass();
+    await taskPanelPage.openTask('usertask_with_many_variables');
+
+    await expect(
+      taskDetailsPage.variablesTable.getByRole('cell', {name: 'variable_0'}),
+    ).toBeVisible();
+
+    const scrollContainer = page.getByTestId('variables-scroll-container');
+    await scrollContainer.evaluate((el) => {
+      el.scrollTop = el.scrollHeight;
+    });
+
+    await expect(async () => {
+      await expect(
+        taskDetailsPage.variablesTable.getByRole('cell', {name: 'variable_59'}),
+      ).toBeVisible();
+    }).toPass();
   });
 
   test('new variable still exists after refresh if task is completed', async ({

--- a/tasklist/client/package-lock.json
+++ b/tasklist/client/package-lock.json
@@ -17,6 +17,7 @@
         "@monaco-editor/react": "4.7.0",
         "@tanstack/eslint-plugin-query": "5.91.4",
         "@tanstack/react-query": "5.90.21",
+        "@tanstack/react-virtual": "3.13.23",
         "@uidotdev/usehooks": "2.4.1",
         "bpmn-js": "18.14.0",
         "classnames": "2.5.1",
@@ -162,6 +163,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -553,6 +555,7 @@
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -733,6 +736,7 @@
       "integrity": "sha512-dco6pSrani/isbuyDSdCHjhkzModxFuQRovdVJ67caCiuI3T30hEmAaspdJI6LQxCrAk8goFeHLlqAMdfRQKyA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.27.3",
         "@carbon/feature-flags": "^1.2.0",
@@ -988,6 +992,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1036,6 +1041,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1365,6 +1371,7 @@
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
       "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -1814,6 +1821,7 @@
       "resolved": "https://registry.npmjs.org/@mixpanel/rrweb/-/rrweb-2.0.0-alpha.18.4.tgz",
       "integrity": "sha512-ICpEYDFEEiCoUuQg+de3VvQCsolF4lNHfEM9DBp5Pwuc7EgXqwWV4wUpiRF/NbhoKk+82X1Qe+oqqlKJb/CGFw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@mixpanel/rrdom": "^2.0.0-alpha.18",
         "@mixpanel/rrweb-snapshot": "^2.0.0-alpha.18",
@@ -1854,7 +1862,8 @@
       "version": "2.0.0-alpha.18.4",
       "resolved": "https://registry.npmjs.org/@mixpanel/rrweb-utils/-/rrweb-utils-2.0.0-alpha.18.4.tgz",
       "integrity": "sha512-c3nUbQl19kxHjf8nowFMeXlJw0ZqLesIVBb9t4g1nC4WtaNEPkFotWRdGt5V2cJNQ+aY38/v2uYb8Ren4IcdSQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@monaco-editor/loader": {
       "version": "1.5.0",
@@ -2427,9 +2436,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2447,9 +2453,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2467,9 +2470,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2487,9 +2487,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2507,9 +2504,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2527,9 +2521,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2958,6 +2949,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/eslint-plugin-query/-/eslint-plugin-query-5.91.4.tgz",
       "integrity": "sha512-8a+GAeR7oxJ5laNyYBQ6miPK09Hi18o5Oie/jx8zioXODv/AUFLZQecKabPdpQSLmuDXEBPKFh+W5DKbWlahjQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/utils": "^8.48.0"
       },
@@ -3001,6 +2993,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.21.tgz",
       "integrity": "sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.90.20"
       },
@@ -3030,11 +3023,39 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.23",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.23.tgz",
+      "integrity": "sha512-XnMRnHQ23piOVj2bzJqHrRrLg4r+F86fuBcwteKfbIjJrtGxb4z7tIvPVAe4B+4UVwo9G4Giuz5fmapcrnZ0OQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.23"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.23",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.23.tgz",
+      "integrity": "sha512-zSz2Z2HNyLjCplANTDyl3BcdQJc2k1+yyFoKhNRmCr7V7dY8o8q5m8uFTI1/Pg1kL+Hgrz6u3Xo6eFUB7l66cg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3240,6 +3261,7 @@
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -3269,6 +3291,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3279,6 +3302,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3325,6 +3349,7 @@
       "integrity": "sha512-eSkwoemjo76bdXl2MYqtxg51HNwUSkWfODUOQ3PaTLZGh9uIWWFZIjyjaJnex7wXDu+TRx+ATsnSxdN9YWfRTQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.58.1",
@@ -3354,6 +3379,7 @@
       "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.1",
         "@typescript-eslint/types": "8.58.1",
@@ -3620,6 +3646,7 @@
       "integrity": "sha512-PXZ5ysw4eHU9h8nDtBvVcGC7Z2C/T9CFdheqSw1NNXFYqViojub0V9bgdYI67iBTOcra2mwD0EYldlY9bGPf2Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "^8.58.0",
         "@typescript-eslint/utils": "^8.58.0"
@@ -3759,6 +3786,7 @@
       "integrity": "sha512-xBPy+43o1fgMLUDlufUXh7tlT/Es8uS5eiyBY2PyPfFYSGpApZskLw65DROoDz+rgYkPuAmb20Mv9Z9g1WQE7w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.1.3",
         "fflate": "^0.8.2",
@@ -3801,6 +3829,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3833,6 +3862,7 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -4152,6 +4182,7 @@
       "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-18.14.0.tgz",
       "integrity": "sha512-z4CjyvK2wtP+IIunQJpZK1g5Xkfa089rueB2MCY2+NeZFz2RaHn17qJcXOvOhXvLHbUo+ldiXnkFuiGqslxIbQ==",
       "license": "SEE LICENSE IN LICENSE",
+      "peer": true,
       "dependencies": {
         "bpmn-moddle": "^10.0.0",
         "diagram-js": "^15.11.0",
@@ -4232,6 +4263,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4716,6 +4748,7 @@
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mdn-data": "2.27.1",
         "source-map-js": "^1.2.1"
@@ -4958,6 +4991,7 @@
       "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.11.0.tgz",
       "integrity": "sha512-BpKCKlyTZ4x4aOwAOBMns2jYiaajEUXqy9IzNQk2WyIaI3hECI8rCTBSxg9A9l8Kq7C4mCUvovULSRZ7G8vpyA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bpmn-io/diagram-js-ui": "^0.2.3",
         "clsx": "^2.1.1",
@@ -5410,6 +5444,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5470,6 +5505,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -5536,6 +5572,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5640,6 +5677,7 @@
       "integrity": "sha512-Qd7cCljVC0h+uJjcIuYjpRFrdzwqBBDCi5U0ocr6Bt/5t3zuBkZSa1Igc4lBLEVBDoUUqIcok/UUNAAu6CtwmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "requireindex": "^1.2.0"
       },
@@ -5653,6 +5691,7 @@
       "integrity": "sha512-hscXkbqUZ2sPithAuLm5MXL+Wph+U7wHngPBv9OMWwlP8iaflyxpjTYZkmdgB4/vPIhemRlBEoLrH7UC1n7aUw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prettier-linter-helpers": "^1.0.1",
         "synckit": "^0.11.12"
@@ -5684,6 +5723,7 @@
       "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5697,6 +5737,7 @@
       "integrity": "sha512-hmgTH57GfzoTFjVN0yBwTggnsVUF2tcqi7RJZHqi9lIezSs4eFyAMktA68YD4r5kNw1mxyY4dmkyoFDb3FIqrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "eslint": "^9 || ^10"
       }
@@ -5707,6 +5748,7 @@
       "integrity": "sha512-8gleGnQXK2ZA3hHwjCwpYTZvM+9VsrJ+/9kDI8CjqAQGAdMQOdn/rJNu7ZySENuiWlGKQWyZJ4ZjEg2zamaRHw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "^8.56.0",
         "@typescript-eslint/utils": "^8.56.0"
@@ -5903,7 +5945,8 @@
       "version": "1.0.31",
       "resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-1.0.31.tgz",
       "integrity": "sha512-4IJSItgS/41IxN5UVAVuAyczwZF7ZIEsM1XAoUzIHA6A+xzusEZUutdXz2Nr+MQPLxfTiCvqE79/C8HT8fKFvA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
@@ -6121,6 +6164,7 @@
       "resolved": "https://registry.npmjs.org/final-form/-/final-form-5.0.0.tgz",
       "integrity": "sha512-HByosvP7x3N4bWTCPoBeUeoMatadewRifxaH3qhCQI2DBwFNO0m5wxETLVUXNGWz2yokdSCMdJEvtjfZoXnqDA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.10.0"
       },
@@ -6137,6 +6181,7 @@
       "resolved": "https://registry.npmjs.org/final-form-arrays/-/final-form-arrays-4.0.0.tgz",
       "integrity": "sha512-ya1mbjTmEcmZ8ettYHp/eB4UpfuSjpLJ+grpaQsgxqi1P0wrm+syr/7qLbbslxNLSDA1zoSUthWVCB1O6B9fqg==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "final-form": "^5.0.0"
       }
@@ -6854,6 +6899,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.29.2"
       },
@@ -7702,6 +7748,7 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -9102,6 +9149,7 @@
       "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.15.0.tgz",
       "integrity": "sha512-UczzB+0nnwGotYSgllfARAqWCJ5e/skuV2K/l+Zyck/H6pJIhLXuBnz+6vn2i211o7DtbE78HQtsYEKICHGI+g==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mobx"
@@ -9136,6 +9184,7 @@
       "resolved": "https://registry.npmjs.org/moddle/-/moddle-8.0.0.tgz",
       "integrity": "sha512-ZjE3D0EtU3Qp6ZpxBckGFydIQi++feYvhvxhjNYKGzlC8+2lpcO0lS86WC/B+s2lbAqjrlOMYCQqu6mHAtz2cg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "min-dash": "^5.0.0"
       }
@@ -9161,6 +9210,7 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
       "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"
@@ -9823,6 +9873,7 @@
       "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -9859,6 +9910,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9988,6 +10040,7 @@
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -10027,6 +10080,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -10175,6 +10229,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10184,6 +10239,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10211,6 +10267,7 @@
       "resolved": "https://registry.npmjs.org/react-final-form/-/react-final-form-7.0.0.tgz",
       "integrity": "sha512-aEeAWbSsCLVXa4GBkJtjjyhPyX4L/Pgp5P/jXZwdz0YYcK6Zs/0PkgB+qWMSyIsbbGGE7m9yYlSpui5E5Gx26A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.15.4"
       },
@@ -10718,6 +10775,7 @@
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.98.0.tgz",
       "integrity": "sha512-+4N/u9dZ4PrgzGgPlKnaaRQx64RO0JBKs9sDhQ2pLgN6JQZ25uPQZKQYaBJU48Kd5BxgXoJ4e09Dq7nMcOUW3A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.1.5",
@@ -11411,6 +11469,7 @@
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.3.12.tgz",
       "integrity": "sha512-hFR6xsVkVYbsdcUlzPYFvFfoc6o2KlV0VvgRIQwSYMtdThM7SCxnjX9efh/cWce2kTq16I/Kl3xM98xiLptsXA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emotion/is-prop-valid": "1.4.0",
         "@emotion/unitless": "0.10.0",
@@ -11585,6 +11644,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -11608,6 +11668,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -12238,6 +12299,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12524,6 +12586,7 @@
       "integrity": "sha512-P1PbweD+2/udplnThz3btF4cf6AgPky7kk23RtHUkJIU5BIxwPprhRGmOAHs6FTI7UiGbTNrgNP6jSYD6JaRnw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -12632,6 +12695,7 @@
       "integrity": "sha512-DBc4Tx0MPNsqb9isoyOq00lHftVx/KIU44QOm2q59npZyLUkENn8TMFsuzuO+4U2FUa9rgbbPt3udrP25GcjXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.3",
         "@vitest/mocker": "4.1.3",
@@ -13071,6 +13135,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/tasklist/client/package.json
+++ b/tasklist/client/package.json
@@ -13,6 +13,7 @@
     "@monaco-editor/react": "4.7.0",
     "@tanstack/eslint-plugin-query": "5.91.4",
     "@tanstack/react-query": "5.90.21",
+    "@tanstack/react-virtual": "3.13.23",
     "@uidotdev/usehooks": "2.4.1",
     "bpmn-js": "18.14.0",
     "classnames": "2.5.1",

--- a/tasklist/client/src/modules/api/useFetchFullVariable.mutation.ts
+++ b/tasklist/client/src/modules/api/useFetchFullVariable.mutation.ts
@@ -7,13 +7,22 @@
  */
 
 import {api} from 'modules/api';
-import {useMutation, useQueryClient} from '@tanstack/react-query';
+import {
+  useMutation,
+  useQueryClient,
+  type InfiniteData,
+} from '@tanstack/react-query';
 import {request} from 'modules/api/request';
 import type {
   Variable,
   QueryVariablesByUserTaskResponseBody,
 } from '@camunda/camunda-api-zod-schemas/8.10';
 import {getAllVariablesQueryKey} from './useQueryAllVariables.query';
+
+type VariablesInfiniteData = InfiniteData<
+  QueryVariablesByUserTaskResponseBody,
+  number
+>;
 
 function useFetchFullVariable() {
   const client = useQueryClient();
@@ -30,30 +39,27 @@ function useFetchFullVariable() {
         >;
         const variablesQueryKey = getAllVariablesQueryKey(userTaskKey);
         const allVariables =
-          client.getQueryData<QueryVariablesByUserTaskResponseBody>(
-            variablesQueryKey,
-          );
+          client.getQueryData<VariablesInfiniteData>(variablesQueryKey);
         const hasVariable =
-          allVariables?.items.some(
-            (variable) => variable.variableKey === variableKey,
+          allVariables?.pages.some((page) =>
+            page.items.some((variable) => variable.variableKey === variableKey),
           ) ?? false;
 
         if (hasVariable) {
-          client.setQueryData<QueryVariablesByUserTaskResponseBody>(
-            variablesQueryKey,
-            {
-              ...allVariables!,
-              items: allVariables!.items.map((oldVariable) =>
+          client.setQueryData<VariablesInfiniteData>(variablesQueryKey, {
+            ...allVariables!,
+            pages: allVariables!.pages.map((page) => ({
+              ...page,
+              items: page.items.map((oldVariable) =>
                 oldVariable.variableKey === variableKey
                   ? {
                       ...variable,
-                      value: variable.value,
                       isTruncated: false,
                     }
                   : oldVariable,
               ),
-            },
-          );
+            })),
+          });
         }
 
         return variable;

--- a/tasklist/client/src/modules/api/useQueryAllVariables.query.ts
+++ b/tasklist/client/src/modules/api/useQueryAllVariables.query.ts
@@ -74,10 +74,9 @@ function useQueryAllVariables(
         }
       : false,
     getNextPageParam: (lastPage, _, lastPageParam) => {
-      const {page} = lastPage;
       const nextPage = lastPageParam + MAX_VARIABLES_PER_REQUEST;
 
-      if (nextPage >= page.totalItems) {
+      if (nextPage >= (lastPage.page?.totalItems ?? 0)) {
         return null;
       }
 

--- a/tasklist/client/src/modules/api/useQueryAllVariables.query.ts
+++ b/tasklist/client/src/modules/api/useQueryAllVariables.query.ts
@@ -26,7 +26,7 @@ type Options = {
   enabled?: boolean;
   refetchOnWindowFocus?: boolean;
   refetchOnReconnect?: boolean;
-  pollingInterval?: number;
+  refetchInterval?: number;
 };
 
 function useQueryAllVariables(
@@ -34,7 +34,7 @@ function useQueryAllVariables(
   options: Options = {},
 ) {
   const {userTaskKey} = params;
-  const {pollingInterval, enabled, refetchOnWindowFocus, refetchOnReconnect} =
+  const {refetchInterval, enabled, refetchOnWindowFocus, refetchOnReconnect} =
     options;
 
   return useInfiniteQuery({
@@ -64,15 +64,7 @@ function useQueryAllVariables(
       totalItems: data.pages.at(-1)?.page.totalItems ?? 0,
     }),
     initialPageParam: 0,
-    refetchInterval: pollingInterval
-      ? (query) => {
-          const pages = query.state.data?.pages;
-          const loadedCount =
-            pages?.reduce((sum, p) => sum + p.items.length, 0) ?? 0;
-          const totalItems = pages?.at(-1)?.page.totalItems ?? 0;
-          return loadedCount < totalItems ? false : pollingInterval;
-        }
-      : false,
+    refetchInterval,
     getNextPageParam: (lastPage, _, lastPageParam) => {
       const nextPage = lastPageParam + MAX_VARIABLES_PER_REQUEST;
 

--- a/tasklist/client/src/modules/api/useQueryAllVariables.query.ts
+++ b/tasklist/client/src/modules/api/useQueryAllVariables.query.ts
@@ -6,13 +6,16 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {useQuery} from '@tanstack/react-query';
+import {useInfiniteQuery, type InfiniteData} from '@tanstack/react-query';
 import {api} from 'modules/api';
 import {request} from 'modules/api/request';
 import type {
   QueryVariablesByUserTaskResponseBody,
   UserTask,
+  Variable,
 } from '@camunda/camunda-api-zod-schemas/8.10';
+
+const MAX_VARIABLES_PER_REQUEST = 50;
 
 const getAllVariablesQueryKey = (userTaskKey: UserTask['userTaskKey']) => [
   'variables',
@@ -23,6 +26,7 @@ type Options = {
   enabled?: boolean;
   refetchOnWindowFocus?: boolean;
   refetchOnReconnect?: boolean;
+  pollingInterval?: number;
 };
 
 function useQueryAllVariables(
@@ -30,16 +34,21 @@ function useQueryAllVariables(
   options: Options = {},
 ) {
   const {userTaskKey} = params;
+  const {pollingInterval, enabled, refetchOnWindowFocus, refetchOnReconnect} =
+    options;
 
-  return useQuery({
-    ...options,
+  return useInfiniteQuery({
+    enabled,
+    refetchOnWindowFocus,
+    refetchOnReconnect,
     queryKey: getAllVariablesQueryKey(userTaskKey),
-    queryFn: async () => {
+    queryFn: async ({pageParam}) => {
       const {response, error} = await request(
         api.queryVariablesByUserTask({
           userTaskKey,
           page: {
-            limit: 1000,
+            from: pageParam,
+            limit: MAX_VARIABLES_PER_REQUEST,
           },
         }),
       );
@@ -50,7 +59,47 @@ function useQueryAllVariables(
 
       throw error;
     },
+    initialPageParam: 0,
+    refetchInterval: pollingInterval
+      ? (query) => {
+          const pages = query.state.data?.pages;
+          const loadedCount =
+            pages?.reduce((sum, p) => sum + p.items.length, 0) ?? 0;
+          const totalItems = pages?.at(-1)?.page.totalItems ?? 0;
+          return loadedCount < totalItems ? false : pollingInterval;
+        }
+      : false,
+    getNextPageParam: (lastPage, _, lastPageParam) => {
+      const {page} = lastPage;
+      const nextPage = lastPageParam + MAX_VARIABLES_PER_REQUEST;
+
+      if (nextPage >= page.totalItems) {
+        return null;
+      }
+
+      return nextPage;
+    },
+    getPreviousPageParam: (_, __, firstPageParam) => {
+      const previousPage = firstPageParam - MAX_VARIABLES_PER_REQUEST;
+
+      if (previousPage < 0) {
+        return null;
+      }
+
+      return previousPage;
+    },
   });
 }
 
-export {useQueryAllVariables, getAllVariablesQueryKey};
+const flattenVariablePages = (
+  data: InfiniteData<QueryVariablesByUserTaskResponseBody, unknown> | undefined,
+): Variable[] => {
+  return data?.pages?.flatMap((page) => page.items) ?? [];
+};
+
+export {
+  useQueryAllVariables,
+  getAllVariablesQueryKey,
+  flattenVariablePages,
+  MAX_VARIABLES_PER_REQUEST,
+};

--- a/tasklist/client/src/modules/api/useQueryAllVariables.query.ts
+++ b/tasklist/client/src/modules/api/useQueryAllVariables.query.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {useInfiniteQuery, type InfiniteData} from '@tanstack/react-query';
+import {useInfiniteQuery} from '@tanstack/react-query';
 import {api} from 'modules/api';
 import {request} from 'modules/api/request';
 import type {
@@ -59,6 +59,10 @@ function useQueryAllVariables(
 
       throw error;
     },
+    select: (data) => ({
+      items: data.pages.flatMap((page) => page.items) as Variable[],
+      totalItems: data.pages.at(-1)?.page.totalItems ?? 0,
+    }),
     initialPageParam: 0,
     refetchInterval: pollingInterval
       ? (query) => {
@@ -79,27 +83,11 @@ function useQueryAllVariables(
 
       return nextPage;
     },
-    getPreviousPageParam: (_, __, firstPageParam) => {
-      const previousPage = firstPageParam - MAX_VARIABLES_PER_REQUEST;
-
-      if (previousPage < 0) {
-        return null;
-      }
-
-      return previousPage;
-    },
   });
 }
-
-const flattenVariablePages = (
-  data: InfiniteData<QueryVariablesByUserTaskResponseBody, unknown> | undefined,
-): Variable[] => {
-  return data?.pages?.flatMap((page) => page.items) ?? [];
-};
 
 export {
   useQueryAllVariables,
   getAllVariablesQueryKey,
-  flattenVariablePages,
   MAX_VARIABLES_PER_REQUEST,
 };

--- a/tasklist/client/src/modules/tasks/variables-editor/VariableEditor/styles.module.scss
+++ b/tasklist/client/src/modules/tasks/variables-editor/VariableEditor/styles.module.scss
@@ -50,6 +50,10 @@
   overflow-y: auto;
 }
 
+.virtualSpacer {
+  height: var(--virtual-spacer-height, 0px);
+}
+
 .singleLineValue {
   white-space: nowrap;
   overflow: hidden;

--- a/tasklist/client/src/modules/tasks/variables-editor/VariableEditor/styles.module.scss
+++ b/tasklist/client/src/modules/tasks/variables-editor/VariableEditor/styles.module.scss
@@ -50,10 +50,6 @@
   overflow-y: auto;
 }
 
-.virtualSpacer {
-  height: var(--virtual-spacer-height, 0px);
-}
-
 .singleLineValue {
   white-space: nowrap;
   overflow: hidden;

--- a/tasklist/client/src/pages/TaskDetails/Variables/VariableEditor.tsx
+++ b/tasklist/client/src/pages/TaskDetails/Variables/VariableEditor.tsx
@@ -153,7 +153,7 @@ const VariableEditor: React.FC<Props> = ({
               }
 
               return (
-                <StructuredListRow key={variable.name}>
+                <StructuredListRow key={variable.variableKey}>
                   <StructuredListCell
                     className={cn(styles.listCell, styles.cellName)}
                   >

--- a/tasklist/client/src/pages/TaskDetails/Variables/VariableEditor.tsx
+++ b/tasklist/client/src/pages/TaskDetails/Variables/VariableEditor.tsx
@@ -128,17 +128,7 @@ const VariableEditor: React.FC<Props> = ({
       <StructuredListBody>
         {readOnly ? (
           <>
-            {paddingTop > 0 && (
-              <div
-                className={styles.virtualSpacer}
-                style={
-                  {
-                    '--virtual-spacer-height': `${paddingTop}px`,
-                  } as React.CSSProperties
-                }
-                aria-hidden
-              />
-            )}
+            {paddingTop > 0 && <div style={{height: paddingTop}} aria-hidden />}
             {virtualItems.map((virtualRow) => {
               const variable = variables[virtualRow.index];
 
@@ -203,15 +193,7 @@ const VariableEditor: React.FC<Props> = ({
               );
             })}
             {paddingBottom > 0 && (
-              <div
-                className={styles.virtualSpacer}
-                style={
-                  {
-                    '--virtual-spacer-height': `${paddingBottom}px`,
-                  } as React.CSSProperties
-                }
-                aria-hidden
-              />
+              <div style={{height: paddingBottom}} aria-hidden />
             )}
           </>
         ) : (

--- a/tasklist/client/src/pages/TaskDetails/Variables/VariableEditor.tsx
+++ b/tasklist/client/src/pages/TaskDetails/Variables/VariableEditor.tsx
@@ -6,9 +6,10 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import type {RefObject} from 'react';
+import {type RefObject, useEffect} from 'react';
 import {
   IconButton,
+  SkeletonText,
   StructuredListBody,
   StructuredListCell,
   StructuredListHead,
@@ -16,6 +17,7 @@ import {
   StructuredListWrapper,
   TextInput,
 } from '@carbon/react';
+import {useVirtualizer} from '@tanstack/react-virtual';
 import {Maximize, Close} from '@carbon/react/icons';
 import type {Variable} from '@camunda/camunda-api-zod-schemas/8.10';
 import {Field, useFormState} from 'react-final-form';
@@ -40,25 +42,75 @@ import styles from 'modules/tasks/variables-editor/VariableEditor/styles.module.
 import cn from 'classnames';
 import {useTranslation} from 'react-i18next';
 
+const ESTIMATED_ROW_HEIGHT = 48;
+const OVERSCAN = 5;
+
 type Props = {
   containerRef: RefObject<HTMLElement | null>;
   variables: Variable[];
+  totalVariables: number;
   readOnly: boolean;
   fetchFullVariable: (variableKey: string) => void;
   variablesLoadingFullValue: string[];
   onEdit: (id: string) => void;
+  fetchNextPage: () => void;
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  scrollContainerRef: RefObject<HTMLElement | null>;
 };
 
 const VariableEditor: React.FC<Props> = ({
   containerRef,
   variables,
+  totalVariables,
   readOnly,
   fetchFullVariable,
   variablesLoadingFullValue,
   onEdit,
+  fetchNextPage,
+  hasNextPage,
+  isFetchingNextPage,
+  scrollContainerRef,
 }) => {
   const {dirtyFields} = useFormState<FormValues>();
   const {t} = useTranslation();
+
+  const virtualizer = useVirtualizer({
+    count: totalVariables,
+    getScrollElement: () => scrollContainerRef.current,
+    estimateSize: () => ESTIMATED_ROW_HEIGHT,
+    overscan: OVERSCAN,
+    enabled: readOnly,
+  });
+
+  const virtualItems = virtualizer.getVirtualItems();
+
+  useEffect(() => {
+    if (!readOnly) {
+      return;
+    }
+
+    const lastItem = virtualItems.at(-1);
+    if (
+      lastItem &&
+      lastItem.index >= variables.length - 1 &&
+      hasNextPage &&
+      !isFetchingNextPage
+    ) {
+      fetchNextPage();
+    }
+  }, [
+    virtualItems,
+    variables.length,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+    readOnly,
+  ]);
+
+  const paddingTop = virtualItems[0]?.start ?? 0;
+  const paddingBottom =
+    virtualizer.getTotalSize() - (virtualItems.at(-1)?.end ?? 0);
 
   return (
     <StructuredListWrapper className={styles.list} isCondensed>
@@ -75,43 +127,93 @@ const VariableEditor: React.FC<Props> = ({
       </StructuredListHead>
       <StructuredListBody>
         {readOnly ? (
-          variables.map((variable) => (
-            <StructuredListRow key={variable.name}>
-              <StructuredListCell
-                className={cn(styles.listCell, styles.cellName)}
-              >
-                {variable.name}
-              </StructuredListCell>
-              <StructuredListCell
-                className={cn(styles.listCell, styles.valueCell)}
-              >
-                <div className={styles.singleLineValue}>
-                  {variable.isTruncated ? variable.value : variable.value}
-                </div>
-              </StructuredListCell>
-              <StructuredListCell
-                className={cn(styles.listCell, styles.controlsCell)}
-              >
-                <div className={cn(styles.iconButtons, styles.extraPadding)}>
-                  <IconButton
-                    label={t('variableEditorOpenJsonLabel')}
-                    onClick={() => {
-                      if (variable.isTruncated) {
-                        fetchFullVariable(variable.variableKey);
-                      }
-                      onEdit(createVariableFieldName(variable.name));
-                    }}
-                    size="sm"
-                    kind="ghost"
-                    align="top-end"
-                    leaveDelayMs={100}
+          <>
+            {paddingTop > 0 && (
+              <div
+                className={styles.virtualSpacer}
+                style={
+                  {
+                    '--virtual-spacer-height': `${paddingTop}px`,
+                  } as React.CSSProperties
+                }
+                aria-hidden
+              />
+            )}
+            {virtualItems.map((virtualRow) => {
+              const variable = variables[virtualRow.index];
+
+              if (variable === undefined) {
+                return (
+                  <StructuredListRow key={virtualRow.index}>
+                    <StructuredListCell
+                      className={cn(styles.listCell, styles.cellName)}
+                    >
+                      <SkeletonText />
+                    </StructuredListCell>
+                    <StructuredListCell
+                      className={cn(styles.listCell, styles.valueCell)}
+                    >
+                      <SkeletonText />
+                    </StructuredListCell>
+                    <StructuredListCell
+                      className={cn(styles.listCell, styles.controlsCell)}
+                    />
+                  </StructuredListRow>
+                );
+              }
+
+              return (
+                <StructuredListRow key={variable.name}>
+                  <StructuredListCell
+                    className={cn(styles.listCell, styles.cellName)}
                   >
-                    <Maximize />
-                  </IconButton>
-                </div>
-              </StructuredListCell>
-            </StructuredListRow>
-          ))
+                    {variable.name}
+                  </StructuredListCell>
+                  <StructuredListCell
+                    className={cn(styles.listCell, styles.valueCell)}
+                  >
+                    <div className={styles.singleLineValue}>
+                      {variable.value}
+                    </div>
+                  </StructuredListCell>
+                  <StructuredListCell
+                    className={cn(styles.listCell, styles.controlsCell)}
+                  >
+                    <div
+                      className={cn(styles.iconButtons, styles.extraPadding)}
+                    >
+                      <IconButton
+                        label={t('variableEditorOpenJsonLabel')}
+                        onClick={() => {
+                          if (variable.isTruncated) {
+                            fetchFullVariable(variable.variableKey);
+                          }
+                          onEdit(createVariableFieldName(variable.name));
+                        }}
+                        size="sm"
+                        kind="ghost"
+                        align="top-end"
+                        leaveDelayMs={100}
+                      >
+                        <Maximize />
+                      </IconButton>
+                    </div>
+                  </StructuredListCell>
+                </StructuredListRow>
+              );
+            })}
+            {paddingBottom > 0 && (
+              <div
+                className={styles.virtualSpacer}
+                style={
+                  {
+                    '--virtual-spacer-height': `${paddingBottom}px`,
+                  } as React.CSSProperties
+                }
+                aria-hidden
+              />
+            )}
+          </>
         ) : (
           <>
             {variables.map((variable) => (

--- a/tasklist/client/src/pages/TaskDetails/Variables/index.test.tsx
+++ b/tasklist/client/src/pages/TaskDetails/Variables/index.test.tsx
@@ -20,6 +20,18 @@ import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/testing/getMockQueryClient';
 import {DEFAULT_TENANT_ID} from 'modules/multitenancy/constants';
 
+vi.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: ({count}: {count: number}) => ({
+    getVirtualItems: () =>
+      Array.from({length: count}, (_, index) => ({
+        index,
+        key: index,
+        start: 0,
+      })),
+    getTotalSize: () => 0,
+  }),
+}));
+
 const {getQueryVariablesResponseMock} = variableMocks;
 
 type VariableSearchRequestBody = {
@@ -38,8 +50,8 @@ const getWrapper = () => {
   return Wrapper;
 };
 
-function isRequestingAllVariables(req: VariableSearchRequestBody) {
-  return req.page?.limit === 1000;
+function isFirstPageRequest(req: VariableSearchRequestBody) {
+  return req.page?.limit === 50;
 }
 
 describe('<Variables />', () => {
@@ -99,7 +111,7 @@ describe('<Variables />', () => {
       http.post<never, VariableSearchRequestBody>(
         '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
-          if (isRequestingAllVariables(await request.json())) {
+          if (isFirstPageRequest(await request.json())) {
             return HttpResponse.json(
               getQueryVariablesResponseMock(variableMocks.variables),
             );
@@ -144,7 +156,7 @@ describe('<Variables />', () => {
       http.post<never, VariableSearchRequestBody>(
         '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
-          if (isRequestingAllVariables(await request.json())) {
+          if (isFirstPageRequest(await request.json())) {
             return HttpResponse.json(getQueryVariablesResponseMock([]));
           }
 
@@ -186,7 +198,7 @@ describe('<Variables />', () => {
       http.post<never, VariableSearchRequestBody>(
         '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
-          if (isRequestingAllVariables(await request.json())) {
+          if (isFirstPageRequest(await request.json())) {
             return HttpResponse.json(
               getQueryVariablesResponseMock(variableMocks.variables),
             );
@@ -239,7 +251,7 @@ describe('<Variables />', () => {
       http.post<never, VariableSearchRequestBody>(
         '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
-          if (isRequestingAllVariables(await request.json())) {
+          if (isFirstPageRequest(await request.json())) {
             return HttpResponse.json(
               getQueryVariablesResponseMock(variableMocks.variables),
             );
@@ -304,7 +316,7 @@ describe('<Variables />', () => {
       http.post<never, VariableSearchRequestBody>(
         '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
-          if (isRequestingAllVariables(await request.json())) {
+          if (isFirstPageRequest(await request.json())) {
             return HttpResponse.json(
               getQueryVariablesResponseMock(variableMocks.variables),
             );
@@ -350,7 +362,7 @@ describe('<Variables />', () => {
       http.post<never, VariableSearchRequestBody>(
         '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
-          if (isRequestingAllVariables(await request.json())) {
+          if (isFirstPageRequest(await request.json())) {
             return HttpResponse.json(
               getQueryVariablesResponseMock(variableMocks.variables),
             );
@@ -403,7 +415,7 @@ describe('<Variables />', () => {
       http.post<never, VariableSearchRequestBody>(
         '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
-          if (isRequestingAllVariables(await request.json())) {
+          if (isFirstPageRequest(await request.json())) {
             return HttpResponse.json(
               getQueryVariablesResponseMock(variableMocks.variables),
             );
@@ -479,7 +491,7 @@ describe('<Variables />', () => {
       http.post<never, VariableSearchRequestBody>(
         '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
-          if (isRequestingAllVariables(await request.json())) {
+          if (isFirstPageRequest(await request.json())) {
             return HttpResponse.json(
               getQueryVariablesResponseMock(variableMocks.variables),
             );
@@ -529,7 +541,7 @@ describe('<Variables />', () => {
       http.post<never, VariableSearchRequestBody>(
         '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
-          if (isRequestingAllVariables(await request.json())) {
+          if (isFirstPageRequest(await request.json())) {
             return HttpResponse.json(
               getQueryVariablesResponseMock(variableMocks.variables),
             );
@@ -586,7 +598,7 @@ describe('<Variables />', () => {
       http.post<never, VariableSearchRequestBody>(
         '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
-          if (isRequestingAllVariables(await request.json())) {
+          if (isFirstPageRequest(await request.json())) {
             return HttpResponse.json(
               getQueryVariablesResponseMock(variableMocks.variables),
             );
@@ -650,7 +662,7 @@ describe('<Variables />', () => {
       http.post<never, VariableSearchRequestBody>(
         '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
-          if (isRequestingAllVariables(await request.json())) {
+          if (isFirstPageRequest(await request.json())) {
             return HttpResponse.json(
               getQueryVariablesResponseMock(variableMocks.variables),
             );
@@ -671,7 +683,7 @@ describe('<Variables />', () => {
       http.post<never, VariableSearchRequestBody>(
         '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
-          if (isRequestingAllVariables(await request.json())) {
+          if (isFirstPageRequest(await request.json())) {
             return HttpResponse.json(
               getQueryVariablesResponseMock(variableMocks.variables),
             );
@@ -776,7 +788,7 @@ describe('<Variables />', () => {
       http.post<never, VariableSearchRequestBody>(
         '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
-          if (isRequestingAllVariables(await request.json())) {
+          if (isFirstPageRequest(await request.json())) {
             return HttpResponse.json(
               getQueryVariablesResponseMock(variableMocks.variables),
             );
@@ -832,7 +844,7 @@ describe('<Variables />', () => {
       http.post<never, VariableSearchRequestBody>(
         '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
-          if (isRequestingAllVariables(await request.json())) {
+          if (isFirstPageRequest(await request.json())) {
             return HttpResponse.json(
               getQueryVariablesResponseMock(variableMocks.variables),
             );
@@ -900,7 +912,7 @@ describe('<Variables />', () => {
       http.post<never, VariableSearchRequestBody>(
         '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
-          if (isRequestingAllVariables(await request.json())) {
+          if (isFirstPageRequest(await request.json())) {
             return HttpResponse.json(
               getQueryVariablesResponseMock(variableMocks.variables),
             );
@@ -943,7 +955,7 @@ describe('<Variables />', () => {
       http.post<never, VariableSearchRequestBody>(
         '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
-          if (isRequestingAllVariables(await request.json())) {
+          if (isFirstPageRequest(await request.json())) {
             return HttpResponse.json(
               getQueryVariablesResponseMock(variableMocks.variables),
             );
@@ -993,7 +1005,7 @@ describe('<Variables />', () => {
       http.post<never, VariableSearchRequestBody>(
         '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
-          if (isRequestingAllVariables(await request.json())) {
+          if (isFirstPageRequest(await request.json())) {
             return HttpResponse.json(
               getQueryVariablesResponseMock(variableMocks.variables),
             );
@@ -1047,7 +1059,7 @@ describe('<Variables />', () => {
       http.post<never, VariableSearchRequestBody>(
         '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
-          if (isRequestingAllVariables(await request.json())) {
+          if (isFirstPageRequest(await request.json())) {
             return HttpResponse.json(
               getQueryVariablesResponseMock(variableMocks.variables),
             );
@@ -1090,7 +1102,7 @@ describe('<Variables />', () => {
       http.post<never, VariableSearchRequestBody>(
         '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
-          if (isRequestingAllVariables(await request.json())) {
+          if (isFirstPageRequest(await request.json())) {
             return HttpResponse.json(
               getQueryVariablesResponseMock(variableMocks.variables),
             );
@@ -1141,7 +1153,7 @@ describe('<Variables />', () => {
       http.post<never, VariableSearchRequestBody>(
         '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
-          if (isRequestingAllVariables(await request.json())) {
+          if (isFirstPageRequest(await request.json())) {
             return HttpResponse.json(
               getQueryVariablesResponseMock(variableMocks.truncatedVariables),
             );
@@ -1222,7 +1234,7 @@ describe('<Variables />', () => {
       http.post<never, VariableSearchRequestBody>(
         '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
-          if (isRequestingAllVariables(await request.json())) {
+          if (isFirstPageRequest(await request.json())) {
             return HttpResponse.json(
               getQueryVariablesResponseMock(variableMocks.truncatedVariables),
             );
@@ -1299,7 +1311,7 @@ describe('<Variables />', () => {
       http.post<never, VariableSearchRequestBody>(
         '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
-          if (isRequestingAllVariables(await request.json())) {
+          if (isFirstPageRequest(await request.json())) {
             return HttpResponse.json(
               getQueryVariablesResponseMock(variableMocks.truncatedVariables),
             );
@@ -1324,7 +1336,7 @@ describe('<Variables />', () => {
       http.post<never, VariableSearchRequestBody>(
         '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
-          if (isRequestingAllVariables(await request.json())) {
+          if (isFirstPageRequest(await request.json())) {
             return HttpResponse.json(
               getQueryVariablesResponseMock(variableMocks.truncatedVariables),
             );
@@ -1375,7 +1387,7 @@ describe('<Variables />', () => {
         http.post<never, VariableSearchRequestBody>(
           '/v2/user-tasks/:userTaskKey/effective-variables/search',
           async ({request}) => {
-            if (isRequestingAllVariables(await request.json())) {
+            if (isFirstPageRequest(await request.json())) {
               return HttpResponse.json(
                 getQueryVariablesResponseMock(variableMocks.variables),
               );
@@ -1490,7 +1502,7 @@ describe('<Variables />', () => {
         http.post<never, VariableSearchRequestBody>(
           '/v2/user-tasks/:userTaskKey/effective-variables/search',
           async ({request}) => {
-            if (isRequestingAllVariables(await request.json())) {
+            if (isFirstPageRequest(await request.json())) {
               return HttpResponse.json(
                 getQueryVariablesResponseMock(variableMocks.variables),
               );
@@ -1554,7 +1566,7 @@ describe('<Variables />', () => {
         http.post<never, VariableSearchRequestBody>(
           '/v2/user-tasks/:userTaskKey/effective-variables/search',
           async ({request}) => {
-            if (isRequestingAllVariables(await request.json())) {
+            if (isFirstPageRequest(await request.json())) {
               return HttpResponse.json(
                 getQueryVariablesResponseMock(variableMocks.variables),
               );
@@ -1646,7 +1658,7 @@ describe('<Variables />', () => {
       http.post<never, VariableSearchRequestBody>(
         '/v2/user-tasks/:userTaskKey/effective-variables/search',
         async ({request}) => {
-          if (isRequestingAllVariables(await request.json())) {
+          if (isFirstPageRequest(await request.json())) {
             return HttpResponse.json(
               getQueryVariablesResponseMock([variableWithDot]),
             );

--- a/tasklist/client/src/pages/TaskDetails/Variables/index.tsx
+++ b/tasklist/client/src/pages/TaskDetails/Variables/index.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {Suspense, lazy, useRef, useState} from 'react';
+import {Suspense, lazy, useCallback, useMemo, useRef, useState} from 'react';
 import {Form} from 'react-final-form';
 import intersection from 'lodash/intersection';
 import get from 'lodash/get';
@@ -25,7 +25,10 @@ import {
   TaskDetailsRow,
 } from 'modules/tasks/details/TaskDetailsLayout';
 import {Separator} from 'modules/tasks/variables-editor/Separator';
-import {useQueryAllVariables} from 'modules/api/useQueryAllVariables.query';
+import {
+  useQueryAllVariables,
+  flattenVariablePages,
+} from 'modules/api/useQueryAllVariables.query';
 import {useTranslation} from 'react-i18next';
 import {FailedVariableFetchError} from 'modules/tasks/details/FailedVariableFetchError';
 import {CompleteTaskButton} from 'modules/tasks/details/CompleteTaskButton';
@@ -67,21 +70,45 @@ const Variables: React.FC<Props> = ({
   user,
 }) => {
   const formRef = useRef<HTMLFormElement | null>(null);
+  const scrollContainerRef = useRef<HTMLDivElement | null>(null);
   const {assignee, state} = task;
   const {t} = useTranslation();
   const [variablesLoadingFullValue, setVariablesLoadingFullValue] = useState<
     string[]
   >([]);
   const {mutateAsync: fetchFullVariable} = useFetchFullVariable();
-  const {data, isLoading, status} = useQueryAllVariables(
+  const {
+    data,
+    isLoading,
+    status,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useQueryAllVariables(
     {
       userTaskKey: task.userTaskKey,
     },
     {
       refetchOnWindowFocus: assignee === null,
       refetchOnReconnect: assignee === null,
+      pollingInterval: assignee === null ? 5000 : undefined,
     },
   );
+
+  const handleScroll = useCallback(
+    (event: React.UIEvent<HTMLDivElement>) => {
+      const {scrollTop, scrollHeight, clientHeight} = event.currentTarget;
+      if (
+        Math.floor(scrollHeight - clientHeight - scrollTop) <= 0 &&
+        hasNextPage &&
+        !isFetchingNextPage
+      ) {
+        fetchNextPage();
+      }
+    },
+    [hasNextPage, isFetchingNextPage, fetchNextPage],
+  );
+
   const [editingVariable, setEditingVariable] = useState<string | undefined>();
   const [localSubmissionState, setLocalSubmissionState] = useState<
     NonNullable<InlineLoadingProps['status']>
@@ -93,7 +120,16 @@ const Variables: React.FC<Props> = ({
     user.username === assignee && state === 'CREATED' && status === 'success';
   const hasEmptyNewVariable = (values: FormValues | undefined) =>
     values?.newVariables?.some((variable) => variable === undefined);
-  const variables = data?.items ?? [];
+  const variables = useMemo(() => flattenVariablePages(data), [data]);
+  const totalVariables =
+    data?.pages.at(-1)?.page.totalItems ?? variables.length;
+  const initialFormValues = useMemo(
+    () =>
+      Object.fromEntries(
+        variables.map((v) => [createVariableFieldName(v.name), v.value]),
+      ),
+    [variables],
+  );
   const isJsonEditorModalOpen = editingVariable !== undefined;
 
   if (isLoading) {
@@ -139,13 +175,7 @@ const Variables: React.FC<Props> = ({
           setLocalSubmissionState('error');
         }
       }}
-      initialValues={variables.reduce(
-        (values, variable) => ({
-          ...values,
-          [createVariableFieldName(variable.name)]: variable.value,
-        }),
-        {},
-      )}
+      initialValues={initialFormValues}
       keepDirtyOnReinitialize
     >
       {({
@@ -178,7 +208,11 @@ const Variables: React.FC<Props> = ({
             )}
           </div>
           <Separator />
-          <ScrollableContent>
+          <ScrollableContent
+            ref={scrollContainerRef}
+            onScroll={handleScroll}
+            data-testid="variables-scroll-container"
+          >
             <form
               className={styles.form}
               onSubmit={handleSubmit}
@@ -241,6 +275,7 @@ const Variables: React.FC<Props> = ({
                         <VariableEditor
                           containerRef={formRef}
                           variables={variables}
+                          totalVariables={totalVariables}
                           readOnly={!canCompleteTask}
                           fetchFullVariable={async (variableKey) => {
                             setVariablesLoadingFullValue((variableKeys) => [
@@ -257,6 +292,10 @@ const Variables: React.FC<Props> = ({
                           }}
                           variablesLoadingFullValue={variablesLoadingFullValue}
                           onEdit={(id) => setEditingVariable(id)}
+                          fetchNextPage={fetchNextPage}
+                          hasNextPage={hasNextPage}
+                          isFetchingNextPage={isFetchingNextPage}
+                          scrollContainerRef={scrollContainerRef}
                         />
                       </Layer>
                     ),

--- a/tasklist/client/src/pages/TaskDetails/Variables/index.tsx
+++ b/tasklist/client/src/pages/TaskDetails/Variables/index.tsx
@@ -25,10 +25,7 @@ import {
   TaskDetailsRow,
 } from 'modules/tasks/details/TaskDetailsLayout';
 import {Separator} from 'modules/tasks/variables-editor/Separator';
-import {
-  useQueryAllVariables,
-  flattenVariablePages,
-} from 'modules/api/useQueryAllVariables.query';
+import {useQueryAllVariables} from 'modules/api/useQueryAllVariables.query';
 import {useTranslation} from 'react-i18next';
 import {FailedVariableFetchError} from 'modules/tasks/details/FailedVariableFetchError';
 import {CompleteTaskButton} from 'modules/tasks/details/CompleteTaskButton';
@@ -120,9 +117,8 @@ const Variables: React.FC<Props> = ({
     user.username === assignee && state === 'CREATED' && status === 'success';
   const hasEmptyNewVariable = (values: FormValues | undefined) =>
     values?.newVariables?.some((variable) => variable === undefined);
-  const variables = useMemo(() => flattenVariablePages(data), [data]);
-  const totalVariables =
-    data?.pages.at(-1)?.page.totalItems ?? variables.length;
+  const variables = useMemo(() => data?.items ?? [], [data?.items]);
+  const totalVariables = data?.totalItems ?? variables.length;
   const initialFormValues = useMemo(
     () =>
       Object.fromEntries(

--- a/tasklist/client/src/pages/TaskDetails/Variables/index.tsx
+++ b/tasklist/client/src/pages/TaskDetails/Variables/index.tsx
@@ -88,7 +88,7 @@ const Variables: React.FC<Props> = ({
     {
       refetchOnWindowFocus: assignee === null,
       refetchOnReconnect: assignee === null,
-      pollingInterval: assignee === null ? 5000 : undefined,
+      refetchInterval: assignee === null ? 5000 : undefined,
     },
   );
 

--- a/tasklist/client/src/pages/TaskDetails/index.test.tsx
+++ b/tasklist/client/src/pages/TaskDetails/index.test.tsx
@@ -644,7 +644,7 @@ describe('<Task />', () => {
       http.post(
         '/v2/user-tasks/:userTaskKey/effective-variables/search',
         () => {
-          return HttpResponse.json([]);
+          return HttpResponse.json(getQueryVariablesResponseMock([]));
         },
       ),
       http.delete('/v2/user-tasks/:userTaskKey/assignee', () => {


### PR DESCRIPTION
## Description

  - Replace single `useQuery(limit: 1000)` with `useInfiniteQuery(limit: 50)` for paginated variable loading
  - Add `@tanstack/react-virtual` for DOM virtualization in read-only mode (only visible rows rendered)
  - Poll every 5s for unassigned tasks, no polling for assigned tasks
  
  > [!NOTE]
  >   Virtualization uses padding-based approach instead of absolute positioning. `react-virtual` controls which rows exist in the DOM, while paddingTop/paddingBottom spacers maintain correct scroll height. Rows render in normal document flow, so no `position: absolute`, no CSS overrides. This preserves Carbon's `StructuredList` `display: table` layout so header and body columns align naturally.
> 
> Also investigated absolute-positioning(typical react-virtual approach) but it breaks Carbon's table layout annd rows opt out of column width coordination with the header. The padding-based approach seem to avoid this(maintaining same `StructuredList` structure as before, just fewer rows in the DOM).
>
> Virtualization is enabled only for read-only mode (unassigned/completed tasks). Editable mode renders all loaded rows to avoid react-final-form field unmounting when rows leave the viewport.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #50177 
