### PR TITLE
ci: use stable VMs for release load tests

### DIFF
--- a/.github/workflows/camunda-release-load-test.yaml
+++ b/.github/workflows/camunda-release-load-test.yaml
@@ -99,6 +99,7 @@ jobs:
       orchestration-tag: ${{ inputs.tag }}
       ttl: 60
       scenario: 'realistic'
+      stable-vms: true
       optimize-tag: ${{ inputs.optimize-tag }}
       identity-tag: ${{ inputs.identity-tag }}
       connectors-tag: ${{ inputs.connectors-tag }}


### PR DESCRIPTION
## Summary

- Hardcodes `stable-vms: true` in `camunda-release-load-test.yaml` so release load tests always deploy to non-spot nodes
- Release load tests validate official release images and must not be interrupted by spot VM preemption
- This also allows to validate whether OOM issues appear over time when running longer then one day
- The `stable-vms` parameter already exists in `camunda-load-test.yml` but was never passed from the release workflow, causing it to default to `false` (spot VMs)

## Test plan

- [ ] Verify next scheduled release load test deploys to non-spot nodes (check `install-stable` make target is called instead of `install`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)