### PR TITLE
feat: add camunda-process-test-spring-boot-4 relocator to main

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -126,6 +126,12 @@
 
       <dependency>
         <groupId>io.camunda</groupId>
+        <artifactId>camunda-process-test-spring-boot-4</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
         <artifactId>camunda-process-test-spring-4</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/testing/camunda-process-test-spring-boot-4/pom.xml
+++ b/testing/camunda-process-test-spring-boot-4/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.camunda</groupId>
+    <artifactId>camunda-testing</artifactId>
+    <version>8.10.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>camunda-process-test-spring-boot-4</artifactId>
+  <packaging>pom</packaging>
+
+  <name>Camunda Process Test Spring Boot 4 (relocated)</name>
+  <description>Relocated artifact. Use camunda-process-test-spring instead.
+    This module exists to provide a migration path for users upgrading from 8.7/8.8,
+    where this artifact was the canonical Spring Boot 4 testing library.</description>
+
+  <distributionManagement>
+    <relocation>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-process-test-spring</artifactId>
+      <message>camunda-process-test-spring-boot-4 has been replaced by camunda-process-test-spring</message>
+    </relocation>
+  </distributionManagement>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <configuration>
+          <pomElements>
+            <distributionManagement/>
+          </pomElements>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -24,6 +24,7 @@
     <module>camunda-process-test-java</module>
     <module>camunda-process-test-spring</module>
     <module>camunda-process-test-spring-boot-3</module>
+    <module>camunda-process-test-spring-boot-4</module>
     <module>camunda-process-test-example</module>
     <module>camunda-process-test-json-test-cases</module>
     <module>camunda-process-test-langchain4j</module>


### PR DESCRIPTION
## Summary

- Adds a shallow pom-only `camunda-process-test-spring-boot-4` module that uses Maven's `<distributionManagement><relocation>` to redirect users to `camunda-process-test-spring`
- Registers the new module in `testing/pom.xml` and `bom/pom.xml`
- Ensures users upgrading from 8.7/8.8 to 8.9+ can keep their `camunda-process-test-spring-boot-4` dependency and Maven will warn them to migrate to `camunda-process-test-spring`

Relates #47483