### PR TITLE
feat: Optimize data generator

### DIFF
--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -285,6 +285,13 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpasyncclient</artifactId>
+      <version>4.1.5</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-protocol-jackson</artifactId>
       <version>${project.version}</version>

--- a/optimize/backend/src/it/java/io/camunda/optimize/test/generator/BpmnFlowParser.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/generator/BpmnFlowParser.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.test.generator;
+
+import static io.camunda.zeebe.protocol.record.value.BpmnElementType.SUB_PROCESS;
+
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+/**
+ * Parses a BPMN 2.0 classpath resource into an immutable {@link ProcessGraph}.
+ *
+ * <p>This class is responsible only for the build phase: reading the resource file, parsing the XML
+ * DOM, and extracting element types, sequence-flow successors, and nested sub-process scopes.
+ * Walking the graph to produce per-instance execution paths is the responsibility of {@link
+ * ProcessGraph#walk}.
+ *
+ * <p>Callers should invoke {@link #parse} once per process ID (before any instance loop) and reuse
+ * the returned {@link ProcessGraph} for all instances of that process.
+ */
+final class BpmnFlowParser {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BpmnFlowParser.class);
+
+  private static final String RESOURCE_PATH = "bpmn/generator/";
+
+  private static final Map<String, BpmnElementType> ELEMENT_TYPES =
+      Map.ofEntries(
+          Map.entry("startEvent", BpmnElementType.START_EVENT),
+          Map.entry("endEvent", BpmnElementType.END_EVENT),
+          Map.entry("serviceTask", BpmnElementType.SERVICE_TASK),
+          Map.entry("userTask", BpmnElementType.USER_TASK),
+          Map.entry("receiveTask", BpmnElementType.RECEIVE_TASK),
+          Map.entry("exclusiveGateway", BpmnElementType.EXCLUSIVE_GATEWAY),
+          Map.entry("eventBasedGateway", BpmnElementType.EVENT_BASED_GATEWAY),
+          Map.entry("parallelGateway", BpmnElementType.PARALLEL_GATEWAY),
+          Map.entry("subProcess", SUB_PROCESS));
+
+  // ── Public API ────────────────────────────────────────────────────────────
+
+  /**
+   * Reads {@code bpmn/generator/<processId>.bpmn} from the classpath, parses its XML, and returns
+   * an immutable {@link ProcessGraph} ready for repeated walks.
+   *
+   * <p>This method is intentionally <em>not</em> cached — the caller controls the lifecycle. Invoke
+   * it once per process ID before the instance-generation loop.
+   */
+  static ProcessGraph parse(final String processId) {
+    LOG.info("Parsing BPMN graph for process '{}'.", processId);
+    final String path = RESOURCE_PATH + processId + ".bpmn";
+    try (final InputStream in = BpmnFlowParser.class.getClassLoader().getResourceAsStream(path)) {
+      if (in == null) {
+        throw new IllegalArgumentException("BPMN resource not found on classpath: " + path);
+      }
+      final var docBuilder = DocumentBuilderFactory.newNSInstance().newDocumentBuilder();
+      final var doc = docBuilder.parse(in);
+      doc.getDocumentElement().normalize();
+
+      final NodeList processes = doc.getElementsByTagNameNS("*", "process");
+      return nodeListStream(processes)
+          .map(Element.class::cast)
+          .filter(proc -> processId.equals(proc.getAttribute("id")))
+          .findFirst()
+          .map(BpmnFlowParser::buildScope)
+          .orElseThrow(
+              () ->
+                  new IllegalStateException(
+                      "No <process id=\"" + processId + "\"> found in " + path));
+    } catch (final IOException e) {
+      throw new UncheckedIOException("Failed to read BPMN resource: " + path, e);
+    } catch (final Exception e) {
+      throw new IllegalStateException("Failed to parse BPMN resource: " + path, e);
+    }
+  }
+
+  // ── Build helpers ─────────────────────────────────────────────────────────
+
+  /**
+   * Recursively extracts all flow elements and sequence flows from one BPMN scope (process root or
+   * sub-process body) into an immutable {@link ProcessGraph}.
+   */
+  private static ProcessGraph buildScope(final Element scope) {
+    final List<Element> flowElements =
+        childElements(scope).filter(el -> ELEMENT_TYPES.containsKey(el.getLocalName())).toList();
+
+    final String startId =
+        flowElements.stream()
+            .filter(el -> ELEMENT_TYPES.get(el.getLocalName()) == BpmnElementType.START_EVENT)
+            .map(el -> el.getAttribute("id"))
+            .findFirst()
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "No startEvent in scope: " + scope.getAttribute("id")));
+
+    final Map<String, BpmnElementType> types =
+        flowElements.stream()
+            .collect(
+                Collectors.toUnmodifiableMap(
+                    el -> el.getAttribute("id"), el -> ELEMENT_TYPES.get(el.getLocalName())));
+
+    final Map<String, ProcessGraph> subScopes =
+        flowElements.stream()
+            .filter(el -> ELEMENT_TYPES.get(el.getLocalName()) == SUB_PROCESS)
+            .collect(
+                Collectors.toUnmodifiableMap(
+                    el -> el.getAttribute("id"), BpmnFlowParser::buildScope));
+
+    final Map<String, List<String>> successors = buildSuccessors(scope, types.keySet());
+
+    return new ProcessGraph(startId, types, successors, subScopes);
+  }
+
+  private static Map<String, List<String>> buildSuccessors(
+      final Element scope, final Set<String> knownIds) {
+    return childElements(scope)
+        .filter(el -> "sequenceFlow".equals(el.getLocalName()))
+        .filter(flow -> knownIds.contains(flow.getAttribute("sourceRef")))
+        .collect(
+            Collectors.groupingBy(
+                flow -> flow.getAttribute("sourceRef"),
+                Collectors.mapping(flow -> flow.getAttribute("targetRef"), Collectors.toList())));
+  }
+
+  // ── DOM helpers ───────────────────────────────────────────────────────────
+
+  /** Returns a stream of all child {@link Element} nodes of {@code parent}. */
+  private static Stream<Element> childElements(final Element parent) {
+    return nodeListStream(parent.getChildNodes())
+        .filter(n -> n.getNodeType() == Node.ELEMENT_NODE)
+        .map(Element.class::cast);
+  }
+
+  /** Converts a {@link NodeList} into an ordered {@link Stream} of {@link Node}s. */
+  private static Stream<Node> nodeListStream(final NodeList nodeList) {
+    return IntStream.range(0, nodeList.getLength()).mapToObj(nodeList::item);
+  }
+
+  private BpmnFlowParser() {}
+}

--- a/optimize/backend/src/it/java/io/camunda/optimize/test/generator/BpmnProvider.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/generator/BpmnProvider.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.test.generator;
+
+/**
+ * Strategy that produces the BPMN 2.0 XML resource for a process definition.
+ *
+ * <p>Separating the provider as a functional interface decouples {@link ZeebeRecordFactory} from
+ * any concrete XML-generation class, satisfying the Dependency Inversion Principle.
+ *
+ * <p>The default implementation is {@code ProcessBpmnBuilder::bpmn}, supplied at wiring time in
+ * {@link ZeebeProcessDataGenerator}.
+ */
+@FunctionalInterface
+interface BpmnProvider {
+
+  /** Returns the BPMN 2.0 XML bytes for the given process definition ID. */
+  byte[] bpmnFor(String processId);
+}

--- a/optimize/backend/src/it/java/io/camunda/optimize/test/generator/ElementRecord.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/generator/ElementRecord.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.test.generator;
+
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+
+/**
+ * Groups the identity fields of one BPMN element instance.
+ *
+ * <p>Passed to {@link ZeebeRecordFactory#processInstanceOp} to avoid a 7-argument method signature.
+ *
+ * @param key the element-instance key (the record key in Zeebe)
+ * @param elementId the BPMN element ID (e.g. {@code "Task_1"})
+ * @param type the BPMN element type
+ * @param flowScopeKey {@code -1} for the root {@code PROCESS} element; the instance key for
+ *     top-level nodes; the enclosing sub-process element-instance key for embedded nodes
+ */
+record ElementRecord(long key, String elementId, BpmnElementType type, long flowScopeKey) {}

--- a/optimize/backend/src/it/java/io/camunda/optimize/test/generator/FlowNode.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/generator/FlowNode.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.test.generator;
+
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+
+/**
+ * A single BPMN flow element within a {@link ProcessLayout}.
+ *
+ * <p>{@code index} is a stable per-element numeric identifier used to derive unique Zeebe element
+ * instance keys (see {@code NODE_KEY_MULTIPLIER} in {@link ZeebeProcessDataGenerator}).
+ *
+ * <p>{@code parentIndex} links elements that live inside an embedded sub-process to their
+ * containing sub-process element. A value of {@code -1} means the element is a direct child of the
+ * process (top-level scope).
+ */
+record FlowNode(String id, BpmnElementType type, int index, int parentIndex) {
+
+  /** Convenience constructor for top-level elements (parentIndex defaults to {@code -1}). */
+  FlowNode(final String id, final BpmnElementType type, final int index) {
+    this(id, type, index, -1);
+  }
+}

--- a/optimize/backend/src/it/java/io/camunda/optimize/test/generator/FlowNodeEmitter.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/generator/FlowNodeEmitter.java
@@ -1,0 +1,311 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.test.generator;
+
+import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_ACTIVATING;
+import static io.camunda.zeebe.protocol.record.value.BpmnElementType.SERVICE_TASK;
+import static io.camunda.zeebe.protocol.record.value.BpmnElementType.SUB_PROCESS;
+import static io.camunda.zeebe.protocol.record.value.BpmnElementType.USER_TASK;
+
+import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.stream.IntStream;
+
+/**
+ * Pure factory for Zeebe record bulk-operations for a single process instance.
+ *
+ * <p>All public methods return immutable lists of {@link BulkOperation}s — they never mutate
+ * external state. Callers decide where to route the returned records.
+ *
+ * <p>Collaborates with {@link ZeebeRecordFactory} (DTO construction) and {@link
+ * NodeTimingSimulator} (duration distribution) but owns no randomness beyond assigning user-task
+ * assignees.
+ */
+class FlowNodeEmitter {
+
+  // ── Key-space partitioning ────────────────────────────────────────────────
+  // Ensures element-instance, user-task, and incident keys from the same
+  // instanceKey never collide.
+
+  static final long NODE_KEY_MULTIPLIER = 1_000L;
+  static final long USER_TASK_KEY_MULTIPLIER = 2_000L;
+  static final long INCIDENT_KEY_MULTIPLIER = 3_000L;
+
+  private final ZeebeRecordFactory factory;
+  private final NodeTimingSimulator timingSimulator;
+  private final Random rng;
+
+  FlowNodeEmitter(
+      final ZeebeRecordFactory factory,
+      final NodeTimingSimulator timingSimulator,
+      final Random rng) {
+    this.factory = factory;
+    this.timingSimulator = timingSimulator;
+    this.rng = rng;
+  }
+
+  // ── Public API ────────────────────────────────────────────────────────────
+
+  /**
+   * Returns all flow-node lifecycle records (ACTIVATING + optional COMPLETED/TERMINATED) for every
+   * node in {@code layout}. Sub-process nodes are expanded in-place, children scoped correctly.
+   *
+   * @return a pair of immutable lists: {@code pi} for process-instance records, {@code ut} for
+   *     user-task records
+   */
+  FlowNodeOps flowNodeOps(
+      final InstanceContext ctx, final List<FlowNode> layout, final InstanceWindow window) {
+
+    final long startMs = window.startMs();
+    final long endMs = window.endMs();
+    final long[] timings =
+        window.isActive() ? null : timingSimulator.compute(layout, startMs, endMs);
+    final FlowWalkContext flowWalkCtx = new FlowWalkContext(ctx, layout, timings, window);
+    final WalkState walkState = WalkState.create();
+
+    for (int ni = 0; ni < layout.size(); ni++) {
+      if (walkState.consumed().contains(ni)) {
+        continue;
+      }
+      final FlowNode node = layout.get(ni);
+      if (node.type() == SUB_PROCESS) {
+        collectSubProcess(flowWalkCtx, ni, walkState);
+      } else {
+        final long nodeStartMs = timings != null ? timings[ni] : window.startMs();
+        final long nodeEndMs = timings != null ? timings[ni + 1] : window.endMs();
+        final long instanceKey = ctx.instanceKey();
+        final NodeEntry nodeEntry = new NodeEntry(node, instanceKey, nodeStartMs, nodeEndMs);
+        collectNode(flowWalkCtx, nodeEntry, walkState);
+      }
+    }
+
+    final List<BulkOperation> piOps = List.copyOf(walkState.pi());
+    final List<BulkOperation> utOps = List.copyOf(walkState.ut());
+    return new FlowNodeOps(piOps, utOps);
+  }
+
+  /**
+   * Returns all variable records for {@code ctx}. Delegates value generation to {@link
+   * ZeebeRecordFactory}/{@link VariableCatalogue}.
+   */
+  List<BulkOperation> variableOps(final InstanceContext ctx, final long timestamp) {
+    return factory.variableOps(ctx, timestamp);
+  }
+
+  /**
+   * Returns {@code UPDATED} variable records for {@code ctx}, simulating mid-flight variable
+   * updates that cause the Optimize importer to merge into existing reporting-metrics docs.
+   */
+  List<BulkOperation> variableUpdateOps(final InstanceContext ctx, final long timestamp) {
+    return factory.variableUpdateOps(ctx, timestamp);
+  }
+
+  /**
+   * Returns a CREATED incident and optionally a RESOLVED incident anchored to the first service
+   * task in {@code layout}. Returns an empty list when the layout has no service tasks.
+   */
+  List<BulkOperation> incidentOps(
+      final InstanceContext ctx, final List<FlowNode> layout, final InstanceWindow window) {
+    return layout.stream()
+        .filter(n -> n.type() == SERVICE_TASK)
+        .findFirst()
+        .map(serviceTask -> buildIncidentOps(ctx, serviceTask, window))
+        .orElse(List.of());
+  }
+
+  // ── Private incident builder ──────────────────────────────────────────────
+
+  /**
+   * Builds CREATED and optionally RESOLVED incident records for one service task. Terminated
+   * instances always resolve; completed ones resolve ~50 % of the time.
+   */
+  private List<BulkOperation> buildIncidentOps(
+      final InstanceContext ctx, final FlowNode serviceTask, final InstanceWindow window) {
+
+    final long elemInstKey = ctx.instanceKey() * NODE_KEY_MULTIPLIER + serviceTask.index();
+    final long incKey = ctx.instanceKey() * INCIDENT_KEY_MULTIPLIER;
+    final long incCreateMs = window.startMs() + (window.endMs() - window.startMs()) / 5;
+
+    final IncidentEvent createdEvent =
+        new IncidentEvent(incKey, elemInstKey, serviceTask.id(), incCreateMs);
+    final BulkOperation createdOp = factory.incidentOp(ctx, createdEvent, IncidentIntent.CREATED);
+
+    final boolean shouldResolve = window.isTerminated() || rng.nextBoolean();
+    if (!shouldResolve) {
+      return List.of(createdOp);
+    }
+
+    final IncidentEvent resolvedEvent =
+        new IncidentEvent(incKey, elemInstKey, serviceTask.id(), incCreateMs + 60_000L);
+    final BulkOperation resolvedOp =
+        factory.incidentOp(ctx, resolvedEvent, IncidentIntent.RESOLVED);
+    return List.of(createdOp, resolvedOp);
+  }
+
+  // ── Private collectors ────────────────────────────────────────────────────
+
+  /**
+   * Collects records for one embedded sub-process and all of its child nodes into {@code
+   * walkState}.
+   */
+  private void collectSubProcess(
+      final FlowWalkContext flowWalkCtx, final int subProcessNi, final WalkState walkState) {
+
+    final List<FlowNode> layout = flowWalkCtx.layout();
+    final long[] timings = flowWalkCtx.timings();
+    final InstanceContext ctx = flowWalkCtx.ctx();
+    final InstanceWindow window = flowWalkCtx.window();
+    final FlowNode subProcess = layout.get(subProcessNi);
+
+    final List<Integer> childNis =
+        IntStream.range(subProcessNi + 1, layout.size())
+            .boxed()
+            .takeWhile(ci -> layout.get(ci).parentIndex() == subProcess.index())
+            .toList();
+    childNis.forEach(walkState.consumed()::add);
+
+    final boolean hasTimingsAndChildren = timings != null && !childNis.isEmpty();
+    final long subStartMs =
+        hasTimingsAndChildren
+            ? timings[childNis.get(0)]
+            : (timings != null ? timings[subProcessNi] : window.startMs());
+    final long subEndMs =
+        hasTimingsAndChildren
+            ? timings[childNis.get(childNis.size() - 1) + 1]
+            : (timings != null ? timings[subProcessNi + 1] : window.endMs());
+
+    final long instanceKey = ctx.instanceKey();
+    final String subProcessId = subProcess.id();
+    final BpmnElementType subType = subProcess.type();
+    final long subElemInstKey = instanceKey * NODE_KEY_MULTIPLIER + subProcess.index();
+    final ElementRecord subElement =
+        new ElementRecord(subElemInstKey, subProcessId, subType, instanceKey);
+
+    final LifecycleEvent subStartEvent = new LifecycleEvent(ELEMENT_ACTIVATING, subStartMs);
+    final BulkOperation subStartOp = factory.processInstanceOp(ctx, subElement, subStartEvent);
+    walkState.pi().add(subStartOp);
+
+    childNis.stream()
+        .map(
+            ci -> {
+              final FlowNode child = layout.get(ci);
+              final long childStart = timings != null ? timings[ci] : window.startMs();
+              final long childEnd = timings != null ? timings[ci + 1] : window.endMs();
+              return new NodeEntry(child, subElemInstKey, childStart, childEnd);
+            })
+        .forEach(childEntry -> collectNode(flowWalkCtx, childEntry, walkState));
+
+    if (!window.isActive()) {
+      final LifecycleEvent subEndEvent = new LifecycleEvent(window.endIntent(), subEndMs);
+      final BulkOperation subEndOp = factory.processInstanceOp(ctx, subElement, subEndEvent);
+      walkState.pi().add(subEndOp);
+    }
+  }
+
+  /**
+   * Collects ACTIVATING (and optionally COMPLETED/TERMINATED) records for a single leaf node, plus
+   * user-task lifecycle records when the node is a {@code USER_TASK}.
+   */
+  private void collectNode(
+      final FlowWalkContext flowWalkCtx, final NodeEntry nodeEntry, final WalkState walkState) {
+
+    final InstanceContext ctx = flowWalkCtx.ctx();
+    final InstanceWindow window = flowWalkCtx.window();
+    final FlowNode node = nodeEntry.node();
+
+    final String elementId = node.id();
+    final BpmnElementType elementType = node.type();
+    final long flowScopeKey = nodeEntry.flowScopeKey();
+    final long elemInstKey = ctx.instanceKey() * NODE_KEY_MULTIPLIER + node.index();
+    final ElementRecord element =
+        new ElementRecord(elemInstKey, elementId, elementType, flowScopeKey);
+
+    final LifecycleEvent startEvent = new LifecycleEvent(ELEMENT_ACTIVATING, nodeEntry.startMs());
+    final BulkOperation startOp = factory.processInstanceOp(ctx, element, startEvent);
+    walkState.pi().add(startOp);
+
+    if (!window.isActive()) {
+      final LifecycleEvent endEvent = new LifecycleEvent(window.endIntent(), nodeEntry.endMs());
+      final BulkOperation endOp = factory.processInstanceOp(ctx, element, endEvent);
+      walkState.pi().add(endOp);
+
+      if (node.type() == USER_TASK) {
+        final boolean isTerminated = window.isTerminated();
+        final long nodeStartMs = nodeEntry.startMs();
+        final long nodeEndMs = nodeEntry.endMs();
+        final UserTaskEntry userTaskEntry =
+            new UserTaskEntry(node, elemInstKey, isTerminated, nodeStartMs, nodeEndMs);
+        collectUserTask(ctx, userTaskEntry, walkState);
+      }
+    }
+  }
+
+  /** Builds CREATING, ASSIGNED, and COMPLETED/CANCELED records for one user-task node. */
+  private void collectUserTask(
+      final InstanceContext ctx, final UserTaskEntry userTaskEntry, final WalkState walkState) {
+
+    final FlowNode node = userTaskEntry.node();
+    final long elemInstKey = userTaskEntry.elemInstKey();
+    final String nodeId = node.id();
+    final long utKey = ctx.instanceKey() * USER_TASK_KEY_MULTIPLIER + node.index();
+    final long assignedMs =
+        userTaskEntry.startMs() + (userTaskEntry.endMs() - userTaskEntry.startMs()) / 4;
+    final String assignee = "user-" + (1 + rng.nextInt(10));
+    final UserTaskIntent endIntent =
+        userTaskEntry.isTerminated() ? UserTaskIntent.CANCELED : UserTaskIntent.COMPLETED;
+
+    final UserTaskEvent creatingEvent =
+        new UserTaskEvent(utKey, elemInstKey, nodeId, userTaskEntry.startMs());
+    final UserTaskEvent assignedEvent = new UserTaskEvent(utKey, elemInstKey, nodeId, assignedMs);
+    final UserTaskEvent endEvent =
+        new UserTaskEvent(utKey, elemInstKey, nodeId, userTaskEntry.endMs());
+
+    final BulkOperation creatingOp = factory.userTaskCreatingOp(ctx, creatingEvent);
+    final BulkOperation assignedOp = factory.userTaskAssignedOp(ctx, assignedEvent, assignee);
+    final BulkOperation endOp = factory.userTaskEndOp(ctx, endEvent, endIntent);
+    walkState.ut().addAll(List.of(creatingOp, assignedOp, endOp));
+  }
+
+  // ── Private parameter objects ─────────────────────────────────────────────
+
+  /** Immutable context shared across all collect calls for one {@link #flowNodeOps} invocation. */
+  private record FlowWalkContext(
+      InstanceContext ctx, List<FlowNode> layout, long[] timings, InstanceWindow window) {}
+
+  /** Groups a leaf flow-node with its timing and flow-scope key for one execution step. */
+  private record NodeEntry(FlowNode node, long flowScopeKey, long startMs, long endMs) {}
+
+  /** Groups a user-task node with its element-instance key, termination flag, and timing. */
+  private record UserTaskEntry(
+      FlowNode node, long elemInstKey, boolean isTerminated, long startMs, long endMs) {}
+
+  /**
+   * Mutable accumulator for all records collected during one {@link #flowNodeOps} walk.
+   *
+   * <p>The record holds references to mutable collections; the record itself is not replaced. After
+   * the walk completes, {@link #flowNodeOps} seals the lists with {@link List#copyOf}.
+   */
+  private record WalkState(List<BulkOperation> pi, List<BulkOperation> ut, Set<Integer> consumed) {
+
+    static WalkState create() {
+      return new WalkState(new ArrayList<>(), new ArrayList<>(), new HashSet<>());
+    }
+  }
+
+  // ── Return type ───────────────────────────────────────────────────────────
+
+  /** Immutable pair of process-instance and user-task records produced by one flow-node walk. */
+  record FlowNodeOps(List<BulkOperation> pi, List<BulkOperation> ut) {}
+}

