### PR TITLE
ci: migrate Slack webhook for reliability testing from repository secret to Vault

### DIFF
--- a/.github/workflows/camunda-daily-load-tests.yml
+++ b/.github/workflows/camunda-daily-load-tests.yml
@@ -83,10 +83,20 @@ jobs:
     permissions: { }
     steps:
       - uses: actions/checkout@v6
+      - name: Import Slack webhook from Vault
+        id: slack-secrets
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_ZEEBOT_RELIABILITY_TESTING_ALERTS_WEBHOOK_URL;
       - id: slack-notify
         uses: slackapi/slack-github-action@v3.0.1
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_RELIABILITY_TESTING_CH }}
+          webhook: ${{ steps.slack-secrets.outputs.SLACK_ZEEBOT_RELIABILITY_TESTING_ALERTS_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
             {

--- a/.github/workflows/camunda-daily-load-tests.yml
+++ b/.github/workflows/camunda-daily-load-tests.yml
@@ -91,6 +91,7 @@ jobs:
           method: approle
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
           secrets: |
             secret/data/products/camunda/ci/github-actions SLACK_ZEEBOT_RELIABILITY_TESTING_ALERTS_WEBHOOK_URL;
       - id: slack-notify

--- a/.github/workflows/camunda-load-test-clean-up.yml
+++ b/.github/workflows/camunda-load-test-clean-up.yml
@@ -56,6 +56,7 @@ jobs:
           method: approle
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
           secrets: |
             secret/data/products/camunda/ci/github-actions SLACK_ZEEBOT_RELIABILITY_TESTING_ALERTS_WEBHOOK_URL;
       - id: slack-notify
@@ -123,6 +124,7 @@ jobs:
           method: approle
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
           secrets: |
             secret/data/products/camunda/ci/github-actions SLACK_ZEEBOT_RELIABILITY_TESTING_ALERTS_WEBHOOK_URL;
       - id: slack-notify

--- a/.github/workflows/camunda-load-test-clean-up.yml
+++ b/.github/workflows/camunda-load-test-clean-up.yml
@@ -48,10 +48,20 @@ jobs:
       - name: Delete namespaces eligible for deletion
         id: delete-namespaces
         run: .github/scripts/clean-up-load-test-namespaces.sh --execute "${{ inputs.date }}"
+      - name: Import Slack webhook from Vault
+        id: slack-secrets
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_ZEEBOT_RELIABILITY_TESTING_ALERTS_WEBHOOK_URL;
       - id: slack-notify
         uses: slackapi/slack-github-action@v3.0.1
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_RELIABILITY_TESTING_CH }}
+          webhook: ${{ steps.slack-secrets.outputs.SLACK_ZEEBOT_RELIABILITY_TESTING_ALERTS_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
             {
@@ -105,10 +115,20 @@ jobs:
       - name: Delete namespaces eligible for deletion
         id: delete-namespaces
         run: .github/scripts/clean-up-load-test-namespaces.sh --execute "${{ inputs.date }}"
+      - name: Import Slack webhook from Vault
+        id: slack-secrets
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_ZEEBOT_RELIABILITY_TESTING_ALERTS_WEBHOOK_URL;
       - id: slack-notify
         uses: slackapi/slack-github-action@v3.0.1
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_RELIABILITY_TESTING_CH }}
+          webhook: ${{ steps.slack-secrets.outputs.SLACK_ZEEBOT_RELIABILITY_TESTING_ALERTS_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
             {

--- a/.github/workflows/camunda-release-load-test.yaml
+++ b/.github/workflows/camunda-release-load-test.yaml
@@ -119,6 +119,7 @@ jobs:
           method: approle
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
           secrets: |
             secret/data/products/camunda/ci/github-actions SLACK_ZEEBOT_RELIABILITY_TESTING_ALERTS_WEBHOOK_URL;
       - id: slack-notify

--- a/.github/workflows/camunda-release-load-test.yaml
+++ b/.github/workflows/camunda-release-load-test.yaml
@@ -111,10 +111,20 @@ jobs:
     permissions: {}
     steps:
       - uses: actions/checkout@v6
+      - name: Import Slack webhook from Vault
+        id: slack-secrets
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_ZEEBOT_RELIABILITY_TESTING_ALERTS_WEBHOOK_URL;
       - id: slack-notify
         uses: slackapi/slack-github-action@v3.0.1
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_RELIABILITY_TESTING_CH }}
+          webhook: ${{ steps.slack-secrets.outputs.SLACK_ZEEBOT_RELIABILITY_TESTING_ALERTS_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
             {

--- a/.github/workflows/camunda-scheduled-release-load-tests.yml
+++ b/.github/workflows/camunda-scheduled-release-load-tests.yml
@@ -140,6 +140,7 @@ jobs:
           method: approle
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
           secrets: |
             secret/data/products/camunda/ci/github-actions SLACK_ZEEBOT_RELIABILITY_TESTING_ALERTS_WEBHOOK_URL;
       - id: slack-notify
@@ -208,6 +209,7 @@ jobs:
           method: approle
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
           secrets: |
             secret/data/products/camunda/ci/github-actions SLACK_ZEEBOT_RELIABILITY_TESTING_ALERTS_WEBHOOK_URL;
       - id: slack-notify

--- a/.github/workflows/camunda-scheduled-release-load-tests.yml
+++ b/.github/workflows/camunda-scheduled-release-load-tests.yml
@@ -132,10 +132,20 @@ jobs:
     permissions: {}
     steps:
       - uses: actions/checkout@v6
+      - name: Import Slack webhook from Vault
+        id: slack-secrets
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_ZEEBOT_RELIABILITY_TESTING_ALERTS_WEBHOOK_URL;
       - id: slack-notify
         uses: slackapi/slack-github-action@v3.0.1
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_RELIABILITY_TESTING_CH }}
+          webhook: ${{ steps.slack-secrets.outputs.SLACK_ZEEBOT_RELIABILITY_TESTING_ALERTS_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
             {
@@ -190,10 +200,20 @@ jobs:
     permissions: {}
     steps:
       - uses: actions/checkout@v6
+      - name: Import Slack webhook from Vault
+        id: slack-secrets
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_ZEEBOT_RELIABILITY_TESTING_ALERTS_WEBHOOK_URL;
       - id: slack-notify
         uses: slackapi/slack-github-action@v3.0.1
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_RELIABILITY_TESTING_CH }}
+          webhook: ${{ steps.slack-secrets.outputs.SLACK_ZEEBOT_RELIABILITY_TESTING_ALERTS_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
             {

--- a/.github/workflows/camunda-weekly-load-tests.yml
+++ b/.github/workflows/camunda-weekly-load-tests.yml
@@ -253,10 +253,20 @@ jobs:
     permissions: { }
     steps:
       - uses: actions/checkout@v6
+      - name: Import Slack webhook from Vault
+        id: slack-secrets
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_ZEEBOT_RELIABILITY_TESTING_ALERTS_WEBHOOK_URL;
       - id: slack-notify
         uses: slackapi/slack-github-action@v3.0.1
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_RELIABILITY_TESTING_CH }}
+          webhook: ${{ steps.slack-secrets.outputs.SLACK_ZEEBOT_RELIABILITY_TESTING_ALERTS_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
             {

--- a/.github/workflows/camunda-weekly-load-tests.yml
+++ b/.github/workflows/camunda-weekly-load-tests.yml
@@ -261,6 +261,7 @@ jobs:
           method: approle
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
           secrets: |
             secret/data/products/camunda/ci/github-actions SLACK_ZEEBOT_RELIABILITY_TESTING_ALERTS_WEBHOOK_URL;
       - id: slack-notify


### PR DESCRIPTION
## Description

Migrates the Slack webhook used for reliability/load test notifications from the repository secret `SLACK_WEBHOOK_RELIABILITY_TESTING_CH` to the Vault secret `SLACK_ZEEBOT_RELIABILITY_TESTING_ALERTS_WEBHOOK_URL` at `secret/data/products/camunda/ci/github-actions`.

### Changes

Each affected workflow now includes a Vault import step (`hashicorp/vault-action`, pinned SHA) before the Slack notification step, replacing `${{ secrets.SLACK_WEBHOOK_RELIABILITY_TESTING_CH }}` with `${{ steps.slack-secrets.outputs.SLACK_ZEEBOT_RELIABILITY_TESTING_ALERTS_WEBHOOK_URL }}`.

**Updated workflows (5 files, 7 occurrences):**
- `camunda-weekly-load-tests.yml` — notify job
- `camunda-daily-load-tests.yml` — notify job
- `camunda-release-load-test.yaml` — notify-on-failure job
- `camunda-scheduled-release-load-tests.yml` — notify-on-success + notify-on-failure jobs
- `camunda-load-test-clean-up.yml` — delete-load-tests-legacy + delete-load-tests jobs

### Why

Repository secrets should be avoided when Vault is available. This aligns the Slack webhook with how other secrets are already managed in this repository.

### Verification

- Confirmed `SLACK_ZEEBOT_RELIABILITY_TESTING_ALERTS_WEBHOOK_URL` exists in Vault at `secret/products/camunda/ci/github-actions`
<img width="1650" height="50" alt="image" src="https://github.com/user-attachments/assets/6fa6b55a-d909-49f8-9345-66ee2e7874c4" />

- Zero remaining references to `SLACK_WEBHOOK_RELIABILITY_TESTING_CH`

After this is merged and verified, the `SLACK_WEBHOOK_RELIABILITY_TESTING_CH` repository secret can be removed.

Related to https://github.com/camunda/camunda/issues/50240