### PR TITLE
test: test archive batches when no search results are found

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AbstractArchiverRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AbstractArchiverRepositoryTest.java
@@ -44,15 +44,34 @@ abstract class AbstractArchiverRepositoryTest {
   @MethodSource("archiveBatchSuppliers")
   void shouldReturnFailedFutureWhenGetNextBatchFails(
       final Function<ArchiverRepository, CompletableFuture<?>> archiveBatchSupplier) {
+    // given
+    givenSearchRequestsFail();
+
     // when
     final var result = archiveBatchSupplier.apply(repository);
 
-    // then fails when it tries to access ES/OS, since there is no backing database
+    // then fails when it tries to access ES/OS
     assertThat(result)
         .as("Should return a future that completes exceptionally, not throw synchronously")
         .failsWithin(Duration.ofSeconds(5))
         .withThrowableOfType(ExecutionException.class)
         .withRootCauseInstanceOf(ConnectException.class);
+  }
+
+  @ParameterizedTest
+  @MethodSource("archiveBatchSuppliers")
+  void shouldReturnEmptyBatchWhenNoResultsFound(
+      final Function<ArchiverRepository, CompletableFuture<?>> archiveBatchSupplier) {
+    // given
+    givenNoSearchResultsFound();
+
+    // when
+    final var result = archiveBatchSupplier.apply(repository);
+
+    // then fails when it tries to access ES/OS, since there is no backing database
+    assertThat(result)
+        .as("Should return a future that completes successfully with an empty batch")
+        .succeedsWithin(Duration.ofSeconds(5));
   }
 
   static Stream<Named<Function<ArchiverRepository, CompletableFuture<?>>>> archiveBatchSuppliers() {
@@ -71,6 +90,7 @@ abstract class AbstractArchiverRepositoryTest {
   @Test
   void shouldNotSetLifecycleIfRetentionIsDisabled() {
     // given
+    givenSearchRequestsFail();
     retention.setEnabled(false);
 
     // when
@@ -81,6 +101,10 @@ abstract class AbstractArchiverRepositoryTest {
         .as("did not try connecting to non existent ES/OS")
         .succeedsWithin(Duration.ofSeconds(5));
   }
+
+  abstract void givenSearchRequestsFail();
+
+  abstract void givenNoSearchResultsFound();
 
   abstract ArchiverRepository createRepository();
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryTest.java
@@ -18,12 +18,11 @@ import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.search.Hit;
+import co.elastic.clients.elasticsearch.core.search.HitsMetadata;
 import co.elastic.clients.elasticsearch.core.search.TotalHitsRelation;
 import co.elastic.clients.elasticsearch.indices.ElasticsearchIndicesAsyncClient;
 import co.elastic.clients.elasticsearch.indices.GetIndexResponse;
 import co.elastic.clients.json.JsonData;
-import co.elastic.clients.json.SimpleJsonpMapper;
-import co.elastic.clients.transport.rest_client.RestClientTransport;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration.ProcessInstanceRetentionMode;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
@@ -32,12 +31,11 @@ import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import jakarta.json.Json;
+import java.net.ConnectException;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
-import org.apache.http.HttpHost;
-import org.elasticsearch.client.RestClient;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
@@ -48,20 +46,37 @@ final class ElasticsearchArchiverRepositoryTest extends AbstractArchiverReposito
   private static final Logger LOGGER =
       LoggerFactory.getLogger(ElasticsearchArchiverRepositoryTest.class);
 
-  private final RestClientTransport transport = Mockito.spy(createRestClient());
+  private final ElasticsearchAsyncClient client = mock(ElasticsearchAsyncClient.class);
 
   @Test
-  void shouldCloseTransportOnClose() throws Exception {
+  void shouldCloseClientOnClose() throws Exception {
     // when
     repository.close();
 
     // then
-    Mockito.verify(transport, Mockito.times(1)).close();
+    Mockito.verify(client, Mockito.times(1)).close();
+  }
+
+  @Override
+  void givenSearchRequestsFail() {
+    when(client.search(any(SearchRequest.class), any()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ConnectException("Simulated ES failure for testing")));
+  }
+
+  @Override
+  void givenNoSearchResultsFound() {
+    final var response = mock(SearchResponse.class);
+    final var hits = mock(HitsMetadata.class);
+    when(response.hits()).thenReturn(hits);
+    when(hits.hits()).thenReturn(List.of());
+    when(client.search(any(SearchRequest.class), any()))
+        .thenReturn(CompletableFuture.completedFuture(response));
   }
 
   @Override
   ElasticsearchArchiverRepository createRepository() {
-    final var client = new ElasticsearchAsyncClient(transport);
     final var metrics = new CamundaExporterMetrics(new SimpleMeterRegistry());
     final var config = new HistoryConfiguration();
     config.setRetention(retention);
@@ -75,17 +90,11 @@ final class ElasticsearchArchiverRepositoryTest extends AbstractArchiverReposito
         LOGGER);
   }
 
-  private RestClientTransport createRestClient() {
-    final var restClient = RestClient.builder(HttpHost.create("http://127.0.0.1:1")).build();
-    return new RestClientTransport(restClient, new SimpleJsonpMapper());
-  }
-
   @Test
   public void shouldConstructCorrectQueryForPIMode() {
     // given
     final var config = new HistoryConfiguration();
     config.setProcessInstanceRetentionMode(ProcessInstanceRetentionMode.PI);
-    final var client = mock(ElasticsearchAsyncClient.class);
     final var repository = createRepository(client, config);
     when(client.search(any(SearchRequest.class), eq(ProcessInstanceForListViewEntity.class)))
         .thenReturn(CompletableFuture.completedFuture(mock(SearchResponse.class)));

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryTest.java
@@ -23,17 +23,16 @@ import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEnt
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import jakarta.json.Json;
 import java.io.IOException;
-import java.net.URISyntaxException;
+import java.net.ConnectException;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
-import org.apache.hc.core5.http.HttpHost;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.opensearch.client.json.JsonData;
-import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
 import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.SearchResponse;
@@ -43,7 +42,6 @@ import org.opensearch.client.opensearch.generic.OpenSearchGenericClient;
 import org.opensearch.client.opensearch.indices.GetIndexResponse;
 import org.opensearch.client.opensearch.indices.OpenSearchIndicesAsyncClient;
 import org.opensearch.client.transport.OpenSearchTransport;
-import org.opensearch.client.transport.httpclient5.ApacheHttpClient5TransportBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,20 +49,45 @@ final class OpenSearchArchiverRepositoryTest extends AbstractArchiverRepositoryT
   private static final Logger LOGGER =
       LoggerFactory.getLogger(OpenSearchArchiverRepositoryTest.class);
 
-  private final OpenSearchTransport transport = Mockito.spy(createOpenSearchTransport());
+  private final OpenSearchTransport transport = mock(OpenSearchTransport.class);
+  private final OpenSearchAsyncClient client = mock(OpenSearchAsyncClient.class);
 
-  @Test
-  void shouldCloseTransportOnClose() throws Exception {
-    // when
-    repository.close();
+  @Override
+  @BeforeEach
+  void setup() {
+    super.setup();
+    when(client._transport()).thenReturn(transport);
+  }
 
-    // then
-    Mockito.verify(transport, Mockito.times(1)).close();
+  @Override
+  void givenSearchRequestsFail() {
+    try {
+      when(client.search(any(SearchRequest.class), any()))
+          .thenReturn(CompletableFuture.failedFuture(new ConnectException("Connection failed")));
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  void givenNoSearchResultsFound() {
+    try {
+      final var response =
+          new SearchResponse.Builder<>()
+              .took(1)
+              .timedOut(false)
+              .shards(s -> s.total(1).successful(1).failed(0))
+              .hits(h -> h.total(t -> t.value(0).relation(TotalHitsRelation.Eq)).hits(List.of()))
+              .build();
+      when(client.search(any(SearchRequest.class), any()))
+          .thenReturn(CompletableFuture.completedFuture(response));
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   @Override
   OpenSearchArchiverRepository createRepository() {
-    final var client = new OpenSearchAsyncClient(transport);
     final var metrics = new CamundaExporterMetrics(new SimpleMeterRegistry());
     final var config = new HistoryConfiguration();
     config.setRetention(retention);
@@ -78,6 +101,15 @@ final class OpenSearchArchiverRepositoryTest extends AbstractArchiverRepositoryT
         Runnable::run,
         metrics,
         LOGGER);
+  }
+
+  @Test
+  void shouldCloseTransportOnClose() throws Exception {
+    // when
+    repository.close();
+
+    // then
+    Mockito.verify(transport, Mockito.times(1)).close();
   }
 
   @Test
@@ -127,7 +159,6 @@ final class OpenSearchArchiverRepositoryTest extends AbstractArchiverRepositoryT
     // given
     final var config = new HistoryConfiguration();
     config.setProcessInstanceRetentionMode(ProcessInstanceRetentionMode.PI_HIERARCHY);
-    final var client = mock(OpenSearchAsyncClient.class);
     final var repository = createRepository(client, config);
     final var hit1 = createHit("1", "2024-01-01", null); // Legacy
     final var hit2 = createHit("2", "2024-01-01", 100L); // Root
@@ -149,7 +180,6 @@ final class OpenSearchArchiverRepositoryTest extends AbstractArchiverRepositoryT
     // given
     final var config = new HistoryConfiguration();
     config.setProcessInstanceRetentionMode(ProcessInstanceRetentionMode.PI_HIERARCHY_IGNORE_LEGACY);
-    final var client = mock(OpenSearchAsyncClient.class);
     final var repository = createRepository(client, config);
 
     final var hit1 = createHit("1", "2024-01-01", null);
@@ -165,21 +195,6 @@ final class OpenSearchArchiverRepositoryTest extends AbstractArchiverRepositoryT
     // then - purely based on mapping logic which splits by root key presence
     assertThat(batch.processInstanceKeys()).containsExactly(1L);
     assertThat(batch.rootProcessInstanceKeys()).containsExactly(100L);
-  }
-
-  private OpenSearchTransport createOpenSearchTransport() {
-    try {
-      return ApacheHttpClient5TransportBuilder.builder(HttpHost.create("http://127.0.0.1:1"))
-          .setHttpClientConfigCallback(
-              httpClientBuilder -> {
-                httpClientBuilder.disableContentCompression();
-                return httpClientBuilder;
-              })
-          .setMapper(new JacksonJsonpMapper())
-          .build();
-    } catch (final URISyntaxException e) {
-      throw new RuntimeException(e);
-    }
   }
 
   private OpenSearchArchiverRepository createRepository(


### PR DESCRIPTION
This adds some more tests to verify handling of empty archiver batches.  Mostly so we've got test parity with the fix for empty batches in 8.8 (#50858)