### PR TITLE
ci: disable renovate for 8.6 (EOL)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,7 +6,7 @@
   ],
   "commitMessagePrefix": "deps:",
   "baseBranchPatterns": [
-    "/^stable\\/8\\.([6-9]|[1-9][0-9])/",
+    "/^stable\\/8\\.([7-9]|[1-9][0-9])/",
     "main"
   ],
   "dependencyDashboard": true,


### PR DESCRIPTION
## Description

 Disabled Renovate updates for the `stable/8.6` branch by adding a rule with `"enabled": false` and a description, ensuring that no automated dependency updates will be created for this EOL branch.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
