### PR TITLE
feat: make OAuth proactive token refresh threshold configurable

### DIFF
--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/CredentialsProviderConfiguration.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/CredentialsProviderConfiguration.java
@@ -91,6 +91,8 @@ public class CredentialsProviderConfiguration {
             .credentialsCachePath(camundaClientProperties.getAuth().getCredentialsCachePath())
             .connectTimeout(camundaClientProperties.getAuth().getConnectTimeout())
             .readTimeout(camundaClientProperties.getAuth().getReadTimeout())
+            .proactiveTokenRefreshThreshold(
+                camundaClientProperties.getAuth().getProactiveTokenRefreshThreshold())
             .clientAssertionKeystorePath(
                 camundaClientProperties.getAuth().getClientAssertion().getKeystorePath())
             .clientAssertionKeystorePassword(

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/CamundaClientAuthProperties.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/CamundaClientAuthProperties.java
@@ -110,6 +110,14 @@ public class CamundaClientAuthProperties {
   /** The data read timeout for requests to the OAuth credentials provider. */
   private Duration readTimeout = DEFAULT_READ_TIMEOUT;
 
+  /**
+   * The lead time before actual token expiry at which a background refresh is triggered. The token
+   * is still considered valid inside this window; this is a policy knob for how early refresh kicks
+   * in so callers don't have to block on a synchronous refresh at the cliff edge. Must be strictly
+   * larger than the internal expiry grace period.
+   */
+  private Duration proactiveTokenRefreshThreshold = DEFAULT_PROACTIVE_TOKEN_REFRESH_THRESHOLD;
+
   @NestedConfigurationProperty
   private CamundaClientAuthClientAssertionProperties clientAssertion =
       new CamundaClientAuthClientAssertionProperties();
@@ -168,6 +176,14 @@ public class CamundaClientAuthProperties {
 
   public void setReadTimeout(final Duration readTimeout) {
     this.readTimeout = readTimeout;
+  }
+
+  public Duration getProactiveTokenRefreshThreshold() {
+    return proactiveTokenRefreshThreshold;
+  }
+
+  public void setProactiveTokenRefreshThreshold(final Duration proactiveTokenRefreshThreshold) {
+    this.proactiveTokenRefreshThreshold = proactiveTokenRefreshThreshold;
   }
 
   public String getCredentialsCachePath() {
@@ -326,6 +342,8 @@ public class CamundaClientAuthProperties {
         + connectTimeout
         + ", readTimeout="
         + readTimeout
+        + ", proactiveTokenRefreshThreshold="
+        + proactiveTokenRefreshThreshold
         + ", clientAssertion="
         + clientAssertion
         + '}';

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/properties/CamundaClientAuthMethodsTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/properties/CamundaClientAuthMethodsTest.java
@@ -17,9 +17,11 @@ package io.camunda.client.spring.properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.client.impl.oauth.OAuthCredentialsProviderBuilder;
 import io.camunda.client.spring.CamundaClientPropertiesTestConfig;
 import io.camunda.client.spring.properties.CamundaClientAuthProperties.AuthMethod;
 import java.net.URI;
+import java.time.Duration;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -145,6 +147,32 @@ public class CamundaClientAuthMethodsTest {
     @Test
     void shouldLoadDefaultsBasic() {
       assertThat(properties.getAuth().getMethod()).isEqualTo(AuthMethod.none);
+    }
+  }
+
+  @Nested
+  @SpringBootTest(classes = CamundaClientPropertiesTestConfig.class)
+  public class ProactiveTokenRefreshThresholdDefault {
+    @Autowired CamundaClientProperties properties;
+
+    @Test
+    void shouldDefaultToBuilderConstant() {
+      assertThat(properties.getAuth().getProactiveTokenRefreshThreshold())
+          .isEqualTo(OAuthCredentialsProviderBuilder.DEFAULT_PROACTIVE_TOKEN_REFRESH_THRESHOLD);
+    }
+  }
+
+  @Nested
+  @SpringBootTest(
+      classes = CamundaClientPropertiesTestConfig.class,
+      properties = {"camunda.client.auth.proactive-token-refresh-threshold=90s"})
+  public class ProactiveTokenRefreshThresholdOverride {
+    @Autowired CamundaClientProperties properties;
+
+    @Test
+    void shouldBindCustomThreshold() {
+      assertThat(properties.getAuth().getProactiveTokenRefreshThreshold())
+          .isEqualTo(Duration.ofSeconds(90));
     }
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientCredentials.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientCredentials.java
@@ -30,24 +30,18 @@ import java.util.Objects;
 public final class CamundaClientCredentials {
 
   /**
-   * Small safety margin subtracted from the actual token expiry when deciding whether the token
-   * is still usable. Guards against clock skew and in-flight latency between this check and the
-   * server validating the token; it is not a policy knob for refresh timing.
+   * Small safety margin subtracted from the actual token expiry when deciding whether the token is
+   * still usable. Guards against clock skew and in-flight latency between this check and the server
+   * validating the token; it is not a policy knob for refresh timing.
    */
-  private static final Duration EXPIRY_GRACE_PERIOD = Duration.ofSeconds(5);
-
-  /**
-   * Window before actual expiry during which a background refresh should be triggered eagerly.
-   * The token is still considered valid inside this window; this is purely a policy knob for how
-   * early we want to start refreshing so callers don't have to block on a synchronous refresh at
-   * the cliff edge.
-   */
-  private static final Duration PROACTIVE_REFRESH_PERIOD = Duration.ofSeconds(60);
+  public static final Duration EXPIRY_GRACE_PERIOD = Duration.ofSeconds(5);
 
   @JsonAlias({"tokentype", "token_type"})
   private String tokenType;
+
   @JsonAlias({"accesstoken", "access_token"})
   private String accessToken;
+
   private ZonedDateTime expiry;
 
   public CamundaClientCredentials() {}
@@ -88,15 +82,16 @@ public final class CamundaClientCredentials {
   }
 
   /**
-   * Returns true if the token has entered the proactive refresh window and a background refresh
-   * should be triggered. This is independent of {@link #isValid()}: callers should compose the
-   * two, using {@code isValid()} to decide whether the token can still be served and this method
-   * to decide whether to kick off an eager refresh alongside. This avoids the cliff edge where
-   * all threads discover the token is invalid at the same time.
+   * Returns true if the token has entered the proactive refresh window (i.e. it will expire within
+   * {@code proactiveTokenRefreshThreshold}) and a background refresh should be triggered. This is
+   * independent of {@link #isValid()}: callers should compose the two, using {@code isValid()} to
+   * decide whether the token can still be served and this method to decide whether to kick off an
+   * eager refresh alongside. This avoids the cliff edge where all threads discover the token is
+   * invalid at the same time.
    */
   @JsonIgnore
-  public boolean shouldRefreshProactively() {
-    return expiry.toInstant().minus(PROACTIVE_REFRESH_PERIOD).isBefore(Instant.now());
+  public boolean shouldRefreshProactively(final Duration proactiveTokenRefreshThreshold) {
+    return expiry.toInstant().minus(proactiveTokenRefreshThreshold).isBefore(Instant.now());
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientCredentials.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientCredentials.java
@@ -30,26 +30,25 @@ import java.util.Objects;
 public final class CamundaClientCredentials {
 
   /**
-   * Grace period before actual token expiry during which the token is considered invalid,
-   * triggering a proactive refresh. This prevents a race where a token that is valid at check time
-   * expires before the request reaches the server.
+   * Small safety margin subtracted from the actual token expiry when deciding whether the token
+   * is still usable. Guards against clock skew and in-flight latency between this check and the
+   * server validating the token; it is not a policy knob for refresh timing.
    */
-  private static final Duration EXPIRY_GRACE_PERIOD = Duration.ofSeconds(30);
+  private static final Duration EXPIRY_GRACE_PERIOD = Duration.ofSeconds(5);
 
   /**
-   * Soft expiry period before actual token expiry during which the token is still valid but a
-   * background refresh should be triggered. This is larger than the grace period, giving the
-   * background refresh time to complete before the token becomes invalid.
+   * Window before actual expiry during which a background refresh should be triggered eagerly.
+   * The token is still considered valid inside this window; this is purely a policy knob for how
+   * early we want to start refreshing so callers don't have to block on a synchronous refresh at
+   * the cliff edge.
    */
   private static final Duration PROACTIVE_REFRESH_PERIOD = Duration.ofSeconds(60);
 
-  @JsonAlias({"accesstoken", "access_token"})
-  private String accessToken;
-
-  private ZonedDateTime expiry;
-
   @JsonAlias({"tokentype", "token_type"})
   private String tokenType;
+  @JsonAlias({"accesstoken", "access_token"})
+  private String accessToken;
+  private ZonedDateTime expiry;
 
   public CamundaClientCredentials() {}
 
@@ -89,18 +88,15 @@ public final class CamundaClientCredentials {
   }
 
   /**
-   * Returns true if the token is still valid but nearing expiry and should be refreshed in the
-   * background. This allows the current token to keep being served while a new one is fetched
-   * asynchronously, avoiding the cliff edge where all threads discover the token is invalid at the
-   * same time.
+   * Returns true if the token has entered the proactive refresh window and a background refresh
+   * should be triggered. This is independent of {@link #isValid()}: callers should compose the
+   * two, using {@code isValid()} to decide whether the token can still be served and this method
+   * to decide whether to kick off an eager refresh alongside. This avoids the cliff edge where
+   * all threads discover the token is invalid at the same time.
    */
   @JsonIgnore
   public boolean shouldRefreshProactively() {
-    final Instant now = Instant.now();
-    final Instant expiryInstant = expiry.toInstant();
-    // Token is in the proactive refresh window: still valid but nearing expiry
-    return expiryInstant.minus(PROACTIVE_REFRESH_PERIOD).isBefore(now)
-        && expiryInstant.minus(EXPIRY_GRACE_PERIOD).isAfter(now);
+    return expiry.toInstant().minus(PROACTIVE_REFRESH_PERIOD).isBefore(Instant.now());
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientEnvironmentVariables.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientEnvironmentVariables.java
@@ -59,6 +59,8 @@ public final class CamundaClientEnvironmentVariables {
   public static final String OAUTH_ENV_CACHE_PATH = "CAMUNDA_CLIENT_CONFIG_PATH";
   public static final String OAUTH_ENV_CONNECT_TIMEOUT = "CAMUNDA_AUTH_CONNECT_TIMEOUT";
   public static final String OAUTH_ENV_READ_TIMEOUT = "CAMUNDA_AUTH_READ_TIMEOUT";
+  public static final String OAUTH_ENV_PROACTIVE_TOKEN_REFRESH_THRESHOLD =
+      "CAMUNDA_AUTH_PROACTIVE_TOKEN_REFRESH_THRESHOLD";
   public static final String OAUTH_ENV_CLIENT_ASSERTION_KEYSTORE_PATH =
       "CAMUNDA_CLIENT_ASSERTION_KEYSTORE_PATH";
   public static final String OAUTH_ENV_CLIENT_ASSERTION_KEYSTORE_PASSWORD =

--- a/clients/java/src/main/java/io/camunda/client/impl/oauth/OAuthCredentialsCache.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/oauth/OAuthCredentialsCache.java
@@ -29,10 +29,12 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -114,14 +116,15 @@ public final class OAuthCredentialsCache {
       final String clientId,
       final SupplierWithIO<CamundaClientCredentials> zeebeClientCredentialsConsumer)
       throws IOException {
-    return computeIfMissingOrInvalid(clientId, zeebeClientCredentialsConsumer, null);
+    return computeIfMissingOrInvalid(clientId, zeebeClientCredentialsConsumer, null, null);
   }
 
   /**
    * Returns a valid cached token, or fetches a new one if missing/invalid. When a {@code
-   * proactiveRefreshCallback} is provided and the cached token is valid but nearing expiry (as
-   * determined by {@link CamundaClientCredentials#shouldRefreshProactively()}), the callback is
-   * invoked to trigger a background refresh while the still-valid token is returned immediately.
+   * proactiveRefreshCallback} is provided and the cached token is valid but within {@code
+   * proactiveTokenRefreshThreshold} of expiry (as determined by {@link
+   * CamundaClientCredentials#shouldRefreshProactively(Duration)}), the callback is invoked to
+   * trigger a background refresh while the still-valid token is returned immediately.
    *
    * <p>This method first checks the in-memory cache (a fast HashMap lookup) before falling back to
    * reading from the on-disk YAML cache. Under high throughput (~300 req/s), this avoids hundreds
@@ -130,8 +133,18 @@ public final class OAuthCredentialsCache {
   public synchronized CamundaClientCredentials computeIfMissingOrInvalid(
       final String clientId,
       final SupplierWithIO<CamundaClientCredentials> zeebeClientCredentialsConsumer,
-      final Runnable proactiveRefreshCallback)
+      final Runnable proactiveRefreshCallback,
+      final Duration proactiveTokenRefreshThreshold)
       throws IOException {
+
+    // Contract: if a proactive-refresh callback is provided, the threshold must be too.
+    // This is enforced here rather than letting a null threshold NPE inside
+    // shouldRefreshProactively() so mis-wiring is caught at the boundary.
+    if (proactiveRefreshCallback != null) {
+      Objects.requireNonNull(
+          proactiveTokenRefreshThreshold,
+          "proactiveTokenRefreshThreshold must be non-null when a proactive refresh callback is provided");
+    }
 
     // Fast path: check the in-memory cache first (no disk I/O).
     // This is the hot path under steady-state load — the token is valid in memory
@@ -139,7 +152,8 @@ public final class OAuthCredentialsCache {
     final Optional<CamundaClientCredentials> inMemoryCredentials = get(clientId);
     if (inMemoryCredentials.isPresent() && inMemoryCredentials.get().isValid()) {
       final CamundaClientCredentials credentials = inMemoryCredentials.get();
-      if (proactiveRefreshCallback != null && credentials.shouldRefreshProactively()) {
+      if (proactiveRefreshCallback != null
+          && credentials.shouldRefreshProactively(proactiveTokenRefreshThreshold)) {
         proactiveRefreshCallback.run();
       }
       return credentials;
@@ -160,7 +174,8 @@ public final class OAuthCredentialsCache {
                 });
     if (optionalCredentials.isPresent()) {
       final CamundaClientCredentials credentials = optionalCredentials.get();
-      if (proactiveRefreshCallback != null && credentials.shouldRefreshProactively()) {
+      if (proactiveRefreshCallback != null
+          && credentials.shouldRefreshProactively(proactiveTokenRefreshThreshold)) {
         proactiveRefreshCallback.run();
       }
       return credentials;

--- a/clients/java/src/main/java/io/camunda/client/impl/oauth/OAuthCredentialsProvider.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/oauth/OAuthCredentialsProvider.java
@@ -89,6 +89,7 @@ public final class OAuthCredentialsProvider implements CredentialsProvider {
   private final OAuthCredentialsCache credentialsCache;
   private final Duration connectionTimeout;
   private final Duration readTimeout;
+  private final Duration proactiveTokenRefreshThreshold;
   // client assertion
   private final boolean clientAssertionEnabled;
   private final Path clientAssertionKeystorePath;
@@ -119,6 +120,7 @@ public final class OAuthCredentialsProvider implements CredentialsProvider {
     credentialsCache = new OAuthCredentialsCache(builder.getCredentialsCache());
     connectionTimeout = builder.getConnectTimeout();
     readTimeout = builder.getReadTimeout();
+    proactiveTokenRefreshThreshold = builder.getProactiveTokenRefreshThreshold();
     clientAssertionEnabled = builder.clientAssertionEnabled();
     clientAssertionKeystorePath = builder.getClientAssertionKeystorePath();
     clientAssertionKeystorePassword = builder.getClientAssertionKeystorePassword();
@@ -135,7 +137,10 @@ public final class OAuthCredentialsProvider implements CredentialsProvider {
   public void applyCredentials(final CredentialsApplier applier) throws IOException {
     final CamundaClientCredentials camundaClientCredentials =
         credentialsCache.computeIfMissingOrInvalid(
-            clientId, this::fetchCredentials, this::triggerProactiveRefresh);
+            clientId,
+            this::fetchCredentials,
+            this::triggerProactiveRefresh,
+            proactiveTokenRefreshThreshold);
 
     String type = camundaClientCredentials.getTokenType();
     if (type == null || type.isEmpty()) {

--- a/clients/java/src/main/java/io/camunda/client/impl/oauth/OAuthCredentialsProviderBuilder.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/oauth/OAuthCredentialsProviderBuilder.java
@@ -26,6 +26,7 @@ import static io.camunda.client.impl.CamundaClientEnvironmentVariables.OAUTH_ENV
 import static io.camunda.client.impl.CamundaClientEnvironmentVariables.OAUTH_ENV_CLIENT_SECRET;
 import static io.camunda.client.impl.CamundaClientEnvironmentVariables.OAUTH_ENV_CONNECT_TIMEOUT;
 import static io.camunda.client.impl.CamundaClientEnvironmentVariables.OAUTH_ENV_ISSUER_URL;
+import static io.camunda.client.impl.CamundaClientEnvironmentVariables.OAUTH_ENV_PROACTIVE_TOKEN_REFRESH_THRESHOLD;
 import static io.camunda.client.impl.CamundaClientEnvironmentVariables.OAUTH_ENV_READ_TIMEOUT;
 import static io.camunda.client.impl.CamundaClientEnvironmentVariables.OAUTH_ENV_SSL_CLIENT_KEYSTORE_KEY_SECRET;
 import static io.camunda.client.impl.CamundaClientEnvironmentVariables.OAUTH_ENV_SSL_CLIENT_KEYSTORE_PATH;
@@ -42,6 +43,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
+import io.camunda.client.impl.CamundaClientCredentials;
 import io.camunda.client.impl.util.SSLContextUtil;
 import io.camunda.client.impl.util.VersionUtil;
 import java.io.File;
@@ -66,6 +68,7 @@ public final class OAuthCredentialsProviderBuilder {
   public static final String INVALID_ARGUMENT_MSG = "Expected valid %s but none was provided.";
   public static final Duration DEFAULT_CONNECT_TIMEOUT = Duration.ofSeconds(5);
   public static final Duration DEFAULT_READ_TIMEOUT = DEFAULT_CONNECT_TIMEOUT;
+  public static final Duration DEFAULT_PROACTIVE_TOKEN_REFRESH_THRESHOLD = Duration.ofSeconds(30);
   public static final String DEFAULT_CREDENTIALS_CACHE_PATH =
       Paths.get(System.getProperty("user.home"), ".camunda", "credentials")
           .toAbsolutePath()
@@ -89,6 +92,7 @@ public final class OAuthCredentialsProviderBuilder {
   private File credentialsCache;
   private Duration connectTimeout;
   private Duration readTimeout;
+  private Duration proactiveTokenRefreshThreshold;
   private boolean applyEnvironmentOverrides = true;
   private Path clientAssertionKeystorePath;
   private String clientAssertionKeystorePassword;
@@ -328,6 +332,35 @@ public final class OAuthCredentialsProviderBuilder {
     return readTimeout;
   }
 
+  /**
+   * Window before actual token expiry during which a background refresh is triggered eagerly. The
+   * token remains valid inside this window; this is purely a policy knob controlling how early
+   * refresh kicks in, so concurrent callers don't have to block on a synchronous refresh at the
+   * cliff edge. Must be strictly larger than {@link CamundaClientCredentials#EXPIRY_GRACE_PERIOD}.
+   * The default is 30 seconds.
+   */
+  public OAuthCredentialsProviderBuilder proactiveTokenRefreshThreshold(
+      final Duration proactiveTokenRefreshThreshold) {
+    this.proactiveTokenRefreshThreshold = proactiveTokenRefreshThreshold;
+    return this;
+  }
+
+  private OAuthCredentialsProviderBuilder proactiveTokenRefreshThreshold(
+      final String proactiveTokenRefreshThreshold) {
+    if (proactiveTokenRefreshThreshold != null) {
+      return proactiveTokenRefreshThreshold(
+          Duration.ofMillis(Long.parseLong(proactiveTokenRefreshThreshold)));
+    }
+    return this;
+  }
+
+  /**
+   * @see #proactiveTokenRefreshThreshold(Duration)
+   */
+  public Duration getProactiveTokenRefreshThreshold() {
+    return proactiveTokenRefreshThreshold;
+  }
+
   public OAuthCredentialsProviderBuilder clientAssertionKeystorePath(
       final String clientAssertionKeystorePath) {
     if (clientAssertionKeystorePath != null) {
@@ -538,6 +571,8 @@ public final class OAuthCredentialsProviderBuilder {
     applyEnvironmentValueIfNotNull(this::credentialsCachePath, OAUTH_ENV_CACHE_PATH);
     applyEnvironmentValueIfNotNull(this::readTimeout, OAUTH_ENV_READ_TIMEOUT);
     applyEnvironmentValueIfNotNull(this::connectTimeout, OAUTH_ENV_CONNECT_TIMEOUT);
+    applyEnvironmentValueIfNotNull(
+        this::proactiveTokenRefreshThreshold, OAUTH_ENV_PROACTIVE_TOKEN_REFRESH_THRESHOLD);
   }
 
   private void applyDefaults() {
@@ -551,6 +586,9 @@ public final class OAuthCredentialsProviderBuilder {
 
     if (readTimeout == null) {
       readTimeout = DEFAULT_READ_TIMEOUT;
+    }
+    if (proactiveTokenRefreshThreshold == null) {
+      proactiveTokenRefreshThreshold = DEFAULT_PROACTIVE_TOKEN_REFRESH_THRESHOLD;
     }
     if (clientAssertionKeystoreKeyPassword == null) {
       clientAssertionKeystoreKeyPassword = clientAssertionKeystorePassword;
@@ -594,12 +632,30 @@ public final class OAuthCredentialsProviderBuilder {
       }
       validateTimeout(connectTimeout, "ConnectTimeout");
       validateTimeout(readTimeout, "ReadTimeout");
+      validateProactiveTokenRefreshThreshold(proactiveTokenRefreshThreshold);
     } catch (final NullPointerException
         | IOException
         | KeyStoreException
         | NoSuchAlgorithmException
         | CertificateException e) {
       throw new IllegalArgumentException(e);
+    }
+  }
+
+  private void validateProactiveTokenRefreshThreshold(final Duration threshold) {
+    if (threshold.isZero() || threshold.isNegative()) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Proactive token refresh threshold is %s milliseconds, expected a positive duration.",
+              threshold.toMillis()));
+    }
+    if (threshold.compareTo(CamundaClientCredentials.EXPIRY_GRACE_PERIOD) <= 0) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Proactive token refresh threshold (%s ms) must be strictly larger than the expiry "
+                  + "grace period (%s ms); otherwise eager refresh would never fire before the "
+                  + "token is considered invalid.",
+              threshold.toMillis(), CamundaClientCredentials.EXPIRY_GRACE_PERIOD.toMillis()));
     }
   }
 

--- a/clients/java/src/test/java/io/camunda/client/OAuthCredentialsProviderBuilderTest.java
+++ b/clients/java/src/test/java/io/camunda/client/OAuthCredentialsProviderBuilderTest.java
@@ -215,6 +215,110 @@ public final class OAuthCredentialsProviderBuilderTest {
   }
 
   @Test
+  void shouldRejectNegativeProactiveTokenRefreshThreshold() {
+    // given
+    final OAuthCredentialsProviderBuilder builder =
+        new OAuthCredentialsProviderBuilder()
+            .audience("a")
+            .clientId("b")
+            .clientSecret("c")
+            .authorizationServerUrl("http://some.url")
+            .proactiveTokenRefreshThreshold(Duration.ofSeconds(-1));
+
+    // then
+    assertThatCode(builder::build)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Proactive token refresh threshold")
+        .hasMessageContaining("expected a positive duration");
+  }
+
+  @Test
+  void shouldRejectZeroProactiveTokenRefreshThreshold() {
+    // given
+    final OAuthCredentialsProviderBuilder builder =
+        new OAuthCredentialsProviderBuilder()
+            .audience("a")
+            .clientId("b")
+            .clientSecret("c")
+            .authorizationServerUrl("http://some.url")
+            .proactiveTokenRefreshThreshold(Duration.ZERO);
+
+    // then
+    assertThatCode(builder::build)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Proactive token refresh threshold")
+        .hasMessageContaining("expected a positive duration");
+  }
+
+  @Test
+  void shouldRejectProactiveTokenRefreshThresholdEqualToGracePeriod() {
+    // given — exactly equal to the grace period: not strictly larger, so must be rejected
+    final OAuthCredentialsProviderBuilder builder =
+        new OAuthCredentialsProviderBuilder()
+            .audience("a")
+            .clientId("b")
+            .clientSecret("c")
+            .authorizationServerUrl("http://some.url")
+            .proactiveTokenRefreshThreshold(
+                io.camunda.client.impl.CamundaClientCredentials.EXPIRY_GRACE_PERIOD);
+
+    // then
+    assertThatCode(builder::build)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("must be strictly larger than the expiry grace period");
+  }
+
+  @Test
+  void shouldRejectProactiveTokenRefreshThresholdBelowGracePeriod() {
+    // given — below the 5s grace period
+    final OAuthCredentialsProviderBuilder builder =
+        new OAuthCredentialsProviderBuilder()
+            .audience("a")
+            .clientId("b")
+            .clientSecret("c")
+            .authorizationServerUrl("http://some.url")
+            .proactiveTokenRefreshThreshold(Duration.ofSeconds(1));
+
+    // then
+    assertThatCode(builder::build)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("must be strictly larger than the expiry grace period");
+  }
+
+  @Test
+  void shouldApplyDefaultProactiveTokenRefreshThresholdWhenUnset() {
+    // given
+    final OAuthCredentialsProviderBuilder builder =
+        new OAuthCredentialsProviderBuilder().audience("a").clientId("b").clientSecret("c");
+
+    // when
+    builder.build();
+
+    // then
+    assertThat(builder.getProactiveTokenRefreshThreshold())
+        .isEqualTo(OAuthCredentialsProviderBuilder.DEFAULT_PROACTIVE_TOKEN_REFRESH_THRESHOLD);
+  }
+
+  @Test
+  void shouldAcceptCustomProactiveTokenRefreshThreshold() {
+    // given
+    final Duration custom = Duration.ofSeconds(90);
+    final OAuthCredentialsProviderBuilder builder =
+        new OAuthCredentialsProviderBuilder()
+            .audience("a")
+            .clientId("b")
+            .clientSecret("c")
+            .authorizationServerUrl("http://some.url")
+            .proactiveTokenRefreshThreshold(custom);
+
+    // when
+    builder.build();
+
+    // then
+    assertThat(builder.getProactiveTokenRefreshThreshold()).isEqualTo(custom);
+  }
+
+  @Test
   void shouldUseDefaultAuthorizationServerUrl() {
     // given
     final OAuthCredentialsProviderBuilder builder =

--- a/clients/java/src/test/java/io/camunda/client/impl/CamundaClientCredentialsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/CamundaClientCredentialsTest.java
@@ -17,6 +17,7 @@ package io.camunda.client.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Duration;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import org.junit.jupiter.api.Test;
@@ -80,8 +81,8 @@ public final class CamundaClientCredentialsTest {
   }
 
   @Test
-  void shouldRefreshProactivelyWhenTokenIsInSoftExpiryWindow() {
-    // given — token expires in 45 seconds: within the 60s proactive window but comfortably
+  void shouldRefreshProactivelyWhenTokenIsWithinRefreshThreshold() {
+    // given — token expires in 45 seconds: within the 60s refresh threshold but comfortably
     // beyond the 5s grace period, so isValid()=true and shouldRefreshProactively()=true
     final ZonedDateTime expiresInFortyFiveSeconds = ZonedDateTime.now().plusSeconds(45);
     final CamundaClientCredentials credentials =
@@ -89,7 +90,7 @@ public final class CamundaClientCredentialsTest {
 
     // when
     final boolean valid = credentials.isValid();
-    final boolean shouldRefresh = credentials.shouldRefreshProactively();
+    final boolean shouldRefresh = credentials.shouldRefreshProactively(Duration.ofSeconds(60));
 
     // then
     assertThat(valid).isTrue();
@@ -97,14 +98,14 @@ public final class CamundaClientCredentialsTest {
   }
 
   @Test
-  void shouldNotRefreshProactivelyWhenTokenIsFarFromExpiry() {
-    // given — token expires in 120 seconds: well beyond the 60s proactive window
+  void shouldNotRefreshProactivelyWhenTokenExpiryIsBeyondRefreshThreshold() {
+    // given — token expires in 120 seconds: well beyond the 60s refresh threshold
     final ZonedDateTime expiresInTwoMinutes = ZonedDateTime.now().plusSeconds(120);
     final CamundaClientCredentials credentials =
         new CamundaClientCredentials("token", expiresInTwoMinutes, "Bearer");
 
     // when
-    final boolean shouldRefresh = credentials.shouldRefreshProactively();
+    final boolean shouldRefresh = credentials.shouldRefreshProactively(Duration.ofSeconds(60));
 
     // then
     assertThat(shouldRefresh).isFalse();
@@ -113,7 +114,7 @@ public final class CamundaClientCredentialsTest {
   @Test
   void shouldRefreshProactivelyWhenTokenIsAlreadyWithinGracePeriod() {
     // given — token expires in 2 seconds: past the grace period (so isValid()=false) and also
-    // inside the proactive window. shouldRefreshProactively() is independent of validity;
+    // inside the refresh threshold. shouldRefreshProactively() is independent of validity;
     // callers compose the two predicates, so here we expect both: not valid, and refresh due.
     final ZonedDateTime expiresInTwoSeconds = ZonedDateTime.now().plusSeconds(2);
     final CamundaClientCredentials credentials =
@@ -121,7 +122,7 @@ public final class CamundaClientCredentialsTest {
 
     // when
     final boolean valid = credentials.isValid();
-    final boolean shouldRefresh = credentials.shouldRefreshProactively();
+    final boolean shouldRefresh = credentials.shouldRefreshProactively(Duration.ofSeconds(60));
 
     // then
     assertThat(valid).isFalse();

--- a/clients/java/src/test/java/io/camunda/client/impl/CamundaClientCredentialsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/CamundaClientCredentialsTest.java
@@ -53,10 +53,10 @@ public final class CamundaClientCredentialsTest {
 
   @Test
   void shouldBeInvalidWhenTokenExpiresWithinGracePeriod() {
-    // given — token that expires in 15 seconds (within the 30-second grace period)
-    final ZonedDateTime expiresInFifteenSeconds = ZonedDateTime.now().plusSeconds(15);
+    // given — token that expires in 2 seconds (within the 5-second grace period)
+    final ZonedDateTime expiresInTwoSeconds = ZonedDateTime.now().plusSeconds(2);
     final CamundaClientCredentials credentials =
-        new CamundaClientCredentials("token", expiresInFifteenSeconds, "Bearer");
+        new CamundaClientCredentials("token", expiresInTwoSeconds, "Bearer");
 
     // when
     final boolean valid = credentials.isValid();
@@ -67,10 +67,10 @@ public final class CamundaClientCredentialsTest {
 
   @Test
   void shouldBeValidWhenTokenExpiresWellAfterGracePeriod() {
-    // given — token that expires in 120 seconds (well beyond the 30-second grace period)
-    final ZonedDateTime expiresInTwoMinutes = ZonedDateTime.now().plusSeconds(120);
+    // given — token that expires in 30 seconds (well beyond the 5-second grace period)
+    final ZonedDateTime expiresInThirtySeconds = ZonedDateTime.now().plusSeconds(30);
     final CamundaClientCredentials credentials =
-        new CamundaClientCredentials("token", expiresInTwoMinutes, "Bearer");
+        new CamundaClientCredentials("token", expiresInThirtySeconds, "Bearer");
 
     // when
     final boolean valid = credentials.isValid();
@@ -81,8 +81,8 @@ public final class CamundaClientCredentialsTest {
 
   @Test
   void shouldRefreshProactivelyWhenTokenIsInSoftExpiryWindow() {
-    // given — token expires in 45 seconds: within the 60s proactive window, but beyond the 30s
-    // grace period, so isValid()=true but shouldRefreshProactively()=true
+    // given — token expires in 45 seconds: within the 60s proactive window but comfortably
+    // beyond the 5s grace period, so isValid()=true and shouldRefreshProactively()=true
     final ZonedDateTime expiresInFortyFiveSeconds = ZonedDateTime.now().plusSeconds(45);
     final CamundaClientCredentials credentials =
         new CamundaClientCredentials("token", expiresInFortyFiveSeconds, "Bearer");
@@ -111,19 +111,20 @@ public final class CamundaClientCredentialsTest {
   }
 
   @Test
-  void shouldNotRefreshProactivelyWhenTokenIsAlreadyInGracePeriod() {
-    // given — token expires in 15 seconds: already past the grace period threshold,
-    // so isValid()=false and shouldRefreshProactively()=false
-    final ZonedDateTime expiresInFifteenSeconds = ZonedDateTime.now().plusSeconds(15);
+  void shouldRefreshProactivelyWhenTokenIsAlreadyWithinGracePeriod() {
+    // given — token expires in 2 seconds: past the grace period (so isValid()=false) and also
+    // inside the proactive window. shouldRefreshProactively() is independent of validity;
+    // callers compose the two predicates, so here we expect both: not valid, and refresh due.
+    final ZonedDateTime expiresInTwoSeconds = ZonedDateTime.now().plusSeconds(2);
     final CamundaClientCredentials credentials =
-        new CamundaClientCredentials("token", expiresInFifteenSeconds, "Bearer");
+        new CamundaClientCredentials("token", expiresInTwoSeconds, "Bearer");
 
     // when
     final boolean valid = credentials.isValid();
     final boolean shouldRefresh = credentials.shouldRefreshProactively();
 
-    // then — not valid, so proactive refresh is irrelevant (synchronous refresh will happen)
+    // then
     assertThat(valid).isFalse();
-    assertThat(shouldRefresh).isFalse();
+    assertThat(shouldRefresh).isTrue();
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/impl/oauth/OAuthCredentialsCacheTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/oauth/OAuthCredentialsCacheTest.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.time.Duration;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -263,6 +264,28 @@ public final class OAuthCredentialsCacheTest {
   }
 
   @Test
+  public void shouldRejectNullRefreshThresholdWhenProactiveCallbackProvided() throws IOException {
+    // given
+    final OAuthCredentialsCache cache = new OAuthCredentialsCache(cacheFile);
+    cache.readCache();
+
+    // when / then — a non-null callback paired with a null threshold should fail fast
+    // rather than NPE inside shouldRefreshProactively()
+    assertThatThrownBy(
+            () ->
+                cache.computeIfMissingOrInvalid(
+                    WOMBAT_CLIENT_ID,
+                    () -> WOMBAT,
+                    () -> {
+                      /* no-op */
+                    },
+                    null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("proactiveTokenRefreshThreshold")
+        .hasMessageContaining("non-null");
+  }
+
+  @Test
   public void shouldInvokeProactiveRefreshCallbackWhenTokenIsNearingExpiry() throws IOException {
     // given — a token that is within the proactive refresh window (expires in 45s: valid but
     // past the 60s proactive threshold)
@@ -276,7 +299,10 @@ public final class OAuthCredentialsCacheTest {
     // when
     final CamundaClientCredentials result =
         cache.computeIfMissingOrInvalid(
-            WOMBAT_CLIENT_ID, () -> WOMBAT, () -> callbackInvoked.set(true));
+            WOMBAT_CLIENT_ID,
+            () -> WOMBAT,
+            () -> callbackInvoked.set(true),
+            Duration.ofSeconds(60));
 
     // then — returns the still-valid token but triggers the callback
     assertThat(result.getAccessToken()).isEqualTo("nearExpiry");
@@ -293,7 +319,10 @@ public final class OAuthCredentialsCacheTest {
     // when — WOMBAT has expiry in year 3020, far from any threshold
     final CamundaClientCredentials result =
         cache.computeIfMissingOrInvalid(
-            WOMBAT_CLIENT_ID, () -> WOMBAT, () -> callbackInvoked.set(true));
+            WOMBAT_CLIENT_ID,
+            () -> WOMBAT,
+            () -> callbackInvoked.set(true),
+            Duration.ofSeconds(60));
 
     // then — returns the token without triggering the callback
     assertThat(result.getAccessToken()).isEqualTo("wombat");


### PR DESCRIPTION
## Description

 Makes the OAuth proactive token refresh threshold (previously a hard-coded `60s` constant on `CamundaClientCredentials`) configurable, so operators can tune refresh eagerness to their OAuth server latency and request patterns without patching the client.

  ## Motivation

  Follow-up from https://github.com/camunda/camunda/pull/50124#discussion_r3051240219. The previous design hard-coded both the grace period (`30s`) and the proactive refresh window (`60s`) inside the credentials DTO, conflating clock-skew safety with refresh policy. This PR separates the two concerns and exposes the policy knob.

  ## Design

  - **`EXPIRY_GRACE_PERIOD`** stays an internal constant (`5s`), now serving only as a clock-skew / in-flight safety margin. `isValid()` means what it says.
  - **`proactiveTokenRefreshThreshold`** is a new public policy knob: "trigger a background refresh when less than *N* seconds remain." Default `30s`.
  - The two predicates on `CamundaClientCredentials` are now independent:
    - `isValid()` — factual: is the token still usable?
    - `shouldRefreshProactively(Duration threshold)` — policy: should we kick off an eager refresh?

    Callers compose them; `OAuthCredentialsCache` already does this correctly.
  - The threshold is **passed per-call** into `OAuthCredentialsCache.computeIfMissingOrInvalid(...)` rather than stored as cache state. The cache is a pure storage/coordination mechanism; the provider owns the policy. This mirrors how the proactive refresh `Runnable` is already passed per-call.

  ## Configuration surfaces

  | Layer               | How to set                                                              |
  |---------------------|-------------------------------------------------------------------------|
  | Java client builder | `OAuthCredentialsProviderBuilder#proactiveTokenRefreshThreshold(Duration)` |
  | Environment         | `CAMUNDA_AUTH_PROACTIVE_TOKEN_REFRESH_THRESHOLD` (milliseconds)         |
  | Spring Boot starter | `camunda.client.auth.proactive-token-refresh-threshold` (e.g. `45s`)   |

  ## Validation

  The threshold must be:
  1. strictly positive, and
  2. **strictly larger than `EXPIRY_GRACE_PERIOD`** — otherwise eager refresh would never fire before the token is already considered invalid, defeating the purpose. Rejected at `build()` time with a clear error message.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] Will require a docs follow-up to document the new property.

## Related issues

closes #
