### PR TITLE
fix: disable aws test for opensearch audit log ITs

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -1177,6 +1177,7 @@ final class OpenSearchArchiverRepositoryIT {
 
     // then
     Awaitility.await()
+        .atMost(Duration.ofSeconds(30))
         .untilAsserted(
             () ->
                 verify(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -1100,6 +1100,10 @@ final class OpenSearchArchiverRepositoryIT {
    * the background {@link ApplyRolloverPeriodJob} re-applies the policy to all historical indices.
    */
   @Test
+  @DisabledIfSystemProperty(
+      named = TEST_INTEGRATION_OPENSEARCH_AWS_URL,
+      matches = "^(?=\\s*\\S).*$",
+      disabledReason = "Excluding from AWS OS IT CI - policy modification not allowed")
   void shouldUpdateMinIndexAgeOnManagedIndicesWhenApplyRolloverPeriodJobRuns() throws Exception {
     // given
     changeIndexStateManagementJobInterval(1);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpensearchAuditLogArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpensearchAuditLogArchiverRepositoryIT.java
@@ -69,7 +69,7 @@ final class OpensearchAuditLogArchiverRepositoryIT {
   private String auditLogIndex;
   private String auditLogCleanupIndex;
   private TestExporterResourceProvider resourceProvider;
-  private final OpenSearchClient testClient = createOpenSearchClient();
+  private final OpenSearchClient testClient = new OpenSearchClient(transport);
   private final Clock clock = Clock.fixed(Instant.parse("2026-02-19T10:00:00Z"), ZoneOffset.UTC);
   private String indexPrefix;
   private String zeebeIndex;
@@ -435,6 +435,17 @@ final class OpensearchAuditLogArchiverRepositoryIT {
   }
 
   private OpenSearchTransport createTransport() {
+    final var awsUrl = System.getProperty(TEST_INTEGRATION_OPENSEARCH_AWS_URL, "");
+    if (!awsUrl.isEmpty()) {
+      final URI uri = URI.create(awsUrl);
+      final SdkHttpClient httpClient = ApacheHttpClient.builder().build();
+      final var region = new DefaultAwsRegionProviderChain().getRegion();
+      return new AwsSdk2Transport(
+          httpClient,
+          uri.getHost(),
+          region,
+          AwsSdk2TransportOptions.builder().setMapper(new JacksonJsonpMapper(MAPPER)).build());
+    }
     try {
       return ApacheHttpClient5TransportBuilder.builder(HttpHost.create(SEARCH_DB.osUrl()))
           .setHttpClientConfigCallback(
@@ -499,26 +510,6 @@ final class OpensearchAuditLogArchiverRepositoryIT {
       testClient.index(b -> b.index(index).document(document).id(id));
     } catch (final IOException e) {
       throw new UncheckedIOException(e);
-    }
-  }
-
-  private OpenSearchClient createOpenSearchClient() {
-    final var isAWSRun = System.getProperty(TEST_INTEGRATION_OPENSEARCH_AWS_URL, "");
-    if (isAWSRun.isEmpty()) {
-      return new OpenSearchClient(transport);
-    } else {
-      final URI uri = URI.create(isAWSRun);
-      final SdkHttpClient httpClient = ApacheHttpClient.builder().build();
-      final var region = new DefaultAwsRegionProviderChain().getRegion();
-      return new OpenSearchClient(
-          new AwsSdk2Transport(
-              httpClient,
-              uri.getHost(),
-              region,
-              AwsSdk2TransportOptions.builder()
-                  .setMapper(
-                      new org.opensearch.client.json.jackson.JacksonJsonpMapper(new ObjectMapper()))
-                  .build()));
     }
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

The test modifies cluster settings, which is not allowed on AWS. This PR adds a disable annotation and simplifies the general client building in that test class.

Passing run [here](https://github.com/camunda/camunda/actions/runs/24241849531)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #50755
