### PR TITLE
feat: enable noUnusedParameters TS config in Operate

### DIFF
--- a/operate/client/e2e-playwright/docs-screenshots/selections-and-operations.spec.ts
+++ b/operate/client/e2e-playwright/docs-screenshots/selections-and-operations.spec.ts
@@ -76,7 +76,6 @@ test.describe('selections and operations', () => {
 
   test('view operations page after retry operation', async ({
     page,
-    commonPage,
     processesPage,
     processesPage: {filtersPanel},
   }) => {

--- a/operate/client/tsconfig.base.json
+++ b/operate/client/tsconfig.base.json
@@ -22,7 +22,7 @@
     "noImplicitOverride": true,
     "noImplicitReturns": false, // TODO: enable with https://github.com/camunda/camunda/issues/50173
     "noUnusedLocals": true,
-    "noUnusedParameters": false, // TODO: enable with https://github.com/camunda/camunda/issues/50173
+    "noUnusedParameters": true,
     "noPropertyAccessFromIndexSignature": false,
     "noUncheckedIndexedAccess": true,
     "allowUnreachableCode": false


### PR DESCRIPTION
## Description

Enables the `noUnusedParameters` TS config option.

**This PR is stacked on #50888!**

## Related issues

relates #50173
