### PR TITLE
fix: ensure conditional on groups enabled is robust

### DIFF
--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/ApiFiltersConfiguration.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/ApiFiltersConfiguration.java
@@ -20,9 +20,14 @@ import io.camunda.zeebe.util.VisibleForTesting;
 import java.util.Arrays;
 import java.util.List;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.type.AnnotatedTypeMetadata;
 import org.springframework.web.util.pattern.PathPattern;
 import org.springframework.web.util.pattern.PathPatternParser;
 
@@ -69,7 +74,7 @@ public class ApiFiltersConfiguration {
     return registration;
   }
 
-  @ConditionalOnExpression("'${camunda.security.authentication.oidc.groupsClaim:}' != ''")
+  @Conditional(GroupsClaimConfiguredCondition.class)
   @Bean
   public FilterRegistrationBean<EndpointAccessErrorFilter> disableGroupApiFilter(
       final ObjectMapper objectMapper) {
@@ -115,5 +120,26 @@ public class ApiFiltersConfiguration {
     registration.addUrlPatterns("/*");
     registration.setOrder(1);
     return registration;
+  }
+
+  /**
+   * Matches when the OIDC groups-claim property is configured, meaning groups are managed
+   * externally via the identity provider. {@code GROUPS_CLAIM_PROPERTY} is camelCase ({@code
+   * groupsClaim}); querying the {@link ConditionContext#getEnvironment()} with that exact string
+   * only matches a camelCase-configured property. Canonicalizing it first makes the lookup match a
+   * kebab-case ({@code groups-claim}) YAML key too, relying on Spring Boot's relaxed property
+   * binding.
+   */
+  static final class GroupsClaimConfiguredCondition implements Condition {
+
+    private static final String CANONICAL_GROUPS_CLAIM_PROPERTY =
+        ConfigurationPropertyName.adapt(GROUPS_CLAIM_PROPERTY, '.').toString();
+
+    @Override
+    public boolean matches(final ConditionContext context, final AnnotatedTypeMetadata metadata) {
+      final String groupsClaim =
+          context.getEnvironment().getProperty(CANONICAL_GROUPS_CLAIM_PROPERTY);
+      return groupsClaim != null && !groupsClaim.isEmpty();
+    }
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupControllerTest.java
@@ -238,6 +238,71 @@ public class GroupControllerTest {
   @Nested
   @WebMvcTest(GroupController.class)
   @Import(ApiFiltersConfiguration.class)
+  @TestPropertySource(properties = "camunda.security.authentication.oidc.groups-claim=g1")
+  public class CamundaGroupsDisabledViaKebabCasePropertyTest extends RestControllerTest {
+
+    private static final String FORBIDDEN_MESSAGE =
+        """
+        {
+          "type": "about:blank",
+          "status": 403,
+          "title": "Access issue",
+          "detail": "%%s endpoint is not accessible: %s",
+          "instance": "%%s"
+        }"""
+            .formatted(GROUPS_API_DISABLED_ERROR_MESSAGE);
+
+    // GroupController's own @ConditionalOnCamundaGroupsEnabled (from the CSL library) does not
+    // yet relax-match the kebab-case property, so the controller bean is still created here
+    // (unlike CamundaGroupsDisabledTest above) and needs the same mocks as
+    // CamundaGroupsEnabledTest. This test only verifies that ApiFiltersConfiguration's Groups API
+    // filter correctly blocks the request regardless.
+    @MockitoBean private ServiceRegistry serviceRegistry;
+    @MockitoBean private GroupServices groupServices;
+    @MockitoBean private UserServices userServices;
+    @MockitoBean private RoleServices roleServices;
+    @MockitoBean private MappingRuleServices mappingRuleServices;
+    @MockitoBean private CamundaAuthenticationProvider authenticationProvider;
+    @MockitoBean private CamundaSecurityLibraryProperties cslProperties;
+
+    @BeforeEach
+    void setup() {
+      when(cslProperties.getCompiledIdValidationPattern()).thenReturn(ID_PATTERN);
+      when(serviceRegistry.groupServices(any())).thenReturn(groupServices);
+      when(serviceRegistry.mappingRuleServices(any())).thenReturn(mappingRuleServices);
+      when(serviceRegistry.roleServices(any())).thenReturn(roleServices);
+    }
+
+    @Test
+    void shouldReturnErrorOnCreateWhenGroupsClaimSetViaKebabCaseKey() {
+      // given
+      final var groupName = "testGroup";
+      final var description = "description";
+      final var groupId = "g1";
+      // when
+      webClient
+          .post()
+          .uri(GROUP_BASE_URL)
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(
+              GroupCreateRequest.Builder.create()
+                  .groupId(groupId)
+                  .name(groupName)
+                  .description(description)
+                  .build())
+          .exchange()
+          .expectStatus()
+          .isForbidden()
+          .expectBody()
+          .json(
+              FORBIDDEN_MESSAGE.formatted(GROUP_BASE_URL, GROUP_BASE_URL), JsonCompareMode.STRICT);
+    }
+  }
+
+  @Nested
+  @WebMvcTest(GroupController.class)
+  @Import(ApiFiltersConfiguration.class)
   @TestPropertySource(properties = "camunda.security.authentication.oidc.groupsClaim=")
   public class CamundaGroupsEnabledTest extends RestControllerTest {
     @MockitoBean private GroupServices groupServices;


### PR DESCRIPTION
## Description

It was spotted in a support case that the check for groups being enabled is strict and doesn't match Spring's relaxed property binding. This PR makes the check forgiving of both the kebab-case (`groups-claim`) and camelCase (`groupsClaim`) spellings.

**Note:** the original version of this PR patched `ConditionalOnCamundaGroupsEnabled`/`ConditionalOnCamundaGroupsDisabled` in `authentication/`. Those annotations have since been migrated out of this repo into the `camunda-security-library` dependency, so the branch has been rebuilt on top of current `main` and rescoped to the one place the bug still reproduces: the Groups API filter condition in `zeebe/gateway-rest`'s `ApiFiltersConfiguration`.

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/47012
