### PR TITLE
fix: show error and keep migration view open on failure

### DIFF
--- a/operate/client/e2e-playwright/docs-screenshots/process-instance-migration.spec.ts
+++ b/operate/client/e2e-playwright/docs-screenshots/process-instance-migration.spec.ts
@@ -243,6 +243,9 @@ test.describe('process instance migration', () => {
 
     await migrationView.confirmMigration();
 
+    await expect(migrationView.step1Header).toBeHidden();
+    await expect(migrationView.step2Header).toBeHidden();
+
     await processesPage.diagram.moveCanvasHorizontally(-200);
 
     await expect(

--- a/operate/client/e2e-playwright/mocks/processes.mocks.ts
+++ b/operate/client/e2e-playwright/mocks/processes.mocks.ts
@@ -145,6 +145,16 @@ function mockResponses({
       });
     }
 
+    if (route.request().url().includes('/v2/process-instances/migration')) {
+      return route.fulfill({
+        status: 200,
+        json: {
+          batchOperationKey: '1234567890',
+          batchOperationType: 'MIGRATE_PROCESS_INSTANCE',
+        },
+      });
+    }
+
     route.continue();
   };
 }

--- a/operate/client/e2e-playwright/pages/Processes/MigrationView.ts
+++ b/operate/client/e2e-playwright/pages/Processes/MigrationView.ts
@@ -17,6 +17,8 @@ export class MigrationView {
   readonly confirmButton: Locator;
   readonly summaryNotification: Locator;
   readonly migrationConfirmationModal: Locator;
+  readonly step1Header: Locator;
+  readonly step2Header: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -42,6 +44,9 @@ export class MigrationView {
     });
 
     this.summaryNotification = page.getByRole('main').getByRole('status');
