### PR TITLE
fix(cpt): Fix conditional behavior engine not executing action on instant probe await behavior

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestExtension.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestExtension.java
@@ -177,7 +177,7 @@ public class CamundaProcessTestExtension
             runtime,
             createdClients::add,
             camundaManagementClient,
-            CamundaAssert.getAwaitBehavior(),
+            CamundaAssert::getAwaitBehavior,
             jsonMapper,
             conditionalBehaviorEngine);
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
@@ -66,6 +66,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import org.camunda.bpm.model.dmn.Dmn;
 import org.camunda.bpm.model.dmn.DmnModelInstance;
 import org.camunda.bpm.model.dmn.instance.Decision;
@@ -113,14 +114,14 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
   private final CamundaManagementClient camundaManagementClient;
 
   private final JsonMapper jsonMapper;
-  private final CamundaAssertAwaitBehavior awaitBehavior;
+  private final Supplier<CamundaAssertAwaitBehavior> awaitBehaviorSupplier;
   private final ConditionalBehaviorEngine conditionalBehaviorEngine;
 
   public CamundaProcessTestContextImpl(
       final CamundaProcessTestRuntime camundaRuntime,
       final Consumer<AutoCloseable> clientCreationCallback,
       final CamundaManagementClient camundaManagementClient,
-      final CamundaAssertAwaitBehavior awaitBehavior,
+      final Supplier<CamundaAssertAwaitBehavior> awaitBehaviorSupplier,
       final JsonMapper jsonMapper,
       final ConditionalBehaviorEngine conditionalBehaviorEngine) {
 
@@ -130,7 +131,7 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
     connectorsRestApiAddress = camundaRuntime.getConnectorsRestApiAddress();
     this.clientCreationCallback = clientCreationCallback;
     this.camundaManagementClient = camundaManagementClient;
-    this.awaitBehavior = awaitBehavior;
+    this.awaitBehaviorSupplier = awaitBehaviorSupplier;
     this.jsonMapper = jsonMapper;
     this.conditionalBehaviorEngine = conditionalBehaviorEngine;
   }
@@ -196,7 +197,7 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
   public JobWorkerMockBuilder mockJobWorker(final String jobType) {
     final CamundaClient client = createClient();
     final BpmnExampleDataReader exampleDataReader =
-        new BpmnExampleDataReader(client, awaitBehavior);
+        new BpmnExampleDataReader(client, awaitBehaviorSupplier.get());
 
     return new JobWorkerMockBuilderImpl(jobType, client, exampleDataReader);
   }
