### PR TITLE
refactor: rename camunda-process-test-spring-4 to camunda-process-test-spring-boot-4 

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -132,6 +132,12 @@
 
       <dependency>
         <groupId>io.camunda</groupId>
+        <artifactId>camunda-process-test-spring-boot-4</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
         <artifactId>camunda-process-test-spring-4</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/clients/camunda-spring-boot-4-starter/pom.xml
+++ b/clients/camunda-spring-boot-4-starter/pom.xml
@@ -24,9 +24,9 @@
     <version.java>17</version.java>
     <license.header.file>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header.file>
     <!-- Override Spring Boot version for 4.x compatibility -->
-    <version.spring-boot>4.0.3</version.spring-boot>
+    <version.spring-boot>4.0.5</version.spring-boot>
     <!-- Spring Framework 7.x is required for Spring Boot 4.0 -->
-    <version.spring>7.0.5</version.spring>
+    <version.spring>7.0.6</version.spring>
     <!-- JUnit 6.x is required for Spring Boot 4.0 compatibility -->
     <version.junit>6.0.3</version.junit>
     <version.roaster>2.30.3.Final</version.roaster>

--- a/testing/camunda-process-test-spring-4/pom.xml
+++ b/testing/camunda-process-test-spring-4/pom.xml
@@ -6,8 +6,9 @@
   ~ Licensed under the Camunda License 1.0. You may not use this file
   ~ except in compliance with the Camunda License 1.0.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-testing</artifactId>
@@ -17,352 +18,35 @@
 
   <artifactId>camunda-process-test-spring-4</artifactId>
 
-  <name>Camunda Process Test Spring Boot 4</name>
-  <description>Camunda's testing library for processes and process applications with Spring Boot 4.x support</description>
+  <name>Camunda Process Test Spring Boot 4 (deprecated)</name>
+  <description>Relocated to camunda-process-test-spring-boot-4. This artifact is kept for backward compatibility.</description>
 
-  <properties>
-    <version.java>17</version.java>
-    <!-- Override Spring Boot version for 4.x compatibility -->
-    <version.spring-boot>4.0.3</version.spring-boot>
-    <!-- Spring Framework 7.x is required for Spring Boot 4.0 -->
-    <version.spring>7.0.5</version.spring>
-    <!-- JUnit 6.x is required for Spring Boot 4.0 compatibility -->
-    <version.junit>6.0.3</version.junit>
-  </properties>
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+    </license>
+  </licenses>
 
-  <dependencies>
-
-    <!-- Base module - will be shaded -->
-    <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>camunda-process-test-spring</artifactId>
-      <!-- this dependency will be shaded into this artifact -->
-      <optional>true</optional>
-      <exclusions>
-        <!-- Exclude Spring Boot 3.x starter - we use 4.x version -->
-        <exclusion>
-          <groupId>io.camunda</groupId>
-          <artifactId>camunda-spring-boot-starter</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <!-- Use Spring Boot 4 starter instead -->
-    <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>camunda-spring-boot-4-starter</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-
-    <!--
-      Original dependencies of the shaded module, except `camunda-spring-boot-starter`.
-      This is done as the shaded module is declared as provided
-      and we cannot use the shade plugin's feature to promoteTransitiveDependencies
-      as this would reintroduce the dependency on `camunda-spring-boot-starter`.
-    -->
-    <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>camunda-process-test-java</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>camunda-client-java</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>zeebe-client-java</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-test</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-core</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-context</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-beans</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-test</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-autoconfigure</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.checkerframework</groupId>
-      <artifactId>checker-qual</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.awaitility</groupId>
-      <artifactId>awaitility</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.httpcomponents.client5</groupId>
-      <artifactId>httpclient5</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.httpcomponents.core5</groupId>
-      <artifactId>httpcore5</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
-
-    <!-- Test dependencies -->
-    <dependency>
-      <groupId>org.wiremock</groupId>
-      <artifactId>wiremock-standalone</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>zeebe-bpmn-model</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-junit-jupiter</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.testcontainers</groupId>
-      <artifactId>testcontainers-junit-jupiter</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-jsr310</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-  </dependencies>
+  <distributionManagement>
+    <relocation>
+      <artifactId>camunda-process-test-spring-boot-4</artifactId>
+      <message>camunda-process-test-spring-4 has been renamed to camunda-process-test-spring-boot-4. Please update your dependency.</message>
+    </relocation>
+  </distributionManagement>
 
   <build>
     <plugins>