+
+    this.step1Header = page.getByText('Migration step 1 - mapping elements');
+    this.step2Header = page.getByText('Migration step 2 - confirm');
   }
 
   async selectTargetProcess(option: string) {

--- a/operate/client/src/App/Processes/MigrationView/Footer/index.test.tsx
+++ b/operate/client/src/App/Processes/MigrationView/Footer/index.test.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {render, screen, within} from 'modules/testing-library';
+import {render, screen, waitFor, within} from 'modules/testing-library';
 import {Footer} from './index';
 import {processInstanceMigrationStore} from 'modules/stores/processInstanceMigration';
 import {useEffect} from 'react';
@@ -18,6 +18,7 @@ import {mockMigrateProcessInstancesBatchOperation} from 'modules/mocks/api/v2/pr
 import {mockQueryBatchOperations} from 'modules/mocks/api/v2/batchOperations/queryBatchOperations';
 import {panelStatesStore} from 'modules/stores/panelStates';
 import {notificationsStore} from 'modules/stores/notifications';
+import {LocationLog} from 'modules/utils/LocationLog';
 
 type Props = {
   children?: React.ReactNode;
@@ -53,6 +54,7 @@ const Wrapper = ({children}: Props) => {
         >
           map element
         </button>
+        <LocationLog />
       </MemoryRouter>
     </QueryClientProvider>
   );
@@ -185,7 +187,10 @@ describe('Footer', () => {
   });
 
   it('should perform migration batch operation successfully and expand operations panel', async () => {
-    vi.useFakeTimers({shouldAdvanceTime: true});
+    mockMigrateProcessInstancesBatchOperation().withDelay({
+      batchOperationKey: 'migrate-operation-123',
+      batchOperationType: 'MIGRATE_PROCESS_INSTANCE',
+    });
 
     processInstanceMigrationStore.setBatchOperationQuery({
       active: true,
@@ -208,19 +213,127 @@ describe('Footer', () => {
     await user.type(withinModal.getByRole('textbox'), 'MIGRATE');
     await user.click(withinModal.getByRole('button', {name: /confirm/i}));
 
-    vi.runOnlyPendingTimers();
+    expect(processInstanceMigrationStore.isEnabled).toBe(true);
+    expect(
+      screen.getByTestId('migration-operation-spinner'),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('pathname')).toHaveTextContent('/');
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId('migration-operation-spinner'),
+      ).not.toBeInTheDocument();
+    });
+
+    expect(processInstanceMigrationStore.isEnabled).toBe(false);
+    expect(panelStatesStore.state.isOperationsCollapsed).toBe(false);
+    expect(screen.getByTestId('pathname')).toHaveTextContent('/processes');
 
     expect(tracking.track).toHaveBeenCalledWith({
       eventName: 'batch-operation',
       operationType: 'MIGRATE_PROCESS_INSTANCE',
     });
 
-    expect(panelStatesStore.state.isOperationsCollapsed).toBe(false);
-
     expect(notificationsStore.displayNotification).not.toHaveBeenCalledWith(
       expect.objectContaining({kind: 'error'}),
     );
+  });
 
-    vi.useRealTimers();
+  it('should show an auth error and keep the migration view open when batch migration creation is forbidden', async () => {
+    mockMigrateProcessInstancesBatchOperation().withServerError(403);
+
+    processInstanceMigrationStore.setBatchOperationQuery({
+      active: true,
+      ids: ['1', '2'],
+    });
+    processInstanceMigrationStore.setTargetProcessDefinitionKey(
+      'target-process-key',
+    );
+    processInstanceMigrationStore.setSourceProcessDefinitionKey(
+      'source-process-key',
+    );
+
+    const {user} = render(<Footer />, {wrapper: Wrapper});
+
+    await user.click(screen.getByRole('button', {name: /map element/i}));
+    await user.click(screen.getByRole('button', {name: /next/i}));
+    await user.click(screen.getByRole('button', {name: /confirm/i}));
+
+    const withinModal = within(screen.getByRole('dialog'));
+    await user.type(withinModal.getByRole('textbox'), 'MIGRATE');
+    await user.click(withinModal.getByRole('button', {name: /confirm/i}));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId('migration-operation-spinner'),
+      ).not.toBeInTheDocument();
+    });
+
+    expect(processInstanceMigrationStore.isEnabled).toBe(true);
+    expect(screen.getByTestId('pathname')).toHaveTextContent('/');
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(notificationsStore.displayNotification).toHaveBeenCalledWith({
+      kind: 'error',
+      title: 'Operation could not be created',
+      subtitle: 'You do not have permission',
+      isDismissable: true,
+    });
+
+    expect(tracking.track).toHaveBeenCalledWith({
+      eventName: 'process-instance-migration-confirmed',
+    });
+    expect(tracking.track).not.toHaveBeenCalledWith({
+      eventName: 'batch-operation',
+      operationType: 'MIGRATE_PROCESS_INSTANCE',
+    });
+  });
+
+  it('should show an error and keep the migration view open when batch migration creation fails', async () => {
+    mockMigrateProcessInstancesBatchOperation().withServerError(500);
+
+    processInstanceMigrationStore.setBatchOperationQuery({
+      active: true,
+      ids: ['1', '2'],
+    });
+    processInstanceMigrationStore.setTargetProcessDefinitionKey(
+      'target-process-key',
+    );
+    processInstanceMigrationStore.setSourceProcessDefinitionKey(
+      'source-process-key',
+    );
+
+    const {user} = render(<Footer />, {wrapper: Wrapper});
+
+    await user.click(screen.getByRole('button', {name: /map element/i}));
+    await user.click(screen.getByRole('button', {name: /next/i}));
+    await user.click(screen.getByRole('button', {name: /confirm/i}));
+
+    const withinModal = within(screen.getByRole('dialog'));
+    await user.type(withinModal.getByRole('textbox'), 'MIGRATE');
+    await user.click(withinModal.getByRole('button', {name: /confirm/i}));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId('migration-operation-spinner'),
+      ).not.toBeInTheDocument();
+    });
+
+    expect(processInstanceMigrationStore.isEnabled).toBe(true);
+    expect(screen.getByTestId('pathname')).toHaveTextContent('/');
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(notificationsStore.displayNotification).toHaveBeenCalledWith({
+      kind: 'error',
+      title: 'Operation could not be created',
+      subtitle: undefined,
+      isDismissable: true,
+    });
+
+    expect(tracking.track).toHaveBeenCalledWith({
+      eventName: 'process-instance-migration-confirmed',
+    });
+    expect(tracking.track).not.toHaveBeenCalledWith({
+      eventName: 'batch-operation',
+      operationType: 'MIGRATE_PROCESS_INSTANCE',
+    });
   });
 });

--- a/operate/client/src/App/Processes/MigrationView/Footer/index.tsx
+++ b/operate/client/src/App/Processes/MigrationView/Footer/index.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {Button, Modal} from '@carbon/react';
+import {Button, InlineLoading, Modal} from '@carbon/react';
 import {observer} from 'mobx-react';
 import {processInstanceMigrationStore} from 'modules/stores/processInstanceMigration';
 import {Container} from './styled';
