### PR TITLE
fix: resolve flaky element statistics tests that assert on incident counts

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionStatisticsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionStatisticsIT.java
@@ -169,27 +169,32 @@ public class ProcessDefinitionStatisticsIT {
     waitForProcessInstances(
         camundaClient, f -> f.processDefinitionKey(processDefinitionKey).hasIncident(true), 2);
 
-    // when
-    final var actual =
-        camundaClient
-            .newProcessDefinitionElementStatisticsRequest(processDefinitionKey)
-            .filter(
-                f ->
-                    f.orFilters(
-                        List.of(
-                            f1 -> f1.elementId(b -> b.like("*Event")),
-                            f2 ->
-                                f2.processInstanceKey(pi1.getProcessInstanceKey())
-                                    .hasElementInstanceIncident(true))))
-            .send()
-            .join();
-
-    // then
-    assertThat(actual).hasSize(2);
-    assertThat(actual)
-        .containsExactlyInAnyOrder(
-            new ProcessElementStatisticsImpl("StartEvent", 0L, 0L, 0L, 2L),
-            new ProcessElementStatisticsImpl("ScriptTask", 0L, 0L, 1L, 0L));
+    // The process instance may report hasIncident=true before the flow node instance record
+    // is updated with the incident, so we poll the element statistics endpoint.
+    Awaitility.await("should return element statistics with incident")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                // when
+                assertThat(
+                        camundaClient
+                            .newProcessDefinitionElementStatisticsRequest(processDefinitionKey)
+                            .filter(
+                                f ->
+                                    f.orFilters(
+                                        List.of(
+                                            f1 -> f1.elementId(b -> b.like("*Event")),
+                                            f2 ->
+                                                f2.processInstanceKey(pi1.getProcessInstanceKey())
+                                                    .hasElementInstanceIncident(true))))
+                            .send()
+                            .join())
+                    // then
+                    .hasSize(2)
+                    .containsExactlyInAnyOrder(
+                        new ProcessElementStatisticsImpl("StartEvent", 0L, 0L, 0L, 2L),
+                        new ProcessElementStatisticsImpl("ScriptTask", 0L, 0L, 1L, 0L)));
   }
 
   @Test
@@ -233,25 +238,30 @@ public class ProcessDefinitionStatisticsIT {
     waitForProcessInstances(
         camundaClient, f -> f.processDefinitionKey(processDefinitionKey).hasIncident(true), 2);
 
-    // when
-    final var actual =
-        camundaClient
-            .newProcessDefinitionElementStatisticsRequest(processDefinitionKey)
-            .filter(
-                f ->
-                    f.orFilters(
-                        List.of(
-                            f1 -> f1.elementId(b -> b.neq("start")),
-                            f2 -> f2.errorMessage(INCIDENT_ERROR_MESSAGE_V1))))
-            .send()
-            .join();
-
-    // then
-    assertThat(actual).hasSize(2);
-    assertThat(actual)
-        .containsExactlyInAnyOrder(
-            new ProcessElementStatisticsImpl("start", 0L, 0L, 0L, 2L),
-            new ProcessElementStatisticsImpl("taskAIncident", 0L, 0L, 2L, 0L));
+    // The process instance may report hasIncident=true before the flow node instance record
+    // is updated with the incident, so we poll the element statistics endpoint.
+    Awaitility.await("should return element statistics with incident")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                // when
+                assertThat(
+                        camundaClient
+                            .newProcessDefinitionElementStatisticsRequest(processDefinitionKey)
+                            .filter(
+                                f ->
+                                    f.orFilters(
+                                        List.of(
+                                            f1 -> f1.elementId(b -> b.neq("start")),
+                                            f2 -> f2.errorMessage(INCIDENT_ERROR_MESSAGE_V1))))
+                            .send()
+                            .join())
+                    // then
+                    .hasSize(2)
+                    .containsExactlyInAnyOrder(
+                        new ProcessElementStatisticsImpl("start", 0L, 0L, 0L, 2L),
+                        new ProcessElementStatisticsImpl("taskAIncident", 0L, 0L, 2L, 0L)));
   }
 
   @Test
