### PR TITLE
refactor: remove 8.6 from scheduled tests

### DIFF
--- a/.github/workflows/camunda-scheduled-release-load-tests.yml
+++ b/.github/workflows/camunda-scheduled-release-load-tests.yml
@@ -29,14 +29,6 @@ jobs:
   # When to update:
   # - A new minor version is released (e.g., 8.10): add a new job and update verify-and-cleanup/notify
   # - A stable branch is deprecated: remove the corresponding job and update verify-and-cleanup/notify
-  release-load-test-8-6:
-    name: Release load test (stable/8.6)
-    uses: camunda/camunda/.github/workflows/camunda-release-load-test.yaml@stable/8.6
-    secrets: inherit
-    with:
-      name: schedule-release-8-6-x
-      tag: '8.6.38'
-
   release-load-test-8-7:
     name: Release load test (stable/8.7)
     uses: camunda/camunda/.github/workflows/camunda-release-load-test.yaml@stable/8.7
@@ -72,15 +64,6 @@ jobs:
 
   # Verify and cleanup jobs — one per branch, run in parallel.
   # Each job waits for pods + gateway connectivity, then deletes the namespace.
-  verify-and-cleanup-8-6:
-    name: Verify and cleanup (stable/8.6)
-    needs: [release-load-test-8-6]
-    if: always()
-    uses: ./.github/workflows/camunda-verify-and-cleanup-load-test.yml
-    secrets: inherit
-    with:
-      namespace: c8-schedule-release-8-6-x
-
   verify-and-cleanup-8-7:
     name: Verify and cleanup (stable/8.7)
     needs: [release-load-test-8-7]
@@ -120,10 +103,9 @@ jobs:
   notify-on-success:
     name: Notify on success
     runs-on: ubuntu-latest
-    needs: [verify-and-cleanup-8-6, verify-and-cleanup-8-7, verify-and-cleanup-8-8, verify-and-cleanup-8-9, verify-and-cleanup-main]
+    needs: [verify-and-cleanup-8-7, verify-and-cleanup-8-8, verify-and-cleanup-8-9, verify-and-cleanup-main]
     if: >-
       always() &&
-      needs.verify-and-cleanup-8-6.result == 'success' &&
       needs.verify-and-cleanup-8-7.result == 'success' &&
       needs.verify-and-cleanup-8-8.result == 'success' &&
       needs.verify-and-cleanup-8-9.result == 'success' &&
@@ -162,7 +144,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*Tested versions:*\n- stable/8.6: `8.6.38` (${{ needs.verify-and-cleanup-8-6.result }})\n- stable/8.7: `8.7.25` (${{ needs.verify-and-cleanup-8-7.result }})\n- stable/8.8: `8.8.17` (${{ needs.verify-and-cleanup-8-8.result }})\n- stable/8.9: `8.9.0-alpha5` (${{ needs.verify-and-cleanup-8-9.result }})\n- main: `8.9.0-alpha5` (${{ needs.verify-and-cleanup-main.result }})"
+                    "text": "*Tested versions:*\n- stable/8.7: `8.7.25` (${{ needs.verify-and-cleanup-8-7.result }})\n- stable/8.8: `8.8.17` (${{ needs.verify-and-cleanup-8-8.result }})\n- stable/8.9: `8.9.0-alpha5` (${{ needs.verify-and-cleanup-8-9.result }})\n- main: `8.9.0-alpha5` (${{ needs.verify-and-cleanup-main.result }})"
                   }
                 },
                 {
@@ -189,11 +171,10 @@ jobs:
   notify-on-failure:
     name: Notify on failure
     runs-on: ubuntu-latest
-    needs: [verify-and-cleanup-8-6, verify-and-cleanup-8-7, verify-and-cleanup-8-8, verify-and-cleanup-8-9, verify-and-cleanup-main]
+    needs: [verify-and-cleanup-8-7, verify-and-cleanup-8-8, verify-and-cleanup-8-9, verify-and-cleanup-main]
     if: >-
       always() &&
-      (needs.verify-and-cleanup-8-6.result == 'failure' ||
-      needs.verify-and-cleanup-8-7.result == 'failure' ||
+      (needs.verify-and-cleanup-8-7.result == 'failure' ||
       needs.verify-and-cleanup-8-8.result == 'failure' ||
       needs.verify-and-cleanup-8-9.result == 'failure' ||
       needs.verify-and-cleanup-main.result == 'failure')
@@ -231,7 +212,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*Job results:*\n- stable/8.6: ${{ needs.verify-and-cleanup-8-6.result }}\n- stable/8.7: ${{ needs.verify-and-cleanup-8-7.result }}\n- stable/8.8: ${{ needs.verify-and-cleanup-8-8.result }}\n- stable/8.9: ${{ needs.verify-and-cleanup-8-9.result }}\n- main: ${{ needs.verify-and-cleanup-main.result }}"
+                    "text": "*Job results:*\n- stable/8.7: ${{ needs.verify-and-cleanup-8-7.result }}\n- stable/8.8: ${{ needs.verify-and-cleanup-8-8.result }}\n- stable/8.9: ${{ needs.verify-and-cleanup-8-9.result }}\n- main: ${{ needs.verify-and-cleanup-main.result }}"
                   }
                 },
                 {


### PR DESCRIPTION
## Description
 * 8.6 reached end of life, we can remove the tests related to it

## Related issues

related https://camunda.slack.com/archives/C0A22S6M4TF/p1775717318168719
