### PR TITLE
fix: use run ID and attempt in image tag for main push

### DIFF
--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Docker image version tag (defaults to pr-<sha> or Maven version)'
+        description: 'Docker image version tag (defaults to ...-pr<PR_NUMBER>-run<run_id>-a<attempt> for PRs, ...-dispatch-run<run_id>-a<attempt> for manual dispatch, or ...-main-run<run_id>-a<attempt> for push to main)'
         type: string
         required: false
       helmRepositoryBranchName:
@@ -206,10 +206,12 @@ jobs:
           elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
             # For PRs: <maven-version>-pr<PR_NUMBER>-run<run_id>-a<run_attempt>
             echo "tag=${MAVEN_VERSION}-pr${{ github.event.pull_request.number }}-run${{ github.run_id }}-a${{ github.run_attempt }}" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            # For manual dispatch: <maven-version>-dispatch-run<run_id>-a<run_attempt> (e.g., 8.10.0-SNAPSHOT-dispatch-run12345678-a1)
+            echo "tag=${MAVEN_VERSION}-dispatch-run${{ github.run_id }}-a${{ github.run_attempt }}" >> "$GITHUB_OUTPUT"
           else
-            # For manual dispatch: <maven-version>-<short-sha> (e.g., 8.9.0-SNAPSHOT-abc1234)
-            SHA_SHORT="${GITHUB_SHA::7}"
-            echo "tag=${MAVEN_VERSION}-${SHA_SHORT}" >> "$GITHUB_OUTPUT"
+            # For push to main: <maven-version>-main-run<run_id>-a<run_attempt> (e.g., 8.10.0-SNAPSHOT-main-run12345678-a1)
+            echo "tag=${MAVEN_VERSION}-main-run${{ github.run_id }}-a${{ github.run_attempt }}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Download Operate frontend artifact


### PR DESCRIPTION
## Description
Changes the Docker image tag format for \`push\` to \`main\` and \`workflow_dispatch\` to be traceable to a specific workflow run.

| Trigger | Before | After |
|---|---|---|
| `push` to `main` | `8.10.0-SNAPSHOT-abc1234` | `8.10.0-SNAPSHOT-main-run12345678-a1` |
| `workflow_dispatch` | `8.10.0-SNAPSHOT-abc1234` | `8.10.0-SNAPSHOT-dispatch-run12345678-a1` |
| `pull_request` | `8.10.0-SNAPSHOT-pr42-run12345678-a1` | _(unchanged)_ |

The new format directly links an image to its workflow run ID and attempt, consistent with the PR tag pattern. `workflow_dispatch` uses a `dispatch-` prefix (instead of `main-`) to avoid mislabeling images built from non-main refs.

## Related Discussions
[slack thread](https://camunda.slack.com/archives/C5AHF1D8T/p1775629889566499)
<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
