### PR TITLE
deps(optimize): bump httpcore5 5.3.4 → 5.3.6 and netty 4.1.130 → 4.1.132 

### DIFF
--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -49,7 +49,7 @@
     <jackson.version>2.18.1</jackson.version>
     <jsonpath.version>2.9.0</jsonpath.version>
     <apache.http5-client.version>5.5</apache.http5-client.version>
-    <apache.http5-core.version>5.3.4</apache.http5-core.version>
+    <apache.http5-core.version>5.3.6</apache.http5-core.version>
     <guava.version>33.3.1-jre</guava.version>
     <spring.boot.version>3.5.13</spring.boot.version>
     <spring.version>6.2.17</spring.version>

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -59,7 +59,7 @@
     <quartz.version>2.3.2</quartz.version>
     <kotlin-stdlib.version>2.1.0</kotlin-stdlib.version>
     <jakarta.rs-api.version>4.0.0</jakarta.rs-api.version>
-    <netty.version>4.1.130.Final</netty.version>
+    <netty.version>4.1.132.Final</netty.version>
     <log4j2.version>2.25.3</log4j2.version>
     <lombok.version>1.18.34</lombok.version>
     <logback.version>1.5.25</logback.version>


### PR DESCRIPTION
## Description

Bumps dependency versions in Optimize to remediate multiple CVEs:

- **Apache HttpCore5**: `5.3.4` → `5.3.6`
  - Fixes CVE-2025-8671 (HTTP/2 "MadeYouReset" vulnerability)
- **Netty**: `4.1.130.Final` → `4.1.132.Final`
  - Fixes CVE-2026-33871, CVE-2026-33870, CVE-2026-24400

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #50771
