### PR TITLE
Fix/add hyphen to image tag format

### DIFF
--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -378,7 +378,7 @@ jobs:
           CORRELATION_ID: ${{ github.repository }}:${{ github.run_id }}:${{ github.run_attempt }}:${{ github.sha }}
         run: |
           # Use the image tag as the generation name to match filter patterns
-          # e.g., "8.10.0-SNAPSHOT-main-run12345678-a1" matches "**-main-run*-a*"
+          # e.g., "8.10.0-SNAPSHOT-main-run12345678-a1" matches "**-main-run**-a**"
           curl -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer $GITHUB_TOKEN" \

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -378,7 +378,7 @@ jobs:
           CORRELATION_ID: ${{ github.repository }}:${{ github.run_id }}:${{ github.run_attempt }}:${{ github.sha }}
         run: |
           # Use the image tag as the generation name to match filter patterns
-          # e.g., "8.10.0-SNAPSHOT-main-run12345678-a1" matches "**-main-run**-a**"
+          # e.g., "8.10.0-SNAPSHOT-main-run12345678-a1" matches "**-main-run*-a*"
           curl -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer $GITHUB_TOKEN" \

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -376,12 +376,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.github-token.outputs.token }}
           CORRELATION_ID: ${{ github.repository }}:${{ github.run_id }}:${{ github.run_attempt }}:${{ github.sha }}
-          IMAGE_TAG: ${{ needs.build-and-push.outputs.image-tag }}
         run: |
           # Use the image tag as the generation name to match filter patterns
           # e.g., "8.10.0-SNAPSHOT-main-run12345678-a1" matches "**-main-run**-a**"
-          GEN_NAME="${IMAGE_TAG}"
-
           curl -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer $GITHUB_TOKEN" \
@@ -392,7 +389,7 @@ jobs:
                       "correlation_id": "'"$CORRELATION_ID"'",
                       "source_repo": "${{ github.repository }}",
                       "source_sha": "${{ github.sha }}",
-                      "gen_name": "'"${GEN_NAME}"'",
+                      "gen_name": "${{ needs.build-and-push.outputs.image-tag }}",
                       "c8Version": "8.10",
                       "zeebeVersion": "${{ needs.build-and-push.outputs.image-tag }}",
                       "operateVersion": "SNAPSHOT",


### PR DESCRIPTION
## Description
Fixes the `gen_name` field passed to downstream SaaS E2E workflows by using GitHub Actions expressions instead of bash variables for proper interpolation.

### Problem
After PR #50747, the `gen_name` field was being sent empty to the downstream workflow. The bash variable expansion `"gen_name": "'"${GEN_NAME}"'"` wasn't working correctly in the JSON payload, causing the downstream workflow to fall back to generating its own name from the commit SHA (e.g., `6f6cfc717bba`).

**Evidence from workflow run [24242401138](https://github.com/camunda/camunda/actions/runs/24242401138/job/70780900935):**
```bash
GEN_NAME="${IMAGE_TAG}"
# Later in curl:
"gen_name": "'"${GEN_NAME}"'",  # This evaluated to empty string
```

**Downstream workflow behavior:**
```bash
Run gen_name="6f6cfc717bba"  # ❌ Generated from SHA, not from payload
```

### Solution
Use the GitHub Actions expression `${{ needs.build-and-push.outputs.image-tag }}` directly in the JSON payload instead of going through a bash variable. This ensures the value is properly interpolated before the curl command executes.

**Before:**
```yaml
env:
  IMAGE_TAG: ${{ needs.build-and-push.outputs.image-tag }}
run: |
  GEN_NAME="${IMAGE_TAG}"
  curl ... -d '{"gen_name": "'"${GEN_NAME}"'"}'  # ❌ Empty
```

**After:**
```yaml
run: |
  curl ... -d '{"gen_name": "${{ needs.build-and-push.outputs.image-tag }}"}'  # ✅ Populated
```

### Generation Name Format
The generation name will match the image tag format across all event types:
- `push` to `main`: `8.10.0-SNAPSHOT-main-run12345678-a1`
- `workflow_dispatch`: `8.10.0-SNAPSHOT-dispatch-run12345678-a1`
- `pull_request`: `8.10.0-SNAPSHOT-pr42-run12345678-a1`

### Impact
- ✅ Generation name is now properly passed to downstream workflows
- ✅ Downstream workflows receive meaningful, traceable generation names
- ✅ Consistent naming between Docker images and SaaS E2E test runs
- ✅ No more fallback to truncated commit SHAs<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
