### PR TITLE
Fix startup failure when permissions config has trailing comma or whitespace

### DIFF
--- a/dist/src/test/java/io/camunda/application/commons/security/ConfiguredAuthorizationPropertiesTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/security/ConfiguredAuthorizationPropertiesTest.java
@@ -33,7 +33,7 @@ class ConfiguredAuthorizationPropertiesTest {
     final var authorizations = securityProperties.getInitialization().getAuthorizations();
 
     // then
-    assertThat(authorizations).hasSize(5);
+    assertThat(authorizations).hasSize(7);
   }
 
   @Test
@@ -129,6 +129,28 @@ class ConfiguredAuthorizationPropertiesTest {
     // Both helper methods return false, indicating the invalid state
     assertThat(auth.hasResourceId()).isFalse();
     assertThat(auth.hasResourcePropertyName()).isFalse();
+  }
+
+  @Test
+  void shouldFilterEmptyPermissionFromTrailingComma() {
+    // when — simulates PERMISSIONS=READ,UPDATE, (trailing comma produces empty string)
+    final var auth = securityProperties.getInitialization().getAuthorizations().get(5);
+
+    // then — empty entry is filtered out, only valid permissions remain
+    assertThat(auth.ownerId()).isEqualTo("trailing.comma");
+    assertThat(auth.permissions())
+        .containsExactlyInAnyOrder(PermissionType.READ, PermissionType.UPDATE);
+  }
+
+  @Test
+  void shouldFilterWhitespaceOnlyPermission() {
+    // when — simulates PERMISSIONS=READ, ,UPDATE (whitespace-only entry)
+    final var auth = securityProperties.getInitialization().getAuthorizations().get(6);
+
+    // then — whitespace entry is filtered out, only valid permissions remain
+    assertThat(auth.ownerId()).isEqualTo("whitespace.entry");
+    assertThat(auth.permissions())
+        .containsExactlyInAnyOrder(PermissionType.READ, PermissionType.UPDATE);
   }
 
   @Configuration

--- a/dist/src/test/resources/properties/application-authorization-props.yaml
+++ b/dist/src/test/resources/properties/application-authorization-props.yaml
@@ -43,3 +43,23 @@ camunda:
           resourceType: PROCESS_DEFINITION
           permissions:
             - CREATE_PROCESS_INSTANCE
+
+        # [5] Trailing comma in permissions (e.g. PERMISSIONS=READ,UPDATE,)
+        - ownerType: USER
+          ownerId: trailing.comma
+          resourceType: PROCESS_DEFINITION
+          resourceId: "*"
+          permissions:
+            - READ
+            - UPDATE
+            - ""
+
+        # [6] Whitespace-only permission entry (e.g. PERMISSIONS=READ, ,UPDATE)
+        - ownerType: USER
+          ownerId: whitespace.entry
+          resourceType: PROCESS_DEFINITION
+          resourceId: "*"
+          permissions:
+            - READ
+            - "  "
+            - UPDATE

--- a/security/security-core/src/main/java/io/camunda/security/configuration/ConfiguredAuthorization.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/ConfiguredAuthorization.java
@@ -11,15 +11,37 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
+import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
-public record ConfiguredAuthorization(
-    AuthorizationOwnerType ownerType,
-    String ownerId,
-    AuthorizationResourceType resourceType,
-    String resourceId,
-    String resourcePropertyName,
-    Set<PermissionType> permissions) {
+public class ConfiguredAuthorization {
+
+  private AuthorizationOwnerType ownerType;
+  private String ownerId;
+  private AuthorizationResourceType resourceType;
+  private String resourceId;
+  private String resourcePropertyName;
+  private Set<PermissionType> permissions;
+
+  /** Default constructor for Spring Boot binding */
+  @SuppressWarnings("unused")
+  public ConfiguredAuthorization() {}
+
+  private ConfiguredAuthorization(
+      final AuthorizationOwnerType ownerType,
+      final String ownerId,
+      final AuthorizationResourceType resourceType,
+      final String resourceId,
+      final String resourcePropertyName,
+      final Set<PermissionType> permissions) {
+    this.ownerType = ownerType;
+    this.ownerId = ownerId;
+    this.resourceType = resourceType;
+    this.resourceId = resourceId;
+    this.resourcePropertyName = resourcePropertyName;
+    this.permissions = permissions;
+  }
 
   public static ConfiguredAuthorization idBased(
       final AuthorizationOwnerType ownerType,
@@ -49,11 +71,75 @@ public record ConfiguredAuthorization(
         ownerType, ownerId, resourceType, null, resourcePropertyName, permissions);
   }
 
+  public AuthorizationOwnerType ownerType() {
+    return ownerType;
+  }
+
+  public String ownerId() {
+    return ownerId;
+  }
+
+  public AuthorizationResourceType resourceType() {
+    return resourceType;
+  }
+
+  public String resourceId() {
+    return resourceId;
+  }
+
+  public String resourcePropertyName() {
+    return resourcePropertyName;
+  }
+
+  public Set<PermissionType> permissions() {
+    return permissions;
+  }
+
   public boolean hasResourceId() {
     return resourceId != null && !resourceId.isBlank();
   }
 
   public boolean hasResourcePropertyName() {
     return resourcePropertyName != null && !resourcePropertyName.isBlank();
+  }
+
+  // --- Spring Boot setters ---
+  public void setOwnerType(final AuthorizationOwnerType ownerType) {
+    this.ownerType = ownerType;
+  }
+
+  public void setOwnerId(final String ownerId) {
+    this.ownerId = ownerId;
+  }
+
+  public void setResourceType(final AuthorizationResourceType resourceType) {
+    this.resourceType = resourceType;
+  }
+
+  public void setResourceId(final String resourceId) {
+    this.resourceId = resourceId;
+  }
+
+  public void setResourcePropertyName(final String resourcePropertyName) {
+    this.resourcePropertyName = resourcePropertyName;
+  }
+
+  /**
+   * Accepts raw permission strings from Spring Boot property binding, filters out null and blank
+   * entries (e.g. from trailing commas or whitespace), and converts valid entries to {@link
+   * PermissionType}. See <a href="https://github.com/camunda/camunda/issues/42323">#42323</a>.
+   */
+  public void setPermissions(final Set<String> permissions) {
+    if (permissions == null) {
+      this.permissions = Set.of();
+      return;
+    }
+    this.permissions =
+        permissions.stream()
+            .filter(Objects::nonNull)
+            .map(String::trim)
+            .filter(s -> !s.isEmpty())
+            .map(PermissionType::valueOf)
+            .collect(Collectors.toUnmodifiableSet());
   }
 }


### PR DESCRIPTION
Convert `ConfiguredAuthorization` from a record to a POJO so that Spring Boot binds permissions as `Set<String> `via the setter, which filters out null, empty, and whitespace-only entries before converting to `PermissionType`. This allows configurations like PERMISSIONS=READ,UPDATE, to work without crashing.

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #42323
