### PR TITLE
fix: bump backwards compat version to 8.9.0

### DIFF
--- a/clients/camunda-spring-boot-starter/revapi.json
+++ b/clients/camunda-spring-boot-starter/revapi.json
@@ -736,6 +736,36 @@
           "code": "java.method.removed",
           "old": "method io.camunda.process.test.api.CamundaProcessTestExtension io.camunda.process.test.api.CamundaProcessTestExtension::withJsonMapper(io.camunda.zeebe.client.api.JsonMapper)",
           "justification": "Removal of V1 APIs in 8.10+; compatibility impact accepted for this release."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method void io.camunda.client.jobhandling.parameter.DefaultParameterResolverStrategy::<init>(io.camunda.client.api.JsonMapper, io.camunda.zeebe.client.api.worker.JobClient)",
+          "justification": "Removal of V1 APIs in 8.10+; compatibility impact accepted for this release."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method io.camunda.client.jobhandling.parameter.ParameterResolverStrategy io.camunda.client.spring.configuration.CamundaClientAllAutoConfiguration::parameterResolverStrategy(io.camunda.client.api.JsonMapper, io.camunda.zeebe.client.ZeebeClient)",
+          "justification": "Removal of V1 APIs in 8.10+; compatibility impact accepted for this release."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method io.camunda.client.spring.annotation.processor.JobWorkerAnnotationProcessor io.camunda.client.spring.configuration.AnnotationProcessorConfiguration::jobWorkerPostProcessor(io.camunda.client.jobhandling.JobWorkerManager, io.camunda.client.jobhandling.CommandExceptionHandlingStrategy, io.camunda.client.metrics.MetricsRecorder, io.camunda.client.jobhandling.parameter.ParameterResolverStrategy, io.camunda.client.jobhandling.result.ResultProcessorStrategy)",
+          "justification": "Removal of V1 APIs in 8.10+; compatibility impact accepted for this release."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method io.camunda.client.jobhandling.CommandExceptionHandlingStrategy io.camunda.client.spring.configuration.CamundaClientAllAutoConfiguration::commandExceptionHandlingStrategy(io.camunda.client.api.worker.BackoffSupplier, io.camunda.client.jobhandling.CamundaClientExecutorService)",
+          "justification": "Removal of V1 APIs in 8.10+; compatibility impact accepted for this release."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method io.camunda.client.jobhandling.JobExceptionHandlerSupplier io.camunda.client.spring.configuration.CamundaClientAllAutoConfiguration::jobExceptionHandlingSupplier(io.camunda.client.jobhandling.CommandExceptionHandlingStrategy, io.camunda.client.metrics.MetricsRecorder)",
+          "justification": "Removal of V1 APIs in 8.10+; compatibility impact accepted for this release."
         }
       ]
     }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -247,7 +247,7 @@
     <extension.version.os-maven-plugin>1.7.1</extension.version.os-maven-plugin>
 
     <!-- version against which backwards compatibility is checked -->
-    <backwards.compat.version>8.8.0</backwards.compat.version>
+    <backwards.compat.version>8.9.0</backwards.compat.version>
     <ignored.changes.file>ignored-changes.json</ignored.changes.file>
 
     <!--

--- a/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupStoreTests.java
+++ b/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupStoreTests.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.backup.s3.manifest.Manifest;
 import io.camunda.zeebe.backup.s3.util.S3TestBackupProvider;
 import io.camunda.zeebe.backup.testkit.BackupStoreTestKit;
 import io.camunda.zeebe.util.SemanticVersion;