-
-      <!-- Shade plugin to include and relocate classes from camunda-process-test-spring -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <version>3.6.2</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-            <phase>package</phase>
-            <configuration>
-              <createDependencyReducedPom>false</createDependencyReducedPom>
-              <createSourcesJar>true</createSourcesJar>
-              <promoteTransitiveDependencies>false</promoteTransitiveDependencies>
-              <artifactSet>
-                <includes>
-                  <!-- Only include the base module in the shaded jar -->
-                  <include>io.camunda:camunda-process-test-spring</include>
-                </includes>
-              </artifactSet>
-              <transformers>
-                <!-- Merge service files -->
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"></transformer>
-                <!-- Keep manifest entries -->
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"></transformer>
-              </transformers>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-failsafe-plugin</artifactId>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <configuration>
-          <!-- Ignore any non-test scoped deps, we only have test source here -->
-          <ignoredNonTestScopedDependencies>
-            <dependency>*</dependency>
-          </ignoredNonTestScopedDependencies>
-          <!-- Ignore all unused, we duplicate all from the base module -->
-          <ignoredUsedUndeclaredDependencies>
-            <dependency>*</dependency>
-          </ignoredUsedUndeclaredDependencies>
-          <ignoredUnusedDeclaredDependencies>
-            <dependency>*</dependency>
-          </ignoredUnusedDeclaredDependencies>
-        </configuration>
-      </plugin>
-
-      <!-- Add test re-/sources from the base module -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>add-test-source</id>
-            <goals>
-              <goal>add-test-source</goal>
-            </goals>
-            <phase>generate-test-sources</phase>
-            <configuration>
-              <sources>
-                <source>${project.basedir}/../camunda-process-test-spring/src/test/java</source>
-              </sources>
-            </configuration>
-          </execution>
-          <execution>
-            <id>add-test-resource</id>
-            <goals>
-              <goal>add-test-resource</goal>
-            </goals>
-            <phase>generate-test-resources</phase>
-            <configuration>
-              <resources>
-                <resource>
-                  <directory>${project.basedir}/../camunda-process-test-spring/src/test/resources</directory>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>
-        </executions>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <configuration>
+          <pomElements>
+            <distributionManagement></distributionManagement>
+          </pomElements>
+        </configuration>
       </plugin>
-
-      <!-- Run tests compiled from base module sources -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-      </plugin>
-
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>central-sonatype-publish</id>
-      <!--
-        This profile is typically activated during release builds refer to
-        org.camunda:camunda-release-parent
-      -->
-      <build>
-        <plugins>
-          <!--
-            Unpack javadoc from base module and repackage them, this is required to ensure we have
-            javadoc available, given this module is a shade of camunda-process-test-spring,
-            we lack them otherwise.
-          -->
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-dependency-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>unpack-javadoc</id>
-                <goals>
-                  <goal>unpack</goal>
-                </goals>
-                <phase>package</phase>
-                <configuration>
-                  <artifactItems>
-                    <artifactItem>
-                      <groupId>io.camunda</groupId>
-                      <artifactId>camunda-process-test-spring</artifactId>
-                      <version>${project.version}</version>
-                      <classifier>javadoc</classifier>
-                      <type>jar</type>
-                      <outputDirectory>${project.build.directory}/apidocs</outputDirectory>
-                    </artifactItem>
-                  </artifactItems>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-jar-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>javadoc-jar</id>
-                <goals>
-                  <goal>jar</goal>
-                </goals>
-                <phase>package</phase>
-                <configuration>
-                  <classifier>javadoc</classifier>
-                  <classesDirectory>${project.build.directory}/apidocs</classesDirectory>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 
 </project>

--- a/testing/camunda-process-test-spring-boot-4/pom.xml
+++ b/testing/camunda-process-test-spring-boot-4/pom.xml
@@ -23,9 +23,9 @@
   <properties>
     <version.java>17</version.java>
     <!-- Override Spring Boot version for 4.x compatibility -->
-    <version.spring-boot>4.0.3</version.spring-boot>
+    <version.spring-boot>4.0.5</version.spring-boot>
     <!-- Spring Framework 7.x is required for Spring Boot 4.0 -->
-    <version.spring>7.0.5</version.spring>
+    <version.spring>7.0.6</version.spring>
     <!-- JUnit 6.x is required for Spring Boot 4.0 compatibility -->
     <version.junit>6.0.3</version.junit>
   </properties>

