### PR TITLE
ci: migrate SNYK_TOKEN from repository secret to Vault

### DIFF
--- a/.github/workflows/ci-operate.yml
+++ b/.github/workflows/ci-operate.yml
@@ -273,10 +273,20 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Print metadata
         uses: ./.github/actions/print-metadata
+      - name: Import Snyk token from Vault
+        id: snyk-secrets
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/camunda/ci/snyk zeebe-api-token | SNYK_TOKEN;
       - name: Generate and scan frontend SBOM
         uses: ./.github/actions/frontend-sbom-snyk
         env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          SNYK_TOKEN: ${{ steps.snyk-secrets.outputs.SNYK_TOKEN }}
         with:
           directory: operate/client
           sbom-file: operate/client/build/cyclonedx/bom.json

--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -137,10 +137,20 @@ jobs:
       - uses: camunda/infra-global-github-actions/setup-yarn-cache@main
         with:
           directory: optimize/client
+      - name: Import Snyk token from Vault
+        id: snyk-secrets
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/camunda/ci/snyk zeebe-api-token | SNYK_TOKEN;
       - name: Generate and scan frontend SBOM
         uses: ./.github/actions/frontend-sbom-snyk
         env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          SNYK_TOKEN: ${{ steps.snyk-secrets.outputs.SNYK_TOKEN }}
         with:
           directory: optimize/client
           package-manager: yarn

--- a/.github/workflows/ci-tasklist.yml
+++ b/.github/workflows/ci-tasklist.yml
@@ -212,10 +212,20 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Print metadata
         uses: ./.github/actions/print-metadata
+      - name: Import Snyk token from Vault
+        id: snyk-secrets
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/camunda/ci/snyk zeebe-api-token | SNYK_TOKEN;
       - name: Generate and scan frontend SBOM
         uses: ./.github/actions/frontend-sbom-snyk
         env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          SNYK_TOKEN: ${{ steps.snyk-secrets.outputs.SNYK_TOKEN }}
         with:
           directory: tasklist/client
           sbom-file: tasklist/client/build/cyclonedx/bom.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1452,9 +1452,19 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Print metadata
         uses: ./.github/actions/print-metadata
+      - name: Import Snyk token from Vault
+        id: snyk-secrets
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/camunda/ci/snyk zeebe-api-token | SNYK_TOKEN;
       - uses: ./.github/actions/frontend-sbom-snyk
         env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          SNYK_TOKEN: ${{ steps.snyk-secrets.outputs.SNYK_TOKEN }}
         with:
           directory: identity/client
           sbom-file: identity/client/dist/cyclonedx/bom.json

--- a/.github/workflows/zeebe-snyk.yml
+++ b/.github/workflows/zeebe-snyk.yml
@@ -108,7 +108,7 @@ jobs:
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           secrets: |
-            secret/data/products/camunda/ci/github-actions SNYK_TOKEN;
+            secret/data/products/camunda/ci/snyk zeebe-api-token | SNYK_TOKEN;
       # We need to build the Docker image (and thus the distribution) to scan it
       - name: Build Zeebe Distribution
         uses: ./.github/actions/build-zeebe

--- a/.github/workflows/zeebe-snyk.yml
+++ b/.github/workflows/zeebe-snyk.yml
@@ -38,9 +38,6 @@ on:
         required: false
         type: string
   workflow_call:
-    secrets:
-      SNYK_TOKEN:
-        required: true
     inputs:
       version:
         description: The project version; defaults to the version as defined by the root POM
@@ -102,6 +99,16 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: true
+      - name: Import Snyk token from Vault
+        id: snyk-secrets
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SNYK_TOKEN;
       # We need to build the Docker image (and thus the distribution) to scan it
       - name: Build Zeebe Distribution
         uses: ./.github/actions/build-zeebe
@@ -176,7 +183,7 @@ jobs:
           } >> "$GITHUB_ENV"
       - name: Run Snyk
         env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          SNYK_TOKEN: ${{ steps.snyk-secrets.outputs.SNYK_TOKEN }}
         # The script is set up to scan all distributable artifacts: the projects listed in the bom,
         # the Go client, and the official Docker image.
         # If we add things to the BOM, for example, we should also add them here to the


### PR DESCRIPTION
## Description

Migrates all `SNYK_TOKEN` usages from the GitHub repository secret to HashiCorp Vault (`secret/data/products/camunda/ci/snyk`).

Related to #50243

### Changes

**`zeebe-snyk.yml`**
- Removed the `workflow_call.secrets.SNYK_TOKEN` declaration — no longer needed since the token is now fetched directly from Vault.
- Added a Vault import step (`Import Snyk token from Vault`) that retrieves `SNYK_TOKEN` from Vault using `hashicorp/vault-action` (pinned SHA).
- Changed the `Run Snyk` step to use `${{ steps.snyk-secrets.outputs.SNYK_TOKEN }}` instead of `${{ secrets.SNYK_TOKEN }}`.

**`ci.yml`, `ci-operate.yml`, `ci-tasklist.yml`, `ci-optimize.yml`**
- Added a Vault import step to each frontend SBOM Snyk job (`identity-frontend-sbom-snyk`, `operate-fe-sbom-snyk`, `fe-sbom-snyk`, and the Optimize equivalent).
- Changed `SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}` to `SNYK_TOKEN: ${{ steps.snyk-secrets.outputs.SNYK_TOKEN }}` in each job.

### Impact

- All callers of `zeebe-snyk.yml` (`ci-zeebe.yml`, `camunda-platform-release.yml`) use `secrets: inherit` and require no changes — they already pass the Vault credentials.
- The `frontend-sbom-snyk` composite action reads `SNYK_TOKEN` from the environment and requires no changes.
- After this is merged and verified, the `SNYK_TOKEN` repository secret can be removed.

## 🧪 Test
<img width="1099" height="35" alt="image" src="https://github.com/user-attachments/assets/0e62cc50-939f-4564-9a7a-48842a627ae4" />

🟢  [workflow run](https://github.com/camunda/camunda/actions/runs/25159967156?pr=50662)