+import io.camunda.zeebe.util.VersionUtil;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
@@ -288,9 +289,10 @@ public interface S3BackupStoreTests extends BackupStoreTestKit {
   default void shouldListBackupsForBothStructures() throws IOException {
     // given
     final var legacyBackup =
-        S3TestBackupProvider.simpleBackupWithId(new BackupIdentifierImpl(1, 2, 3), true);
+        S3TestBackupProvider.simpleBackupWithId(new BackupIdentifierImpl(1, 2, 3), "8.8.0");
     final var backup =
-        S3TestBackupProvider.simpleBackupWithId(new BackupIdentifierImpl(1, 2, 10), false);
+        S3TestBackupProvider.simpleBackupWithId(
+            new BackupIdentifierImpl(1, 2, 10), VersionUtil.getVersion());
 
     getStore().save(legacyBackup).join();
     getStore().save(backup).join();
@@ -311,9 +313,10 @@ public interface S3BackupStoreTests extends BackupStoreTestKit {
   default void backupStructureShouldBeDistinct() throws IOException {
     // given
     final var legacyBackup =
-        S3TestBackupProvider.simpleBackupWithId(new BackupIdentifierImpl(1, 2, 3), true);
+        S3TestBackupProvider.simpleBackupWithId(new BackupIdentifierImpl(1, 2, 3), "8.8.0");
     final var backup =
-        S3TestBackupProvider.simpleBackupWithId(new BackupIdentifierImpl(1, 2, 10), false);
+        S3TestBackupProvider.simpleBackupWithId(
+            new BackupIdentifierImpl(1, 2, 10), VersionUtil.getVersion());
 
     // when
     getStore().save(legacyBackup).join();

--- a/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/util/S3TestBackupProvider.java
+++ b/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/util/S3TestBackupProvider.java
@@ -11,38 +11,15 @@ import static io.camunda.zeebe.backup.testkit.support.TestBackupProvider.simpleB
 import static org.junit.jupiter.api.Named.named;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-import io.camunda.zeebe.backup.api.Backup;
-import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.backup.testkit.support.TestBackupProvider;
-import io.camunda.zeebe.util.VersionUtil;
-import java.io.IOException;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.provider.Arguments;
 
 public class S3TestBackupProvider extends TestBackupProvider {
 
-  static String version(final boolean legacy) {
-    return legacy ? VersionUtil.getPreviousVersion() : VersionUtil.getVersion();
-  }
-
   public static Stream<? extends Arguments> provideArguments() throws Exception {
     return Stream.of(
-        arguments(named("stub", simpleBackup(false))),
-        arguments(named("stub legacy", simpleBackup(true))),
-        arguments(named("stub without snapshot", backupWithoutSnapshot(false))),
-        arguments(named("stub without snapshot legacy", backupWithoutSnapshot(true))));
-  }
-
-  public static Backup simpleBackup(final boolean legacy) throws IOException {
-    return simpleBackup(version(legacy));
-  }
-
-  public static Backup simpleBackupWithId(final BackupIdentifierImpl id, final boolean legacy)
-      throws IOException {
-    return simpleBackupWithId(id, version(legacy));
-  }
-
-  public static Backup backupWithoutSnapshot(final boolean legacy) throws IOException {
-    return backupWithoutSnapshot(version(legacy));
+        arguments(named("stub", simpleBackup())),
+        arguments(named("stub without snapshot", backupWithoutSnapshot())));
   }
 }

--- a/zeebe/gateway/src/test/resources/configuration/gateway.default.yaml
+++ b/zeebe/gateway/src/test/resources/configuration/gateway.default.yaml
@@ -66,11 +66,6 @@
 # Default is 127.0.0.1:26502
 # initialContactPoints : [127.0.0.1:26502]
 
-# WARNING: This setting is deprecated! Use initialContactPoints instead.
-# Sets the broker the gateway should initial contact
-# This setting can also be overridden using the environment variable ZEEBE_GATEWAY_CLUSTER_CONTACTPOINT.
-# contactPoint: 127.0.0.1:26502
-
 # Sets the timeout of requests send to the broker cluster
 # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_CLUSTER_REQUESTTIMEOUT.
 # requestTimeout: 15s

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/network/Ipv6IntegrationTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/network/Ipv6IntegrationTest.java
@@ -124,7 +124,7 @@ final class Ipv6IntegrationTest {
         .withEnv("ZEEBE_LOG_LEVEL", "DEBUG")
         .withEnv("ATOMIX_LOG_LEVEL", "INFO")
         .withEnv(
-            "ZEEBE_GATEWAY_CLUSTER_CONTACTPOINT",
+            "CAMUNDA_CLUSTER_INITIALCONTACTPOINTS",
             String.format("[%s]:%d", BROKER_IP, ZeebePort.INTERNAL.getPort()))
         .withEnv("ZEEBE_GATEWAY_NETWORK_HOST", INADDR6_ANY)
         .withEnv("ZEEBE_GATEWAY_NETWORK_ADVERTISEDHOST", hostName)

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/ContainerState.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/ContainerState.java
@@ -187,7 +187,7 @@ final class ContainerState implements AutoCloseable {
     } else {
       gateway =
           new ZeebeGatewayContainer(gatewayImage)
-              .withEnv("ZEEBE_GATEWAY_CLUSTER_CONTACTPOINT", broker.getInternalClusterAddress())
+              .withEnv("CAMUNDA_CLUSTER_INITIALCONTACTPOINTS", broker.getInternalClusterAddress())
               .withEnv("ZEEBE_LOG_LEVEL", "DEBUG")
               .withEnv(CREATE_SCHEMA_ENV_VAR, "false")
               .withEnv(UNPROTECTED_API_ENV_VAR, "true")

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/ContainerState.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/ContainerState.java
@@ -192,6 +192,7 @@ final class ContainerState implements AutoCloseable {
               .withEnv(CREATE_SCHEMA_ENV_VAR, "false")
               .withEnv(UNPROTECTED_API_ENV_VAR, "true")
               .withEnv(AUTHORIZATION_CHECKS_ENV_VAR, "false")
+              .withEnv("CAMUNDA_DATA_SECONDARYSTORAGE_TYPE", "NONE")
               .withNetwork(network);
 
       Failsafe.with(CONTAINER_START_RETRY_POLICY).run(() -> gateway.self().start());


### PR DESCRIPTION
## Summary

- Bumps `backwards.compat.version` from 8.8.0 to 8.9.0 now that 8.9.0 is released
- Updates S3 backup/restore tests to pin against 8.8 explicitly (they were relying on `previous.version`)
- Adds revapi ignores for several differences between 8.9.0 and 8.10.0

Extracted from #50538 to unblock CI.