--- a/testing/camunda-process-test-spring-boot-4/pom.xml
+++ b/testing/camunda-process-test-spring-boot-4/pom.xml
@@ -1,0 +1,368 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.camunda</groupId>
+    <artifactId>camunda-testing</artifactId>
+    <version>8.8.22-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>camunda-process-test-spring-boot-4</artifactId>
+
+  <name>Camunda Process Test Spring Boot 4</name>
+  <description>Camunda's testing library for processes and process applications with Spring Boot 4.x support</description>
+
+  <properties>
+    <version.java>17</version.java>
+    <!-- Override Spring Boot version for 4.x compatibility -->
+    <version.spring-boot>4.0.3</version.spring-boot>
+    <!-- Spring Framework 7.x is required for Spring Boot 4.0 -->
+    <version.spring>7.0.5</version.spring>
+    <!-- JUnit 6.x is required for Spring Boot 4.0 compatibility -->
+    <version.junit>6.0.3</version.junit>
+  </properties>
+
+  <dependencies>
+
+    <!-- Base module - will be shaded -->
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-process-test-spring</artifactId>
+      <!-- this dependency will be shaded into this artifact -->
+      <optional>true</optional>
+      <exclusions>
+        <!-- Exclude Spring Boot 3.x starter - we use 4.x version -->
+        <exclusion>
+          <groupId>io.camunda</groupId>
+          <artifactId>camunda-spring-boot-starter</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <!-- Use Spring Boot 4 starter instead -->
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-spring-boot-4-starter</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!--
+      Original dependencies of the shaded module, except `camunda-spring-boot-starter`.
+      This is done as the shaded module is declared as provided
+      and we cannot use the shade plugin's feature to promoteTransitiveDependencies
+      as this would reintroduce the dependency on `camunda-spring-boot-starter`.
+    -->
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-process-test-java</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-client-java</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-client-java</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-beans</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-test</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.checkerframework</groupId>
+      <artifactId>checker-qual</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.httpcomponents.client5</groupId>
+      <artifactId>httpclient5</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.httpcomponents.core5</groupId>
+      <artifactId>httpcore5</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock-standalone</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-bpmn-model</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+
+      <!-- Shade plugin to include and relocate classes from camunda-process-test-spring -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.6.2</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <createSourcesJar>true</createSourcesJar>
+              <promoteTransitiveDependencies>false</promoteTransitiveDependencies>
+              <artifactSet>
+                <includes>
+                  <!-- Only include the base module in the shaded jar -->
+                  <include>io.camunda:camunda-process-test-spring</include>
+                </includes>
+              </artifactSet>
+              <transformers>
+                <!-- Merge service files -->
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"></transformer>
+                <!-- Keep manifest entries -->
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"></transformer>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <!-- Ignore any non-test scoped deps, we only have test source here -->
+          <ignoredNonTestScopedDependencies>
+            <dependency>*</dependency>
+          </ignoredNonTestScopedDependencies>
+          <!-- Ignore all unused, we duplicate all from the base module -->
+          <ignoredUsedUndeclaredDependencies>
+            <dependency>*</dependency>
+          </ignoredUsedUndeclaredDependencies>
+          <ignoredUnusedDeclaredDependencies>
+            <dependency>*</dependency>
+          </ignoredUnusedDeclaredDependencies>
+        </configuration>
+      </plugin>
+
+      <!-- Add test re-/sources from the base module -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>add-test-source</id>
+            <goals>
+              <goal>add-test-source</goal>
+            </goals>
+            <phase>generate-test-sources</phase>
+            <configuration>
+              <sources>
+                <source>${project.basedir}/../camunda-process-test-spring/src/test/java</source>
+              </sources>
+            </configuration>
+          </execution>
+          <execution>
+            <id>add-test-resource</id>
+            <goals>
+              <goal>add-test-resource</goal>
+            </goals>
+            <phase>generate-test-resources</phase>
+            <configuration>
+              <resources>
+                <resource>
+                  <directory>${project.basedir}/../camunda-process-test-spring/src/test/resources</directory>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- Run tests compiled from base module sources -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+      </plugin>
+
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>central-sonatype-publish</id>
+      <!--
+        This profile is typically activated during release builds refer to
+        org.camunda:camunda-release-parent
+      -->
+      <build>
+        <plugins>
+          <!--
+            Unpack javadoc from base module and repackage them, this is required to ensure we have
+            javadoc available, given this module is a shade of camunda-process-test-spring,
+            we lack them otherwise.
+          -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>unpack-javadoc</id>
+                <goals>
+                  <goal>unpack</goal>
+                </goals>
+                <phase>package</phase>
+                <configuration>
+                  <artifactItems>
+                    <artifactItem>
+                      <groupId>io.camunda</groupId>
+                      <artifactId>camunda-process-test-spring</artifactId>
+                      <version>${project.version}</version>
+                      <classifier>javadoc</classifier>
+                      <type>jar</type>
+                      <outputDirectory>${project.build.directory}/apidocs</outputDirectory>
+                    </artifactItem>
+                  </artifactItems>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>javadoc-jar</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+                <phase>package</phase>
+                <configuration>
+                  <classifier>javadoc</classifier>
+                  <classesDirectory>${project.build.directory}/apidocs</classesDirectory>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+</project>

--- a/testing/camunda-process-test-spring-boot-4/pom.xml
+++ b/testing/camunda-process-test-spring-boot-4/pom.xml
@@ -51,7 +51,6 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-spring-boot-4-starter</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <!--
@@ -190,6 +189,12 @@
 
     <dependency>
       <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
@@ -209,7 +214,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.6.2</version>
         <executions>
           <execution>
             <goals>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -24,6 +24,7 @@
     <module>camunda-process-test-java</module>
     <module>camunda-process-test-spring</module>
     <module>camunda-process-test-spring-boot-3</module>
+    <module>camunda-process-test-spring-boot-4</module>
     <module>camunda-process-test-spring-4</module>
     <module>camunda-process-test-example</module>
   </modules>


### PR DESCRIPTION
## Summary

- Renames `testing/camunda-process-test-spring-4/` → `testing/camunda-process-test-spring-boot-4/` for naming consistency with `camunda-spring-boot-4-starter`
- Adds a backward-compat `camunda-process-test-spring-4` relocation POM (no compiled classes) that emits a deprecation warning pointing to the new artifact name
- Updates `testing/pom.xml` and `bom/pom.xml` accordingly

Relates to #47483
Relates to #41279