@@ -25,31 +25,41 @@ import {getProcessInstancesRequestFilters} from 'modules/utils/filter';
 const Footer: React.FC = observer(() => {
   const navigate = useNavigate();
 
-  const {mutate: migrateProcess} = useMigrateProcessInstancesBatchOperation({
-    onSuccess: () => {
-      tracking.track({
-        eventName: 'batch-operation',
-        operationType: 'MIGRATE_PROCESS_INSTANCE',
-      });
-    },
-    onError: ({message}) =>
-      notificationsStore.displayNotification({
-        kind: 'error',
-        title: 'Operation could not be created',
-        subtitle: message.includes('403')
-          ? 'You do not have permission'
-          : undefined,
-        isDismissable: true,
-      }),
-  });
+  const {isPending, mutate: migrateProcess} =
+    useMigrateProcessInstancesBatchOperation({
+      onSuccess: () => {
+        tracking.track({
+          eventName: 'batch-operation',
+          operationType: 'MIGRATE_PROCESS_INSTANCE',
+        });
+      },
+      onError: (error) => {
+        notificationsStore.displayNotification({
+          kind: 'error',
+          title: 'Operation could not be created',
+          subtitle:
+            error.response?.status === 403
+              ? 'You do not have permission'
+              : undefined,
+          isDismissable: true,
+        });
+      },
+    });
 
   return (
     <Container orientation="horizontal" gap={5}>
+      {isPending && (
+        <InlineLoading
+          data-testid="migration-operation-spinner"
+          title="Migration operation is being created"
+        />
+      )}
       <ModalStateManager
         renderLauncher={({setOpen}) => (
           <Button
             kind="secondary"
             size="sm"
+            disabled={isPending}
             onClick={() => {
               setOpen(true);
             }}
@@ -102,6 +112,7 @@ const Footer: React.FC = observer(() => {
           <Button
             kind="secondary"
             size="sm"
+            disabled={isPending}
             onClick={() =>
               processInstanceMigrationStore.setCurrentStep('elementMapping')
             }
@@ -114,6 +125,7 @@ const Footer: React.FC = observer(() => {
               <Button
                 aria-label="Confirm"
                 size="sm"
+                disabled={isPending}
                 onClick={() => {
                   setOpen(true);
                 }}
@@ -172,37 +184,43 @@ const Footer: React.FC = observer(() => {
                       sourceProcessDefinitionKey ?? undefined,
                   });
 
-                  migrateProcess({
-                    filter: requestBody.filter,
-                    migrationPlan: {
-                      targetProcessDefinitionKey,
-                      mappingInstructions: Object.entries(elementMapping).map(
-                        ([sourceElementId, targetElementId]) => ({
-                          sourceElementId,
-                          targetElementId,
-                        }),
-                      ),
-                    },
-                  });
-
-                  panelStatesStore.expandOperationsPanel();
-                  processInstanceMigrationStore.disable();
-
                   tracking.track({
                     eventName: 'process-instance-migration-confirmed',
                   });
 
-                  navigate(
-                    Locations.processes({
-                      active: true,
-                      incidents: true,
-                      ...(selectedTargetProcess
-                        ? {process: selectedTargetProcess.bpmnProcessId}
-                        : {}),
-                      ...(selectedTargetVersion
-                        ? {version: selectedTargetVersion.toString()}
-                        : {}),
-                    }),
+                  setOpen(false);
+                  migrateProcess(
+                    {
+                      filter: requestBody.filter,
+                      migrationPlan: {
+                        targetProcessDefinitionKey,
+                        mappingInstructions: Object.entries(elementMapping).map(
+                          ([sourceElementId, targetElementId]) => ({
+                            sourceElementId,
+                            targetElementId,
+                          }),
+                        ),
+                      },
+                    },
+                    {
+                      onSuccess: () => {
+                        panelStatesStore.expandOperationsPanel();
+                        processInstanceMigrationStore.disable();
+
+                        navigate(
+                          Locations.processes({
+                            active: true,
+                            incidents: true,
+                            ...(selectedTargetProcess
+                              ? {process: selectedTargetProcess.bpmnProcessId}
+                              : {}),
+                            ...(selectedTargetVersion
+                              ? {version: selectedTargetVersion.toString()}
+                              : {}),
+                          }),
+                        );
+                      },
+                    },
                   );
                 }}
               />

--- a/operate/client/src/modules/mutations/processes/useMigrateProcessInstancesBatchOperation.ts
+++ b/operate/client/src/modules/mutations/processes/useMigrateProcessInstancesBatchOperation.ts
@@ -17,19 +17,24 @@ import type {
   CreateMigrationBatchOperationResponseBody,
 } from '@camunda/camunda-api-zod-schemas/8.8';
 import {BATCH_OPERATIONS_QUERY_KEY} from 'modules/queries/batch-operations/useBatchOperations.ts';
+import type {RequestError} from 'modules/request';
 
 const useMigrateProcessInstancesBatchOperation = (
   options?: Partial<
     UseMutationOptions<
       CreateMigrationBatchOperationResponseBody,
-      Error,
+      RequestError,
       CreateMigrationBatchOperationRequestBody
     >
   >,
 ) => {
   const queryClient = useQueryClient();
 
-  return useMutation({
+  return useMutation<
+    CreateMigrationBatchOperationResponseBody,
+    RequestError,
+    CreateMigrationBatchOperationRequestBody
+  >({
     mutationKey: ['createProcessInstanceMigrationBatchOperation'],
     mutationFn: async (payload) => {
       const {response, error} =


### PR DESCRIPTION
## Description

This PR is a port of #50508 to `stable/8.8`. In addition to keeping the the migration view open, this PR actually had to fix the notification message. The mutation's `onError` callback acted like the error is a `Error` instance, but its actually a `RequestError` object. This caused a runtime error when calling properties on `message` (is `undefined`), which where silently swallowed... I updated the typing of the mutation hook so TS provides correct type information here.

## Related issues

closes #39075
