### PR TITLE
Enable prefering REST for real

### DIFF
--- a/load-tests/load-test-values.yaml
+++ b/load-tests/load-test-values.yaml
@@ -2,6 +2,16 @@ global:
   preferRest:
     enabled: true
 
+  nodeSelector:
+    component: benchmark-n2-standard-4
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule
+
 # Saas configuration to run load tests against Camunda SaaS environment
 saas:
   # Saas.enabled if true enables the load tests to run against Camunda SaaS
@@ -42,14 +52,3 @@ saas:
     zeebeGrpcAddress: "http://camunda-gateway:26500"
     # Saas.credentials.authorizationAudience to define the auth audience of the cluster
     authorizationAudience: "orchestration-api"
-
-global:
-  nodeSelector:
-    component: benchmark-n2-standard-4
-    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
-
-  tolerations:
-    - key: nodepool
-      operator: Equal
-      value: n2-standard-4
-      effect: NoSchedule


### PR DESCRIPTION
We recently enabled REST api per default via https://github.com/camunda/camunda/pull/49938 but this didn't work in our daily tests.


 * We had global value section twice. This caused to override the first one
 * Merging both - moving the second above fixes the rest, enabling
 * Moving on top, as global should be at the top (for consistency)


Before

```
camunda/load-tests main $? k8s:camunda-benchmark-prod:c8-medic-daily-2026-04-10-42067c3e-test 
$ helm template test camunda-load-tests/camunda-load-tests -f load-test-values.yaml --show-only templates/starter.yaml | grep preferRest
                -Dapp.preferRest=false
```


After

```
$ helm template test camunda-load-tests/camunda-load-tests -f load-test-values.yaml --show-only templates/starter.yaml | grep preferRest
                -Dapp.preferRest=true
```


Related thread https://camunda.slack.com/archives/C0A22S6M4TF/p1775840263313199