### PR TITLE
feat: enable noUnusedLocals TS config in Operate

### DIFF
--- a/operate/client/e2e-playwright/pages/Processes/Processes.ts
+++ b/operate/client/e2e-playwright/pages/Processes/Processes.ts
@@ -7,7 +7,6 @@
  */
 
 import type {Page, Locator} from '@playwright/test';
-import {expect} from '@playwright/test';
 import {convertToQueryString} from '../../utils/convertToQueryString';
 import {DeleteResourceModal} from '../components/DeleteResourceModal';
 import MigrationModal from '../components/MigrationModal';

--- a/operate/client/e2e-playwright/pages/components/JSONEditor.ts
+++ b/operate/client/e2e-playwright/pages/components/JSONEditor.ts
@@ -10,12 +10,10 @@ import type {Locator, Page} from '@playwright/test';
 
 class JSONEditor {
   private readonly page: Page;
-  private readonly readOnlyEditor: Locator;
   private readonly codeEditor: Locator;
 
   constructor(page: Page) {
     this.page = page;
-    this.readOnlyEditor = this.page.getByTestId('json-editor-readonly');
     this.codeEditor = this.page.getByRole('code').first();
   }
 

--- a/operate/client/tsconfig.base.json
+++ b/operate/client/tsconfig.base.json
@@ -21,7 +21,7 @@
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": false, // TODO: enable with https://github.com/camunda/camunda/issues/50173
     "noImplicitReturns": false, // TODO: enable with https://github.com/camunda/camunda/issues/50173
-    "noUnusedLocals": false, // TODO: enable with https://github.com/camunda/camunda/issues/50173
+    "noUnusedLocals": true,
     "noUnusedParameters": false, // TODO: enable with https://github.com/camunda/camunda/issues/50173
     "noPropertyAccessFromIndexSignature": false,
     "noUncheckedIndexedAccess": false, // TODO: enable with https://github.com/camunda/camunda/issues/50173


### PR DESCRIPTION
## Description

Enables the `noUnusedLocals` TS config option.

**This PR is stacked on #50888!**

## Related issues

relates #50173
