### PR TITLE
feat: add delete button to batch operation toolbar

### DIFF
--- a/operate/client/src/App/Processes/ListView/InstancesTable/BatchModificationFooter/tests/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/BatchModificationFooter/tests/index.test.tsx
@@ -40,6 +40,7 @@ const Wrapper: React.FC<{children?: React.ReactNode}> = observer(
         totalProcessInstancesCount: 10,
         visibleIds: ['123', '456', '789'],
         visibleRunningIds: ['123', '456', '789'],
+        visibleFinishedIds: [],
       });
 
       return () => {

--- a/operate/client/src/App/Processes/ListView/InstancesTable/InstancesTableWrapper.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/InstancesTableWrapper.tsx
@@ -76,10 +76,18 @@ const InstancesTableWrapper: React.FC = observer(() => {
       .filter((instance) => instance.state === 'ACTIVE' || instance.hasIncident)
       .map((instance) => instance.processInstanceKey);
 
+    const visibleFinishedIds = processInstances
+      .filter(
+        (instance) =>
+          instance.state === 'COMPLETED' || instance.state === 'TERMINATED',
+      )
+      .map((instance) => instance.processInstanceKey);
+
     processInstancesSelectionStore.setRuntime({
       totalProcessInstancesCount,
       visibleIds,
       visibleRunningIds,
+      visibleFinishedIds,
     });
   }, [processInstances, totalProcessInstancesCount]);
 

--- a/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/index.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/index.tsx
@@ -10,7 +10,7 @@ import {TableToolbar, Modal, TableBatchAction} from '@carbon/react';
 import {TableBatchActions} from './styled';
 import pluralSuffix from 'modules/utils/pluralSuffix';
 import {useState} from 'react';
-import {RetryFailed, Error} from '@carbon/react/icons';
+import {RetryFailed, Error, TrashCan} from '@carbon/react/icons';
 import {MigrateAction} from './MigrateAction';
 import {MoveAction} from './MoveAction';
 import {batchModificationStore} from 'modules/stores/batchModification';
@@ -22,6 +22,7 @@ import {handleOperationError} from 'modules/utils/notifications';
 import {useBatchOperationMutationRequestBody} from 'modules/hooks/useBatchOperationMutationRequestBody';
 import {useBatchOperationSuccessNotification} from 'modules/hooks/useBatchOperationSuccessNotification';
 import {processInstancesSelectionStore} from 'modules/stores/processInstancesSelection';
+import {IS_DELETE_BATCH_OPERATION_ENABLED} from 'modules/feature-flags';
 
 type Props = {
   selectedInstancesCount: number;
@@ -147,6 +148,25 @@ const Toolbar: React.FC<Props> = observer(({selectedInstancesCount}) => {
         >
           <MoveAction />
           <MigrateAction />
+          {IS_DELETE_BATCH_OPERATION_ENABLED && (
+            <TableBatchAction
+              renderIcon={TrashCan}
+              disabled={
+                batchModificationStore.state.isEnabled ||
+                !processInstancesSelectionStore.hasSelectedFinishedInstances
+              }
+              title={
+                batchModificationStore.state.isEnabled
+                  ? 'Not available in batch modification mode'
+                  : !processInstancesSelectionStore.hasSelectedFinishedInstances
+                    ? 'No finished process instances selected. Please select at least one completed or canceled process instance to delete.'
+                    : undefined
+              }
+              data-testid="delete-batch-operation"
+            >
+              Delete
+            </TableBatchAction>
+          )}
           <TableBatchAction
             renderIcon={Error}
             onClick={() => setModalMode('CANCEL_PROCESS_INSTANCE')}

--- a/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/tests/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/tests/index.test.tsx
@@ -83,6 +83,7 @@ describe('<ProcessOperations />', () => {
       totalProcessInstancesCount: 2,
       visibleIds: ['1', '2'],
       visibleRunningIds: ['1', '2'],
+      visibleFinishedIds: [],
     });
     processInstancesSelectionStore.selectProcessInstance('1');
     processInstancesSelectionStore.selectProcessInstance('2');

--- a/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/tests/mocks.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/tests/mocks.tsx
@@ -104,11 +104,18 @@ const setupSelectionStoreWithInstances = (
   const visibleRunningIds = instances
     .filter((instance) => instance.state === 'ACTIVE' || instance.hasIncident)
     .map((instance) => instance.processInstanceKey);
+  const visibleFinishedIds = instances
+    .filter(
+      (instance) =>
+        instance.state === 'COMPLETED' || instance.state === 'TERMINATED',
+    )
+    .map((instance) => instance.processInstanceKey);
 
   processInstancesSelectionStore.setRuntime({
     totalProcessInstancesCount: instances.length,
     visibleIds,
     visibleRunningIds,
+    visibleFinishedIds,
   });
 };
 

--- a/operate/client/src/modules/feature-flags.ts
+++ b/operate/client/src/modules/feature-flags.ts
@@ -6,4 +6,6 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-export {};
+const IS_DELETE_BATCH_OPERATION_ENABLED = false;
+
+export {IS_DELETE_BATCH_OPERATION_ENABLED};

--- a/operate/client/src/modules/stores/processInstancesSelection.test.ts
+++ b/operate/client/src/modules/stores/processInstancesSelection.test.ts
@@ -15,6 +15,7 @@ describe('ProcessInstancesSelection - checkedProcessInstanceIds', () => {
       totalProcessInstancesCount: 4,
       visibleIds: ['1', '2', '3', '4'],
       visibleRunningIds: ['1', '3', '4'],
+      visibleFinishedIds: ['2'],
     });
   });
 
@@ -57,6 +58,7 @@ describe('ProcessInstancesSelection - checkedProcessInstanceIds', () => {
       totalProcessInstancesCount: 0,
       visibleIds: [],
       visibleRunningIds: [],
+      visibleFinishedIds: [],
     });
 
     processInstancesSelectionStore.state = {
@@ -86,5 +88,65 @@ describe('ProcessInstancesSelection - checkedProcessInstanceIds', () => {
 
     const result = processInstancesSelectionStore.checkedProcessInstanceIds;
     expect(result).toEqual([]);
+  });
+});
+
+describe('ProcessInstancesSelection - hasSelectedFinishedInstances', () => {
+  beforeEach(() => {
+    processInstancesSelectionStore.reset();
+    processInstancesSelectionStore.setRuntime({
+      totalProcessInstancesCount: 5,
+      visibleIds: ['1', '2', '3', '4', '5'],
+      visibleRunningIds: ['1', '3', '4'],
+      visibleFinishedIds: ['2', '5'],
+    });
+  });
+
+  afterEach(() => {
+    processInstancesSelectionStore.reset();
+  });
+
+  it('should return true when finished instances are selected in INCLUDE mode', () => {
+    processInstancesSelectionStore.state = {
+      selectedProcessInstanceIds: ['2', '3'],
+      selectionMode: 'INCLUDE',
+    };
+
+    expect(processInstancesSelectionStore.hasSelectedFinishedInstances).toBe(
+      true,
+    );
+  });
+
+  it('should return false when no finished instances are selected in INCLUDE mode', () => {
+    processInstancesSelectionStore.state = {
+      selectedProcessInstanceIds: ['1', '3', '4'],
+      selectionMode: 'INCLUDE',
+    };
+
+    expect(processInstancesSelectionStore.hasSelectedFinishedInstances).toBe(
+      false,
+    );
+  });
+
+  it('should return true when selectionMode is ALL', () => {
+    processInstancesSelectionStore.state = {
+      selectedProcessInstanceIds: [],
+      selectionMode: 'ALL',
+    };
+
+    expect(processInstancesSelectionStore.hasSelectedFinishedInstances).toBe(
+      true,
+    );
+  });
+
+  it('should return true when selectionMode is EXCLUDE', () => {
+    processInstancesSelectionStore.state = {
+      selectedProcessInstanceIds: ['1', '3'],
+      selectionMode: 'EXCLUDE',
+    };
+
+    expect(processInstancesSelectionStore.hasSelectedFinishedInstances).toBe(
+      true,
+    );
   });
 });

--- a/operate/client/src/modules/stores/processInstancesSelection.ts
+++ b/operate/client/src/modules/stores/processInstancesSelection.ts
@@ -19,6 +19,7 @@ type SelectionRuntime = {
   totalProcessInstancesCount: number;
   visibleIds: string[];
   visibleRunningIds: string[];
+  visibleFinishedIds: string[];
 };
 
 type Mode = 'INCLUDE' | 'EXCLUDE' | 'ALL';
@@ -38,6 +39,7 @@ class ProcessInstancesSelection {
     totalProcessInstancesCount: 0,
     visibleIds: [],
     visibleRunningIds: [],
+    visibleFinishedIds: [],
   };
   autorunDisposer: null | IReactionDisposer = null;
   observeDisposer: null | Lambda = null;
@@ -70,7 +72,8 @@ class ProcessInstancesSelection {
     if (
       prev.totalProcessInstancesCount === next.totalProcessInstancesCount &&
       isEqual(prev.visibleIds, next.visibleIds) &&
-      isEqual(prev.visibleRunningIds, next.visibleRunningIds)
+      isEqual(prev.visibleRunningIds, next.visibleRunningIds) &&
+      isEqual(prev.visibleFinishedIds, next.visibleFinishedIds)
     ) {
       return;
     }
@@ -186,6 +189,21 @@ class ProcessInstancesSelection {
     );
   }
 
+  get hasSelectedFinishedInstances() {
+    const {
+      selectedProcessInstanceIds,
+      isAllChecked,
+      state: {selectionMode},
+    } = this;
+    const {visibleFinishedIds} = this.runtime;
+
+    return (
+      isAllChecked ||
+      selectionMode === 'EXCLUDE' ||
+      visibleFinishedIds.some((id) => selectedProcessInstanceIds.includes(id))
+    );
+  }
+
   get checkedRunningProcessInstanceIds() {
     const {selectionMode, selectedProcessInstanceIds} = this.state;
     const {visibleRunningIds} = this.runtime;
@@ -229,6 +247,7 @@ class ProcessInstancesSelection {
       totalProcessInstancesCount: 0,
       visibleIds: [],
       visibleRunningIds: [],
+      visibleFinishedIds: [],
     };
     this.autorunDisposer?.();
     this.observeDisposer?.();


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

- Add button, icon, tooltip for batch deletion to toolbar

The button has no functionality yet, this will be done in followup PRs


:bulb: Manual testing can be done in the [deployment](https://operate-50576-b.camunda.camunda.cloud/orchestration/operate/processes?processDefinitionId=Process_1skpuws&processDefinitionVersion=1&active=true&incidents=true&completed=true&canceled=true)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [x] :warning: Set feature flag to false

## Related issues

closes #50576 
