### PR TITLE
feat: add namespace statistics to load test cleanup Slack notifications

### DIFF
--- a/.github/scripts/clean-up-load-test-namespaces.sh
+++ b/.github/scripts/clean-up-load-test-namespaces.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 #
 # Outputs:
 #   NAMESPACES: multiline list of deleted namespaces (written to $GITHUB_OUTPUT if set)
+#   STATS:      summary counts — total, deleted, retained (written to $GITHUB_OUTPUT if set)
 
 dryRun=true
 if [[ "${1:-}" == "--execute" ]]; then
@@ -25,28 +26,43 @@ if [[ "$dryRun" == true ]]; then
 fi
 
 namespacesDeleted=""
+totalCount=0
+deletedCount=0
+retainedCount=0
 
 for row in $(kubectl get namespace -l deadline-date -o json | jq -r '.items[] | "\(.metadata.name)=\(.metadata.labels["deadline-date"])"');
 do
   ns="${row%%=*}"
   deadlineDate="${row#*=}"
+  totalCount=$((totalCount + 1))
   if [[ "${deadlineDate//-/}" -le "${currentDate//-/}" ]]; then
+    deletedCount=$((deletedCount + 1))
     if [[ "$dryRun" == true ]]; then
       echo "[DRY-RUN] Would delete namespace: $ns (deadline: $deadlineDate)"
     else
       kubectl delete namespace "$ns" --wait=false
     fi
     namespacesDeleted+=" * $ns (deadline: $deadlineDate)\n"
+  else
+    retainedCount=$((retainedCount + 1))
   fi
 done
 
 echo -e "Namespaces eligible for deletion:\n$namespacesDeleted"
+echo "Stats: total=$totalCount deleted=$deletedCount retained=$retainedCount"
+
+stats="*Total namespaces:* $totalCount  |  *Deleted:* $deletedCount  |  *Retained:* $retainedCount"
 
 # Write output for GitHub Actions if running in CI
 if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
   {
     echo 'NAMESPACES<<EOF'
     echo "$namespacesDeleted"
+    echo 'EOF'
+  } >> "$GITHUB_OUTPUT"
+  {
+    echo 'STATS<<EOF'
+    echo "$stats"
     echo 'EOF'
   } >> "$GITHUB_OUTPUT"
 fi

--- a/.github/workflows/camunda-load-test-clean-up.yml
+++ b/.github/workflows/camunda-load-test-clean-up.yml
@@ -78,7 +78,14 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "${{ steps.delete-namespaces.outputs.namespaces }}"
+                    "text": "${{ steps.delete-namespaces.outputs.STATS }}"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "${{ steps.delete-namespaces.outputs.NAMESPACES }}"
                   }
                 }
               ]
@@ -146,7 +153,14 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "${{ steps.delete-namespaces.outputs.namespaces }}"
+                    "text": "${{ steps.delete-namespaces.outputs.STATS }}"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "${{ steps.delete-namespaces.outputs.NAMESPACES }}"
                   }
                 }
               ]


### PR DESCRIPTION
## Summary

- Tracks total, deleted, and retained namespace counts during the daily `camunda-load-test-clean-up` run
- Surfaces a stats line in both Slack notifications (legacy + new infra): `*Total namespaces:* N  |  *Deleted:* N  |  *Retained:* N`
- Provides a daily cost overview of how many namespaces were active vs removed

## Test plan

- [ ] Trigger `camunda-load-test-clean-up` via `workflow_dispatch` and verify the Slack message includes the stats block above the namespace list
- [ ] Verify dry-run mode (no `--execute`) also reports correct counts without deleting anything

🤖 Generated with [Claude Code](https://claude.com/claude-code)