### PR TITLE
fix: preserve interrupt status during close

### DIFF
--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClientImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClientImpl.java
@@ -155,7 +155,11 @@ public final class BrokerClientImpl implements BrokerClient {
     try {
       r.run();
     } catch (final Exception e) {
-      LOG.error("Exception when closing client. Ignoring", e);
+      if (e instanceof InterruptedException) {
+        LOG.debug("Interrupted while closing client. Continuing shutdown", e);
+      } else {
+        LOG.error("Exception when closing client. Ignoring", e);
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- handle interruption during broker client shutdown as a dedicated shutdown case
- restore the thread interrupt flag when close throws (or wraps) InterruptedException
- avoid logging interruption during close as an error; keep other close exceptions unchanged
- add coverage in BrokerClientTest shouldPreserveInterruptStatusWhenCloseIsInterrupted

## Verification
- ./mvnw -pl zeebe/broker-client -DskipChecks clean test

Related to #17098