### PR TITLE
fix: add gen_name to SaaS E2E dispatch payload

### DIFF
--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -376,7 +376,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.github-token.outputs.token }}
           CORRELATION_ID: ${{ github.repository }}:${{ github.run_id }}:${{ github.run_attempt }}:${{ github.sha }}
+          IMAGE_TAG: ${{ needs.build-and-push.outputs.image-tag }}
         run: |
+          # Use the image tag as the generation name to match filter patterns
+          # e.g., "8.10.0-SNAPSHOT-main-run12345678-a1" matches "**-main-run**-a**"
+          GEN_NAME="${IMAGE_TAG}"
+
           curl -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer $GITHUB_TOKEN" \
@@ -387,6 +392,7 @@ jobs:
                       "correlation_id": "'"$CORRELATION_ID"'",
                       "source_repo": "${{ github.repository }}",
                       "source_sha": "${{ github.sha }}",
+                      "gen_name": "'"${GEN_NAME}"'",
                       "c8Version": "8.10",
                       "zeebeVersion": "${{ needs.build-and-push.outputs.image-tag }}",
                       "operateVersion": "SNAPSHOT",


### PR DESCRIPTION

## Description

<!-- Describe the goal and purpose of this PR. -->
Adds an explicit `gen_name` field to the `client_payload` sent to the downstream SaaS E2E workflow in `c8-cross-component-e2e-tests`. The generation name matches the image tag format exactly to ensure compatibility with filter patterns used in the downstream workflow.

### Problem
After PR #50660 changed the image tag format to be traceable (e.g., `8.10.0-SNAPSHOT-main-run12345678-a1`), the downstream SaaS E2E workflow was still generating its own generation name as a truncated commit hash (e.g., `7a6b143bebd6`), which doesn't match filter patterns like `**-main-run**-a**`.

### Solution
Explicitly pass a `gen_name` field in the dispatch payload that uses the same value as the image tag. This ensures:
- Generation names match filter patterns in downstream workflows
- Consistent naming between Docker images and SaaS E2E test runs
- Traceability back to the source workflow run

### Generation Name Format
Same as image tag for all triggers:

| Trigger | Format | Example | Matches Filter |
|---------|--------|---------|----------------|
| `push` to `main` | `<version>-main-run<id>-a<attempt>` | `8.10.0-SNAPSHOT-main-run12345678-a1` | `**-main-run**-a**` |
| `workflow_dispatch` | `<version>-dispatch-run<id>-a<attempt>` | `8.10.0-SNAPSHOT-dispatch-run12345678-a1` | `**-dispatch-run**-a**` |
| `pull_request` | `<version>-pr<num>-run<id>-a<attempt>` | `8.10.0-SNAPSHOT-pr42-run12345678-a1` | `**-pr**-run**-a**` |

### Changes
- Sets `gen_name` to the full image tag value
- Adds `gen_name` to the `client_payload` for the downstream workflow
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