--- a/optimize/backend/src/it/java/io/camunda/optimize/test/generator/GeneratorConfig.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/generator/GeneratorConfig.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.test.generator;
+
+import static io.camunda.optimize.service.util.importing.ZeebeConstants.ZEEBE_RECORD_TEST_PREFIX;
+
+/**
+ * Immutable configuration for {@link ZeebeProcessDataGenerator}.
+ *
+ * <p>Owns the process-definition pool, key-derivation logic, and all tunable knobs. Configuration
+ * concerns are kept here so the generator class itself only orchestrates.
+ *
+ * <pre>{@code
+ * GeneratorConfig config = new GeneratorConfig.Builder()
+ *     .instanceCount(50_000)
+ *     .processDefinitionCount(5)
+ *     .zeebeRecordPrefix(zeebeExtension.getZeebeRecordPrefix())
+ *     .build();
+ * }</pre>
+ */
+public final class GeneratorConfig {
+
+  private static final String SIMPLE_PROCESS_ID = "order-fulfillment";
+  private static final String MEDIUM_PROCESS_ID = "invoice-processing";
+  private static final String COMPLEX_PROCESS_ID = "loan-approval";
+  private static final String BRANCHING_PROCESS_ID = "claim-processing";
+  private static final String EVENT_BASED_PROCESS_ID = "customer-onboarding";
+  private static final String FRAUD_PROCESS_ID = "fraud-dispute-handling";
+
+  static final String[] DEFAULT_PROCESS_IDS = {
+    SIMPLE_PROCESS_ID,
+    MEDIUM_PROCESS_ID,
+    COMPLEX_PROCESS_ID,
+    BRANCHING_PROCESS_ID,
+    EVENT_BASED_PROCESS_ID,
+    FRAUD_PROCESS_ID,
+  };
+
+  /** Total number of process instances to generate. */
+  public final int instanceCount;
+
+  /**
+   * Number of distinct process definitions to use (ignored if {@code processDefinitionKeys} is
+   * set).
+   */
+  public final int processDefinitionCount;
+
+  /** Explicit list of process definition IDs (overrides {@code processDefinitionCount}). */
+  public final String[] processDefinitionKeys;
+
+  /**
+   * Number of calendar months of history to simulate. Instances are spread uniformly across this
+   * window ending at "now".
+   */
+  public final int monthsOfHistory;
+
+  /**
+   * Prefix for all Zeebe record indexes (e.g. {@code zeebe-record-abc123}). Each index will be
+   * {@code {prefix}-{type}}, e.g. {@code zeebe-record-abc123-process-instance}.
+   */
+  public final String zeebeRecordPrefix;
+
+  /** Partition ID written to all generated records. */
+  public final int partitionId;
+
+  /**
+   * Base value for process instance keys. Use a value that doesn't overlap with other generators.
+   */
+  public final long instanceKeyOffset;
+
+  /**
+   * Starting {@code position} value for all record types. Must be higher than the last imported
+   * position if you want the import pipeline to pick up these records.
+   */
+  public final long positionOffset;
+
+  /** Number of records per ES bulk request. */
+  public final int batchSize;
+
+  /** RNG seed for reproducible data sets. */
+  public final long seed;
+
+  /**
+   * Fraction of generated instances that also receive a {@code UPDATED} variable record after all
+   * {@code CREATED} records have been written. Range [0.0, 1.0]. Default is {@code 0.0} (disabled).
+   */
+  public final double updateRate;
+
+  private GeneratorConfig(final Builder builder) {
+    this.instanceCount = builder.instanceCount;
+    this.processDefinitionCount = builder.processDefinitionCount;
+    this.processDefinitionKeys = builder.processDefinitionKeys;
+    this.monthsOfHistory = builder.monthsOfHistory;
+    this.zeebeRecordPrefix = builder.zeebeRecordPrefix;
+    this.partitionId = builder.partitionId;
+    this.instanceKeyOffset = builder.instanceKeyOffset;
+    this.positionOffset = builder.positionOffset;
+    this.batchSize = builder.batchSize;
+    this.seed = builder.seed;
+    this.updateRate = builder.updateRate;
+  }
+
+  /**
+   * Returns the resolved list of process definition IDs. Explicit keys take priority; otherwise a
+   * slice of the built-in defaults is used.
+   */
+  String[] resolveProcessIds() {
+    if (processDefinitionKeys != null && processDefinitionKeys.length > 0) {
+      return processDefinitionKeys;
+    }
+    final int count = Math.min(processDefinitionCount, DEFAULT_PROCESS_IDS.length);
+    final String[] resolved = new String[count];
+    System.arraycopy(DEFAULT_PROCESS_IDS, 0, resolved, 0, count);
+    return resolved;
+  }
+
+  /**
+   * Derives a stable numeric process definition key from the definition's array index. Stable
+   * across generator calls with the same config so variable records and PI records reference the
+   * same key.
+   */
+  long definitionKeyFor(final int defIndex) {
+    return (defIndex + 1) * 1_000L + partitionId;
+  }
+
+  public static final class Builder {
+
+    public static final long DEFAULT_INSTANCE_KEY_OFFSET = 3_000_000_000L;
+
+    private int instanceCount = 10_000;
+    private int processDefinitionCount = 6;
+    private String[] processDefinitionKeys = null;
+    private int monthsOfHistory = 6;
+    private String zeebeRecordPrefix = ZEEBE_RECORD_TEST_PREFIX + "-test";
+    private int partitionId = 1;
+    private long instanceKeyOffset = DEFAULT_INSTANCE_KEY_OFFSET;
+    private long positionOffset = 0L;
+    private int batchSize = 1_000;
+    private long seed = 42L;
+    private double updateRate = 0.0;
+
+    public Builder instanceCount(final int instanceCount) {
+      this.instanceCount = instanceCount;
+      return this;
+    }
+
+    public Builder processDefinitionCount(final int processDefinitionCount) {
+      this.processDefinitionCount = processDefinitionCount;
+      return this;
+    }
+
+    public Builder processDefinitionKeys(final String... keys) {
+      this.processDefinitionKeys = keys;
+      return this;
+    }
+
+    public Builder monthsOfHistory(final int months) {
+      this.monthsOfHistory = months;
+      return this;
+    }
+
+    public Builder zeebeRecordPrefix(final String prefix) {
+      this.zeebeRecordPrefix = prefix;
+      return this;
+    }
+
+    public Builder partitionId(final int partitionId) {
+      this.partitionId = partitionId;
+      return this;
+    }
+
+    public Builder instanceKeyOffset(final long offset) {
+      this.instanceKeyOffset = offset;
+      return this;
+    }
+
+    public Builder positionOffset(final long offset) {
+      this.positionOffset = offset;
+      return this;
+    }
+
+    public Builder batchSize(final int batchSize) {
+      this.batchSize = batchSize;
+      return this;
+    }
+
+    public Builder seed(final long seed) {
+      this.seed = seed;
+      return this;
+    }
+
+    public Builder updateRate(final double updateRate) {
+      this.updateRate = updateRate;
+      return this;
+    }
+
+    public GeneratorConfig build() {
+      return new GeneratorConfig(this);
+    }
+  }
+}

--- a/optimize/backend/src/it/java/io/camunda/optimize/test/generator/IncidentEvent.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/generator/IncidentEvent.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.test.generator;
+
+/**
+ * Groups the identity and timestamp of one incident lifecycle event.
+ *
+ * <p>Passed to {@link ZeebeRecordFactory#incidentOp} to reduce its argument count.
+ *
+ * @param incKey the incident key
+ * @param elemInstKey the element-instance key of the service task that raised the incident
+ * @param elementId the BPMN element ID of the service task
+ * @param timestamp epoch-millisecond timestamp of the incident event
+ */
+record IncidentEvent(long incKey, long elemInstKey, String elementId, long timestamp) {}

--- a/optimize/backend/src/it/java/io/camunda/optimize/test/generator/InstanceContext.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/generator/InstanceContext.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.test.generator;
+
+/** Groups the three identity fields shared across all records of a single process instance. */
+record InstanceContext(long instanceKey, long defKey, String processId) {}

--- a/optimize/backend/src/it/java/io/camunda/optimize/test/generator/InstanceWindow.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/generator/InstanceWindow.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.test.generator;
+
+import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_COMPLETED;
+import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_TERMINATED;
+
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+
+/**
+ * Immutable value object capturing the time bounds and lifecycle state of one generated process
+ * instance.
+ *
+ * <p>Extracted as a top-level type so both {@link ZeebeProcessDataGenerator} (which constructs it)
+ * and {@link FlowNodeEmitter} (which reads it) can reference it without coupling through the
+ * generator class.
+ */
+record InstanceWindow(
+    long startMs, long endMs, boolean isActive, boolean isTerminated, boolean hasIncident) {
+
+  /** The correct {@link ProcessInstanceIntent} to close a node given this instance's outcome. */
+  ProcessInstanceIntent endIntent() {
+    return isTerminated ? ELEMENT_TERMINATED : ELEMENT_COMPLETED;
+  }
+}

--- a/optimize/backend/src/it/java/io/camunda/optimize/test/generator/LifecycleEvent.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/generator/LifecycleEvent.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.test.generator;
+
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+
+/**
+ * Groups the intent and timestamp of one process-instance lifecycle transition.
+ *
+ * <p>Paired with {@link ElementRecord} to reduce {@link ZeebeRecordFactory#processInstanceOp} from
+ * 7 arguments to 3.
+ *
+ * @param intent the lifecycle intent (e.g. {@code ELEMENT_ACTIVATING}, {@code ELEMENT_COMPLETED})
+ * @param timestamp epoch-millisecond timestamp of the transition
+ */
+record LifecycleEvent(ProcessInstanceIntent intent, long timestamp) {}

--- a/optimize/backend/src/it/java/io/camunda/optimize/test/generator/NodeTimingSimulator.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/generator/NodeTimingSimulator.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.test.generator;
+
+import static io.camunda.zeebe.protocol.record.value.BpmnElementType.END_EVENT;
+import static io.camunda.zeebe.protocol.record.value.BpmnElementType.EVENT_BASED_GATEWAY;
+import static io.camunda.zeebe.protocol.record.value.BpmnElementType.EXCLUSIVE_GATEWAY;
+import static io.camunda.zeebe.protocol.record.value.BpmnElementType.START_EVENT;
+import static io.camunda.zeebe.protocol.record.value.BpmnElementType.SUB_PROCESS;
+
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import java.util.List;
+import java.util.Random;
+
+/**
+ * Distributes a process-instance time window across its flow nodes, producing per-node timestamps
+ * that drive realistic heatmap data in Optimize.
+ *
+ * <p>Events and gateways are treated as near-instant (weight 0.01). Work nodes receive random
+ * weights in {@code [0.5, 1.5)}; ~15 % are promoted to a high-outlier weight (3–5×) so the Optimize
+ * heatmap highlights them as higher-duration nodes.
+ *
+ * <p>This class owns only the timing algorithm. How those timestamps are embedded in Zeebe records
+ * is the responsibility of {@link ZeebeRecordFactory}.
+ */
+class NodeTimingSimulator {
+
+  private final Random rng;
+
+  NodeTimingSimulator(final Random rng) {
+    this.rng = rng;
+  }
+
+  /**
+   * Returns {@code n + 1} monotonically increasing timestamps where {@code result[i]} is the start
+   * of node {@code i} and {@code result[i+1]} is its end, distributing {@code startMs..endMs}
+   * proportionally by node weight.
+   */
+  long[] compute(final List<FlowNode> nodes, final long startMs, final long endMs) {
+    final int n = nodes.size();
+    final long totalMs = Math.max(1L, endMs - startMs);
+    final double[] weights = new double[n];
+    double sum = 0;
+
+    for (int i = 0; i < n; i++) {
+      weights[i] = isInstant(nodes.get(i).type()) ? 0.01 : workNodeWeight();
+      sum += weights[i];
+    }
+
+    final long[] timestamps = new long[n + 1];
+    timestamps[0] = startMs;
+    long cursor = startMs;
+    for (int i = 0; i < n - 1; i++) {
+      cursor += (long) (totalMs * weights[i] / sum);
+      timestamps[i + 1] = cursor;
+    }
+    timestamps[n] = endMs;
+    return timestamps;
+  }
+
+  private static boolean isInstant(final BpmnElementType type) {
+    // Sub-process elements have no duration of their own — their time span is derived from
+    // children.
+    // Event-based gateways are routing elements and do not hold time themselves.
+    return type == START_EVENT
+        || type == END_EVENT
+        || type == EXCLUSIVE_GATEWAY
+        || type == EVENT_BASED_GATEWAY
+        || type == SUB_PROCESS;
+  }
+
+  /** Returns a random weight; ~15 % of calls produce a high-outlier weight (3–5×). */
+  private double workNodeWeight() {
+    final double baseWeight = 0.5 + rng.nextDouble();
+    return rng.nextDouble() < 0.15 ? baseWeight * (3.0 + rng.nextDouble() * 2.0) : baseWeight;
+  }
+}

--- a/optimize/backend/src/it/java/io/camunda/optimize/test/generator/ProcessBpmnBuilder.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/generator/ProcessBpmnBuilder.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.test.generator;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+
+/**
+ * Loads BPMN 2.0 XML resources from the classpath for each process definition.
+ *
+ * <p>Each process has a dedicated {@code .bpmn} file under {@code bpmn/generator/<processId>.bpmn}
+ * on the test classpath. This class simply reads and returns the file bytes, keeping all diagram
+ * concerns in the resource files themselves.
+ *
+ * <p>Used as a method reference {@code ProcessBpmnBuilder::bpmn} satisfying {@link BpmnProvider}.
+ */
+final class ProcessBpmnBuilder {
+
+  private static final String RESOURCE_PATH = "bpmn/generator/";
+
+  static byte[] bpmn(final String processId) {
+    final String path = RESOURCE_PATH + processId + ".bpmn";
+    try (final InputStream in =
+        ProcessBpmnBuilder.class.getClassLoader().getResourceAsStream(path)) {
+      if (in == null) {
+        throw new IllegalArgumentException("BPMN resource not found on classpath: " + path);
+      }
+      return in.readAllBytes();
+    } catch (final IOException e) {
+      throw new UncheckedIOException("Failed to load BPMN resource: " + path, e);
+    }
+  }
+
+  private ProcessBpmnBuilder() {}
+}

