### PR TITLE
Fix old version tests

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -250,7 +250,7 @@
     <extension.version.os-maven-plugin>1.7.1</extension.version.os-maven-plugin>
 
     <!-- version against which backwards compatibility is checked -->
-    <backwards.compat.version>8.9.0</backwards.compat.version>
+    <backwards.compat.version>8.8.21</backwards.compat.version>
     <ignored.changes.file>ignored-changes.json</ignored.changes.file>
 
     <!--

--- a/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupStoreTests.java
+++ b/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupStoreTests.java
@@ -310,8 +310,10 @@ public interface S3BackupStoreTests extends BackupStoreTestKit {
   @Test
   default void backupStructureShouldBeDistinct() throws IOException {
     // given
+    // Pin the legacy version, as 8.8.is the last version with the old directory structure
+    final String legacyVersion = "8.8.0";
     final var legacyBackup =
-        S3TestBackupProvider.simpleBackupWithId(new BackupIdentifierImpl(1, 2, 3), true);
+        S3TestBackupProvider.simpleBackupWithId(new BackupIdentifierImpl(1, 2, 3), legacyVersion);
     final var backup =
         S3TestBackupProvider.simpleBackupWithId(new BackupIdentifierImpl(1, 2, 10), false);
 

--- a/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/util/S3TestBackupProvider.java
+++ b/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/util/S3TestBackupProvider.java
@@ -34,15 +34,20 @@ public class S3TestBackupProvider extends TestBackupProvider {
   }
 
   public static Backup simpleBackup(final boolean legacy) throws IOException {
-    return simpleBackup(version(legacy));
+    return TestBackupProvider.simpleBackup(version(legacy));
   }
 
   public static Backup simpleBackupWithId(final BackupIdentifierImpl id, final boolean legacy)
       throws IOException {
-    return simpleBackupWithId(id, version(legacy));
+    return TestBackupProvider.simpleBackupWithId(id, version(legacy));
+  }
+
+  public static Backup simpleBackupWithId(final BackupIdentifierImpl id, final String legacyVersion)
+      throws IOException {
+    return TestBackupProvider.simpleBackupWithId(id, legacyVersion);
   }
 
   public static Backup backupWithoutSnapshot(final boolean legacy) throws IOException {
-    return backupWithoutSnapshot(version(legacy));
+    return TestBackupProvider.backupWithoutSnapshot(version(legacy));
   }
 }

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
@@ -61,6 +61,12 @@ import org.junit.jupiter.params.provider.EnumSource;
 @Execution(ExecutionMode.CONCURRENT)
 final class BulkIndexRequestTest {
 
+  /**
+   * Set previous version to <8.9.0 to assert if old pre-8.9 index templates ignore new >=8.9
+   * properties.
+   */
+  private static final String PRE_8_9_VERSION = "8.8.0";
+
   private static final ObjectMapper MAPPER =
       new ObjectMapper().registerModule(new ZeebeProtocolModule());
 
@@ -334,7 +340,7 @@ final class BulkIndexRequestTest {
       final var record =
           recordFactory.generateRecord(
               r ->
-                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                  r.withBrokerVersion(PRE_8_9_VERSION)
                       .withValue(
                           new CheckpointRecord()
                               .setCheckpointType(CheckpointType.SCHEDULED_BACKUP)
@@ -390,7 +396,7 @@ final class BulkIndexRequestTest {
       final var record =
           recordFactory.generateRecord(
               r ->
-                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                  r.withBrokerVersion(PRE_8_9_VERSION)
                       .withValue(
                           new MessageSubscriptionRecord()
                               .setProcessInstanceKey(1L)
@@ -446,7 +452,7 @@ final class BulkIndexRequestTest {
       final var record =
           recordFactory.generateRecord(
               r ->
-                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                  r.withBrokerVersion(PRE_8_9_VERSION)
                       .withValue(
                           new ProcessMessageSubscriptionRecord()
                               .setProcessInstanceKey(1L)
@@ -502,7 +508,7 @@ final class BulkIndexRequestTest {
       final var record =
           recordFactory.generateRecord(
               r ->
-                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                  r.withBrokerVersion(PRE_8_9_VERSION)
                       .withValue(
                           new ProcessInstanceModificationRecord()
                               .setProcessInstanceKey(1L)
@@ -532,7 +538,7 @@ final class BulkIndexRequestTest {
       final var record =
           recordFactory.generateRecord(
               r ->
-                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                  r.withBrokerVersion(PRE_8_9_VERSION)
                       .withValue(
                           new ProcessInstanceModificationRecord()
                               .setProcessInstanceKey(1L)
@@ -637,8 +643,7 @@ final class BulkIndexRequestTest {
     void shouldIndexWithoutBusinessIdOnPreviousVersion(final ValueType valueType) throws Exception {
       // given
       final var record =
-          recordFactory.generateRecord(
-              valueType, r -> r.withBrokerVersion(VersionUtil.getPreviousVersion()));
+          recordFactory.generateRecord(valueType, r -> r.withBrokerVersion(PRE_8_9_VERSION));
 
       final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
 
@@ -714,8 +719,7 @@ final class BulkIndexRequestTest {
         throws Exception {
       // given
       final var record =
-          recordFactory.generateRecord(
-              valueType, r -> r.withBrokerVersion(VersionUtil.getPreviousVersion()));
+          recordFactory.generateRecord(valueType, r -> r.withBrokerVersion(PRE_8_9_VERSION));
 
       final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
 
@@ -780,7 +784,7 @@ final class BulkIndexRequestTest {
       final var record =
           recordFactory.generateRecord(
               r ->
-                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                  r.withBrokerVersion(PRE_8_9_VERSION)
                       .withValue(
                           new JobRecord().setType("test-job").setIsJobToUserTaskMigration(true)));
 
@@ -833,7 +837,7 @@ final class BulkIndexRequestTest {
       final var record =
           recordFactory.generateRecord(
               r ->
-                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                  r.withBrokerVersion(PRE_8_9_VERSION)
                       .withValue(
                           new ProcessInstanceMigrationRecord()
                               .setProcessInstanceKey(1L)
@@ -897,7 +901,7 @@ final class BulkIndexRequestTest {
       final var record =
           recordFactory.generateRecord(
               r ->
-                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                  r.withBrokerVersion(PRE_8_9_VERSION)
                       .withValue(
                           new ProcessInstanceModificationRecord()
                               .setProcessInstanceKey(1L)
@@ -962,8 +966,7 @@ final class BulkIndexRequestTest {
     void shouldIndexWithoutElementInstanceKeyOnPreviousVersion(final ValueType valueType) {
       // given
       final var record =
-          recordFactory.generateRecord(
-              valueType, r -> r.withBrokerVersion(VersionUtil.getPreviousVersion()));
+          recordFactory.generateRecord(valueType, r -> r.withBrokerVersion(PRE_8_9_VERSION));
 
       final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
 
@@ -1017,7 +1020,7 @@ final class BulkIndexRequestTest {
           recordFactory.generateRecord(
               ValueType.VARIABLE,
               r ->
-                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                  r.withBrokerVersion(PRE_8_9_VERSION)
                       .withValue(
                           new VariableRecord()
                               .setName(BufferUtil.wrapString("varName"))
@@ -1102,7 +1105,7 @@ final class BulkIndexRequestTest {
       final var record =
           recordFactory.generateRecord(
               r ->
-                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                  r.withBrokerVersion(PRE_8_9_VERSION)
                       .withValue(
                           new JobBatchRecord()
                               .setType("test-type")
@@ -1166,7 +1169,7 @@ final class BulkIndexRequestTest {
           .setIsJobToUserTaskMigration(true);
       final var record =
           recordFactory.generateRecord(
-              r -> r.withBrokerVersion(VersionUtil.getPreviousVersion()).withValue(jobBatchRecord));
+              r -> r.withBrokerVersion(PRE_8_9_VERSION).withValue(jobBatchRecord));
 
       final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
 
@@ -1232,7 +1235,7 @@ final class BulkIndexRequestTest {
           recordFactory.generateRecord(
               ValueType.USER_TASK,
               r ->
-                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                  r.withBrokerVersion(PRE_8_9_VERSION)
                       .withValue(new UserTaskRecord().setUserTaskKey(1L).setTags(Set.of("tag1"))));
 
       final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
@@ -1285,7 +1288,7 @@ final class BulkIndexRequestTest {
           recordFactory.generateRecord(
               ValueType.DECISION_REQUIREMENTS,
               r ->
-                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                  r.withBrokerVersion(PRE_8_9_VERSION)
                       .withValue(
                           new DecisionRequirementsRecord()
                               .setDecisionRequirementsId("drg-1")
@@ -1344,7 +1347,7 @@ final class BulkIndexRequestTest {
           recordFactory.generateRecord(
               ValueType.DEPLOYMENT,
               r ->
-                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                  r.withBrokerVersion(PRE_8_9_VERSION)
                       .withValue(new DeploymentRecord().setDeploymentKey(42L)));
 
       final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
@@ -1395,7 +1398,7 @@ final class BulkIndexRequestTest {
       final var record =
           recordFactory.generateRecord(
               r ->
-                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                  r.withBrokerVersion(PRE_8_9_VERSION)
                       .withValue(
                           new ResourceDeletionRecord()
                               .setResourceKey(1L)
@@ -1467,7 +1470,7 @@ final class BulkIndexRequestTest {
       final var record =
           recordFactory.generateRecord(
               r ->
-                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                  r.withBrokerVersion(PRE_8_9_VERSION)
                       .withValue(
                           new MessageCorrelationRecord()
                               .setName("msg")
@@ -1527,7 +1530,7 @@ final class BulkIndexRequestTest {
       final var record =
           recordFactory.generateRecord(
               r ->
-                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                  r.withBrokerVersion(PRE_8_9_VERSION)
                       .withValue(
                           new ProcessInstanceBatchRecord()
                               .setProcessInstanceKey(1L)
@@ -1585,7 +1588,7 @@ final class BulkIndexRequestTest {
       final var record =
           recordFactory.generateRecord(
               r ->
-                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                  r.withBrokerVersion(PRE_8_9_VERSION)
                       .withValue(
                           new RuntimeInstructionRecord()
                               .setProcessInstanceKey(1L)
@@ -1644,7 +1647,7 @@ final class BulkIndexRequestTest {
       final var record =
           recordFactory.generateRecord(
               r ->
-                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                  r.withBrokerVersion(PRE_8_9_VERSION)
                       .withValue(
                           new ProcessInstanceMigrationRecord()
                               .setProcessInstanceKey(1L)
@@ -1714,7 +1717,7 @@ final class BulkIndexRequestTest {
       final var record =
           recordFactory.generateRecord(
               r ->
-                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                  r.withBrokerVersion(PRE_8_9_VERSION)
                       .withValue(
                           new ProcessInstanceModificationRecord()
                               .setProcessInstanceKey(1L)
@@ -1858,7 +1861,7 @@ final class BulkIndexRequestTest {
       final var record =
           recordFactory.generateRecord(
               r ->
-                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                  r.withBrokerVersion(PRE_8_9_VERSION)
                       .withValue(
                           new CheckpointRecord()
                               .setCheckpointType(CheckpointType.SCHEDULED_BACKUP)
@@ -1953,9 +1956,7 @@ final class BulkIndexRequestTest {
       final var record =
           recordFactory.generateRecord(
               ValueType.DEPLOYMENT,
-              r ->
-                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
-                      .withValue(deploymentRecord));
+              r -> r.withBrokerVersion(PRE_8_9_VERSION).withValue(deploymentRecord));
 
       final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Ensure a pre-8.9 version is used in several tests where a pre-8.9 version needs to be used for "legacy" entities (ex. backup ID, record version, and gateway).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
