### PR TITLE
fix: use composite cache IDs in batch operation exporters to prevent entity collisions

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedHandler.java
@@ -60,11 +60,11 @@ public class BatchOperationChunkCreatedHandler
 
   @Override
   public List<String> generateIds(final Record<BatchOperationChunkRecordValue> record) {
-    // Use a composite ID (batchOperationKey:chunkKey) so that each chunk gets its own cached entity
-    // in the ExporterBatchWriter. This prevents sharing the entity with
-    // BatchOperationCreatedHandler (which uses just the batchOperationKey as ID), avoiding
-    // double-counting of operationsTotalCount.
-    return List.of(record.getValue().getBatchOperationKey() + ":" + record.getKey());
+    // Use a composite ID with a static suffix (batchOperationKey:chunk) so that all chunks for the
+    // same batch operation share a single cached entity in the ExporterBatchWriter, while still
+    // being separate from BatchOperationCreatedHandler (which uses just the batchOperationKey).
+    // This avoids double-counting of operationsTotalCount without inflating the batch size.
+    return List.of(record.getValue().getBatchOperationKey() + ":chunk");
   }
 
   @Override
@@ -83,11 +83,8 @@ public class BatchOperationChunkCreatedHandler
   @Override
   public void flush(final BatchOperationEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    // The document always exists: on every partition, BatchOperation CREATED is exported before any
-    // CHUNK_CREATED events. We use updateWithScript to atomically increment the total and reset
-    // endDate so the BatchOperationUpdateTask re-processes the counts.
-
-    // Extract just the batchKey from the composite cache ID (batchKey:chunkKey).
+    // Atomically increment the total and reset endDate so the BatchOperationUpdateTask
+    // re-processes the counts. Extract the batchKey from the composite cache ID (batchKey:chunk).
     final String batchOperationKey = entity.getId().split(":")[0];
 
     batchRequest.updateWithScript(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedHandler.java
@@ -83,19 +83,16 @@ public class BatchOperationChunkCreatedHandler
   @Override
   public void flush(final BatchOperationEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    // Use upsertWithScript to be resilient against cross-partition ordering: if the batch operation
-    // document has not been created yet (e.g., a slow partition's CREATED event export), the upsert
-    // creates a minimal document from the entity. When the document already exists, the script
-    // atomically increments the total count and resets endDate to null so that the
-    // BatchOperationUpdateTask will re-process this batch operation to update all counts.
+    // The document always exists: on every partition, BatchOperation CREATED is exported before any
+    // CHUNK_CREATED events. We use updateWithScript to atomically increment the total and reset
+    // endDate so the BatchOperationUpdateTask re-processes the counts.
 
-    // The entity ID is "batchKey:chunkKey", but the ES document ID is just the batchKey.
+    // Extract just the batchKey from the composite cache ID (batchKey:chunkKey).
     final String batchOperationKey = entity.getId().split(":")[0];
 
-    batchRequest.upsertWithScript(
+    batchRequest.updateWithScript(
         indexName,
         batchOperationKey,
-        entity,
         """
             ctx._source.operationsTotalCount = ctx._source.operationsTotalCount + params.operationsTotalCount;
             ctx._source.endDate = null;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedHandler.java
@@ -60,7 +60,11 @@ public class BatchOperationChunkCreatedHandler
 
   @Override
   public List<String> generateIds(final Record<BatchOperationChunkRecordValue> record) {
-    return List.of(String.valueOf(record.getValue().getBatchOperationKey()));
+    // Use a composite ID (batchOperationKey:chunkKey) so that each chunk gets its own cached entity
+    // in the ExporterBatchWriter. This prevents sharing the entity with
+    // BatchOperationCreatedHandler (which uses just the batchOperationKey as ID), avoiding
+    // double-counting of operationsTotalCount.
+    return List.of(record.getValue().getBatchOperationKey() + ":" + record.getKey());
   }
 
   @Override
@@ -84,9 +88,13 @@ public class BatchOperationChunkCreatedHandler
     // creates a minimal document from the entity. When the document already exists, the script
     // atomically increments the total count and resets endDate to null so that the
     // BatchOperationUpdateTask will re-process this batch operation to update all counts.
+
+    // The entity ID is "batchKey:chunkKey", but the ES document ID is just the batchKey.
+    final String batchOperationKey = entity.getId().split(":")[0];
+
     batchRequest.upsertWithScript(
         indexName,
-        entity.getId(),
+        batchOperationKey,
         entity,
         """
             ctx._source.operationsTotalCount = ctx._source.operationsTotalCount + params.operationsTotalCount;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/listview/AbstractProcessInstanceFromOperationItemHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/listview/AbstractProcessInstanceFromOperationItemHandler.java
@@ -48,7 +48,11 @@ public abstract class AbstractProcessInstanceFromOperationItemHandler<
 
   @Override
   public List<String> generateIds(final Record<R> record) {
-    return List.of(String.valueOf(record.getValue().getProcessInstanceKey()));
+    // Use a composite ID (processInstanceKey:batchOperationReference) so that each (PI, batchOp)
+    // pair gets its own cached entity. This prevents a second batch operation targeting the same PI
+    // from overwriting the first one's batchOperationId in the shared entity.
+    return List.of(
+        record.getValue().getProcessInstanceKey() + ":" + record.getBatchOperationReference());
   }
 
   @Override
@@ -64,6 +68,9 @@ public abstract class AbstractProcessInstanceFromOperationItemHandler<
   @Override
   public void flush(final ProcessInstanceForListViewEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
+    // Extract just the processInstanceKey from the composite cache ID
+    // (processInstanceKey:batchOperationReference).
+    final String processInstanceKey = entity.getId().split(":")[0];
     final String script =
         "if (ctx._source.batchOperationIds == null){"
             + "ctx._source.batchOperationIds = new String[]{params.batchOperationId};"
@@ -72,7 +79,7 @@ public abstract class AbstractProcessInstanceFromOperationItemHandler<
             + "}";
     batchRequest.updateWithScript(
         indexName,
-        entity.getId(),
+        processInstanceKey,
         script,
         Map.of("batchOperationId", entity.getBatchOperationIds().getFirst()));
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromChunkItemHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromChunkItemHandler.java
@@ -43,8 +43,12 @@ public class ListViewFromChunkItemHandler
 
   @Override
   public List<String> generateIds(final Record<BatchOperationChunkRecordValue> record) {
+    // Use a composite ID (processInstanceKey:batchOperationKey) so that each (PI, batchOp) pair
+    // gets its own cached entity. This prevents a second batch operation targeting the same PI
+    // from overwriting the first one's batchOperationId in the shared entity.
+    final var batchOpKey = record.getValue().getBatchOperationKey();
     return record.getValue().getItems().stream()
-        .map(item -> String.valueOf(item.getProcessInstanceKey()))
+        .map(item -> item.getProcessInstanceKey() + ":" + batchOpKey)
         .toList();
   }
 
@@ -57,12 +61,15 @@ public class ListViewFromChunkItemHandler
   public void updateEntity(
       final Record<BatchOperationChunkRecordValue> record,
       final ProcessInstanceForListViewEntity entity) {
-    entity.setBatchOperationIds(List.of(String.valueOf(record.getBatchOperationReference())));
+    entity.setBatchOperationIds(List.of(String.valueOf(record.getValue().getBatchOperationKey())));
   }
 
   @Override
   public void flush(final ProcessInstanceForListViewEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
+    // Extract just the processInstanceKey from the composite cache ID
+    // (processInstanceKey:batchOperationKey).
+    final String processInstanceKey = entity.getId().split(":")[0];
     final String script =
         "if (ctx._source.batchOperationIds == null){"
             + "ctx._source.batchOperationIds = new String[]{params.batchOperationId};"
@@ -71,7 +78,7 @@ public class ListViewFromChunkItemHandler
             + "}";
     batchRequest.updateWithScript(
         indexName,
-        entity.getId(),
+        processInstanceKey,
         script,
         Map.of("batchOperationId", entity.getBatchOperationIds().getFirst()));
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ExporterBatchWriter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ExporterBatchWriter.java
@@ -79,10 +79,7 @@ public final class ExporterBatchWriter {
     totalMemoryEstimate += length;
     final var cached =
         cachedEntities.computeIfAbsent(
-            cacheKey,
-            (k) -> {
-              return new CachedEntity(handler.createNewEntity(id), length);
-            });
+            cacheKey, (k) -> new CachedEntity(handler.createNewEntity(id), length));
 
     handler.updateEntity(record, cached.entity());
     cachedRecordTimestamps.put(record.getPosition(), record.getTimestamp());

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedHandlerTest.java
@@ -117,7 +117,7 @@ class BatchOperationChunkCreatedHandlerTest {
   }
 
   @Test
-  void shouldUpsertWithScriptEntityOnFlush() throws PersistenceException {
+  void shouldUpdateWithScriptOnFlush() throws PersistenceException {
     // given
     final var entity = new BatchOperationEntity().setId("123:456").setEndDate(null);
     final Record<BatchOperationChunkRecordValue> record = createRecord(1L, 11L);
@@ -130,11 +130,10 @@ class BatchOperationChunkCreatedHandlerTest {
     final Map<String, Object> expectedParams = new HashMap<>();
     expectedParams.put(BatchOperationTemplate.OPERATIONS_TOTAL_COUNT, 1);
 
-    // then - the ES document ID should be just the batchKey (123), not the composite entity ID
+    // then - the ES document ID is just the batchKey extracted from the composite ID
     final var scriptCaptor = ArgumentCaptor.forClass(String.class);
     verify(mockRequest, times(1))
-        .upsertWithScript(
-            eq(indexName), eq("123"), eq(entity), scriptCaptor.capture(), eq(expectedParams));
+        .updateWithScript(eq(indexName), eq("123"), scriptCaptor.capture(), eq(expectedParams));
 
     final var script = scriptCaptor.getValue();
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedHandlerTest.java
@@ -69,9 +69,8 @@ class BatchOperationChunkCreatedHandlerTest {
     // when
     final var idList = underTest.generateIds(record);
 
-    // then - composite ID (batchKey:chunkKey) to avoid entity sharing with CreatedHandler
-    assertThat(idList)
-        .containsExactly(record.getValue().getBatchOperationKey() + ":" + record.getKey());
+    // then - static composite ID (batchKey:chunk) to collapse all chunks into one cached entity
+    assertThat(idList).containsExactly(record.getValue().getBatchOperationKey() + ":chunk");
   }
 
   @Test
@@ -119,7 +118,7 @@ class BatchOperationChunkCreatedHandlerTest {
   @Test
   void shouldUpdateWithScriptOnFlush() throws PersistenceException {
     // given
-    final var entity = new BatchOperationEntity().setId("123:456").setEndDate(null);
+    final var entity = new BatchOperationEntity().setId("123:chunk").setEndDate(null);
     final Record<BatchOperationChunkRecordValue> record = createRecord(1L, 11L);
     underTest.updateEntity(record, entity);
     final var mockRequest = mock(BatchRequest.class);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedHandlerTest.java
@@ -69,8 +69,9 @@ class BatchOperationChunkCreatedHandlerTest {
     // when
     final var idList = underTest.generateIds(record);
 
-    // then
-    assertThat(idList).containsExactly(String.valueOf(record.getValue().getBatchOperationKey()));
+    // then - composite ID (batchKey:chunkKey) to avoid entity sharing with CreatedHandler
+    assertThat(idList)
+        .containsExactly(record.getValue().getBatchOperationKey() + ":" + record.getKey());
   }
 
   @Test
@@ -118,25 +119,22 @@ class BatchOperationChunkCreatedHandlerTest {
   @Test
   void shouldUpsertWithScriptEntityOnFlush() throws PersistenceException {
     // given
-    final var entity =
-        new BatchOperationEntity().setId("123").setOperationsTotalCount(123).setEndDate(null);
+    final var entity = new BatchOperationEntity().setId("123:456").setEndDate(null);
+    final Record<BatchOperationChunkRecordValue> record = createRecord(1L, 11L);
+    underTest.updateEntity(record, entity);
     final var mockRequest = mock(BatchRequest.class);
 
     // when
     underTest.flush(entity, mockRequest);
 
-    final Map<String, Object> updateFields = new HashMap<>();
-    updateFields.put(BatchOperationTemplate.OPERATIONS_TOTAL_COUNT, 123);
+    final Map<String, Object> expectedParams = new HashMap<>();
+    expectedParams.put(BatchOperationTemplate.OPERATIONS_TOTAL_COUNT, 1);
 
-    // then
+    // then - the ES document ID should be just the batchKey (123), not the composite entity ID
     final var scriptCaptor = ArgumentCaptor.forClass(String.class);
     verify(mockRequest, times(1))
         .upsertWithScript(
-            eq(indexName),
-            eq(entity.getId()),
-            eq(entity),
-            scriptCaptor.capture(),
-            eq(updateFields));
+            eq(indexName), eq("123"), eq(entity), scriptCaptor.capture(), eq(expectedParams));
 
     final var script = scriptCaptor.getValue();
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/AbstractProcessInstanceFromOperationItemHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/AbstractProcessInstanceFromOperationItemHandlerTest.java
@@ -158,8 +158,10 @@ public abstract class AbstractProcessInstanceFromOperationItemHandlerTest<
     // When
     final var idList = underTest.generateIds(record);
 
-    // Then
-    assertThat(idList).containsExactly(String.valueOf(record.getValue().getProcessInstanceKey()));
+    // Then - composite ID (processInstanceKey:batchOperationReference)
+    assertThat(idList)
+        .containsExactly(
+            record.getValue().getProcessInstanceKey() + ":" + record.getBatchOperationReference());
   }
 
   @Test
@@ -178,21 +180,23 @@ public abstract class AbstractProcessInstanceFromOperationItemHandlerTest<
 
   @Test
   void shouldFlushEntity() {
-    // Given
-    final var entity = underTest.createNewEntity("test-id");
-    entity.setBatchOperationIds(List.of("batch-op-1"));
+    // Given - entity uses composite cache ID (processInstanceKey:batchOperationReference)
+    final String processInstanceKey = "42";
+    final String batchOperationKey = "batch-op-1";
+    final var entity = underTest.createNewEntity(processInstanceKey + ":" + batchOperationKey);
+    entity.setBatchOperationIds(List.of(batchOperationKey));
     final var batchRequest = mock(BatchRequest.class);
 
     // When
     underTest.flush(entity, batchRequest);
 
-    // Then
+    // Then - the ES document ID is just the processInstanceKey, extracted from the composite ID
     Mockito.verify(batchRequest)
         .updateWithScript(
             eq(underTest.getIndexName()),
-            eq(entity.getId()),
+            eq(processInstanceKey),
             anyString(),
-            eq(Map.of("batchOperationId", "batch-op-1")));
+            eq(Map.of("batchOperationId", batchOperationKey)));
   }
 
   protected abstract Record<R> createCompletedRecord(final long processInstanceKey);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromChunkItemHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromChunkItemHandlerTest.java
@@ -63,17 +63,17 @@ class ListViewFromChunkItemHandlerTest {
     final Record<BatchOperationChunkRecordValue> record = aChunkRecordWithMultipleItems(numItems);
     factory.generateRecordWithIntent(
         ValueType.BATCH_OPERATION_CHUNK, BatchOperationChunkIntent.CREATED);
-    final var itemPIKeys =
+    final var batchOpKey = record.getValue().getBatchOperationKey();
+    final var expectedIds =
         record.getValue().getItems().stream()
-            .map(BatchOperationItemValue::getProcessInstanceKey)
-            .map(String::valueOf)
+            .map(item -> item.getProcessInstanceKey() + ":" + batchOpKey)
             .toList();
     // when
     final var ids = underTest.generateIds(record);
 
     // then
     assertThat(ids).hasSize(numItems);
-    assertThat(ids).containsExactlyInAnyOrderElementsOf(itemPIKeys);
+    assertThat(ids).containsExactlyInAnyOrderElementsOf(expectedIds);
   }
 
   @Test
@@ -99,30 +99,29 @@ class ListViewFromChunkItemHandlerTest {
 
     // then
     assertThat(entity.getBatchOperationIds())
-        .containsExactly(String.valueOf(record.getBatchOperationReference()));
+        .containsExactly(String.valueOf(record.getValue().getBatchOperationKey()));
   }
 
   @Test
   void shouldFlushEntity() {
     // given
-    final Record<BatchOperationChunkRecordValue> record =
-        factory.generateRecordWithIntent(
-            ValueType.BATCH_OPERATION_CHUNK, BatchOperationChunkIntent.CREATED);
-    final var entity = underTest.createNewEntity("id");
-    final String batchOpKey = String.valueOf(record.getBatchOperationReference());
-    entity.setBatchOperationIds(List.of(batchOpKey));
+    final String batchOperationKey = "batch-op-1";
+    final String processInstanceKey = "42";
+    // entity uses composite cache ID (processInstanceKey:batchOperationKey)
+    final var entity = underTest.createNewEntity(processInstanceKey + ":" + batchOperationKey);
+    entity.setBatchOperationIds(List.of(batchOperationKey));
 
     // when
     final var batchRequest = mock(BatchRequest.class);
     underTest.flush(entity, batchRequest);
 
-    // then
+    // then - the ES document ID is just the processInstanceKey, extracted from the composite ID
     Mockito.verify(batchRequest)
         .updateWithScript(
             eq(underTest.getIndexName()),
-            eq(entity.getId()),
+            eq(processInstanceKey),
             anyString(),
-            eq(Map.of("batchOperationId", batchOpKey)));
+            eq(Map.of("batchOperationId", batchOperationKey)));
   }
 
   private Record<BatchOperationChunkRecordValue> aChunkRecordWithMultipleItems(final int numItems) {


### PR DESCRIPTION
## Description

Fixes multiple bugs caused by the `ExporterBatchWriter` sharing cached
entities between logically independent handlers. All stem from the same
root cause: the writer caches by `(entityId, entityType)`, so two
handlers that produce the same key silently share — and corrupt — each
other's state.

### Bug 1 — `operationsTotalCount` double-counting

`BatchOperationCreatedHandler` and `BatchOperationChunkCreatedHandler`
both used the bare `batchOperationKey` as their entity ID, sharing the
same `BatchOperationEntity`. This caused `operationsTotalCount` to be
counted once during `updateEntity` and then incremented again by the
Painless script at flush time.

### Bug 2 — list-view `batchOperationIds` silently dropped

When two batch operations target the same process instance and their
records land in the same export batch, both list-view handlers produced
the same cache key (`processInstanceKey`). The second record's
`setBatchOperationIds` overwrote the first, silently losing it.

### Fix

Introduce **composite cache IDs** in all affected handlers so each
logical unit gets its own cached entity, while the Elasticsearch
document ID remains unchanged (extracted at flush time):

| Handler | Cache ID | ES doc ID |
|---|---|---|
| `BatchOperationChunkCreatedHandler` | `batchOpKey:chunk` | `batchOpKey` |
| `ListViewBatchOperationHandler` | `piKey:batchOpKey` | `piKey` |

Additional changes:
- **Collapsed chunk entities** — all chunks for the same batch operation
  now accumulate into a single cached entity (`batchKey:chunk` static
  suffix) instead of one per chunk, avoiding exporter batch inflation
  for large operations.
- **Switched to `updateWithScript`** in the chunk handler — the
  `CREATED` event is always exported before any `CHUNK_CREATED` events
  on every partition, so the document is guaranteed to exist and
  `upsertWithScript` is unnecessary (and harmful with composite IDs).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #42478