@@ -306,7 +307,7 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
   public void completeJobWithExampleData(final JobSelector jobSelector) {
     final CamundaClient client = createClient();
     final BpmnExampleDataReader exampleDataReader =
-        new BpmnExampleDataReader(client, awaitBehavior);
+        new BpmnExampleDataReader(client, awaitBehaviorSupplier.get());
 
     // completing the job inside the await block to handle the eventual consistency of the API
     awaitJob(
@@ -450,7 +451,7 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
   public void completeUserTaskWithExampleData(final UserTaskSelector userTaskSelector) {
     final CamundaClient client = createClient();
     final BpmnExampleDataReader exampleDataReader =
-        new BpmnExampleDataReader(client, awaitBehavior);
+        new BpmnExampleDataReader(client, awaitBehaviorSupplier.get());
 
     // completing the user task inside the await block to handle the eventual consistency of the API
     awaitUserTask(
@@ -677,17 +678,19 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
       final CamundaClient client,
       final Consumer<UserTask> userTaskConsumer) {
 
-    awaitBehavior.untilAsserted(
-        () -> findUserTask(userTaskSelector, client),
-        userTask -> {
-          assertThat(userTask)
-              .withFailMessage(
-                  "Expected to complete user task [%s] but no user task is available.",
-                  userTaskSelector.describe())
-              .isPresent();
+    awaitBehaviorSupplier
+        .get()
+        .untilAsserted(
+            () -> findUserTask(userTaskSelector, client),
+            userTask -> {
+              assertThat(userTask)
+                  .withFailMessage(
+                      "Expected to complete user task [%s] but no user task is available.",
+                      userTaskSelector.describe())
+                  .isPresent();
 
-          userTask.ifPresent(userTaskConsumer);
-        });
+              userTask.ifPresent(userTaskConsumer);
+            });
   }
 
   private Optional<UserTask> findUserTask(
@@ -710,16 +713,19 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
   private void awaitJob(
       final JobSelector jobSelector, final CamundaClient client, final Consumer<Job> jobConsumer) {
 
-    awaitBehavior.untilAsserted(
-        () -> findJob(jobSelector, client),
-        job -> {
-          assertThat(job)
-              .withFailMessage(
-                  "Expected to complete job [%s] but no job is available.", jobSelector.describe())
-              .isPresent();
+    awaitBehaviorSupplier
+        .get()
+        .untilAsserted(
+            () -> findJob(jobSelector, client),
+            job -> {
+              assertThat(job)
+                  .withFailMessage(
+                      "Expected to complete job [%s] but no job is available.",
+                      jobSelector.describe())
+                  .isPresent();
 
-          job.ifPresent(jobConsumer);
-        });
+              job.ifPresent(jobConsumer);
+            });
   }
 
   private Optional<Job> findJob(final JobSelector jobSelector, final CamundaClient client) {
@@ -741,17 +747,19 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
       final CamundaClient client,
       final Consumer<Incident> incidentConsumer) {
 
-    awaitBehavior.untilAsserted(
-        () -> findIncident(incidentSelector, client),
-        incident -> {
-          assertThat(incident)
-              .withFailMessage(
-                  "Expected to resolve an incident [%s] but no incident was found.",
-                  incidentSelector.describe())
-              .isPresent();
+    awaitBehaviorSupplier
+        .get()
+        .untilAsserted(
+            () -> findIncident(incidentSelector, client),
+            incident -> {
+              assertThat(incident)
+                  .withFailMessage(
+                      "Expected to resolve an incident [%s] but no incident was found.",
+                      incidentSelector.describe())
+                  .isPresent();
 
-          incident.ifPresent(incidentConsumer);
-        });
+              incident.ifPresent(incidentConsumer);
+            });
   }
 
   private Optional<Incident> findIncident(
@@ -809,17 +817,19 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
       final CamundaClient client,
       final Consumer<ProcessInstance> processInstanceConsumer) {
 
-    awaitBehavior.untilAsserted(
-        () -> findProcessInstance(processInstanceSelector, client),
-        processInstance -> {
-          assertThat(processInstance)
-              .withFailMessage(
-                  "Expected to update variables for process instance [%s] but no process instance is available.",
-                  processInstanceSelector.describe())
-              .isPresent();
+    awaitBehaviorSupplier
+        .get()
+        .untilAsserted(
+            () -> findProcessInstance(processInstanceSelector, client),
+            processInstance -> {
+              assertThat(processInstance)
+                  .withFailMessage(
+                      "Expected to update variables for process instance [%s] but no process instance is available.",
+                      processInstanceSelector.describe())
+                  .isPresent();
 
-          processInstance.ifPresent(processInstanceConsumer);
-        });
+              processInstance.ifPresent(processInstanceConsumer);
+            });
   }
 
   private void awaitElementInstance(
@@ -828,16 +838,18 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
       final CamundaClient client,
       final Consumer<ElementInstance> elementInstanceConsumer) {
 
-    awaitBehavior.untilAsserted(
-        () -> findElementInstance(processInstanceKey, elementSelector, client),
-        elementInstance -> {
-          assertThat(elementInstance)
-              .withFailMessage(
-                  "Expected to update local variables for element [%s] in process instance [processInstanceKey: %s] but no element is available.",
-                  elementSelector.describe(), processInstanceKey)
-              .isPresent();
+    awaitBehaviorSupplier
+        .get()
+        .untilAsserted(
+            () -> findElementInstance(processInstanceKey, elementSelector, client),
+            elementInstance -> {
+              assertThat(elementInstance)
+                  .withFailMessage(
+                      "Expected to update local variables for element [%s] in process instance [processInstanceKey: %s] but no element is available.",
+                      elementSelector.describe(), processInstanceKey)
+                  .isPresent();
 
-          elementInstance.ifPresent(elementInstanceConsumer);
-        });
+              elementInstance.ifPresent(elementInstanceConsumer);
+            });
   }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/CamundaProcessTestContextAwaitBehaviorResolutionTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/CamundaProcessTestContextAwaitBehaviorResolutionTest.java
@@ -61,7 +61,6 @@ class CamundaProcessTestContextAwaitBehaviorResolutionTest {
   @Mock private Consumer<AutoCloseable> clientCreationCallback;
   @Mock private CamundaManagementClient camundaManagementClient;
   @Mock private JsonMapper jsonMapper;
-  @Mock private io.camunda.zeebe.client.api.JsonMapper zeebeJsonMapper;
 
   @Mock private CamundaClientBuilderFactory camundaClientBuilderFactory;
   @Mock private CamundaClientBuilder camundaClientBuilder;
@@ -94,7 +93,6 @@ class CamundaProcessTestContextAwaitBehaviorResolutionTest {
             camundaManagementClient,
             CamundaAssert::getAwaitBehavior,
             jsonMapper,
-            zeebeJsonMapper,
             engine);
 
     engine.start(
@@ -138,7 +136,7 @@ class CamundaProcessTestContextAwaitBehaviorResolutionTest {
     await().untilAsserted(() -> assertThat(trackingBehavior.wasUsed()).isTrue());
   }
 
-  private static class TrackingAwaitBehavior implements CamundaAssertAwaitBehavior {
+  private static final class TrackingAwaitBehavior implements CamundaAssertAwaitBehavior {
 
     private final AtomicBoolean used = new AtomicBoolean(false);
 

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/CamundaProcessTestContextAwaitBehaviorResolutionTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/CamundaProcessTestContextAwaitBehaviorResolutionTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.CamundaClientBuilder;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.search.response.Job;
+import io.camunda.client.api.search.response.UserTask;
+import io.camunda.process.test.impl.assertions.util.InstantProbeAwaitBehavior;
+import io.camunda.process.test.impl.client.CamundaManagementClient;
+import io.camunda.process.test.impl.extension.CamundaProcessTestContextImpl;
+import io.camunda.process.test.impl.extension.ConditionalBehaviorEngine;
+import io.camunda.process.test.impl.runtime.CamundaProcessTestRuntime;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import org.assertj.core.api.SoftAssertionsProvider.ThrowingRunnable;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Verifies that {@link CamundaProcessTestContextImpl} resolves the await behavior dynamically at
+ * execution time (via the supplier) rather than using a statically pre-evaluated behavior. This is
+ * critical for the conditional behavior engine, where the evaluation scope sets a thread-local
+ * override via {@link CamundaAssert#withAwaitBehaviorOverride}.
+ */
+@ExtendWith(MockitoExtension.class)
+class CamundaProcessTestContextAwaitBehaviorResolutionTest {
+
+  private static final long JOB_KEY = 100L;
+  private static final String JOB_TYPE = "test-job";
+  private static final long USER_TASK_KEY = 200L;
+  private static final String USER_TASK_ELEMENT_ID = "task1";
+
+  @Mock private CamundaProcessTestRuntime camundaProcessTestRuntime;
+  @Mock private Consumer<AutoCloseable> clientCreationCallback;
+  @Mock private CamundaManagementClient camundaManagementClient;
+  @Mock private JsonMapper jsonMapper;
+  @Mock private io.camunda.zeebe.client.api.JsonMapper zeebeJsonMapper;
+
+  @Mock private CamundaClientBuilderFactory camundaClientBuilderFactory;
+  @Mock private CamundaClientBuilder camundaClientBuilder;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private CamundaClient camundaClient;
+
+  @Mock private Job job;
+  @Mock private UserTask userTask;
+
+  private TrackingAwaitBehavior trackingBehavior;
+  private ConditionalBehaviorEngine engine;
+  private CamundaProcessTestContext context;
+
+  @BeforeEach
+  void setup() {
+    trackingBehavior = new TrackingAwaitBehavior();
+    engine = new ConditionalBehaviorEngine();
+
+    // given - mock client wiring
+    when(camundaProcessTestRuntime.getCamundaClientBuilderFactory())
+        .thenReturn(camundaClientBuilderFactory);
+    when(camundaClientBuilderFactory.get()).thenReturn(camundaClientBuilder);
+    when(camundaClientBuilder.build()).thenReturn(camundaClient);
+
+    context =
+        new CamundaProcessTestContextImpl(
+            camundaProcessTestRuntime,
+            clientCreationCallback,
+            camundaManagementClient,
+            CamundaAssert::getAwaitBehavior,
+            jsonMapper,
+            zeebeJsonMapper,
+            engine);
+
+    engine.start(
+        () -> {},
+        evaluation -> CamundaAssert.withAwaitBehaviorOverride(trackingBehavior, evaluation),
+        Duration.ofMillis(50));
+  }
+
+  @AfterEach
+  void tearDown() {
+    engine.stop();
+  }
+
+  @Test
+  void shouldUseOverriddenAwaitBehaviorWhenCompletingJobInsideConditionalEngine() {
+    // given
+    when(camundaClient.newJobSearchRequest().filter(any(Consumer.class)).send().join().items())
+        .thenReturn(Collections.singletonList(job));
+    when(job.getJobKey()).thenReturn(JOB_KEY);
+    when(job.getType()).thenReturn(JOB_TYPE);
+
+    // when - complete job inside conditional engine
+    engine.when(() -> {}).then(() -> context.completeJob(JOB_TYPE));
+
+    // then - the tracking behavior was used, proving the supplier resolved the override
+    await().untilAsserted(() -> assertThat(trackingBehavior.wasUsed()).isTrue());
+  }
+
+  @Test
+  void shouldUseOverriddenAwaitBehaviorWhenCompletingUserTaskInsideConditionalEngine() {
+    // given
+    when(camundaClient.newUserTaskSearchRequest().filter(any(Consumer.class)).send().join().items())
+        .thenReturn(Collections.singletonList(userTask));
+    when(userTask.getUserTaskKey()).thenReturn(USER_TASK_KEY);
+    when(userTask.getElementId()).thenReturn(USER_TASK_ELEMENT_ID);
+
+    // when - complete user task inside conditional engine
+    engine.when(() -> {}).then(() -> context.completeUserTask(USER_TASK_ELEMENT_ID));
+
+    // then - the tracking behavior was used, proving the supplier resolved the override
+    await().untilAsserted(() -> assertThat(trackingBehavior.wasUsed()).isTrue());
+  }
+
+  private static class TrackingAwaitBehavior implements CamundaAssertAwaitBehavior {
+
+    private final AtomicBoolean used = new AtomicBoolean(false);
+
+    private final CamundaAssertAwaitBehavior delegate = new InstantProbeAwaitBehavior();
+
+    boolean wasUsed() {
+      return used.get();
+    }
+
+    @Override
+    public void untilAsserted(final ThrowingRunnable assertion) throws AssertionError {
+      delegate.untilAsserted(assertion);
+      used.set(true);
+    }
+
+    @Override
+    public Duration getAssertionInterval() {
+      return Duration.ZERO;
+    }
+
+    @Override
+    public void setAssertionInterval(final Duration assertionInterval) {
+      // no-op
+    }
+
+    @Override
+    public Duration getAssertionTimeout() {
+      return Duration.ZERO;
+    }
+
+    @Override
+    public void setAssertionTimeout(final Duration assertionTimeout) {
+      // no-op
+    }
+
+    @Override
+    public CamundaAssertAwaitBehavior withAssertionTimeout(final Duration assertionTimeout) {
+      return this;
+    }
+  }
+}

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extension/ConditionalBehaviorEngineTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extension/ConditionalBehaviorEngineTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -154,6 +155,66 @@ class ConditionalBehaviorEngineTest {
             });
 
     await().untilAsserted(() -> assertThat(actionSawScope.get()).isTrue());
+  }
+
+  @Test
+  void shouldResolveThreadLocalSetByEvaluationScopeInCondition() {
+    // given - a ThreadLocal-based supplier, simulating CamundaAssert.getAwaitBehavior()
+    final ThreadLocal<String> scopeContext = new ThreadLocal<>();
+    final AtomicReference<String> conditionResolvedValue = new AtomicReference<>();
+
+    engine.start(
+        () -> {},
+        evaluation -> {
+          scopeContext.set("scoped");
+          try {
+            evaluation.run();
+          } finally {
+            scopeContext.remove();
+          }
+        },
+        Duration.ofMillis(50));
+
+    // when - the condition reads from the ThreadLocal
+    engine
+        .when(
+            () -> {
+              conditionResolvedValue.set(scopeContext.get());
+            })
+        .then(() -> {});
+
+    // then - the condition resolved the scoped value, not null
+    await().untilAsserted(() -> assertThat(conditionResolvedValue.get()).isEqualTo("scoped"));
+  }
+
+  @Test
+  void shouldResolveThreadLocalSetByEvaluationScopeInAction() {
+    // given - a ThreadLocal-based supplier, simulating CamundaAssert.getAwaitBehavior()
+    final ThreadLocal<String> scopeContext = new ThreadLocal<>();
+    final AtomicReference<String> actionResolvedValue = new AtomicReference<>();
+
+    engine.start(
+        () -> {},
+        evaluation -> {
+          scopeContext.set("scoped");
+          try {
+            evaluation.run();
+          } finally {
+            scopeContext.remove();
+          }
+        },
+        Duration.ofMillis(50));
+
+    // when - the action reads from the ThreadLocal (like awaitJob calling supplier.get())
+    engine
+        .when(() -> {})
+        .then(
+            () -> {
+              actionResolvedValue.set(scopeContext.get());
+            });
+
+    // then - the action resolved the scoped value, not null
+    await().untilAsserted(() -> assertThat(actionResolvedValue.get()).isEqualTo("scoped"));
   }
 
   // --- Core behavior ---

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extension/ConditionalBehaviorEngineTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extension/ConditionalBehaviorEngineTest.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -155,66 +154,6 @@ class ConditionalBehaviorEngineTest {
             });
 
     await().untilAsserted(() -> assertThat(actionSawScope.get()).isTrue());
-  }
-
-  @Test
-  void shouldResolveThreadLocalSetByEvaluationScopeInCondition() {
-    // given - a ThreadLocal-based supplier, simulating CamundaAssert.getAwaitBehavior()
-    final ThreadLocal<String> scopeContext = new ThreadLocal<>();
-    final AtomicReference<String> conditionResolvedValue = new AtomicReference<>();
-
-    engine.start(
-        () -> {},
-        evaluation -> {
-          scopeContext.set("scoped");
-          try {
-            evaluation.run();
-          } finally {
-            scopeContext.remove();
-          }
-        },
-        Duration.ofMillis(50));
-
-    // when - the condition reads from the ThreadLocal
-    engine
-        .when(
-            () -> {
-              conditionResolvedValue.set(scopeContext.get());
-            })
-        .then(() -> {});
-
-    // then - the condition resolved the scoped value, not null
-    await().untilAsserted(() -> assertThat(conditionResolvedValue.get()).isEqualTo("scoped"));
-  }
-
-  @Test
-  void shouldResolveThreadLocalSetByEvaluationScopeInAction() {
-    // given - a ThreadLocal-based supplier, simulating CamundaAssert.getAwaitBehavior()
-    final ThreadLocal<String> scopeContext = new ThreadLocal<>();
-    final AtomicReference<String> actionResolvedValue = new AtomicReference<>();
-
-    engine.start(
-        () -> {},
-        evaluation -> {
-          scopeContext.set("scoped");
-          try {
-            evaluation.run();
-          } finally {
-            scopeContext.remove();
-          }
-        },
-        Duration.ofMillis(50));
-
-    // when - the action reads from the ThreadLocal (like awaitJob calling supplier.get())
-    engine
-        .when(() -> {})
-        .then(
-            () -> {
-              actionResolvedValue.set(scopeContext.get());
-            });
-
-    // then - the action resolved the scoped value, not null
-    await().untilAsserted(() -> assertThat(actionResolvedValue.get()).isEqualTo("scoped"));
   }
 
   // --- Core behavior ---

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CompleteJobTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CompleteJobTest.java
@@ -113,7 +113,7 @@ public class CompleteJobTest {
               camundaProcessTestRuntime,
               clientCreationCallback,
               camundaManagementClient,
-              DevAwaitBehavior.expectSuccess(),
+              DevAwaitBehavior::expectSuccess,
               jsonMapper,
               new ConditionalBehaviorEngine());
 
@@ -246,7 +246,7 @@ public class CompleteJobTest {
               camundaProcessTestRuntime,
               clientCreationCallback,
               camundaManagementClient,
-              DevAwaitBehavior.expectFailure(),
+              DevAwaitBehavior::expectFailure,
               jsonMapper,
               new ConditionalBehaviorEngine());
     }
@@ -333,7 +333,7 @@ public class CompleteJobTest {
               camundaProcessTestRuntime,
               clientCreationCallback,
               camundaManagementClient,
-              DevAwaitBehavior.expectSuccess(),
+              DevAwaitBehavior::expectSuccess,
               jsonMapper,
               new ConditionalBehaviorEngine());
 
@@ -481,7 +481,7 @@ public class CompleteJobTest {
               camundaProcessTestRuntime,
               clientCreationCallback,
               camundaManagementClient,
-              DevAwaitBehavior.expectSuccess(),
+              DevAwaitBehavior::expectSuccess,
               jsonMapper,
               new ConditionalBehaviorEngine());
 

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CompleteUserTaskTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CompleteUserTaskTest.java
@@ -94,7 +94,7 @@ public class CompleteUserTaskTest {
               camundaProcessTestRuntime,
               clientCreationCallback,
               camundaManagementClient,
-              DevAwaitBehavior.expectSuccess(),
+              DevAwaitBehavior::expectSuccess,
               jsonMapper,
               new ConditionalBehaviorEngine());
 
@@ -214,7 +214,7 @@ public class CompleteUserTaskTest {
               camundaProcessTestRuntime,
               clientCreationCallback,
               camundaManagementClient,
-              DevAwaitBehavior.expectFailure(),
+              DevAwaitBehavior::expectFailure,
               jsonMapper,
               new ConditionalBehaviorEngine());
     }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/ResolveIncidentTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/ResolveIncidentTest.java
@@ -98,7 +98,7 @@ public class ResolveIncidentTest {
               camundaProcessTestRuntime,
               clientCreationCallback,
               camundaManagementClient,
-              DevAwaitBehavior.expectSuccess(),
+              DevAwaitBehavior::expectSuccess,
               jsonMapper,
               new ConditionalBehaviorEngine());
 
@@ -273,7 +273,7 @@ public class ResolveIncidentTest {
               camundaProcessTestRuntime,
               clientCreationCallback,
               camundaManagementClient,
-              DevAwaitBehavior.expectFailure(),
+              DevAwaitBehavior::expectFailure,
               jsonMapper,
               new ConditionalBehaviorEngine());
     }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/ThrowBpmnErrorTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/ThrowBpmnErrorTest.java
@@ -108,7 +108,7 @@ public class ThrowBpmnErrorTest {
               camundaProcessTestRuntime,
               clientCreationCallback,
               camundaManagementClient,
-              DevAwaitBehavior.expectSuccess(),
+              DevAwaitBehavior::expectSuccess,
               jsonMapper,
               new ConditionalBehaviorEngine());
 
@@ -267,7 +267,7 @@ public class ThrowBpmnErrorTest {
               camundaProcessTestRuntime,
               clientCreationCallback,
               camundaManagementClient,
-              DevAwaitBehavior.expectFailure(),
+              DevAwaitBehavior::expectFailure,
               jsonMapper,
               new ConditionalBehaviorEngine());
     }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/UpdateVariablesTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/UpdateVariablesTest.java
@@ -102,7 +102,7 @@ public class UpdateVariablesTest {
               camundaProcessTestRuntime,
               clientCreationCallback,
               camundaManagementClient,
-              DevAwaitBehavior.expectSuccess(),
+              DevAwaitBehavior::expectSuccess,
               jsonMapper,
               new ConditionalBehaviorEngine());
 
@@ -273,7 +273,7 @@ public class UpdateVariablesTest {
               camundaProcessTestRuntime,
               clientCreationCallback,
               camundaManagementClient,
-              DevAwaitBehavior.expectFailure(),
+              DevAwaitBehavior::expectFailure,
               jsonMapper,
               new ConditionalBehaviorEngine());
     }

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/api/CamundaProcessTestExecutionListener.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/api/CamundaProcessTestExecutionListener.java
@@ -135,7 +135,7 @@ public class CamundaProcessTestExecutionListener implements TestExecutionListene
             runtime,
             createdClients::add,
             camundaManagementClient,
-            CamundaAssert.getAwaitBehavior(),
+            CamundaAssert::getAwaitBehavior,
             jsonMapper,
             conditionalBehaviorEngine);
 


### PR DESCRIPTION
## Description

Fixes an issue where the `ConditionalBehaviorEngine` is hanging until the global assertion timeout is exceeded. This is due to actions triggered on the `CamundaProcessTestContext` still relying on the `AwaitilityAwaitBehavior` instead of instant probing. 

The fix provides the `awaitBehavior` using a supplier instead of a pre-evaluated behavior, which retrieves the currently applicable await behavior per execution.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates to #46126 
