### PR TITLE
Fix/job api tests isolation with unique ids

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-api-tests.spec.ts
@@ -7,10 +7,11 @@
  */
 
 import {expect, test} from '@playwright/test';
+import {randomUUID} from 'crypto';
 import {
   cancelProcessInstance,
   createInstances,
-  deploy,
+  deployWithSubstitutions,
 } from '../../../../utils/zeebeClient';
 import {
   assertBadRequest,
@@ -20,7 +21,6 @@ import {
   assertUnauthorizedRequest,
   buildUrl,
   jsonHeaders,
-  paginatedResponseFields,
 } from '../../../../utils/http';
 import {
   validateResponse,
@@ -31,14 +31,19 @@ import {jobResponseFields} from '../../../../utils/beans/requestBeans';
 
 test.describe.parallel('Job API Tests', () => {
   const state: Record<string, unknown> = {};
+  const runSuffix = randomUUID().slice(0, 8);
+  const processId = `processWithThreeParallelTasks-${runSuffix}`;
+  const someTaskType = `someTask-${runSuffix}`;
 
   test.beforeAll(async () => {
-    await deploy(['./resources/processWithThreeParallelTasks.bpmn']);
-    const processInstance = await createInstances(
-      'processWithThreeParallelTasks',
-      1,
-      1,
+    await deployWithSubstitutions(
+      './resources/processWithThreeParallelTasks.bpmn',
+      {
+        processWithThreeParallelTasks: processId,
+        someTask: someTaskType,
+      },
     );
+    const processInstance = await createInstances(processId, 1, 1);
     state['processInstanceKey'] = processInstance[0].processInstanceKey;
     state['processDefinitionKey'] = processInstance[0].processDefinitionKey;
     state['processDefinitionVersion'] =
@@ -54,8 +59,8 @@ test.describe.parallel('Job API Tests', () => {
 
   test('Activate Jobs - only required fields', async ({request}) => {
     const expectedJobFields: Record<string, unknown> = {
-      type: 'someTask',
-      processDefinitionId: 'processWithThreeParallelTasks',
+      type: someTaskType,
+      processDefinitionId: processId,
       processDefinitionVersion: state['processDefinitionVersion'],
       elementId: 'Activity_0r0cymb',
       customHeaders: {},
@@ -71,7 +76,7 @@ test.describe.parallel('Job API Tests', () => {
     const res = await request.post(buildUrl('/jobs/activation'), {
       headers: jsonHeaders(),
       data: {
-        type: 'someTask',
+        type: someTaskType,
         timeout: 10000,
         maxJobsToActivate: 1,
       },

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-completion-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-completion-api-tests.spec.ts
@@ -7,10 +7,11 @@
  */
 
 import {test} from '@playwright/test';
+import {randomUUID} from 'crypto';
 import {
   cancelProcessInstance,
   createInstances,
-  deploy,
+  deployWithSubstitutions,
 } from '../../../../utils/zeebeClient';
 import {
   assertBadRequest,
@@ -21,17 +22,24 @@ import {
 } from '../../../../utils/http';
 import {activateJobToObtainAValidJobKey} from '@requestHelpers';
 
+const runSuffix = randomUUID().slice(0, 8);
+const processId = `jobApiProcess-completion-${runSuffix}`;
+const taskType = `jobApiTaskType-completion-${runSuffix}`;
+
 // Running the job tests on the same process instance leads to conflicts
 /* eslint-disable playwright/expect-expect */
 test.describe('Job Completion API Tests', () => {
   const state: Record<string, unknown> = {};
 
   test.beforeAll(async () => {
-    await deploy(['./resources/job_api_process.bpmn']);
+    await deployWithSubstitutions('./resources/job_api_process.bpmn', {
+      jobApiProcess: processId,
+      jobApiTaskType: taskType,
+    });
   });
 
   test.beforeEach(async () => {
-    const processInstance = await createInstances('jobApiProcess', 1, 1);
+    const processInstance = await createInstances(processId, 1, 1);
     state['processInstanceKey'] = processInstance[0].processInstanceKey;
   });
 
@@ -42,10 +50,7 @@ test.describe('Job Completion API Tests', () => {
   });
 
   test('Complete Job - success', async ({request}) => {
-    const jobKey = await activateJobToObtainAValidJobKey(
-      request,
-      'jobApiTaskType',
-    );
+    const jobKey = await activateJobToObtainAValidJobKey(request, taskType);
 
     const completeRes = await request.post(
       buildUrl(`/jobs/${jobKey}/completion`),
@@ -99,7 +104,7 @@ test.describe('Job Completion API Tests', () => {
     await test.step('Activate a job to obtain a valid job key', async () => {
       localState['jobKey'] = await activateJobToObtainAValidJobKey(
         request,
-        'jobApiTaskType',
+        taskType,
       );
     });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-error-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-error-api-tests.spec.ts
@@ -7,6 +7,7 @@
  */
 
 import {expect, test} from '@playwright/test';
+import {randomUUID} from 'crypto';
 import {
   assertBadRequest,
   assertNotFoundRequest,
@@ -19,11 +20,18 @@ import {
   setupProcessInstanceForTests,
 } from '@requestHelpers';
 
+const runSuffix = randomUUID().slice(0, 8);
+const processId = `jobApiProcess-error-${runSuffix}`;
+const taskType = `jobApiTaskType-error-${runSuffix}`;
+
 /* eslint-disable playwright/expect-expect */
 test.describe('Job Error API Tests', () => {
   const {beforeAll, beforeEach, afterEach} = setupProcessInstanceForTests(
     'job_api_process',
-    'jobApiProcess',
+    {
+      processName: processId,
+      substitutions: {jobApiProcess: processId, jobApiTaskType: taskType},
+    },
   );
 
   test.beforeAll(beforeAll);
@@ -33,10 +41,7 @@ test.describe('Job Error API Tests', () => {
   test.afterEach(afterEach);
 
   test('Throw Error for Job - success', async ({request}) => {
-    const jobKey = await activateJobToObtainAValidJobKey(
-      request,
-      'jobApiTaskType',
-    );
+    const jobKey = await activateJobToObtainAValidJobKey(request, taskType);
 
     const errorRes = await request.post(buildUrl(`/jobs/${jobKey}/error`), {
       headers: jsonHeaders(),
@@ -84,7 +89,7 @@ test.describe('Job Error API Tests', () => {
     await test.step('Activate job to obtain a valid job key', async () => {
       localState['jobKey'] = await activateJobToObtainAValidJobKey(
         request,
-        'jobApiTaskType',
+        taskType,
       );
     });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-failure-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-failure-api-tests.spec.ts
@@ -7,6 +7,7 @@
  */
 
 import {test} from '@playwright/test';
+import {randomUUID} from 'crypto';
 import {
   assertBadRequest,
   assertNotFoundRequest,
@@ -19,11 +20,18 @@ import {
   setupProcessInstanceForTests,
 } from '@requestHelpers';
 
+const runSuffix = randomUUID().slice(0, 8);
+const processId = `jobApiProcess-failure-${runSuffix}`;
+const taskType = `jobApiTaskType-failure-${runSuffix}`;
+
 /* eslint-disable playwright/expect-expect */
 test.describe('Job Fail API Tests', () => {
   const {beforeAll, beforeEach, afterEach} = setupProcessInstanceForTests(
     'job_api_process',
-    'jobApiProcess',
+    {
+      processName: processId,
+      substitutions: {jobApiProcess: processId, jobApiTaskType: taskType},
+    },
   );
 
   test.beforeAll(beforeAll);
@@ -33,10 +41,7 @@ test.describe('Job Fail API Tests', () => {
   test.afterEach(afterEach);
 
   test('Fail Job - success', async ({request}) => {
-    const jobKey = await activateJobToObtainAValidJobKey(
-      request,
-      'jobApiTaskType',
-    );
+    const jobKey = await activateJobToObtainAValidJobKey(request, taskType);
 
     // Now fail the job
     const failRes = await request.post(buildUrl(`/jobs/${jobKey}/failure`), {
@@ -85,7 +90,7 @@ test.describe('Job Fail API Tests', () => {
     await test.step('First activate a job', async () => {
       localState['jobKey'] = await activateJobToObtainAValidJobKey(
         request,
-        'jobApiTaskType',
+        taskType,
       );
     });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-update-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-update-api-tests.spec.ts
@@ -7,6 +7,7 @@
  */
 
 import {test} from '@playwright/test';
+import {randomUUID} from 'crypto';
 import {
   assertBadRequest,
   assertNotFoundRequest,
@@ -19,11 +20,18 @@ import {
   setupProcessInstanceForTests,
 } from '@requestHelpers';
 
+const runSuffix = randomUUID().slice(0, 8);
+const processId = `jobApiProcess-update-${runSuffix}`;
+const taskType = `jobApiTaskType-update-${runSuffix}`;
+
 /* eslint-disable playwright/expect-expect */
 test.describe('Job Update API Tests', () => {
   const {beforeAll, beforeEach, afterEach} = setupProcessInstanceForTests(
     'job_api_process',
-    'jobApiProcess',
+    {
+      processName: processId,
+      substitutions: {jobApiProcess: processId, jobApiTaskType: taskType},
+    },
   );
 
   test.beforeAll(beforeAll);
@@ -33,10 +41,7 @@ test.describe('Job Update API Tests', () => {
   test.afterEach(afterEach);
 
   test('Update Job - success', async ({request}) => {
-    const jobKey = await activateJobToObtainAValidJobKey(
-      request,
-      'jobApiTaskType',
-    );
+    const jobKey = await activateJobToObtainAValidJobKey(request, taskType);
 
     await test.step('PATCH update the job', async () => {
       const updateRes = await request.patch(buildUrl(`/jobs/${jobKey}`), {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-resolve-related-incident-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-resolve-related-incident-api.spec.ts
@@ -87,35 +87,39 @@ test.describe.parallel('Resolve related incidents API Tests', () => {
     let incidentKeys: string[] = [];
 
     await test.step('Search for incidents related to created process instance', async () => {
-      const incidents = await request.post(
-        buildUrl(
-          `/process-instances/${processInstanceKeyWithIncidentToResolve}/incidents/search`,
-        ),
-        {
-          headers: jsonHeaders(),
-        },
-      );
-      await assertStatusCode(incidents, 200);
-      await validateResponse(
-        {
-          path: '/process-instances/{processInstanceKey}/incidents/search',
-          method: 'POST',
-          status: '200',
-        },
-        incidents,
-      );
-      const body = await incidents.json();
-      expect(body.page.totalItems).toEqual(2);
-      expect(body.items.length).toEqual(2);
-      for (const incident of body.items) {
-        incidentKeys.push(incident.incidentKey);
-        expect(incident.state).toBe('ACTIVE');
-        if (incident.errorType === 'EXTRACT_VALUE_ERROR') {
-          elementInstanceKey = incident.elementInstanceKey;
+      await expect(async () => {
+        incidentKeys = [];
+        elementInstanceKey = '';
+        const incidents = await request.post(
+          buildUrl(
+            `/process-instances/${processInstanceKeyWithIncidentToResolve}/incidents/search`,
+          ),
+          {
+            headers: jsonHeaders(),
+          },
+        );
+        await assertStatusCode(incidents, 200);
+        await validateResponse(
+          {
+            path: '/process-instances/{processInstanceKey}/incidents/search',
+            method: 'POST',
+            status: '200',
+          },
+          incidents,
+        );
+        const body = await incidents.json();
+        expect(body.page.totalItems).toEqual(2);
+        expect(body.items.length).toEqual(2);
+        for (const incident of body.items) {
+          incidentKeys.push(incident.incidentKey);
+          expect(incident.state).toBe('ACTIVE');
+          if (incident.errorType === 'EXTRACT_VALUE_ERROR') {
+            elementInstanceKey = incident.elementInstanceKey;
+          }
         }
-      }
-      expect(elementInstanceKey).not.toEqual('');
-      expect(incidentKeys.length).toEqual(2);
+        expect(elementInstanceKey).not.toEqual('');
+        expect(incidentKeys.length).toEqual(2);
+      }).toPass(defaultAssertionOptions);
     });
 
     await test.step('Update element instance variables', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-search-variables-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-search-variables-api-tests.spec.ts
@@ -21,11 +21,10 @@ import {findUserTask} from '@requestHelpers';
 /* eslint-disable playwright/expect-expect */
 test.describe.parallel('Search User Task Variables Tests', () => {
   const {state, beforeAll, beforeEach, afterEach} =
-    setupProcessInstanceForTests(
-      'user_task_api_test_process',
-      'user_task_api_test_process',
-      {testset1: 'something', testset2: 'something else', zip: 123},
-    );
+    setupProcessInstanceForTests('user_task_api_test_process', {
+      processName: 'user_task_api_test_process',
+      variables: {testset1: 'something', testset2: 'something else', zip: 123},
+    });
 
   test.beforeAll(beforeAll);
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/job-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/job-requestHelpers.ts
@@ -10,7 +10,12 @@ import type {APIRequestContext} from 'playwright-core';
 import {assertStatusCode, buildUrl, jsonHeaders} from '../http';
 import {expect} from '@playwright/test';
 import {JSONDoc} from '@camunda8/sdk/dist/zeebe/types';
-import {cancelProcessInstance, createInstances, deploy} from '../zeebeClient';
+import {
+  cancelProcessInstance,
+  createInstances,
+  deploy,
+  deployWithSubstitutions,
+} from '../zeebeClient';
 import {defaultAssertionOptions} from '../constants';
 import {validateResponse} from 'json-body-assertions';
 
@@ -85,15 +90,26 @@ export async function completeJob(
 
 export function setupProcessInstanceForTests(
   processFileName: string,
-  processName?: string,
-  variables?: JSONDoc,
+  options?: {
+    processName?: string;
+    variables?: JSONDoc;
+    substitutions?: Record<string, string>;
+  },
 ) {
+  const {processName, variables, substitutions} = options ?? {};
   const state: Record<string, unknown> = {};
 
   return {
     state,
     beforeAll: async () => {
-      await deploy([`./resources/${processFileName}.bpmn`]);
+      if (substitutions) {
+        await deployWithSubstitutions(
+          `./resources/${processFileName}.bpmn`,
+          substitutions,
+        );
+      } else {
+        await deploy([`./resources/${processFileName}.bpmn`]);
+      }
     },
     beforeEach: async () => {
       const processInstance = await createInstances(
@@ -121,19 +137,19 @@ export function getLast24HoursRange() {
   };
 }
 
-export interface StatisticsJobItem {      
-    jobType: string,
-    created: {
-        count: number,
-        lastUpdatedAt: string
-    },
-    completed: {
-        count: number,
-        lastUpdatedAt: string
-    },
-    failed: {
-        count: number,
-        lastUpdatedAt: string
-    },
-    workers: number,
-};
+export interface StatisticsJobItem {
+  jobType: string;
+  created: {
+    count: number;
+    lastUpdatedAt: string;
+  };
+  completed: {
+    count: number;
+    lastUpdatedAt: string;
+  };
+  failed: {
+    count: number;
+    lastUpdatedAt: string;
+  };
+  workers: number;
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/zeebeClient.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/zeebeClient.ts
@@ -6,6 +6,8 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import {readFileSync} from 'fs';
+import {basename} from 'path';
 import {Camunda8} from '@camunda8/sdk';
 import {JSONDoc} from '@camunda8/sdk/dist/zeebe/types.js';
 
@@ -41,6 +43,28 @@ const deploy = async (processFilePaths: string[]) => {
   try {
     const results = await zeebe.deployResourcesFromFiles(processFilePaths);
     return results;
+  } catch (error) {
+    console.error('Deployment failed:', error);
+    throw error;
+  }
+};
+
+const deployWithSubstitutions = async (
+  bpmnFilePath: string,
+  substitutions: Record<string, string>,
+): Promise<void> => {
+  let content = readFileSync(bpmnFilePath, 'utf-8');
+  for (const [placeholder, replacement] of Object.entries(substitutions)) {
+    if (!content.includes(placeholder)) {
+      throw new Error(
+        `Placeholder '${placeholder}' not found in BPMN file '${bpmnFilePath}'`,
+      );
+    }
+    content = content.split(placeholder).join(replacement);
+  }
+  const name = basename(bpmnFilePath);
+  try {
+    await zeebe.deployResources([{content, name}]);
   } catch (error) {
     console.error('Deployment failed:', error);
     throw error;
@@ -125,6 +149,7 @@ async function checkUpdateOnVersion(
 
 export {
   deploy,
+  deployWithSubstitutions,
   createInstances,
   generateManyVariables,
   checkUpdateOnVersion,


### PR DESCRIPTION
## Description

Fixes flaky job API e2e tests caused by parallel test workers stealing each other's jobs. When multiple test files all deploy and activate the same `jobApiTaskType` job type, workers running in parallel can pick up jobs belonging to a different test file, causing assertion failures.

**Root cause:** All 5 job API test specs shared the same hardcoded BPMN process ID and job type string, so any worker could steal another worker's activated jobs.

**Fix:** Each test file now generates a unique 8-character suffix via `randomUUID()` at module load time and deploys a per-run copy of the BPMN with substituted process ID and job type, ensuring complete isolation between parallel workers.

### Changes

- **`utils/zeebeClient.ts`**: Added `deployWithSubstitutions()` — reads a BPMN file, performs string substitutions for process ID and job type placeholders, then deploys the modified content in memory. Validates that every placeholder exists in the file before deploying and includes error logging consistent with the existing `deploy()` helper.

- **`utils/requestHelpers/job-requestHelpers.ts`**: Extended `setupProcessInstanceForTests()` with an optional `substitutions` field via an options object, so callers can specify substitutions without passing positional `undefined` arguments.

- **`tests/api/v2/job/*.spec.ts`**: All 5 job API test files now generate unique `processId` and `taskType` per run using `randomUUID().slice(0, 8)` and deploy substituted BPMN instead of the static file.

- **`tests/api/v2/process-instance/process-instance-resolve-related-incident-api.spec.ts`**: Fixed a separate flaky assertion where `incident.state` was checked immediately after instance creation while incidents were still in `PENDING` state. The search step is now wrapped in `.toPass()` to poll until incidents reach `ACTIVE`.

## Testing
[API successful test run](https://github.com/camunda/camunda/actions/runs/24338219988/job/71060529479)

## Related issues

closes #49604
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
