### PR TITLE
feat: allow generic resource deployments

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -178,6 +178,9 @@ public final class DeploymentCreateProcessor
   public ProcessingError tryHandleError(
       final TypedRecord<DeploymentRecord> command, final Throwable error) {
     // Make sure the cache does not contain any leftovers from this run (by hard resetting)
+
+    // TODO: this needs to be re-thought based on the new transformer architecture and the generic
+    // resources
     if (command.getValue().hasBpmnResources()) {
       processState.clearCache();
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/BpmnDeploymentBindingValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/BpmnDeploymentBindingValidator.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.engine.processing.deployment.transform.ValidationErrorFo
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledDecision;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledElement;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeFormDefinition;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeLinkedResource;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import java.io.StringWriter;
 import java.util.List;
@@ -25,11 +26,13 @@ public class BpmnDeploymentBindingValidator {
   private final ZeebeCalledElementDeploymentBindingValidator calledElementValidator;
   private final ZeebeCalledDecisionDeploymentBindingValidator calledDecisionValidator;
   private final ZeebeFormDefinitionDeploymentBindingValidator formDefinitionValidator;
+  private final ZeebeLinkedResourceDeploymentBindingValidator linkedResourceValidator;
 
   public BpmnDeploymentBindingValidator(final DeploymentRecord deployment) {
     calledElementValidator = new ZeebeCalledElementDeploymentBindingValidator(deployment);
     calledDecisionValidator = new ZeebeCalledDecisionDeploymentBindingValidator(deployment);
     formDefinitionValidator = new ZeebeFormDefinitionDeploymentBindingValidator(deployment);
+    linkedResourceValidator = new ZeebeLinkedResourceDeploymentBindingValidator(deployment);
   }
 
   public String validate(final BpmnElementsWithDeploymentBinding elements) {
@@ -38,6 +41,7 @@ public class BpmnDeploymentBindingValidator {
     validateCalledElements(elements.getCalledElements(), resultsCollector);
     validateCalledDecisions(elements.getCalledDecisions(), resultsCollector);
     validateFormDefinitions(elements.getFormDefinitions(), resultsCollector);
+    validateLinkedResources(elements.getLinkedResources(), resultsCollector);
 
     final var validationResults = resultsCollector.getResults();
 
@@ -71,6 +75,16 @@ public class BpmnDeploymentBindingValidator {
         element -> {
           collector.setCurrentElement(element);
           formDefinitionValidator.validate(element, collector);
+        });
+  }
+
+  private void validateLinkedResources(
+      final List<ZeebeLinkedResource> linkedResources,
+      final ValidationResultsCollectorImpl collector) {
+    linkedResources.forEach(
+        element -> {
+          collector.setCurrentElement(element);
+          linkedResourceValidator.validate(element, collector);
         });
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/DeploymentValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/DeploymentValidator.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.validation;
+
+import io.camunda.zeebe.engine.processing.common.Failure;
+import io.camunda.zeebe.engine.processing.deployment.transform.BpmnElementsWithDeploymentBinding;
+import io.camunda.zeebe.engine.processing.deployment.transform.DeploymentResourceContext;
+import io.camunda.zeebe.engine.processing.deployment.transform.ValidationConfig;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentResource;
+import io.camunda.zeebe.util.Either;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * Validates deployment records at various stages of the deployment pipeline.
+ *
+ * <p>This class is stateless and can be reused across deployments. It covers:
+ *
+ * <ul>
+ *   <li>Structural validation (non-empty deployment, resource name length)
+ *   <li>Cross-resource ID uniqueness (processes, decisions, forms, generic resources)
+ *   <li>BPMN deployment binding satisfaction
+ * </ul>
+ */
+public final class DeploymentValidator {
+
+  private final ValidationConfig config;
+
+  public DeploymentValidator(final ValidationConfig config) {
+    this.config = config;
+  }
+
+  /**
+   * Validates structural properties of all resources in the deployment.
+   *
+   * <p>Checks that the deployment is non-empty and that all resource names are within the
+   * configured maximum length.
+   *
+   * @param deployment the deployment to validate
+   * @return Either.right(null) if valid, or Either.left with all validation errors
+   */
+  public Either<Failure, Void> validateResources(final DeploymentRecord deployment) {
+    if (!deployment.resources().iterator().hasNext()) {
+      return Either.left(new Failure("Expected to deploy at least one resource, but none given"));
+    }
+
+    final var errors = new ErrorCollector();
+
+    for (final DeploymentResource resource : deployment.resources()) {
+      final var resourceName = resource.getResourceName();
+      if (resourceName.length() > config.maxNameFieldLength()) {
+        errors.add(
+            "- Resource name '%s' exceeds maximum length of %d characters"
+                + " as it has a length of %d characters",
+            resourceName, config.maxNameFieldLength(), resourceName.length());
+      }
+    }
+
+    return errors.toEither();
+  }
+
+  /**
+   * Validates cross-resource constraints on the collected metadata.
+   *
+   * <p>First checks for duplicate resource IDs across the deployment, then validates that all BPMN
+   * deployment bindings are satisfied.
+   *
+   * @param deployment the deployment record
+   * @param contexts the contexts produced by each transformer during metadata creation
+   * @return Either.right(null) if validation succeeds, or Either.left with validation errors
+   */
+  public Either<Failure, Void> validateMetadata(
+      final DeploymentRecord deployment, final List<DeploymentResourceContext> contexts) {
+    return validateResourceIds(deployment)
+        .flatMap(ok -> validateDeploymentBindings(deployment, contexts));
+  }
+
+  /**
+   * Validates that there are no conflicting resource IDs within the deployment.
+   *
+   * <p>Checks all metadata collections for duplicate IDs:
+   *
+   * <ul>
+   *   <li>BPMN process IDs (bpmnProcessId)
+   *   <li>DMN decision requirements IDs (decisionRequirementsId)
+   *   <li>DMN decision IDs (decisionId)
+   *   <li>Form IDs (formId)
+   *   <li>Generic resource IDs (resourceId)
+   * </ul>
+   */
+  private Either<Failure, Void> validateResourceIds(final DeploymentRecord deployment) {
+    final var errors = new ErrorCollector();
+
+    checkForDuplicateIds(
+        deployment.getProcessesMetadata(),
+        metadata -> metadata.getBpmnProcessId(),
+        metadata -> metadata.getResourceName(),
+        "Duplicated process id in resources '%2$s' and '%3$s'",
+        errors);
+
+    checkForDuplicateIds(
+        deployment.getDecisionRequirementsMetadata(),
+        metadata -> metadata.getDecisionRequirementsId(),
+        metadata -> metadata.getResourceName(),
+        "Expected the decision requirements ids to be unique within a deployment"
+            + " but found a duplicated id '%s' in the resources '%s' and '%s'",
+        errors);
+
+    checkForDuplicateIds(
+        deployment.getDecisionsMetadata(),
+        metadata -> metadata.getDecisionId(),
+        metadata -> deployment.getResourceNameForDecision(metadata),
+        "Expected the decision ids to be unique within a deployment"
+            + " but found a duplicated id '%s' in the resources '%s' and '%s'",
+        errors);
+
+    checkForDuplicateIds(
+        deployment.getFormMetadata(),
+        metadata -> metadata.getFormId(),
+        metadata -> metadata.getResourceName(),
+        "Expected the form ids to be unique within a deployment"
+            + " but found a duplicated id '%s' in the resources '%s' and '%s'.",
+        errors);
+
+    checkForDuplicateIds(
+        deployment.getResourceMetadata(),
+        metadata -> metadata.getResourceId(),
+        metadata -> metadata.getResourceName(),
+        "Expected the resource ids to be unique within a deployment"
+            + " but found a duplicated id '%s' in the resources '%s' and '%s'.",
+        errors);
+
+    return errors.toEither();
+  }
+
+  /**
+   * Checks a collection of metadata entries for duplicate IDs and appends errors for each duplicate
+   * found.
+   *
+   * @param items the metadata entries to check
+   * @param idExtractor extracts the ID from a metadata entry
+   * @param nameExtractor extracts the resource name from a metadata entry (for error messages)
+   * @param messageFormat format string with 3 placeholders: id, first resource name, second
+   *     resource name
+   * @param errors the error collector to append duplicate errors to
+   */
+  private <T> void checkForDuplicateIds(
+      final Iterable<T> items,
+      final Function<T, String> idExtractor,
+      final Function<T, String> nameExtractor,
+      final String messageFormat,
+      final ErrorCollector errors) {
+    final var firstOccurrence = new HashMap<String, String>();
+
+    for (final T item : items) {
+      final var id = idExtractor.apply(item);
+      final var resourceName = Objects.requireNonNullElse(nameExtractor.apply(item), "<?>");
+      final var previousResourceName = firstOccurrence.putIfAbsent(id, resourceName);
+      if (previousResourceName != null) {
+        errors.add(messageFormat, id, previousResourceName, resourceName);
+      }
+    }
+  }
+
+  /**
+   * Validates deployment bindings for BPMN resources in the deployment. Ensures that all referenced
+   * resources (via zeebe:calledElement, zeebe:calledDecision, zeebe:formDefinition,
+   * zeebe:linkedResource) with binding type "deployment" are present in the deployment.
+   */
+  private Either<Failure, Void> validateDeploymentBindings(
+      final DeploymentRecord deploymentEvent, final List<DeploymentResourceContext> contexts) {
+    final var bpmnContexts =
+        contexts.stream()
+            .filter(BpmnElementsWithDeploymentBinding.class::isInstance)
+            .map(BpmnElementsWithDeploymentBinding.class::cast)
+            .toList();
+
+    if (bpmnContexts.isEmpty()) {
+      return Either.right(null);
+    }
+
+    final var errors = new ErrorCollector();
+
+    final var validator = new BpmnDeploymentBindingValidator(deploymentEvent);
+    for (final var elements : bpmnContexts) {
+      final var validationError = validator.validate(elements);
+      if (validationError != null) {
+        errors.add("'%s':\n%s", elements.getResourceName(), validationError);
+      }
+    }
+
+    return errors.toEither();
+  }
+
+  /** Collects validation errors and converts them into a {@link Failure}. */
+  private static final class ErrorCollector {
+
+    private static final String DEFAULT_PREFIX =
+        "Expected to deploy new resources, but encountered the following errors:";
+
+    private final StringBuilder errors = new StringBuilder();
+
+    void add(final String format, final Object... args) {
+      errors.append("\n").append(String.format(format, args));
+    }
+
+    Either<Failure, Void> toEither() {
+      if (errors.isEmpty()) {
+        return Either.right(null);
+      }
+      return Either.left(new Failure(DEFAULT_PREFIX + errors));
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeLinkedResourceDeploymentBindingValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeLinkedResourceDeploymentBindingValidator.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.validation;
+
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeLinkedResource;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.record.value.deployment.ResourceMetadataValue;
+import java.util.List;
+import org.camunda.bpm.model.xml.validation.ModelElementValidator;
+import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
+
+public class ZeebeLinkedResourceDeploymentBindingValidator
+    implements ModelElementValidator<ZeebeLinkedResource> {
+
+  private final List<ResourceMetadataValue> resourceMetadata;
+
+  public ZeebeLinkedResourceDeploymentBindingValidator(final DeploymentRecord deployment) {
+    resourceMetadata = deployment.getResourceMetadata();
+  }
+
+  @Override
+  public Class<ZeebeLinkedResource> getElementType() {
+    return ZeebeLinkedResource.class;
+  }
+
+  @Override
+  public void validate(
+      final ZeebeLinkedResource linkedResource,
+      final ValidationResultCollector validationResultCollector) {
+    if (resourceMetadata.stream()
+        .noneMatch(r -> linkedResource.getResourceId().equals(r.getResourceId()))) {
+      validationResultCollector.addError(
+          0,
+          "Expected to find resource with id '%s' in current deployment, but not found."
+              .formatted(linkedResource.getResourceId()));
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnElementsWithDeploymentBinding.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnElementsWithDeploymentBinding.java
@@ -30,10 +30,6 @@ public class BpmnElementsWithDeploymentBinding implements DeploymentResourceCont
   private final List<ZeebeLinkedResource> linkedResources = new ArrayList<>();
   private final String resourceName;
 
-  public BpmnElementsWithDeploymentBinding() {
-    this.resourceName = null;
-  }
-
   public BpmnElementsWithDeploymentBinding(final String resourceName) {
     this.resourceName = resourceName;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnElementsWithDeploymentBinding.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnElementsWithDeploymentBinding.java
@@ -9,12 +9,15 @@ package io.camunda.zeebe.engine.processing.deployment.transform;
 
 import io.camunda.zeebe.model.bpmn.instance.BusinessRuleTask;
 import io.camunda.zeebe.model.bpmn.instance.CallActivity;
+import io.camunda.zeebe.model.bpmn.instance.FlowElement;
 import io.camunda.zeebe.model.bpmn.instance.Process;
 import io.camunda.zeebe.model.bpmn.instance.UserTask;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledDecision;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledElement;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeFormDefinition;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeLinkedResource;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeLinkedResources;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -24,6 +27,20 @@ public class BpmnElementsWithDeploymentBinding implements DeploymentResourceCont
   private final List<ZeebeCalledElement> calledElements = new ArrayList<>();
   private final List<ZeebeCalledDecision> calledDecisions = new ArrayList<>();
   private final List<ZeebeFormDefinition> formDefinitions = new ArrayList<>();
+  private final List<ZeebeLinkedResource> linkedResources = new ArrayList<>();
+  private final String resourceName;
+
+  public BpmnElementsWithDeploymentBinding() {
+    this.resourceName = null;
+  }
+
+  public BpmnElementsWithDeploymentBinding(final String resourceName) {
+    this.resourceName = resourceName;
+  }
+
+  public String getResourceName() {
+    return resourceName;
+  }
 
   public void addFromProcess(final Process process) {
     process
@@ -36,6 +53,7 @@ public class BpmnElementsWithDeploymentBinding implements DeploymentResourceCont
                 case final UserTask task -> handleUserTask(task);
                 default -> {}
               }
+              handleLinkedResources(element);
             });
   }
 
@@ -49,6 +67,10 @@ public class BpmnElementsWithDeploymentBinding implements DeploymentResourceCont
 
   public List<ZeebeFormDefinition> getFormDefinitions() {
     return formDefinitions;
+  }
+
+  public List<ZeebeLinkedResource> getLinkedResources() {
+    return linkedResources;
   }
 
   private void handleCallActivity(final CallActivity callActivity) {
@@ -76,6 +98,16 @@ public class BpmnElementsWithDeploymentBinding implements DeploymentResourceCont
                 formDefinition.getBindingType() == ZeebeBindingType.deployment
                     && isNotExpression(formDefinition.getFormId()))
         .ifPresent(formDefinitions::add);
+  }
+
+  private void handleLinkedResources(final FlowElement element) {
+    Optional.ofNullable(element.getSingleExtensionElement(ZeebeLinkedResources.class))
+        .ifPresent(
+            resources ->
+                resources.getLinkedResources().stream()
+                    .filter(r -> r.getBindingType() == ZeebeBindingType.deployment)
+                    .filter(r -> isNotExpression(r.getResourceId()))
+                    .forEach(linkedResources::add));
   }
 
   private boolean isNotExpression(final String s) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
@@ -43,6 +43,7 @@ public final class BpmnResourceTransformer implements DeploymentResourceTransfor
 
   private final BpmnTransformer bpmnTransformer;
 
+
   private final KeyGenerator keyGenerator;
   private final StateWriter stateWriter;
   private final ChecksumGenerator checksumGenerator;
@@ -71,6 +72,21 @@ public final class BpmnResourceTransformer implements DeploymentResourceTransfor
     validator =
         BpmnFactory.createValidator(clock, expressionProcessor, config, expressionLanguageMetrics);
     this.enableStraightThroughProcessingLoopDetector = enableStraightThroughProcessingLoopDetector;
+  }
+
+  @Override
+  public boolean canTransform(final DeploymentResource resource) {
+    final var resourceName = resource.getResourceName();
+    // .bpmn files must always be handled by this transformer (even if invalid)
+    if (resourceName.endsWith(".bpmn")) {
+      return true;
+    }
+    // .xml files: try to parse as BPMN and only handle if it's valid BPMN.
+    // This is necessary to distinguish BPMN .xml files from generic .xml files.
+    if (resourceName.endsWith(".xml")) {
+      return readProcessDefinition(resource).isRight();
+    }
+    return false;
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
@@ -22,7 +22,6 @@ import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
-import io.camunda.zeebe.model.bpmn.instance.BaseElement;
 import io.camunda.zeebe.model.bpmn.instance.Process;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeVersionTag;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
@@ -42,7 +41,6 @@ import org.camunda.bpm.model.xml.ModelParseException;
 public final class BpmnResourceTransformer implements DeploymentResourceTransformer {
 
   private final BpmnTransformer bpmnTransformer;
-
 
   private final KeyGenerator keyGenerator;
   private final StateWriter stateWriter;
@@ -81,7 +79,8 @@ public final class BpmnResourceTransformer implements DeploymentResourceTransfor
     if (resourceName.endsWith(".bpmn")) {
       return true;
     }
-    // .xml files: try to parse as BPMN and only handle if it's valid BPMN.
+    // .xml files: try to parse as BPMN and only handle if it's valid BPMN
+    // Note: This requires parsing the resource, which will be done again in createMetadata().
     // This is necessary to distinguish BPMN .xml files from generic .xml files.
     if (resourceName.endsWith(".xml")) {
       return readProcessDefinition(resource).isRight();
@@ -90,10 +89,8 @@ public final class BpmnResourceTransformer implements DeploymentResourceTransfor
   }
 
   @Override
-  public Either<Failure, Void> createMetadata(
-      final DeploymentResource resource,
-      final DeploymentRecord deployment,
-      final DeploymentResourceContext context) {
+  public Either<Failure, DeploymentResourceContext> createMetadata(
+      final DeploymentResource resource, final DeploymentRecord deployment) {
 
     return readProcessDefinition(resource)
         .flatMap(
@@ -105,11 +102,8 @@ public final class BpmnResourceTransformer implements DeploymentResourceTransfor
                 // validator
                 final var executableProcesses = bpmnTransformer.transformDefinitions(definition);
 
-                return checkForDuplicateBpmnId(definition, resource, deployment)
-                    .flatMap(
-                        ok ->
-                            UnsupportedMultiTenantFeaturesValidator.validate(
-                                resource, executableProcesses, deployment.getTenantId()))
+                return UnsupportedMultiTenantFeaturesValidator.validate(
+                        resource, executableProcesses, deployment.getTenantId())
                     .flatMap(
                         ok -> {
                           if (enableStraightThroughProcessingLoopDetector) {
@@ -120,8 +114,10 @@ public final class BpmnResourceTransformer implements DeploymentResourceTransfor
                         })
                     .map(
                         ok -> {
-                          createProcessMetadata(deployment, resource, definition, context);
-                          return null;
+                          final var elements =
+                              new BpmnElementsWithDeploymentBinding(resource.getResourceName());
+                          createProcessMetadata(deployment, resource, definition, elements);
+                          return (DeploymentResourceContext) elements;
                         });
 
               } else {
@@ -134,9 +130,6 @@ public final class BpmnResourceTransformer implements DeploymentResourceTransfor
 
   @Override
   public void writeRecords(final DeploymentResource resource, final DeploymentRecord deployment) {
-    if (deployment.hasDuplicatesOnly()) {
-      return;
-    }
     final var checksum = checksumGenerator.checksum(resource.getResourceBuffer());
     deployment.processesMetadata().stream()
         .filter(metadata -> checksum.equals(metadata.getChecksumBuffer()))
@@ -176,35 +169,11 @@ public final class BpmnResourceTransformer implements DeploymentResourceTransfor
     }
   }
 
-  private Either<Failure, ?> checkForDuplicateBpmnId(
-      final BpmnModelInstance process,
-      final DeploymentResource resource,
-      final DeploymentRecord record) {
-
-    final var bpmnProcessIds =
-        process.getDefinitions().getChildElementsByType(Process.class).stream()
-            .map(BaseElement::getId)
-            .toList();
-
-    return record.getProcessesMetadata().stream()
-        .filter(metadata -> bpmnProcessIds.contains(metadata.getBpmnProcessId()))
-        .findFirst()
-        .map(
-            previousResource -> {
-              final var failureMessage =
-                  String.format(
-                      "Duplicated process id in resources '%s' and '%s'",
-                      previousResource.getResourceName(), resource.getResourceName());
-              return Either.left(new Failure(failureMessage));
-            })
-        .orElse(Either.right(null));
-  }
-
   private void createProcessMetadata(
       final DeploymentRecord deploymentEvent,
       final DeploymentResource deploymentResource,
       final BpmnModelInstance definition,
-      final DeploymentResourceContext context) {
+      final BpmnElementsWithDeploymentBinding elements) {
     for (final Process process : getExecutableProcesses(definition)) {
       final String bpmnProcessId = process.getId();
       final String tenantId = deploymentEvent.getTenantId();
@@ -241,9 +210,7 @@ public final class BpmnResourceTransformer implements DeploymentResourceTransfor
             .setDeploymentKey(deploymentEvent.getDeploymentKey());
       }
 
-      if (context instanceof final BpmnElementsWithDeploymentBinding elements) {
-        elements.addFromProcess(process);
-      }
+      elements.addFromProcess(process);
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DefaultResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DefaultResourceTransformer.java
@@ -32,10 +32,14 @@ import org.agrona.DirectBuffer;
  * <h2>Duplicate detection</h2>
  *
  * <p>A resource deployment is considered a <em>duplicate</em> when both the checksum (MD5 of the
- * raw bytes) and the resource name match the previously deployed version. Only if either value
+ * raw bytes) and the resource ID match the previously deployed version. Only if either value
  * differs will a new version be created.
  *
  * <h2>Filename (resourceName) vs. resource ID</h2>
+ *
+ * <p>The {@code resourceName} field always reflects the filename used in the deployment command,
+ * even for duplicates. This lets callers see which filename was used in each deployment. However,
+ * {@code resourceName} is <em>not</em> part of the identity check:
  *
  * <ul>
  *   <li><b>Generic resources</b> (no known extension, e.g. {@code .txt}): the filename <em>is</em>
@@ -66,6 +70,12 @@ class DefaultResourceTransformer implements DeploymentResourceTransformer {
     this.resourceState = resourceState;
   }
 
+  /**
+   * The default transformer accepts any resource that was not handled by other transformers.
+   *
+   * @param resource the raw deployment resource
+   * @return always returns {@code true} as this is the fallback transformer
+   */
   @Override
   public boolean canTransform(final DeploymentResource resource) {
     return true;
@@ -85,28 +95,19 @@ class DefaultResourceTransformer implements DeploymentResourceTransformer {
   }
 
   @Override
-  public Either<Failure, Void> createMetadata(
-      final DeploymentResource deploymentResource,
-      final DeploymentRecord deployment,
-      final DeploymentResourceContext context) {
+  public final Either<Failure, DeploymentResourceContext> createMetadata(
+      final DeploymentResource deploymentResource, final DeploymentRecord deployment) {
     return parseResourceInfo(deploymentResource)
-        .flatMap(
-            resourceInfo ->
-                checkForDuplicateResourceId(
-                        resourceInfo.id(), deploymentResource, deployment)
-                    .map(
-                        ok -> {
-                          addResourceMetadata(resourceInfo, deploymentResource, deployment);
-                          return null;
-                        }));
+        .map(
+            resourceInfo -> {
+              addResourceMetadata(resourceInfo, deploymentResource, deployment);
+              return DeploymentResourceContext.NONE;
+            });
   }
 
   @Override
-  public void writeRecords(
+  public final void writeRecords(
       final DeploymentResource resource, final DeploymentRecord deployment) {
-    if (deployment.hasDuplicatesOnly()) {
-      return;
-    }
     final var checksum = checksumGenerator.checksum(resource.getResourceBuffer());
     deployment.resourceMetadata().stream()
         .filter(metadata -> checksum.equals(metadata.getChecksumBuffer()))
@@ -114,6 +115,8 @@ class DefaultResourceTransformer implements DeploymentResourceTransformer {
         .ifPresent(
             metadata -> {
               if (metadata.isDuplicate()) {
+                // create new version as the deployment contains at least one other non-duplicate
+                // resource and all resources in a deployment should be versioned together
                 metadata
                     .setResourceKey(keyGenerator.nextKey())
                     .setVersion(
@@ -173,25 +176,6 @@ class DefaultResourceTransformer implements DeploymentResourceTransformer {
                     .setResourceKey(keyGenerator.nextKey())
                     .setVersion(INITIAL_VERSION)
                     .setDeploymentKey(deploymentRecord.getDeploymentKey()));
-  }
-
-  private Either<Failure, ?> checkForDuplicateResourceId(
-      final String resourceId,
-      final DeploymentResource resource,
-      final DeploymentRecord record) {
-    return record.getResourceMetadata().stream()
-        .filter(metadata -> metadata.getResourceId().equals(resourceId))
-        .findFirst()
-        .map(
-            dupeResource -> {
-              final var failureMessage =
-                  String.format(
-                      "Expected the resource ids to be unique within a deployment"
-                          + " but found a duplicated id '%s' in the resources '%s' and '%s'.",
-                      resourceId, dupeResource.getResourceName(), resource.getResourceName());
-              return Either.left(new Failure(failureMessage));
-            })
-        .orElse(Either.right(null));
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DefaultResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DefaultResourceTransformer.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment.transform;
+
+import io.camunda.zeebe.engine.processing.common.Failure;
+import io.camunda.zeebe.engine.processing.deployment.ChecksumGenerator;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.state.immutable.ResourceState;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentResource;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ResourceMetadataRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ResourceRecord;
+import io.camunda.zeebe.protocol.record.intent.ResourceIntent;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import io.camunda.zeebe.util.Either;
+import java.util.Optional;
+import org.agrona.DirectBuffer;
+
+/**
+ * Default transformer for resources stored in the {@link ResourceState}.
+ *
+ * <p>Handles the common logic for versioning and writing resource records. By default, the resource
+ * name (filename) is used as the resource ID. Subclasses can override {@link
+ * #parseResourceInfo(DeploymentResource)} to resolve the resource ID (and optional version tag)
+ * from the raw resource content.
+ *
+ * <h2>Duplicate detection</h2>
+ *
+ * <p>A resource deployment is considered a <em>duplicate</em> when both the checksum (MD5 of the
+ * raw bytes) and the resource name match the previously deployed version. Only if either value
+ * differs will a new version be created.
+ *
+ * <h2>Filename (resourceName) vs. resource ID</h2>
+ *
+ * <ul>
+ *   <li><b>Generic resources</b> (no known extension, e.g. {@code .txt}): the filename <em>is</em>
+ *       the resource ID. Renaming the file therefore creates an entirely new, independently
+ *       versioned resource.
+ *   <li><b>Structured resources</b> (e.g. {@code .rpa}): the resource ID is parsed from the file
+ *       content. Renaming the file while keeping the same content and ID is treated as a duplicate
+ *       — no new version is created.
+ * </ul>
+ */
+class DefaultResourceTransformer implements DeploymentResourceTransformer {
+
+  private static final int INITIAL_VERSION = 1;
+
+  protected final KeyGenerator keyGenerator;
+  protected final StateWriter stateWriter;
+  protected final ChecksumGenerator checksumGenerator;
+  protected final ResourceState resourceState;
+
+  DefaultResourceTransformer(
+      final KeyGenerator keyGenerator,
+      final StateWriter stateWriter,
+      final ChecksumGenerator checksumGenerator,
+      final ResourceState resourceState) {
+    this.keyGenerator = keyGenerator;
+    this.stateWriter = stateWriter;
+    this.checksumGenerator = checksumGenerator;
+    this.resourceState = resourceState;
+  }
+
+  @Override
+  public boolean canTransform(final DeploymentResource resource) {
+    return true;
+  }
+
+  /**
+   * Parses the deployment resource to extract the resource identity (ID and optional version tag).
+   *
+   * <p>The default implementation uses the resource name (filename) as the resource ID. Subclasses
+   * can override this method to parse a structured resource ID from the resource content.
+   *
+   * @param resource the raw deployment resource
+   * @return either the parsed {@link ResourceInfo}, or a {@link Failure} if the resource is invalid
+   */
+  protected Either<Failure, ResourceInfo> parseResourceInfo(final DeploymentResource resource) {
+    return Either.right(ResourceInfo.of(resource.getResourceName()));
+  }
+
+  @Override
+  public Either<Failure, Void> createMetadata(
+      final DeploymentResource deploymentResource,
+      final DeploymentRecord deployment,
+      final DeploymentResourceContext context) {
+    return parseResourceInfo(deploymentResource)
+        .flatMap(
+            resourceInfo ->
+                checkForDuplicateResourceId(
+                        resourceInfo.id(), deploymentResource, deployment)
+                    .map(
+                        ok -> {
+                          addResourceMetadata(resourceInfo, deploymentResource, deployment);
+                          return null;
+                        }));
+  }
+
+  @Override
+  public void writeRecords(
+      final DeploymentResource resource, final DeploymentRecord deployment) {
+    if (deployment.hasDuplicatesOnly()) {
+      return;
+    }
+    final var checksum = checksumGenerator.checksum(resource.getResourceBuffer());
+    deployment.resourceMetadata().stream()
+        .filter(metadata -> checksum.equals(metadata.getChecksumBuffer()))
+        .findFirst()
+        .ifPresent(
+            metadata -> {
+              if (metadata.isDuplicate()) {
+                metadata
+                    .setResourceKey(keyGenerator.nextKey())
+                    .setVersion(
+                        resourceState.getNextResourceVersion(
+                            metadata.getResourceId(), metadata.getTenantId()))
+                    .setDuplicate(false)
+                    .setDeploymentKey(deployment.getDeploymentKey());
+              }
+              writeResourceRecord(metadata, resource);
+            });
+  }
+
+  private void writeResourceRecord(
+      final ResourceMetadataRecord metadata, final DeploymentResource resource) {
+    stateWriter.appendFollowUpEvent(
+        metadata.getResourceKey(),
+        ResourceIntent.CREATED,
+        new ResourceRecord().wrap(metadata, resource.getResource()));
+  }
+
+  private void addResourceMetadata(
+      final ResourceInfo resourceInfo,
+      final DeploymentResource deploymentResource,
+      final DeploymentRecord deploymentRecord) {
+    final ResourceMetadataRecord metadata = deploymentRecord.resourceMetadata().add();
+    final DirectBuffer checksum =
+        checksumGenerator.checksum(deploymentResource.getResourceBuffer());
+    final String resourceId = resourceInfo.id();
+    final String tenantId = deploymentRecord.getTenantId();
+
+    metadata.setResourceId(resourceId);
+    metadata.setChecksum(checksum);
+    metadata.setResourceName(deploymentResource.getResourceName());
+    metadata.setTenantId(tenantId);
+    resourceInfo.versionTag().ifPresent(metadata::setVersionTag);
+
+    resourceState
+        .findLatestResourceById(resourceId, tenantId)
+        .ifPresentOrElse(
+            latestResource -> {
+              if (latestResource.isDuplicateOf(
+                  deploymentResource.getResourceNameBuffer(), checksum)) {
+                metadata
+                    .setResourceKey(latestResource.getResourceKey())
+                    .setVersion(latestResource.getVersion())
+                    .setDeploymentKey(latestResource.getDeploymentKey())
+                    .setDuplicate(true);
+              } else {
+                metadata
+                    .setResourceKey(keyGenerator.nextKey())
+                    .setVersion(resourceState.getNextResourceVersion(resourceId, tenantId))
+                    .setDeploymentKey(deploymentRecord.getDeploymentKey());
+              }
+            },
+            () ->
+                metadata
+                    .setResourceKey(keyGenerator.nextKey())
+                    .setVersion(INITIAL_VERSION)
+                    .setDeploymentKey(deploymentRecord.getDeploymentKey()));
+  }
+
+  private Either<Failure, ?> checkForDuplicateResourceId(
+      final String resourceId,
+      final DeploymentResource resource,
+      final DeploymentRecord record) {
+    return record.getResourceMetadata().stream()
+        .filter(metadata -> metadata.getResourceId().equals(resourceId))
+        .findFirst()
+        .map(
+            dupeResource -> {
+              final var failureMessage =
+                  String.format(
+                      "Expected the resource ids to be unique within a deployment"
+                          + " but found a duplicated id '%s' in the resources '%s' and '%s'.",
+                      resourceId, dupeResource.getResourceName(), resource.getResourceName());
+              return Either.left(new Failure(failureMessage));
+            })
+        .orElse(Either.right(null));
+  }
+
+  /**
+   * Holds the parsed identity of a deployment resource: its unique ID and an optional version tag.
+   *
+   * @param id the resource identifier (must not be null or blank)
+   * @param versionTag an optional version tag
+   */
+  public record ResourceInfo(String id, Optional<String> versionTag) {
+
+    static ResourceInfo of(final String id) {
+      return new ResourceInfo(id, Optional.empty());
+    }
+
+    static ResourceInfo of(final String id, final String versionTag) {
+      return new ResourceInfo(id, Optional.ofNullable(versionTag));
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentResourceContext.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentResourceContext.java
@@ -7,4 +7,9 @@
  */
 package io.camunda.zeebe.engine.processing.deployment.transform;
 
-public interface DeploymentResourceContext {}
+@SuppressWarnings("checkstyle:InterfaceIsType")
+public interface DeploymentResourceContext {
+
+  /** A no-op context for resource types that don't produce additional metadata. */
+  DeploymentResourceContext NONE = new DeploymentResourceContext() {};
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentResourceTransformer.java
@@ -15,6 +15,18 @@ import io.camunda.zeebe.util.Either;
 interface DeploymentResourceTransformer {
 
   /**
+   * Determines if this transformer can handle the given resource.
+   *
+   * <p>Transformers are checked in order, and the first transformer that returns {@code true} will
+   * be used to process the resource. This allows transformers to make decisions based on file
+   * extension, content, or any other criteria.
+   *
+   * @param resource the resource to check
+   * @return {@code true} if this transformer can handle the resource, {@code false} otherwise
+   */
+  boolean canTransform(DeploymentResource resource);
+
+  /**
    * Step 1 of transforming the given resource: The transformer should add the deployed resource's
    * metadata to the deployment record, but not write any event records yet.
    *

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentResourceTransformer.java
@@ -30,26 +30,37 @@ interface DeploymentResourceTransformer {
    * Step 1 of transforming the given resource: The transformer should add the deployed resource's
    * metadata to the deployment record, but not write any event records yet.
    *
+   * <p>This method validates the internal consistency of a single resource file (e.g., valid XML,
+   * valid JSON structure) and creates metadata entries. Cross-file validation (e.g., duplicate IDs
+   * across the deployment) is handled by the DeploymentTransformer after all metadata is collected.
+   *
+   * <p>Transformers may return a {@link DeploymentResourceContext} carrying additional information
+   * needed by later validation steps (e.g., BPMN deployment binding elements). Transformers that
+   * have no additional context should return {@link DeploymentResourceContext#NONE}.
+   *
    * @param resource the resource to transform
    * @param deployment the deployment to add the deployed resource to
-   * @param context optional parameter to store additional information
-   * @return either {@link Either.Right} if the resource is transformed successfully, or {@link
-   *     Either.Left} if the transformation failed
+   * @return either {@link Either.Right} with the resource context if the resource is transformed
+   *     successfully, or {@link Either.Left} if the transformation failed
    */
-  Either<Failure, Void> createMetadata(
-      final DeploymentResource resource,
-      final DeploymentRecord deployment,
-      final DeploymentResourceContext context);
+  Either<Failure, DeploymentResourceContext> createMetadata(
+      final DeploymentResource resource, final DeploymentRecord deployment);
 
   /**
    * Step 2 of transforming the given resource: The transformer should update the previously created
    * metadata (if necessary) and eventually write the actual event record(s) (e.g. "process
    * created").
    *
+   * <p><b>Versioning invariant:</b> when the deployment contains at least one non-duplicate
+   * resource, every resource that was individually marked as a duplicate in {@link #createMetadata}
+   * must have its {@code duplicate} flag cleared and must receive a fresh key and a new version
+   * number before the record is written. Note that the caller (DeploymentTransformer) will skip
+   * calling this method entirely for all-duplicate deployments by checking {@link
+   * DeploymentRecord#hasDuplicatesOnly()}.
+   *
    * @param resource the resource to transform
    * @param deployment the deployment record containing the metadata created in {@link
-   *     DeploymentResourceTransformer#createMetadata(DeploymentResource, DeploymentRecord,
-   *     DeploymentResourceContext)}
+   *     DeploymentResourceTransformer#createMetadata(DeploymentResource, DeploymentRecord)}
    */
   void writeRecords(DeploymentResource resource, DeploymentRecord deployment);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.engine.processing.deployment.transform;
 
 import static io.camunda.zeebe.util.buffer.BufferUtil.wrapArray;
-import static java.util.Map.entry;
 
 import io.camunda.zeebe.el.ExpressionLanguageMetrics;
 import io.camunda.zeebe.engine.Loggers;
@@ -27,18 +26,15 @@ import io.camunda.zeebe.util.FeatureFlags;
 import java.time.InstantSource;
 import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.Map;
-import java.util.Map.Entry;
+import java.util.List;
 import org.agrona.DirectBuffer;
 import org.slf4j.Logger;
 
 public final class DeploymentTransformer {
 
   private static final Logger LOG = Loggers.PROCESS_PROCESSOR_LOGGER;
-  private static final DeploymentResourceTransformer UNKNOWN_RESOURCE =
-      new UnknownResourceTransformer();
   private final ValidationConfig config;
-  private final Map<String, DeploymentResourceTransformer> resourceTransformers;
+  private final List<DeploymentResourceTransformer> resourceTransformers;
   private final ChecksumGenerator checksumGenerator = new ChecksumGenerator();
   // internal changes during processing
   private RejectionType rejectionType;
@@ -78,17 +74,23 @@ public final class DeploymentTransformer {
         new FormResourceTransformer(
             keyGenerator, stateWriter, checksumGenerator, processingState.getFormState(), config);
 
-    final var resourceTransformer =
+    final var rpaTransformer =
         new RpaTransformer(
             keyGenerator, stateWriter, checksumGenerator, processingState.getResourceState());
 
+    final var defaultResourceTransformer =
+        new DefaultResourceTransformer(
+            keyGenerator, stateWriter, checksumGenerator, processingState.getResourceState());
+
+    // Order matters: transformers are checked in order, and the first that can handle the resource
+    // will be used. DefaultResourceTransformer should be last as it accepts any file.
     resourceTransformers =
-        Map.ofEntries(
-            entry(".bpmn", bpmnResourceTransformer),
-            entry(".xml", bpmnResourceTransformer),
-            entry(".dmn", dmnResourceTransformer),
-            entry(".form", formResourceTransformer),
-            entry(".rpa", resourceTransformer));
+        List.of(
+            bpmnResourceTransformer,
+            dmnResourceTransformer,
+            formResourceTransformer,
+            rpaTransformer,
+            defaultResourceTransformer);
   }
 
   public DirectBuffer getChecksum(final byte[] resource) {
@@ -112,14 +114,19 @@ public final class DeploymentTransformer {
     final var bpmnResources = new ArrayList<BpmnResource>();
     while (resourceIterator.hasNext()) {
       final DeploymentResource deploymentResource = resourceIterator.next();
-      if (isBpmnResource(deploymentResource)) {
+      final var transformer = getResourceTransformer(deploymentResource);
+      if (transformer instanceof BpmnResourceTransformer) {
         final var context = new BpmnElementsWithDeploymentBinding();
         bpmnResources.add(new BpmnResource(deploymentResource, context));
-        success &= createMetadata(deploymentResource, deploymentEvent, context, errors);
+        success &= createMetadata(deploymentResource, deploymentEvent, context, transformer, errors);
       } else {
         success &=
             createMetadata(
-                deploymentResource, deploymentEvent, new DeploymentResourceContext() {}, errors);
+                deploymentResource,
+                deploymentEvent,
+                new DeploymentResourceContext() {},
+                transformer,
+                errors);
       }
     }
 
@@ -159,18 +166,13 @@ public final class DeploymentTransformer {
     return Either.right(null);
   }
 
-  private boolean isBpmnResource(final DeploymentResource resource) {
-    return resource.getResourceName().endsWith(".bpmn")
-        || resource.getResourceName().endsWith(".xml");
-  }
-
   private boolean createMetadata(
       final DeploymentResource deploymentResource,
       final DeploymentRecord deploymentEvent,
       final DeploymentResourceContext context,
+      final DeploymentResourceTransformer transformer,
       final StringBuilder errors) {
     final var resourceName = deploymentResource.getResourceName();
-    final var transformer = getResourceTransformer(resourceName);
 
     if (resourceName.length() > config.maxNameFieldLength()) {
       errors.append(
@@ -202,7 +204,7 @@ public final class DeploymentTransformer {
       final DeploymentRecord deploymentEvent,
       final StringBuilder errors) {
     final var resourceName = deploymentResource.getResourceName();
-    final var transformer = getResourceTransformer(resourceName);
+    final var transformer = getResourceTransformer(deploymentResource);
     try {
       transformer.writeRecords(deploymentResource, deploymentEvent);
       return true;
@@ -220,35 +222,21 @@ public final class DeploymentTransformer {
     return rejectionReason;
   }
 
-  private DeploymentResourceTransformer getResourceTransformer(final String resourceName) {
-    return resourceTransformers.entrySet().stream()
-        .filter(entry -> resourceName.endsWith(entry.getKey()))
-        .map(Entry::getValue)
+  private DeploymentResourceTransformer getResourceTransformer(
+      final DeploymentResource resource) {
+    return resourceTransformers.stream()
+        .filter(transformer -> transformer.canTransform(resource))
         .findFirst()
-        .orElse(UNKNOWN_RESOURCE);
+        .orElseThrow(
+            () ->
+                new IllegalStateException(
+                    "No transformer found for resource: " + resource.getResourceName()));
   }
 
   private static void handleUnexpectedError(
       final String resourceName, final RuntimeException exception, final StringBuilder errors) {
     LOG.error("Unexpected error while processing resource '{}'", resourceName, exception);
     errors.append("\n'").append(resourceName).append("': ").append(exception.getMessage());
-  }
-
-  private static final class UnknownResourceTransformer implements DeploymentResourceTransformer {
-
-    @Override
-    public Either<Failure, Void> createMetadata(
-        final DeploymentResource resource,
-        final DeploymentRecord deployment,
-        final DeploymentResourceContext context) {
-      final var failureMessage =
-          String.format("%n'%s': unknown resource type", resource.getResourceName());
-      return Either.left(new Failure(failureMessage));
-    }
-
-    @Override
-    public void writeRecords(
-        final DeploymentResource resource, final DeploymentRecord deployment) {}
   }
 
   private record BpmnResource(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
@@ -14,18 +14,16 @@ import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.ChecksumGenerator;
-import io.camunda.zeebe.engine.processing.deployment.model.validation.BpmnDeploymentBindingValidator;
+import io.camunda.zeebe.engine.processing.deployment.model.validation.DeploymentValidator;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentResource;
-import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.FeatureFlags;
 import java.time.InstantSource;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import org.agrona.DirectBuffer;
 import org.slf4j.Logger;
@@ -33,12 +31,9 @@ import org.slf4j.Logger;
 public final class DeploymentTransformer {
 
   private static final Logger LOG = Loggers.PROCESS_PROCESSOR_LOGGER;
-  private final ValidationConfig config;
+  private final DeploymentValidator validator;
   private final List<DeploymentResourceTransformer> resourceTransformers;
   private final ChecksumGenerator checksumGenerator = new ChecksumGenerator();
-  // internal changes during processing
-  private RejectionType rejectionType;
-  private String rejectionReason;
 
   public DeploymentTransformer(
       final StateWriter stateWriter,
@@ -49,7 +44,7 @@ public final class DeploymentTransformer {
       final ValidationConfig config,
       final InstantSource clock,
       final ExpressionLanguageMetrics expressionLanguageMetrics) {
-    this.config = config;
+    validator = new DeploymentValidator(config);
 
     final var bpmnResourceTransformer =
         new BpmnResourceTransformer(
@@ -62,6 +57,7 @@ public final class DeploymentTransformer {
             config,
             clock,
             expressionLanguageMetrics);
+
     final var dmnResourceTransformer =
         new DmnResourceTransformer(
             keyGenerator,
@@ -98,132 +94,82 @@ public final class DeploymentTransformer {
   }
 
   public Either<Failure, Void> transform(final DeploymentRecord deploymentEvent) {
-    final StringBuilder errors = new StringBuilder();
-    boolean success = true;
+    // Step 1: Validate structural properties of all resources (non-empty, name length)
+    return validator
+        .validateResources(deploymentEvent)
+        // Step 2: Parse each resource and build metadata
+        .flatMap(ok -> buildMetadata(deploymentEvent))
+        // Step 3+4: Validate cross-resource constraints (duplicate IDs, deployment bindings)
+        .flatMap(contexts -> validator.validateMetadata(deploymentEvent, contexts))
+        // Step 5: Write the actual resources/deployment to state
+        .map(
+            ok -> {
+              writeResourceRecords(deploymentEvent);
+              return null;
+            });
+  }
 
-    final Iterator<DeploymentResource> resourceIterator = deploymentEvent.resources().iterator();
-    if (!resourceIterator.hasNext()) {
-      rejectionType = RejectionType.INVALID_ARGUMENT;
-      rejectionReason = "Expected to deploy at least one resource, but none given";
+  /**
+   * Step 2: Iterates over all resources and builds metadata for each. This step validates each
+   * resource individually and adds its metadata to the deployment record.
+   *
+   * @param deploymentEvent the deployment record
+   * @return Either.right with the list of contexts produced by each transformer, or Either.left
+   *     with error details
+   */
+  private Either<Failure, List<DeploymentResourceContext>> buildMetadata(
+      final DeploymentRecord deploymentEvent) {
+    final var errors = new ErrorCollector();
+    final List<DeploymentResourceContext> contexts = new ArrayList<>();
 
-      return Either.left(new Failure(rejectionReason));
-    }
-
-    // step 1: only validate the resources and add their metadata to the deployment record (no event
-    // records are being written yet)
-    final var bpmnResources = new ArrayList<BpmnResource>();
-    while (resourceIterator.hasNext()) {
-      final DeploymentResource deploymentResource = resourceIterator.next();
+    for (final DeploymentResource deploymentResource : deploymentEvent.resources()) {
       final var transformer = getResourceTransformer(deploymentResource);
-      if (transformer instanceof BpmnResourceTransformer) {
-        final var context = new BpmnElementsWithDeploymentBinding();
-        bpmnResources.add(new BpmnResource(deploymentResource, context));
-        success &= createMetadata(deploymentResource, deploymentEvent, context, transformer, errors);
-      } else {
-        success &=
-            createMetadata(
-                deploymentResource,
-                deploymentEvent,
-                new DeploymentResourceContext() {},
-                transformer,
-                errors);
-      }
-    }
+      try {
+        final var result = transformer.createMetadata(deploymentResource, deploymentEvent);
 
-    // intermediate step (for BPMN resources only): validate process elements that use deployment
-    // binding (all linked resources must be part of the current deployment)
-    if (success && !bpmnResources.isEmpty()) {
-      final var validator = new BpmnDeploymentBindingValidator(deploymentEvent);
-      for (final var bpmnResource : bpmnResources) {
-        final var validationError = validator.validate(bpmnResource.elements);
-        if (validationError != null) {
-          success = false;
-          errors
-              .append("\n'")
-              .append(bpmnResource.resource.getResourceName())
-              .append("':\n")
-              .append(validationError);
+        if (result.isRight()) {
+          contexts.add(result.get());
+        } else {
+          errors.add(result.getLeft().getMessage());
         }
+      } catch (final RuntimeException e) {
+        logAndCollectUnexpectedError(deploymentResource.getResourceName(), e, errors);
       }
     }
 
-    // step 2: update metadata (optionally) and write actual event records
-    if (success) {
-      for (final DeploymentResource deploymentResource : deploymentEvent.resources()) {
-        success &= writeRecords(deploymentResource, deploymentEvent, errors);
+    return errors.toEither(contexts);
+  }
+
+  /**
+   * Step 5: Writes the actual resource records to state. This is called after all validation has
+   * passed. Skips writing if the deployment contains only duplicates (versioning invariant).
+   *
+   * @param deploymentEvent the deployment record with metadata
+   */
+  private void writeResourceRecords(final DeploymentRecord deploymentEvent) {
+    // Check if all resources are duplicates - if so, skip writing entirely (versioning invariant)
+    if (deploymentEvent.hasDuplicatesOnly()) {
+      return;
+    }
+
+    final var errors = new ErrorCollector();
+
+    for (final DeploymentResource deploymentResource : deploymentEvent.resources()) {
+      final var transformer = getResourceTransformer(deploymentResource);
+      try {
+        transformer.writeRecords(deploymentResource, deploymentEvent);
+      } catch (final RuntimeException e) {
+        logAndCollectUnexpectedError(deploymentResource.getResourceName(), e, errors);
       }
     }
 
-    if (!success) {
-      rejectionType = RejectionType.INVALID_ARGUMENT;
-      rejectionReason =
-          String.format(
-              "Expected to deploy new resources, but encountered the following errors:%s", errors);
-
-      return Either.left(new Failure(rejectionReason));
+    if (errors.hasErrors()) {
+      // Note: In practice, this should never happen as validation already passed
+      throw new IllegalStateException(errors.formatMessage());
     }
-
-    return Either.right(null);
   }
 
-  private boolean createMetadata(
-      final DeploymentResource deploymentResource,
-      final DeploymentRecord deploymentEvent,
-      final DeploymentResourceContext context,
-      final DeploymentResourceTransformer transformer,
-      final StringBuilder errors) {
-    final var resourceName = deploymentResource.getResourceName();
-
-    if (resourceName.length() > config.maxNameFieldLength()) {
-      errors.append(
-          String.format(
-              "\n- Resource name '%s' exceeds maximum length of %d characters as it has a length of %d characters",
-              resourceName, config.maxNameFieldLength(), resourceName.length()));
-      return false;
-    }
-
-    try {
-      final var result = transformer.createMetadata(deploymentResource, deploymentEvent, context);
-
-      if (result.isRight()) {
-        return true;
-      } else {
-        final var failureMessage = result.getLeft().getMessage();
-        errors.append("\n").append(failureMessage);
-        return false;
-      }
-
-    } catch (final RuntimeException e) {
-      handleUnexpectedError(resourceName, e, errors);
-    }
-    return false;
-  }
-
-  private boolean writeRecords(
-      final DeploymentResource deploymentResource,
-      final DeploymentRecord deploymentEvent,
-      final StringBuilder errors) {
-    final var resourceName = deploymentResource.getResourceName();
-    final var transformer = getResourceTransformer(deploymentResource);
-    try {
-      transformer.writeRecords(deploymentResource, deploymentEvent);
-      return true;
-    } catch (final RuntimeException e) {
-      handleUnexpectedError(resourceName, e, errors);
-    }
-    return false;
-  }
-
-  public RejectionType getRejectionType() {
-    return rejectionType;
-  }
-
-  public String getRejectionReason() {
-    return rejectionReason;
-  }
-
-  private DeploymentResourceTransformer getResourceTransformer(
-      final DeploymentResource resource) {
+  private DeploymentResourceTransformer getResourceTransformer(final DeploymentResource resource) {
     return resourceTransformers.stream()
         .filter(transformer -> transformer.canTransform(resource))
         .findFirst()
@@ -233,12 +179,41 @@ public final class DeploymentTransformer {
                     "No transformer found for resource: " + resource.getResourceName()));
   }
 
-  private static void handleUnexpectedError(
-      final String resourceName, final RuntimeException exception, final StringBuilder errors) {
+  private static void logAndCollectUnexpectedError(
+      final String resourceName, final RuntimeException exception, final ErrorCollector errors) {
     LOG.error("Unexpected error while processing resource '{}'", resourceName, exception);
-    errors.append("\n'").append(resourceName).append("': ").append(exception.getMessage());
+    errors.add("'%s': %s", resourceName, exception.getMessage());
   }
 
-  private record BpmnResource(
-      DeploymentResource resource, BpmnElementsWithDeploymentBinding elements) {}
+  /** Collects errors during metadata building and record writing. */
+  private static final class ErrorCollector {
+
+    private static final String DEFAULT_PREFIX =
+        "Expected to deploy new resources, but encountered the following errors:";
+
+    private final StringBuilder errors = new StringBuilder();
+
+    void add(final String message) {
+      errors.append("\n").append(message);
+    }
+
+    void add(final String format, final Object... args) {
+      errors.append("\n").append(String.format(format, args));
+    }
+
+    boolean hasErrors() {
+      return !errors.isEmpty();
+    }
+
+    String formatMessage() {
+      return DEFAULT_PREFIX + errors;
+    }
+
+    <T> Either<Failure, T> toEither(final T value) {
+      if (hasErrors()) {
+        return Either.left(new Failure(formatMessage()));
+      }
+      return Either.right(value);
+    }
+  }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DmnResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DmnResourceTransformer.java
@@ -33,7 +33,6 @@ import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentResource;
 import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
-import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsMetadataValue;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -41,7 +40,6 @@ import java.io.ByteArrayInputStream;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.function.LongSupplier;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.agrona.DirectBuffer;
 import org.camunda.bpm.model.dmn.instance.ExtensionElements;
@@ -82,22 +80,19 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
   }
 
   @Override
-  public Either<Failure, Void> createMetadata(
-      final DeploymentResource resource,
-      final DeploymentRecord deployment,
-      final DeploymentResourceContext context) {
+  public Either<Failure, DeploymentResourceContext> createMetadata(
+      final DeploymentResource resource, final DeploymentRecord deployment) {
 
     final var dmnResource = new ByteArrayInputStream(resource.getResource());
     final var parsedDrg = decisionEngine.parse(dmnResource);
 
     if (parsedDrg.isValid()) {
-      return checkForDuplicateIds(resource, parsedDrg, deployment)
-          .flatMap(valid -> checkDrdIdNameLength(resource, parsedDrg))
+      return checkDrdIdNameLength(resource, parsedDrg)
           .flatMap(valid -> checkDecisions(resource, parsedDrg))
           .map(
               valid -> {
                 appendMetadataToDeploymentEvent(resource, parsedDrg, deployment);
-                return null;
+                return DeploymentResourceContext.NONE;
               });
 
     } else {
@@ -109,9 +104,6 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
 
   @Override
   public void writeRecords(final DeploymentResource resource, final DeploymentRecord deployment) {
-    if (deployment.hasDuplicatesOnly()) {
-      return;
-    }
     final var checksum = checksumGenerator.checksum(resource.getResourceBuffer());
     deployment.decisionRequirementsMetadata().stream()
         .filter(drg -> checksum.equals(drg.getChecksumBuffer()))
@@ -175,65 +167,6 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
                                 .setDeploymentKey(decision.getDeploymentKey()));
                       });
             });
-  }
-
-  private Either<Failure, ?> checkForDuplicateIds(
-      final DeploymentResource resource,
-      final ParsedDecisionRequirementsGraph parsedDrg,
-      final DeploymentRecord deploymentEvent) {
-
-    return checkDuplicatedDrgIds(resource, parsedDrg, deploymentEvent)
-        .flatMap(noDuplicates -> checkDuplicatedDecisionIds(resource, parsedDrg, deploymentEvent));
-  }
-
-  private Either<Failure, ?> checkDuplicatedDrgIds(
-      final DeploymentResource resource,
-      final ParsedDecisionRequirementsGraph parsedDrg,
-      final DeploymentRecord deploymentEvent) {
-
-    final var decisionRequirementsId = parsedDrg.getId();
-
-    return deploymentEvent.getDecisionRequirementsMetadata().stream()
-        .filter(drg -> drg.getDecisionRequirementsId().equals(decisionRequirementsId))
-        .findFirst()
-        .map(
-            duplicatedDrg -> {
-              final var failureMessage =
-                  String.format(
-                      "Expected the decision requirements ids to be unique within a deployment"
-                          + " but found a duplicated id '%s' in the resources '%s' and '%s'.",
-                      decisionRequirementsId,
-                      duplicatedDrg.getResourceName(),
-                      resource.getResourceName());
-              return Either.left(new Failure(failureMessage));
-            })
-        .orElse(NO_VALIDATION_ERROR);
-  }
-
-  private Either<Failure, ?> checkDuplicatedDecisionIds(
-      final DeploymentResource resource,
-      final ParsedDecisionRequirementsGraph parsedDrg,
-      final DeploymentRecord deploymentEvent) {
-
-    final var decisionIds =
-        parsedDrg.getDecisions().stream().map(ParsedDecision::getId).collect(Collectors.toList());
-
-    return deploymentEvent.getDecisionsMetadata().stream()
-        .filter(decision -> decisionIds.contains(decision.getDecisionId()))
-        .findFirst()
-        .map(
-            duplicatedDecision -> {
-              final var failureMessage =
-                  String.format(
-                      "Expected the decision ids to be unique within a deployment"
-                          + " but found a duplicated id '%s' in the resources '%s' and '%s'.",
-                      duplicatedDecision.getDecisionId(),
-                      findResourceName(
-                          deploymentEvent, duplicatedDecision.getDecisionRequirementsKey()),
-                      resource.getResourceName());
-              return Either.left(new Failure(failureMessage));
-            })
-        .orElse(NO_VALIDATION_ERROR);
   }
 
   private Either<Failure, ?> checkDrdIdNameLength(
@@ -371,16 +304,6 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
                 Either.left(
                     new Failure(String.format(message, maxLength, id, resource.getResourceName()))))
         .orElse(NO_VALIDATION_ERROR);
-  }
-
-  private String findResourceName(
-      final DeploymentRecord deploymentEvent, final long decisionRequirementsKey) {
-
-    return deploymentEvent.getDecisionRequirementsMetadata().stream()
-        .filter(drg -> drg.getDecisionRequirementsKey() == decisionRequirementsKey)
-        .map(DecisionRequirementsMetadataValue::getResourceName)
-        .findFirst()
-        .orElse("<?>");
   }
 
   private void appendMetadataToDeploymentEvent(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DmnResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DmnResourceTransformer.java
@@ -77,6 +77,11 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
   }
 
   @Override
+  public boolean canTransform(final DeploymentResource resource) {
+    return resource.getResourceName().endsWith(".dmn");
+  }
+
+  @Override
   public Either<Failure, Void> createMetadata(
       final DeploymentResource resource,
       final DeploymentRecord deployment,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/FormResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/FormResourceTransformer.java
@@ -52,6 +52,11 @@ public final class FormResourceTransformer implements DeploymentResourceTransfor
   }
 
   @Override
+  public boolean canTransform(final DeploymentResource resource) {
+    return resource.getResourceName().endsWith(".form");
+  }
+
+  @Override
   public Either<Failure, Void> createMetadata(
       final DeploymentResource resource,
       final DeploymentRecord deployment,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/FormResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/FormResourceTransformer.java
@@ -57,41 +57,33 @@ public final class FormResourceTransformer implements DeploymentResourceTransfor
   }
 
   @Override
-  public Either<Failure, Void> createMetadata(
-      final DeploymentResource resource,
-      final DeploymentRecord deployment,
-      final DeploymentResourceContext context) {
+  public Either<Failure, DeploymentResourceContext> createMetadata(
+      final DeploymentResource resource, final DeploymentRecord deployment) {
     return parseForm(resource)
         .flatMap(
             form ->
-                checkForDuplicateFormId(form.id, resource, deployment)
-                    .flatMap(valid -> checkForFormIdLength(form.id, resource))
+                checkForFormIdLength(form.id, resource)
                     .map(
                         valid -> {
                           final FormMetadataRecord formRecord = deployment.formMetadata().add();
                           appendMetadataToFormRecord(formRecord, form, resource, deployment);
-                          return null;
+                          return DeploymentResourceContext.NONE;
                         }));
   }
 
   @Override
   public void writeRecords(final DeploymentResource resource, final DeploymentRecord deployment) {
-    if (deployment.hasDuplicatesOnly()) {
-      return;
-    }
     final var checksum = checksumGenerator.checksum(resource.getResourceBuffer());
     deployment.formMetadata().stream()
         .filter(metadata -> checksum.equals(metadata.getChecksumBuffer()))
         .findFirst()
         .ifPresent(
             metadata -> {
-              var key = metadata.getFormKey();
               if (metadata.isDuplicate()) {
                 // create new version as the deployment contains at least one other non-duplicate
                 // resource and all resources in a deployment should be versioned together
-                key = keyGenerator.nextKey();
                 metadata
-                    .setFormKey(key)
+                    .setFormKey(keyGenerator.nextKey())
                     .setVersion(
                         formState.getNextFormVersion(metadata.getFormId(), metadata.getTenantId()))
                     .setDuplicate(false)
@@ -122,23 +114,6 @@ public final class FormResourceTransformer implements DeploymentResourceTransfor
     return Optional.ofNullable(exception.getCause())
         .map(Throwable::getMessage)
         .orElse(exception.getMessage());
-  }
-
-  private Either<Failure, ?> checkForDuplicateFormId(
-      final String formId, final DeploymentResource resource, final DeploymentRecord record) {
-    return record.getFormMetadata().stream()
-        .filter(metadata -> metadata.getFormId().equals(formId))
-        .findFirst()
-        .map(
-            duplicatedForm -> {
-              final var failureMessage =
-                  String.format(
-                      "Expected the form ids to be unique within a deployment"
-                          + " but found a duplicated id '%s' in the resources '%s' and '%s'.",
-                      formId, duplicatedForm.getResourceName(), resource.getResourceName());
-              return Either.left(new Failure(failureMessage));
-            })
-        .orElse(NO_VALIDATION_ERROR);
   }
 
   private Either<Failure, ?> checkForFormIdLength(
@@ -174,15 +149,11 @@ public final class FormResourceTransformer implements DeploymentResourceTransfor
         .findLatestFormById(formRecord.getFormId(), tenantId)
         .ifPresentOrElse(
             latestForm -> {
-              final boolean isDuplicate =
-                  latestForm.getChecksum().equals(formRecord.getChecksumBuffer())
-                      && latestForm.getResourceName().equals(formRecord.getResourceNameBuffer());
-
-              if (isDuplicate) {
-                final int latestVersion = latestForm.getVersion();
+              if (latestForm.isDuplicateOf(
+                  formRecord.getResourceNameBuffer(), formRecord.getChecksumBuffer())) {
                 formRecord
                     .setFormKey(latestForm.getFormKey())
-                    .setVersion(latestVersion)
+                    .setVersion(latestForm.getVersion())
                     .setDeploymentKey(latestForm.getDeploymentKey())
                     .setDuplicate(true);
               } else {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/RpaTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/RpaTransformer.java
@@ -14,36 +14,22 @@ import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.ChecksumGenerator;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.state.immutable.ResourceState;
-import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentResource;
-import io.camunda.zeebe.protocol.impl.record.value.deployment.ResourceMetadataRecord;
-import io.camunda.zeebe.protocol.impl.record.value.deployment.ResourceRecord;
-import io.camunda.zeebe.protocol.record.intent.ResourceIntent;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.Either;
 import java.io.IOException;
 import java.util.Optional;
-import java.util.function.LongSupplier;
-import org.agrona.DirectBuffer;
 
-public class RpaTransformer implements DeploymentResourceTransformer {
-  private static final int INITIAL_VERSION = 1;
+public class RpaTransformer extends DefaultResourceTransformer {
+
   private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
-
-  private final KeyGenerator keyGenerator;
-  private final StateWriter stateWriter;
-  private final ChecksumGenerator checksumGenerator;
-  private final ResourceState resourceState;
 
   public RpaTransformer(
       final KeyGenerator keyGenerator,
       final StateWriter stateWriter,
       final ChecksumGenerator checksumGenerator,
       final ResourceState resourceState) {
-    this.keyGenerator = keyGenerator;
-    this.stateWriter = stateWriter;
-    this.checksumGenerator = checksumGenerator;
-    this.resourceState = resourceState;
+    super(keyGenerator, stateWriter, checksumGenerator, resourceState);
   }
 
   @Override
@@ -52,109 +38,12 @@ public class RpaTransformer implements DeploymentResourceTransformer {
   }
 
   @Override
-  public Either<Failure, Void> createMetadata(
-      final DeploymentResource deploymentResource,
-      final DeploymentRecord deployment,
-      final DeploymentResourceContext context) {
-    return parseResource(deploymentResource)
-        .flatMap(
-            resource ->
-                checkForDuplicateResourceId(resource.id, deploymentResource, deployment)
-                    .map(
-                        noDuplicates -> {
-                          final ResourceMetadataRecord resourceMetadataRecord =
-                              deployment.resourceMetadata().add();
-                          appendMetadataToResourceRecord(
-                              resourceMetadataRecord, resource, deploymentResource, deployment);
-                          return null;
-                        }));
-  }
-
-  @Override
-  public void writeRecords(final DeploymentResource resource, final DeploymentRecord deployment) {
-    if (deployment.hasDuplicatesOnly()) {
-      return;
-    }
-    final var checksum = checksumGenerator.checksum(resource.getResourceBuffer());
-    deployment.resourceMetadata().stream()
-        .filter(metadata -> checksum.equals(metadata.getChecksumBuffer()))
-        .findFirst()
-        .ifPresent(
-            metadata -> {
-              var key = metadata.getResourceKey();
-              if (metadata.isDuplicate()) {
-                key = keyGenerator.nextKey();
-                metadata
-                    .setResourceKey(key)
-                    .setVersion(
-                        resourceState.getNextResourceVersion(
-                            metadata.getResourceId(), metadata.getTenantId()))
-                    .setDuplicate(false)
-                    .setDeploymentKey(deployment.getDeploymentKey());
-              }
-              writeResourceRecord(metadata, resource);
-            });
-  }
-
-  private void writeResourceRecord(
-      final ResourceMetadataRecord resourceMetadataRecord, final DeploymentResource resource) {
-    stateWriter.appendFollowUpEvent(
-        resourceMetadataRecord.getResourceKey(),
-        ResourceIntent.CREATED,
-        new ResourceRecord().wrap(resourceMetadataRecord, resource.getResource()));
-  }
-
-  private void appendMetadataToResourceRecord(
-      final ResourceMetadataRecord resourceMetadataRecord,
-      final Resource resource,
-      final DeploymentResource deploymentResource,
-      final DeploymentRecord deploymentRecord) {
-    final LongSupplier newResourceKey = keyGenerator::nextKey;
-    final DirectBuffer checksum =
-        checksumGenerator.checksum(deploymentResource.getResourceBuffer());
-    final String tenantId = deploymentRecord.getTenantId();
-
-    resourceMetadataRecord.setResourceId(resource.id);
-    resourceMetadataRecord.setChecksum(checksum);
-    resourceMetadataRecord.setResourceName(deploymentResource.getResourceName());
-    resourceMetadataRecord.setTenantId(tenantId);
-    Optional.ofNullable(resource.versionTag).ifPresent(resourceMetadataRecord::setVersionTag);
-
-    resourceState
-        .findLatestResourceById(resourceMetadataRecord.getResourceId(), tenantId)
-        .ifPresentOrElse(
-            latestResource -> {
-              final boolean isDuplicate =
-                  latestResource.getChecksum().equals(resourceMetadataRecord.getChecksumBuffer())
-                      && latestResource
-                          .getResourceName()
-                          .equals(resourceMetadataRecord.getResourceNameBuffer());
-
-              if (isDuplicate) {
-                final int latestVersion = latestResource.getVersion();
-                resourceMetadataRecord
-                    .setResourceKey(latestResource.getResourceKey())
-                    .setVersion(latestVersion)
-                    .setDeploymentKey(latestResource.getDeploymentKey())
-                    .setDuplicate(true);
-              } else {
-                resourceMetadataRecord
-                    .setResourceKey(newResourceKey.getAsLong())
-                    .setVersion(resourceState.getNextResourceVersion(resource.id, tenantId))
-                    .setDeploymentKey(deploymentRecord.getDeploymentKey());
-              }
-            },
-            () ->
-                resourceMetadataRecord
-                    .setResourceKey(newResourceKey.getAsLong())
-                    .setVersion(INITIAL_VERSION)
-                    .setDeploymentKey(deploymentRecord.getDeploymentKey()));
-  }
-
-  private Either<Failure, Resource> parseResource(final DeploymentResource resource) {
+  protected Either<Failure, ResourceInfo> parseResourceInfo(final DeploymentResource resource) {
     try {
-      final var res = JSON_MAPPER.readValue(resource.getResource(), Resource.class);
-      return validateResource(res);
+      final var rpaResource =
+          JSON_MAPPER.readValue(resource.getResource(), ParsedRpaResource.class);
+      return validateRpaResource(rpaResource)
+          .map(valid -> ResourceInfo.of(valid.id, valid.versionTag));
     } catch (final JsonProcessingException e) {
       final var failureMessage =
           String.format(
@@ -174,7 +63,7 @@ public class RpaTransformer implements DeploymentResourceTransformer {
         .orElse(exception.getMessage());
   }
 
-  private Either<Failure, Resource> validateResource(final Resource res) {
+  private Either<Failure, ParsedRpaResource> validateRpaResource(final ParsedRpaResource res) {
     if (res.id == null) {
       return Either.left(new Failure("Expected the resource id to be present, but none given"));
     }
@@ -184,23 +73,6 @@ public class RpaTransformer implements DeploymentResourceTransformer {
     return Either.right(res);
   }
 
-  private Either<Failure, ?> checkForDuplicateResourceId(
-      final String resourceId, final DeploymentResource resource, final DeploymentRecord record) {
-    return record.getResourceMetadata().stream()
-        .filter(metadata -> metadata.getResourceId().equals(resourceId))
-        .findFirst()
-        .map(
-            dupeResource -> {
-              final var failureMessage =
-                  String.format(
-                      "Expected the resource ids to be unique within a deployment"
-                          + " but found a duplicated id '%s' in the resources '%s' and '%s'.",
-                      resourceId, dupeResource.getResourceName(), resource.getResourceName());
-              return Either.left(new Failure(failureMessage));
-            })
-        .orElse(Either.right(null));
-  }
-
   @JsonIgnoreProperties(ignoreUnknown = true)
-  private record Resource(String id, String versionTag) {}
+  private record ParsedRpaResource(String id, String versionTag) {}
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/RpaTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/RpaTransformer.java
@@ -47,6 +47,11 @@ public class RpaTransformer implements DeploymentResourceTransformer {
   }
 
   @Override
+  public boolean canTransform(final DeploymentResource resource) {
+    return resource.getResourceName().endsWith(".rpa");
+  }
+
+  @Override
   public Either<Failure, Void> createMetadata(
       final DeploymentResource deploymentResource,
       final DeploymentRecord deployment,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedForm.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedForm.java
@@ -119,4 +119,12 @@ public final class PersistedForm extends UnpackedObject implements DbValue {
     deploymentKeyProp.setValue(record.getDeploymentKey());
     versionTagProp.setValue(record.getVersionTag());
   }
+
+  public boolean isDuplicateOf(final DirectBuffer resourceName, final DirectBuffer checksum) {
+    if (!bufferAsString(getResourceName()).equals(bufferAsString(resourceName))) {
+      return false;
+    }
+    return java.util.Arrays.equals(
+        BufferUtil.bufferAsArray(getChecksum()), BufferUtil.bufferAsArray(checksum));
+  }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedResource.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedResource.java
@@ -107,4 +107,12 @@ public class PersistedResource extends UnpackedObject implements DbValue {
     versionTagProp.setValue(record.getVersionTag());
     resourceProp.setValue(record.getResourceProp());
   }
+
+  public boolean isDuplicateOf(final DirectBuffer resourceName, final DirectBuffer checksum) {
+    if (!getResourceName().equals(resourceName)) {
+      return false;
+    }
+    return java.util.Arrays.equals(
+        BufferUtil.bufferAsArray(getChecksum()), BufferUtil.bufferAsArray(checksum));
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/ServiceTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/ServiceTaskTest.java
@@ -19,7 +19,9 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
+import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ResourceIntent;
@@ -282,6 +284,72 @@ public class ServiceTaskTest {
   }
 
   @Test
+  public void shouldCreateJobWithLinkedGenericResourceDeploymentBinding()
+      throws JsonProcessingException {
+    // given
+    final var genericResourceContent = "My script content".getBytes(StandardCharsets.UTF_8);
+    final var genericResourceName = "my-generic-script.txt";
+
+    final BpmnModelInstance modelInstance =
+        Bpmn.createExecutableProcess("genericResourceProcess")
+            .startEvent()
+            .serviceTask(
+                "my_linked_resource",
+                t ->
+                    t.zeebeLinkedResources(
+                            l ->
+                                l.resourceId(genericResourceName)
+                                    .resourceType("GenericScript")
+                                    .bindingType(ZeebeBindingType.deployment)
+                                    .linkName("my_generic_link"))
+                        .zeebeJobType("type"))
+            .endEvent()
+            .done();
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withJsonResource(genericResourceContent, genericResourceName)
+            .withXmlResource(modelInstance)
+            .deploy();
+
+    // Deploy a second version of the generic resource (should not be used — deployment binding
+    // pins to the version deployed alongside the process definition)
+    ENGINE
+        .deployment()
+        .withJsonResource("Updated content".getBytes(StandardCharsets.UTF_8), genericResourceName)
+        .deploy();
+
+    // when
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId("genericResourceProcess").create();
+
+    // then
+    final Record<JobRecordValue> jobCreated =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    assertThat(jobCreated.getValue().getCustomHeaders()).containsKey("linkedResources");
+    final List<LinkedResourceProps> resourcePropsList =
+        MAPPER.readValue(
+            jobCreated.getValue().getCustomHeaders().get("linkedResources"),
+            new TypeReference<>() {});
+
+    assertThat(resourcePropsList).hasSize(1);
+    final LinkedResourceProps resourceProps = resourcePropsList.get(0);
+    assertThat(resourceProps)
+        .hasFieldOrPropertyWithValue("resourceType", "GenericScript")
+        .hasFieldOrPropertyWithValue("linkName", "my_generic_link");
+
+    // The resource key should refer to the version deployed WITH the process (deployment binding),
+    // not the later version
+    final var expectedResourceKey =
+        deployment.getValue().getResourceMetadata().getFirst().getResourceKey();
+    assertThat(resourceProps.getResourceKey()).isEqualTo(String.valueOf(expectedResourceKey));
+  }
+
+  @Test
   public void shouldHandleNotFoundVersionTagBinding() {
     final BpmnModelInstance modelInstance =
         Bpmn.createExecutableProcess("process")
@@ -321,6 +389,9 @@ public class ServiceTaskTest {
 
   @Test
   public void shouldHandleNotFoundDeploymentBinding() {
+    // A deployment with bindingType=deployment is rejected at deploy time when the referenced
+    // resource is not included in the same deployment (validated by
+    // ZeebeLinkedResourceDeploymentBindingValidator).
     final BpmnModelInstance modelInstance =
         Bpmn.createExecutableProcess("process")
             .startEvent()
@@ -338,24 +409,12 @@ public class ServiceTaskTest {
             .endEvent()
             .done();
 
-    final var deployment = ENGINE.deployment().withXmlResource(modelInstance).deploy();
+    final var rejection =
+        ENGINE.deployment().withXmlResource(modelInstance).expectRejection().deploy();
 
-    // when
-    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
-
-    // then
-    final IncidentRecordValue incidentRecordValue =
-        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
-            .withProcessInstanceKey(processInstanceKey)
-            .getFirst()
-            .getValue();
-    assertThat(incidentRecordValue.getErrorType()).isEqualTo(ErrorType.RESOURCE_NOT_FOUND);
-    assertThat(incidentRecordValue.getErrorMessage())
-        .isEqualTo(
-            String.format(
-                BpmnJobBehavior.FIND_RESOURCE_BY_ID_IN_SAME_DEPLOYMENT_FAILED_MESSAGE,
-                "2",
-                deployment.getKey()));
+    Assertions.assertThat(rejection).hasRejectionType(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejection.getRejectionReason())
+        .contains("Expected to find resource with id '2' in current deployment, but not found.");
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -710,4 +710,86 @@ public class DeploymentRejectionTest {
         .hasValueType(ValueType.DEPLOYMENT)
         .hasIntent(DeploymentIntent.CREATED);
   }
+
+  @Test
+  public void
+      shouldRejectDeploymentIfLinkedResourceNotIncludedForServiceTaskWithBindingTypeDeployment() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask(
+                "serviceTask",
+                builder ->
+                    builder
+                        .zeebeLinkedResources(
+                            l ->
+                                l.resourceId("test-rpa-resource")
+                                    .resourceType("RPA")
+                                    .bindingType(ZeebeBindingType.deployment))
+                        .zeebeJobType("type"))
+            .endEvent()
+            .done();
+
+    // when
+    final var rejectedDeployment =
+        ENGINE.deployment().withXmlResource("process.bpmn", process).expectRejection().deploy();
+
+    // then
+    Assertions.assertThat(rejectedDeployment)
+        .hasKey(ExecuteCommandResponseDecoder.keyNullValue())
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasIntent(DeploymentIntent.CREATE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejectedDeployment.getRejectionReason())
+        .isEqualTo(
+            """
+            Expected to deploy new resources, but encountered the following errors:
+            'process.bpmn':
+            - Element: serviceTask > extensionElements > linkedResources > linkedResource
+                - ERROR: Expected to find resource with id 'test-rpa-resource' in current deployment, but not found.
+            """);
+  }
+
+  @Test
+  public void
+      shouldDeploySuccessfullyIfLinkedResourceIncludedForServiceTaskWithBindingTypeDeployment() {
+    // given
+    final var rpaResource =
+        """
+        {
+          "id": "test-rpa-resource",
+          "resourceType": "RPA"
+        }
+        """;
+    final var process =
+        Bpmn.createExecutableProcess("process-linked-resource-success")
+            .startEvent()
+            .serviceTask(
+                "serviceTask",
+                builder ->
+                    builder
+                        .zeebeLinkedResources(
+                            l ->
+                                l.resourceId("test-rpa-resource")
+                                    .resourceType("RPA")
+                                    .bindingType(ZeebeBindingType.deployment))
+                        .zeebeJobType("type"))
+            .endEvent()
+            .done();
+
+    // when
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource("process.bpmn", process)
+            .withJsonResource(rpaResource.getBytes(UTF_8), "resource.rpa")
+            .deploy();
+
+    // then
+    Assertions.assertThat(deployment)
+        .hasRecordType(RecordType.EVENT)
+        .hasValueType(ValueType.DEPLOYMENT)
+        .hasIntent(DeploymentIntent.CREATED);
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -144,21 +144,22 @@ public class DeploymentRejectionTest {
   }
 
   @Test
-  public void shouldRejectDeploymentIfNotParsable() {
-    // when
-    final Record<DeploymentRecordValue> rejectedDeployment =
-        ENGINE
-            .deployment()
-            .withXmlResource("not a process".getBytes(UTF_8))
-            .expectRejection()
-            .deploy();
+  public void shouldDeployNonBpmnXmlAsGenericResource() {
+    // when - deploy invalid BPMN/XML content with .xml extension
+    final Record<DeploymentRecordValue> deployment =
+        ENGINE.deployment().withXmlResource("not a process".getBytes(UTF_8)).deploy();
 
-    // then
-    Assertions.assertThat(rejectedDeployment)
-        .hasKey(ExecuteCommandResponseDecoder.keyNullValue())
-        .hasRecordType(RecordType.COMMAND_REJECTION)
-        .hasIntent(DeploymentIntent.CREATE)
-        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+    // then - it should be accepted as a generic resource, not rejected
+    Assertions.assertThat(deployment)
+        .hasRecordType(RecordType.EVENT)
+        .hasIntent(DeploymentIntent.CREATED);
+
+    assertThat(deployment.getValue().getResourceMetadata())
+        .hasSize(1)
+        .first()
+        .satisfies(
+            metadata ->
+                Assertions.assertThat(metadata).hasResourceName("process.xml").hasVersion(1));
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/ResourceDeploymentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/ResourceDeploymentTest.java
@@ -42,6 +42,9 @@ public class ResourceDeploymentTest {
   private static final String TEST_RESOURCE_WITH_BLANK_ID = "/resource/test-rpa_with_blank_id.rpa";
   private static final String TEST_RESOURCE_1_ID = "Rpa_0w7r08e";
   private static final String TEST_RESOURCE_2_ID = "Rpa_6s1b76p";
+  private static final String TEST_GENERIC_RESOURCE_1 = "/resource/test-generic-1.txt";
+  private static final String TEST_GENERIC_RESOURCE_2 = "/resource/test-generic-2.txt";
+  private static final String TEST_GENERIC_XML_CONFIG = "/resource/test-generic-config.xml";
 
   @Rule public final EngineRule engine = EngineRule.singlePartition();
 
@@ -269,20 +272,24 @@ public class ResourceDeploymentTest {
   }
 
   @Test
-  public void shouldIncreaseVersionIfResourceNameDiffers() {
-    // given
+  public void shouldNotBeDuplicateIfResourceNameDiffers() {
+    // given - two deployments with the same content and resource ID but different filenames
     final var resource = readResource(TEST_RESOURCE_1);
     engine.deployment().withJsonResource(resource, "test-rpa-1.rpa").deploy();
 
-    // when
+    // when - same content deployed under a different filename
     final var deploymentEvent =
         engine.deployment().withJsonResource(resource, "renamed-test-rpa-1.rpa").deploy();
 
-    // then
+    // then - not a duplicate because resourceName is part of the duplicate check
     assertThat(deploymentEvent.getValue().getResourceMetadata())
-        .extracting(ResourceMetadataValue::getVersion)
-        .describedAs("Expect that the Resource version is increased")
-        .containsExactly(2);
+        .singleElement()
+        .satisfies(
+            resourceMetadata ->
+                Assertions.assertThat(resourceMetadata)
+                    .hasVersion(2)
+                    .hasResourceName("renamed-test-rpa-1.rpa")
+                    .isNotDuplicate());
   }
 
   @Test
@@ -548,5 +555,227 @@ public class ResourceDeploymentTest {
       fail("Failed to calculate the checksum", e);
     }
     return checksum;
+  }
+
+  @Test
+  public void shouldDeployGenericResourceAndReturnMetadata() {
+    // when
+    final var deploymentEvent =
+        engine.deployment().withJsonClasspathResource(TEST_GENERIC_RESOURCE_1).deploy();
+
+    // then
+    Assertions.assertThat(deploymentEvent)
+        .hasIntent(DeploymentIntent.CREATED)
+        .hasValueType(ValueType.DEPLOYMENT)
+        .hasRecordType(RecordType.EVENT);
+    assertThat(deploymentEvent.getValue().getResourceMetadata())
+        .singleElement()
+        .satisfies(
+            resourceMetadata ->
+                Assertions.assertThat(resourceMetadata)
+                    .hasResourceId(TEST_GENERIC_RESOURCE_1)
+                    .hasVersion(1)
+                    .hasVersionTag("")
+                    .hasResourceName(TEST_GENERIC_RESOURCE_1)
+                    .hasChecksum(getChecksum(TEST_GENERIC_RESOURCE_1))
+                    .isNotDuplicate()
+                    .hasDeploymentKey(deploymentEvent.getKey()));
+  }
+
+  @Test
+  public void shouldWriteResourceRecordForGenericResource() {
+    // when
+    final var deployment =
+        engine.deployment().withJsonClasspathResource(TEST_GENERIC_RESOURCE_1).deploy();
+
+    // then
+    final Record<Resource> record = RecordingExporter.resourceRecords().getFirst();
+
+    Assertions.assertThat(record)
+        .hasIntent(ResourceIntent.CREATED)
+        .hasValueType(ValueType.RESOURCE)
+        .hasRecordType(RecordType.EVENT);
+
+    final Resource resourceRecord = record.getValue();
+    Assertions.assertThat(resourceRecord)
+        .hasResourceId(TEST_GENERIC_RESOURCE_1)
+        .hasResourceName(TEST_GENERIC_RESOURCE_1)
+        .hasVersion(1)
+        .hasVersionTag("")
+        .hasDeploymentKey(deployment.getKey());
+
+    assertThat(resourceRecord.getResourceKey()).isPositive();
+    assertThat(resourceRecord.isDuplicate()).isFalse();
+  }
+
+  @Test
+  public void shouldDeployGenericResourceDuplicateInSeparateCommand() {
+    // given
+    final var firstDeployment =
+        engine.deployment().withJsonClasspathResource(TEST_GENERIC_RESOURCE_1).deploy();
+    final var resourceV1 = firstDeployment.getValue().getResourceMetadata().get(0);
+
+    // when
+    final var secondDeployment =
+        engine.deployment().withJsonClasspathResource(TEST_GENERIC_RESOURCE_1).deploy();
+
+    // then
+    assertThat(secondDeployment.getValue().getResourceMetadata()).hasSize(1);
+    final var resourceMetadata = secondDeployment.getValue().getResourceMetadata().get(0);
+    Assertions.assertThat(resourceMetadata)
+        .hasVersion(1)
+        .hasResourceKey(resourceV1.getResourceKey())
+        .isDuplicate();
+  }
+
+  @Test
+  public void shouldIncreaseVersionForGenericResourceWithChangedContent() {
+    // given
+    engine.deployment().withJsonClasspathResource(TEST_GENERIC_RESOURCE_1).deploy();
+
+    // when
+    final var secondDeployment =
+        engine
+            .deployment()
+            .withJsonResource(readResource(TEST_GENERIC_RESOURCE_2), TEST_GENERIC_RESOURCE_1)
+            .deploy();
+
+    // then
+    assertThat(secondDeployment.getValue().getResourceMetadata())
+        .extracting(ResourceMetadataValue::getVersion)
+        .describedAs("Expect that the resource version is increased")
+        .containsExactly(2);
+  }
+
+  @Test
+  public void shouldRejectGenericDeploymentWithDuplicateResourceName() {
+    // given
+    final var resource = readResource(TEST_GENERIC_RESOURCE_1);
+
+    // when
+    final var deploymentEvent =
+        engine
+            .deployment()
+            .withJsonResource(resource, TEST_GENERIC_RESOURCE_1)
+            .withJsonResource(resource, TEST_GENERIC_RESOURCE_1)
+            .expectRejection()
+            .deploy();
+
+    // then
+    Assertions.assertThat(deploymentEvent)
+        .hasIntent(DeploymentIntent.CREATE)
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+
+    assertThat(deploymentEvent.getRejectionReason())
+        .contains(
+            String.format(
+                "Expected the resource ids to be unique within a deployment"
+                    + " but found a duplicated id '%s' in the resources '%s' and '%s'.",
+                TEST_GENERIC_RESOURCE_1, TEST_GENERIC_RESOURCE_1, TEST_GENERIC_RESOURCE_1));
+  }
+
+  @Test
+  public void shouldRejectGenericDeploymentWithSameNameButDifferentContent() {
+    // given
+    final var resource1 = readResource(TEST_GENERIC_RESOURCE_1);
+    final var resource2 = readResource(TEST_GENERIC_RESOURCE_2);
+
+    // when - two different files deployed under the same name
+    final var deploymentEvent =
+        engine
+            .deployment()
+            .withJsonResource(resource1, TEST_GENERIC_RESOURCE_1)
+            .withJsonResource(resource2, TEST_GENERIC_RESOURCE_1)
+            .expectRejection()
+            .deploy();
+
+    // then - duplicate resource ID (filename) is rejected
+    Assertions.assertThat(deploymentEvent)
+        .hasIntent(DeploymentIntent.CREATE)
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+
+    assertThat(deploymentEvent.getRejectionReason())
+        .contains(
+            String.format(
+                "Expected the resource ids to be unique within a deployment"
+                    + " but found a duplicated id '%s' in the resources '%s' and '%s'.",
+                TEST_GENERIC_RESOURCE_1, TEST_GENERIC_RESOURCE_1, TEST_GENERIC_RESOURCE_1));
+  }
+
+  @Test
+  public void shouldDeployNonBpmnXmlFileAsGenericResource() {
+    // given - an XML file that is not BPMN
+
+    // when
+    final var deploymentEvent =
+        engine.deployment().withXmlClasspathResource(TEST_GENERIC_XML_CONFIG).deploy();
+
+    // then - it should be deployed as a generic resource, not fail as invalid BPMN
+    Assertions.assertThat(deploymentEvent)
+        .hasIntent(DeploymentIntent.CREATED)
+        .hasValueType(ValueType.DEPLOYMENT)
+        .hasRecordType(RecordType.EVENT);
+
+    assertThat(deploymentEvent.getValue().getResourceMetadata())
+        .singleElement()
+        .satisfies(
+            resourceMetadata ->
+                Assertions.assertThat(resourceMetadata)
+                    .hasResourceId(TEST_GENERIC_XML_CONFIG)
+                    .hasVersion(1)
+                    .hasResourceName(TEST_GENERIC_XML_CONFIG)
+                    .hasChecksum(getChecksum(TEST_GENERIC_XML_CONFIG))
+                    .isNotDuplicate()
+                    .hasDeploymentKey(deploymentEvent.getKey()));
+
+    // Verify resource record was created
+    final Record<Resource> record = RecordingExporter.resourceRecords().getFirst();
+    Assertions.assertThat(record)
+        .hasIntent(ResourceIntent.CREATED)
+        .hasValueType(ValueType.RESOURCE)
+        .hasRecordType(RecordType.EVENT);
+    Assertions.assertThat(record.getValue())
+        .hasResourceId(TEST_GENERIC_XML_CONFIG)
+        .hasVersion(1)
+        .hasResourceName(TEST_GENERIC_XML_CONFIG)
+        .hasChecksum(getChecksum(TEST_GENERIC_XML_CONFIG));
+  }
+
+  @Test
+  public void shouldCreateNewResourceWhenGenericResourceIsRenamed() {
+    // given - first deployment under original filename (filename is the resource ID for generic
+    // resources)
+    final var firstDeployment =
+        engine.deployment().withJsonClasspathResource(TEST_GENERIC_RESOURCE_1).deploy();
+    final var resourceV1 = firstDeployment.getValue().getResourceMetadata().get(0);
+
+    // when - same content deployed under a different filename
+    final var secondDeployment =
+        engine
+            .deployment()
+            .withJsonResource(
+                readResource(TEST_GENERIC_RESOURCE_1), "/resource/renamed-generic-1.txt")
+            .deploy();
+
+    // then - a new, separate resource is created because the filename (= resource ID) changed.
+    assertThat(secondDeployment.getValue().getResourceMetadata())
+        .singleElement()
+        .satisfies(
+            resourceMetadata ->
+                Assertions.assertThat(resourceMetadata)
+                    .hasResourceId("/resource/renamed-generic-1.txt")
+                    .hasResourceName("/resource/renamed-generic-1.txt")
+                    .hasVersion(1)
+                    .isNotDuplicate());
+
+    // and the original resource is unaffected (still at version 1 under the old name)
+    assertThat(resourceV1)
+        .satisfies(
+            metadata ->
+                Assertions.assertThat(metadata)
+                    .hasResourceId(TEST_GENERIC_RESOURCE_1)
+                    .hasVersion(1));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/DeploymentValidatorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/DeploymentValidatorTest.java
@@ -12,7 +12,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.zeebe.engine.processing.deployment.transform.DeploymentResourceContext;
 import io.camunda.zeebe.engine.processing.deployment.transform.ValidationConfig;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
+import org.agrona.DirectBuffer;
 import org.junit.jupiter.api.Test;
 
 class DeploymentValidatorTest {
@@ -20,8 +22,14 @@ class DeploymentValidatorTest {
   private static final int MAX_ID_LENGTH = 256;
   private static final int MAX_NAME_LENGTH = 256;
 
+  private static final DirectBuffer DUMMY_CHECKSUM = BufferUtil.wrapString("checksum");
+
   private final DeploymentValidator validator =
-      new DeploymentValidator(new ValidationConfig(MAX_ID_LENGTH, MAX_NAME_LENGTH));
+      new DeploymentValidator(
+          ValidationConfig.builder()
+              .withMaxIdFieldLength(MAX_ID_LENGTH)
+              .withMaxNameFieldLength(MAX_NAME_LENGTH)
+              .build());
 
   // --- validateResources ---
 
@@ -110,12 +118,18 @@ class DeploymentValidatorTest {
         .processesMetadata()
         .add()
         .setBpmnProcessId("process1")
-        .setResourceName("file1.bpmn");
+        .setResourceName("file1.bpmn")
+        .setChecksum(DUMMY_CHECKSUM)
+        .setVersion(1)
+        .setKey(1);
     deployment
         .processesMetadata()
         .add()
         .setBpmnProcessId("process1")
-        .setResourceName("file2.bpmn");
+        .setResourceName("file2.bpmn")
+        .setChecksum(DUMMY_CHECKSUM)
+        .setVersion(1)
+        .setKey(2);
 
     // when
     final var result =
@@ -137,12 +151,18 @@ class DeploymentValidatorTest {
         .processesMetadata()
         .add()
         .setBpmnProcessId("process1")
-        .setResourceName("file1.bpmn");
+        .setResourceName("file1.bpmn")
+        .setChecksum(DUMMY_CHECKSUM)
+        .setVersion(1)
+        .setKey(1);
     deployment
         .processesMetadata()
         .add()
         .setBpmnProcessId("process2")
-        .setResourceName("file2.bpmn");
+        .setResourceName("file2.bpmn")
+        .setChecksum(DUMMY_CHECKSUM)
+        .setVersion(1)
+        .setKey(2);
 
     // when
     final var result =
@@ -158,8 +178,22 @@ class DeploymentValidatorTest {
   void shouldRejectDuplicateFormIds() {
     // given
     final var deployment = new DeploymentRecord();
-    deployment.formMetadata().add().setFormId("form1").setResourceName("form1.form");
-    deployment.formMetadata().add().setFormId("form1").setResourceName("form1-copy.form");
+    deployment
+        .formMetadata()
+        .add()
+        .setFormId("form1")
+        .setResourceName("form1.form")
+        .setVersion(1)
+        .setFormKey(1)
+        .setChecksum(DUMMY_CHECKSUM);
+    deployment
+        .formMetadata()
+        .add()
+        .setFormId("form1")
+        .setResourceName("form1-copy.form")
+        .setVersion(1)
+        .setFormKey(2)
+        .setChecksum(DUMMY_CHECKSUM);
 
     // when
     final var result =
@@ -183,12 +217,18 @@ class DeploymentValidatorTest {
         .resourceMetadata()
         .add()
         .setResourceId("my-script.txt")
-        .setResourceName("my-script.txt");
+        .setResourceName("my-script.txt")
+        .setVersion(1)
+        .setResourceKey(1)
+        .setChecksum(DUMMY_CHECKSUM);
     deployment
         .resourceMetadata()
         .add()
         .setResourceId("my-script.txt")
-        .setResourceName("my-script.txt");
+        .setResourceName("my-script.txt")
+        .setVersion(1)
+        .setResourceKey(2)
+        .setChecksum(DUMMY_CHECKSUM);
 
     // when
     final var result =
@@ -209,12 +249,18 @@ class DeploymentValidatorTest {
         .resourceMetadata()
         .add()
         .setResourceId("script1.txt")
-        .setResourceName("script1.txt");
+        .setResourceName("script1.txt")
+        .setVersion(1)
+        .setResourceKey(1)
+        .setChecksum(DUMMY_CHECKSUM);
     deployment
         .resourceMetadata()
         .add()
         .setResourceId("script2.txt")
-        .setResourceName("script2.txt");
+        .setResourceName("script2.txt")
+        .setVersion(1)
+        .setResourceKey(2)
+        .setChecksum(DUMMY_CHECKSUM);
 
     // when
     final var result =
@@ -234,12 +280,18 @@ class DeploymentValidatorTest {
         .decisionRequirementsMetadata()
         .add()
         .setDecisionRequirementsId("drg1")
-        .setResourceName("decisions1.dmn");
+        .setResourceName("decisions1.dmn")
+        .setDecisionRequirementsVersion(1)
+        .setDecisionRequirementsKey(1)
+        .setChecksum(DUMMY_CHECKSUM);
     deployment
         .decisionRequirementsMetadata()
         .add()
         .setDecisionRequirementsId("drg1")
-        .setResourceName("decisions2.dmn");
+        .setResourceName("decisions2.dmn")
+        .setDecisionRequirementsVersion(1)
+        .setDecisionRequirementsKey(2)
+        .setChecksum(DUMMY_CHECKSUM);
 
     // when
     final var result =
@@ -266,7 +318,8 @@ class DeploymentValidatorTest {
     // then
     assertThat(result.isLeft()).isTrue();
     // Empty deployment error doesn't use the prefix (it's a standalone message)
-    assertThat(result.getLeft().getMessage()).startsWith("Expected to deploy at least one resource");
+    assertThat(result.getLeft().getMessage())
+        .startsWith("Expected to deploy at least one resource");
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/DeploymentValidatorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/DeploymentValidatorTest.java
@@ -1,0 +1,301 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.processing.deployment.transform.DeploymentResourceContext;
+import io.camunda.zeebe.engine.processing.deployment.transform.ValidationConfig;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class DeploymentValidatorTest {
+
+  private static final int MAX_ID_LENGTH = 256;
+  private static final int MAX_NAME_LENGTH = 256;
+
+  private final DeploymentValidator validator =
+      new DeploymentValidator(new ValidationConfig(MAX_ID_LENGTH, MAX_NAME_LENGTH));
+
+  // --- validateResources ---
+
+  @Test
+  void shouldRejectEmptyDeployment() {
+    // given
+    final var deployment = new DeploymentRecord();
+
+    // when
+    final var result = validator.validateResources(deployment);
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft().getMessage())
+        .isEqualTo("Expected to deploy at least one resource, but none given");
+  }
+
+  @Test
+  void shouldAcceptDeploymentWithResources() {
+    // given
+    final var deployment = new DeploymentRecord();
+    deployment.resources().add().setResourceName("process.bpmn");
+
+    // when
+    final var result = validator.validateResources(deployment);
+
+    // then
+    assertThat(result.isRight()).isTrue();
+  }
+
+  @Test
+  void shouldRejectResourceNameExceedingMaxLength() {
+    // given
+    final var deployment = new DeploymentRecord();
+    final var longName = "a".repeat(MAX_NAME_LENGTH + 1) + ".bpmn";
+    deployment.resources().add().setResourceName(longName);
+
+    // when
+    final var result = validator.validateResources(deployment);
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft().getMessage())
+        .contains("exceeds maximum length of %d characters".formatted(MAX_NAME_LENGTH));
+  }
+
+  @Test
+  void shouldAcceptResourceNameAtMaxLength() {
+    // given
+    final var deployment = new DeploymentRecord();
+    final var name = "a".repeat(MAX_NAME_LENGTH);
+    deployment.resources().add().setResourceName(name);
+
+    // when
+    final var result = validator.validateResources(deployment);
+
+    // then
+    assertThat(result.isRight()).isTrue();
+  }
+
+  @Test
+  void shouldCollectMultipleResourceNameErrors() {
+    // given
+    final var deployment = new DeploymentRecord();
+    final var longName1 = "a".repeat(MAX_NAME_LENGTH + 1) + ".bpmn";
+    final var longName2 = "b".repeat(MAX_NAME_LENGTH + 1) + ".dmn";
+    deployment.resources().add().setResourceName(longName1);
+    deployment.resources().add().setResourceName(longName2);
+
+    // when
+    final var result = validator.validateResources(deployment);
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    final var message = result.getLeft().getMessage();
+    assertThat(message).contains(longName1).contains(longName2);
+  }
+
+  // --- validateMetadata: duplicate process IDs ---
+
+  @Test
+  void shouldRejectDuplicateProcessIds() {
+    // given
+    final var deployment = new DeploymentRecord();
+    deployment
+        .processesMetadata()
+        .add()
+        .setBpmnProcessId("process1")
+        .setResourceName("file1.bpmn");
+    deployment
+        .processesMetadata()
+        .add()
+        .setBpmnProcessId("process1")
+        .setResourceName("file2.bpmn");
+
+    // when
+    final var result =
+        validator.validateMetadata(deployment, List.of(DeploymentResourceContext.NONE));
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft().getMessage())
+        .contains("Duplicated process id")
+        .contains("file1.bpmn")
+        .contains("file2.bpmn");
+  }
+
+  @Test
+  void shouldAcceptUniqueProcessIds() {
+    // given
+    final var deployment = new DeploymentRecord();
+    deployment
+        .processesMetadata()
+        .add()
+        .setBpmnProcessId("process1")
+        .setResourceName("file1.bpmn");
+    deployment
+        .processesMetadata()
+        .add()
+        .setBpmnProcessId("process2")
+        .setResourceName("file2.bpmn");
+
+    // when
+    final var result =
+        validator.validateMetadata(deployment, List.of(DeploymentResourceContext.NONE));
+
+    // then
+    assertThat(result.isRight()).isTrue();
+  }
+
+  // --- validateMetadata: duplicate form IDs ---
+
+  @Test
+  void shouldRejectDuplicateFormIds() {
+    // given
+    final var deployment = new DeploymentRecord();
+    deployment.formMetadata().add().setFormId("form1").setResourceName("form1.form");
+    deployment.formMetadata().add().setFormId("form1").setResourceName("form1-copy.form");
+
+    // when
+    final var result =
+        validator.validateMetadata(deployment, List.of(DeploymentResourceContext.NONE));
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft().getMessage())
+        .contains("duplicated id 'form1'")
+        .contains("form1.form")
+        .contains("form1-copy.form");
+  }
+
+  // --- validateMetadata: duplicate resource IDs ---
+
+  @Test
+  void shouldRejectDuplicateResourceIds() {
+    // given
+    final var deployment = new DeploymentRecord();
+    deployment
+        .resourceMetadata()
+        .add()
+        .setResourceId("my-script.txt")
+        .setResourceName("my-script.txt");
+    deployment
+        .resourceMetadata()
+        .add()
+        .setResourceId("my-script.txt")
+        .setResourceName("my-script.txt");
+
+    // when
+    final var result =
+        validator.validateMetadata(deployment, List.of(DeploymentResourceContext.NONE));
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft().getMessage())
+        .contains("duplicated id 'my-script.txt'")
+        .contains("my-script.txt");
+  }
+
+  @Test
+  void shouldAcceptUniqueResourceIds() {
+    // given
+    final var deployment = new DeploymentRecord();
+    deployment
+        .resourceMetadata()
+        .add()
+        .setResourceId("script1.txt")
+        .setResourceName("script1.txt");
+    deployment
+        .resourceMetadata()
+        .add()
+        .setResourceId("script2.txt")
+        .setResourceName("script2.txt");
+
+    // when
+    final var result =
+        validator.validateMetadata(deployment, List.of(DeploymentResourceContext.NONE));
+
+    // then
+    assertThat(result.isRight()).isTrue();
+  }
+
+  // --- validateMetadata: duplicate DRG IDs ---
+
+  @Test
+  void shouldRejectDuplicateDecisionRequirementsIds() {
+    // given
+    final var deployment = new DeploymentRecord();
+    deployment
+        .decisionRequirementsMetadata()
+        .add()
+        .setDecisionRequirementsId("drg1")
+        .setResourceName("decisions1.dmn");
+    deployment
+        .decisionRequirementsMetadata()
+        .add()
+        .setDecisionRequirementsId("drg1")
+        .setResourceName("decisions2.dmn");
+
+    // when
+    final var result =
+        validator.validateMetadata(deployment, List.of(DeploymentResourceContext.NONE));
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft().getMessage())
+        .contains("duplicated id 'drg1'")
+        .contains("decisions1.dmn")
+        .contains("decisions2.dmn");
+  }
+
+  // --- error message formatting ---
+
+  @Test
+  void shouldPrefixErrorMessageCorrectly() {
+    // given
+    final var deployment = new DeploymentRecord();
+
+    // when
+    final var result = validator.validateResources(deployment);
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    // Empty deployment error doesn't use the prefix (it's a standalone message)
+    assertThat(result.getLeft().getMessage()).startsWith("Expected to deploy at least one resource");
+  }
+
+  @Test
+  void shouldIncludeErrorPrefixForResourceNameErrors() {
+    // given
+    final var deployment = new DeploymentRecord();
+    final var longName = "a".repeat(MAX_NAME_LENGTH + 1) + ".bpmn";
+    deployment.resources().add().setResourceName(longName);
+
+    // when
+    final var result = validator.validateResources(deployment);
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft().getMessage())
+        .startsWith("Expected to deploy new resources, but encountered the following errors:");
+  }
+
+  // --- validateMetadata with empty contexts ---
+
+  @Test
+  void shouldAcceptEmptyDeploymentMetadata() {
+    // given - no metadata at all (no processes, no decisions, no forms, no resources)
+    final var deployment = new DeploymentRecord();
+
+    // when
+    final var result = validator.validateMetadata(deployment, List.of());
+
+    // then
+    assertThat(result.isRight()).isTrue();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceFetchTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceFetchTest.java
@@ -89,6 +89,38 @@ public class ResourceFetchTest {
   }
 
   @Test
+  public void shouldFetchGenericResource() throws Exception {
+    // given
+    final var resourceContent = "Hello, generic resource!".getBytes();
+    final var resourceName = "my-script.txt";
+    final var deployment =
+        engine.deployment().withJsonResource(resourceContent, resourceName).deploy();
+    final var resourceMetadata = deployment.getValue().getResourceMetadata().getFirst();
+    final var resourceKey = resourceMetadata.getResourceKey();
+
+    // when
+    final var record =
+        engine
+            .resourceFetch()
+            .withResourceKey(resourceKey)
+            .withRequestStreamId(10)
+            .withRequestId(123456789L)
+            .fetch();
+
+    // then - resourceId equals the filename for generic resources
+    ResourceAssert.assertThat(record.getValue())
+        .isNotNull()
+        .hasResourceProp(new String(resourceContent))
+        .hasResourceKey(resourceKey)
+        .hasResourceId(resourceName)
+        .hasResourceName(resourceName)
+        .hasVersion(1)
+        .hasVersionTag("")
+        .hasDeploymentKey(deployment.getKey())
+        .hasChecksum(resourceMetadata.getChecksum());
+  }
+
+  @Test
   public void shouldRejectIfResourceNotFound() {
     // given
     final var unknownResourceKey = 123456789L;

--- a/zeebe/engine/src/test/resources/resource/test-generic-1.txt
+++ b/zeebe/engine/src/test/resources/resource/test-generic-1.txt
@@ -1,0 +1,1 @@
+Hello, I am a generic resource.

--- a/zeebe/engine/src/test/resources/resource/test-generic-2.txt
+++ b/zeebe/engine/src/test/resources/resource/test-generic-2.txt
@@ -1,0 +1,1 @@
+Hello, I am a different generic resource.

--- a/zeebe/engine/src/test/resources/resource/test-generic-config.xml
+++ b/zeebe/engine/src/test/resources/resource/test-generic-config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <setting name="timeout" value="30"/>
+  <setting name="retries" value="3"/>
+  <setting name="mode" value="production"/>
+  <features>
+    <feature name="logging" enabled="true"/>
+    <feature name="monitoring" enabled="false"/>
+  </features>
+</configuration>

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentRecord.java
@@ -246,11 +246,33 @@ public final class DeploymentRecord extends UnifiedRecordValue implements Deploy
         .anyMatch(x -> x.endsWith(".rpa"));
   }
 
+  /**
+   * Returns {@code true} if every resource in this deployment is a duplicate of an already-deployed
+   * version (i.e. its content and filename have not changed since the last deployment), {@code
+   * false} if at least one resource is new or changed.
+   */
   public boolean hasDuplicatesOnly() {
     return processesMetadata().stream().allMatch(ProcessMetadata::isDuplicate)
         && decisionRequirementsMetadata().stream()
             .allMatch(DecisionRequirementsMetadataValue::isDuplicate)
         && formMetadata().stream().allMatch(FormMetadataValue::isDuplicate)
         && resourceMetadata().stream().allMatch(ResourceMetadataValue::isDuplicate);
+  }
+
+  /**
+   * Returns the resource name (filename) of the DRG that contains the given decision. Decisions
+   * don't carry their own resource name — they belong to a decision requirements graph (DRG), and
+   * the DRG carries the resource name.
+   *
+   * @param decision the decision metadata to look up
+   * @return the resource name of the parent DRG, or {@code null} if not found
+   */
+  public String getResourceNameForDecision(final DecisionRecordValue decision) {
+    for (final var drg : decisionRequirementsMetadataProp) {
+      if (drg.getDecisionRequirementsKey() == decision.getDecisionRequirementsKey()) {
+        return drg.getResourceName();
+      }
+    }
+    return null;
   }
 }


### PR DESCRIPTION
## Summary
- **Commit 1**: Add support for deploying arbitrary file types as generic resources. Introduces `DefaultResourceTransformer` as fallback, `canTransform()` dispatch, XML-sniffing for BPMN vs generic `.xml` files
- **Commit 2**: Validate `zeebe:linkedResource` with `bindingType=deployment` at deploy time (shifts from runtime incident to deploy-time rejection)
- **Commit 3**: Extract cross-resource validation into `DeploymentValidator`, simplify `DeploymentTransformer` into a clean multi-step pipeline, `RpaTransformer` extends `DefaultResourceTransformer`
- **Commit 4**: Mark cache invalidation in `DeploymentCreateProcessor` as needing review for generic resources

## Test plan
- [x] New unit tests for `DeploymentValidator` (14 tests covering all validation error cases)
- [x] Integration tests for generic resource deployment (deploy, versioning, duplicates, rename, non-BPMN XML)
- [x] Integration tests for linked resource binding validation (rejection when missing, success when present)
- [x] Integration test for generic resource fetch via `ResourceFetchTest`
- [x] `ServiceTaskTest` for generic resource deployment binding with job creation
- [ ] CI pipeline validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)