### PR TITLE
test: fix flaky OAuthCredentialsCacheTest#shouldSkipRedundantFetchWhenConcurrentRefreshCompleted

### DIFF
--- a/clients/java/src/test/java/io/camunda/client/impl/oauth/OAuthCredentialsCacheTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/oauth/OAuthCredentialsCacheTest.java
@@ -36,6 +36,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.awaitility.Awaitility;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -306,6 +308,7 @@ public final class OAuthCredentialsCacheTest {
     final CountDownLatch fetchStarted = new CountDownLatch(1);
     final CountDownLatch fetchCanComplete = new CountDownLatch(1);
     final AtomicInteger fetchCount = new AtomicInteger(0);
+    final AtomicReference<Thread> thread2 = new AtomicReference<>();
     final CamundaClientCredentials freshCredentials =
         new CamundaClientCredentials("freshToken", EXPIRY, "Bearer");
 
@@ -314,7 +317,8 @@ public final class OAuthCredentialsCacheTest {
     // it sees the generation was incremented and skips the fetch.
     final ExecutorService pool = Executors.newFixedThreadPool(2);
     try {
-      final Callable<Boolean> refreshTask =
+      // Thread 1: enters the synchronized block, signals fetchStarted, then waits
+      final Callable<Boolean> task1 =
           () ->
               cache.forceRefreshIfChanged(
                   WOMBAT_CLIENT_ID,
@@ -329,12 +333,40 @@ public final class OAuthCredentialsCacheTest {
                     return freshCredentials;
                   });
 
-      final Future<Boolean> first = pool.submit(refreshTask);
-      final Future<Boolean> second = pool.submit(refreshTask);
+      // Thread 2: records itself so we can observe its state, then calls forceRefreshIfChanged
+      final Callable<Boolean> task2 =
+          () -> {
+            thread2.set(Thread.currentThread());
+            return cache.forceRefreshIfChanged(
+                WOMBAT_CLIENT_ID,
+                () -> {
+                  fetchCount.incrementAndGet();
+                  return freshCredentials;
+                });
+          };
 
-      // Wait for the first thread to start fetching (it holds the lock)
+      // Submit only task1 first; task2 is submitted only after task1 holds the lock.
+      // This guarantees task2 reads generationOnEntry = 0 while Thread 1 is mid-fetch.
+      final Future<Boolean> first = pool.submit(task1);
+
+      // Wait for Thread 1 to be inside the supplier (it holds the synchronized lock)
       assertThat(fetchStarted.await(5, TimeUnit.SECONDS)).isTrue();
-      // Release the fetch so the first thread can complete
+
+      // Now submit task2: it will read generationOnEntry = 0, then block on the monitor
+      final Future<Boolean> second = pool.submit(task2);
+
+      // Wait until Thread 2 is blocked on the synchronized monitor entry.
+      // At this point Thread 2 has already read generationOnEntry = 0 (before the lock),
+      // so releasing Thread 1 now guarantees Thread 2 will observe the incremented generation.
+      Awaitility.await()
+          .atMost(5, TimeUnit.SECONDS)
+          .until(
+              () -> {
+                final Thread t = thread2.get();
+                return t != null && t.getState() == Thread.State.BLOCKED;
+              });
+
+      // Release Thread 1 to complete its fetch and increment the generation
       fetchCanComplete.countDown();
 
       // then — only one thread should have performed the expensive fetch


### PR DESCRIPTION
## Summary

Fixes a flaky test caused by an inherent race condition in the test's synchronization logic.

## Root cause

The original test submitted both tasks simultaneously and used `fetchStarted` (signaled from inside the supplier, which runs while holding the lock) to know when Thread 1 had the lock. The intent was:

```
T1: generationOnEntry = 0 → blocks on synchronized
T2: generationOnEntry = 0 → blocks on synchronized
T1: acquires lock, fetches, increments generation to 1, releases
T2: acquires lock, sees generation(1) > generationOnEntry(0) → skips fetch → returns true ✓
```

But if the OS scheduler ran task2 before task1 acquired the lock, a different sequence was possible:

```
T2: generationOnEntry = 0 → acquires lock, fetches, increments generation to 1, releases
T1: generationOnEntry = 1 → acquires lock, sees generation(1) == generationOnEntry(1) → performs fetch
    fetchStarted fires → main releases fetchCanComplete
T1: returns !fresh.equals(previous) = false ← ASSERTION FAILS
```

Even worse: if T2 ran so fast it completed before T1 entered the supplier, `fetchStarted` was never counted down and the 5-second `await` timed out, causing a different assertion failure at the latch check.

## Fix

Submit task2 only **after** task1 signals it is already inside the synchronized block (`fetchStarted` countdown). This guarantees task2 always reads `generationOnEntry = 0` while Thread 1 holds the lock mid-fetch — making the intended interleaving deterministic.

An Awaitility wait for Thread 2 to reach `BLOCKED` state then ensures task2 is waiting on the monitor before Thread 1 is released, so Thread 2 is guaranteed to observe the incremented generation when it eventually acquires the lock.

No production code changes required.

## Test plan

- [ ] `./mvnw verify -pl clients/java -Dtest=OAuthCredentialsCacheTest#shouldSkipRedundantFetchWhenConcurrentRefreshCompleted -DskipTests=false -DskipITs -Dquickly` passes reliably

🤖 Generated with [Claude Code](https://claude.com/claude-code)