### PR TITLE
ci: add customManagers for Spring/JUnit version properties in submodule poms

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -208,14 +208,13 @@
       "enabled": false
     },
     {
-      "description": "Exclude major updates to Spring and JUnit Jupiter, we will do those manually",
+      "description": "Exclude major updates to Spring, we will do those manually",
       "matchManagers": [
         "maven",
         "custom.regex"
       ],
       "matchPackageNames": [
-        "org.springframework**",
-        "org.junit.jupiter**"
+        "org.springframework**"
       ],
       "matchUpdateTypes": [
         "major"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -210,10 +210,12 @@
     {
       "description": "Exclude major updates to Spring, we will do those manually",
       "matchManagers": [
-        "maven"
+        "maven",
+        "custom.regex"
       ],
       "matchPackageNames": [
-        "org.springframework**"
+        "org.springframework**",
+        "org.junit.jupiter**"
       ],
       "matchUpdateTypes": [
         "major"
@@ -223,7 +225,8 @@
     {
       "description": "Spring updates are often security-relevant, get those first (prio 10)",
       "matchManagers": [
-        "maven"
+        "maven",
+        "custom.regex"
       ],
       "matchPackageNames": [
         "org.springframework**"
@@ -607,6 +610,45 @@
         "(?<depName>docker\\.io\\/library\\/alpine):(?<currentValue>\\d+\\.\\d+\\.\\d+)"
       ],
       "datasourceTemplate": "docker"
+    },
+    {
+      "description": "Track Spring Boot version overrides in submodule poms (not visible to Maven manager due to BOM inheritance).",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/clients/camunda-spring-boot-[34]-starter/pom\\.xml$/",
+        "/testing/camunda-process-test-spring-boot-[34]/pom\\.xml$/"
+      ],
+      "matchStrings": [
+        "<version\\.spring-boot>(?<currentValue>[^<]+)</version\\.spring-boot>"
+      ],
+      "depNameTemplate": "org.springframework.boot:spring-boot",
+      "datasourceTemplate": "maven"
+    },
+    {
+      "description": "Track Spring Framework version overrides in submodule poms (not visible to Maven manager due to BOM inheritance).",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/clients/camunda-spring-boot-[34]-starter/pom\\.xml$/",
+        "/testing/camunda-process-test-spring-boot-[34]/pom\\.xml$/"
+      ],
+      "matchStrings": [
+        "<version\\.spring>(?<currentValue>[^<]+)</version\\.spring>"
+      ],
+      "depNameTemplate": "org.springframework:spring-core",
+      "datasourceTemplate": "maven"
+    },
+    {
+      "description": "Track JUnit version overrides in submodule poms (not visible to Maven manager due to BOM inheritance).",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/clients/camunda-spring-boot-[34]-starter/pom\\.xml$/",
+        "/testing/camunda-process-test-spring-boot-[34]/pom\\.xml$/"
+      ],
+      "matchStrings": [
+        "<version\\.junit>(?<currentValue>[^<]+)</version\\.junit>"
+      ],
+      "depNameTemplate": "org.junit.jupiter:junit-jupiter",
+      "datasourceTemplate": "maven"
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -208,7 +208,7 @@
       "enabled": false
     },
     {
-      "description": "Exclude major updates to Spring, we will do those manually",
+      "description": "Exclude major updates to Spring and JUnit Jupiter, we will do those manually",
       "matchManagers": [
         "maven",
         "custom.regex"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -615,7 +615,8 @@
       "customType": "regex",
       "managerFilePatterns": [
         "/clients/camunda-spring-boot-[34]-starter/pom\\.xml$/",
-        "/testing/camunda-process-test-spring-boot-[34]/pom\\.xml$/"
+        "/testing/camunda-process-test-spring-boot-[34]/pom\\.xml$/",
+        "/library-parent/pom\\.xml$/"
       ],
       "matchStrings": [
         "<version\\.spring-boot>(?<currentValue>[^<]+)</version\\.spring-boot>"
@@ -628,7 +629,8 @@
       "customType": "regex",
       "managerFilePatterns": [
         "/clients/camunda-spring-boot-[34]-starter/pom\\.xml$/",
-        "/testing/camunda-process-test-spring-boot-[34]/pom\\.xml$/"
+        "/testing/camunda-process-test-spring-boot-[34]/pom\\.xml$/",
+        "/library-parent/pom\\.xml$/"
       ],
       "matchStrings": [
         "<version\\.spring>(?<currentValue>[^<]+)</version\\.spring>"
@@ -641,7 +643,8 @@
       "customType": "regex",
       "managerFilePatterns": [
         "/clients/camunda-spring-boot-[34]-starter/pom\\.xml$/",
-        "/testing/camunda-process-test-spring-boot-[34]/pom\\.xml$/"
+        "/testing/camunda-process-test-spring-boot-[34]/pom\\.xml$/",
+        "/library-parent/pom\\.xml$/"
       ],
       "matchStrings": [
         "<version\\.junit>(?<currentValue>[^<]+)</version\\.junit>"


### PR DESCRIPTION
## Summary

- Adds three `customManagers` (regex type) to make Renovate track `version.spring-boot`, `version.spring`, and `version.junit` properties defined in submodule poms (`camunda-spring-boot-[34]-starter`, `camunda-process-test-spring-boot-[34]`)
- Extends the Spring no-major and priority-10 `packageRules` to also apply to `custom.regex` manager (previously only `maven`)

## Why Renovate missed these

Renovate's Maven manager finds all `pom.xml` files including submodules, but skips version properties when no `<dependency>` in the **same file** uses that property — dependencies here inherit their version from the parent BOM. It marks the property as `name-placeholder` and silently skips it. (See [renovatebot/renovate#31004](https://github.com/renovatebot/renovate/issues/31004).)

The `customManagers` regex approach hard-codes the `groupId:artifactId` mapping in the Renovate config, bypassing the inference entirely.

## Update policy (unchanged)

- `main`: patch + minor allowed for Spring; major blocked (same as before via extended rule)
- `stable/8.x`: patch only (existing global stable-branch rule covers `custom.regex` already since it matches all managers)
- SB3 files with `3.5.x` will not be proposed 4.x updates — that's a major version bump, blocked by the no-major rule

Closes #47507