@@ -267,26 +277,33 @@ public class ProcessDefinitionStatisticsIT {
     waitForProcessInstances(
         camundaClient, f -> f.hasIncident(true).variables(getScopedVariables(testScopeId)), 2);
 
-    // when
-    final var actual =
-        camundaClient
-            .newProcessDefinitionElementStatisticsRequest(processDefinitionKey)
-            .filter(
-                f ->
-                    f.orFilters(
-                            List.of(
-                                f1 -> f1.elementId(b -> b.eq("start")),
-                                f2 -> f2.incidentErrorHashCode(INCIDENT_ERROR_HASH_CODE_V1)))
-                        .variables(getScopedVariables(testScopeId)))
-            .send()
-            .join();
-
-    // then
-    assertThat(actual).hasSize(2);
-    assertThat(actual)
-        .containsExactlyInAnyOrder(
-            new ProcessElementStatisticsImpl("start", 0L, 0L, 0L, 2L),
-            new ProcessElementStatisticsImpl("taskAIncident", 0L, 0L, 2L, 0L));
+    // The process instance may report hasIncident=true before the flow node instance record
+    // is updated with the incident, so we poll the element statistics endpoint.
+    Awaitility.await("should return element statistics with incident")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                // when
+                assertThat(
+                        camundaClient
+                            .newProcessDefinitionElementStatisticsRequest(processDefinitionKey)
+                            .filter(
+                                f ->
+                                    f.orFilters(
+                                            List.of(
+                                                f1 -> f1.elementId(b -> b.eq("start")),
+                                                f2 ->
+                                                    f2.incidentErrorHashCode(
+                                                        INCIDENT_ERROR_HASH_CODE_V1)))
+                                        .variables(getScopedVariables(testScopeId)))
+                            .send()
+                            .join())
+                    // then
+                    .hasSize(2)
+                    .containsExactlyInAnyOrder(
+                        new ProcessElementStatisticsImpl("start", 0L, 0L, 0L, 2L),
+                        new ProcessElementStatisticsImpl("taskAIncident", 0L, 0L, 2L, 0L)));
   }
 
   @Test
@@ -715,20 +732,25 @@ public class ProcessDefinitionStatisticsIT {
     waitForProcessInstances(
         camundaClient, f -> f.processDefinitionKey(processDefinitionKey).hasIncident(true), 3);
 
-    // when
-    final var actual =
-        camundaClient
-            .newProcessDefinitionElementStatisticsRequest(processDefinitionKey)
-            .filter(f -> f.hasIncident(true))
-            .send()
-            .join();
-
-    // then
-    assertThat(actual).hasSize(2);
-    assertThat(actual)
-        .containsExactlyInAnyOrder(
-            new ProcessElementStatisticsImpl("StartEvent", 0L, 0L, 0L, 3L),
-            new ProcessElementStatisticsImpl("ScriptTask", 0L, 0L, 3L, 0L));
+    // The process instance may report hasIncident=true before the flow node instance record
+    // is updated with the incident, so we poll the element statistics endpoint.
+    Awaitility.await("should return element statistics with incident")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                // when
+                assertThat(
+                        camundaClient
+                            .newProcessDefinitionElementStatisticsRequest(processDefinitionKey)
+                            .filter(f -> f.hasIncident(true))
+                            .send()
+                            .join())
+                    // then
+                    .hasSize(2)
+                    .containsExactlyInAnyOrder(
+                        new ProcessElementStatisticsImpl("StartEvent", 0L, 0L, 0L, 3L),
+                        new ProcessElementStatisticsImpl("ScriptTask", 0L, 0L, 3L, 0L)));
   }
 
   @Test
