### PR TITLE
Avoid inconsistency exception when pinning listener

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -598,6 +598,7 @@ public final class EventAppliers implements EventApplier {
     register(UserTaskIntent.CANCELING, 1, new UserTaskCancelingV1Applier(state));
     register(UserTaskIntent.CANCELING, 2, new UserTaskCancelingV2Applier(state));
     register(UserTaskIntent.CANCELING, 3, new UserTaskCancelingV3Applier(state));
+    register(UserTaskIntent.CANCELING, 4, new UserTaskCancelingV4Applier(state));
     register(UserTaskIntent.CANCELED, new UserTaskCanceledApplier(state));
     register(UserTaskIntent.CANCELED, 2, new UserTaskCanceledV2Applier(state));
     register(UserTaskIntent.COMPLETING, 1, new UserTaskCompletingV1Applier(state));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCancelingV4Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCancelingV4Applier.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.globallistener.MutableGlobalListenersState;
+import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
+import io.camunda.zeebe.engine.state.mutable.MutableVariableState;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+
+public final class UserTaskCancelingV4Applier
+    implements TypedEventApplier<UserTaskIntent, UserTaskRecord> {
+
+  private final MutableUserTaskState userTaskState;
+  private final MutableVariableState variableState;
+  private final MutableElementInstanceState elementInstanceState;
+  private final MutableGlobalListenersState globalListenersState;
+
+  public UserTaskCancelingV4Applier(final MutableProcessingState processingState) {
+    userTaskState = processingState.getUserTaskState();
+    variableState = processingState.getVariableState();
+    elementInstanceState = processingState.getElementInstanceState();
+    globalListenersState = processingState.getGlobalListenersState();
+  }
+
+  @Override
+  public void applyState(final long key, final UserTaskRecord value) {
+    userTaskState.updateUserTaskLifecycleState(key, LifecycleState.CANCELING);
+
+    // Clean up data that may have been persisted by a previous transition
+    variableState.removeVariableDocumentState(value.getElementInstanceKey());
+    userTaskState.deleteIntermediateStateIfExists(key);
+    resetTaskListenerIndices(value);
+
+    pinGlobalListenersConfig(value);
+
+    // Persist new data related to "canceling" user task transition
+    userTaskState.storeIntermediateState(value, LifecycleState.CANCELING);
+    userTaskState.deleteInitialAssignee(key);
+  }
+
+  private void resetTaskListenerIndices(final UserTaskRecord record) {
+    final long userTaskInstanceKey = record.getElementInstanceKey();
+    final var userTaskInstance = elementInstanceState.getInstance(userTaskInstanceKey);
+
+    if (userTaskInstance != null) {
+      userTaskInstance.resetTaskListenerIndices();
+      elementInstanceState.updateInstance(userTaskInstance);
+    }
+  }
+
+  public void pinGlobalListenersConfig(final UserTaskRecord userTaskRecord) {
+    // Only pin the configuration if it exists
+    final var currentConfig = globalListenersState.getCurrentConfig();
+    if (currentConfig == null) {
+      return;
+    }
+
+    final long currentConfigKey = currentConfig.getGlobalListenerBatchKey();
+
+    // Create versioned config if it does not exist
+    if (!globalListenersState.isConfigurationVersionStored(currentConfigKey)) {
+      globalListenersState.storeConfigurationVersion(currentConfig);
+    }
+
+    // Create pinned entry
+    globalListenersState.pinConfiguration(currentConfigKey, userTaskRecord.getUserTaskKey());
+
+    // Update user task record to reference the pinned config
+    // Note: this value is then stored in the intermediate state
+    userTaskRecord.setListenersConfigKey(currentConfigKey);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCancelingV4Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCancelingV4Applier.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.state.appliers;
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.globallistener.MutableGlobalListenersState;
 import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
+import io.camunda.zeebe.engine.state.instance.UserTaskIntermediateStateValue;
 import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
@@ -35,6 +36,17 @@ public final class UserTaskCancelingV4Applier
   @Override
   public void applyState(final long key, final UserTaskRecord value) {
     userTaskState.updateUserTaskLifecycleState(key, LifecycleState.CANCELING);
+
+    // It is possible that the user task is canceled while another lifecycle event was still being
+    // processed (i.e. in between an -ing and -ed event).
+    // This can cause a global listener configuration to already be pinned by the user task. The old
+    // pin should be removed (unless it is pinning the same configuration which would be pinned by
+    // this event).
+    final UserTaskIntermediateStateValue intermediateState =
+        userTaskState.getIntermediateState(value.getUserTaskKey());
+    if (intermediateState != null) {
+      unpinGlobalListenersConfig(intermediateState.getRecord());
+    }
 
     // Clean up data that may have been persisted by a previous transition
     variableState.removeVariableDocumentState(value.getElementInstanceKey());
@@ -78,5 +90,21 @@ public final class UserTaskCancelingV4Applier
     // Update user task record to reference the pinned config
     // Note: this value is then stored in the intermediate state
     userTaskRecord.setListenersConfigKey(currentConfigKey);
+  }
+
+  public void unpinGlobalListenersConfig(final UserTaskRecord userTaskRecord) {
+    final long pinnedConfigKey = userTaskRecord.getListenersConfigKey();
+    // Only unpin if there is a pinned config
+    if (pinnedConfigKey < 0) {
+      return;
+    }
+
+    // Remove pinned entry
+    globalListenersState.unpinConfiguration(pinnedConfigKey, userTaskRecord.getUserTaskKey());
+
+    // If no other user task references this config, remove the versioned config
+    if (!globalListenersState.isConfigurationVersionPinned(pinnedConfigKey)) {
+      globalListenersState.deleteConfigurationVersion(pinnedConfigKey);
+    }
   }
 }

--- a/zeebe/engine/src/test/resources/state/appliers/golden/UserTask_CANCELING_v4.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/UserTask_CANCELING_v4.golden
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.globallistener.MutableGlobalListenersState;
+import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
+import io.camunda.zeebe.engine.state.mutable.MutableVariableState;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+
+public final class UserTaskCancelingV4Applier
+    implements TypedEventApplier<UserTaskIntent, UserTaskRecord> {
+
+  private final MutableUserTaskState userTaskState;
+  private final MutableVariableState variableState;
+  private final MutableElementInstanceState elementInstanceState;
+  private final MutableGlobalListenersState globalListenersState;
+
+  public UserTaskCancelingV4Applier(final MutableProcessingState processingState) {
+    userTaskState = processingState.getUserTaskState();
+    variableState = processingState.getVariableState();
+    elementInstanceState = processingState.getElementInstanceState();
+    globalListenersState = processingState.getGlobalListenersState();
+  }
+
+  @Override
+  public void applyState(final long key, final UserTaskRecord value) {
+    userTaskState.updateUserTaskLifecycleState(key, LifecycleState.CANCELING);
+
+    // Clean up data that may have been persisted by a previous transition
+    variableState.removeVariableDocumentState(value.getElementInstanceKey());
+    userTaskState.deleteIntermediateStateIfExists(key);
+    resetTaskListenerIndices(value);
+
+    pinGlobalListenersConfig(value);
+
+    // Persist new data related to "canceling" user task transition
+    userTaskState.storeIntermediateState(value, LifecycleState.CANCELING);
+    userTaskState.deleteInitialAssignee(key);
+  }
+
+  private void resetTaskListenerIndices(final UserTaskRecord record) {
+    final long userTaskInstanceKey = record.getElementInstanceKey();
+    final var userTaskInstance = elementInstanceState.getInstance(userTaskInstanceKey);
+
+    if (userTaskInstance != null) {
+      userTaskInstance.resetTaskListenerIndices();
+      elementInstanceState.updateInstance(userTaskInstance);
+    }
+  }
+
+  public void pinGlobalListenersConfig(final UserTaskRecord userTaskRecord) {
+    // Only pin the configuration if it exists
+    final var currentConfig = globalListenersState.getCurrentConfig();
+    if (currentConfig == null) {
+      return;
+    }
+
+    final long currentConfigKey = currentConfig.getGlobalListenerBatchKey();
+
+    // Create versioned config if it does not exist
+    if (!globalListenersState.isConfigurationVersionStored(currentConfigKey)) {
+      globalListenersState.storeConfigurationVersion(currentConfig);
+    }
+
+    // Create pinned entry
+    globalListenersState.pinConfiguration(currentConfigKey, userTaskRecord.getUserTaskKey());
+
+    // Update user task record to reference the pinned config
+    // Note: this value is then stored in the intermediate state
+    userTaskRecord.setListenersConfigKey(currentConfigKey);
+  }
+}

--- a/zeebe/engine/src/test/resources/state/appliers/golden/UserTask_CANCELING_v4.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/UserTask_CANCELING_v4.golden
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.state.appliers;
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.globallistener.MutableGlobalListenersState;
 import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
+import io.camunda.zeebe.engine.state.instance.UserTaskIntermediateStateValue;
 import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
@@ -35,6 +36,17 @@ public final class UserTaskCancelingV4Applier
   @Override
   public void applyState(final long key, final UserTaskRecord value) {
     userTaskState.updateUserTaskLifecycleState(key, LifecycleState.CANCELING);
+
+    // It is possible that the user task is canceled while another lifecycle event was still being
+    // processed (i.e. in between an -ing and -ed event).
+    // This can cause a global listener configuration to already be pinned by the user task. The old
+    // pin should be removed (unless it is pinning the same configuration which would be pinned by
+    // this event).
+    final UserTaskIntermediateStateValue intermediateState =
+        userTaskState.getIntermediateState(value.getUserTaskKey());
+    if (intermediateState != null) {
+      unpinGlobalListenersConfig(intermediateState.getRecord());
+    }
 
     // Clean up data that may have been persisted by a previous transition
     variableState.removeVariableDocumentState(value.getElementInstanceKey());
@@ -78,5 +90,21 @@ public final class UserTaskCancelingV4Applier
     // Update user task record to reference the pinned config
     // Note: this value is then stored in the intermediate state
     userTaskRecord.setListenersConfigKey(currentConfigKey);
+  }
+
+  public void unpinGlobalListenersConfig(final UserTaskRecord userTaskRecord) {
+    final long pinnedConfigKey = userTaskRecord.getListenersConfigKey();
+    // Only unpin if there is a pinned config
+    if (pinnedConfigKey < 0) {
+      return;
+    }
+
+    // Remove pinned entry
+    globalListenersState.unpinConfiguration(pinnedConfigKey, userTaskRecord.getUserTaskKey());
+
+    // If no other user task references this config, remove the versioned config
+    if (!globalListenersState.isConfigurationVersionPinned(pinnedConfigKey)) {
+      globalListenersState.deleteConfigurationVersion(pinnedConfigKey);
+    }
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/GlobalUserTaskListenersTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/GlobalUserTaskListenersTest.java
@@ -542,9 +542,14 @@ public class GlobalUserTaskListenersTest {
     // Cancel the process (with the task)
     camundaClient.newCancelInstanceCommand(processInstanceKey).send();
 
-    // then: the task is correctly canceled
+    // then: the "creating" job and the task are correctly canceled
     RecordingExporter.userTaskRecords(UserTaskIntent.CANCELED)
         .withProcessInstanceKey(processInstanceKey)
+        .await();
+    RecordingExporter.jobRecords(JobIntent.CANCELED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withJobListenerEventType(JobListenerEventType.CREATING)
+        .withType("global")
         .await();
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/GlobalUserTaskListenersTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/GlobalUserTaskListenersTest.java
@@ -510,6 +510,44 @@ public class GlobalUserTaskListenersTest {
         .containsExactly("15_api", "20_configuration", "30_api", "40_configuration");
   }
 
+  @Test
+  public void shouldAllowCancellingUserTaskWhileWaitingForListener() {
+    // given: global listener configuration and a process with a task
+    // a listener is configured for the "creating" event but no associated worker is present
+    configureGlobalListeners(List.of(createListenerConfig("global", List.of("creating"), false)));
+    restartBroker();
+
+    // deploy process definition
+    final BpmnModelInstance processDefinition =
+        Bpmn.createExecutableProcess("processWithUserTask")
+            .startEvent("start")
+            .userTask("task")
+            .zeebeUserTask()
+            .endEvent("end")
+            .done();
+    final long processDefinitionKey = resourcesHelper.deployProcess(processDefinition);
+
+    // create process instance
+    final var processInstanceKey = resourcesHelper.createProcessInstance(processDefinitionKey);
+
+    // when: the process is canceled while waiting for the listener
+
+    // Wait for the listener job to be created
+    // Note that the listener will never complete because no related job worker has been registered.
+    RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType("global")
+        .await();
+
+    // Cancel the process (with the task)
+    camundaClient.newCancelInstanceCommand(processInstanceKey).send();
+
+    // then: the task is correctly canceled
+    RecordingExporter.userTaskRecords(UserTaskIntent.CANCELED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+  }
+
   private void setupAutocompleteWorker(final String jobType) {
     camundaClient
         .newWorker()


### PR DESCRIPTION
## Description
User task lifecycle events are generally process in pairs of -ing/-ed events (e.g. creating/created, assigning/assigned, ...) with no other events in-between.
The global listener configuration pinning logic was based on this and assumed that the configuration was pinned and unpinned while processing an event, ensuring a clean state when a new event was processed.

The "CANCELING" event is an exception though: this event is triggered when a process is canceled and it can disrupt the normal lifecycle of the user task, causing the "CANCELING" event to be processed while another lifecycle event has not been completed yet (and never will since the task is being canceled).
With the previous implementation of the pinning logic, this could cause a ZeebeDbInconsistentException due to the fact that the same config key/user task key pair can be added twice to the GLOBAL_LISTENER_CONFIG column family (once for the previous lifecycle event and a second time for the canceling event, without it being removed for the first event).

The new implementation takes into account the fact that a pinned configuration could already be present when the CANCELING event is triggered, ensuring that:
- no new pinning is performed if the correct configuration is already
pinned
- the previous configuration is unpinned before pinning the correct one
if they differ

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #50518
