### PR TITLE
feat: Add logic to filter out new flaky tests

### DIFF
--- a/.github/actions/detect-new-flaky-tests/README.md
+++ b/.github/actions/detect-new-flaky-tests/README.md
@@ -200,6 +200,10 @@ The `detect-new-flaky-tests` job is defined in `.github/workflows/ci.yml`:
   from all test jobs)
 - **Part of:** `check-results` aggregation (failures block merge)
 
+> **Note:** This gate can only detect flaky tests from CI jobs that are wired
+> into the `collect-flaky-tests` action. If a new test job is added to CI but
+> not connected to `collect-flaky-tests`, its flaky tests won't be checked.
+
 ### Secrets used
 
 |      Secret       |                        Source                        |      Purpose       |

--- a/.github/actions/detect-new-flaky-tests/README.md
+++ b/.github/actions/detect-new-flaky-tests/README.md
@@ -185,7 +185,7 @@ When new flaky tests are found, the action posts (or updates) a PR comment:
 > **What to do:**
 > 1. Check if the flaky test is caused by your changes and fix it
 > 2. If the test is unrelated to your changes:
-> - Contact the monorepo devops (#top-monorepo-ci) to triage and discuss the next steps
+> - Contact the Monorepo DevOps team (#ask-monorepo-devops) to triage and discuss the next steps
 > - Create an issue with the `kind/flake` label documenting the test, job, and a link to this CI run
 > - Add the `ci:flaky-test-bypass` label to this PR to skip the gate and unblock merging
 > - Re-run CI after adding the label

--- a/.github/actions/detect-new-flaky-tests/README.md
+++ b/.github/actions/detect-new-flaky-tests/README.md
@@ -166,7 +166,7 @@ and exits successfully without querying BigQuery or comparing tests.
 
 ## PR Comment
 
-When new flaky tests are found, the action posts a comment like:
+When new flaky tests are found, the action posts (or updates) a PR comment:
 
 > ## ⚠️ New Flaky Tests Detected
 >
@@ -188,6 +188,25 @@ When new flaky tests are found, the action posts a comment like:
 > - Create an issue with the `kind/flake` label documenting the test, job, and a link to this CI run
 > - Add the `ci:flaky-test-bypass` label to this PR to skip the gate and unblock merging
 > - Re-run CI after adding the label
+
+If a subsequent CI run finds **no new flaky tests**, the existing comment is
+updated to show it's resolved — the original warning is kept in a collapsed
+`<details>` block with ~~strikethrough~~ formatting:
+
+> ## ✅ Resolved — No New Flaky Tests
+>
+> A previous CI run flagged new flaky tests, but the latest run found none.
+>
+> <details>
+> <summary>Previous warning (resolved)</summary>
+>
+> ~~⚠️ New Flaky Tests Detected~~
+> ~~This PR introduces **1 new flaky test(s)**...~~
+>
+> </details>
+>
+> The comment is identified by a hidden HTML marker (`<!-- new-flaky-tests-alert -->`)
+> so it is always updated in-place rather than creating duplicates.
 
 ## CI Job Configuration
 

--- a/.github/actions/detect-new-flaky-tests/README.md
+++ b/.github/actions/detect-new-flaky-tests/README.md
@@ -207,6 +207,10 @@ updated to show it's resolved — the original warning is kept in a collapsed
 >
 > The comment is identified by a hidden HTML marker (`<!-- new-flaky-tests-alert -->`)
 > so it is always updated in-place rather than creating duplicates.
+>
+> If the comment is already resolved and another passing run occurs, it is left
+> unchanged (no double-strikethrough). If new flaky tests appear in a later run,
+> the comment is fully replaced with a fresh warning.
 
 ## CI Job Configuration
 

--- a/.github/actions/detect-new-flaky-tests/README.md
+++ b/.github/actions/detect-new-flaky-tests/README.md
@@ -91,8 +91,8 @@ the last 60 days. The GCP service account key is fetched from Vault.
 The raw `flaky_tests` string from each job is split into individual test names.
 Each test name is parsed into its components:
 
-| Raw test name from Maven | Parsed |
-|---|---|
+|                                                        Raw test name from Maven                                                        |                                                              Parsed                                                               |
+|----------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
 | `io.camunda.it.rdbms.db.processinstance.ProcessInstanceIT.shouldSelectRootExpiredRootProcessInstances(CamundaRdbmsTestApplication)[5]` | package=`io.camunda.it.rdbms.db.processinstance`, class=`ProcessInstanceIT`, method=`shouldSelectRootExpiredRootProcessInstances` |
 
 The `(CamundaRdbmsTestApplication)` (parameter info) and `[5]` (index) are
@@ -120,10 +120,10 @@ These raw keys preserve parameter info and database variant suffixes.
 For each PR flaky test, we check if any baseline key refers to the same test
 method. The challenge is that the two sides have **different formats**:
 
-| Side | Key format | Example |
-|---|---|---|
-| **PR** (normalized) | `pkg.Class.method` | `...ProcessInstanceIT.shouldSelectRoot` |
-| **Baseline** (raw) | `pkg.Class.method(Param) variant` | `...ProcessInstanceIT.shouldSelectRoot(CamundaRdbmsTestApplication) camundaWithOracleDB` |
+|        Side         |            Key format             |                                         Example                                          |
+|---------------------|-----------------------------------|------------------------------------------------------------------------------------------|
+| **PR** (normalized) | `pkg.Class.method`                | `...ProcessInstanceIT.shouldSelectRoot`                                                  |
+| **Baseline** (raw)  | `pkg.Class.method(Param) variant` | `...ProcessInstanceIT.shouldSelectRoot(CamundaRdbmsTestApplication) camundaWithOracleDB` |
 
 The matching function `_is_same_test(baseline_key, normalized_key)` works as
 follows:
@@ -137,19 +137,19 @@ follows:
 
 ### Boundary matching examples
 
-| Normalized key | Baseline key | Next char | Match? | Why |
-|---|---|---|---|---|
-| `...shouldSelectRoot` | `...shouldSelectRoot` | *(end)* | ✅ | Exact match |
-| `...shouldSelectRoot` | `...shouldSelectRoot(Param) variant` | `(` | ✅ | `(` is a boundary |
-| `...shouldSelectRoot` | `...shouldSelectRoot[5]` | `[` | ✅ | `[` is a boundary |
-| `...shouldFind` | `...shouldFindAllItems(Param)` | `A` | ❌ | `A` is alphanumeric → different method |
-| `...shouldFind` | `...shouldFind_v2(Param)` | `_` | ❌ | `_` is identifier char → different method |
+|    Normalized key     |             Baseline key             | Next char | Match? |                    Why                    |
+|-----------------------|--------------------------------------|-----------|--------|-------------------------------------------|
+| `...shouldSelectRoot` | `...shouldSelectRoot`                | *(end)*   | ✅      | Exact match                               |
+| `...shouldSelectRoot` | `...shouldSelectRoot(Param) variant` | `(`       | ✅      | `(` is a boundary                         |
+| `...shouldSelectRoot` | `...shouldSelectRoot[5]`             | `[`       | ✅      | `[` is a boundary                         |
+| `...shouldFind`       | `...shouldFindAllItems(Param)`       | `A`       | ❌      | `A` is alphanumeric → different method    |
+| `...shouldFind`       | `...shouldFind_v2(Param)`            | `_`       | ❌      | `_` is identifier char → different method |
 
 ### Decision
 
-| Scenario | Result |
-|---|---|
-| All PR flaky tests match a baseline key | ✅ **Pass** — sets `has-new-flaky-tests=false` |
+|                Scenario                 |                                       Result                                        |
+|-----------------------------------------|-------------------------------------------------------------------------------------|
+| All PR flaky tests match a baseline key | ✅ **Pass** — sets `has-new-flaky-tests=false`                                       |
 | At least one PR flaky test has no match | ❌ **Fail** — posts a PR comment, sets `has-new-flaky-tests=true`, exits with code 1 |
 
 ## Bypass Label
@@ -180,13 +180,14 @@ When new flaky tests are found, the action posts a comment like:
 >   - Retries in this run: 1
 >
 > ---
+>
 > **What to do:**
 > 1. Check if the flaky test is caused by your changes and fix it
 > 2. If the test is unrelated to your changes:
->    - Contact the monorepo devops (#top-monorepo-ci) to triage and discuss the next steps
->    - Create an issue with the `kind/flake` label documenting the test, job, and a link to this CI run
->    - Add the `ci:flaky-test-bypass` label to this PR to skip the gate and unblock merging
->    - Re-run CI after adding the label
+> - Contact the monorepo devops (#top-monorepo-ci) to triage and discuss the next steps
+> - Create an issue with the `kind/flake` label documenting the test, job, and a link to this CI run
+> - Add the `ci:flaky-test-bypass` label to this PR to skip the gate and unblock merging
+> - Re-run CI after adding the label
 
 ## CI Job Configuration
 
@@ -201,12 +202,12 @@ The `detect-new-flaky-tests` job is defined in `.github/workflows/ci.yml`:
 
 ### Secrets used
 
-| Secret | Source | Purpose |
-|---|---|---|
-| `VAULT_ADDR` | Repository secret | Vault server URL |
-| `VAULT_ROLE_ID` | Repository secret | Vault AppRole auth |
-| `VAULT_SECRET_ID` | Repository secret | Vault AppRole auth |
-| GCP SA key | Vault (`secret/data/products/zeebe/ci/ci-analytics`) | BigQuery access |
+|      Secret       |                        Source                        |      Purpose       |
+|-------------------|------------------------------------------------------|--------------------|
+| `VAULT_ADDR`      | Repository secret                                    | Vault server URL   |
+| `VAULT_ROLE_ID`   | Repository secret                                    | Vault AppRole auth |
+| `VAULT_SECRET_ID` | Repository secret                                    | Vault AppRole auth |
+| GCP SA key        | Vault (`secret/data/products/zeebe/ci/ci-analytics`) | BigQuery access    |
 
 ## Running Locally
 
@@ -333,3 +334,4 @@ access while maintaining security.
 ├── detect_new_flaky_tests.py   # Detection logic (Python, stdlib only)
 └── README.md                   # This file
 ```
+

--- a/.github/actions/detect-new-flaky-tests/README.md
+++ b/.github/actions/detect-new-flaky-tests/README.md
@@ -1,0 +1,335 @@
+# Detect New Flaky Tests
+
+A CI quality gate that prevents PRs from introducing **new** flaky tests.
+It compares flaky tests detected in the PR's CI run against a baseline of
+tests that are already known to be flaky on `main` and `stable/*` branches.
+
+Only truly **new** flaky tests block the PR — pre-existing flaky tests are ignored.
+
+## How It Works
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│                        CI pipeline (ci.yml)                          │
+│                                                                      │
+│  1. Test jobs run (unit, integration, RDBMS, etc.)                   │
+│     └─ Maven rerun count = 3 for PRs                                 │
+│     └─ Flaky tests produce FLAKY.xml via analyze-test-runs           │
+│                                                                      │
+│  2. utils-flaky-tests-summary                                        │
+│     └─ collect-flaky-tests gathers all FLAKY.xml results             │
+│     └─ Outputs: flaky_tests_data (JSON)                              │
+│                                                                      │
+│  3. detect-new-flaky-tests  ← THIS ACTION                            │
+│     ├─ Checks for `ci:flaky-test-bypass` label → skip if present     │
+│     ├─ Queries BigQuery for baseline (known flaky tests)             │
+│     ├─ Compares PR flaky tests against baseline                      │
+│     ├─ If new flaky tests found → posts comment + fails              │
+│     └─ If all known or bypassed → passes                             │
+│                                                                      │
+│  4. check-results                                                    │
+│     └─ Aggregates all job results including detect-new-flaky-tests   │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+## Data Flow
+
+### Input 1: PR flaky tests (`PR_FLAKY_TESTS_DATA`)
+
+Comes from the `collect-flaky-tests` action. This is a JSON array of objects,
+one per CI job that had flaky tests:
+
+```json
+[
+  {
+    "job": "rdbms-integration-tests",
+    "flaky_tests": "io.camunda.it.rdbms.db.processinstance.ProcessInstanceIT.shouldSelectRootExpiredRootProcessInstances(CamundaRdbmsTestApplication)[5]"
+  }
+]
+```
+
+### Input 2: Baseline flaky tests (`KNOWN_FLAKY_TESTS`)
+
+Queried from BigQuery at runtime. Contains all tests that have been flaky on
+`main` or `stable/*` in the last 60 days:
+
+```json
+[
+  {
+    "test_class_name": "io.camunda.it.rdbms.db.processinstance.ProcessInstanceIT",
+    "test_name": "shouldSelectRootExpiredRootProcessInstances(CamundaRdbmsTestApplication) camundaWithOracleDB"
+  }
+]
+```
+
+### BigQuery Query
+
+```sql
+SELECT DISTINCT test_class_name, test_name
+FROM `ci-30-162810.prod_ci_analytics.test_status_v1` ts
+LEFT OUTER JOIN `ci-30-162810.prod_ci_analytics.build_status_v2` bs
+  ON ts.ci_url = bs.ci_url AND ts.build_id = bs.build_id AND ts.job_name = bs.job_name
+WHERE ts.report_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 60 DAY)
+  AND ts.ci_url = "https://github.com/camunda/camunda"
+  AND test_status = "flaky"
+  AND (
+    (build_trigger = "merge_group"
+      AND (build_base_ref = "refs/heads/main" OR build_base_ref LIKE "refs/heads/stable/%"))
+    OR
+    (build_trigger = "push"
+      AND (build_ref = "refs/heads/main" OR build_ref LIKE "refs/heads/stable/%"))
+  )
+```
+
+This returns every test that flaked at least once on `main` or `stable/*` in
+the last 60 days. The GCP service account key is fetched from Vault.
+
+## Processing Steps
+
+### Step 1: Parse PR flaky tests
+
+The raw `flaky_tests` string from each job is split into individual test names.
+Each test name is parsed into its components:
+
+| Raw test name from Maven | Parsed |
+|---|---|
+| `io.camunda.it.rdbms.db.processinstance.ProcessInstanceIT.shouldSelectRootExpiredRootProcessInstances(CamundaRdbmsTestApplication)[5]` | package=`io.camunda.it.rdbms.db.processinstance`, class=`ProcessInstanceIT`, method=`shouldSelectRootExpiredRootProcessInstances` |
+
+The `(CamundaRdbmsTestApplication)` (parameter info) and `[5]` (index) are
+stripped during parsing. This produces a **normalized key**:
+
+```
+io.camunda.it.rdbms.db.processinstance.ProcessInstanceIT.shouldSelectRootExpiredRootProcessInstances
+```
+
+If the same test appears in multiple jobs, it's deduplicated (jobs are merged).
+
+### Step 2: Parse baseline flaky tests
+
+BigQuery results are built into **baseline keys** by concatenating
+`test_class_name` + `.` + `test_name` **without any normalization**:
+
+```
+io.camunda.it.rdbms.db.processinstance.ProcessInstanceIT.shouldSelectRootExpiredRootProcessInstances(CamundaRdbmsTestApplication) camundaWithOracleDB
+```
+
+These raw keys preserve parameter info and database variant suffixes.
+
+### Step 3: Compare (boundary-aware matching)
+
+For each PR flaky test, we check if any baseline key refers to the same test
+method. The challenge is that the two sides have **different formats**:
+
+| Side | Key format | Example |
+|---|---|---|
+| **PR** (normalized) | `pkg.Class.method` | `...ProcessInstanceIT.shouldSelectRoot` |
+| **Baseline** (raw) | `pkg.Class.method(Param) variant` | `...ProcessInstanceIT.shouldSelectRoot(CamundaRdbmsTestApplication) camundaWithOracleDB` |
+
+The matching function `_is_same_test(baseline_key, normalized_key)` works as
+follows:
+
+1. **Exact match?** If `baseline_key == normalized_key` → match.
+2. **Starts with?** If `baseline_key.startswith(normalized_key)` → check step 3.
+3. **Boundary check:** Look at the character immediately after the normalized
+   key ends. If it's a **non-alphanumeric, non-underscore** character (like `(`
+   or ` `), it's a boundary → match. If it's a letter, digit, or `_`, it means
+   we matched a prefix of a *different* method name → no match.
+
+### Boundary matching examples
+
+| Normalized key | Baseline key | Next char | Match? | Why |
+|---|---|---|---|---|
+| `...shouldSelectRoot` | `...shouldSelectRoot` | *(end)* | ✅ | Exact match |
+| `...shouldSelectRoot` | `...shouldSelectRoot(Param) variant` | `(` | ✅ | `(` is a boundary |
+| `...shouldSelectRoot` | `...shouldSelectRoot[5]` | `[` | ✅ | `[` is a boundary |
+| `...shouldFind` | `...shouldFindAllItems(Param)` | `A` | ❌ | `A` is alphanumeric → different method |
+| `...shouldFind` | `...shouldFind_v2(Param)` | `_` | ❌ | `_` is identifier char → different method |
+
+### Decision
+
+| Scenario | Result |
+|---|---|
+| All PR flaky tests match a baseline key | ✅ **Pass** — sets `has-new-flaky-tests=false` |
+| At least one PR flaky test has no match | ❌ **Fail** — posts a PR comment, sets `has-new-flaky-tests=true`, exits with code 1 |
+
+## Bypass Label
+
+If the gate flags a flaky test that is **not caused by your changes**, you can
+skip the gate by adding the `ci:flaky-test-bypass` label to your PR and
+re-running CI.
+
+When the label is present, the `detect-new-flaky-tests` job prints a notice
+and exits successfully without querying BigQuery or comparing tests.
+
+> **Important:** Before bypassing, create a `kind/flake` issue so the flaky
+> test is tracked and eventually fixed.
+
+## PR Comment
+
+When new flaky tests are found, the action posts a comment like:
+
+> ## ⚠️ New Flaky Tests Detected
+>
+> This PR introduces **1 new flaky test(s)** that are not currently flaky on
+> `main` or `stable/*` branches.
+>
+> - **shouldDoSomething**
+>   - Jobs: `rdbms-integration-tests`
+>   - Package: `io.camunda.it.example`
+>   - Class: `ExampleIT`
+>   - Retries in this run: 1
+>
+> ---
+> **What to do:**
+> 1. Check if the flaky test is caused by your changes and fix it
+> 2. If the test is unrelated to your changes:
+>    - Contact the monorepo devops (#top-monorepo-ci) to triage and discuss the next steps
+>    - Create an issue with the `kind/flake` label documenting the test, job, and a link to this CI run
+>    - Add the `ci:flaky-test-bypass` label to this PR to skip the gate and unblock merging
+>    - Re-run CI after adding the label
+
+## CI Job Configuration
+
+The `detect-new-flaky-tests` job is defined in `.github/workflows/ci.yml`:
+
+- **Runs on:** `ubuntu-latest`
+- **Timeout:** 10 minutes
+- **Condition:** Only on `pull_request` events from non-fork repos
+- **Depends on:** `utils-flaky-tests-summary` (which collects flaky test data
+  from all test jobs)
+- **Part of:** `check-results` aggregation (failures block merge)
+
+### Secrets used
+
+| Secret | Source | Purpose |
+|---|---|---|
+| `VAULT_ADDR` | Repository secret | Vault server URL |
+| `VAULT_ROLE_ID` | Repository secret | Vault AppRole auth |
+| `VAULT_SECRET_ID` | Repository secret | Vault AppRole auth |
+| GCP SA key | Vault (`secret/data/products/zeebe/ci/ci-analytics`) | BigQuery access |
+
+## Running Locally
+
+You can test the script locally if you have `bq` CLI authenticated:
+
+```bash
+# 1. Query BigQuery for baseline (or use a subset)
+KNOWN=$(bq query --project_id=ci-30-162810 --use_legacy_sql=false --format=json \
+  'SELECT DISTINCT test_class_name, test_name
+   FROM `ci-30-162810.prod_ci_analytics.test_status_v1` ts
+   LEFT OUTER JOIN `ci-30-162810.prod_ci_analytics.build_status_v2` bs
+     ON ts.ci_url=bs.ci_url AND ts.build_id=bs.build_id AND ts.job_name=bs.job_name
+   WHERE ts.report_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 60 DAY)
+     AND ts.ci_url="https://github.com/camunda/camunda"
+     AND test_status = "flaky"
+     AND (
+       (build_trigger="merge_group" AND (build_base_ref="refs/heads/main" OR build_base_ref LIKE "refs/heads/stable/%"))
+       OR (build_trigger="push" AND (build_ref="refs/heads/main" OR build_ref LIKE "refs/heads/stable/%"))
+     )' 2>/dev/null)
+
+# 2. Simulate PR flaky test data
+PR_DATA='[{"job":"rdbms-integration-tests","flaky_tests":"io.camunda.it.rdbms.db.processinstance.ProcessInstanceIT.shouldSelectRootExpiredRootProcessInstances(CamundaRdbmsTestApplication)[5]"}]'
+
+# 3. Run (will fail at post_comment since GITHUB_TOKEN is fake — that's OK)
+PR_FLAKY_TESTS_DATA="$PR_DATA" \
+KNOWN_FLAKY_TESTS="$KNOWN" \
+PR_NUMBER=12345 \
+GITHUB_TOKEN=fake \
+GITHUB_REPOSITORY=camunda/camunda \
+python3 .github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
+```
+
+The script will print all 3 steps with debug output and show whether each test
+is KNOWN or NEW. It will fail at the `post_comment` step if a test is NEW
+(since the token is fake), but the comparison output is still visible.
+
+## FAQ
+
+<details>
+<summary><strong>Will old flaky tests be flagged as new after 60 days?</strong></summary>
+
+No. The 60-day window is a rolling query against `main` and `stable/*`
+branches. Tests on those branches keep running normally (via `push` and
+`merge_group` triggers). As long as a test continues to flake on `main`, fresh
+entries keep appearing in BigQuery — it never falls out of the window.
+
+A test only drops out of the baseline if it **hasn't flaked on `main`/`stable/*`
+for 60+ days**. That likely means it was fixed. If a PR triggers it again,
+flagging it as NEW is the correct behavior.
+
+</details>
+
+<details>
+<summary><strong>What about tests that flake very rarely (e.g., once every few months)?</strong></summary>
+
+If a test last flaked on main 61+ days ago and your PR hits it, it will be
+flagged as NEW. In this case:
+
+1. Add the `ci:flaky-test-bypass` label to your PR
+2. Create a `kind/flake` issue to track the test
+3. Re-run CI — the gate will be skipped
+
+</details>
+
+<details>
+<summary><strong>Does this gate run on main or stable branches?</strong></summary>
+
+No. It only runs on `pull_request` events from non-fork repos. Test jobs on
+`main` and `stable/*` continue to run normally and feed the BigQuery baseline.
+
+</details>
+
+<details>
+<summary><strong>What happens if BigQuery is down or the query fails?</strong></summary>
+
+The BigQuery query step will fail, which causes the `detect-new-flaky-tests`
+job to fail. Since this job is in the `check-results` aggregation, it would
+block merge. The `ci:flaky-test-bypass` label can be used to unblock.
+
+</details>
+
+<details>
+<summary><strong>Can the gate produce false positives?</strong></summary>
+
+The main source of false positives was mismatched test name formats between
+Maven output and BigQuery. This is handled by boundary-aware matching (see
+Step 3 above). Known cases:
+
+- **Parameterized tests**: Maven reports `shouldDoX(Param)[5]`, BigQuery stores
+  `shouldDoX(Param) variant` — both match the normalized key `shouldDoX`
+- **Different methods sharing a prefix**: `shouldFind` will NOT match
+  `shouldFindAllItems` thanks to the boundary check
+
+If you encounter a false positive, use `ci:flaky-test-bypass` and report it to @monorepo-devops-team.
+
+</details>
+
+<details>
+<summary><strong>Does the gate run on fork PRs?</strong></summary>
+
+No. Fork PRs don't have access to repository secrets (Vault credentials),
+which are required to query BigQuery for the baseline. GitHub enforces this
+restriction for security — fork PRs cannot access secrets from the base repo.
+
+This means fork PRs can potentially introduce new flaky tests without being
+blocked. However:
+
+- Fork PRs are rare in this repo
+- Once a fork PR merges and the flaky test starts appearing on `main`, it will
+  enter the BigQuery baseline and be tracked going forward
+- Reviewers can still see test failures in the CI logs
+
+A future improvement could use a `workflow_run` trigger to run the gate in the
+base repo's context after the fork PR's CI completes. This would provide secret
+access while maintaining security.
+
+</details>
+
+## File Structure
+
+```
+.github/actions/detect-new-flaky-tests/
+├── action.yml                  # Composite action definition
+├── detect_new_flaky_tests.py   # Detection logic (Python, stdlib only)
+└── README.md                   # This file
+```

--- a/.github/actions/detect-new-flaky-tests/README.md
+++ b/.github/actions/detect-new-flaky-tests/README.md
@@ -48,10 +48,11 @@ one per CI job that had flaky tests:
 ]
 ```
 
-### Input 2: Baseline flaky tests (`KNOWN_FLAKY_TESTS`)
+### Input 2: Baseline flaky tests (`KNOWN_FLAKY_TESTS_FILE`)
 
-Queried from BigQuery at runtime. Contains all tests that have been flaky on
-`main` or `stable/*` in the last 60 days:
+Queried from BigQuery at runtime and written to a temporary JSON file.
+The file path is passed to the action. Contains all tests that have been flaky
+on `main` or `stable/*` in the last 14 days:
 
 ```json
 [
@@ -69,7 +70,7 @@ SELECT DISTINCT test_class_name, test_name
 FROM `ci-30-162810.prod_ci_analytics.test_status_v1` ts
 LEFT OUTER JOIN `ci-30-162810.prod_ci_analytics.build_status_v2` bs
   ON ts.ci_url = bs.ci_url AND ts.build_id = bs.build_id AND ts.job_name = bs.job_name
-WHERE ts.report_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 60 DAY)
+WHERE ts.report_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 14 DAY)
   AND ts.ci_url = "https://github.com/camunda/camunda"
   AND test_status = "flaky"
   AND (
@@ -82,7 +83,7 @@ WHERE ts.report_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 60 DAY)
 ```
 
 This returns every test that flaked at least once on `main` or `stable/*` in
-the last 60 days. The GCP service account key is fetched from Vault.
+the last 14 days. The GCP service account key is fetched from Vault.
 
 ## Processing Steps
 
@@ -241,26 +242,26 @@ The `detect-new-flaky-tests` job is defined in `.github/workflows/ci.yml`:
 You can test the script locally if you have `bq` CLI authenticated:
 
 ```bash
-# 1. Query BigQuery for baseline (or use a subset)
-KNOWN=$(bq query --project_id=ci-30-162810 --use_legacy_sql=false --format=json \
+# 1. Query BigQuery for baseline and save to file
+bq query --project_id=ci-30-162810 --use_legacy_sql=false --format=json \
   'SELECT DISTINCT test_class_name, test_name
    FROM `ci-30-162810.prod_ci_analytics.test_status_v1` ts
    LEFT OUTER JOIN `ci-30-162810.prod_ci_analytics.build_status_v2` bs
      ON ts.ci_url=bs.ci_url AND ts.build_id=bs.build_id AND ts.job_name=bs.job_name
-   WHERE ts.report_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 60 DAY)
+   WHERE ts.report_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 14 DAY)
      AND ts.ci_url="https://github.com/camunda/camunda"
      AND test_status = "flaky"
      AND (
        (build_trigger="merge_group" AND (build_base_ref="refs/heads/main" OR build_base_ref LIKE "refs/heads/stable/%"))
        OR (build_trigger="push" AND (build_ref="refs/heads/main" OR build_ref LIKE "refs/heads/stable/%"))
-     )' 2>/dev/null)
+     )' 2>/dev/null > /tmp/known-flaky-tests.json
 
 # 2. Simulate PR flaky test data
 PR_DATA='[{"job":"rdbms-integration-tests","flaky_tests":"io.camunda.it.rdbms.db.processinstance.ProcessInstanceIT.shouldSelectRootExpiredRootProcessInstances(CamundaRdbmsTestApplication)[5]"}]'
 
 # 3. Run (will fail at post_comment since GITHUB_TOKEN is fake — that's OK)
 PR_FLAKY_TESTS_DATA="$PR_DATA" \
-KNOWN_FLAKY_TESTS="$KNOWN" \
+KNOWN_FLAKY_TESTS_FILE=/tmp/known-flaky-tests.json \
 PR_NUMBER=12345 \
 GITHUB_TOKEN=fake \
 GITHUB_REPOSITORY=camunda/camunda \
@@ -274,15 +275,15 @@ is KNOWN or NEW. It will fail at the `post_comment` step if a test is NEW
 ## FAQ
 
 <details>
-<summary><strong>Will old flaky tests be flagged as new after 60 days?</strong></summary>
+<summary><strong>Will old flaky tests be flagged as new after 14 days?</strong></summary>
 
-No. The 60-day window is a rolling query against `main` and `stable/*`
+No. The 14-day window is a rolling query against `main` and `stable/*`
 branches. Tests on those branches keep running normally (via `push` and
 `merge_group` triggers). As long as a test continues to flake on `main`, fresh
 entries keep appearing in BigQuery — it never falls out of the window.
 
 A test only drops out of the baseline if it **hasn't flaked on `main`/`stable/*`
-for 60+ days**. That likely means it was fixed. If a PR triggers it again,
+for 14+ days**. That likely means it was fixed. If a PR triggers it again,
 flagging it as NEW is the correct behavior.
 
 </details>
@@ -290,7 +291,7 @@ flagging it as NEW is the correct behavior.
 <details>
 <summary><strong>What about tests that flake very rarely (e.g., once every few months)?</strong></summary>
 
-If a test last flaked on main 61+ days ago and your PR hits it, it will be
+If a test last flaked on main 15+ days ago and your PR hits it, it will be
 flagged as NEW. In this case:
 
 1. Add the `ci:flaky-test-bypass` label to your PR

--- a/.github/actions/detect-new-flaky-tests/action.yml
+++ b/.github/actions/detect-new-flaky-tests/action.yml
@@ -1,12 +1,10 @@
----
+# owner: @camunda/monorepo-devops-team
 name: Detect New Flaky Tests
 
 description: >
   Compares flaky tests from the current PR run against known flaky tests from BigQuery.
   Posts a PR comment if new (previously unknown) flaky tests are detected.
   Can optionally fail the job to block the PR.
-
-# owner: @camunda/monorepo-devops-team
 
 inputs:
   pr-flaky-tests-data:

--- a/.github/actions/detect-new-flaky-tests/action.yml
+++ b/.github/actions/detect-new-flaky-tests/action.yml
@@ -1,0 +1,37 @@
+---
+name: Detect New Flaky Tests
+
+description: >
+  Compares flaky tests from the current PR run against known flaky tests from BigQuery.
+  Posts a new PR comment and fails if new (previously unknown) flaky tests are detected.
+
+# owner: @camunda/monorepo-devops-team
+
+inputs:
+  pr-flaky-tests-data:
+    description: 'JSON array of {job, flaky_tests} from collect-flaky-tests'
+    required: true
+  known-flaky-tests:
+    description: 'JSON array of {test_class_name, test_name} from BigQuery'
+    required: true
+  pr-number:
+    description: 'Pull request number'
+    required: true
+
+outputs:
+  has-new-flaky-tests:
+    description: 'Whether new flaky tests were detected (true/false)'
+    value: ${{ steps.detect.outputs.has-new-flaky-tests }}
+
+runs:
+  using: composite
+  steps:
+    - name: Detect new flaky tests
+      id: detect
+      shell: bash
+      env:
+        PR_FLAKY_TESTS_DATA: ${{ inputs.pr-flaky-tests-data }}
+        KNOWN_FLAKY_TESTS: ${{ inputs.known-flaky-tests }}
+        PR_NUMBER: ${{ inputs.pr-number }}
+        GITHUB_TOKEN: ${{ github.token }}
+      run: python3 ${{ github.action_path }}/detect_new_flaky_tests.py

--- a/.github/actions/detect-new-flaky-tests/action.yml
+++ b/.github/actions/detect-new-flaky-tests/action.yml
@@ -10,8 +10,8 @@ inputs:
   pr-flaky-tests-data:
     description: 'JSON array of {job, flaky_tests} from collect-flaky-tests'
     required: true
-  known-flaky-tests:
-    description: 'JSON array of {test_class_name, test_name} from BigQuery'
+  known-flaky-tests-file:
+    description: 'Path to a JSON file containing an array of {test_class_name, test_name} from BigQuery'
     required: true
   pr-number:
     description: 'Pull request number'
@@ -34,7 +34,7 @@ runs:
       shell: bash
       env:
         PR_FLAKY_TESTS_DATA: ${{ inputs.pr-flaky-tests-data }}
-        KNOWN_FLAKY_TESTS: ${{ inputs.known-flaky-tests }}
+        KNOWN_FLAKY_TESTS_FILE: ${{ inputs.known-flaky-tests-file }}
         PR_NUMBER: ${{ inputs.pr-number }}
         BLOCKING: ${{ inputs.blocking }}
         GITHUB_TOKEN: ${{ github.token }}

--- a/.github/actions/detect-new-flaky-tests/action.yml
+++ b/.github/actions/detect-new-flaky-tests/action.yml
@@ -3,7 +3,8 @@ name: Detect New Flaky Tests
 
 description: >
   Compares flaky tests from the current PR run against known flaky tests from BigQuery.
-  Posts a new PR comment and fails if new (previously unknown) flaky tests are detected.
+  Posts a PR comment if new (previously unknown) flaky tests are detected.
+  Can optionally fail the job to block the PR.
 
 # owner: @camunda/monorepo-devops-team
 
@@ -17,6 +18,10 @@ inputs:
   pr-number:
     description: 'Pull request number'
     required: true
+  blocking:
+    description: 'If true, fail the job when new flaky tests are found. If false, only post a comment.'
+    required: false
+    default: 'true'
 
 outputs:
   has-new-flaky-tests:
@@ -33,5 +38,6 @@ runs:
         PR_FLAKY_TESTS_DATA: ${{ inputs.pr-flaky-tests-data }}
         KNOWN_FLAKY_TESTS: ${{ inputs.known-flaky-tests }}
         PR_NUMBER: ${{ inputs.pr-number }}
+        BLOCKING: ${{ inputs.blocking }}
         GITHUB_TOKEN: ${{ github.token }}
       run: python3 ${{ github.action_path }}/detect_new_flaky_tests.py

--- a/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
+++ b/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
@@ -77,6 +77,8 @@ def process_flaky_tests_data(raw_data: list) -> list:
             print(f'{PREFIX} Skipping job "{job}" - no flaky tests')
             continue
 
+        # Tests are space-separated; each is: fully.qualified.Class.method(Params)[index]
+        # Params are Java class names (no spaces), e.g. (CamundaClient, CamundaClient).
         test_names = re.findall(r"[^\s\[(]+(?:\([^)]*\))?(?:\[[^\]]*])?", flaky_tests_str)
 
         for test_name in test_names:
@@ -101,6 +103,9 @@ def process_flaky_tests_data(raw_data: list) -> list:
 # GitHub helpers
 # ---------------------------------------------------------------------------
 
+COMMENT_MARKER = "<!-- new-flaky-tests-alert -->"
+
+
 def set_output(name: str, value: str) -> None:
     output_file = os.environ.get("GITHUB_OUTPUT")
     if output_file:
@@ -108,9 +113,7 @@ def set_output(name: str, value: str) -> None:
             fh.write(f"{name}={value}\n")
 
 
-def post_comment(owner: str, repo: str, pr_number: int, body: str, token: str) -> None:
-    url = f"https://api.github.com/repos/{owner}/{repo}/issues/{pr_number}/comments"
-    data = json.dumps({"body": body}).encode()
+def _github_api(url: str, token: str, method: str = "GET", data: bytes | None = None) -> bytes:
     req = urllib.request.Request(
         url,
         data=data,
@@ -119,16 +122,45 @@ def post_comment(owner: str, repo: str, pr_number: int, body: str, token: str) -
             "Accept": "application/vnd.github+json",
             "Content-Type": "application/json",
         },
-        method="POST",
+        method=method,
     )
     try:
         with urllib.request.urlopen(req) as resp:
-            if resp.status < 200 or resp.status >= 300:
-                print(f"{PREFIX} GitHub API responded with status {resp.status}")
-                sys.exit(1)
+            return resp.read()
     except urllib.error.HTTPError as exc:
-        print(f"{PREFIX} Failed to post comment: {exc.status} {exc.reason}")
+        body = exc.read().decode(errors="replace")
+        print(f"{PREFIX} GitHub API error: {exc.status} {exc.reason} — {body}")
         sys.exit(1)
+
+
+def _find_existing_comment(owner: str, repo: str, pr_number: int, token: str) -> int | None:
+    """Find an existing comment with COMMENT_MARKER and return its id, or None."""
+    page = 1
+    while True:
+        url = f"https://api.github.com/repos/{owner}/{repo}/issues/{pr_number}/comments?per_page=100&page={page}"
+        raw = _github_api(url, token)
+        comments = json.loads(raw)
+        if not comments:
+            break
+        for c in comments:
+            if COMMENT_MARKER in (c.get("body") or ""):
+                return c["id"]
+        page += 1
+    return None
+
+
+def post_or_update_comment(owner: str, repo: str, pr_number: int, body: str, token: str) -> None:
+    """Create a new comment or update the existing one (matched by COMMENT_MARKER)."""
+    existing_id = _find_existing_comment(owner, repo, pr_number, token)
+    payload = json.dumps({"body": body}).encode()
+    if existing_id:
+        url = f"https://api.github.com/repos/{owner}/{repo}/issues/comments/{existing_id}"
+        _github_api(url, token, method="PATCH", data=payload)
+        print(f"{PREFIX} Updated existing comment (id={existing_id}).")
+    else:
+        url = f"https://api.github.com/repos/{owner}/{repo}/issues/{pr_number}/comments"
+        _github_api(url, token, method="POST", data=payload)
+        print(f"{PREFIX} Created new comment.")
 
 
 # ---------------------------------------------------------------------------
@@ -269,7 +301,7 @@ def main() -> None:
 
     # -- Build alert comment --------------------------------------------------
     lines = [
-        "<!-- new-flaky-tests-alert -->",
+        COMMENT_MARKER,
         "# ⚠️ New Flaky Tests Detected",
         "",
         f"This PR introduces **{len(new_flaky_tests)} new flaky test(s)** that are not currently flaky on `main` or `stable/*` branches.",
@@ -305,10 +337,9 @@ def main() -> None:
 
     comment_body = "\n".join(lines)
 
-    # -- Post comment ---------------------------------------------------------
+    # -- Post or update comment ------------------------------------------------
     owner, repo = github_repository.split("/", 1)
-    post_comment(owner, repo, pr_number, comment_body, github_token)
-    print(f"{PREFIX} Posted new flaky tests alert comment.")
+    post_or_update_comment(owner, repo, pr_number, comment_body, github_token)
 
     set_output("has-new-flaky-tests", "true")
     if blocking:

--- a/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
+++ b/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
@@ -169,24 +169,30 @@ def _resolve_comment(owner: str, repo: str, comment_id: int, token: str) -> None
     url = f"https://api.github.com/repos/{owner}/{repo}/issues/comments/{comment_id}"
     raw = _github_api(url, token)
     current_body = json.loads(raw).get("body", "")
+
+    # If the comment is already resolved, don't re-wrap it in strikethrough
+    if "✅ Resolved — No New Flaky Tests" in current_body:
+        print(f"{PREFIX} Comment (id={comment_id}) is already resolved — skipping update.")
+        return
+
     # Strip the marker line — we'll re-add it at the top
-    old_body = current_body.replace(COMMENT_MARKER, "").strip()
+    previous_warning_body = current_body.replace(COMMENT_MARKER, "").strip()
     # Wrap each line in strikethrough, preserving markdown structural syntax
     # (headings and list markers must stay outside ~~ or they break rendering)
-    struck_lines = []
-    for line in old_body.splitlines():
+    strikethrough_lines = []
+    for line in previous_warning_body.splitlines():
         stripped = line.strip()
         if not stripped:
-            struck_lines.append("")
+            strikethrough_lines.append("")
         elif stripped.startswith("#"):
             text = stripped.lstrip("#").strip()
-            struck_lines.append(f"~~{text}~~")
+            strikethrough_lines.append(f"~~{text}~~")
         elif stripped.startswith("- "):
             indent = line[: len(line) - len(line.lstrip())]
-            struck_lines.append(f"{indent}- ~~{stripped[2:]}~~")
+            strikethrough_lines.append(f"{indent}- ~~{stripped[2:]}~~")
         else:
-            struck_lines.append(f"~~{stripped}~~")
-    struck = "\n".join(struck_lines)
+            strikethrough_lines.append(f"~~{stripped}~~")
+    strikethrough_body = "\n".join(strikethrough_lines)
     resolved_body = "\n".join([
         COMMENT_MARKER,
         "# ✅ Resolved — No New Flaky Tests",
@@ -196,7 +202,7 @@ def _resolve_comment(owner: str, repo: str, comment_id: int, token: str) -> None
         "<details>",
         "<summary>Previous warning (resolved)</summary>",
         "",
-        struck,
+        strikethrough_body,
         "",
         "</details>",
     ])
@@ -253,24 +259,24 @@ def main() -> None:
         return
 
     try:
-        pr_flaky_entries = json.loads(pr_flaky_json)
+        raw_pr_flaky_entries = json.loads(pr_flaky_json)
     except json.JSONDecodeError as exc:
         print(f"{PREFIX} Failed to parse PR flaky tests data: {exc}")
         set_output("has-new-flaky-tests", "false")
         return
 
-    if not isinstance(pr_flaky_entries, list) or len(pr_flaky_entries) == 0:
+    if not isinstance(raw_pr_flaky_entries, list) or len(raw_pr_flaky_entries) == 0:
         print(f"{PREFIX} No PR flaky tests found.")
         set_output("has-new-flaky-tests", "false")
         return
 
-    print(f"{PREFIX} Raw PR flaky test entries ({len(pr_flaky_entries)} jobs):")
-    for i, entry in enumerate(pr_flaky_entries):
+    print(f"{PREFIX} Raw PR flaky test entries ({len(raw_pr_flaky_entries)} jobs):")
+    for i, entry in enumerate(raw_pr_flaky_entries):
         job = entry.get('job', '<unknown>')
         tests = entry.get('flaky_tests', '')
         print(f"{PREFIX}   [{i+1}] job='{job}' flaky_tests='{tests}'")
 
-    pr_flaky_tests = process_flaky_tests_data(pr_flaky_entries)
+    pr_flaky_tests = process_flaky_tests_data(raw_pr_flaky_entries)
     if not pr_flaky_tests:
         print(f"{PREFIX} No processed flaky tests from PR.")
         set_output("has-new-flaky-tests", "false")

--- a/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
+++ b/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Detect new flaky tests introduced by a PR.
+
+Compares flaky tests from the current PR run against known flaky tests
+(queried from BigQuery). Posts a PR comment and fails if new flaky tests
+are found.
+
+Inputs (environment variables):
+  PR_FLAKY_TESTS_DATA  – JSON array of {job, flaky_tests}
+  KNOWN_FLAKY_TESTS    – JSON array of {test_class_name, test_name}
+  PR_NUMBER            – Pull request number
+  GITHUB_TOKEN         – GitHub API token
+  GITHUB_REPOSITORY    – owner/repo
+  GITHUB_OUTPUT        – Path to the output file for setting step outputs
+"""
+
+import json
+import os
+import re
+import sys
+import urllib.request
+import urllib.error
+
+PREFIX = "[new-flaky]"
+
+
+# ---------------------------------------------------------------------------
+# Test‑name helpers (mirror the JS helpers in flaky-tests-summary-comment)
+# ---------------------------------------------------------------------------
+
+def parse_test_name(test_name: str) -> dict:
+    """Parse a fully-qualified test name into package, class, and method."""
+    last_dot = test_name.rfind(".")
+    if last_dot == -1:
+        return {"fullName": test_name.strip()}
+
+    fully_qualified_class = test_name[:last_dot]
+    method_name = test_name[last_dot + 1 :]
+
+    # Remove trailing [index]
+    method_name = re.sub(r"\[.*?]\s*$", "", method_name)
+    # Remove parameter list
+    method_name = re.sub(r"\(.*?\)\s*$", "", method_name).strip()
+
+    class_parts = fully_qualified_class.split(".")
+    class_name = class_parts[-1]
+    package_name = ".".join(class_parts[:-1])
+
+    return {
+        "packageName": package_name,
+        "className": class_name,
+        "methodName": method_name,
+    }
+
+
+def get_test_key(test: dict) -> str:
+    """Build a unique key for a parsed test dict."""
+    if "fullName" in test and test["fullName"]:
+        return test["fullName"]
+    method = test.get("methodName", "")
+    method = re.sub(r"\[([^\]]+)]\([^)]+\)", r"\1", method)
+    return f"{test.get('packageName', '')}.{test.get('className', '')}.{method}"
+
+
+# ---------------------------------------------------------------------------
+# Data processing (mirrors processFlakyTestsData from JS)
+# ---------------------------------------------------------------------------
+
+def process_flaky_tests_data(raw_data: list) -> list:
+    """Deduplicate and structure raw flaky test entries."""
+    test_map: dict[str, dict] = {}
+
+    for entry in raw_data:
+        job = entry.get("job", "")
+        flaky_tests_str = entry.get("flaky_tests", "")
+        if not flaky_tests_str or not flaky_tests_str.strip():
+            print(f'{PREFIX} Skipping job "{job}" - no flaky tests')
+            continue
+
+        test_names = re.findall(r"[^\s\[(]+(?:\([^)]*\))?(?:\[[^\]]*])?", flaky_tests_str)
+
+        for test_name in test_names:
+            parsed = parse_test_name(test_name)
+            key = get_test_key(parsed)
+            if key in test_map:
+                existing = test_map[key]
+                if job not in existing["jobs"]:
+                    existing["jobs"].append(job)
+                existing["currentRunFailures"] += 1
+            else:
+                test_map[key] = {
+                    **parsed,
+                    "jobs": [job],
+                    "currentRunFailures": 1,
+                }
+
+    return list(test_map.values())
+
+
+# ---------------------------------------------------------------------------
+# GitHub helpers
+# ---------------------------------------------------------------------------
+
+def set_output(name: str, value: str) -> None:
+    output_file = os.environ.get("GITHUB_OUTPUT")
+    if output_file:
+        with open(output_file, "a") as fh:
+            fh.write(f"{name}={value}\n")
+
+
+def post_comment(owner: str, repo: str, pr_number: int, body: str, token: str) -> None:
+    url = f"https://api.github.com/repos/{owner}/{repo}/issues/{pr_number}/comments"
+    data = json.dumps({"body": body}).encode()
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={
+            "Authorization": f"token {token}",
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req) as resp:
+            if resp.status < 200 or resp.status >= 300:
+                print(f"{PREFIX} GitHub API responded with status {resp.status}")
+                sys.exit(1)
+    except urllib.error.HTTPError as exc:
+        print(f"{PREFIX} Failed to post comment: {exc.status} {exc.reason}")
+        sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    pr_flaky_input = os.environ.get("PR_FLAKY_TESTS_DATA", "")
+    known_flaky_input = os.environ.get("KNOWN_FLAKY_TESTS", "")
+    pr_number = int(os.environ.get("PR_NUMBER", "0"))
+    github_token = os.environ.get("GITHUB_TOKEN", "")
+    github_repository = os.environ.get("GITHUB_REPOSITORY", "")
+
+    # -- Parse PR flaky tests ------------------------------------------------
+    print(f"\n{'='*80}")
+    print(f"{PREFIX} === STEP 1: Parse PR flaky tests ===")
+    print(f"{'='*80}")
+
+    if not pr_flaky_input or pr_flaky_input.strip() in ("", "[]"):
+        print(f"{PREFIX} No PR flaky tests data provided - nothing to check.")
+        set_output("has-new-flaky-tests", "false")
+        return
+
+    try:
+        pr_flaky_raw = json.loads(pr_flaky_input)
+    except json.JSONDecodeError as exc:
+        print(f"{PREFIX} Failed to parse PR flaky tests data: {exc}")
+        set_output("has-new-flaky-tests", "false")
+        return
+
+    if not isinstance(pr_flaky_raw, list) or len(pr_flaky_raw) == 0:
+        print(f"{PREFIX} No PR flaky tests found.")
+        set_output("has-new-flaky-tests", "false")
+        return
+
+    print(f"{PREFIX} Raw PR flaky test entries ({len(pr_flaky_raw)} jobs):")
+    for i, entry in enumerate(pr_flaky_raw):
+        job = entry.get('job', '<unknown>')
+        tests = entry.get('flaky_tests', '')
+        print(f"{PREFIX}   [{i+1}] job='{job}' flaky_tests='{tests}'")
+
+    processed_pr_tests = process_flaky_tests_data(pr_flaky_raw)
+    if not processed_pr_tests:
+        print(f"{PREFIX} No processed flaky tests from PR.")
+        set_output("has-new-flaky-tests", "false")
+        return
+
+    print(f"\n{PREFIX} Processed PR flaky tests ({len(processed_pr_tests)} unique):")
+    for i, test in enumerate(processed_pr_tests):
+        key = get_test_key(test)
+        print(f"{PREFIX}   [{i+1}] key='{key}' jobs={test['jobs']} retries={test['currentRunFailures']}")
+
+    # -- Parse known flaky tests from BigQuery --------------------------------
+    print(f"\n{'='*80}")
+    print(f"{PREFIX} === STEP 2: Parse known flaky tests (BigQuery baseline) ===")
+    print(f"{'='*80}")
+
+    known_flaky_tests: list[dict] = []
+    try:
+        if known_flaky_input and known_flaky_input.strip():
+            known_flaky_tests = json.loads(known_flaky_input)
+    except json.JSONDecodeError as exc:
+        print(f"{PREFIX} Failed to parse known flaky tests - treating all PR flaky tests as new: {exc}")
+
+    print(f"{PREFIX} Known flaky tests from main/stable (last 30 days): {len(known_flaky_tests)} entries")
+
+    # BigQuery format: {test_class_name, test_name}  →  key = "class.method"
+    known_keys: set[str] = set()
+    for known in known_flaky_tests:
+        key = f"{known['test_class_name']}.{known['test_name']}"
+        known_keys.add(key)
+
+    print(f"{PREFIX} Unique known flaky test keys: {len(known_keys)}")
+    for i, key in enumerate(sorted(known_keys)):
+        print(f"{PREFIX}   [{i+1}] {key}")
+
+    # -- Compare --------------------------------------------------------------
+    print(f"\n{'='*80}")
+    print(f"{PREFIX} === STEP 3: Compare PR flaky tests against known baseline ===")
+    print(f"{'='*80}")
+
+    new_flaky_tests: list[dict] = []
+    for test in processed_pr_tests:
+        key = get_test_key(test)
+        is_known = key in known_keys
+        status = "KNOWN (already flaky on main/stable)" if is_known else "NEW (not seen on main/stable)"
+        print(f"{PREFIX}   {key} → {status}")
+        if not is_known:
+            new_flaky_tests.append(test)
+
+    print(f"\n{PREFIX} --- Result ---")
+    print(f"{PREFIX} Total PR flaky tests: {len(processed_pr_tests)}")
+    print(f"{PREFIX} Already known:        {len(processed_pr_tests) - len(new_flaky_tests)}")
+    print(f"{PREFIX} NEW flaky tests:      {len(new_flaky_tests)}")
+
+    if not new_flaky_tests:
+        print(f"{PREFIX} ✅ All flaky tests in this PR are already known. No new flaky tests.")
+        set_output("has-new-flaky-tests", "false")
+        return
+
+    print(f"\n{PREFIX} ❌ Found {len(new_flaky_tests)} NEW flaky test(s)!")
+    for i, test in enumerate(new_flaky_tests):
+        key = get_test_key(test)
+        print(f"{PREFIX}   [{i+1}] {key}")
+        print(f"{PREFIX}        jobs: {', '.join(test['jobs'])}")
+        print(f"{PREFIX}        retries: {test['currentRunFailures']}")
+
+    # -- Build alert comment --------------------------------------------------
+    lines = [
+        "<!-- new-flaky-tests-alert -->",
+        "# ⚠️ New Flaky Tests Detected",
+        "",
+        f"This PR introduces **{len(new_flaky_tests)} new flaky test(s)** that are not currently flaky on `main` or `stable/*` branches.",
+        "",
+    ]
+
+    for test in new_flaky_tests:
+        test_name = test.get("methodName") or test.get("fullName", "unknown")
+        lines.append(f"- **{test_name}**")
+        lines.append(f"  - Jobs: `{', '.join(test['jobs'])}`")
+        if test.get("packageName"):
+            lines.append(f"  - Package: `{test['packageName']}`")
+        if test.get("className"):
+            lines.append(f"  - Class: `{test['className']}`")
+        lines.append(f"  - Retries in this run: {test['currentRunFailures']}")
+        lines.append("")
+
+    lines.extend(
+        [
+            "---",
+            "",
+            "**What to do:**",
+            "1. Check if the flaky test is caused by your changes",
+            "2. Fix the test if possible",
+            "3. If the test is unrelated to your changes, create a `kind/flake` issue and link it in a comment",
+            "",
+            "_This check compares flaky tests in this PR against tests known to be flaky on `main`/`stable/*` in the last 30 days._",
+        ]
+    )
+
+    comment_body = "\n".join(lines)
+
+    # -- Post comment ---------------------------------------------------------
+    owner, repo = github_repository.split("/", 1)
+    post_comment(owner, repo, pr_number, comment_body, github_token)
+    print(f"{PREFIX} Posted new flaky tests alert comment.")
+
+    set_output("has-new-flaky-tests", "true")
+    print(f"::error::{len(new_flaky_tests)} new flaky test(s) detected. See the PR comment for details.")
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
+++ b/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
@@ -6,9 +6,9 @@ Compares flaky tests from the current PR run against known flaky tests
 are found.
 
 Inputs (environment variables):
-  PR_FLAKY_TESTS_DATA  – JSON array of {job, flaky_tests}
-  KNOWN_FLAKY_TESTS    – JSON array of {test_class_name, test_name}
-  PR_NUMBER            – Pull request number
+  PR_FLAKY_TESTS_DATA    – JSON array of {job, flaky_tests}
+  KNOWN_FLAKY_TESTS_FILE – Path to a JSON file with [{test_class_name, test_name}]
+  PR_NUMBER              – Pull request number
   GITHUB_TOKEN         – GitHub API token
   GITHUB_REPOSITORY    – owner/repo
   GITHUB_OUTPUT        – Path to the output file for setting step outputs
@@ -113,6 +113,10 @@ def set_output(name: str, value: str) -> None:
             fh.write(f"{name}={value}\n")
 
 
+class GitHubAPIError(Exception):
+    """Raised when a GitHub API call fails."""
+
+
 def _github_api(url: str, token: str, method: str = "GET", data: bytes | None = None) -> bytes:
     req = urllib.request.Request(
         url,
@@ -129,8 +133,9 @@ def _github_api(url: str, token: str, method: str = "GET", data: bytes | None = 
             return resp.read()
     except urllib.error.HTTPError as exc:
         body = exc.read().decode(errors="replace")
-        print(f"{PREFIX} GitHub API error: {exc.status} {exc.reason} — {body}")
-        sys.exit(1)
+        msg = f"GitHub API error: {exc.status} {exc.reason} — {body}"
+        print(f"{PREFIX} {msg}")
+        raise GitHubAPIError(msg) from exc
 
 
 def _find_existing_comment(owner: str, repo: str, pr_number: int, token: str) -> int | None:
@@ -242,7 +247,7 @@ def _is_same_test(baseline_key: str, normalized_key: str) -> bool:
 
 def main() -> None:
     pr_flaky_json = os.environ.get("PR_FLAKY_TESTS_DATA", "")
-    baseline_flaky_json = os.environ.get("KNOWN_FLAKY_TESTS", "")
+    known_flaky_file = os.environ.get("KNOWN_FLAKY_TESTS_FILE", "")
     pr_number = int(os.environ.get("PR_NUMBER", "0"))
     github_token = os.environ.get("GITHUB_TOKEN", "")
     github_repository = os.environ.get("GITHUB_REPOSITORY", "")
@@ -294,12 +299,15 @@ def main() -> None:
 
     baseline_flaky_tests: list[dict] = []
     try:
-        if baseline_flaky_json and baseline_flaky_json.strip():
-            baseline_flaky_tests = json.loads(baseline_flaky_json)
+        if known_flaky_file and os.path.isfile(known_flaky_file):
+            with open(known_flaky_file, encoding="utf-8") as f:
+                baseline_flaky_tests = json.load(f)
+        elif known_flaky_file:
+            print(f"{PREFIX} WARNING: Known flaky tests file not found: {known_flaky_file}")
     except json.JSONDecodeError as exc:
         print(f"{PREFIX} Failed to parse baseline flaky tests - treating all PR flaky tests as new: {exc}")
 
-    print(f"{PREFIX} Baseline flaky tests from main/stable (last 60 days): {len(baseline_flaky_tests)} entries")
+    print(f"{PREFIX} Baseline flaky tests from main/stable (last 14 days): {len(baseline_flaky_tests)} entries")
 
     # BigQuery test_name may include parameters and suffixes, e.g.
     #   "shouldDoSomething(CamundaRdbmsTestApplication) camundaWithOracleDB"
@@ -310,8 +318,6 @@ def main() -> None:
         baseline_keys.add(key)
 
     print(f"{PREFIX} Unique baseline flaky test keys: {len(baseline_keys)}")
-    for i, key in enumerate(sorted(baseline_keys)):
-        print(f"{PREFIX}   [{i+1}] {key}")
 
     # -- Compare --------------------------------------------------------------
     print(f"\n{'='*80}")
@@ -321,13 +327,10 @@ def main() -> None:
     new_flaky_tests: list[dict] = []
     for test in pr_flaky_tests:
         normalized_key = get_test_key(test)
-        # Normalized keys have no params; baseline keys may have params/suffixes.
-        # Match if the baseline key is the same test method (exact or with param suffix).
-        is_known = any(_is_same_test(k, normalized_key) for k in baseline_keys)
-        matched = [k for k in baseline_keys if _is_same_test(k, normalized_key)] if is_known else []
-        status = f"KNOWN (matched: {matched})" if is_known else "NEW (not seen on main/stable)"
+        matched = [k for k in baseline_keys if _is_same_test(k, normalized_key)]
+        status = f"KNOWN (matched: {matched})" if matched else "NEW (not seen on main/stable)"
         print(f"{PREFIX}   {normalized_key} → {status}")
-        if not is_known:
+        if not matched:
             new_flaky_tests.append(test)
 
     print(f"\n{PREFIX} --- Result ---")
@@ -340,9 +343,14 @@ def main() -> None:
         set_output("has-new-flaky-tests", "false")
         # If a previous run left a warning comment, update it to "resolved".
         owner, repo = github_repository.split("/", 1)
-        existing_id = _find_existing_comment(owner, repo, pr_number, github_token)
-        if existing_id:
-            _resolve_comment(owner, repo, existing_id, github_token)
+        try:
+            existing_id = _find_existing_comment(owner, repo, pr_number, github_token)
+            if existing_id:
+                _resolve_comment(owner, repo, existing_id, github_token)
+        except GitHubAPIError:
+            if blocking:
+                sys.exit(1)
+            print(f"{PREFIX} WARNING: Failed to resolve comment (non-blocking mode) — continuing.")
         return
 
     print(f"\n{PREFIX} ❌ Found {len(new_flaky_tests)} NEW flaky test(s)!")
@@ -392,7 +400,12 @@ def main() -> None:
 
     # -- Post or update comment ------------------------------------------------
     owner, repo = github_repository.split("/", 1)
-    post_or_update_comment(owner, repo, pr_number, comment_body, github_token)
+    try:
+        post_or_update_comment(owner, repo, pr_number, comment_body, github_token)
+    except GitHubAPIError:
+        if blocking:
+            sys.exit(1)
+        print(f"{PREFIX} WARNING: Failed to post/update comment (non-blocking mode) — continuing.")
 
     set_output("has-new-flaky-tests", "true")
     if blocking:

--- a/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
+++ b/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
@@ -135,23 +135,24 @@ def post_comment(owner: str, repo: str, pr_number: int, body: str, token: str) -
 # Test comparison
 # ---------------------------------------------------------------------------
 
-def _is_same_test(known_key: str, pr_key: str) -> bool:
-    """Check if a BigQuery known key matches a normalized PR key.
+def _is_same_test(baseline_key: str, normalized_key: str) -> bool:
+    """Check if a BigQuery baseline key matches a normalized PR key.
 
-    BigQuery keys may have trailing params/suffixes that parse_test_name strips:
-      known: "pkg.Class.method(Param) variant"
-      pr:    "pkg.Class.method"
+    Baseline keys (from BigQuery) may have trailing params/suffixes that
+    parse_test_name strips:
+      baseline:   "pkg.Class.method(Param) variant"
+      normalized: "pkg.Class.method"
 
-    We accept a match if the known key equals the PR key, or starts with
-    the PR key followed by a non-alphanumeric char (to avoid "shouldFind"
-    matching "shouldFindAll").
+    We accept a match if the baseline key equals the normalized key, or starts
+    with the normalized key followed by a non-alphanumeric, non-underscore char
+    (to avoid "shouldFind" matching "shouldFindAll").
     """
-    if known_key == pr_key:
+    if baseline_key == normalized_key:
         return True
-    if not known_key.startswith(pr_key):
+    if not baseline_key.startswith(normalized_key):
         return False
-    # The character right after the PR key must be a boundary (not part of a method name)
-    next_char = known_key[len(pr_key)]
+    # The character right after the normalized key must be a boundary
+    next_char = baseline_key[len(normalized_key)]
     return not next_char.isalnum() and next_char != "_"
 
 
@@ -160,48 +161,49 @@ def _is_same_test(known_key: str, pr_key: str) -> bool:
 # ---------------------------------------------------------------------------
 
 def main() -> None:
-    pr_flaky_input = os.environ.get("PR_FLAKY_TESTS_DATA", "")
-    known_flaky_input = os.environ.get("KNOWN_FLAKY_TESTS", "")
+    pr_flaky_json = os.environ.get("PR_FLAKY_TESTS_DATA", "")
+    baseline_flaky_json = os.environ.get("KNOWN_FLAKY_TESTS", "")
     pr_number = int(os.environ.get("PR_NUMBER", "0"))
     github_token = os.environ.get("GITHUB_TOKEN", "")
     github_repository = os.environ.get("GITHUB_REPOSITORY", "")
+    blocking = os.environ.get("BLOCKING", "true").lower() == "true"
 
     # -- Parse PR flaky tests ------------------------------------------------
     print(f"\n{'='*80}")
     print(f"{PREFIX} === STEP 1: Parse PR flaky tests ===")
     print(f"{'='*80}")
 
-    if not pr_flaky_input or pr_flaky_input.strip() in ("", "[]"):
+    if not pr_flaky_json or pr_flaky_json.strip() in ("", "[]"):
         print(f"{PREFIX} No PR flaky tests data provided - nothing to check.")
         set_output("has-new-flaky-tests", "false")
         return
 
     try:
-        pr_flaky_raw = json.loads(pr_flaky_input)
+        pr_flaky_entries = json.loads(pr_flaky_json)
     except json.JSONDecodeError as exc:
         print(f"{PREFIX} Failed to parse PR flaky tests data: {exc}")
         set_output("has-new-flaky-tests", "false")
         return
 
-    if not isinstance(pr_flaky_raw, list) or len(pr_flaky_raw) == 0:
+    if not isinstance(pr_flaky_entries, list) or len(pr_flaky_entries) == 0:
         print(f"{PREFIX} No PR flaky tests found.")
         set_output("has-new-flaky-tests", "false")
         return
 
-    print(f"{PREFIX} Raw PR flaky test entries ({len(pr_flaky_raw)} jobs):")
-    for i, entry in enumerate(pr_flaky_raw):
+    print(f"{PREFIX} Raw PR flaky test entries ({len(pr_flaky_entries)} jobs):")
+    for i, entry in enumerate(pr_flaky_entries):
         job = entry.get('job', '<unknown>')
         tests = entry.get('flaky_tests', '')
         print(f"{PREFIX}   [{i+1}] job='{job}' flaky_tests='{tests}'")
 
-    processed_pr_tests = process_flaky_tests_data(pr_flaky_raw)
-    if not processed_pr_tests:
+    pr_flaky_tests = process_flaky_tests_data(pr_flaky_entries)
+    if not pr_flaky_tests:
         print(f"{PREFIX} No processed flaky tests from PR.")
         set_output("has-new-flaky-tests", "false")
         return
 
-    print(f"\n{PREFIX} Processed PR flaky tests ({len(processed_pr_tests)} unique):")
-    for i, test in enumerate(processed_pr_tests):
+    print(f"\n{PREFIX} Processed PR flaky tests ({len(pr_flaky_tests)} unique):")
+    for i, test in enumerate(pr_flaky_tests):
         key = get_test_key(test)
         print(f"{PREFIX}   [{i+1}] key='{key}' jobs={test['jobs']} retries={test['currentRunFailures']}")
 
@@ -210,25 +212,25 @@ def main() -> None:
     print(f"{PREFIX} === STEP 2: Parse known flaky tests (BigQuery baseline) ===")
     print(f"{'='*80}")
 
-    known_flaky_tests: list[dict] = []
+    baseline_flaky_tests: list[dict] = []
     try:
-        if known_flaky_input and known_flaky_input.strip():
-            known_flaky_tests = json.loads(known_flaky_input)
+        if baseline_flaky_json and baseline_flaky_json.strip():
+            baseline_flaky_tests = json.loads(baseline_flaky_json)
     except json.JSONDecodeError as exc:
-        print(f"{PREFIX} Failed to parse known flaky tests - treating all PR flaky tests as new: {exc}")
+        print(f"{PREFIX} Failed to parse baseline flaky tests - treating all PR flaky tests as new: {exc}")
 
-    print(f"{PREFIX} Known flaky tests from main/stable (last 30 days): {len(known_flaky_tests)} entries")
+    print(f"{PREFIX} Baseline flaky tests from main/stable (last 60 days): {len(baseline_flaky_tests)} entries")
 
     # BigQuery test_name may include parameters and suffixes, e.g.
     #   "shouldDoSomething(CamundaRdbmsTestApplication) camundaWithOracleDB"
     # Keep the raw keys for full fidelity in debug output.
-    known_keys: set[str] = set()
-    for known in known_flaky_tests:
-        key = f"{known['test_class_name']}.{known['test_name']}"
-        known_keys.add(key)
+    baseline_keys: set[str] = set()
+    for entry in baseline_flaky_tests:
+        key = f"{entry['test_class_name']}.{entry['test_name']}"
+        baseline_keys.add(key)
 
-    print(f"{PREFIX} Unique known flaky test keys: {len(known_keys)}")
-    for i, key in enumerate(sorted(known_keys)):
+    print(f"{PREFIX} Unique baseline flaky test keys: {len(baseline_keys)}")
+    for i, key in enumerate(sorted(baseline_keys)):
         print(f"{PREFIX}   [{i+1}] {key}")
 
     # -- Compare --------------------------------------------------------------
@@ -237,20 +239,20 @@ def main() -> None:
     print(f"{'='*80}")
 
     new_flaky_tests: list[dict] = []
-    for test in processed_pr_tests:
-        pr_key = get_test_key(test)
-        # PR keys are normalized (no params), BigQuery keys may have params/suffixes.
-        # Match if the known key is the same test method (exact or with param suffix).
-        is_known = any(_is_same_test(k, pr_key) for k in known_keys)
-        matched = [k for k in known_keys if _is_same_test(k, pr_key)] if is_known else []
+    for test in pr_flaky_tests:
+        normalized_key = get_test_key(test)
+        # Normalized keys have no params; baseline keys may have params/suffixes.
+        # Match if the baseline key is the same test method (exact or with param suffix).
+        is_known = any(_is_same_test(k, normalized_key) for k in baseline_keys)
+        matched = [k for k in baseline_keys if _is_same_test(k, normalized_key)] if is_known else []
         status = f"KNOWN (matched: {matched})" if is_known else "NEW (not seen on main/stable)"
-        print(f"{PREFIX}   {pr_key} → {status}")
+        print(f"{PREFIX}   {normalized_key} → {status}")
         if not is_known:
             new_flaky_tests.append(test)
 
     print(f"\n{PREFIX} --- Result ---")
-    print(f"{PREFIX} Total PR flaky tests: {len(processed_pr_tests)}")
-    print(f"{PREFIX} Already known:        {len(processed_pr_tests) - len(new_flaky_tests)}")
+    print(f"{PREFIX} Total PR flaky tests: {len(pr_flaky_tests)}")
+    print(f"{PREFIX} Already known:        {len(pr_flaky_tests) - len(new_flaky_tests)}")
     print(f"{PREFIX} NEW flaky tests:      {len(new_flaky_tests)}")
 
     if not new_flaky_tests:
@@ -290,11 +292,14 @@ def main() -> None:
             "---",
             "",
             "**What to do:**",
-            "1. Check if the flaky test is caused by your changes",
-            "2. Fix the test if possible",
-            "3. If the test is unrelated to your changes, create a `kind/flake` issue and link it in a comment",
+            "1. Check if the flaky test is caused by your changes and fix it",
+            "2. If the test is unrelated to your changes:",
+            "   - Contact the monorepo devops (#top-monorepo-ci) to triage and discuss the next steps",
+            "   - Create an issue with the `kind/flake` label documenting the test, job, and a link to this CI run",
+            "   - Add the `ci:flaky-test-bypass` label to this PR to skip the gate and unblock merging",
+            "   - Re-run CI after adding the label",
             "",
-            "_This check compares flaky tests in this PR against tests known to be flaky on `main`/`stable/*` in the last 30 days._",
+            "_This check compares flaky tests in this PR against tests known to be flaky on `main`/`stable/*` in the last 60 days._",
         ]
     )
 
@@ -306,8 +311,11 @@ def main() -> None:
     print(f"{PREFIX} Posted new flaky tests alert comment.")
 
     set_output("has-new-flaky-tests", "true")
-    print(f"::error::{len(new_flaky_tests)} new flaky test(s) detected. See the PR comment for details.")
-    sys.exit(1)
+    if blocking:
+        print(f"::error::{len(new_flaky_tests)} new flaky test(s) detected. See the PR comment for details.")
+        sys.exit(1)
+    else:
+        print(f"::warning::{len(new_flaky_tests)} new flaky test(s) detected (non-blocking mode). See the PR comment for details.")
 
 
 if __name__ == "__main__":

--- a/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
+++ b/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
@@ -171,8 +171,22 @@ def _resolve_comment(owner: str, repo: str, comment_id: int, token: str) -> None
     current_body = json.loads(raw).get("body", "")
     # Strip the marker line — we'll re-add it at the top
     old_body = current_body.replace(COMMENT_MARKER, "").strip()
-    # Wrap each line in strikethrough
-    struck = "\n".join(f"~~{line}~~" if line.strip() else "" for line in old_body.splitlines())
+    # Wrap each line in strikethrough, preserving markdown structural syntax
+    # (headings and list markers must stay outside ~~ or they break rendering)
+    struck_lines = []
+    for line in old_body.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            struck_lines.append("")
+        elif stripped.startswith("#"):
+            text = stripped.lstrip("#").strip()
+            struck_lines.append(f"~~{text}~~")
+        elif stripped.startswith("- "):
+            indent = line[: len(line) - len(line.lstrip())]
+            struck_lines.append(f"{indent}- ~~{stripped[2:]}~~")
+        else:
+            struck_lines.append(f"~~{stripped}~~")
+    struck = "\n".join(struck_lines)
     resolved_body = "\n".join([
         COMMENT_MARKER,
         "# ✅ Resolved — No New Flaky Tests",

--- a/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
+++ b/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
@@ -132,6 +132,30 @@ def post_comment(owner: str, repo: str, pr_number: int, body: str, token: str) -
 
 
 # ---------------------------------------------------------------------------
+# Test comparison
+# ---------------------------------------------------------------------------
+
+def _is_same_test(known_key: str, pr_key: str) -> bool:
+    """Check if a BigQuery known key matches a normalized PR key.
+
+    BigQuery keys may have trailing params/suffixes that parse_test_name strips:
+      known: "pkg.Class.method(Param) variant"
+      pr:    "pkg.Class.method"
+
+    We accept a match if the known key equals the PR key, or starts with
+    the PR key followed by a non-alphanumeric char (to avoid "shouldFind"
+    matching "shouldFindAll").
+    """
+    if known_key == pr_key:
+        return True
+    if not known_key.startswith(pr_key):
+        return False
+    # The character right after the PR key must be a boundary (not part of a method name)
+    next_char = known_key[len(pr_key)]
+    return not next_char.isalnum() and next_char != "_"
+
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -216,9 +240,9 @@ def main() -> None:
     for test in processed_pr_tests:
         pr_key = get_test_key(test)
         # PR keys are normalized (no params), BigQuery keys may have params/suffixes.
-        # Match if the PR key equals the known key OR the known key starts with the PR key.
-        is_known = any(k == pr_key or k.startswith(pr_key) for k in known_keys)
-        matched = [k for k in known_keys if k == pr_key or k.startswith(pr_key)] if is_known else []
+        # Match if the known key is the same test method (exact or with param suffix).
+        is_known = any(_is_same_test(k, pr_key) for k in known_keys)
+        matched = [k for k in known_keys if _is_same_test(k, pr_key)] if is_known else []
         status = f"KNOWN (matched: {matched})" if is_known else "NEW (not seen on main/stable)"
         print(f"{PREFIX}   {pr_key} → {status}")
         if not is_known:

--- a/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
+++ b/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
@@ -393,7 +393,7 @@ def main() -> None:
             "**What to do:**",
             "1. Check if the flaky test is caused by your changes and fix it",
             "2. If the test is unrelated to your changes:",
-            "   - Contact the monorepo devops (#top-monorepo-ci) to triage and discuss the next steps",
+            "   - Contact the Monorepo DevOps team (#ask-monorepo-devops) to triage and discuss the next steps",
             "   - Create an issue with the `kind/flake` label documenting the test, job, and a link to this CI run",
             "   - Add the `ci:flaky-test-bypass` label to this PR to skip the gate and unblock merging",
             "   - Re-run CI after adding the label",

--- a/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
+++ b/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
@@ -163,6 +163,34 @@ def post_or_update_comment(owner: str, repo: str, pr_number: int, body: str, tok
         print(f"{PREFIX} Created new comment.")
 
 
+def _resolve_comment(owner: str, repo: str, comment_id: int, token: str) -> None:
+    """Update an existing warning comment to show it's resolved, keeping the old body as strikethrough."""
+    # Fetch the current comment body
+    url = f"https://api.github.com/repos/{owner}/{repo}/issues/comments/{comment_id}"
+    raw = _github_api(url, token)
+    current_body = json.loads(raw).get("body", "")
+    # Strip the marker line — we'll re-add it at the top
+    old_body = current_body.replace(COMMENT_MARKER, "").strip()
+    # Wrap each line in strikethrough
+    struck = "\n".join(f"~~{line}~~" if line.strip() else "" for line in old_body.splitlines())
+    resolved_body = "\n".join([
+        COMMENT_MARKER,
+        "# ✅ Resolved — No New Flaky Tests",
+        "",
+        "A previous CI run flagged new flaky tests, but the latest run found none.",
+        "",
+        "<details>",
+        "<summary>Previous warning (resolved)</summary>",
+        "",
+        struck,
+        "",
+        "</details>",
+    ])
+    payload = json.dumps({"body": resolved_body}).encode()
+    _github_api(url, token, method="PATCH", data=payload)
+    print(f"{PREFIX} Updated comment (id={comment_id}) to resolved.")
+
+
 # ---------------------------------------------------------------------------
 # Test comparison
 # ---------------------------------------------------------------------------
@@ -290,6 +318,11 @@ def main() -> None:
     if not new_flaky_tests:
         print(f"{PREFIX} ✅ All flaky tests in this PR are already known. No new flaky tests.")
         set_output("has-new-flaky-tests", "false")
+        # If a previous run left a warning comment, update it to "resolved".
+        owner, repo = github_repository.split("/", 1)
+        existing_id = _find_existing_comment(owner, repo, pr_number, github_token)
+        if existing_id:
+            _resolve_comment(owner, repo, existing_id, github_token)
         return
 
     print(f"\n{PREFIX} ❌ Found {len(new_flaky_tests)} NEW flaky test(s)!")

--- a/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
+++ b/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
@@ -195,7 +195,9 @@ def main() -> None:
 
     print(f"{PREFIX} Known flaky tests from main/stable (last 30 days): {len(known_flaky_tests)} entries")
 
-    # BigQuery format: {test_class_name, test_name}  →  key = "class.method"
+    # BigQuery test_name may include parameters and suffixes, e.g.
+    #   "shouldDoSomething(CamundaRdbmsTestApplication) camundaWithOracleDB"
+    # Keep the raw keys for full fidelity in debug output.
     known_keys: set[str] = set()
     for known in known_flaky_tests:
         key = f"{known['test_class_name']}.{known['test_name']}"
@@ -212,10 +214,13 @@ def main() -> None:
 
     new_flaky_tests: list[dict] = []
     for test in processed_pr_tests:
-        key = get_test_key(test)
-        is_known = key in known_keys
-        status = "KNOWN (already flaky on main/stable)" if is_known else "NEW (not seen on main/stable)"
-        print(f"{PREFIX}   {key} → {status}")
+        pr_key = get_test_key(test)
+        # PR keys are normalized (no params), BigQuery keys may have params/suffixes.
+        # Match if the PR key equals the known key OR the known key starts with the PR key.
+        is_known = any(k == pr_key or k.startswith(pr_key) for k in known_keys)
+        matched = [k for k in known_keys if k == pr_key or k.startswith(pr_key)] if is_known else []
+        status = f"KNOWN (matched: {matched})" if is_known else "NEW (not seen on main/stable)"
+        print(f"{PREFIX}   {pr_key} → {status}")
         if not is_known:
             new_flaky_tests.append(test)
 

--- a/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
+++ b/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
@@ -138,8 +138,11 @@ def _github_api(url: str, token: str, method: str = "GET", data: bytes | None = 
         raise GitHubAPIError(msg) from exc
 
 
-def _find_existing_comment(owner: str, repo: str, pr_number: int, token: str) -> int | None:
-    """Find an existing comment with COMMENT_MARKER and return its id, or None."""
+def _find_existing_comment(owner: str, repo: str, pr_number: int, token: str) -> tuple[int, bool] | None:
+    """Find an existing comment with COMMENT_MARKER.
+
+    Returns (comment_id, is_resolved) or None if no comment exists.
+    """
     page = 1
     while True:
         url = f"https://api.github.com/repos/{owner}/{repo}/issues/{pr_number}/comments?per_page=100&page={page}"
@@ -148,17 +151,20 @@ def _find_existing_comment(owner: str, repo: str, pr_number: int, token: str) ->
         if not comments:
             break
         for c in comments:
-            if COMMENT_MARKER in (c.get("body") or ""):
-                return c["id"]
+            body = c.get("body") or ""
+            if COMMENT_MARKER in body:
+                is_resolved = "✅ Resolved — No New Flaky Tests" in body
+                return c["id"], is_resolved
         page += 1
     return None
 
 
 def post_or_update_comment(owner: str, repo: str, pr_number: int, body: str, token: str) -> None:
     """Create a new comment or update the existing one (matched by COMMENT_MARKER)."""
-    existing_id = _find_existing_comment(owner, repo, pr_number, token)
+    result = _find_existing_comment(owner, repo, pr_number, token)
     payload = json.dumps({"body": body}).encode()
-    if existing_id:
+    if result:
+        existing_id, _ = result
         url = f"https://api.github.com/repos/{owner}/{repo}/issues/comments/{existing_id}"
         _github_api(url, token, method="PATCH", data=payload)
         print(f"{PREFIX} Updated existing comment (id={existing_id}).")
@@ -175,10 +181,6 @@ def _resolve_comment(owner: str, repo: str, comment_id: int, token: str) -> None
     raw = _github_api(url, token)
     current_body = json.loads(raw).get("body", "")
 
-    # If the comment is already resolved, don't re-wrap it in strikethrough
-    if "✅ Resolved — No New Flaky Tests" in current_body:
-        print(f"{PREFIX} Comment (id={comment_id}) is already resolved — skipping update.")
-        return
 
     # Strip the marker line — we'll re-add it at the top
     previous_warning_body = current_body.replace(COMMENT_MARKER, "").strip()
@@ -344,9 +346,13 @@ def main() -> None:
         # If a previous run left a warning comment, update it to "resolved".
         owner, repo = github_repository.split("/", 1)
         try:
-            existing_id = _find_existing_comment(owner, repo, pr_number, github_token)
-            if existing_id:
-                _resolve_comment(owner, repo, existing_id, github_token)
+            result = _find_existing_comment(owner, repo, pr_number, github_token)
+            if result:
+                existing_id, is_resolved = result
+                if is_resolved:
+                    print(f"{PREFIX} Comment (id={existing_id}) is already resolved — skipping update.")
+                else:
+                    _resolve_comment(owner, repo, existing_id, github_token)
         except GitHubAPIError:
             if blocking:
                 sys.exit(1)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1409,7 +1409,19 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Check for bypass label
+        id: bypass
+        shell: bash
+        run: |
+          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'ci:flaky-test-bypass') }}" == "true" ]]; then
+            echo "::notice::Bypass label 'ci:flaky-test-bypass' detected — skipping new flaky test gate."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Check if there are flaky tests to analyze
+        if: steps.bypass.outputs.skip != 'true'
         id: check
         env:
           FLAKY_DATA: ${{ needs.utils-flaky-tests-summary.outputs.flaky_tests_data }}
@@ -1458,7 +1470,7 @@ jobs:
                FROM `ci-30-162810.prod_ci_analytics.test_status_v1` ts
                LEFT OUTER JOIN `ci-30-162810.prod_ci_analytics.build_status_v2` bs
                  ON ts.ci_url=bs.ci_url AND ts.build_id=bs.build_id AND ts.job_name=bs.job_name
-               WHERE ts.report_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 30 DAY)
+               WHERE ts.report_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 60 DAY)
                  AND ts.ci_url="https://github.com/camunda/camunda"
                  AND test_status = "flaky"
                  AND (
@@ -1475,6 +1487,7 @@ jobs:
           pr-flaky-tests-data: '${{ needs.utils-flaky-tests-summary.outputs.flaky_tests_data }}'
           known-flaky-tests: '${{ steps.query-known-flaky.outputs.known_flaky_tests }}'
           pr-number: ${{ github.event.pull_request.number }}
+          blocking: 'false'
 
   identity-frontend-tests:
     if: needs.detect-changes.outputs.identity-frontend-tests == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1331,6 +1331,8 @@ jobs:
       - zeebe-unit-tests
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    outputs:
+      flaky_tests_data: ${{ steps.collect-results.outputs.flaky_tests_data }}
     permissions:
       pull-requests: write
       contents: read
@@ -1393,6 +1395,86 @@ jobs:
           name: |
             zeebe-unit-tests-*
             integration-tests-*
+
+  detect-new-flaky-tests:
+    name: detect new flaky tests
+    if: always() && github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
+    needs:
+      - utils-flaky-tests-summary
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check if there are flaky tests to analyze
+        id: check
+        env:
+          FLAKY_DATA: ${{ needs.utils-flaky-tests-summary.outputs.flaky_tests_data }}
+        shell: bash
+        run: |
+          if [[ -z "$FLAKY_DATA" ]] || [[ "$FLAKY_DATA" == '[]' ]]; then
+            echo "has_flaky_tests=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_flaky_tests=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Import Secrets
+        if: steps.check.outputs.has_flaky_tests == 'true'
+        id: secrets
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/zeebe/ci/ci-analytics gcloud_sa_key;
+
+      - name: Login to Google Cloud
+        if: steps.check.outputs.has_flaky_tests == 'true'
+        id: auth
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          credentials_json: ${{ steps.secrets.outputs.gcloud_sa_key }}
+
+      - name: Setup Google Cloud SDK
+        if: steps.check.outputs.has_flaky_tests == 'true'
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
+
+      - name: Query known flaky tests from BigQuery
+        if: steps.check.outputs.has_flaky_tests == 'true'
+        id: query-known-flaky
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo "known_flaky_tests<<BQEOF"
+            bq query --format=json --use_legacy_sql=false --quiet=true \
+              'SELECT DISTINCT test_class_name, test_name
+               FROM `ci-30-162810.prod_ci_analytics.test_status_v1` ts
+               LEFT OUTER JOIN `ci-30-162810.prod_ci_analytics.build_status_v2` bs
+                 ON ts.ci_url=bs.ci_url AND ts.build_id=bs.build_id AND ts.job_name=bs.job_name
+               WHERE ts.report_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 30 DAY)
+                 AND ts.ci_url="https://github.com/camunda/camunda"
+                 AND test_status = "flaky"
+                 AND (
+                   (build_trigger="merge_group" AND (build_base_ref="refs/heads/main" OR build_base_ref LIKE "refs/heads/stable/%"))
+                   OR (build_trigger="push" AND (build_ref="refs/heads/main" OR build_ref LIKE "refs/heads/stable/%"))
+                 )'
+            echo "BQEOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Detect new flaky tests
+        if: steps.check.outputs.has_flaky_tests == 'true'
+        uses: ./.github/actions/detect-new-flaky-tests
+        with:
+          pr-flaky-tests-data: '${{ needs.utils-flaky-tests-summary.outputs.flaky_tests_data }}'
+          known-flaky-tests: '${{ steps.query-known-flaky.outputs.known_flaky_tests }}'
+          pr-number: ${{ github.event.pull_request.number }}
 
   identity-frontend-tests:
     if: needs.detect-changes.outputs.identity-frontend-tests == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1463,10 +1463,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # shellcheck disable=SC2016 -- backticks are BigQuery SQL syntax, not shell expressions
+          # Backticks in the SQL below are BigQuery identifier quoting, not shell substitution.
+          # shellcheck disable=SC2016
           {
             echo "known_flaky_tests<<BQEOF"
-            bq query --format=json --use_legacy_sql=false --quiet=true \
+            bq query --format=json --use_legacy_sql=false --quiet=true --max_rows=100000 \
               'SELECT DISTINCT test_class_name, test_name
                FROM `ci-30-162810.prod_ci_analytics.test_status_v1` ts
                LEFT OUTER JOIN `ci-30-162810.prod_ci_analytics.build_status_v2` bs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1810,6 +1810,7 @@ jobs:
       - database-integration-tests
       - dependency-cycle-check
       - detect-changes
+      - detect-new-flaky-tests
       - docker-checks
       - general-unit-tests
       - history-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1316,10 +1316,11 @@ jobs:
           user_description: "General"
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
 
-  utils-flaky-tests-summary:
-    name: flaky tests summary comment
+  detect-new-flaky-tests:
+    name: detect new flaky tests
     if: always() && github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
     needs:
+      - detect-changes
       - archunit-tests
       - database-integration-tests
       - docker-checks
@@ -1330,40 +1331,57 @@ jobs:
       - rdbms-integration-tests
       - zeebe-unit-tests
     runs-on: ubuntu-latest
-    timeout-minutes: 5
-    outputs:
-      flaky_tests_data: ${{ steps.collect-results.outputs.flaky_tests_data }}
+    timeout-minutes: 10
     permissions:
       pull-requests: write
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Check for bypass label
+        id: bypass
+        shell: bash
+        run: |
+          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'ci:flaky-test-bypass') }}" == "true" ]]; then
+            echo "::notice::Bypass label 'ci:flaky-test-bypass' detected — skipping new flaky test gate."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Read Zeebe unit tests matrix outputs
+        if: steps.bypass.outputs.skip != 'true'
         uses: cloudposse/github-action-matrix-outputs-read@33cac12fa9282a7230a418d859b93fdbc4f27b5a # 1.0.0
         id: zeebe-matrix-read
         with:
           matrix-step-name: zeebe-unit-tests
       - name: Read Integration tests matrix outputs
+        if: steps.bypass.outputs.skip != 'true'
         uses: cloudposse/github-action-matrix-outputs-read@33cac12fa9282a7230a418d859b93fdbc4f27b5a # 1.0.0
         id: integration-matrix-read
         with:
           matrix-step-name: integration-tests
       - name: Read Database integration tests matrix outputs
+        if: steps.bypass.outputs.skip != 'true'
         uses: cloudposse/github-action-matrix-outputs-read@33cac12fa9282a7230a418d859b93fdbc4f27b5a # 1.0.0
         id: database-integration-matrix-read
         with:
           matrix-step-name: database-integration-tests
       - name: Read history tests matrix outputs
+        if: steps.bypass.outputs.skip != 'true'
         uses: cloudposse/github-action-matrix-outputs-read@33cac12fa9282a7230a418d859b93fdbc4f27b5a # 1.0.0
         id: history-matrix-read
         with:
           matrix-step-name: history-tests
       - name: Read identity tests matrix outputs
+        if: steps.bypass.outputs.skip != 'true'
         uses: cloudposse/github-action-matrix-outputs-read@33cac12fa9282a7230a418d859b93fdbc4f27b5a # 1.0.0
         id: identity-matrix-read
         with:
           matrix-step-name: identity-tests
+
       - name: Collect flaky test results
+        if: steps.bypass.outputs.skip != 'true'
         id: collect-results
         uses: ./.github/actions/collect-flaky-tests
         with:
@@ -1383,49 +1401,12 @@ jobs:
           zeebe-matrix-output-result: ${{ steps.zeebe-matrix-read.outputs.result }}
           integration-tests-result: ${{ needs.integration-tests.result }}
           integration-matrix-output-result: ${{ steps.integration-matrix-read.outputs.result }}
-      - name: Update flaky tests comment
-        uses: ./.github/actions/flaky-tests-summary-comment
-        with:
-          flaky-tests-data: '${{ steps.collect-results.outputs.flaky_tests_data }}'
-          pr-number: ${{ github.event.pull_request.number }}
-          branch-name: ${{ github.event.pull_request.head.ref }}
-      - name: Delete matrix job generated artifacts
-        uses: geekyeggo/delete-artifact@176a747ab7e287e3ff4787bf8a148716375ca118 # v6.0.0
-        with:
-          name: |
-            zeebe-unit-tests-*
-            integration-tests-*
-
-  detect-new-flaky-tests:
-    name: detect new flaky tests
-    if: always() && github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
-    needs:
-      - detect-changes
-      - utils-flaky-tests-summary
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      pull-requests: write
-      contents: read
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Check for bypass label
-        id: bypass
-        shell: bash
-        run: |
-          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'ci:flaky-test-bypass') }}" == "true" ]]; then
-            echo "::notice::Bypass label 'ci:flaky-test-bypass' detected — skipping new flaky test gate."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
 
       - name: Check if there are flaky tests to analyze
         if: steps.bypass.outputs.skip != 'true'
         id: check
         env:
-          FLAKY_DATA: ${{ needs.utils-flaky-tests-summary.outputs.flaky_tests_data }}
+          FLAKY_DATA: ${{ steps.collect-results.outputs.flaky_tests_data }}
         shell: bash
         run: |
           if [[ -z "$FLAKY_DATA" ]] || [[ "$FLAKY_DATA" == '[]' ]]; then
@@ -1484,10 +1465,18 @@ jobs:
         if: steps.check.outputs.has_flaky_tests == 'true'
         uses: ./.github/actions/detect-new-flaky-tests
         with:
-          pr-flaky-tests-data: '${{ needs.utils-flaky-tests-summary.outputs.flaky_tests_data }}'
+          pr-flaky-tests-data: '${{ steps.collect-results.outputs.flaky_tests_data }}'
           known-flaky-tests-file: '${{ steps.query-known-flaky.outputs.known_flaky_tests_file }}'
           pr-number: ${{ github.event.pull_request.number }}
           blocking: 'false'
+
+      - name: Delete matrix job generated artifacts
+        if: always()
+        uses: geekyeggo/delete-artifact@v6
+        with:
+          name: |
+            zeebe-unit-tests-*
+            integration-tests-*
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1400,6 +1400,7 @@ jobs:
     name: detect new flaky tests
     if: always() && github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
     needs:
+      - detect-changes
       - utils-flaky-tests-summary
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -1490,6 +1491,15 @@ jobs:
           known-flaky-tests: '${{ steps.query-known-flaky.outputs.known_flaky_tests }}'
           pr-number: ${{ github.event.pull_request.number }}
           blocking: 'false'
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
   identity-frontend-tests:
     if: needs.detect-changes.outputs.identity-frontend-tests == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1463,6 +1463,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # shellcheck disable=SC2016 -- backticks are BigQuery SQL syntax, not shell expressions
           {
             echo "known_flaky_tests<<BQEOF"
             bq query --format=json --use_legacy_sql=false --quiet=true \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1466,29 +1466,26 @@ jobs:
           set -euo pipefail
           # Backticks in the SQL below are BigQuery identifier quoting, not shell substitution.
           # shellcheck disable=SC2016
-          {
-            echo "known_flaky_tests<<BQEOF"
-            bq query --format=json --use_legacy_sql=false --quiet=true --max_rows=100000 \
-              'SELECT DISTINCT test_class_name, test_name
-               FROM `ci-30-162810.prod_ci_analytics.test_status_v1` ts
-               LEFT OUTER JOIN `ci-30-162810.prod_ci_analytics.build_status_v2` bs
-                 ON ts.ci_url=bs.ci_url AND ts.build_id=bs.build_id AND ts.job_name=bs.job_name
-               WHERE ts.report_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 60 DAY)
-                 AND ts.ci_url="https://github.com/camunda/camunda"
-                 AND test_status = "flaky"
-                 AND (
-                   (build_trigger="merge_group" AND (build_base_ref="refs/heads/main" OR build_base_ref LIKE "refs/heads/stable/%"))
-                   OR (build_trigger="push" AND (build_ref="refs/heads/main" OR build_ref LIKE "refs/heads/stable/%"))
-                 )'
-            echo "BQEOF"
-          } >> "$GITHUB_OUTPUT"
+          bq query --format=json --use_legacy_sql=false --quiet=true --max_rows=100000 \
+            'SELECT DISTINCT test_class_name, test_name
+             FROM `ci-30-162810.prod_ci_analytics.test_status_v1` ts
+             LEFT OUTER JOIN `ci-30-162810.prod_ci_analytics.build_status_v2` bs
+               ON ts.ci_url=bs.ci_url AND ts.build_id=bs.build_id AND ts.job_name=bs.job_name
+             WHERE ts.report_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 14 DAY)
+               AND ts.ci_url="https://github.com/camunda/camunda"
+               AND test_status = "flaky"
+               AND (
+                 (build_trigger="merge_group" AND (build_base_ref="refs/heads/main" OR build_base_ref LIKE "refs/heads/stable/%"))
+                 OR (build_trigger="push" AND (build_ref="refs/heads/main" OR build_ref LIKE "refs/heads/stable/%"))
+               )' > "$RUNNER_TEMP/known-flaky-tests.json"
+          echo "known_flaky_tests_file=$RUNNER_TEMP/known-flaky-tests.json" >> "$GITHUB_OUTPUT"
 
       - name: Detect new flaky tests
         if: steps.check.outputs.has_flaky_tests == 'true'
         uses: ./.github/actions/detect-new-flaky-tests
         with:
           pr-flaky-tests-data: '${{ needs.utils-flaky-tests-summary.outputs.flaky_tests_data }}'
-          known-flaky-tests: '${{ steps.query-known-flaky.outputs.known_flaky_tests }}'
+          known-flaky-tests-file: '${{ steps.query-known-flaky.outputs.known_flaky_tests_file }}'
           pr-number: ${{ github.event.pull_request.number }}
           blocking: 'false'
       - name: Observe build status


### PR DESCRIPTION
## Summary

Adds a CI quality gate that prevents PRs from introducing **new** flaky tests.
It compares flaky tests detected in the PR's CI run against a baseline of
tests that are already known to be flaky on `main` and `stable/*` branches
(queried from BigQuery over a 14-day rolling window).

Only truly **new** flaky tests block the PR — pre-existing flaky tests are ignored.


#### Disclaimer 
**Initial rollout is non-blocking** (`blocking: 'false'`) — the gate will warn but not fail. This is because testing this  new feature is not straightforward, so initially  only a warning will be added and the results have to be checked back in order to be sure the the new quality gate is working as expected without blocking developers for false positive results.

## How It Works

```
┌──────────────────────────────────────────────────────────────────────┐
│                        CI pipeline (ci.yml)                          │
│                                                                      │
│  1. Test jobs run (unit, integration, RDBMS, etc.)                   │
│     └─ Maven rerun count = 3 for PRs                                 │
│     └─ Flaky tests produce FLAKY.xml via analyze-test-runs           │
│                                                                      │
│  2. utils-flaky-tests-summary                                        │
│     └─ collect-flaky-tests gathers all FLAKY.xml results             │
│     └─ Outputs: flaky_tests_data (JSON)                              │
│                                                                      │
│  3. detect-new-flaky-tests  ← NEW                                    │
│     ├─ Checks for `ci:flaky-test-bypass` label → skip if present     │
│     ├─ Queries BigQuery for baseline (known flaky tests)             │
│     ├─ Compares PR flaky tests against baseline                      │
│     ├─ If new flaky tests found → posts comment + fails              │
│     └─ If all known or bypassed → passes                             │
│                                                                      │
│  4. check-results                                                    │
│     └─ Aggregates all job results including detect-new-flaky-tests   │
└──────────────────────────────────────────────────────────────────────┘
```

## Data Flow

### Input 1: PR flaky tests (`PR_FLAKY_TESTS_DATA`)

Comes from the `collect-flaky-tests` action. JSON array of objects, one per CI job that had flaky tests:

```json
[
  {
    "job": "rdbms-integration-tests",
    "flaky_tests": "io.camunda.it.rdbms.db.processinstance.ProcessInstanceIT.shouldSelectRootExpiredRootProcessInstances(CamundaRdbmsTestApplication)[5]"
  }
]
```

### Input 2: Baseline flaky tests (`KNOWN_FLAKY_TESTS_FILE`)

Queried from BigQuery at runtime and written to a temporary JSON file. The file path is passed to the action. Contains all tests that have been flaky on `main` or `stable/*` in the last 14 days:

```json
[
  {
    "test_class_name": "io.camunda.it.rdbms.db.processinstance.ProcessInstanceIT",
    "test_name": "shouldSelectRootExpiredRootProcessInstances(CamundaRdbmsTestApplication) camundaWithOracleDB"
  }
]
```

### BigQuery Query

```sql
SELECT DISTINCT test_class_name, test_name
FROM `ci-30-162810.prod_ci_analytics.test_status_v1` ts
LEFT OUTER JOIN `ci-30-162810.prod_ci_analytics.build_status_v2` bs
  ON ts.ci_url = bs.ci_url AND ts.build_id = bs.build_id AND ts.job_name = bs.job_name
WHERE ts.report_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 14 DAY)
  AND ts.ci_url = "https://github.com/camunda/camunda"
  AND test_status = "flaky"
  AND (
    (build_trigger = "merge_group"
      AND (build_base_ref = "refs/heads/main" OR build_base_ref LIKE "refs/heads/stable/%"))
    OR
    (build_trigger = "push"
      AND (build_ref = "refs/heads/main" OR build_ref LIKE "refs/heads/stable/%"))
  )
```

## Processing Steps

### Step 1: Parse PR flaky tests

The raw `flaky_tests` string from each job is split into individual test names.
Each test name is parsed into its components:

| Raw test name from Maven | Parsed |
|---|---|
| `io.camunda.it.rdbms.db.processinstance.ProcessInstanceIT.shouldSelectRootExpiredRootProcessInstances(CamundaRdbmsTestApplication)[5]` | package=`io.camunda.it.rdbms.db.processinstance`, class=`ProcessInstanceIT`, method=`shouldSelectRootExpiredRootProcessInstances` |

The `(CamundaRdbmsTestApplication)` (parameter info) and `[5]` (index) are
stripped during parsing. This produces a **normalized key**:

```
io.camunda.it.rdbms.db.processinstance.ProcessInstanceIT.shouldSelectRootExpiredRootProcessInstances
```

If the same test appears in multiple jobs, it's deduplicated (jobs are merged).

### Step 2: Parse baseline flaky tests

BigQuery results are built into **baseline keys** by concatenating
`test_class_name` + `.` + `test_name` **without any normalization**:

```
io.camunda.it.rdbms.db.processinstance.ProcessInstanceIT.shouldSelectRootExpiredRootProcessInstances(CamundaRdbmsTestApplication) camundaWithOracleDB
```

These raw keys preserve parameter info and database variant suffixes.

### Step 3: Compare (boundary-aware matching)

For each PR flaky test, we check if any baseline key refers to the same test
method. The matching uses `_is_same_test(baseline_key, normalized_key)`:

1. **Exact match?** If `baseline_key == normalized_key` → match.
2. **Starts with?** If `baseline_key.startswith(normalized_key)` → check step 3.
3. **Boundary check:** The character immediately after the normalized key must be
   **non-alphanumeric, non-underscore** (like `(` or ` `) to count as a match.

### Boundary matching examples

| Normalized key | Baseline key | Next char | Match? | Why |
|---|---|---|---|---|
| `...shouldSelectRoot` | `...shouldSelectRoot` | *(end)* | ✅ | Exact match |
| `...shouldSelectRoot` | `...shouldSelectRoot(Param) variant` | `(` | ✅ | `(` is a boundary |
| `...shouldFind` | `...shouldFindAllItems(Param)` | `A` | ❌ | `A` is alphanumeric → different method |
| `...shouldFind` | `...shouldFind_v2(Param)` | `_` | ❌ | `_` is identifier char → different method |

## Bypass Label

If the gate flags a flaky test that is **not caused by your changes**, you can
skip the gate by adding the `ci:flaky-test-bypass` label to your PR and
re-running CI.

> **Important:** Before bypassing, create a `kind/flake` issue so the flaky
> test is tracked and eventually fixed.

## PR Comment

When new flaky tests are found, the action posts (or updates) a PR comment:

> ### ⚠️ New Flaky Tests Detected
>
> This PR introduces **1 new flaky test(s)** not currently flaky on `main`/`stable/*`.
>
> - **shouldDoSomething**
>   - Jobs: `rdbms-integration-tests`
>   - Package: `io.camunda.it.example`
>   - Class: `ExampleIT`
>
> **What to do:**
> 1. Check if the flaky test is caused by your changes and fix it
> 2. If the test is unrelated to your changes:
>    - Contact #top-monorepo-ci to triage
>    - Create a `kind/flake` issue
>    - Add the `ci:flaky-test-bypass` label and re-run CI

If a subsequent CI run finds **no new flaky tests**, the existing comment is
updated to resolved — the original warning is kept in a collapsed block with
~~strikethrough~~ formatting:

> ### ✅ Resolved — No New Flaky Tests
>
> A previous CI run flagged new flaky tests, but the latest run found none.
>
> <details>
> <summary>Previous warning (resolved)</summary>
>
> ~~⚠️ New Flaky Tests Detected~~
> ~~This PR introduces **1 new flaky test(s)**...~~
>
> </details>

Comments are identified by a hidden HTML marker and always updated in-place (no duplicates).

## CI Job Configuration

- **Runs on:** `ubuntu-latest`
- **Timeout:** 10 minutes
- **Condition:** Only on `pull_request` events from non-fork repos
- **Depends on:** `utils-flaky-tests-summary`
- **Part of:** `check-results` aggregation

### Secrets used

| Secret | Source | Purpose |
|---|---|---|
| `VAULT_ADDR` | Repository secret | Vault server URL |
| `VAULT_ROLE_ID` | Repository secret | Vault AppRole auth |
| `VAULT_SECRET_ID` | Repository secret | Vault AppRole auth |
| GCP SA key | Vault (`secret/data/products/zeebe/ci/ci-analytics`) | BigQuery access |

## FAQ

<details>
<summary><strong>Will old flaky tests be flagged as new after 14 days?</strong></summary>

No. The 14-day window is rolling. As long as a test continues to flake on `main`, fresh
entries keep appearing in BigQuery. A test only drops out if it **hasn't flaked for 14+ days**
(likely fixed). If a PR triggers it again, flagging it as NEW is correct.

</details>

<details>
<summary><strong>What about tests that flake very rarely?</strong></summary>

If a test last flaked on main 15+ days ago and your PR hits it, it will be
flagged as NEW. Use `ci:flaky-test-bypass` and create a `kind/flake` issue.

</details>

<details>
<summary><strong>Does this gate run on fork PRs?</strong></summary>

No. Fork PRs don't have access to Vault credentials needed for BigQuery.
Once a fork PR merges, any new flaky tests will enter the baseline via `main`.

</details>

<details>
<summary><strong>What if BigQuery is down?</strong></summary>

The query step fails, blocking merge. Use `ci:flaky-test-bypass` to unblock.

</details>

<details>
<summary><strong>Can the gate produce false positives?</strong></summary>

The main source was mismatched test name formats between Maven and BigQuery.
This is handled by boundary-aware matching (see Step 3). If you encounter one,
use `ci:flaky-test-bypass` and report it to @monorepo-devops-team.

</details>

relates to https://github.com/camunda/camunda/issues/37640
