### PR TITLE
test: fix flaky test in ClusterMultiplePartitionsBatchOperationIT

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/ClusterMultiplePartitionsBatchOperationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/cluster/ClusterMultiplePartitionsBatchOperationIT.java
@@ -8,37 +8,39 @@
 package io.camunda.it.cluster;
 
 import static io.camunda.it.util.TestHelper.deployResource;
-import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.getScopedVariables;
+import static io.camunda.it.util.TestHelper.startScopedProcessInstance;
 import static io.camunda.it.util.TestHelper.waitForBatchOperationCompleted;
 import static io.camunda.it.util.TestHelper.waitForBatchOperationWithCorrectTotalCount;
-import static io.camunda.it.util.TestHelper.waitForElementInstances;
 import static io.camunda.it.util.TestHelper.waitForProcessInstanceToBeTerminated;
-import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
 import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
+import static io.camunda.it.util.TestHelper.waitForScopedProcessInstancesToStart;
 import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import io.camunda.client.CamundaClient;
-import io.camunda.client.api.response.Process;
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.client.api.search.enums.BatchOperationItemState;
 import io.camunda.client.api.search.response.BatchOperationItems.BatchOperationItem;
-import io.camunda.client.impl.search.filter.ProcessInstanceFilterImpl;
-import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.stream.IntStream;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
@@ -56,28 +58,38 @@ public class ClusterMultiplePartitionsBatchOperationIT {
                 b.setCluster(cluster);
               });
 
-  private static Process deployedProcess;
-  private static final List<ProcessInstanceEvent> ACTIVE_PROCESS_INSTANCES = new ArrayList<>();
+  private static CamundaClient camundaClient;
+
+  private String testScopeId;
+  private final List<ProcessInstanceEvent> activeProcessInstances = new ArrayList<>();
 
   @BeforeAll
-  public static void beforeAll(@Authenticated final CamundaClient camundaClient) {
+  static void beforeAll() {
     Objects.requireNonNull(camundaClient);
 
     // Deploy process definitions
-    deployedProcess =
+    final var deployedProcess =
         deployResource(camundaClient, "process/service_tasks_v1.bpmn").getProcesses().getFirst();
-    waitForProcessesToBeDeployed(camundaClient, 1);
+    waitForProcessesToBeDeployed(
+        camundaClient, f -> f.processDefinitionKey(deployedProcess.getProcessDefinitionKey()), 1);
+  }
 
-    // Start process instances
+  @BeforeEach
+  void beforeEach(final TestInfo testInfo) {
+    testScopeId =
+        testInfo.getTestMethod().map(Method::toString).orElse(UUID.randomUUID().toString());
+
+    // Start scoped process instances
     IntStream.range(0, 10)
         .forEach(
             i ->
-                ACTIVE_PROCESS_INSTANCES.add(
-                    startProcessInstance(camundaClient, "service_tasks_v1", "{\"xyz\":\"bar\"}")));
+                activeProcessInstances.add(
+                    startScopedProcessInstance(
+                        camundaClient, "service_tasks_v1", testScopeId, Map.of("xyz", "bar"))));
 
     // given we really have processes on more than one partitions
     final long countPartitionsDeployedTo =
-        ACTIVE_PROCESS_INSTANCES.stream()
+        activeProcessInstances.stream()
             .map(ProcessInstanceEvent::getProcessInstanceKey)
             .map(Protocol::decodePartitionId)
             .distinct()
@@ -86,26 +98,23 @@ public class ClusterMultiplePartitionsBatchOperationIT {
         countPartitionsDeployedTo > 1,
         "Test requires process instances to be deployed to multiple partitions.");
 
-    // Wait for process instances to start
-    waitForProcessInstancesToStart(camundaClient, ACTIVE_PROCESS_INSTANCES.size());
-    waitForElementInstances(camundaClient, ACTIVE_PROCESS_INSTANCES.size() * 2);
+    // Wait for scoped process instances to start
+    waitForScopedProcessInstancesToStart(camundaClient, testScopeId, activeProcessInstances.size());
   }
 
   @AfterEach
