### PR TITLE
ci: remove 8.6 from dry-run due to EOL

### DIFF
--- a/.github/workflows/zeebe-release-stable-dry-run.yml
+++ b/.github/workflows/zeebe-release-stable-dry-run.yml
@@ -1,7 +1,7 @@
 # type: Release
 # owner: @camunda/monorepo-devops-team
 ---
-# NOTE: This workflow is not just for Zeebe, but also for 8.6+ monorepo release!
+# NOTE: This workflow is not just for Zeebe, but also for 8.7+ monorepo release!
 name: Zeebe Release Dry Run from stable branches
 
 on:
@@ -37,7 +37,7 @@ jobs:
           token: ${{ steps.github-token.outputs.token }}
       - name: Create branches
         run: |
-          for version in 8.6 8.7 8.8 8.9; do
+          for version in 8.7 8.8 8.9; do
             branch_name="tmp-dryrun-${version}-${{ github.run_id }}"
             git checkout "origin/stable/${version}"
             git checkout -b "${branch_name}"
@@ -47,13 +47,12 @@ jobs:
       - name: Create fake dry-run tags
         run: |
           declare -A tags=(
-            [8.6]=0.0.0-dryrun-86
             [8.7]=0.0.0-dryrun-87
             [8.8]=0.0.0-dryrun-88
             [8.9]=0.0.0-dryrun-89
           )
 
-          for version in 8.6 8.7 8.8 8.9; do
+          for version in 8.7 8.8 8.9; do
             tag_name="${tags[$version]}"
             git checkout "origin/stable/${version}"
             git tag -f "${tag_name}"
@@ -103,27 +102,12 @@ jobs:
       nextDevelopmentVersion: 0.0.0-SNAPSHOT
       isLatest: true
       dryRun: true
-  dry-run-release-86:
-    name: "Release from stable/8.6"
-    needs: create-dry-run-branches
-    uses: camunda/camunda/.github/workflows/camunda-platform-release.yml@stable/8.6
-    secrets: inherit
-    strategy:
-      fail-fast: false
-    with:
-      releaseBranch: tmp-dryrun-8.6-${{ github.run_id }}
-      # Uses fake tag for dry run testing without affecting real releases
-      releaseVersion: 0.0.0-dryrun-86
-      nextDevelopmentVersion: 0.0.0-SNAPSHOT
-      isLatest: true
-      dryRun: true
-
   # Always run cleanup. Delete refs for successful dry runs and keep failed
   # ones available for targeted reruns.
   cleanup-dry-run-branches:
     name: Delete temporary dry-run branches
     runs-on: ubuntu-slim
-    needs: [dry-run-release-86, dry-run-release-87, dry-run-release-88, dry-run-release-89]
+    needs: [dry-run-release-87, dry-run-release-88, dry-run-release-89]
     if: always()
     timeout-minutes: 5
     permissions: {}  # Uses GitHub App token instead of GITHUB_TOKEN
@@ -161,17 +145,10 @@ jobs:
           branch_name="tmp-dryrun-8.7-${{ github.run_id }}"
           git push origin --delete "${branch_name}" || echo "::warning::Failed to delete ${branch_name}, it may have already been deleted"
           git push origin --delete "refs/tags/0.0.0-dryrun-87" 2>/dev/null || echo "::warning::Failed to delete 0.0.0-dryrun-87, it may have already been deleted"
-      - name: Delete temporary dryrun 8.6 branch and tag
-        if: ${{ needs.dry-run-release-86.result == 'success' }}
-        run: |
-          branch_name="tmp-dryrun-8.6-${{ github.run_id }}"
-          git push origin --delete "${branch_name}" || echo "::warning::Failed to delete ${branch_name}, it may have already been deleted"
-          git push origin --delete "refs/tags/0.0.0-dryrun-86" 2>/dev/null || echo "::warning::Failed to delete 0.0.0-dryrun-86, it may have already been deleted"
-
   notify-camunda:
-    name: Send Slack notification for 8.6+
+    name: Send Slack notification for 8.7+
     runs-on: ubuntu-latest
-    needs: [dry-run-release-86, dry-run-release-87, dry-run-release-88, dry-run-release-89, cleanup-dry-run-branches]
+    needs: [dry-run-release-87, dry-run-release-88, dry-run-release-89, cleanup-dry-run-branches]
     if: always()
     timeout-minutes: 5
     permissions: {}  # GITHUB_TOKEN unused in this job
@@ -190,7 +167,7 @@ jobs:
 
       - name: Send failure Slack notification
         uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
-        if: ${{ (needs.dry-run-release-86.result != 'success' || needs.dry-run-release-87.result != 'success' || needs.dry-run-release-88.result != 'success' || needs.dry-run-release-89.result != 'success') && github.event_name == 'schedule' }}
+        if: ${{ (needs.dry-run-release-87.result != 'success' || needs.dry-run-release-88.result != 'success' || needs.dry-run-release-89.result != 'success') && github.event_name == 'schedule' }}
         with:
           webhook: ${{ steps.secrets.outputs.SLACK_TOPMONOREPORELEASE_WEBHOOK_URL }}
           webhook-type: incoming-webhook


### PR DESCRIPTION
## Description

This pull request updates the Zeebe release dry run workflow to remove support for version 8.6, focusing the workflow on versions 8.7 and above. The main changes involve cleaning up all steps, tags, and notifications related to 8.6, ensuring the workflow is streamlined for current and future releases.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
