### PR TITLE
fix: always clear ES scroll context on exception

### DIFF
--- a/operate/schema/src/main/java/io/camunda/operate/util/ElasticsearchUtil.java
+++ b/operate/schema/src/main/java/io/camunda/operate/util/ElasticsearchUtil.java
@@ -503,28 +503,30 @@ public abstract class ElasticsearchUtil {
     String scrollId = response.getScrollId();
     SearchHits hits = response.getHits();
 
-    while (hits.getHits().length != 0) {
-      if (searchHitMapper != null) {
-        result.addAll(mapSearchHits(hits.getHits(), searchHitMapper));
-      } else {
-        result.addAll(mapSearchHits(hits.getHits(), objectMapper, clazz));
+    try {
+      while (hits.getHits().length != 0) {
+        if (searchHitMapper != null) {
+          result.addAll(mapSearchHits(hits.getHits(), searchHitMapper));
+        } else {
+          result.addAll(mapSearchHits(hits.getHits(), objectMapper, clazz));
+        }
+
+        // call response processor
+        if (searchHitsProcessor != null) {
+          searchHitsProcessor.accept(response.getHits());
+        }
+
+        final SearchScrollRequest scrollRequest = new SearchScrollRequest(scrollId);
+        scrollRequest.scroll(TimeValue.timeValueMillis(SCROLL_KEEP_ALIVE_MS));
+
+        response = esClient.scroll(scrollRequest, RequestOptions.DEFAULT);
+
+        scrollId = response.getScrollId();
+        hits = response.getHits();
       }
-
-      // call response processor
-      if (searchHitsProcessor != null) {
-        searchHitsProcessor.accept(response.getHits());
-      }
-
-      final SearchScrollRequest scrollRequest = new SearchScrollRequest(scrollId);
-      scrollRequest.scroll(TimeValue.timeValueMillis(SCROLL_KEEP_ALIVE_MS));
-
-      response = esClient.scroll(scrollRequest, RequestOptions.DEFAULT);
-
-      scrollId = response.getScrollId();
-      hits = response.getHits();
+    } finally {
+      clearScroll(scrollId, esClient);
     }
-
-    clearScroll(scrollId, esClient);
 
     return result;
   }
@@ -551,23 +553,25 @@ public abstract class ElasticsearchUtil {
     String scrollId = response.getScrollId();
     SearchHits hits = response.getHits();
 
-    while (hits.getHits().length != 0) {
+    try {
+      while (hits.getHits().length != 0) {
 
-      // call response processor
-      if (searchHitsProcessor != null) {
-        searchHitsProcessor.accept(response.getHits());
+        // call response processor
+        if (searchHitsProcessor != null) {
+          searchHitsProcessor.accept(response.getHits());
+        }
+
+        final SearchScrollRequest scrollRequest = new SearchScrollRequest(scrollId);
+        scrollRequest.scroll(scrollKeepAliveTimeValue);
+
+        response = esClient.scroll(scrollRequest, RequestOptions.DEFAULT);
+
+        scrollId = response.getScrollId();
+        hits = response.getHits();
       }
-
-      final SearchScrollRequest scrollRequest = new SearchScrollRequest(scrollId);
-      scrollRequest.scroll(scrollKeepAliveTimeValue);
-
-      response = esClient.scroll(scrollRequest, RequestOptions.DEFAULT);
-
-      scrollId = response.getScrollId();
-      hits = response.getHits();
+    } finally {
+      clearScroll(scrollId, esClient);
     }
-
-    clearScroll(scrollId, esClient);
   }
 
   public static void scrollWith(
@@ -600,22 +604,24 @@ public abstract class ElasticsearchUtil {
 
     String scrollId = response.getScrollId();
     SearchHits hits = response.getHits();
-    while (hits.getHits().length != 0) {
-      // call response processor
-      if (searchHitsProcessor != null) {
-        searchHitsProcessor.accept(response.getHits());
+    try {
+      while (hits.getHits().length != 0) {
+        // call response processor
+        if (searchHitsProcessor != null) {
+          searchHitsProcessor.accept(response.getHits());
+        }
+
+        final SearchScrollRequest scrollRequest = new SearchScrollRequest(scrollId);
+        scrollRequest.scroll(TimeValue.timeValueMillis(SCROLL_KEEP_ALIVE_MS));
+
+        response = esClient.scroll(scrollRequest, RequestOptions.DEFAULT);
+
+        scrollId = response.getScrollId();
+        hits = response.getHits();
       }
-
-      final SearchScrollRequest scrollRequest = new SearchScrollRequest(scrollId);
-      scrollRequest.scroll(TimeValue.timeValueMillis(SCROLL_KEEP_ALIVE_MS));
-
-      response = esClient.scroll(scrollRequest, RequestOptions.DEFAULT);
-
-      scrollId = response.getScrollId();
-      hits = response.getHits();
+    } finally {
+      clearScroll(scrollId, esClient);
     }
-
-    clearScroll(scrollId, esClient);
   }
 
   public static void clearScroll(final String scrollId, final RestHighLevelClient esClient) {

--- a/operate/schema/src/test/java/io/camunda/operate/util/ElasticsearchUtilTest.java
+++ b/operate/schema/src/test/java/io/camunda/operate/util/ElasticsearchUtilTest.java
@@ -8,12 +8,14 @@
 package io.camunda.operate.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.operate.schema.templates.TemplateDescriptor;
 import io.camunda.operate.util.ElasticsearchUtil.QueryType;
 import java.io.IOException;
@@ -21,8 +23,10 @@ import java.util.Map;
 import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.action.search.ClearScrollRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchScrollRequest;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
@@ -53,7 +57,7 @@ class ElasticsearchUtilTest {
   void setup() throws IOException {
     lenient().when(templateDescr.getFullQualifiedName()).thenReturn(INDEX_NAME);
     lenient().when(templateDescr.getAlias()).thenReturn(ALIAS_NAME);
-    when(esClient.get(any(), any())).thenReturn(getResponse);
+    lenient().when(esClient.get(any(), any())).thenReturn(getResponse);
   }
 
   @Test
@@ -143,6 +147,61 @@ class ElasticsearchUtilTest {
         .isEqualTo(
             """
             {"query":{"ids":{"values":["123"],"boost":1.0}},"_source":{"includes":["treePath"],"excludes":[]}}""");
+  }
+
+  @Test
+  void shouldClearScrollWhenProcessorThrowsInScrollWith() throws IOException {
+    final SearchHits nonEmptyHits =
+        new SearchHits(
+            new SearchHit[] {searchHit}, new TotalHits(1, TotalHits.Relation.EQUAL_TO), 1.0f);
+    when(searchResponse.getHits()).thenReturn(nonEmptyHits);
+    when(searchResponse.getScrollId()).thenReturn("scroll-id-1");
+    when(esClient.search(any(SearchRequest.class), any())).thenReturn(searchResponse);
+
+    final SearchRequest request = new SearchRequest(ALIAS_NAME);
+    assertThatThrownBy(
+            () ->
+                ElasticsearchUtil.scrollWith(
+                    request,
+                    esClient,
+                    hits -> {
+                      throw new RuntimeException("processor failure");
+                    },
+                    null,
+                    null))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("processor failure");
+
+    final ArgumentCaptor<ClearScrollRequest> clearCaptor =
+        ArgumentCaptor.forClass(ClearScrollRequest.class);
+    verify(esClient).clearScroll(clearCaptor.capture(), any());
+    assertThat(clearCaptor.getValue().getScrollIds()).containsExactly("scroll-id-1");
+  }
+
+  @Test
+  void shouldClearScrollWhenScrollCallThrowsInScroll() throws IOException {
+    final SearchHits nonEmptyHits =
+        new SearchHits(
+            new SearchHit[] {searchHit}, new TotalHits(1, TotalHits.Relation.EQUAL_TO), 1.0f);
+    when(searchResponse.getHits()).thenReturn(nonEmptyHits);
+    when(searchResponse.getScrollId()).thenReturn("scroll-id-2");
+    when(searchHit.getSourceAsString()).thenReturn("{}");
+    when(esClient.search(any(SearchRequest.class), any())).thenReturn(searchResponse);
+    when(esClient.scroll(any(SearchScrollRequest.class), any()))
+        .thenThrow(new IOException("network boom"));
+
+    final SearchRequest request = new SearchRequest(ALIAS_NAME);
+    assertThatThrownBy(
+            () ->
+                ElasticsearchUtil.scroll(
+                    request, Object.class, new ObjectMapper(), esClient, null, null))
+        .isInstanceOf(IOException.class)
+        .hasMessage("network boom");
+
+    final ArgumentCaptor<ClearScrollRequest> clearCaptor =
+        ArgumentCaptor.forClass(ClearScrollRequest.class);
+    verify(esClient).clearScroll(clearCaptor.capture(), any());
+    assertThat(clearCaptor.getValue().getScrollIds()).containsExactly("scroll-id-2");
   }
 
   private void givenSearchReturns(final SearchHit... hits) throws IOException {

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/ElasticsearchUtil.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/ElasticsearchUtil.java
@@ -503,24 +503,26 @@ public abstract class ElasticsearchUtil {
     String scrollId = response.getScrollId();
     SearchHits hits = response.getHits();
 
-    while (hits.getHits().length != 0) {
-      result.addAll(mapSearchHits(hits.getHits(), objectMapper, clazz));
+    try {
+      while (hits.getHits().length != 0) {
+        result.addAll(mapSearchHits(hits.getHits(), objectMapper, clazz));
 
-      // call response processor
-      if (searchHitsProcessor != null) {
-        searchHitsProcessor.accept(response.getHits());
+        // call response processor
+        if (searchHitsProcessor != null) {
+          searchHitsProcessor.accept(response.getHits());
+        }
+
+        final SearchScrollRequest scrollRequest = new SearchScrollRequest(scrollId);
+        scrollRequest.scroll(TimeValue.timeValueMillis(SCROLL_KEEP_ALIVE_MS));
+
+        response = esClient.scroll(scrollRequest, RequestOptions.DEFAULT);
+
+        scrollId = response.getScrollId();
+        hits = response.getHits();
       }
-
-      final SearchScrollRequest scrollRequest = new SearchScrollRequest(scrollId);
-      scrollRequest.scroll(TimeValue.timeValueMillis(SCROLL_KEEP_ALIVE_MS));
-
-      response = esClient.scroll(scrollRequest, RequestOptions.DEFAULT);
-
-      scrollId = response.getScrollId();
-      hits = response.getHits();
+    } finally {
+      clearScroll(scrollId, esClient);
     }
-
-    clearScroll(scrollId, esClient);
 
     return result;
   }
@@ -547,22 +549,24 @@ public abstract class ElasticsearchUtil {
 
     String scrollId = response.getScrollId();
     SearchHits hits = response.getHits();
-    while (hits.getHits().length != 0) {
-      // call response processor
-      if (searchHitsProcessor != null) {
-        searchHitsProcessor.accept(response.getHits());
+    try {
+      while (hits.getHits().length != 0) {
+        // call response processor
+        if (searchHitsProcessor != null) {
+          searchHitsProcessor.accept(response.getHits());
+        }
+
+        final SearchScrollRequest scrollRequest = new SearchScrollRequest(scrollId);
+        scrollRequest.scroll(TimeValue.timeValueMillis(SCROLL_KEEP_ALIVE_MS));
+
+        response = esClient.scroll(scrollRequest, RequestOptions.DEFAULT);
+
+        scrollId = response.getScrollId();
+        hits = response.getHits();
       }
-
-      final SearchScrollRequest scrollRequest = new SearchScrollRequest(scrollId);
-      scrollRequest.scroll(TimeValue.timeValueMillis(SCROLL_KEEP_ALIVE_MS));
-
-      response = esClient.scroll(scrollRequest, RequestOptions.DEFAULT);
-
-      scrollId = response.getScrollId();
-      hits = response.getHits();
+    } finally {
+      clearScroll(scrollId, esClient);
     }
-
-    clearScroll(scrollId, esClient);
   }
 
   public static void clearScroll(final String scrollId, final RestHighLevelClient esClient) {

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/OpenSearchUtil.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/OpenSearchUtil.java
@@ -466,22 +466,25 @@ public abstract class OpenSearchUtil {
     String scrollId = response.scrollId();
     HitsMetadata hits = response.hits();
 
-    while (hits.hits().size() != 0) {
-      result.addAll(hits.hits().stream().map(m -> ((Hit) m).source()).toList());
-      // call response processor
-      if (searchHitsProcessor != null) {
-        searchHitsProcessor.accept(response.hits());
+    try {
+      while (hits.hits().size() != 0) {
+        result.addAll(hits.hits().stream().map(m -> ((Hit) m).source()).toList());
+        // call response processor
+        if (searchHitsProcessor != null) {
+          searchHitsProcessor.accept(response.hits());
+        }
+
+        final ScrollRequest.Builder scrollRequest = new ScrollRequest.Builder();
+        scrollRequest.scrollId(scrollId);
+        scrollRequest.scroll(Time.of(t -> t.time(SCROLL_KEEP_ALIVE_MS)));
+
+        response = osClient.scroll(scrollRequest.build(), clazz);
+        scrollId = response.scrollId();
+        hits = response.hits();
       }
-
-      final ScrollRequest.Builder scrollRequest = new ScrollRequest.Builder();
-      scrollRequest.scrollId(scrollId);
-      scrollRequest.scroll(Time.of(t -> t.time(SCROLL_KEEP_ALIVE_MS)));
-
-      response = osClient.scroll(scrollRequest.build(), clazz);
-      scrollId = response.scrollId();
-      hits = response.hits();
+    } finally {
+      clearScroll(scrollId, osClient);
     }
-    clearScroll(scrollId, osClient);
 
     return result;
   }

--- a/tasklist/els-schema/src/test/java/io/camunda/tasklist/util/ElasticsearchUtilTest.java
+++ b/tasklist/els-schema/src/test/java/io/camunda/tasklist/util/ElasticsearchUtilTest.java
@@ -19,12 +19,19 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.tasklist.exceptions.PersistenceException;
 import java.io.IOException;
+import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.search.ClearScrollRequest;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchScrollRequest;
 import org.elasticsearch.action.support.WriteRequest.RefreshPolicy;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.xcontent.XContentType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -131,6 +138,61 @@ class ElasticsearchUtilTest {
                     esClient, bulkRequest, RefreshPolicy.NONE, maxBulkRequestSize))
         .isInstanceOf(PersistenceException.class)
         .hasMessageContaining("greater than max allowed");
+  }
+
+  @Test
+  void shouldClearScrollWhenProcessorThrowsInScrollWith() throws Exception {
+    final RestHighLevelClient esClient = mock(RestHighLevelClient.class);
+    final SearchResponse searchResponse = mock(SearchResponse.class);
+    final SearchHit hit = mock(SearchHit.class);
+    final SearchHits hits =
+        new SearchHits(new SearchHit[] {hit}, new TotalHits(1, TotalHits.Relation.EQUAL_TO), 1.0f);
+    when(searchResponse.getHits()).thenReturn(hits);
+    when(searchResponse.getScrollId()).thenReturn("scroll-id-1");
+    when(esClient.search(any(SearchRequest.class), any())).thenReturn(searchResponse);
+
+    final SearchRequest request = new SearchRequest("some-alias");
+    assertThatThrownBy(
+            () ->
+                ElasticsearchUtil.scrollWith(
+                    request,
+                    esClient,
+                    h -> {
+                      throw new RuntimeException("processor failure");
+                    },
+                    null,
+                    null))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("processor failure");
+
+    final ArgumentCaptor<ClearScrollRequest> clearCaptor =
+        ArgumentCaptor.forClass(ClearScrollRequest.class);
+    verify(esClient).clearScroll(clearCaptor.capture(), any());
+    assertThat(clearCaptor.getValue().getScrollIds()).containsExactly("scroll-id-1");
+  }
+
+  @Test
+  void shouldClearScrollWhenScrollCallThrowsInScrollWith() throws Exception {
+    final RestHighLevelClient esClient = mock(RestHighLevelClient.class);
+    final SearchResponse searchResponse = mock(SearchResponse.class);
+    final SearchHit hit = mock(SearchHit.class);
+    final SearchHits hits =
+        new SearchHits(new SearchHit[] {hit}, new TotalHits(1, TotalHits.Relation.EQUAL_TO), 1.0f);
+    when(searchResponse.getHits()).thenReturn(hits);
+    when(searchResponse.getScrollId()).thenReturn("scroll-id-2");
+    when(esClient.search(any(SearchRequest.class), any())).thenReturn(searchResponse);
+    when(esClient.scroll(any(SearchScrollRequest.class), any()))
+        .thenThrow(new IOException("network boom"));
+
+    final SearchRequest request = new SearchRequest("some-alias");
+    assertThatThrownBy(() -> ElasticsearchUtil.scrollWith(request, esClient, h -> {}, null, null))
+        .isInstanceOf(IOException.class)
+        .hasMessage("network boom");
+
+    final ArgumentCaptor<ClearScrollRequest> clearCaptor =
+        ArgumentCaptor.forClass(ClearScrollRequest.class);
+    verify(esClient).clearScroll(clearCaptor.capture(), any());
+    assertThat(clearCaptor.getValue().getScrollIds()).containsExactly("scroll-id-2");
   }
 
   @Test

--- a/tasklist/els-schema/src/test/java/io/camunda/tasklist/util/OpenSearchUtilTest.java
+++ b/tasklist/els-schema/src/test/java/io/camunda/tasklist/util/OpenSearchUtilTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.tasklist.entities.UserEntity;
+import java.io.IOException;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch.core.ClearScrollRequest;
+import org.opensearch.client.opensearch.core.ScrollRequest;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.search.Hit;
+import org.opensearch.client.opensearch.core.search.HitsMetadata;
+
+class OpenSearchUtilTest {
+
+  @Test
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  void shouldClearScrollWhenScrollCallThrowsInScroll() throws Exception {
+    final OpenSearchClient osClient = mock(OpenSearchClient.class);
+    final SearchResponse<UserEntity> searchResponse = mock(SearchResponse.class);
+    final HitsMetadata<UserEntity> hitsMetadata = mock(HitsMetadata.class);
+    final Hit<UserEntity> hit = mock(Hit.class);
+    when(hit.source()).thenReturn(new UserEntity());
+    when(hitsMetadata.hits()).thenReturn(List.of(hit));
+    when(searchResponse.hits()).thenReturn(hitsMetadata);
+    when(searchResponse.scrollId()).thenReturn("scroll-id-os");
+    when(osClient.search(any(SearchRequest.class), any(Class.class))).thenReturn(searchResponse);
+    when(osClient.scroll(any(ScrollRequest.class), any(Class.class)))
+        .thenThrow(new IOException("network boom"));
+
+    final SearchRequest.Builder request = new SearchRequest.Builder().index("some-alias");
+    assertThatThrownBy(() -> OpenSearchUtil.scroll(request, UserEntity.class, osClient))
+        .isInstanceOf(IOException.class)
+        .hasMessage("network boom");
+
+    final ArgumentCaptor<ClearScrollRequest> clearCaptor =
+        ArgumentCaptor.forClass(ClearScrollRequest.class);
+    verify(osClient).clearScroll(clearCaptor.capture());
+    assertThat(clearCaptor.getValue().scrollId()).contains("scroll-id-os");
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #50892
