### PR TITLE
Fix issues with handling of empty archiver batches

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -395,7 +395,7 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
       final SearchResponse<?> response, final String field, final String rolloverInterval) {
     final var hits = response.hits().hits();
     if (hits.isEmpty()) {
-      new ArchiveBatch(null, List.of());
+      return new ArchiveBatch(null, List.of());
     }
 
     final String endDate = hits.getFirst().fields().get(field).toJson().asJsonArray().getString(0);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AbstractArchiverRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AbstractArchiverRepositoryTest.java
@@ -44,6 +44,9 @@ abstract class AbstractArchiverRepositoryTest {
   @MethodSource("archiveBatchSuppliers")
   void shouldReturnFailedFutureWhenGetNextBatchFails(
       final Function<ArchiverRepository, CompletableFuture<ArchiveBatch>> archiveBatchSupplier) {
+    // given
+    givenSearchRequestsFail();
+
     // when
     final var result = archiveBatchSupplier.apply(repository);
 
@@ -53,6 +56,22 @@ abstract class AbstractArchiverRepositoryTest {
         .failsWithin(Duration.ofSeconds(5))
         .withThrowableOfType(ExecutionException.class)
         .withRootCauseInstanceOf(ConnectException.class);
+  }
+
+  @ParameterizedTest
+  @MethodSource("archiveBatchSuppliers")
+  void shouldReturnEmptyBatchWhenNoResultsFound(
+      final Function<ArchiverRepository, CompletableFuture<?>> archiveBatchSupplier) {
+    // given
+    givenNoSearchResultsFound();
+
+    // when
+    final var result = archiveBatchSupplier.apply(repository);
+
+    // then fails when it tries to access ES/OS, since there is no backing database
+    assertThat(result)
+        .as("Should return a future that completes successfully with an empty batch")
+        .succeedsWithin(Duration.ofSeconds(5));
   }
 
   static Stream<Named<Function<ArchiverRepository, CompletableFuture<ArchiveBatch>>>>
@@ -71,6 +90,7 @@ abstract class AbstractArchiverRepositoryTest {
   @Test
   void shouldNotSetLifecycleIfRetentionIsDisabled() {
     // given
+    givenSearchRequestsFail();
     retention.setEnabled(false);
 
     // when
@@ -81,6 +101,10 @@ abstract class AbstractArchiverRepositoryTest {
         .as("did not try connecting to non existent ES/OS")
         .succeedsWithin(Duration.ofSeconds(5));
   }
+
+  abstract void givenSearchRequestsFail();
+
+  abstract void givenNoSearchResultsFound();
 
   abstract ArchiverRepository createRepository();
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryTest.java
@@ -7,15 +7,25 @@
  */
 package io.camunda.exporter.tasks.archiver;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
-import co.elastic.clients.json.SimpleJsonpMapper;
-import co.elastic.clients.transport.rest_client.RestClientTransport;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.HitsMetadata;
+import co.elastic.clients.elasticsearch.indices.ElasticsearchIndicesAsyncClient;
+import co.elastic.clients.elasticsearch.indices.GetIndexResponse;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.tasks.utils.TestExporterResourceProvider;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.apache.http.HttpHost;
-import org.elasticsearch.client.RestClient;
+import java.net.ConnectException;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
@@ -25,20 +35,35 @@ final class ElasticsearchArchiverRepositoryTest extends AbstractArchiverReposito
   private static final Logger LOGGER =
       LoggerFactory.getLogger(ElasticsearchArchiverRepositoryTest.class);
 
-  private final RestClientTransport transport = Mockito.spy(createRestClient());
+  private final ElasticsearchAsyncClient client = mock(ElasticsearchAsyncClient.class);
 
-  @Test
-  void shouldCloseTransportOnClose() throws Exception {
-    // when
-    repository.close();
+  @Override
+  @BeforeEach
+  void setup() {
+    super.setup();
+    givenNoArchivingStatus();
+  }
 
-    // then
-    Mockito.verify(transport, Mockito.times(1)).close();
+  @Override
+  void givenSearchRequestsFail() {
+    when(client.search(any(SearchRequest.class), any()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ConnectException("Simulated ES failure for testing")));
+  }
+
+  @Override
+  void givenNoSearchResultsFound() {
+    final var response = mock(SearchResponse.class);
+    final var hits = mock(HitsMetadata.class);
+    when(response.hits()).thenReturn(hits);
+    when(hits.hits()).thenReturn(List.of());
+    when(client.search(any(SearchRequest.class), any()))
+        .thenReturn(CompletableFuture.completedFuture(response));
   }
 
   @Override
   ElasticsearchArchiverRepository createRepository() {
-    final var client = new ElasticsearchAsyncClient(transport);
     final var metrics = new CamundaExporterMetrics(new SimpleMeterRegistry());
     final var config = new HistoryConfiguration();
     config.setRetention(retention);
@@ -52,8 +77,20 @@ final class ElasticsearchArchiverRepositoryTest extends AbstractArchiverReposito
         LOGGER);
   }
 
-  private RestClientTransport createRestClient() {
-    final var restClient = RestClient.builder(HttpHost.create("http://127.0.0.1:1")).build();
-    return new RestClientTransport(restClient, new SimpleJsonpMapper());
+  @Test
+  void shouldCloseTransportOnClose() throws Exception {
+    // when
+    repository.close();
+
+    // then
+    Mockito.verify(client, Mockito.times(1)).close();
+  }
+
+  private void givenNoArchivingStatus() {
+    final var indicesClient = mock(ElasticsearchIndicesAsyncClient.class);
+    when(client.indices()).thenReturn(indicesClient);
+    final var response = mock(GetIndexResponse.class);
+    when(indicesClient.get(any(Function.class)))
+        .thenReturn(CompletableFuture.completedFuture(response));
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryTest.java
@@ -7,18 +7,30 @@
  */
 package io.camunda.exporter.tasks.archiver;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.tasks.utils.TestExporterResourceProvider;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.apache.http.HttpHost;
+import java.io.IOException;
+import java.net.ConnectException;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import org.opensearch.client.RestClient;
-import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.search.TotalHitsRelation;
 import org.opensearch.client.opensearch.generic.OpenSearchGenericClient;
-import org.opensearch.client.transport.rest_client.RestClientTransport;
+import org.opensearch.client.opensearch.indices.GetIndexResponse;
+import org.opensearch.client.opensearch.indices.OpenSearchIndicesAsyncClient;
+import org.opensearch.client.transport.OpenSearchTransport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,20 +38,46 @@ final class OpenSearchArchiverRepositoryTest extends AbstractArchiverRepositoryT
   private static final Logger LOGGER =
       LoggerFactory.getLogger(OpenSearchArchiverRepositoryTest.class);
 
-  private final RestClientTransport transport = Mockito.spy(createRestClient());
+  private final OpenSearchTransport transport = mock(OpenSearchTransport.class);
+  private final OpenSearchAsyncClient client = mock(OpenSearchAsyncClient.class);
 
-  @Test
-  void shouldCloseTransportOnClose() throws Exception {
-    // when
-    repository.close();
+  @Override
+  @BeforeEach
+  void setup() {
+    super.setup();
+    when(client._transport()).thenReturn(transport);
+    givenNoArchivingStatus();
+  }
 
-    // then
-    Mockito.verify(transport, Mockito.times(1)).close();
+  @Override
+  void givenSearchRequestsFail() {
+    try {
+      when(client.search(any(SearchRequest.class), any()))
+          .thenReturn(CompletableFuture.failedFuture(new ConnectException("Connection failed")));
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  void givenNoSearchResultsFound() {
+    try {
+      final var response =
+          new SearchResponse.Builder<>()
+              .took(1)
+              .timedOut(false)
+              .shards(s -> s.total(1).successful(1).failed(0))
+              .hits(h -> h.total(t -> t.value(0).relation(TotalHitsRelation.Eq)).hits(List.of()))
+              .build();
+      when(client.search(any(SearchRequest.class), any()))
+          .thenReturn(CompletableFuture.completedFuture(response));
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   @Override
   OpenSearchArchiverRepository createRepository() {
-    final var client = new OpenSearchAsyncClient(transport);
     final var metrics = new CamundaExporterMetrics(new SimpleMeterRegistry());
     final var config = new HistoryConfiguration();
     config.setRetention(retention);
@@ -55,8 +93,24 @@ final class OpenSearchArchiverRepositoryTest extends AbstractArchiverRepositoryT
         LOGGER);
   }
 
-  private RestClientTransport createRestClient() {
-    final var restClient = RestClient.builder(HttpHost.create("http://127.0.0.1:1")).build();
-    return new RestClientTransport(restClient, new JacksonJsonpMapper());
+  @Test
+  void shouldCloseTransportOnClose() throws Exception {
+    // when
+    repository.close();
+
+    // then
+    Mockito.verify(transport, Mockito.times(1)).close();
+  }
+
+  private void givenNoArchivingStatus() {
+    try {
+      final var indicesClient = mock(OpenSearchIndicesAsyncClient.class);
+      when(client.indices()).thenReturn(indicesClient);
+      final var response = mock(GetIndexResponse.class);
+      when(indicesClient.get(any(Function.class)))
+          .thenReturn(CompletableFuture.completedFuture(response));
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 }


### PR DESCRIPTION
This fixes errors in logs like (basically just a missing `return`):

```
10:37:35.518 [] [exporter-camundaexporter-p1-tasks-5] [] DEBUG io.camunda.zeebe.broker.exporter.camundaexporter - Error occurred while performing a background task StandaloneDecisionArchiverJob; error message null; operation will be retried
java.util.concurrent.CompletionException: java.util.NoSuchElementException
	at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:315)
	at java.base/java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:320)
	at java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:649)
	at java.base/java.util.concurrent.CompletableFuture$Completion.run(CompletableFuture.java:482)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: java.util.NoSuchElementException
	at java.base/java.util.List.getFirst(List.java:825)
	at io.camunda.exporter.tasks.archiver.ElasticsearchArchiverRepository.createArchiveBatch(ElasticsearchArchiverRepository.java:401)
	at io.camunda.exporter.tasks.archiver.ElasticsearchArchiverRepository.createArchiveBatch(ElasticsearchArchiverRepository.java:391)
	at io.camunda.exporter.tasks.archiver.ElasticsearchArchiverRepository.lambda$getStandaloneDecisionNextBatch$14(ElasticsearchArchiverRepository.java:216)
	at java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:646)
	... 7 more
```


Adding these test to main/8.9: #50855