@@ -882,18 +904,24 @@ public class ProcessDefinitionStatisticsIT {
     waitForProcessInstances(
         camundaClient, f -> f.processDefinitionKey(processDefinitionKey).hasIncident(true), 1);
 
-    // when
-    final var actual =
-        camundaClient
-            .newProcessDefinitionElementStatisticsRequest(processDefinitionKey)
-            .filter(f -> f.hasElementInstanceIncident(true))
-            .send()
-            .join();
-
-    // then
-    assertThat(actual).hasSize(1);
-    assertThat(actual)
-        .containsExactly(new ProcessElementStatisticsImpl("ScriptTask", 0L, 0L, 1L, 0L));
+    // The process instance may report hasIncident=true before the flow node instance record
+    // is updated with the incident, so we poll the element statistics endpoint.
+    Awaitility.await("should return element statistics with incident")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                // when
+                assertThat(
+                        camundaClient
+                            .newProcessDefinitionElementStatisticsRequest(processDefinitionKey)
+                            .filter(f -> f.hasElementInstanceIncident(true))
+                            .send()
+                            .join())
+                    // then
+                    .hasSize(1)
+                    .containsExactly(
+                        new ProcessElementStatisticsImpl("ScriptTask", 0L, 0L, 1L, 0L)));
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceStatisticsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceStatisticsIT.java
@@ -125,16 +125,24 @@ public class ProcessInstanceStatisticsIT {
     final var processInstanceKey = createInstance(processDefinitionKey).getProcessInstanceKey();
     waitForProcessInstances(1, f -> f.processDefinitionKey(processDefinitionKey).hasIncident(true));
 
-    // when
-    final var actual =
-        camundaClient.newProcessInstanceElementStatisticsRequest(processInstanceKey).send().join();
-
-    // then
-    assertThat(actual).hasSize(2);
-    assertThat(actual)
-        .containsExactlyInAnyOrder(
-            new ProcessElementStatisticsImpl("ScriptTask", 0L, 0L, 1L, 0L),
-            new ProcessElementStatisticsImpl("StartEvent", 0L, 0L, 0L, 1L));
+    // The process instance may report hasIncident=true before the flow node instance record
+    // for ScriptTask is updated with the incident, so we poll the element statistics endpoint.
+    Awaitility.await("should return element statistics with incident")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                // when
+                assertThat(
+                        camundaClient
+                            .newProcessInstanceElementStatisticsRequest(processInstanceKey)
+                            .send()
+                            .join())
+                    // then
+                    .hasSize(2)
+                    .containsExactlyInAnyOrder(
+                        new ProcessElementStatisticsImpl("ScriptTask", 0L, 0L, 1L, 0L),
+                        new ProcessElementStatisticsImpl("StartEvent", 0L, 0L, 0L, 1L)));
   }
 
   @Test


### PR DESCRIPTION
## What

Wrap element statistics assertions in Awaitility for tests that wait on `hasIncident=true` at the process instance level but then assert element-level (flow node instance) statistics.

## Why

These tests are intermittently failing in CI because the process instance record and the flow node instance records are exported separately. The process instance can report `hasIncident=true` while the flow node instance still shows `active=1` instead of `incidents=1`.

For example, `ProcessInstanceStatisticsIT#shouldGetStatisticsForIncidents` would observe:
```
ScriptTask: active=1, canceled=0, incidents=0, completed=0
```
instead of:
```
ScriptTask: active=0, canceled=0, incidents=1, completed=0
```

The test passes on retry because the flow node instance eventually catches up.

See e.g. the failure [here](https://github.com/camunda/camunda/actions/runs/24194172448) with:
```
java.lang.AssertionError: 

Expecting actual:
  [ProcessElementStatisticsImpl{elementId='ScriptTask', active=1, canceled=0, incidents=0, completed=0},
    ProcessElementStatisticsImpl{elementId='StartEvent', active=0, canceled=0, incidents=0, completed=1}]
to contain exactly in any order:
  [ProcessElementStatisticsImpl{elementId='ScriptTask', active=0, canceled=0, incidents=1, completed=0},
    ProcessElementStatisticsImpl{elementId='StartEvent', active=0, canceled=0, incidents=0, completed=1}]
elements not found:
  [ProcessElementStatisticsImpl{elementId='ScriptTask', active=0, canceled=0, incidents=1, completed=0}]
and elements not expected:
  [ProcessElementStatisticsImpl{elementId='ScriptTask', active=1, canceled=0, incidents=0, completed=0}]

	at io.camunda.it.client.ProcessInstanceStatisticsIT.shouldGetStatisticsForIncidents(ProcessInstanceStatisticsIT.java:135)
```

## How

Wrap the element statistics assertion in `Awaitility.await()` so it polls until the flow node instance data is consistent with the incident state. This is the same pattern already used in other tests in the same classes (e.g. `shouldGetStatisticsForActive`, `shouldReturnStatisticsForCanceled`).

