### PR TITLE
ci: remove unused argument in docker/setup-buildx-action

### DIFF
--- a/.github/actions/build-platform-docker/action.yml
+++ b/.github/actions/build-platform-docker/action.yml
@@ -89,7 +89,6 @@ runs:
         driver-opts: network=host
         buildkitd-flags: ${{ inputs.debug == 'true' && '--debug' || '' }}
         endpoint: zeebe-context
-        install: true
 
     - name: Set semantic version from Maven project
       id: get-version


### PR DESCRIPTION
The `install` argument is deprecated, unused and raises a warning in all the runs using this workflow.

## Description

Example: https://github.com/camunda/camunda/actions/runs/24134470706:
<img width="1858" height="93" alt="image" src="https://github.com/user-attachments/assets/dcadf120-93a4-42c5-9a66-2e4bfcd69bef" />


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related

* https://github.com/docker/setup-buildx-action/pull/464/
* https://github.com/docker/setup-buildx-action/releases/tag/v4.0.0