-  void afterAll() {
-    deployedProcess = null;
-    ACTIVE_PROCESS_INSTANCES.clear();
+  void afterEach() {
+    activeProcessInstances.clear();
   }
 
   @Test
-  void shouldCancelProcessInstancesOnSeveralPartitionsWithBatch(
-      @Authenticated final CamundaClient camundaClient) {
+  void shouldCancelProcessInstancesOnSeveralPartitionsWithBatch() {
     // when
     final var result =
         camundaClient
             .newCreateBatchOperationCommand()
             .processInstanceCancel()
-            .filter(new ProcessInstanceFilterImpl().processDefinitionId("service_tasks_v1"))
+            .filter(b -> b.variables(getScopedVariables(testScopeId)))
             .send()
             .join();
     final var batchOperationKey = result.getBatchOperationKey();
@@ -115,13 +124,13 @@ public class ClusterMultiplePartitionsBatchOperationIT {
 
     // and
     waitForBatchOperationWithCorrectTotalCount(
-        camundaClient, batchOperationKey, ACTIVE_PROCESS_INSTANCES.size());
+        camundaClient, batchOperationKey, activeProcessInstances.size());
     waitForBatchOperationCompleted(
-        camundaClient, batchOperationKey, ACTIVE_PROCESS_INSTANCES.size(), 0);
+        camundaClient, batchOperationKey, activeProcessInstances.size(), 0);
 
     // Now wait until all process instances are terminated
     final var activeKeys =
-        ACTIVE_PROCESS_INSTANCES.stream().map(ProcessInstanceEvent::getProcessInstanceKey).toList();
+        activeProcessInstances.stream().map(ProcessInstanceEvent::getProcessInstanceKey).toList();
     for (final Long key : activeKeys) {
       waitForProcessInstanceToBeTerminated(camundaClient, key);
     }
@@ -141,7 +150,7 @@ public class ClusterMultiplePartitionsBatchOperationIT {
               final var itemKeys =
                   itemsObj.items().stream().map(BatchOperationItem::getItemKey).toList();
 
-              assertThat(itemsObj.items()).hasSize(ACTIVE_PROCESS_INSTANCES.size());
+              assertThat(itemsObj.items()).hasSize(activeProcessInstances.size());
               assertThat(
                       itemsObj.items().stream()
                           .map(BatchOperationItem::getStatus)


### PR DESCRIPTION
## Description

The test `ClusterMultiplePartitionsBatchOperationIT.shouldCancelProcessInstancesOnSeveralPartitionsWithBatch` has been flaky due to

```
Condition with alias 'should complete batch operation with correct completed/failed count' didn't complete within 2 minutes because assertion condition defined as a Lambda expression in io.camunda.it.util.TestHelper 
expected: 10
 but was: 7.
	at org.awaitility.core.ConditionAwaiter.await(ConditionAwaiter.java:167)
	at org.awaitility.core.AssertionCondition.await(AssertionCondition.java:119)
	at org.awaitility.core.AssertionCondition.await(AssertionCondition.java:31)
	at org.awaitility.core.ConditionFactory.until(ConditionFactory.java:1160)
	at org.awaitility.core.ConditionFactory.untilAsserted(ConditionFactory.java:790)
	at io.camunda.it.util.TestHelper.waitForBatchOperationCompleted(TestHelper.java:616)
	at io.camunda.it.cluster.ClusterMultiplePartitionsBatchOperationIT.shouldCancelProcessInstancesOnSeveralPartitionsWithBatch(ClusterMultiplePartitionsBatchOperationIT.java:119)
Caused by: org.opentest4j.AssertionFailedError: 
expected: 10
 but was: 7
	at io.camunda.it.util.TestHelper.lambda$waitForBatchOperationCompleted$18(TestHelper.java:623)
	at org.awaitility.core.AssertionCondition.lambda$new$0(AssertionCondition.java:53)
	at org.awaitility.core.ConditionAwaiter$ConditionPoller.call(ConditionAwaiter.java:248)
	at org.awaitility.core.ConditionAwaiter$ConditionPoller.call(ConditionAwaiter.java:235)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```

see [example](https://github.com/camunda/camunda/actions/runs/24155995486/job/70495791533)

My theory is that this is happening because the test is using a process definition shared with other tests (`process/service_tasks_v1.bpmn`) but there is no isolation when the test setup is fetching instances of this process. This means it could be fetching instances started by other tests. 

This PR introduces the use of scoped process instances, just like it's done in [BatchOperationCancelProcessInstanceIT](https://github.com/camunda/camunda/blob/cb3eb4c19b46020ce0cba01b589e355fa756c0a8/qa/acceptance-tests/src/test/java/io/camunda/it/client/BatchOperationCancelProcessInstanceIT.java)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
