### PR TITLE
ci: label load tests namespaces for searching

### DIFF
--- a/load-tests/setup/newLoadTest.sh
+++ b/load-tests/setup/newLoadTest.sh
@@ -149,6 +149,9 @@ sanitize_k8s_label() {
   echo "$value"
 }
 
+# Label to easily find related namespaces
+kubectl label namespace "$namespace" "camunda.io/purpose=load-test" --overwrite
+
 # Label namespace with author (based on git author)
 raw_git_author=$(git config user.name || echo "unknown")
 git_author=$(sanitize_k8s_label "$raw_git_author")


### PR DESCRIPTION
## Description

The new label will allow to quickly filter through the list of namespaces with a "well known" label. 

We currently don't have conventions for these labels, so they may change ; feel free to suggest an alternative for the "purpose" label too.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

* https://camunda.slack.com/archives/C0AQQD5BJ07/p1775761833324559