--- a/optimize/backend/src/it/java/io/camunda/optimize/test/generator/ProcessGraph.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/generator/ProcessGraph.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.test.generator;
+
+import static io.camunda.zeebe.protocol.record.value.BpmnElementType.EVENT_BASED_GATEWAY;
+import static io.camunda.zeebe.protocol.record.value.BpmnElementType.EXCLUSIVE_GATEWAY;
+import static io.camunda.zeebe.protocol.record.value.BpmnElementType.SUB_PROCESS;
+
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * An immutable, pre-computed representation of one BPMN scope (process root or sub-process body).
+ *
+ * <p>Built once per process ID by {@link BpmnFlowParser#parse} and reused across all generated
+ * instances. Each call to {@link #walk} performs a cheap in-memory random walk over the graph,
+ * returning a concrete execution path as an ordered list of {@link FlowNode}s.
+ *
+ * <p>At {@code EXCLUSIVE_GATEWAY} and {@code EVENT_BASED_GATEWAY} nodes a single outgoing branch is
+ * chosen at random, replacing what were previously hardcoded layout variants.
+ *
+ * <p>Sub-processes are expanded in-place: the sub-process node is emitted at its natural position,
+ * immediately followed by its children (which carry the sub-process {@code index} as their {@code
+ * parentIndex}). This satisfies the consecutive-child contract required by {@link
+ * FlowNodeEmitter#flowNodeOps}.
+ */
+final class ProcessGraph {
+
+  private final String startId;
+  private final Map<String, BpmnElementType> types;
+  private final Map<String, List<String>> successors;
+  private final Map<String, ProcessGraph> subScopes;
+
+  ProcessGraph(
+      final String startId,
+      final Map<String, BpmnElementType> types,
+      final Map<String, List<String>> successors,
+      final Map<String, ProcessGraph> subScopes) {
+    this.startId = startId;
+    this.types = types;
+    this.successors = successors;
+    this.subScopes = subScopes;
+  }
+
+  // ── Public API ────────────────────────────────────────────────────────────
+
+  /**
+   * Performs a random walk from the start event to an end event and returns the visited nodes as an
+   * ordered, flat list. Sub-process children appear consecutively after their parent node.
+   *
+   * <p>Only {@link Random} is consumed per call — all graph data is read-only and shared.
+   */
+  List<FlowNode> walk(final Random rng) {
+    final WalkState walkState = WalkState.create(rng);
+    walkFrom(startId, -1, walkState);
+    return walkState.result();
+  }
+
+  // ── Walk helpers ──────────────────────────────────────────────────────────
+
+  private void walkFrom(final String id, final int parentIndex, final WalkState walkState) {
+    if (walkState.visited().contains(id) || !types.containsKey(id)) {
+      return;
+    }
+    walkState.visited().add(id);
+
+    final BpmnElementType type = types.get(id);
+    final int index = walkState.counter().getAndIncrement();
+    final FlowNode node = new FlowNode(id, type, index, parentIndex);
+    walkState.result().add(node);
+
+    expandSubProcess(id, type, index, walkState);
+
+    final List<String> next = successors.getOrDefault(id, List.of());
+    if (!next.isEmpty()) {
+      final String chosen = chooseSuccessor(type, next, walkState.rng());
+      walkFrom(chosen, parentIndex, walkState);
+    }
+  }
+
+  /**
+   * If {@code type} is {@link io.camunda.zeebe.protocol.record.value.BpmnElementType#SUB_PROCESS},
+   * walks the sub-scope and appends its nodes into the shared walk state consecutively after the
+   * parent. Does nothing for all other element types.
+   */
+  private void expandSubProcess(
+      final String id,
+      final BpmnElementType type,
+      final int parentIndex,
+      final WalkState walkState) {
+    if (type != SUB_PROCESS) {
+      return;
+    }
+    final ProcessGraph sub = subScopes.get(id);
+    final WalkState subState = WalkState.forSubScope(walkState);
+    sub.walkFrom(sub.startId, parentIndex, subState);
+  }
+
+  /**
+   * Returns the next node ID to visit. Forking gateways pick a branch at random; all other elements
+   * follow their single outgoing sequence flow.
+   */
+  private static String chooseSuccessor(
+      final BpmnElementType type, final List<String> options, final Random rng) {
+    return isForking(type) ? pickRandom(options, rng) : options.getFirst();
+  }
+
+  /** Returns a uniformly random element from {@code options}. */
+  private static String pickRandom(final List<String> options, final Random rng) {
+    final int randomIndex = rng.nextInt(options.size());
+    return options.get(randomIndex);
+  }
+
+  private static boolean isForking(final BpmnElementType type) {
+    return type == EXCLUSIVE_GATEWAY || type == EVENT_BASED_GATEWAY;
+  }
+
+  // ── Private parameter objects ─────────────────────────────────────────────
+
+  /**
+   * Mutable accumulator passed through the recursive walk.
+   *
+   * <p>The record holds references to mutable collections; the record itself is not replaced.
+   * Sub-process scopes share the same {@code result} and {@code counter} but get a fresh {@code
+   * visited} set so their own nodes are not considered already-visited.
+   */
+  private record WalkState(
+      List<FlowNode> result, AtomicInteger counter, HashSet<String> visited, Random rng) {
+
+    /** Creates a fresh walk state for a new top-level walk. */
+    static WalkState create(final Random rng) {
+      final List<FlowNode> result = new ArrayList<>();
+      final AtomicInteger counter = new AtomicInteger();
+      final HashSet<String> visited = new HashSet<>();
+      return new WalkState(result, counter, visited, rng);
+    }
+
+    /**
+     * Creates a sub-scope walk state that shares the parent's {@code result} list and {@code
+     * counter} but starts with a fresh {@code visited} set.
+     */
+    static WalkState forSubScope(final WalkState parent) {
+      return new WalkState(parent.result(), parent.counter(), new HashSet<>(), parent.rng());
+    }
+  }
+}

--- a/optimize/backend/src/it/java/io/camunda/optimize/test/generator/README.md
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/generator/README.md
@@ -1,0 +1,119 @@
+# Zeebe Data Generator
+
+Synthetic Zeebe record generator that writes directly to Elasticsearch, bypassing a live Zeebe
+broker. Used to populate the raw Zeebe record indexes so the Optimize importers can run against
+realistic data volumes.
+
+## Building and Running
+
+Compile the module:
+
+```bash
+./mvnw install -f optimize/backend/pom.xml -Dquickly -T1C
+```
+
+The CLI entry point is `ZeebeDataGeneratorCli`. The easiest way to run it is directly from your
+IDE — open `ZeebeDataGeneratorCli`, set the desired program arguments (see Options below), and
+run `main()`.
+
+## Options
+
+|      Flag       |    Default     |                                 Description                                  |
+|-----------------|----------------|------------------------------------------------------------------------------|
+| `--host`        | `localhost`    | Elasticsearch host                                                           |
+| `--port`        | `9200`         | Elasticsearch HTTP port                                                      |
+| `--username`    | _(none)_       | Basic-auth username                                                          |
+| `--password`    | _(none)_       | Basic-auth password                                                          |
+| `--prefix`      | `zeebe-record` | Zeebe record index prefix (e.g. `zeebe-record-abc123`)                       |
+| `--instances`   | `300000`       | Number of process instances to generate                                      |
+| `--defs`        | `6`            | Number of distinct process definitions to use (max 6)                        |
+| `--months`      | `6`            | Months of history to spread instances across                                 |
+| `--seed`        | `42`           | RNG seed — same seed produces the same data set                              |
+| `--batch-size`  | `1000`         | ES bulk-request batch size                                                   |
+| `--update-rate` | `0.0`          | Fraction [0.0–1.0] of instances that also receive `UPDATED` variable records |
+
+## Incremental Runs
+
+The generator automatically continues from where the previous run left off. On startup it queries
+Elasticsearch for:
+
+- **Max `position`** across all Zeebe record indexes (per partition) → used as `positionOffset`
+- **Max `processInstanceKey`** in the process-instance index → used as `instanceKeyOffset`
+
+This ensures no document-ID collisions and that Optimize's position-based importer picks up the
+new records in the next import cycle.
+
+```bash
+# First run — generates instances 3_000_000_000 … 3_000_299_999
+java -cp ... ZeebeDataGeneratorCli --instances 300000
+
+# Second run — continues from max position and instanceKey automatically
+java -cp ... ZeebeDataGeneratorCli --instances 300000
+```
+
+## Process Definitions
+
+Six built-in process definitions are available (selected in order by `--defs`):
+
+| # |        Process ID        |    Shape    |
+|---|--------------------------|-------------|
+| 1 | `order-fulfillment`      | Simple      |
+| 2 | `invoice-processing`     | Medium      |
+| 3 | `loan-approval`          | Complex     |
+| 4 | `claim-processing`       | Branching   |
+| 5 | `customer-onboarding`    | Event-based |
+| 6 | `fraud-dispute-handling` | Fraud       |
+
+## Variables Per Instance
+
+Each instance receives:
+
+**Business variables** (always present):
+`customerId`, `orderId`, `amount`, `status`, `requiresReview`, `priority`
+
+**Core `REPORTING_PROCESS_*` metrics** (always present):
+
+|           Variable name            |  Type  |          Range           |
+|------------------------------------|--------|--------------------------|
+| `REPORTING_PROCESS_baselineCost`   | double | 400 – 2 000              |
+| `REPORTING_PROCESS_llmCost`        | double | 20 – 300                 |
+| `REPORTING_PROCESS_automationCost` | double | 50 – 400                 |
+| `REPORTING_PROCESS_totalCost`      | double | llmCost + automationCost |
+| `REPORTING_PROCESS_valueCreated`   | double | 40–100 % of baselineCost |
+| `REPORTING_PROCESS_agentTaskCount` | int    | 0 – 5                    |
+| `REPORTING_PROCESS_humanTaskCount` | int    | 0 – 3                    |
+| `REPORTING_PROCESS_autoTaskCount`  | int    | 1 – 6                    |
+| `REPORTING_PROCESS_tokenUsage`     | long   | 1 000 – 50 000           |
+
+**Optional `REPORTING_PROCESS_*` metrics** (each present with 60 % probability):
+
+`errorCount`, `retryCount`, `processingTimeMs`, `queueWaitTimeMs`, `apiCallCount`,
+`complianceChecksPassed`, `dataVolumeMb`, `confidenceScore`, `co2EmissionsKg`,
+`customerSatisfactionScore`, `fraudRiskScore`, `externalServiceCostUsd`,
+`slaBreached`, `escalated`, `manualOverride`
+
+## Simulating Variable Updates (`--update-rate`)
+
+By default all variable records use `VariableIntent.CREATED`. Passing `--update-rate` causes the
+generator to emit an additional batch of `VariableIntent.UPDATED` records **after** all `CREATED`
+records, at higher positions. This simulates mid-flight variable updates on existing process
+instances.
+
+The Optimize importer processes these in a later round (higher position → picked up on next cycle),
+merging the new field values into existing docs. Each merge produces a soft-deleted Lucene document,
+visible in index stats as `docs.deleted > 0`.
+
+```bash
+# 30 % of instances get an UPDATED variable record at a higher position
+java -cp ... ZeebeDataGeneratorCli --instances 100000 --update-rate 0.3
+```
+
+## Instance State Distribution
+
+|     State     |        Rate        |
+|---------------|--------------------|
+| Active        | ~3 %               |
+| Terminated    | ~5 % of non-active |
+| With incident | ~5 % of non-active |
+| Completed     | remainder          |
+

--- a/optimize/backend/src/it/java/io/camunda/optimize/test/generator/UserTaskEvent.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/generator/UserTaskEvent.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.test.generator;
+
+/**
+ * Groups the identity and timestamp of one user-task lifecycle event.
+ *
+ * <p>Passed to {@link ZeebeRecordFactory} user-task methods to reduce their argument count. A new
+ * instance is created for each lifecycle step (creating, assigned, completed/canceled) because each
+ * step has a different timestamp.
+ *
+ * @param utKey the user-task key
+ * @param elemInstKey the element-instance key of the user-task flow node
+ * @param elementId the BPMN element ID of the user-task
+ * @param timestamp epoch-millisecond timestamp of this lifecycle step
+ */
+record UserTaskEvent(long utKey, long elemInstKey, String elementId, long timestamp) {}

--- a/optimize/backend/src/it/java/io/camunda/optimize/test/generator/VariableCatalogue.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/generator/VariableCatalogue.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.test.generator;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * Generates variable name→value pairs for one synthetic process instance.
+ *
+ * <p>Three categories are emitted:
+ *
+ * <ul>
+ *   <li>Business variables — stable string sentinels keyed by instance key
+ *   <li>Core {@code REPORTING_PROCESS_*} metrics — always present, randomly valued
+ *   <li>Optional {@code REPORTING_PROCESS_*} metrics — each included with 60 % probability
+ * </ul>
+ *
+ * <p>This class owns only the variable catalogue and value generation. How those values are
+ * packaged as Zeebe records is the responsibility of {@link ZeebeRecordFactory}.
+ */
+class VariableCatalogue {
+
+  private static final List<String> BUSINESS_VARS =
+      List.of("customerId", "orderId", "amount", "status", "requiresReview", "priority");
+
+  private enum VarType {
+    INT,
+    DOUBLE,
+    BOOLEAN
+  }
+
+  private record OptionalVar(String name, VarType type) {}
+
+  private static final List<OptionalVar> OPTIONAL_VARS =
+      List.of(
+          new OptionalVar("REPORTING_PROCESS_errorCount", VarType.INT),
+          new OptionalVar("REPORTING_PROCESS_retryCount", VarType.INT),
+          new OptionalVar("REPORTING_PROCESS_processingTimeMs", VarType.INT),
+          new OptionalVar("REPORTING_PROCESS_queueWaitTimeMs", VarType.INT),
+          new OptionalVar("REPORTING_PROCESS_apiCallCount", VarType.INT),
+          new OptionalVar("REPORTING_PROCESS_complianceChecksPassed", VarType.INT),
+          new OptionalVar("REPORTING_PROCESS_dataVolumeMb", VarType.DOUBLE),
+          new OptionalVar("REPORTING_PROCESS_confidenceScore", VarType.DOUBLE),
+          new OptionalVar("REPORTING_PROCESS_co2EmissionsKg", VarType.DOUBLE),
+          new OptionalVar("REPORTING_PROCESS_customerSatisfactionScore", VarType.DOUBLE),
+          new OptionalVar("REPORTING_PROCESS_fraudRiskScore", VarType.DOUBLE),
+          new OptionalVar("REPORTING_PROCESS_externalServiceCostUsd", VarType.DOUBLE),
+          new OptionalVar("REPORTING_PROCESS_slaBreached", VarType.BOOLEAN),
+          new OptionalVar("REPORTING_PROCESS_escalated", VarType.BOOLEAN),
+          new OptionalVar("REPORTING_PROCESS_manualOverride", VarType.BOOLEAN));
+
+  private final Random rng;
+
+  VariableCatalogue(final Random rng) {
+    this.rng = rng;
+  }
+
+  /**
+   * Returns all variable name→value pairs for one process instance. The caller is responsible for
+   * wrapping each entry as a Zeebe variable record.
+   */
+  List<Map.Entry<String, String>> generate(final long instanceKey) {
+    final List<Map.Entry<String, String>> vars = new ArrayList<>();
+    vars.addAll(businessVars(instanceKey));
+    vars.addAll(coreReportingVars());
+    vars.addAll(optionalReportingVars());
+    return vars;
+  }
+
+  private List<Map.Entry<String, String>> businessVars(final long instanceKey) {
+    return IntStream.range(0, BUSINESS_VARS.size())
+        .mapToObj(i -> Map.entry(BUSINESS_VARS.get(i), "\"synth-" + instanceKey + "-" + i + "\""))
+        .collect(Collectors.toList());
+  }
+
+  private List<Map.Entry<String, String>> coreReportingVars() {
+    final double baselineCost = round2(400 + rng.nextDouble() * 1_600);
+    final double llmCost = round2(20 + rng.nextDouble() * 280);
+    final double automationCost = round2(50 + rng.nextDouble() * 350);
+    final double valueCreated = round2(baselineCost * (0.4 + rng.nextDouble() * 0.6));
+    final long tokenUsage = 1_000L + (long) (rng.nextDouble() * 49_000);
+
+    return List.of(
+        Map.entry("REPORTING_PROCESS_baselineCost", String.valueOf(baselineCost)),
+        Map.entry("REPORTING_PROCESS_llmCost", String.valueOf(llmCost)),
+        Map.entry("REPORTING_PROCESS_automationCost", String.valueOf(automationCost)),
+        Map.entry("REPORTING_PROCESS_totalCost", String.valueOf(round2(llmCost + automationCost))),
+        Map.entry("REPORTING_PROCESS_valueCreated", String.valueOf(valueCreated)),
+        Map.entry("REPORTING_PROCESS_agentTaskCount", String.valueOf(rng.nextInt(6))),
+        Map.entry("REPORTING_PROCESS_humanTaskCount", String.valueOf(rng.nextInt(4))),
+        Map.entry("REPORTING_PROCESS_autoTaskCount", String.valueOf(1 + rng.nextInt(6))),
+        Map.entry("REPORTING_PROCESS_tokenUsage", String.valueOf(tokenUsage)));
+  }
+
+  /** Emits a random 60 %-probable subset of optional reporting variables. */
+  private List<Map.Entry<String, String>> optionalReportingVars() {
+    return OPTIONAL_VARS.stream()
+        .filter(optVar -> rng.nextDouble() < 0.60)
+        .map(optVar -> Map.entry(optVar.name(), randomValue(optVar.type())))
+        .collect(Collectors.toList());
+  }
+
+  private String randomValue(final VarType type) {
+    return switch (type) {
+      case INT -> String.valueOf(rng.nextInt(1_000));
+      case BOOLEAN -> String.valueOf(rng.nextBoolean());
+      case DOUBLE -> String.valueOf(round2(rng.nextDouble() * 1_000));
+    };
+  }
+
+  private static double round2(final double v) {
+    return Math.round(v * 100.0) / 100.0;
+  }
+}

--- a/optimize/backend/src/it/java/io/camunda/optimize/test/generator/ZeebeBulkWriter.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/generator/ZeebeBulkWriter.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.test.generator;
+
+import co.elastic.clients.elasticsearch._types.Refresh;
+import co.elastic.clients.elasticsearch.core.BulkRequest;
+import co.elastic.clients.elasticsearch.core.BulkResponse;
+import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
+import co.elastic.clients.elasticsearch.indices.CreateIndexRequest;
+import co.elastic.clients.elasticsearch.indices.ExistsRequest;
+import io.camunda.optimize.service.db.es.OptimizeElasticsearchClient;
+import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Infrastructure wrapper around {@link OptimizeElasticsearchClient} for bulk-writing Zeebe records.
+ *
+ * <p>Provides index lifecycle management ({@link #ensureIndexExists}) and a stateful {@link
+ * IndexBatch} accumulator that auto-flushes when the configured batch size is reached.
+ */
+class ZeebeBulkWriter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ZeebeBulkWriter.class);
+  private final OptimizeElasticsearchClient esClient;
+  private final int batchSize;
+
+  ZeebeBulkWriter(final OptimizeElasticsearchClient esClient, final int batchSize) {
+    this.esClient = esClient;
+    this.batchSize = batchSize;
+  }
+
+  /** Creates the index with dynamic mapping if it does not already exist. */
+  void ensureIndexExists(final String index) {
+    try {
+      if (!indexExists(index)) {
+        LOG.info("Index '{}' not found — creating with dynamic mapping.", index);
+        createIndex(index);
+      }
+    } catch (final IOException e) {
+      throw new OptimizeRuntimeException("Failed to check/create index: " + index, e);
+    }
+  }
+
+  /** Returns a new empty {@link IndexBatch} targeting {@code index}. */
+  IndexBatch newBatch(final String index) {
+    return new IndexBatch(index);
+  }
+
+  /** Flushes {@code batch} when its accumulated ops reach the configured batch size. */
+  void flushIfNeeded(final IndexBatch batch) {
+    if (batch.pendingSize() >= batchSize) {
+      flush(batch);
+    }
+  }
+
+  /** Unconditionally flushes any remaining ops in {@code batch}. */
+  void flush(final IndexBatch batch) {
+    if (batch.isEmpty()) {
+      return;
+    }
+    final int pendingSize = batch.pendingSize();
+    final String index = batch.index();
+    final long total = batch.totalCount();
+    LOG.debug("Flushing {} records into '{}' (total so far: {}).", pendingSize, index, total);
+    final List<BulkOperation> ops = batch.consume();
+    bulkWrite(index, ops);
+  }
+
+  /** Writes {@code ops} directly to {@code index} and logs the count. */
+  void write(final String index, final List<BulkOperation> ops) {
+    bulkWrite(index, ops);
+    LOG.info("Inserted {} records into '{}'.", ops.size(), index);
+  }
+
+  /** Returns {@code true} when {@code index} exists in Elasticsearch. */
+  private boolean indexExists(final String index) throws IOException {
+    return esClient.getEsClient().indices().exists(ExistsRequest.of(r -> r.index(index))).value();
+  }
+
+  // ── Private helpers ───────────────────────────────────────────────────────
+
+  /** Creates {@code index} in Elasticsearch with dynamic mapping. */
+  private void createIndex(final String index) throws IOException {
+    esClient.getEsClient().indices().create(CreateIndexRequest.of(r -> r.index(index)));
+  }
+
+  /**
+   * Splits {@code ops} into slices of at most {@code batchSize} and sends each slice to
+   * Elasticsearch.
+   */
+  private void bulkWrite(final String index, final List<BulkOperation> ops) {
+    sliceOps(ops).forEach(slice -> sendBulkSlice(index, slice));
+  }
+
+  /** Sends one pre-sized slice of bulk operations and logs any per-item errors. */
+  private void sendBulkSlice(final String index, final List<BulkOperation> slice) {
+    final BulkRequest request = buildBulkRequest(index, slice);
+    try {
+      final BulkResponse response = esClient.getEsClient().bulk(request);
+      if (response.errors()) {
+        final long failures =
+            response.items().stream().filter(item -> item.error() != null).count();
+        LOG.warn("{} bulk errors for index '{}'", failures, index);
+      }
+    } catch (final IOException e) {
+      throw new OptimizeRuntimeException("Bulk insert failed for index: " + index, e);
+    }
+  }
+
+  /** Builds a {@link BulkRequest} targeting {@code index} with the given operations. */
+  private static BulkRequest buildBulkRequest(final String index, final List<BulkOperation> slice) {
+    return BulkRequest.of(
+        b -> {
+          b.index(index).refresh(Refresh.True);
+          slice.forEach(b::operations);
+          return b;
+        });
+  }
+
+  /**
+   * Partitions {@code ops} into consecutive sublists of at most {@code batchSize} elements. The
+   * last sublist may be smaller.
+   */
+  private List<List<BulkOperation>> sliceOps(final List<BulkOperation> ops) {
+    final int total = ops.size();
+    return IntStream.range(0, (total + batchSize - 1) / batchSize)
+        .mapToObj(
+            i -> {
+              final int start = i * batchSize;
+              final int end = Math.min(start + batchSize, total);
+              return ops.subList(start, end);
+            })
+        .toList();
+  }
+
+  /**
+   * Accumulates bulk operations for a single Zeebe index and tracks the running flush total.
+   *
+   * <p>Callers interact exclusively through the typed mutator and accessor methods — the underlying
+   * list is never exposed directly.
+   */
+  static final class IndexBatch {
+
+    private final String index;
+    private final List<BulkOperation> pendingOps = new ArrayList<>();
+    private long flushedCount;
+
+    IndexBatch(final String index) {
+      this.index = index;
+    }
+
+    String index() {
+      return index;
+    }
+
+    void addAll(final List<BulkOperation> ops) {
+      pendingOps.addAll(ops);
+    }
+
+    boolean isEmpty() {
+      return pendingOps.isEmpty();
+    }
+
+    int pendingSize() {
+      return pendingOps.size();
+    }
+
+    /** Returns the total number of records written (flushed + pending). */
+    long totalCount() {
+      return flushedCount + pendingOps.size();
+    }
+
+    /** Returns only the flushed record count (i.e. after all flushes have completed). */
+    long flushedCount() {
+      return flushedCount;
+    }
+
+    /**
+     * Drains all pending operations, records their count in {@code flushedCount}, and returns the
+     * drained list for writing to Elasticsearch.
+     */
+    List<BulkOperation> consume() {
+      final List<BulkOperation> drained = new ArrayList<>(pendingOps);
+      flushedCount += pendingOps.size();
+      pendingOps.clear();
+      return drained;
+    }
+  }
+}

--- a/optimize/backend/src/it/java/io/camunda/optimize/test/generator/ZeebeDataGeneratorCli.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/generator/ZeebeDataGeneratorCli.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.test.generator;
+
+import static io.camunda.optimize.service.db.DatabaseConstants.ZEEBE_INCIDENT_INDEX_NAME;
+import static io.camunda.optimize.service.db.DatabaseConstants.ZEEBE_PROCESS_DEFINITION_INDEX_NAME;
+import static io.camunda.optimize.service.db.DatabaseConstants.ZEEBE_PROCESS_INSTANCE_INDEX_NAME;
+import static io.camunda.optimize.service.db.DatabaseConstants.ZEEBE_USER_TASK_INDEX_NAME;
+import static io.camunda.optimize.service.db.DatabaseConstants.ZEEBE_VARIABLE_INDEX_NAME;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.optimize.service.db.es.OptimizeElasticsearchClient;
+import io.camunda.optimize.service.db.schema.OptimizeIndexNameService;
+import io.camunda.optimize.service.util.mapper.ObjectMapperFactory;
+import java.io.IOException;
+import java.util.List;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.elasticsearch.client.RestClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Command-line entry point for {@link ZeebeProcessDataGenerator}.
+ *
+ * <p>This class has one responsibility: parse CLI arguments and construct the Elasticsearch client,
+ * then delegate data generation to {@link ZeebeProcessDataGenerator}. Connection setup and argument
+ * parsing are the only reasons this class should change.
+ *
+ * <pre>
+ * Options:
+ *   --host         Elasticsearch host            (default: localhost)
+ *   --port         Elasticsearch HTTP port       (default: 9200)
+ *   --username     Basic-auth username           (default: none)
+ *   --password     Basic-auth password           (default: none)
+ *   --prefix       Zeebe record index prefix     (default: zeebe-record)
+ *   --instances    Number of process instances   (default: 10000)
+ *   --defs         Number of process definitions (default: 6)
+ *   --months       Months of history to cover    (default: 6)
+ *   --seed         RNG seed for reproducibility  (default: 42)
+ *   --batch-size   ES bulk-request batch size    (default: 1000)
+ * </pre>
+ */
+public final class ZeebeDataGeneratorCli {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ZeebeDataGeneratorCli.class);
+
+  private ZeebeDataGeneratorCli() {}
+
+  public static void main(final String[] args) {
+    String host = "localhost";
+    int port = 9200;
+    String username = null;
+    String password = null;
+    String prefix = "zeebe-record";
+    int instances = 300000;
+    int defs = 6;
+    int months = 6;
+    long seed = 42L;
+    int batchSize = 1_000;
+    double updateRate = 0.25;
+
+    for (int i = 0; i < args.length; i++) {
+      switch (args[i]) {
+        case "--host" -> host = args[++i];
+        case "--port" -> port = Integer.parseInt(args[++i]);
+        case "--username" -> username = args[++i];
+        case "--password" -> password = args[++i];
+        case "--prefix" -> prefix = args[++i];
+        case "--instances" -> instances = Integer.parseInt(args[++i]);
+        case "--defs" -> defs = Integer.parseInt(args[++i]);
+        case "--months" -> months = Integer.parseInt(args[++i]);
+        case "--seed" -> seed = Long.parseLong(args[++i]);
+        case "--batch-size" -> batchSize = Integer.parseInt(args[++i]);
+        case "--update-rate" -> updateRate = Double.parseDouble(args[++i]);
+        default -> LOG.warn("Unknown argument '{}' — ignored", args[i]);
+      }
+    }
+
+    LOG.info("Connecting to Elasticsearch at {}:{} with prefix '{}'", host, port, prefix);
+
+    final ElasticsearchConnection connection =
+        new ElasticsearchConnection(host, port, username, password);
+    final RestClient restClient = buildRestClient(connection);
+    final ElasticsearchClient rawClient =
+        new ElasticsearchClient(
+            new RestClientTransport(
+                restClient, new JacksonJsonpMapper(ObjectMapperFactory.OPTIMIZE_MAPPER)));
+    final OptimizeElasticsearchClient esClient = buildEsClient(restClient, prefix);
+
+    final long positionOffset = queryMaxPosition(rawClient, prefix) + 1;
+    final long instanceKeyOffset = queryMaxInstanceKey(rawClient, prefix) + 1;
+    LOG.info(
+        "Continuing from positionOffset={}, instanceKeyOffset={}",
+        positionOffset,
+        instanceKeyOffset);
+
+    final GeneratorConfig config =
+        new GeneratorConfig.Builder()
+            .zeebeRecordPrefix(prefix)
+            .instanceCount(instances)
+            .processDefinitionCount(defs)
+            .monthsOfHistory(months)
+            .seed(seed)
+            .batchSize(batchSize)
+            .positionOffset(positionOffset)
+            .instanceKeyOffset(instanceKeyOffset)
+            .updateRate(updateRate)
+            .build();
+
+    LOG.info(
+        "Generating {} instances across {} process definitions, {} months of history",
+        instances,
+        defs,
+        months);
+    new ZeebeProcessDataGenerator(config).generate(esClient);
+    LOG.info("Generation complete.");
+
+    try {
+      restClient.close();
+    } catch (final IOException e) {
+      LOG.warn("Failed to close REST client cleanly", e);
+    }
+  }
+
+  /**
+   * Returns the highest {@code position} value found across all Zeebe record indexes for the given
+   * prefix, or {@code 0} if the indexes are empty or do not exist yet.
+   */
+  private static long queryMaxPosition(final ElasticsearchClient esClient, final String prefix) {
+    final List<String> indexes =
+        List.of(
+            prefix + "-" + ZEEBE_PROCESS_DEFINITION_INDEX_NAME,
+            prefix + "-" + ZEEBE_PROCESS_INSTANCE_INDEX_NAME,
+            prefix + "-" + ZEEBE_VARIABLE_INDEX_NAME,
+            prefix + "-" + ZEEBE_USER_TASK_INDEX_NAME,
+            prefix + "-" + ZEEBE_INCIDENT_INDEX_NAME);
+    long maxPosition = 0L;
+    for (final String index : indexes) {
+      try {
+        final var response =
+            esClient.search(
+                s ->
+                    s.index(index)
+                        .size(0)
+                        .aggregations("max_pos", a -> a.max(m -> m.field("position"))),
+                Void.class);
+        final double value = response.aggregations().get("max_pos").max().value();
+        if (Double.isFinite(value)) {
+          maxPosition = Math.max(maxPosition, (long) value);
+        }
+      } catch (final Exception e) {
+        LOG.debug(
+            "Could not query max position from '{}' (may not exist yet): {}",
+            index,
+            e.getMessage());
+      }
+    }
+    return maxPosition;
+  }
+
+  /**
+   * Returns the highest {@code value.processInstanceKey} found in the process-instance index, or
+   * {@code 3_000_000_000L - 1} (so the default offset is preserved) when the index is empty.
+   */
+  private static long queryMaxInstanceKey(final ElasticsearchClient esClient, final String prefix) {
+    final String index = prefix + "-" + ZEEBE_PROCESS_INSTANCE_INDEX_NAME;
+    try {
+      final var response =
+          esClient.search(
+              s ->
+                  s.index(index)
+                      .size(0)
+                      .aggregations(
+                          "max_key", a -> a.max(m -> m.field("value.processInstanceKey"))),
+              Void.class);
+      final double value = response.aggregations().get("max_key").max().value();
+      if (Double.isFinite(value)) {
+        return (long) value;
+      }
+    } catch (final Exception e) {
+      LOG.debug(
+          "Could not query max instance key from '{}' (may not exist yet): {}",
+          index,
+          e.getMessage());
+    }
+    return GeneratorConfig.Builder.DEFAULT_INSTANCE_KEY_OFFSET - 1;
+  }
+
+  static RestClient buildRestClient(final ElasticsearchConnection connection) {
+    final org.elasticsearch.client.RestClientBuilder builder =
+        RestClient.builder(new HttpHost(connection.host(), connection.port(), "http"));
+    if (connection.username() != null) {
+      final BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+      credentialsProvider.setCredentials(
+          AuthScope.ANY,
+          new UsernamePasswordCredentials(connection.username(), connection.password()));
+      builder.setHttpClientConfigCallback(
+          b -> b.setDefaultCredentialsProvider(credentialsProvider));
+    }
+    return builder.build();
+  }
+
+  static OptimizeElasticsearchClient buildEsClient(
+      final RestClient restClient, final String prefix) {
+    final ObjectMapper mapper = ObjectMapperFactory.OPTIMIZE_MAPPER;
+    final ElasticsearchClient esClient =
+        new ElasticsearchClient(
+            new RestClientTransport(restClient, new JacksonJsonpMapper(mapper)));
+    return new OptimizeElasticsearchClient(
+        restClient, mapper, esClient, new OptimizeIndexNameService(prefix));
+  }
+
+  /** Groups the Elasticsearch connection parameters passed via CLI arguments. */
+  record ElasticsearchConnection(String host, int port, String username, String password) {}
+}

--- a/optimize/backend/src/it/java/io/camunda/optimize/test/generator/ZeebeProcessDataGenerator.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/generator/ZeebeProcessDataGenerator.java
@@ -1,0 +1,357 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.test.generator;
+
+import static io.camunda.optimize.service.db.DatabaseConstants.ZEEBE_INCIDENT_INDEX_NAME;
+import static io.camunda.optimize.service.db.DatabaseConstants.ZEEBE_PROCESS_DEFINITION_INDEX_NAME;
+import static io.camunda.optimize.service.db.DatabaseConstants.ZEEBE_PROCESS_INSTANCE_INDEX_NAME;
+import static io.camunda.optimize.service.db.DatabaseConstants.ZEEBE_USER_TASK_INDEX_NAME;
+import static io.camunda.optimize.service.db.DatabaseConstants.ZEEBE_VARIABLE_INDEX_NAME;
+import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_ACTIVATING;
+import static io.camunda.zeebe.protocol.record.value.BpmnElementType.PROCESS;
+
+import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
+import io.camunda.optimize.service.db.es.OptimizeElasticsearchClient;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Orchestrates synthetic Zeebe data generation, populating raw Zeebe record indexes so the Optimize
+ * importers can run without a live Zeebe broker.
+ *
+ * <p>This class owns only orchestration: it loops over configured process definitions, constructs
+ * {@link InstanceWindow} for each instance, and delegates all record emission to collaborators.
+ *
+ * <p>Collaborators:
+ *
+ * <ul>
+ *   <li>{@link GeneratorConfig} — immutable configuration and key-derivation logic
+ *   <li>{@link ZeebeRecordFactory} — builds Zeebe record DTOs and wraps them as ES operations
+ *   <li>{@link FlowNodeEmitter} — pure factory for per-instance record lists
+ *   <li>{@link BpmnFlowParser} — parses BPMN resources into reusable {@link ProcessGraph}s
+ *   <li>{@link ZeebeBulkWriter} — handles ES index lifecycle and batched bulk writes
+ * </ul>
+ *
+ * <p>Usage:
+ *
+ * <pre>{@code
+ * new ZeebeProcessDataGenerator(
+ *     new GeneratorConfig.Builder()
+ *         .instanceCount(50_000)
+ *         .zeebeRecordPrefix(zeebeExtension.getZeebeRecordPrefix())
+ *         .build())
+ *     .generate(esClient);
+ * }</pre>
+ */
+public class ZeebeProcessDataGenerator {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ZeebeProcessDataGenerator.class);
+
+  private static final double ACTIVE_INSTANCE_RATE = 0.03;
+  private static final double TERMINATED_INSTANCE_RATE = 0.05;
+  private static final double INCIDENT_RATE = 0.05;
+
+  private final GeneratorConfig config;
+  private final Random random;
+  private final ZeebeRecordFactory factory;
+  private final FlowNodeEmitter emitter;
+
+  public ZeebeProcessDataGenerator(final GeneratorConfig config) {
+    this.config = config;
+    random = new Random(config.seed);
+    final VariableCatalogue catalogue = new VariableCatalogue(random);
+    final NodeTimingSimulator timingSimulator = new NodeTimingSimulator(random);
+    factory =
+        new ZeebeRecordFactory(
+            config.partitionId, config.positionOffset, catalogue, ProcessBpmnBuilder::bpmn);
+    emitter = new FlowNodeEmitter(factory, timingSimulator, random);
+  }
+
+  // ── Public API ────────────────────────────────────────────────────────────
+
+  /** Generates and bulk-inserts all synthetic Zeebe records. */
+  public void generate(final OptimizeElasticsearchClient esClient) {
+    final String[] processIds = config.resolveProcessIds();
+    final ZeebeBulkWriter writer = new ZeebeBulkWriter(esClient, config.batchSize);
+    requiredIndexNames().forEach(writer::ensureIndexExists);
+    insertProcessDefinitions(writer, processIds);
+    insertProcessInstances(writer, processIds);
+
+    if (config.updateRate > 0.0) {
+      insertVariableUpdates(writer, processIds);
+    }
+  }
+
+  // ── Index setup ───────────────────────────────────────────────────────────
+
+  private List<String> requiredIndexNames() {
+    return List.of(
+        zeebeIndexName(ZEEBE_PROCESS_DEFINITION_INDEX_NAME),
+        zeebeIndexName(ZEEBE_PROCESS_INSTANCE_INDEX_NAME),
+        zeebeIndexName(ZEEBE_VARIABLE_INDEX_NAME),
+        zeebeIndexName(ZEEBE_USER_TASK_INDEX_NAME),
+        zeebeIndexName(ZEEBE_INCIDENT_INDEX_NAME));
+  }
+
+  // ── Process definitions ───────────────────────────────────────────────────
+
+  private void insertProcessDefinitions(final ZeebeBulkWriter writer, final String[] processIds) {
+    final long creationTimestampMs = OffsetDateTime.now(ZoneOffset.UTC).toInstant().toEpochMilli();
+    final List<BulkOperation> processDefinitionOps =
+        IntStream.range(0, processIds.length)
+            .mapToObj(
+                i -> {
+                  final String processId = processIds[i];
+                  final long definitionKey = config.definitionKeyFor(i);
+                  return factory.processDefinitionOp(processId, definitionKey, creationTimestampMs);
+                })
+            .toList();
+    writer.write(zeebeIndexName(ZEEBE_PROCESS_DEFINITION_INDEX_NAME), processDefinitionOps);
+  }
+
+  // ── Process instances ─────────────────────────────────────────────────────
+
+  private void insertProcessInstances(final ZeebeBulkWriter writer, final String[] processIds) {
+    final OffsetDateTime endTime = OffsetDateTime.now(ZoneOffset.UTC);
+    final OffsetDateTime earliestStartTime = endTime.minusMonths(config.monthsOfHistory);
+    final long historicalRangeSeconds = endTime.toEpochSecond() - earliestStartTime.toEpochSecond();
+
+    final ProcessGraph[] processGraphs = parseProcessGraphs(processIds);
+    final InstanceBatches writeBatches = createWriteBatches(writer);
+    final int logProgressEvery = Math.max(1, config.instanceCount / 10);
+
+    for (int instanceIndex = 0; instanceIndex < config.instanceCount; instanceIndex++) {
+      final int definitionIndex = instanceIndex % processIds.length;
+      final long instanceKey = config.instanceKeyOffset + instanceIndex;
+      final long definitionKey = config.definitionKeyFor(definitionIndex);
+      final String processId = processIds[definitionIndex];
+      final InstanceContext instanceContext =
+          new InstanceContext(instanceKey, definitionKey, processId);
+      final List<FlowNode> executionPath = processGraphs[definitionIndex].walk(random);
+      final InstanceWindow instanceWindow =
+          sampleInstanceWindow(earliestStartTime, historicalRangeSeconds);
+
+      final var instanceOps = generateInstance(instanceContext, executionPath, instanceWindow);
+      writeBatches.addAll(instanceOps);
+      writeBatches.flushIfNeeded(writer);
+
+      final int completedCount = instanceIndex + 1;
+      final boolean isProgressCheckpoint =
+          completedCount % logProgressEvery == 0 || completedCount == config.instanceCount;
+      if (isProgressCheckpoint) {
+        logProgress(completedCount, writeBatches);
+      }
+    }
+
+    writeBatches.flush(writer);
+    logCompletion(writeBatches);
+  }
+
+  // ── Variable updates ──────────────────────────────────────────────────────
+
+  /**
+   * Emits {@code UPDATED} variable records for a random fraction of the generated instances. These
+   * records land at higher positions than the {@code CREATED} records, so the Optimize importer
+   * processes them in a later round and merges the new values into existing docs — producing the
+   * "deleted" Lucene segments visible in index stats.
+   */
+  private void insertVariableUpdates(final ZeebeBulkWriter writer, final String[] processIds) {
+    final int updateCount = (int) Math.round(config.instanceCount * config.updateRate);
+    LOG.info(
+        "Emitting UPDATED variable records for {} instances (updateRate={})",
+        updateCount,
+        config.updateRate);
+
+    final ZeebeBulkWriter.IndexBatch variableBatch =
+        writer.newBatch(zeebeIndexName(ZEEBE_VARIABLE_INDEX_NAME));
+    final long updateTimestampMs = OffsetDateTime.now(ZoneOffset.UTC).toInstant().toEpochMilli();
+
+    for (int i = 0; i < updateCount; i++) {
+      final int definitionIndex = i % processIds.length;
+      final long instanceKey = config.instanceKeyOffset + i;
+      final long definitionKey = config.definitionKeyFor(definitionIndex);
+      final String processId = processIds[definitionIndex];
+      final InstanceContext ctx = new InstanceContext(instanceKey, definitionKey, processId);
+
+      variableBatch.addAll(emitter.variableUpdateOps(ctx, updateTimestampMs));
+      writer.flushIfNeeded(variableBatch);
+    }
+    writer.flush(variableBatch);
+    LOG.info("UPDATED variable records flushed: {}", variableBatch.flushedCount());
+  }
+
+  private ProcessGraph[] parseProcessGraphs(final String[] processIds) {
+    return Arrays.stream(processIds).map(BpmnFlowParser::parse).toArray(ProcessGraph[]::new);
+  }
+
+  private InstanceBatches createWriteBatches(final ZeebeBulkWriter writer) {
+    final ZeebeBulkWriter.IndexBatch processInstanceBatch =
+        writer.newBatch(zeebeIndexName(ZEEBE_PROCESS_INSTANCE_INDEX_NAME));
+    final ZeebeBulkWriter.IndexBatch variableBatch =
+        writer.newBatch(zeebeIndexName(ZEEBE_VARIABLE_INDEX_NAME));
+    final ZeebeBulkWriter.IndexBatch userTaskBatch =
+        writer.newBatch(zeebeIndexName(ZEEBE_USER_TASK_INDEX_NAME));
+    final ZeebeBulkWriter.IndexBatch incidentBatch =
+        writer.newBatch(zeebeIndexName(ZEEBE_INCIDENT_INDEX_NAME));
+    return new InstanceBatches(processInstanceBatch, variableBatch, userTaskBatch, incidentBatch);
+  }
+
+  private InstanceOps generateInstance(
+      final InstanceContext instanceContext,
+      final List<FlowNode> executionPath,
+      final InstanceWindow instanceWindow) {
+
+    final ElementRecord processElement =
+        new ElementRecord(instanceContext.instanceKey(), instanceContext.processId(), PROCESS, -1L);
+
+    final LifecycleEvent processStart =
+        new LifecycleEvent(ELEMENT_ACTIVATING, instanceWindow.startMs());
+    final BulkOperation processStartOp =
+        factory.processInstanceOp(instanceContext, processElement, processStart);
+
+    final FlowNodeEmitter.FlowNodeOps flowNodeOps =
+        emitter.flowNodeOps(instanceContext, executionPath, instanceWindow);
+
+    final Optional<BulkOperation> processEndOp =
+        buildProcessEndOp(instanceContext, processElement, instanceWindow);
+
+    final List<BulkOperation> processInstanceOps =
+        Stream.of(Stream.of(processStartOp), flowNodeOps.pi().stream(), processEndOp.stream())
+            .flatMap(s -> s)
+            .toList();
+
+    final List<BulkOperation> variableOps =
+        emitter.variableOps(instanceContext, instanceWindow.endMs());
+    final List<BulkOperation> incidentOps =
+        instanceWindow.hasIncident()
+            ? emitter.incidentOps(instanceContext, executionPath, instanceWindow)
+            : List.of();
+
+    final var userTasksOps = flowNodeOps.ut();
+    return new InstanceOps(processInstanceOps, variableOps, userTasksOps, incidentOps);
+  }
+
+  private Optional<BulkOperation> buildProcessEndOp(
+      final InstanceContext ctx,
+      final ElementRecord processElement,
+      final InstanceWindow instanceWindow) {
+    if (instanceWindow.isActive()) {
+      return Optional.empty();
+    }
+    final LifecycleEvent processEnd =
+        new LifecycleEvent(instanceWindow.endIntent(), instanceWindow.endMs());
+    final BulkOperation endOp = factory.processInstanceOp(ctx, processElement, processEnd);
+    return Optional.of(endOp);
+  }
+
+  // ── Instance window sampling ──────────────────────────────────────────────
+
+  private InstanceWindow sampleInstanceWindow(
+      final OffsetDateTime earliestStartTime, final long historicalRangeSeconds) {
+
+    final boolean isActive = random.nextDouble() < ACTIVE_INSTANCE_RATE;
+    final boolean isTerminated = !isActive && random.nextDouble() < TERMINATED_INSTANCE_RATE;
+    final boolean hasIncident = !isActive && random.nextDouble() < INCIDENT_RATE;
+
+    final long randomOffsetSeconds = (long) (random.nextDouble() * historicalRangeSeconds);
+    final OffsetDateTime instanceStart = earliestStartTime.plusSeconds(randomOffsetSeconds);
+
+    final long durationMinutes = 10L + (long) (random.nextDouble() * 4310);
+    final OffsetDateTime instanceEnd = isActive ? null : instanceStart.plusMinutes(durationMinutes);
+
+    final long startMs = instanceStart.toInstant().toEpochMilli();
+    final long endMs = instanceEnd != null ? instanceEnd.toInstant().toEpochMilli() : startMs;
+
+    return new InstanceWindow(startMs, endMs, isActive, isTerminated, hasIncident);
+  }
+
+  // ── Logging ───────────────────────────────────────────────────────────────
+
+  private void logProgress(final int completedCount, final InstanceBatches writeBatches) {
+    final int progressPercent = 100 * completedCount / config.instanceCount;
+    LOG.info(
+        "Progress: {}/{} instances ({} %) — pi={}, var={}, ut={}, inc={} records so far",
+        completedCount,
+        config.instanceCount,
+        progressPercent,
+        writeBatches.processInstance().totalCount(),
+        writeBatches.variable().totalCount(),
+        writeBatches.userTask().totalCount(),
+        writeBatches.incident().totalCount());
+  }
+
+  private void logCompletion(final InstanceBatches writeBatches) {
+    LOG.info(
+        "Generation complete: {} instances — pi={}, var={}, ut={}, inc={} records inserted",
+        config.instanceCount,
+        writeBatches.processInstance().flushedCount(),
+        writeBatches.variable().flushedCount(),
+        writeBatches.userTask().flushedCount(),
+        writeBatches.incident().flushedCount());
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
+
+  private String zeebeIndexName(final String suffix) {
+    return config.zeebeRecordPrefix + "-" + suffix;
+  }
+
+  // ── Value objects ─────────────────────────────────────────────────────────
+
+  /**
+   * Immutable set of records produced for one process instance, grouped by target index. Returned
+   * by {@link #generateInstance} — no mutable state, no side effects.
+   */
+  private record InstanceOps(
+      List<BulkOperation> processInstance,
+      List<BulkOperation> variable,
+      List<BulkOperation> userTask,
+      List<BulkOperation> incident) {}
+
+  /**
+   * Groups the per-index write batches for one generation run.
+   *
+   * <p>Owns only the ES batch lifecycle (size-based flushing and final flush). Records are added
+   * via {@link #addAll} from a single call site in the generation loop.
+   *
+   * <p>To add a new Zeebe index: add one field here and one entry in {@link #all()}.
+   */
+  private record InstanceBatches(
+      ZeebeBulkWriter.IndexBatch processInstance,
+      ZeebeBulkWriter.IndexBatch variable,
+      ZeebeBulkWriter.IndexBatch userTask,
+      ZeebeBulkWriter.IndexBatch incident) {
+
+    void addAll(final InstanceOps ops) {
+      processInstance.addAll(ops.processInstance());
+      variable.addAll(ops.variable());
+      userTask.addAll(ops.userTask());
+      incident.addAll(ops.incident());
+    }
+
+    void flushIfNeeded(final ZeebeBulkWriter writer) {
+      all().forEach(writer::flushIfNeeded);
+    }
+
+    void flush(final ZeebeBulkWriter writer) {
+      all().forEach(writer::flush);
+    }
+
+    private Stream<ZeebeBulkWriter.IndexBatch> all() {
+      return Stream.of(processInstance, variable, userTask, incident);
+    }
+  }
+}

--- a/optimize/backend/src/it/java/io/camunda/optimize/test/generator/ZeebeRecordFactory.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/generator/ZeebeRecordFactory.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.test.generator;
+
+import static io.camunda.optimize.service.util.importing.ZeebeConstants.ZEEBE_DEFAULT_TENANT_ID;
+
+import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
+import co.elastic.clients.elasticsearch.core.bulk.IndexOperation;
+import io.camunda.optimize.dto.zeebe.ZeebeRecordDto;
+import io.camunda.optimize.dto.zeebe.definition.ZeebeProcessDefinitionDataDto;
+import io.camunda.optimize.dto.zeebe.definition.ZeebeProcessDefinitionRecordDto;
+import io.camunda.optimize.dto.zeebe.incident.ZeebeIncidentDataDto;
+import io.camunda.optimize.dto.zeebe.incident.ZeebeIncidentRecordDto;
+import io.camunda.optimize.dto.zeebe.process.ZeebeProcessInstanceDataDto;
+import io.camunda.optimize.dto.zeebe.process.ZeebeProcessInstanceRecordDto;
+import io.camunda.optimize.dto.zeebe.usertask.ZeebeUserTaskDataDto;
+import io.camunda.optimize.dto.zeebe.usertask.ZeebeUserTaskRecordDto;
+import io.camunda.optimize.dto.zeebe.variable.ZeebeVariableDataDto;
+import io.camunda.optimize.dto.zeebe.variable.ZeebeVariableRecordDto;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.protocol.record.intent.VariableIntent;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Purely deterministic factory that builds Zeebe {@link BulkOperation} records for every Zeebe
+ * record type.
+ *
+ * <p>This class has one responsibility: translate domain data into correctly structured Zeebe
+ * record DTOs and wrap them as ES bulk index operations. It owns no randomness and no business
+ * rules about what data to generate — those concerns belong to {@link VariableCatalogue} (variable
+ * values) and {@link NodeTimingSimulator} (duration distribution).
+ *
+ * <p>Each record type owns its own monotonically increasing position counter so that the Optimize
+ * import position tracker advances correctly per index.
+ */
+class ZeebeRecordFactory {
+
+  private static final String BROKER_VERSION = "8.8.0";
+
+  private final int partitionId;
+  private final VariableCatalogue catalogue;
+  private final BpmnProvider bpmnProvider;
+
+  private long pdPosition;
+  private long piPosition;
+  private long varPosition;
+  private long utPosition;
+  private long incPosition;
+
+  ZeebeRecordFactory(
+      final int partitionId,
+      final long positionOffset,
+      final VariableCatalogue catalogue,
+      final BpmnProvider bpmnProvider) {
+    this.partitionId = partitionId;
+    this.catalogue = catalogue;
+    this.bpmnProvider = bpmnProvider;
+    pdPosition = positionOffset;
+    piPosition = positionOffset;
+    varPosition = positionOffset;
+    utPosition = positionOffset;
+    incPosition = positionOffset;
+  }
+
+  // ── Process definition ────────────────────────────────────────────────────
+
+  BulkOperation processDefinitionOp(
+      final String bpmnProcessId, final long defKey, final long timestamp) {
+    final ZeebeProcessDefinitionDataDto data = new ZeebeProcessDefinitionDataDto();
+    data.setBpmnProcessId(bpmnProcessId);
+    data.setProcessDefinitionKey(defKey);
+    data.setVersion(1);
+    data.setResourceName(bpmnProcessId + ".bpmn");
+    data.setResource(bpmnProvider.bpmnFor(bpmnProcessId));
+    data.setTenantId(ZEEBE_DEFAULT_TENANT_ID);
+
+    final ZeebeProcessDefinitionRecordDto record = new ZeebeProcessDefinitionRecordDto();
+    record.setKey(defKey);
+    record.setTimestamp(timestamp);
+    record.setValueType(ValueType.PROCESS);
+    record.setIntent(ProcessIntent.CREATED);
+    record.setValue(data);
+    return wrap(record, ++pdPosition);
+  }
+
+  // ── Process instance ──────────────────────────────────────────────────────
+
+  /**
+   * Builds a process instance record.
+   *
+   * <p>See {@link ElementRecord#flowScopeKey()} for the expected values of that field.
+   */
+  BulkOperation processInstanceOp(
+      final InstanceContext ctx, final ElementRecord element, final LifecycleEvent event) {
+
+    final ZeebeProcessInstanceDataDto data = new ZeebeProcessInstanceDataDto();
+    data.setProcessInstanceKey(ctx.instanceKey());
+    data.setProcessDefinitionKey(ctx.defKey());
+    data.setBpmnProcessId(ctx.processId());
+    data.setElementId(element.elementId());
+    data.setBpmnElementType(element.type());
+    data.setFlowScopeKey(element.flowScopeKey());
+    data.setVersion(1);
+    data.setTenantId(ZEEBE_DEFAULT_TENANT_ID);
+
+    final ZeebeProcessInstanceRecordDto record = new ZeebeProcessInstanceRecordDto();
+    record.setKey(element.key());
+    record.setTimestamp(event.timestamp());
+    record.setValueType(ValueType.PROCESS_INSTANCE);
+    record.setIntent(event.intent());
+    record.setValue(data);
+    return wrap(record, ++piPosition);
+  }
+
+  // ── Variables ─────────────────────────────────────────────────────────────
+
+  /**
+   * Builds all variable records for one instance by delegating value generation to the catalogue.
+   */
+  List<BulkOperation> variableOps(final InstanceContext ctx, final long timestamp) {
+    return catalogue.generate(ctx.instanceKey()).stream()
+        .map(
+            entry ->
+                variableOp(ctx, new NamedVariable(entry.getKey(), entry.getValue()), timestamp))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Builds {@code UPDATED} variable records for one instance. Used to simulate mid-flight variable
+   * updates, which cause the Optimize importer to merge new field values into an existing doc.
+   */
+  List<BulkOperation> variableUpdateOps(final InstanceContext ctx, final long timestamp) {
+    return catalogue.generate(ctx.instanceKey()).stream()
+        .map(
+            entry ->
+                variableUpdateOp(
+                    ctx, new NamedVariable(entry.getKey(), entry.getValue()), timestamp))
+        .collect(Collectors.toList());
+  }
+
+  // ── User task ─────────────────────────────────────────────────────────────
+
+  BulkOperation userTaskCreatingOp(final InstanceContext ctx, final UserTaskEvent event) {
+    final ZeebeUserTaskDataDto data = baseUserTaskData(ctx, event);
+    return wrapUserTask(data, event, UserTaskIntent.CREATING);
+  }
+
+  /** {@code assignee} is supplied by the caller so the factory itself has no randomness. */
+  BulkOperation userTaskAssignedOp(
+      final InstanceContext ctx, final UserTaskEvent event, final String assignee) {
+    final ZeebeUserTaskDataDto data = baseUserTaskData(ctx, event);
+    data.setAssignee(assignee);
+    data.setChangedAttributes(List.of("assignee"));
+    return wrapUserTask(data, event, UserTaskIntent.ASSIGNED);
+  }
+
+  BulkOperation userTaskEndOp(
+      final InstanceContext ctx, final UserTaskEvent event, final UserTaskIntent intent) {
+    final ZeebeUserTaskDataDto data = baseUserTaskData(ctx, event);
+    if (intent == UserTaskIntent.COMPLETED) {
+      data.setAction("complete");
+    }
+    return wrapUserTask(data, event, intent);
+  }
+
+  // ── Incident ──────────────────────────────────────────────────────────────
+
+  BulkOperation incidentOp(
+      final InstanceContext ctx, final IncidentEvent event, final IncidentIntent intent) {
+
+    final ZeebeIncidentDataDto data = new ZeebeIncidentDataDto();
+    data.setElementId(event.elementId());
+    data.setElementInstanceKey(event.elemInstKey());
+    data.setProcessInstanceKey(ctx.instanceKey());
+    data.setProcessDefinitionKey(ctx.defKey());
+    data.setBpmnProcessId(ctx.processId());
+    data.setJobKey(event.elemInstKey());
+    data.setVariableScopeKey(ctx.instanceKey());
+    data.setErrorType(ErrorType.JOB_NO_RETRIES);
+    data.setErrorMessage("Job retries exhausted (simulated)");
+    data.setTenantId(ZEEBE_DEFAULT_TENANT_ID);
+
+    final ZeebeIncidentRecordDto record = new ZeebeIncidentRecordDto();
+    record.setKey(event.incKey());
+    record.setTimestamp(event.timestamp());
+    record.setValueType(ValueType.INCIDENT);
+    record.setIntent(intent);
+    record.setValue(data);
+    return wrap(record, ++incPosition);
+  }
+
+  // ── Private helpers ───────────────────────────────────────────────────────
+
+  private BulkOperation variableUpdateOp(
+      final InstanceContext ctx, final NamedVariable variable, final long timestamp) {
+    final ZeebeVariableDataDto data = new ZeebeVariableDataDto();
+    data.setName(variable.name());
+    data.setValue(variable.value());
+    data.setScopeKey(ctx.instanceKey());
+    data.setProcessInstanceKey(ctx.instanceKey());
+    data.setProcessDefinitionKey(ctx.defKey());
+    data.setBpmnProcessId(ctx.processId());
+    data.setTenantId(ZEEBE_DEFAULT_TENANT_ID);
+
+    final ZeebeVariableRecordDto record = new ZeebeVariableRecordDto();
+    record.setKey(++varPosition * 1_000L + Math.abs(variable.name().hashCode() % 1_000));
+    record.setTimestamp(timestamp);
+    record.setValueType(ValueType.VARIABLE);
+    record.setIntent(VariableIntent.UPDATED);
+    record.setValue(data);
+    return wrap(record, varPosition);
+  }
+
+  private BulkOperation variableOp(
+      final InstanceContext ctx, final NamedVariable variable, final long timestamp) {
+    final ZeebeVariableDataDto data = new ZeebeVariableDataDto();
+    data.setName(variable.name());
+    data.setValue(variable.value());
+    data.setScopeKey(ctx.instanceKey());
+    data.setProcessInstanceKey(ctx.instanceKey());
+    data.setProcessDefinitionKey(ctx.defKey());
+    data.setBpmnProcessId(ctx.processId());
+    data.setTenantId(ZEEBE_DEFAULT_TENANT_ID);
+
+    final ZeebeVariableRecordDto record = new ZeebeVariableRecordDto();
+    record.setKey(++varPosition * 1_000L + Math.abs(variable.name().hashCode() % 1_000));
+    record.setTimestamp(timestamp);
+    record.setValueType(ValueType.VARIABLE);
+    record.setIntent(VariableIntent.CREATED);
+    record.setValue(data);
+    return wrap(record, varPosition);
+  }
+
+  private ZeebeUserTaskDataDto baseUserTaskData(
+      final InstanceContext ctx, final UserTaskEvent event) {
+    final ZeebeUserTaskDataDto data = new ZeebeUserTaskDataDto();
+    data.setUserTaskKey(event.utKey());
+    data.setElementId(event.elementId());
+    data.setElementInstanceKey(event.elemInstKey());
+    data.setBpmnProcessId(ctx.processId());
+    data.setProcessDefinitionKey(ctx.defKey());
+    data.setProcessDefinitionVersion(1);
+    data.setProcessInstanceKey(ctx.instanceKey());
+    data.setTenantId(ZEEBE_DEFAULT_TENANT_ID);
+    data.setCreationTimestamp(event.timestamp());
+    return data;
+  }
+
+  private BulkOperation wrapUserTask(
+      final ZeebeUserTaskDataDto data, final UserTaskEvent event, final UserTaskIntent intent) {
+    final ZeebeUserTaskRecordDto record = new ZeebeUserTaskRecordDto();
+    record.setKey(event.utKey());
+    record.setTimestamp(event.timestamp());
+    record.setValueType(ValueType.USER_TASK);
+    record.setIntent(intent);
+    record.setValue(data);
+    return wrap(record, ++utPosition);
+  }
+
+  /**
+   * Populates the common envelope fields on any Zeebe record DTO and wraps it as an ES bulk index
+   * operation. All concrete DTO types extend {@link ZeebeRecordDto}, so no instanceof dispatch is
+   * needed.
+   */
+  private BulkOperation wrap(final ZeebeRecordDto<?, ?> record, final long position) {
+    record.setPosition(position);
+    record.setSequence(position);
+    record.setPartitionId(partitionId);
+    record.setRecordType(RecordType.EVENT);
+    record.setBrokerVersion(BROKER_VERSION);
+    final String docId = partitionId + "-" + position;
+    return BulkOperation.of(b -> b.index(IndexOperation.of(i -> i.id(docId).document(record))));
+  }
+
+  // ── Private parameter objects ─────────────────────────────────────────────
+
+  /** Groups a variable name and its serialized value. Used only inside {@link #variableOp}. */
+  private record NamedVariable(String name, String value) {}
+}

--- a/optimize/backend/src/it/resources/bpmn/generator/claim-processing.bpmn
+++ b/optimize/backend/src/it/resources/bpmn/generator/claim-processing.bpmn
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+             xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+             xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+             id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn"
+             exporter="Camunda Web Modeler" exporterVersion="0.0.0">
+
+  <process id="claim-processing" isExecutable="true">
+    <startEvent id="startEvent_1">
+      <outgoing>f0</outgoing>
+    </startEvent>
+    <serviceTask id="serviceTask_1" name="Assess claim">
+      <incoming>f0</incoming>
+      <outgoing>f1</outgoing>
+    </serviceTask>
+    <exclusiveGateway id="exclusiveGateway_1" name="Eligible?">
+      <incoming>f1</incoming>
+      <outgoing>f2</outgoing>
+      <outgoing>f3</outgoing>
+    </exclusiveGateway>
+    <serviceTask id="serviceTask_2" name="Process payout">
+      <incoming>f2</incoming>
+      <outgoing>f4</outgoing>
+    </serviceTask>
+    <endEvent id="endEvent_1">
+      <incoming>f4</incoming>
+    </endEvent>
+    <userTask id="userTask_1" name="Manual review">
+      <incoming>f3</incoming>
+      <outgoing>f5</outgoing>
+    </userTask>
+    <endEvent id="endEvent_B">
+      <incoming>f5</incoming>
+    </endEvent>
+    <sequenceFlow id="f0" sourceRef="startEvent_1"       targetRef="serviceTask_1"/>
+    <sequenceFlow id="f1" sourceRef="serviceTask_1"      targetRef="exclusiveGateway_1"/>
+    <sequenceFlow id="f2" name="eligible"                sourceRef="exclusiveGateway_1" targetRef="serviceTask_2"/>
+    <sequenceFlow id="f3" name="needs review"            sourceRef="exclusiveGateway_1" targetRef="userTask_1"/>
+    <sequenceFlow id="f4" sourceRef="serviceTask_2"      targetRef="endEvent_1"/>
+    <sequenceFlow id="f5" sourceRef="userTask_1"         targetRef="endEvent_B"/>
+  </process>
+
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="claim-processing">
+      <bpmndi:BPMNShape id="startEvent_1_di" bpmnElement="startEvent_1">
+        <dc:Bounds x="152" y="162" width="36" height="36"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="serviceTask_1_di" bpmnElement="serviceTask_1">
+        <dc:Bounds x="240" y="140" width="100" height="80"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="exclusiveGateway_1_di" bpmnElement="exclusiveGateway_1" isMarkerVisible="true">
+        <dc:Bounds x="400" y="155" width="50" height="50"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="serviceTask_2_di" bpmnElement="serviceTask_2">
+        <dc:Bounds x="510" y="40" width="100" height="80"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="endEvent_1_di" bpmnElement="endEvent_1">
+        <dc:Bounds x="672" y="62" width="36" height="36"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="userTask_1_di" bpmnElement="userTask_1">
+        <dc:Bounds x="510" y="220" width="100" height="80"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="endEvent_B_di" bpmnElement="endEvent_B">
+        <dc:Bounds x="672" y="242" width="36" height="36"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="f0_di" bpmnElement="f0">
+        <di:waypoint x="188" y="180"/><di:waypoint x="240" y="180"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f1_di" bpmnElement="f1">
+        <di:waypoint x="340" y="180"/><di:waypoint x="400" y="180"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f2_di" bpmnElement="f2">
+        <di:waypoint x="425" y="155"/><di:waypoint x="425" y="80"/><di:waypoint x="510" y="80"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f3_di" bpmnElement="f3">
+        <di:waypoint x="425" y="205"/><di:waypoint x="425" y="260"/><di:waypoint x="510" y="260"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f4_di" bpmnElement="f4">
+        <di:waypoint x="610" y="80"/><di:waypoint x="672" y="80"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f5_di" bpmnElement="f5">
+        <di:waypoint x="610" y="260"/><di:waypoint x="672" y="260"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/optimize/backend/src/it/resources/bpmn/generator/customer-onboarding.bpmn
+++ b/optimize/backend/src/it/resources/bpmn/generator/customer-onboarding.bpmn
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+             xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+             xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+             id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn"
+             exporter="Camunda Web Modeler" exporterVersion="0.0.0">
+
+  <process id="customer-onboarding" isExecutable="true">
+    <startEvent id="startEvent_1">
+      <outgoing>f0</outgoing>
+    </startEvent>
+    <serviceTask id="serviceTask_1" name="Send onboarding request">
+      <incoming>f0</incoming>
+      <outgoing>f1</outgoing>
+    </serviceTask>
+    <eventBasedGateway id="eventBasedGateway_1" name="Await customer response">
+      <incoming>f1</incoming>
+      <outgoing>f_ev1</outgoing>
+      <outgoing>f_ev2</outgoing>
+    </eventBasedGateway>
+    <receiveTask id="receiveTask_1" name="Receive acceptance">
+      <incoming>f_ev1</incoming>
+      <outgoing>f_ev3</outgoing>
+    </receiveTask>
+    <endEvent id="endEvent_evA">
+      <incoming>f_ev3</incoming>
+    </endEvent>
+    <receiveTask id="receiveTask_2" name="Receive rejection">
+      <incoming>f_ev2</incoming>
+      <outgoing>f_ev4</outgoing>
+    </receiveTask>
+    <serviceTask id="serviceTask_4" name="Close application">
+      <incoming>f_ev4</incoming>
+      <outgoing>f_ev5</outgoing>
+    </serviceTask>
+    <endEvent id="endEvent_evB">
+      <incoming>f_ev5</incoming>
+    </endEvent>
+    <sequenceFlow id="f0"    sourceRef="startEvent_1"        targetRef="serviceTask_1"/>
+    <sequenceFlow id="f1"    sourceRef="serviceTask_1"       targetRef="eventBasedGateway_1"/>
+    <sequenceFlow id="f_ev1" sourceRef="eventBasedGateway_1" targetRef="receiveTask_1"/>
+    <sequenceFlow id="f_ev2" sourceRef="eventBasedGateway_1" targetRef="receiveTask_2"/>
+    <sequenceFlow id="f_ev3" sourceRef="receiveTask_1"       targetRef="endEvent_evA"/>
+    <sequenceFlow id="f_ev4" sourceRef="receiveTask_2"       targetRef="serviceTask_4"/>
+    <sequenceFlow id="f_ev5" sourceRef="serviceTask_4"       targetRef="endEvent_evB"/>
+  </process>
+
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="customer-onboarding">
+      <bpmndi:BPMNShape id="startEvent_1_di" bpmnElement="startEvent_1">
+        <dc:Bounds x="152" y="162" width="36" height="36"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="serviceTask_1_di" bpmnElement="serviceTask_1">
+        <dc:Bounds x="240" y="140" width="100" height="80"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="eventBasedGateway_1_di" bpmnElement="eventBasedGateway_1" isMarkerVisible="true">
+        <dc:Bounds x="400" y="155" width="50" height="50"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="receiveTask_1_di" bpmnElement="receiveTask_1">
+        <dc:Bounds x="510" y="40" width="100" height="80"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="endEvent_evA_di" bpmnElement="endEvent_evA">
+        <dc:Bounds x="672" y="62" width="36" height="36"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="receiveTask_2_di" bpmnElement="receiveTask_2">
+        <dc:Bounds x="510" y="220" width="100" height="80"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="serviceTask_4_di" bpmnElement="serviceTask_4">
+        <dc:Bounds x="670" y="220" width="100" height="80"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="endEvent_evB_di" bpmnElement="endEvent_evB">
+        <dc:Bounds x="832" y="242" width="36" height="36"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="f0_di" bpmnElement="f0">
+        <di:waypoint x="188" y="180"/><di:waypoint x="240" y="180"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f1_di" bpmnElement="f1">
+        <di:waypoint x="340" y="180"/><di:waypoint x="400" y="180"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f_ev1_di" bpmnElement="f_ev1">
+        <di:waypoint x="425" y="155"/><di:waypoint x="425" y="80"/><di:waypoint x="510" y="80"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f_ev2_di" bpmnElement="f_ev2">
+        <di:waypoint x="425" y="205"/><di:waypoint x="425" y="260"/><di:waypoint x="510" y="260"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f_ev3_di" bpmnElement="f_ev3">
+        <di:waypoint x="610" y="80"/><di:waypoint x="672" y="80"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f_ev4_di" bpmnElement="f_ev4">
+        <di:waypoint x="610" y="260"/><di:waypoint x="670" y="260"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f_ev5_di" bpmnElement="f_ev5">
+        <di:waypoint x="770" y="260"/><di:waypoint x="832" y="260"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/optimize/backend/src/it/resources/bpmn/generator/fraud-dispute-handling.bpmn
+++ b/optimize/backend/src/it/resources/bpmn/generator/fraud-dispute-handling.bpmn
@@ -1,0 +1,213 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+             xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+             xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+             id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn"
+             exporter="Camunda Web Modeler" exporterVersion="0.0.0">
+
+  <process id="fraud-dispute-handling" name="Fraud Dispute Handling" isExecutable="true">
+    <startEvent id="StartEvent_1" name="Credit card fraud dispute started">
+      <outgoing>f0</outgoing>
+    </startEvent>
+    <subProcess id="documentCollection" name="Document Collection">
+      <incoming>f0</incoming>
+      <outgoing>f_dc_fa</outgoing>
+      <startEvent id="sub1_start">
+        <outgoing>f_s1_0</outgoing>
+      </startEvent>
+      <serviceTask id="requestDocuments" name="Request documents from customer">
+        <incoming>f_s1_0</incoming>
+        <outgoing>f_s1_1</outgoing>
+      </serviceTask>
+      <userTask id="provideDocuments" name="Collect and verify documents">
+        <incoming>f_s1_1</incoming>
+        <outgoing>f_s1_2</outgoing>
+      </userTask>
+      <endEvent id="sub1_end">
+        <incoming>f_s1_2</incoming>
+      </endEvent>
+      <sequenceFlow id="f_s1_0" sourceRef="sub1_start"       targetRef="requestDocuments"/>
+      <sequenceFlow id="f_s1_1" sourceRef="requestDocuments"  targetRef="provideDocuments"/>
+      <sequenceFlow id="f_s1_2" sourceRef="provideDocuments"  targetRef="sub1_end"/>
+    </subProcess>
+    <subProcess id="fraudAssessment" name="Fraud Assessment">
+      <incoming>f_dc_fa</incoming>
+      <outgoing>f_fa_ar</outgoing>
+      <startEvent id="sub2_start">
+        <outgoing>f_s2_0</outgoing>
+      </startEvent>
+      <serviceTask id="analyzeTransaction" name="Analyze transaction">
+        <incoming>f_s2_0</incoming>
+        <outgoing>f_s2_1</outgoing>
+      </serviceTask>
+      <serviceTask id="evaluateRisk" name="Evaluate fraud risk">
+        <incoming>f_s2_1</incoming>
+        <outgoing>f_s2_2</outgoing>
+      </serviceTask>
+      <endEvent id="sub2_end">
+        <incoming>f_s2_2</incoming>
+      </endEvent>
+      <sequenceFlow id="f_s2_0" sourceRef="sub2_start"         targetRef="analyzeTransaction"/>
+      <sequenceFlow id="f_s2_1" sourceRef="analyzeTransaction"  targetRef="evaluateRisk"/>
+      <sequenceFlow id="f_s2_2" sourceRef="evaluateRisk"        targetRef="sub2_end"/>
+    </subProcess>
+    <exclusiveGateway id="assessmentResult" name="Assessment result">
+      <incoming>f_fa_ar</incoming>
+      <outgoing>f4</outgoing>
+      <outgoing>f5</outgoing>
+      <outgoing>f6</outgoing>
+    </exclusiveGateway>
+    <serviceTask id="processRefund" name="Process refund">
+      <incoming>f4</incoming>
+      <outgoing>f7</outgoing>
+    </serviceTask>
+    <userTask id="decideOnFraudCase" name="Decide on fraud case">
+      <incoming>f5</incoming>
+      <outgoing>f8</outgoing>
+    </userTask>
+    <serviceTask id="initiateClawback" name="Initiate credit and clawback">
+      <incoming>f8</incoming>
+      <outgoing>f9</outgoing>
+    </serviceTask>
+    <serviceTask id="informDecline" name="Inform customer about unsuccessful claim">
+      <incoming>f6</incoming>
+      <outgoing>f11</outgoing>
+    </serviceTask>
+    <endEvent id="EndEvent_noRefund" name="Dispute settled - no refund">
+      <incoming>f11</incoming>
+    </endEvent>
+    <serviceTask id="informCustomerSuccess" name="Inform customer about successful claim">
+      <incoming>f7</incoming>
+      <incoming>f9</incoming>
+      <outgoing>f10</outgoing>
+    </serviceTask>
+    <endEvent id="EndEvent_refund" name="Dispute settled - refund">
+      <incoming>f10</incoming>
+    </endEvent>
+    <sequenceFlow id="f0"      sourceRef="StartEvent_1"          targetRef="documentCollection"/>
+    <sequenceFlow id="f_dc_fa" sourceRef="documentCollection"    targetRef="fraudAssessment"/>
+    <sequenceFlow id="f_fa_ar" sourceRef="fraudAssessment"       targetRef="assessmentResult"/>
+    <sequenceFlow id="f4"  name="refund approved"                sourceRef="assessmentResult"  targetRef="processRefund"/>
+    <sequenceFlow id="f5"  name="manual review required"         sourceRef="assessmentResult"  targetRef="decideOnFraudCase"/>
+    <sequenceFlow id="f6"  name="no refund"                      sourceRef="assessmentResult"  targetRef="informDecline"/>
+    <sequenceFlow id="f7"      sourceRef="processRefund"         targetRef="informCustomerSuccess"/>
+    <sequenceFlow id="f8"      sourceRef="decideOnFraudCase"     targetRef="initiateClawback"/>
+    <sequenceFlow id="f9"      sourceRef="initiateClawback"      targetRef="informCustomerSuccess"/>
+    <sequenceFlow id="f10"     sourceRef="informCustomerSuccess"  targetRef="EndEvent_refund"/>
+    <sequenceFlow id="f11"     sourceRef="informDecline"         targetRef="EndEvent_noRefund"/>
+  </process>
+
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="fraud-dispute-handling">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="272" width="36" height="36"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="documentCollection_di" bpmnElement="documentCollection" isExpanded="true">
+        <dc:Bounds x="230" y="160" width="420" height="260"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="sub1_start_di" bpmnElement="sub1_start">
+        <dc:Bounds x="260" y="272" width="36" height="36"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="requestDocuments_di" bpmnElement="requestDocuments">
+        <dc:Bounds x="330" y="250" width="100" height="80"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="provideDocuments_di" bpmnElement="provideDocuments">
+        <dc:Bounds x="460" y="250" width="100" height="80"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="sub1_end_di" bpmnElement="sub1_end">
+        <dc:Bounds x="590" y="272" width="36" height="36"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="fraudAssessment_di" bpmnElement="fraudAssessment" isExpanded="true">
+        <dc:Bounds x="690" y="160" width="380" height="260"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="sub2_start_di" bpmnElement="sub2_start">
+        <dc:Bounds x="710" y="272" width="36" height="36"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="analyzeTransaction_di" bpmnElement="analyzeTransaction">
+        <dc:Bounds x="770" y="250" width="100" height="80"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="evaluateRisk_di" bpmnElement="evaluateRisk">
+        <dc:Bounds x="900" y="250" width="100" height="80"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="sub2_end_di" bpmnElement="sub2_end">
+        <dc:Bounds x="1022" y="272" width="36" height="36"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="assessmentResult_di" bpmnElement="assessmentResult" isMarkerVisible="true">
+        <dc:Bounds x="1130" y="265" width="50" height="50"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="processRefund_di" bpmnElement="processRefund">
+        <dc:Bounds x="1240" y="80" width="100" height="80"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="decideOnFraudCase_di" bpmnElement="decideOnFraudCase">
+        <dc:Bounds x="1240" y="250" width="100" height="80"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="initiateClawback_di" bpmnElement="initiateClawback">
+        <dc:Bounds x="1400" y="250" width="100" height="80"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="informDecline_di" bpmnElement="informDecline">
+        <dc:Bounds x="1240" y="400" width="100" height="80"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_noRefund_di" bpmnElement="EndEvent_noRefund">
+        <dc:Bounds x="1402" y="422" width="36" height="36"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="informCustomerSuccess_di" bpmnElement="informCustomerSuccess">
+        <dc:Bounds x="1560" y="250" width="100" height="80"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_refund_di" bpmnElement="EndEvent_refund">
+        <dc:Bounds x="1722" y="272" width="36" height="36"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="f0_di" bpmnElement="f0">
+        <di:waypoint x="188" y="290"/><di:waypoint x="230" y="290"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f_dc_fa_di" bpmnElement="f_dc_fa">
+        <di:waypoint x="650" y="290"/><di:waypoint x="690" y="290"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f_fa_ar_di" bpmnElement="f_fa_ar">
+        <di:waypoint x="1070" y="290"/><di:waypoint x="1130" y="290"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f4_di" bpmnElement="f4">
+        <di:waypoint x="1155" y="265"/><di:waypoint x="1155" y="120"/><di:waypoint x="1240" y="120"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f5_di" bpmnElement="f5">
+        <di:waypoint x="1180" y="290"/><di:waypoint x="1240" y="290"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f6_di" bpmnElement="f6">
+        <di:waypoint x="1155" y="315"/><di:waypoint x="1155" y="440"/><di:waypoint x="1240" y="440"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f7_di" bpmnElement="f7">
+        <di:waypoint x="1340" y="120"/><di:waypoint x="1610" y="120"/><di:waypoint x="1610" y="250"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f8_di" bpmnElement="f8">
+        <di:waypoint x="1340" y="290"/><di:waypoint x="1400" y="290"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f9_di" bpmnElement="f9">
+        <di:waypoint x="1500" y="290"/><di:waypoint x="1560" y="290"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f10_di" bpmnElement="f10">
+        <di:waypoint x="1660" y="290"/><di:waypoint x="1722" y="290"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f11_di" bpmnElement="f11">
+        <di:waypoint x="1340" y="440"/><di:waypoint x="1402" y="440"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f_s1_0_di" bpmnElement="f_s1_0">
+        <di:waypoint x="296" y="290"/><di:waypoint x="330" y="290"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f_s1_1_di" bpmnElement="f_s1_1">
+        <di:waypoint x="430" y="290"/><di:waypoint x="460" y="290"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f_s1_2_di" bpmnElement="f_s1_2">
+        <di:waypoint x="560" y="290"/><di:waypoint x="590" y="290"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f_s2_0_di" bpmnElement="f_s2_0">
+        <di:waypoint x="746" y="290"/><di:waypoint x="770" y="290"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f_s2_1_di" bpmnElement="f_s2_1">
+        <di:waypoint x="870" y="290"/><di:waypoint x="900" y="290"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f_s2_2_di" bpmnElement="f_s2_2">
+        <di:waypoint x="1000" y="290"/><di:waypoint x="1022" y="290"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/optimize/backend/src/it/resources/bpmn/generator/invoice-processing.bpmn
+++ b/optimize/backend/src/it/resources/bpmn/generator/invoice-processing.bpmn
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+             xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+             xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+             id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn"
+             exporter="Camunda Web Modeler" exporterVersion="0.0.0">
+
+  <process id="invoice-processing" isExecutable="true">
+    <startEvent id="startEvent_1">
+      <outgoing>f0</outgoing>
+    </startEvent>
+    <serviceTask id="serviceTask_1" name="Validate invoice">
+      <incoming>f0</incoming>
+      <outgoing>f1</outgoing>
+    </serviceTask>
+    <serviceTask id="serviceTask_2" name="Calculate amounts">
+      <incoming>f1</incoming>
+      <outgoing>f2</outgoing>
+    </serviceTask>
+    <userTask id="userTask_1" name="Approve invoice">
+      <incoming>f2</incoming>
+      <outgoing>f3</outgoing>
+    </userTask>
+    <endEvent id="endEvent_1">
+      <incoming>f3</incoming>
+    </endEvent>
+    <sequenceFlow id="f0" sourceRef="startEvent_1"  targetRef="serviceTask_1"/>
+    <sequenceFlow id="f1" sourceRef="serviceTask_1" targetRef="serviceTask_2"/>
+    <sequenceFlow id="f2" sourceRef="serviceTask_2" targetRef="userTask_1"/>
+    <sequenceFlow id="f3" sourceRef="userTask_1"    targetRef="endEvent_1"/>
+  </process>
+
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="invoice-processing">
+      <bpmndi:BPMNShape id="startEvent_1_di" bpmnElement="startEvent_1">
+        <dc:Bounds x="152" y="62" width="36" height="36"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="serviceTask_1_di" bpmnElement="serviceTask_1">
+        <dc:Bounds x="240" y="40" width="100" height="80"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="serviceTask_2_di" bpmnElement="serviceTask_2">
+        <dc:Bounds x="390" y="40" width="100" height="80"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="userTask_1_di" bpmnElement="userTask_1">
+        <dc:Bounds x="540" y="40" width="100" height="80"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="endEvent_1_di" bpmnElement="endEvent_1">
+        <dc:Bounds x="702" y="62" width="36" height="36"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="f0_di" bpmnElement="f0">
+        <di:waypoint x="188" y="80"/><di:waypoint x="240" y="80"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f1_di" bpmnElement="f1">
+        <di:waypoint x="340" y="80"/><di:waypoint x="390" y="80"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f2_di" bpmnElement="f2">
+        <di:waypoint x="490" y="80"/><di:waypoint x="540" y="80"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f3_di" bpmnElement="f3">
+        <di:waypoint x="640" y="80"/><di:waypoint x="702" y="80"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/optimize/backend/src/it/resources/bpmn/generator/loan-approval.bpmn
+++ b/optimize/backend/src/it/resources/bpmn/generator/loan-approval.bpmn
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+             xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+             xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+             id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn"
+             exporter="Camunda Web Modeler" exporterVersion="0.0.0">
+
+  <process id="loan-approval" isExecutable="true">
+    <startEvent id="startEvent_1">
+      <outgoing>f0</outgoing>
+    </startEvent>
+    <serviceTask id="serviceTask_1" name="Assess application">
+      <incoming>f0</incoming>
+      <outgoing>f1</outgoing>
+    </serviceTask>
+    <userTask id="userTask_1" name="Initial review">
+      <incoming>f1</incoming>
+      <outgoing>f2</outgoing>
+    </userTask>
+    <serviceTask id="serviceTask_2" name="Credit check">
+      <incoming>f2</incoming>
+      <outgoing>f3</outgoing>
+    </serviceTask>
+    <userTask id="userTask_2" name="Underwriter review">
+      <incoming>f3</incoming>
+      <outgoing>f4</outgoing>
+    </userTask>
+    <serviceTask id="serviceTask_3" name="Disburse loan">
+      <incoming>f4</incoming>
+      <outgoing>f5</outgoing>
+    </serviceTask>
+    <endEvent id="endEvent_1">
+      <incoming>f5</incoming>
+    </endEvent>
+    <sequenceFlow id="f0" sourceRef="startEvent_1"  targetRef="serviceTask_1"/>
+    <sequenceFlow id="f1" sourceRef="serviceTask_1" targetRef="userTask_1"/>
+    <sequenceFlow id="f2" sourceRef="userTask_1"    targetRef="serviceTask_2"/>
+    <sequenceFlow id="f3" sourceRef="serviceTask_2" targetRef="userTask_2"/>
+    <sequenceFlow id="f4" sourceRef="userTask_2"    targetRef="serviceTask_3"/>
+    <sequenceFlow id="f5" sourceRef="serviceTask_3" targetRef="endEvent_1"/>
+  </process>
+
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="loan-approval">
+      <bpmndi:BPMNShape id="startEvent_1_di" bpmnElement="startEvent_1">
+        <dc:Bounds x="152" y="62" width="36" height="36"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="serviceTask_1_di" bpmnElement="serviceTask_1">
+        <dc:Bounds x="240" y="40" width="100" height="80"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="userTask_1_di" bpmnElement="userTask_1">
+        <dc:Bounds x="390" y="40" width="100" height="80"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="serviceTask_2_di" bpmnElement="serviceTask_2">
+        <dc:Bounds x="540" y="40" width="100" height="80"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="userTask_2_di" bpmnElement="userTask_2">
+        <dc:Bounds x="690" y="40" width="100" height="80"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="serviceTask_3_di" bpmnElement="serviceTask_3">
+        <dc:Bounds x="840" y="40" width="100" height="80"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="endEvent_1_di" bpmnElement="endEvent_1">
+        <dc:Bounds x="1002" y="62" width="36" height="36"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="f0_di" bpmnElement="f0">
+        <di:waypoint x="188" y="80"/><di:waypoint x="240" y="80"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f1_di" bpmnElement="f1">
+        <di:waypoint x="340" y="80"/><di:waypoint x="390" y="80"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f2_di" bpmnElement="f2">
+        <di:waypoint x="490" y="80"/><di:waypoint x="540" y="80"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f3_di" bpmnElement="f3">
+        <di:waypoint x="640" y="80"/><di:waypoint x="690" y="80"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f4_di" bpmnElement="f4">
+        <di:waypoint x="790" y="80"/><di:waypoint x="840" y="80"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f5_di" bpmnElement="f5">
+        <di:waypoint x="940" y="80"/><di:waypoint x="1002" y="80"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/optimize/backend/src/it/resources/bpmn/generator/order-fulfillment.bpmn
+++ b/optimize/backend/src/it/resources/bpmn/generator/order-fulfillment.bpmn
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+             xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+             xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+             id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn"
+             exporter="Camunda Web Modeler" exporterVersion="0.0.0">
+
+  <process id="order-fulfillment" isExecutable="true">
+    <startEvent id="startEvent_1">
+      <outgoing>f0</outgoing>
+    </startEvent>
+    <serviceTask id="serviceTask_1" name="Process order">
+      <incoming>f0</incoming>
+      <outgoing>f1</outgoing>
+    </serviceTask>
+    <serviceTask id="serviceTask_2" name="Notify fulfillment">
+      <incoming>f1</incoming>
+      <outgoing>f2</outgoing>
+    </serviceTask>
+    <endEvent id="endEvent_1">
+      <incoming>f2</incoming>
+    </endEvent>
+    <sequenceFlow id="f0" sourceRef="startEvent_1"  targetRef="serviceTask_1"/>
+    <sequenceFlow id="f1" sourceRef="serviceTask_1" targetRef="serviceTask_2"/>
+    <sequenceFlow id="f2" sourceRef="serviceTask_2" targetRef="endEvent_1"/>
+  </process>
+
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="order-fulfillment">
+      <bpmndi:BPMNShape id="startEvent_1_di" bpmnElement="startEvent_1">
+        <dc:Bounds x="152" y="62" width="36" height="36"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="serviceTask_1_di" bpmnElement="serviceTask_1">
+        <dc:Bounds x="240" y="40" width="100" height="80"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="serviceTask_2_di" bpmnElement="serviceTask_2">
+        <dc:Bounds x="390" y="40" width="100" height="80"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="endEvent_1_di" bpmnElement="endEvent_1">
+        <dc:Bounds x="552" y="62" width="36" height="36"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="f0_di" bpmnElement="f0">
+        <di:waypoint x="188" y="80"/><di:waypoint x="240" y="80"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f1_di" bpmnElement="f1">
+        <di:waypoint x="340" y="80"/><di:waypoint x="390" y="80"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="f2_di" bpmnElement="f2">
+        <di:waypoint x="490" y="80"/><di:waypoint x="552" y="80"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/optimize/backend/src/it/resources/poc-scripts/README.md
+++ b/optimize/backend/src/it/resources/poc-scripts/README.md
@@ -1,0 +1,224 @@
+# Reporting Metrics Query
+
+A continuous data pipeline that reads process variables from a source Elasticsearch index and aggregates them into a destination index for reporting.
+
+## What it does
+
+On each run, the script:
+1. Fetches `REPORTING_PROCESS_*` variable records from `zeebe-record-variable` (source) that were written after the last known position
+2. Groups them by process instance
+3. Upserts aggregated process instance documents into `optimize-reporting-metrics` (destination)
+4. Persists the latest position so the next run only processes new records
+
+It loops continuously until `TOTAL_DURATION_S` is reached, sleeping between rounds when caught up.
+
+## Configuration
+
+All options are set at the top of `query.py`:
+
+|      Variable      |              Default               |                            Meaning                             |
+|--------------------|------------------------------------|----------------------------------------------------------------|
+| `ES_HOST`          | `http://localhost:9200`            | Elasticsearch URL                                              |
+| `SOURCE_INDEX`     | `zeebe-record-variable`            | Source index containing Zeebe variable records                 |
+| `DEST_INDEX`       | `optimize-reporting-metrics`       | Destination index for aggregated metrics                       |
+| `RUN_EVERY_S`      | `60`                               | Seconds to sleep between rounds when no pending records remain |
+| `TOTAL_DURATION_S` | `3600`                             | Maximum total runtime in seconds before the script exits       |
+| `PAGE_SIZE`        | `1000`                             | Number of records fetched per scroll page                      |
+| `STATE_FILE`       | `.reporting_metrics_position.json` | File used to persist the last processed position               |
+
+## Running
+
+```bash
+pip install elasticsearch
+python query.py
+```
+
+Requires Elasticsearch running at `ES_HOST` with the source index populated by Zeebe.
+
+### Resetting the position (full reprocess)
+
+The script resumes from where it left off using `.reporting_metrics_position.json`. If you need to reprocess all records from the beginning (e.g. after deleting and recreating the destination index), delete that file before starting:
+
+```bash
+rm .reporting_metrics_position.json
+python query.py
+```
+
+> **Warning:** without deleting the state file, re-running the script after a `DELETE optimize-reporting-metrics` will only import records written *after* the last saved position. Documents from earlier positions will be missing from the index.
+
+The script prints a warning at startup if a state file is found, reminding you of this.
+
+---
+
+## Log output — glossary
+
+Every term that appears in the logs is defined below.
+
+### Startup
+
+```
+Starting — interval 60s, total 3600s
+State file: /path/to/.reporting_metrics_position.json
+```
+
+|     Term     |                                         Meaning                                         |
+|--------------|-----------------------------------------------------------------------------------------|
+| `interval`   | Seconds the script sleeps between rounds when no pending records remain (`RUN_EVERY_S`) |
+| `total`      | Maximum seconds the script will run before exiting (`TOTAL_DURATION_S`)                 |
+| `State file` | Path to the JSON file that stores the last processed position                           |
+
+---
+
+### Round header
+
+```
+[Round 3] position=9380678
+```
+
+|    Term    |                                                                                 Meaning                                                                                 |
+|------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `Round`    | Sequential round counter, incremented on every loop iteration                                                                                                           |
+| `position` | The Elasticsearch `position` field value of the last record successfully processed in the previous round; only records with a higher position are fetched in this round |
+
+---
+
+### Index stats
+
+Printed at the start and end of each round, and whenever the index is first created.
+
+```
+index stats (0.45s): live=1,234,567  deleted=45,678 (3.6% dirty)  size=2.3 GB  wasted≈82.5 MB
+```
+
+|    Term     |                                                                                            Meaning                                                                                             |
+|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `index`     | The destination Elasticsearch index (`optimize-reporting-metrics`)                                                                                                                             |
+| `live`      | Number of documents currently active and searchable in the index                                                                                                                               |
+| `deleted`   | Number of documents that have been deleted or superseded but whose disk space has not yet been reclaimed by Elasticsearch (tombstones); these are invisible to queries but still consume space |
+| `dirty_pct` | `deleted / (live + deleted) * 100` — the percentage of tracked document slots that are dead weight; a high value means the index is fragmented and a forcemerge would recover space            |
+| `size`      | Total disk space used by the index, including both live documents and unreclaimed deleted tombstones                                                                                           |
+| `wasted`    | Estimated bytes consumed by deleted tombstones (`size * deleted / (live + deleted)`); this space is not doing useful work and will be freed once Elasticsearch runs a segment merge            |
+
+---
+
+### Fetch phase
+
+```
+fetch : 2.34s — 5,642 REPORTING_PROCESS_* variable records from zeebe-record-variable in 6 page(s)
+```
+
+|          Term           |                                                     Meaning                                                      |
+|-------------------------|------------------------------------------------------------------------------------------------------------------|
+| `fetch`                 | The phase where records are read from the source index using the Elasticsearch scroll API                        |
+| `REPORTING_PROCESS_*`   | Variable records whose `value.name` starts with the `REPORTING_PROCESS_` prefix; all other variables are ignored |
+| `zeebe-record-variable` | The source Elasticsearch index written by Zeebe (the workflow engine)                                            |
+| `page(s)`               | Number of scroll API calls made; each page returns up to `PAGE_SIZE` (1 000) records                             |
+
+---
+
+### Upsert phase
+
+```
+upsert: 1.12s — 845 PIs (300 created, 545 updated)
+upsert: 1.12s — 845 PIs (300 created, 545 updated) ⚠ 2 errors
+```
+
+|     Term     |                                                                       Meaning                                                                       |
+|--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `upsert`     | The phase where documents are written to the destination index; each operation inserts a new document or updates an existing one (insert-or-update) |
+| `PIs`        | Process instances — one document per unique `processInstanceKey`                                                                                    |
+| `created`    | Documents that did not exist in the destination index and were newly inserted                                                                       |
+| `updated`    | Documents that already existed and had one or more fields overwritten with new values                                                               |
+| `⚠ N errors` | Number of individual bulk operations that Elasticsearch rejected; the rest of the batch still succeeds                                              |
+
+---
+
+### Round completion
+
+```
+[Round 3] done in 3.82s — 845 PIs (221 PI/s), new position: 9386320
+```
+
+|      Term      |                                                          Meaning                                                           |
+|----------------|----------------------------------------------------------------------------------------------------------------------------|
+| `done in`      | Wall-clock time for the entire round (fetch + upsert + index stats)                                                        |
+| `PI/s`         | Throughput: process instances upserted per second                                                                          |
+| `new position` | The highest `position` value seen in this round; saved to the state file and used as the starting point for the next round |
+
+---
+
+### Pending check
+
+```
+pending check: 0.18s — 2,341 variable records still pending in zeebe-record-variable
+```
+
+|      Term       |                                                           Meaning                                                            |
+|-----------------|------------------------------------------------------------------------------------------------------------------------------|
+| `pending`       | Variable records in the source index whose `position` is greater than the current position — i.e., records not yet processed |
+| `pending check` | A count query run after each round to decide whether to sleep or immediately start the next round                            |
+
+---
+
+### Scheduling decision
+
+```
+2,341 records still pending — running next round immediately
+```
+
+```
+caught up — sleeping 60s...
+```
+
+|      Term       |                                           Meaning                                            |
+|-----------------|----------------------------------------------------------------------------------------------|
+| `still pending` | Unprocessed records exist; the next round starts without sleeping                            |
+| `caught up`     | No pending records remain; the script sleeps for `RUN_EVERY_S` seconds before checking again |
+
+---
+
+### Shutdown
+
+```
+Total duration reached (3600s). Stopping.
+Finished. Total time: 3601.23s across 47 round(s).
+```
+
+The script exits cleanly once the total duration limit is reached. The state file retains the last position so the next invocation continues from where it stopped.
+
+---
+
+## Destination document fields
+
+Each document in `optimize-reporting-metrics` represents one process instance and maps directly from the `REPORTING_PROCESS_*` variable names in Zeebe.
+
+|            Field            |  Type  |                Source variable                |
+|-----------------------------|--------|-----------------------------------------------|
+| `baselineCost`              | float  | `REPORTING_PROCESS_baselineCost`              |
+| `llmCost`                   | float  | `REPORTING_PROCESS_llmCost`                   |
+| `automationCost`            | float  | `REPORTING_PROCESS_automationCost`            |
+| `totalCost`                 | float  | `REPORTING_PROCESS_totalCost`                 |
+| `valueCreated`              | float  | `REPORTING_PROCESS_valueCreated`              |
+| `agentTaskCount`            | int    | `REPORTING_PROCESS_agentTaskCount`            |
+| `humanTaskCount`            | int    | `REPORTING_PROCESS_humanTaskCount`            |
+| `autoTaskCount`             | int    | `REPORTING_PROCESS_autoTaskCount`             |
+| `tokenUsage`                | int    | `REPORTING_PROCESS_tokenUsage`                |
+| `processLabel`              | string | `REPORTING_PROCESS_processLabel`              |
+| `startDate`                 | string | `REPORTING_PROCESS_startDate`                 |
+| `endDate`                   | string | `REPORTING_PROCESS_endDate`                   |
+| `errorCount`                | int    | `REPORTING_PROCESS_errorCount`                |
+| `retryCount`                | int    | `REPORTING_PROCESS_retryCount`                |
+| `processingTimeMs`          | int    | `REPORTING_PROCESS_processingTimeMs`          |
+| `queueWaitTimeMs`           | int    | `REPORTING_PROCESS_queueWaitTimeMs`           |
+| `apiCallCount`              | int    | `REPORTING_PROCESS_apiCallCount`              |
+| `complianceChecksPassed`    | int    | `REPORTING_PROCESS_complianceChecksPassed`    |
+| `dataVolumeMb`              | float  | `REPORTING_PROCESS_dataVolumeMb`              |
+| `confidenceScore`           | float  | `REPORTING_PROCESS_confidenceScore`           |
+| `co2EmissionsKg`            | float  | `REPORTING_PROCESS_co2EmissionsKg`            |
+| `customerSatisfactionScore` | float  | `REPORTING_PROCESS_customerSatisfactionScore` |
+| `fraudRiskScore`            | float  | `REPORTING_PROCESS_fraudRiskScore`            |
+| `externalServiceCostUsd`    | float  | `REPORTING_PROCESS_externalServiceCostUsd`    |
+| `slaBreached`               | bool   | `REPORTING_PROCESS_slaBreached`               |
+| `escalated`                 | bool   | `REPORTING_PROCESS_escalated`                 |
+| `manualOverride`            | bool   | `REPORTING_PROCESS_manualOverride`            |
+

--- a/optimize/backend/src/it/resources/poc-scripts/query.py
+++ b/optimize/backend/src/it/resources/poc-scripts/query.py
@@ -1,0 +1,386 @@
+import json
+import time
+from collections import defaultdict
+from pathlib import Path
+
+from elasticsearch import Elasticsearch
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+ES_HOST          = "http://localhost:9200"
+SOURCE_INDEX     = "zeebe-record-variable"
+DEST_INDEX       = "optimize-reporting-metrics"
+RUN_EVERY_S      = 60
+TOTAL_DURATION_S = 60 * 60
+PAGE_SIZE        = 1000
+STATE_FILE       = Path(__file__).parent / ".reporting_metrics_position.json"
+# ──────────────────────────────────────────────────────────────────────────────
+
+FIELD_MAP = {
+    "REPORTING_PROCESS_baselineCost":              ("baselineCost",              float),
+    "REPORTING_PROCESS_llmCost":                   ("llmCost",                   float),
+    "REPORTING_PROCESS_automationCost":            ("automationCost",            float),
+    "REPORTING_PROCESS_totalCost":                 ("totalCost",                 float),
+    "REPORTING_PROCESS_valueCreated":              ("valueCreated",              float),
+    "REPORTING_PROCESS_agentTaskCount":            ("agentTaskCount",            int),
+    "REPORTING_PROCESS_humanTaskCount":            ("humanTaskCount",            int),
+    "REPORTING_PROCESS_autoTaskCount":             ("autoTaskCount",             int),
+    "REPORTING_PROCESS_tokenUsage":                ("tokenUsage",                int),
+    "REPORTING_PROCESS_processLabel":              ("processLabel",              str),
+    "REPORTING_PROCESS_startDate":                 ("startDate",                 str),
+    "REPORTING_PROCESS_endDate":                   ("endDate",                   str),
+    "REPORTING_PROCESS_errorCount":                ("errorCount",                int),
+    "REPORTING_PROCESS_retryCount":                ("retryCount",                int),
+    "REPORTING_PROCESS_processingTimeMs":          ("processingTimeMs",          int),
+    "REPORTING_PROCESS_queueWaitTimeMs":           ("queueWaitTimeMs",           int),
+    "REPORTING_PROCESS_apiCallCount":              ("apiCallCount",              int),
+    "REPORTING_PROCESS_complianceChecksPassed":    ("complianceChecksPassed",    int),
+    "REPORTING_PROCESS_dataVolumeMb":              ("dataVolumeMb",              float),
+    "REPORTING_PROCESS_confidenceScore":           ("confidenceScore",           float),
+    "REPORTING_PROCESS_co2EmissionsKg":            ("co2EmissionsKg",            float),
+    "REPORTING_PROCESS_customerSatisfactionScore": ("customerSatisfactionScore", float),
+    "REPORTING_PROCESS_fraudRiskScore":            ("fraudRiskScore",            float),
+    "REPORTING_PROCESS_externalServiceCostUsd":    ("externalServiceCostUsd",    float),
+    "REPORTING_PROCESS_slaBreached":               ("slaBreached",               bool),
+    "REPORTING_PROCESS_escalated":                 ("escalated",                 bool),
+    "REPORTING_PROCESS_manualOverride":            ("manualOverride",            bool),
+}
+
+
+def load_position() -> int:
+    if STATE_FILE.exists():
+        return json.loads(STATE_FILE.read_text()).get("position", -1)
+    return -1
+
+
+def save_position(position: int) -> None:
+    STATE_FILE.write_text(json.dumps({"position": position}))
+
+
+def ensure_index_exists(es: Elasticsearch) -> None:
+    if es.indices.exists(index=DEST_INDEX):
+        return
+    es.indices.create(
+        index=DEST_INDEX,
+        mappings={
+            "properties": {
+                "processInstanceKey":           {"type": "keyword"},
+                "processDefinitionKey":         {"type": "keyword"},
+                "tenantId":                     {"type": "keyword"},
+                "startDate":                    {"type": "date"},
+                "endDate":                      {"type": "date"},
+                "firstSeenAt":                  {"type": "date"},
+                "lastSeenAt":                   {"type": "date"},
+                "state":                        {"type": "keyword"},
+                "processLabel":                 {"type": "keyword"},
+                "baselineCost":                 {"type": "double"},
+                "llmCost":                      {"type": "double"},
+                "automationCost":               {"type": "double"},
+                "totalCost":                    {"type": "double"},
+                "valueCreated":                 {"type": "double"},
+                "agentTaskCount":               {"type": "integer"},
+                "humanTaskCount":               {"type": "integer"},
+                "autoTaskCount":                {"type": "integer"},
+                "tokenUsage":                   {"type": "long"},
+                "errorCount":                   {"type": "integer"},
+                "retryCount":                   {"type": "integer"},
+                "processingTimeMs":             {"type": "integer"},
+                "queueWaitTimeMs":              {"type": "integer"},
+                "apiCallCount":                 {"type": "integer"},
+                "complianceChecksPassed":       {"type": "integer"},
+                "dataVolumeMb":                 {"type": "double"},
+                "confidenceScore":              {"type": "double"},
+                "co2EmissionsKg":               {"type": "double"},
+                "customerSatisfactionScore":    {"type": "double"},
+                "fraudRiskScore":               {"type": "double"},
+                "externalServiceCostUsd":       {"type": "double"},
+                "slaBreached":                  {"type": "boolean"},
+                "escalated":                    {"type": "boolean"},
+                "manualOverride":               {"type": "boolean"},
+            }
+        },
+    )
+    print(f"  Created index '{DEST_INDEX}'.")
+
+
+def print_index_stats(es: Elasticsearch) -> None:
+    """Prints live docs, deleted docs, store size and estimated wasted bytes for DEST_INDEX."""
+    try:
+        t0 = time.monotonic()
+        stats = es.indices.stats(index=DEST_INDEX, metric=["docs", "store"])
+        segs  = es.indices.segments(index=DEST_INDEX)
+        elapsed = time.monotonic() - t0
+
+        idx      = stats["indices"][DEST_INDEX]["total"]
+        live     = idx["docs"]["count"]
+        deleted  = idx["docs"]["deleted"]
+        size_b   = idx["store"]["size_in_bytes"]
+
+        # Estimate wasted bytes from segment data
+        wasted_b = 0
+        for _shard in segs["indices"][DEST_INDEX]["shards"].values():
+            for seg in _shard[0]["segments"].values():
+                num  = seg.get("num_docs", 0)
+                dels = seg.get("deleted_docs", 0)
+                seg_b = seg.get("size_in_bytes", 0)
+                if num + dels > 0:
+                    wasted_b += int(seg_b * dels / (num + dels))
+
+        def fmt(b: int) -> str:
+            for unit in ("B", "KB", "MB", "GB"):
+                if b < 1024:
+                    return f"{b:.1f} {unit}"
+                b /= 1024
+            return f"{b:.1f} TB"
+
+        dirty_pct = 100 * deleted / (live + deleted) if (live + deleted) > 0 else 0
+        print(
+            f"  index stats ({elapsed:.2f}s): "
+            f"live={live:,}  deleted={deleted:,} ({dirty_pct:.1f}% dirty)  "
+            f"size={fmt(size_b)}  wasted≈{fmt(wasted_b)}"
+        )
+    except Exception as e:
+        print(f"  index stats: unavailable ({e})")
+
+
+def count_pending(es: Elasticsearch, from_position: int) -> int:
+    """Returns the number of REPORTING_PROCESS_* variable records not yet imported."""
+    t0 = time.monotonic()
+    result = es.count(
+        index=SOURCE_INDEX,
+        query={
+            "bool": {
+                "must": [
+                    {"prefix": {"value.name.keyword": "REPORTING_PROCESS_"}},
+                    {"range": {"position": {"gt": from_position}}},
+                ]
+            }
+        },
+    )
+    count = result["count"]
+    print(f"  pending check: {time.monotonic() - t0:.2f}s — {count} variable records still pending in {SOURCE_INDEX}")
+    return count
+
+
+def run_import_round(es: Elasticsearch, from_position: int) -> tuple[int, int, int]:
+    """
+    Fetch REPORTING_PROCESS_* variable records with position > from_position,
+    group by processInstanceKey, bulk-upsert into dest index.
+
+    Returns (new_max_position, records_read, pis_upserted).
+    """
+    ensure_index_exists(es)
+
+    # ── Fetch ──────────────────────────────────────────────────────────────
+    t0 = time.monotonic()
+    pi_docs: dict[str, dict] = defaultdict(dict)
+    max_position = from_position
+    records_read = 0
+    page = 0
+
+    resp = es.search(
+        index=SOURCE_INDEX,
+        query={
+            "bool": {
+                "must": [
+                    {"prefix": {"value.name.keyword": "REPORTING_PROCESS_"}},
+                    {"range": {"position": {"gt": from_position}}},
+                ]
+            }
+        },
+        _source=["position", "timestamp", "value"],
+        sort=[{"position": "asc"}],
+        scroll="2m",
+        size=PAGE_SIZE,
+    )
+    scroll_id = resp["_scroll_id"]
+    hits = resp["hits"]["hits"]
+
+    while hits:
+        page += 1
+        for hit in hits:
+            src = hit["_source"]
+            pos = src["position"]
+            if pos > max_position:
+                max_position = pos
+            v = src["value"]
+            pi_key = str(v["processInstanceKey"])
+            mapping = FIELD_MAP.get(v["name"])
+            if mapping is None:
+                continue
+            records_read += 1
+            field_name, cast = mapping
+            ts = src.get("timestamp")  # epoch ms from the Zeebe record
+            if pi_key not in pi_docs:
+                pi_docs[pi_key] = {
+                    "processInstanceKey": pi_key,
+                    "processDefinitionKey": str(v.get("processDefinitionKey", "")),
+                    "tenantId": v.get("tenantId", ""),
+                }
+            pi_docs[pi_key][field_name] = cast(v["value"].strip('"'))
+            if ts is not None:
+                prev_first = pi_docs[pi_key].get("firstSeenAt")
+                prev_last  = pi_docs[pi_key].get("lastSeenAt")
+                if prev_first is None or ts < prev_first:
+                    pi_docs[pi_key]["firstSeenAt"] = ts
+                if prev_last is None or ts > prev_last:
+                    pi_docs[pi_key]["lastSeenAt"] = ts
+
+        resp = es.scroll(scroll_id=scroll_id, scroll="2m")
+        scroll_id = resp["_scroll_id"]
+        hits = resp["hits"]["hits"]
+
+    fetch_s = time.monotonic() - t0
+    print(f"  fetch : {fetch_s:.2f}s — {records_read} REPORTING_PROCESS_* variable records from {SOURCE_INDEX} in {page} page(s)")
+
+    if not pi_docs:
+        return max_position, 0, 0, 0, 0, 0
+
+    # ── Upsert ─────────────────────────────────────────────────────────────
+    t1 = time.monotonic()
+    created = updated = errors = 0
+    bulk_ops = []
+
+    def flush_bulk(ops: list) -> None:
+        nonlocal created, updated, errors
+        resp = es.bulk(operations=ops)
+        for item in resp["items"]:
+            result = item["update"].get("result")
+            status = item["update"].get("status", 0)
+            if status >= 400:
+                errors += 1
+            elif result == "created":
+                created += 1
+            else:
+                updated += 1
+
+    for pi_key, doc in pi_docs.items():
+        bulk_ops.append({"update": {"_index": DEST_INDEX, "_id": pi_key}})
+        bulk_ops.append({"doc": doc, "doc_as_upsert": True})
+        if len(bulk_ops) >= 500:
+            flush_bulk(bulk_ops)
+            bulk_ops.clear()
+    if bulk_ops:
+        flush_bulk(bulk_ops)
+
+    upsert_s = time.monotonic() - t1
+    error_str = f"  ⚠ {errors} errors" if errors else ""
+    print(f"  upsert: {upsert_s:.2f}s — {len(pi_docs)} PIs ({created} created, {updated} updated){error_str}")
+
+    return max_position, records_read, len(pi_docs), created, updated, errors
+
+
+def print_summary(round_stats: list[dict], total_elapsed: float) -> None:
+    """Print a per-round summary table after the run ends."""
+    print("\n" + "═" * 92)
+    print("  SUMMARY REPORT")
+    print("═" * 92)
+
+    if not round_stats:
+        print("  No rounds completed.")
+        print("═" * 92)
+        return
+
+    header = (
+        f"  {'Round':>5}  {'Records':>10}  {'PIs':>7}  {'Created':>8}  "
+        f"{'Updated':>8}  {'Errors':>6}  {'Elapsed':>8}  Position"
+    )
+    print(header)
+    print("  " + "-" * 88)
+
+    total_records = total_pis = total_created = total_updated = total_errors = 0
+    for r in round_stats:
+        print(
+            f"  {r['round']:>5}  {r['records']:>10,}  {r['pis']:>7,}  {r['created']:>8,}  "
+            f"{r['updated']:>8,}  {r['errors']:>6,}  {r['elapsed']:>7.2f}s  {r['position']}"
+        )
+        total_records  += r["records"]
+        total_pis      += r["pis"]
+        total_created  += r["created"]
+        total_updated  += r["updated"]
+        total_errors   += r["errors"]
+
+    print("  " + "-" * 88)
+    active_elapsed = sum(r["elapsed"] for r in round_stats if r["pis"] > 0)
+    pi_per_s = total_pis / active_elapsed if active_elapsed > 0 else 0
+    print(
+        f"  {'TOTAL':>5}  {total_records:>10,}  {total_pis:>7,}  {total_created:>8,}  "
+        f"{total_updated:>8,}  {total_errors:>6,}  {total_elapsed:>7.2f}s"
+    )
+    print(f"\n  {len(round_stats)} round(s)  ·  {pi_per_s:.0f} PI/s overall"
+          + (f"  ·  ⚠ {total_errors} total errors" if total_errors else ""))
+    print("═" * 92)
+
+
+def main() -> None:
+    es = Elasticsearch(ES_HOST)
+    overall_start = time.monotonic()
+    round_num = 0
+    round_stats: list[dict] = []
+
+    print(f"Starting — interval {RUN_EVERY_S}s, total {TOTAL_DURATION_S}s")
+    print(f"State file: {STATE_FILE}")
+    if STATE_FILE.exists():
+        print(f"  ⚠  Resuming from saved position. Delete {STATE_FILE.name} to reprocess from the beginning.")
+    else:
+        print(f"  No state file found — starting from position -1 (full reprocess).")
+    print()
+
+    try:
+        while True:
+            if time.monotonic() - overall_start >= TOTAL_DURATION_S:
+                print(f"Total duration reached ({TOTAL_DURATION_S}s). Stopping.")
+                break
+
+            round_num += 1
+            position = load_position()
+            t0 = time.monotonic()
+            print(f"[Round {round_num}] position={position}")
+            print_index_stats(es)
+
+            new_position, records_read, pis_upserted, created, updated, errors = run_import_round(es, position)
+
+            if new_position > position:
+                save_position(new_position)
+
+            elapsed = time.monotonic() - t0
+            pi_per_s = pis_upserted / elapsed if elapsed > 0 else 0
+            print(
+                f"[Round {round_num}] done in {elapsed:.2f}s — "
+                f"{pis_upserted} PIs ({pi_per_s:.0f} PI/s), "
+                f"new position: {new_position}"
+            )
+            print_index_stats(es)
+
+            round_stats.append({
+                "round":    round_num,
+                "records":  records_read,
+                "pis":      pis_upserted,
+                "created":  created,
+                "updated":  updated,
+                "errors":   errors,
+                "elapsed":  elapsed,
+                "position": new_position,
+            })
+
+            remaining = TOTAL_DURATION_S - (time.monotonic() - overall_start)
+            if remaining <= 0:
+                continue
+
+            pending = count_pending(es, new_position)
+            if pending > 0:
+                print(f"  {pending} records still pending — running next round immediately\n")
+            else:
+                sleep_s = min(RUN_EVERY_S, remaining)
+                print(f"  caught up — sleeping {sleep_s:.0f}s...\n")
+                time.sleep(sleep_s)
+
+    except KeyboardInterrupt:
+        print("\nInterrupted.")
+
+    total_elapsed = time.monotonic() - overall_start
+    print_summary(round_stats, total_elapsed)
+    print(f"Finished. Total time: {total_elapsed:.2f}s across {round_num} round(s).")
+
+
+if __name__ == "__main__":
+    main()

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/ZeebeRecordDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/ZeebeRecordDto.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.optimize.dto.zeebe;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.protocol.record.Agent;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
@@ -42,6 +43,7 @@ public abstract class ZeebeRecordDto<VALUE extends RecordValue, INTENT extends I
 
   public ZeebeRecordDto() {}
 
+  @JsonIgnore
   @Override
   public String toJson() {
     throw new UnsupportedOperationException("Operation not supported");
@@ -111,6 +113,7 @@ public abstract class ZeebeRecordDto<VALUE extends RecordValue, INTENT extends I
     return null;
   }
 
+  @JsonIgnore
   @Override
   public int getRecordVersion() {
     throw new UnsupportedOperationException("Operation not supported");
@@ -131,6 +134,7 @@ public abstract class ZeebeRecordDto<VALUE extends RecordValue, INTENT extends I
     return operationReference;
   }
 
+  @JsonIgnore
   @Override
   public Record<VALUE> copyOf() {
     throw new UnsupportedOperationException("Operation not supported");

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/definition/ZeebeProcessDefinitionDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/definition/ZeebeProcessDefinitionDataDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.zeebe.definition;
 
 import static io.camunda.optimize.service.util.importing.ZeebeConstants.ZEEBE_DEFAULT_TENANT_ID;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.protocol.record.value.deployment.ProcessMetadataValue;
 import java.util.Arrays;
 import java.util.Objects;
@@ -27,6 +28,7 @@ public class ZeebeProcessDefinitionDataDto implements ProcessMetadataValue {
 
   public ZeebeProcessDefinitionDataDto() {}
 
+  @JsonIgnore
   @Override
   public String toJson() {
     throw new UnsupportedOperationException("Operation not supported");
@@ -38,6 +40,7 @@ public class ZeebeProcessDefinitionDataDto implements ProcessMetadataValue {
     return false;
   }
 
+  @JsonIgnore
   @Override
   public long getDeploymentKey() {
     throw new UnsupportedOperationException("Operation not supported");

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/incident/ZeebeIncidentDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/incident/ZeebeIncidentDataDto.java
@@ -31,6 +31,7 @@ public class ZeebeIncidentDataDto implements IncidentRecordValue {
 
   public ZeebeIncidentDataDto() {}
 
+  @JsonIgnore
   @Override
   public String toJson() {
     throw new UnsupportedOperationException("Operation not supported");

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/usertask/ZeebeUserTaskDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/usertask/ZeebeUserTaskDataDto.java
@@ -146,6 +146,7 @@ public class ZeebeUserTaskDataDto implements UserTaskRecordValue {
     return processDefinitionKey;
   }
 
+  @JsonIgnore
   @Override
   public int getPriority() {
     throw new UnsupportedOperationException("Operation not supported");

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/variable/ZeebeVariableDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/variable/ZeebeVariableDataDto.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.dto.zeebe.variable;
 
 import static io.camunda.optimize.service.util.importing.ZeebeConstants.ZEEBE_DEFAULT_TENANT_ID;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
 import io.camunda.zeebe.protocol.record.value.VariableSourceValue;
 import java.util.Objects;
@@ -26,6 +27,7 @@ public class ZeebeVariableDataDto implements VariableRecordValue {
 
   public ZeebeVariableDataDto() {}
 
+  @JsonIgnore
   @Override
   public String toJson() {
     throw new UnsupportedOperationException("Operation not supported");


### PR DESCRIPTION
** This PR is to be merged into **poc_optimize_business_value_dashboard**

## Description

Adds a self-contained Zeebe data generator that populates raw Zeebe record indexes in Elasticsearch without requiring a live broker or process engine. This enables Optimize integration tests to run against large, realistic datasets in a fully controlled and reproducible way.

What the generator produces

The generator writes records into the five standard Zeebe indexes:

zeebe-record_process-definition_*
zeebe-record_process-instance_*
zeebe-record_variable_*
zeebe-record_user-task_*
zeebe-record_incident_*

### Process definitions

Six BPMN definitions with varying structural complexity:

- **order-fulfillment** – simple linear flow
- **invoice-processing** – medium complexity
- **loan-approval** – complex flow
- **claim-processing** – gateway-heavy branching
- **customer-onboarding** – event-based gateway routing
- **fraud-dispute-handling** – mixed flow with sub-processes

### Process instance lifecycles

Instances are spread uniformly over a configurable historical window and assigned one of four end states:

Active (~3%) – started but not yet completed
Completed (~92%) – reached an end event
Terminated (~5%) – force-cancelled
With incident (~5%) – service task raises a CREATED incident, optionally resolved

### Flow node records

Each instance walks the BPMN graph, choosing branches at random at exclusive and event-based gateways. Every visited node emits:

ELEMENT_ACTIVATING, and for non-active instances, the corresponding completion intent.
Sub-process scopes are expanded in place with correct flowScopeKey nesting.

### User task lifecycle

For every user task node in a completed/terminated instance, the generator emits:

- CREATING
- ASSIGNED (random assignee from a pool of 10 users)
- COMPLETED / CANCELED

### Variables

Each instance receives:

- Six business variables (customerId, orderId, amount, status, requiresReview, priority) with stable sentinel values keyed by the instance key.
- Nine core REPORTING_PROCESS_* cost/value metrics (always present, randomly valued).
- Up to 15 optional REPORTING_PROCESS_* metrics (each included with 60% probability) covering error counts, processing times, CO₂ emissions, satisfaction scores, fraud risk, SLA breaches, and more.

## Related issues

closes https://github.com/camunda/camunda/issues/50633
