### PR TITLE
fix: update auto-merge actor and backport PR description for GitHub App

### DIFF
--- a/.ci/scripts/stale-backport-scripts/collect-stale-backports.sh
+++ b/.ci/scripts/stale-backport-scripts/collect-stale-backports.sh
@@ -69,8 +69,13 @@ for repo in "${REPO_LIST[@]}"; do
     branch_args+=(--search "base:stable/")
   fi
 
-  # Fetch backport PRs created by backport-action targeting stable branches
-  gh pr list "${common_args[@]}" "${branch_args[@]}" --author backport-action > "$TMPDIR_WORK/backport_prs.json"
+  # Fetch backport PRs targeting stable branches.
+  # Backport PRs may be authored by either:
+  #   - backport-action (via BACKPORT_ACTION_PAT on older stable branches)
+  #   - monorepo-devops-automation[bot] (via GitHub App token on main / newer branches)
+  gh pr list "${common_args[@]}" "${branch_args[@]}" --author backport-action > "$TMPDIR_WORK/backport_prs_pat.json"
+  gh pr list "${common_args[@]}" "${branch_args[@]}" --author 'monorepo-devops-automation[bot]' > "$TMPDIR_WORK/backport_prs_app.json"
+  jq -s 'add' "$TMPDIR_WORK/backport_prs_pat.json" "$TMPDIR_WORK/backport_prs_app.json" > "$TMPDIR_WORK/backport_prs.json"
 
   pr_count=$(jq 'length' "$TMPDIR_WORK/backport_prs.json")
   echo "  📋 Found $pr_count open backport PR(s) on stable/* branches" >&2

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -58,11 +58,17 @@ jobs:
           # Placeholders can be used to define variable values.
           # These are indicated by a dollar sign and curly braces (`${placeholder}`).
           # Please refer to this action's README for all available placeholders.
+          #
+          # WARNING: The stale backport tracker parses "Backport of #NNNN" from this description
+          # to link backport PRs to their parent. Changing this format will break tracking.
+          # See: .ci/scripts/stale-backport-scripts/collect-stale-backports.sh (line ~87)
           pull_description: |-
-            # Description
-            Backport of #${pull_number} to `${target_branch}`.
+            ⤵️ Backport of #${pull_number} → `${target_branch}`
 
             relates to ${issue_refs}
+
+            ---
+            <sub><img src="https://avatars.githubusercontent.com/u/97796249?s=16" width="16" height="16" align="absmiddle"> Created by <a href="https://github.com/korthout/backport-action">backport-action</a></sub>
 
           add_author_as_assignee: true
           add_author_as_reviewer: true

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -59,9 +59,11 @@ jobs:
           # These are indicated by a dollar sign and curly braces (`${placeholder}`).
           # Please refer to this action's README for all available placeholders.
           #
-          # WARNING: The stale backport tracker parses "Backport of #NNNN" from this description
-          # to link backport PRs to their parent. Changing this format will break tracking.
-          # See: .ci/scripts/stale-backport-scripts/collect-stale-backports.sh (line ~87)
+          # WARNING: The stale backport tracker depends on two things:
+          #   1. PR author being "backport-action" or "monorepo-devops-automation[bot]"
+          #   2. Body containing "Backport of #NNNN" (parsed to link to parent PR)
+          # Changing either will break tracking.
+          # See: .ci/scripts/stale-backport-scripts/collect-stale-backports.sh
           pull_description: |-
             ⤵️ Backport of #${pull_number} → `${target_branch}`
 

--- a/.github/workflows/ci-zeebe.yml
+++ b/.github/workflows/ci-zeebe.yml
@@ -516,11 +516,11 @@ jobs:
       build: true
     secrets: inherit
   auto-merge:
-    # This workflow will auto merge a PR authored by backport-action.
+    # This workflow will auto merge backport PRs created by the Monorepo DevOps
+    # Automation GitHub App (via korthout/backport-action).
     # It runs only on open PRs ready for review.
     #
-    # It will merge the PR only if it is authored by backport-action and all CI checks are successful
-    # OR if it is authored by renovate[bot] and all CI checks are successful.
+    # It will approve and auto-merge the PR only if all CI checks are successful.
     #
     # The workflow is divided into multiple sequential jobs to allow giving only minimal permissions to
     # the GitHub token passed around.
@@ -531,7 +531,7 @@ jobs:
     if: |
       github.repository == 'camunda/camunda' &&
       github.event_name == 'pull_request' &&
-      (github.actor == 'backport-action')
+      github.actor == 'monorepo-devops-automation[bot]'
     permissions:
       checks: read
       pull-requests: write


### PR DESCRIPTION
## Description

Backport PRs  are now created by the **Monorepo DevOps Automation** GitHub App
(`monorepo-devops-automation[bot]`) instead of the `backport-action` PAT user. This broke
the auto-merge job in `ci-zeebe.yml`, which only checked for `github.actor == 'backport-action'`.

### Changes

**`ci-zeebe.yml`** — Fix auto-merge actor condition:
- Change actor check from `backport-action` to `monorepo-devops-automation[bot]`
- Update comments to reflect the GitHub App is the creator of backport PRs
- Remove stale reference to `renovate[bot]` in the comment

**`backport.yml`** — Improve backport PR description template:
- Replace `# Description` heading with compact `⤵️ Backport of #NNN → \`target\`` format
- Add attribution footer with backport-action avatar and link
- Add `WARNING` comment about stale backport tracker dependency on `"Backport of #NNNN"` format
  (parsed by `collect-stale-backports.sh`)