### PR TITLE
feat: prepare Operate TS configs for stricter type checking

### DIFF
--- a/operate/client/e2e-playwright/tsconfig.json
+++ b/operate/client/e2e-playwright/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "tsBuildInfoFile": "../node_modules/.tmp/tsconfig.e2e-playwright.tsbuildinfo",
     "baseUrl": ".",
     "paths": {
       "@/*": ["./*"]

--- a/operate/client/tsconfig.app.json
+++ b/operate/client/tsconfig.app.json
@@ -19,8 +19,6 @@
   ],
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
-    "jsx": "react-jsx",
     "baseUrl": "src"
   }
 }

--- a/operate/client/tsconfig.base.json
+++ b/operate/client/tsconfig.base.json
@@ -1,23 +1,30 @@
 {
   "compilerOptions": {
+    /* Language and Environment */
     "target": "ESNext",
-    "module": "ESNext",
-    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "skipLibCheck": true,
-
-    /* Bundler mode */
-    "moduleResolution": "bundler",
-    "isolatedModules": true,
-    "moduleDetection": "force",
+    "jsx": "react-jsx",
     "noEmit": true,
-    "verbatimModuleSyntax": true,
 
-    /* Linting */
-    "strict": true,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "noFallthroughCasesInSwitch": true,
+    /* Modules and Constraints */
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "moduleDetection": "force",
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
     "noUncheckedSideEffectImports": true,
-    "erasableSyntaxOnly": true
+    "erasableSyntaxOnly": true,
+
+    /* Type Checking */
+    "strict": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": false, // TODO: enable with https://github.com/camunda/camunda/issues/50173
+    "noImplicitReturns": false, // TODO: enable with https://github.com/camunda/camunda/issues/50173
+    "noUnusedLocals": false, // TODO: enable with https://github.com/camunda/camunda/issues/50173
+    "noUnusedParameters": false, // TODO: enable with https://github.com/camunda/camunda/issues/50173
+    "noPropertyAccessFromIndexSignature": false,
+    "noUncheckedIndexedAccess": false, // TODO: enable with https://github.com/camunda/camunda/issues/50173
+    "allowUnreachableCode": false
   }
 }

--- a/operate/client/tsconfig.node.json
+++ b/operate/client/tsconfig.node.json
@@ -1,24 +1,8 @@
 {
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
-    "target": "ES2022",
-    "lib": ["ES2022"],
-    "module": "ESNext",
-    "skipLibCheck": true,
-
-    /* Bundler mode */
-    "moduleResolution": "bundler",
-    "verbatimModuleSyntax": true,
-    "moduleDetection": "force",
-    "noEmit": true,
-
-    /* Linting */
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "erasableSyntaxOnly": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "lib": ["ES2022"]
   },
   "include": ["vite.config.ts", "license-build.js", "playwright.config.ts"]
 }

--- a/operate/client/tsconfig.vitest.browser.json
+++ b/operate/client/tsconfig.vitest.browser.json
@@ -1,8 +1,9 @@
 {
-  "extends": "./tsconfig.app.json",
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.vitest.tsbuildinfo",
-    "types": ["vitest/globals", "@vitest/browser/matchers", "node"]
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.vitest.browser.tsbuildinfo",
+    "types": ["vitest/globals", "@vitest/browser/matchers", "node"],
+    "baseUrl": "src"
   },
   "include": [
     "src/**/*",

--- a/operate/client/tsconfig.vitest.json
+++ b/operate/client/tsconfig.vitest.json
@@ -1,8 +1,9 @@
 {
-  "extends": "./tsconfig.app.json",
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.vitest.tsbuildinfo",
-    "types": ["vitest/globals", "@testing-library/jest-dom", "node"]
+    "types": ["vitest/globals", "@testing-library/jest-dom", "node"],
+    "baseUrl": "src"
   },
   "include": [
     "src/**/*",


### PR DESCRIPTION
## Description

This PR enables the TS configs in Operate to gradually harden the type checking options:
- Base config properties are now grouped by [TS config groups](https://www.typescriptlang.org/tsconfig/). This is similar to the upcoming Tasklist changes in #50866
- All configs now extend the base config. Previously some extended nothing, while others extended the app config. This should simplify the relation between configs.

## Related issues

relates #50173
