### PR TITLE
fix: revert Fix/add hyphen to image tag format (#50772)

### DIFF
--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -376,9 +376,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.github-token.outputs.token }}
           CORRELATION_ID: ${{ github.repository }}:${{ github.run_id }}:${{ github.run_attempt }}:${{ github.sha }}
+          IMAGE_TAG: ${{ needs.build-and-push.outputs.image-tag }}
         run: |
           # Use the image tag as the generation name to match filter patterns
           # e.g., "8.10.0-SNAPSHOT-main-run12345678-a1" matches "**-main-run**-a**"
+          GEN_NAME="${IMAGE_TAG}"
+
           curl -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer $GITHUB_TOKEN" \
@@ -389,7 +392,7 @@ jobs:
                       "correlation_id": "'"$CORRELATION_ID"'",
                       "source_repo": "${{ github.repository }}",
                       "source_sha": "${{ github.sha }}",
-                      "gen_name": "${{ needs.build-and-push.outputs.image-tag }}",
+                      "gen_name": "'"${GEN_NAME}"'",
                       "c8Version": "8.10",
                       "zeebeVersion": "${{ needs.build-and-push.outputs.image-tag }}",
                       "operateVersion": "SNAPSHOT",


### PR DESCRIPTION


## Description
This reverts changes made by https://github.com/camunda/camunda/pull/50772, to unblock AG as AWS cluster creation now succeeds but GCP fails. checking it with the team [here](https://camunda.slack.com/archives/C5AHF1D8T/p1775831917986249?thread_ts=1775736101.411239&cid=C5AHF1D8T) and will add it back after a solution is provided
<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
