### PR TITLE
Set default passwords for test applications

### DIFF
--- a/load-tests/setup/default/createCredsLoadTest.sh
+++ b/load-tests/setup/default/createCredsLoadTest.sh
@@ -28,8 +28,8 @@ gen_password() { LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 20; }
 gen_token() { openssl rand -hex 16; }
 
 # You can optionally export any of these beforehand to control their values.
-: "${IDENTITY_FIRSTUSER_PASSWORD:=$(gen_password)}"
-: "${IDENTITY_KEYCLOAK_ADMIN_PASSWORD:=$(gen_password)}"
+: "${IDENTITY_FIRSTUSER_PASSWORD:=demo}"
+: "${IDENTITY_KEYCLOAK_ADMIN_PASSWORD:=admin}"
 : "${IDENTITY_KEYCLOAK_POSTGRESQL_ADMIN_PASSWORD:=$(gen_password)}"
 : "${IDENTITY_KEYCLOAK_POSTGRESQL_USER_PASSWORD:=$(gen_password)}"
 : "${IDENTITY_POSTGRESQL_ADMIN_PASSWORD:=$(gen_password)}"


### PR DESCRIPTION
## Description

 * Set default password for mgmt identity to demo
 * Set the default admin password for Keycloak to admin
 * Should make it easier to test and investigate issues - to avoid reading secrets from kubernetes etc


TBH I'm a bit on a fence with this. It makes our investigation/testing right now easier, especially as it just load test setups, but I wouldn't recommend this in general as a normal setup 😅 

In addition, I'm wondering whether we might not detect issues if we always use the same secret 🤔, but I guess this should be covered differently anyway? 🤔 

Open for discussion. 
