### PR TITLE
feat: allow generic resource deployments

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
@@ -74,6 +74,21 @@ public final class BpmnResourceTransformer implements DeploymentResourceTransfor
   }
 
   @Override
+  public boolean canTransform(final DeploymentResource resource) {
+    final var resourceName = resource.getResourceName();
+    // .bpmn files must always be handled by this transformer (even if invalid)
+    if (resourceName.endsWith(".bpmn")) {
+      return true;
+    }
+    // .xml files: try to parse as BPMN and only handle if it's valid BPMN.
+    // Non-BPMN .xml files fall through to the default transformer (generic resource).
+    if (resourceName.endsWith(".xml")) {
+      return readProcessDefinition(resource).isRight();
+    }
+    return false;
+  }
+
+  @Override
   public Either<Failure, Void> createMetadata(
       final DeploymentResource resource,
       final DeploymentRecord deployment,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DefaultResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DefaultResourceTransformer.java
@@ -206,7 +206,8 @@ class DefaultResourceTransformer implements DeploymentResourceTransformer {
   /**
    * Holds the parsed identity of a deployment resource: its unique ID and an optional version tag.
    *
-   * @param id the resource identifier (must not be null or blank)
+   * @param id the resource identifier — for generic resources this is the filename, for structured
+   *     resources (e.g. RPA) it is parsed from the content
    * @param versionTag an optional version tag
    */
   public record ResourceInfo(String id, Optional<String> versionTag) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DefaultResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DefaultResourceTransformer.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment.transform;
+
+import io.camunda.zeebe.engine.processing.common.Failure;
+import io.camunda.zeebe.engine.processing.deployment.ChecksumGenerator;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.state.immutable.ResourceState;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentResource;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ResourceMetadataRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ResourceRecord;
+import io.camunda.zeebe.protocol.record.intent.ResourceIntent;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import io.camunda.zeebe.util.Either;
+import java.util.Optional;
+import org.agrona.DirectBuffer;
+
+/**
+ * Default transformer for resources stored in the {@link ResourceState}.
+ *
+ * <p>Handles the common logic for versioning and writing resource records. By default, the resource
+ * name (filename) is used as the resource ID. Subclasses can override {@link
+ * #parseResourceInfo(DeploymentResource)} to resolve the resource ID (and optional version tag)
+ * from the raw resource content.
+ *
+ * <h2>Duplicate detection</h2>
+ *
+ * <p>Duplicate detection is a two-step process: First, the latest deployed version is looked up by
+ * <em>resource ID</em>. Then, the found version is compared against the new deployment using both
+ * the <em>resourceName</em> (filename) and the <em>checksum</em> (MD5 of raw bytes). A resource is
+ * considered a duplicate only when both match. If either the filename or the content changed, a new
+ * version is created.
+ *
+ * <h2>Filename (resourceName) vs. resource ID</h2>
+ *
+ * <ul>
+ *   <li><b>Generic resources</b> (no known extension, e.g. {@code .txt}): the filename <em>is</em>
+ *       the resource ID. Renaming the file therefore creates an entirely new, independently
+ *       versioned resource.
+ *   <li><b>Structured resources</b> (e.g. {@code .rpa}): the resource ID is parsed from the file
+ *       content. Re-deploying the same content under a different filename creates a new version for
+ *       that resource ID because the filename changed.
+ * </ul>
+ */
+class DefaultResourceTransformer implements DeploymentResourceTransformer {
+
+  private static final int INITIAL_VERSION = 1;
+
+  protected final KeyGenerator keyGenerator;
+  protected final StateWriter stateWriter;
+  protected final ChecksumGenerator checksumGenerator;
+  protected final ResourceState resourceState;
+
+  DefaultResourceTransformer(
+      final KeyGenerator keyGenerator,
+      final StateWriter stateWriter,
+      final ChecksumGenerator checksumGenerator,
+      final ResourceState resourceState) {
+    this.keyGenerator = keyGenerator;
+    this.stateWriter = stateWriter;
+    this.checksumGenerator = checksumGenerator;
+    this.resourceState = resourceState;
+  }
+
+  /**
+   * The default transformer accepts any resource that was not handled by other transformers.
+   *
+   * @param resource the raw deployment resource
+   * @return always returns {@code true} as this is the fallback transformer
+   */
+  @Override
+  public boolean canTransform(final DeploymentResource resource) {
+    return true;
+  }
+
+  /**
+   * Parses the deployment resource to extract the resource identity (ID and optional version tag).
+   *
+   * <p>The default implementation uses the resource name (filename) as the resource ID. Subclasses
+   * can override this method to parse a structured resource ID from the resource content.
+   *
+   * @param resource the raw deployment resource
+   * @return either the parsed {@link ResourceInfo}, or a {@link Failure} if the resource is invalid
+   */
+  protected Either<Failure, ResourceInfo> parseResourceInfo(final DeploymentResource resource) {
+    return Either.right(ResourceInfo.of(resource.getResourceName()));
+  }
+
+  @Override
+  public Either<Failure, Void> createMetadata(
+      final DeploymentResource deploymentResource,
+      final DeploymentRecord deployment,
+      final DeploymentResourceContext context) {
+    return parseResourceInfo(deploymentResource)
+        .flatMap(
+            resourceInfo ->
+                checkForDuplicateResourceId(resourceInfo.id(), deploymentResource, deployment)
+                    .map(
+                        noDuplicates -> {
+                          addResourceMetadata(resourceInfo, deploymentResource, deployment);
+                          return null;
+                        }));
+  }
+
+  @Override
+  public void writeRecords(final DeploymentResource resource, final DeploymentRecord deployment) {
+    if (deployment.hasDuplicatesOnly()) {
+      return;
+    }
+    final var checksum = checksumGenerator.checksum(resource.getResourceBuffer());
+    deployment.resourceMetadata().stream()
+        .filter(
+            metadata ->
+                resource.getResourceName().equals(metadata.getResourceName())
+                    && checksum.equals(metadata.getChecksumBuffer()))
+        .findFirst()
+        .ifPresent(
+            metadata -> {
+              if (metadata.isDuplicate()) {
+                // create new version as the deployment contains at least one other non-duplicate
+                // resource and all resources in a deployment should be versioned together
+                metadata
+                    .setResourceKey(keyGenerator.nextKey())
+                    .setVersion(
+                        resourceState.getNextResourceVersion(
+                            metadata.getResourceId(), metadata.getTenantId()))
+                    .setDuplicate(false)
+                    .setDeploymentKey(deployment.getDeploymentKey());
+              }
+              writeResourceRecord(metadata, resource);
+            });
+  }
+
+  private void writeResourceRecord(
+      final ResourceMetadataRecord metadata, final DeploymentResource resource) {
+    stateWriter.appendFollowUpEvent(
+        metadata.getResourceKey(),
+        ResourceIntent.CREATED,
+        new ResourceRecord().wrap(metadata, resource.getResource()));
+  }
+
+  private void addResourceMetadata(
+      final ResourceInfo resourceInfo,
+      final DeploymentResource deploymentResource,
+      final DeploymentRecord deploymentRecord) {
+    final ResourceMetadataRecord metadata = deploymentRecord.resourceMetadata().add();
+    final DirectBuffer checksum =
+        checksumGenerator.checksum(deploymentResource.getResourceBuffer());
+    final String resourceId = resourceInfo.id();
+    final String tenantId = deploymentRecord.getTenantId();
+
+    metadata.setResourceId(resourceId);
+    metadata.setChecksum(checksum);
+    metadata.setResourceName(deploymentResource.getResourceName());
+    metadata.setTenantId(tenantId);
+    resourceInfo.versionTag().ifPresent(metadata::setVersionTag);
+
+    resourceState
+        .findLatestResourceById(resourceId, tenantId)
+        .ifPresentOrElse(
+            latestResource -> {
+              if (latestResource.isDuplicateOf(
+                  deploymentResource.getResourceNameBuffer(), checksum)) {
+                metadata
+                    .setResourceKey(latestResource.getResourceKey())
+                    .setVersion(latestResource.getVersion())
+                    .setDeploymentKey(latestResource.getDeploymentKey())
+                    .setDuplicate(true);
+              } else {
+                metadata
+                    .setResourceKey(keyGenerator.nextKey())
+                    .setVersion(resourceState.getNextResourceVersion(resourceId, tenantId))
+                    .setDeploymentKey(deploymentRecord.getDeploymentKey());
+              }
+            },
+            () ->
+                metadata
+                    .setResourceKey(keyGenerator.nextKey())
+                    .setVersion(INITIAL_VERSION)
+                    .setDeploymentKey(deploymentRecord.getDeploymentKey()));
+  }
+
+  private Either<Failure, ?> checkForDuplicateResourceId(
+      final String resourceId, final DeploymentResource resource, final DeploymentRecord record) {
+    return record.getResourceMetadata().stream()
+        .filter(metadata -> metadata.getResourceId().equals(resourceId))
+        .findFirst()
+        .map(
+            dupeResource -> {
+              final var failureMessage =
+                  String.format(
+                      "Expected the resource ids to be unique within a deployment"
+                          + " but found a duplicated id '%s' in the resources '%s' and '%s'.",
+                      resourceId, dupeResource.getResourceName(), resource.getResourceName());
+              return Either.left(new Failure(failureMessage));
+            })
+        .orElse(Either.right(null));
+  }
+
+  /**
+   * Holds the parsed identity of a deployment resource: its unique ID and an optional version tag.
+   *
+   * @param id the resource identifier (must not be null or blank)
+   * @param versionTag an optional version tag
+   */
+  public record ResourceInfo(String id, Optional<String> versionTag) {
+
+    static ResourceInfo of(final String id) {
+      return new ResourceInfo(id, Optional.empty());
+    }
+
+    static ResourceInfo of(final String id, final String versionTag) {
+      return new ResourceInfo(id, Optional.ofNullable(versionTag));
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentResourceTransformer.java
@@ -15,6 +15,18 @@ import io.camunda.zeebe.util.Either;
 interface DeploymentResourceTransformer {
 
   /**
+   * Determines if this transformer can handle the given resource.
+   *
+   * <p>Transformers are checked in order, and the first transformer that returns {@code true} will
+   * be used to process the resource. This allows transformers to make decisions based on file
+   * extension, content, or any other criteria.
+   *
+   * @param resource the resource to check
+   * @return {@code true} if this transformer can handle the resource, {@code false} otherwise
+   */
+  boolean canTransform(DeploymentResource resource);
+
+  /**
    * Step 1 of transforming the given resource: The transformer should add the deployed resource's
    * metadata to the deployment record, but not write any event records yet.
    *

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.engine.processing.deployment.transform;
 
 import static io.camunda.zeebe.util.buffer.BufferUtil.wrapArray;
-import static java.util.Map.entry;
 
 import io.camunda.zeebe.el.ExpressionLanguageMetrics;
 import io.camunda.zeebe.engine.Loggers;
@@ -27,18 +26,15 @@ import io.camunda.zeebe.util.FeatureFlags;
 import java.time.InstantSource;
 import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.Map;
-import java.util.Map.Entry;
+import java.util.List;
 import org.agrona.DirectBuffer;
 import org.slf4j.Logger;
 
 public final class DeploymentTransformer {
 
   private static final Logger LOG = Loggers.PROCESS_PROCESSOR_LOGGER;
-  private static final DeploymentResourceTransformer UNKNOWN_RESOURCE =
-      new UnknownResourceTransformer();
   private final ValidationConfig config;
-  private final Map<String, DeploymentResourceTransformer> resourceTransformers;
+  private final List<DeploymentResourceTransformer> resourceTransformers;
   private final ChecksumGenerator checksumGenerator = new ChecksumGenerator();
   // internal changes during processing
   private RejectionType rejectionType;
@@ -66,6 +62,7 @@ public final class DeploymentTransformer {
             config,
             clock,
             expressionLanguageMetrics);
+
     final var dmnResourceTransformer =
         new DmnResourceTransformer(
             keyGenerator,
@@ -78,17 +75,23 @@ public final class DeploymentTransformer {
         new FormResourceTransformer(
             keyGenerator, stateWriter, checksumGenerator, processingState.getFormState(), config);
 
-    final var resourceTransformer =
+    final var rpaTransformer =
         new RpaTransformer(
             keyGenerator, stateWriter, checksumGenerator, processingState.getResourceState());
 
+    final var defaultResourceTransformer =
+        new DefaultResourceTransformer(
+            keyGenerator, stateWriter, checksumGenerator, processingState.getResourceState());
+
+    // Order matters: transformers are checked in order, and the first that can handle the resource
+    // will be used. DefaultResourceTransformer should be last as it accepts any file.
     resourceTransformers =
-        Map.ofEntries(
-            entry(".bpmn", bpmnResourceTransformer),
-            entry(".xml", bpmnResourceTransformer),
-            entry(".dmn", dmnResourceTransformer),
-            entry(".form", formResourceTransformer),
-            entry(".rpa", resourceTransformer));
+        List.of(
+            bpmnResourceTransformer,
+            dmnResourceTransformer,
+            formResourceTransformer,
+            rpaTransformer,
+            defaultResourceTransformer);
   }
 
   public DirectBuffer getChecksum(final byte[] resource) {
@@ -170,7 +173,7 @@ public final class DeploymentTransformer {
       final DeploymentResourceContext context,
       final StringBuilder errors) {
     final var resourceName = deploymentResource.getResourceName();
-    final var transformer = getResourceTransformer(resourceName);
+    final var transformer = getResourceTransformer(deploymentResource);
 
     if (resourceName.length() > config.maxNameFieldLength()) {
       errors.append(
@@ -201,13 +204,12 @@ public final class DeploymentTransformer {
       final DeploymentResource deploymentResource,
       final DeploymentRecord deploymentEvent,
       final StringBuilder errors) {
-    final var resourceName = deploymentResource.getResourceName();
-    final var transformer = getResourceTransformer(resourceName);
+    final var transformer = getResourceTransformer(deploymentResource);
     try {
       transformer.writeRecords(deploymentResource, deploymentEvent);
       return true;
     } catch (final RuntimeException e) {
-      handleUnexpectedError(resourceName, e, errors);
+      handleUnexpectedError(deploymentResource.getResourceName(), e, errors);
     }
     return false;
   }
@@ -220,35 +222,20 @@ public final class DeploymentTransformer {
     return rejectionReason;
   }
 
-  private DeploymentResourceTransformer getResourceTransformer(final String resourceName) {
-    return resourceTransformers.entrySet().stream()
-        .filter(entry -> resourceName.endsWith(entry.getKey()))
-        .map(Entry::getValue)
+  private DeploymentResourceTransformer getResourceTransformer(final DeploymentResource resource) {
+    return resourceTransformers.stream()
+        .filter(transformer -> transformer.canTransform(resource))
         .findFirst()
-        .orElse(UNKNOWN_RESOURCE);
+        .orElseThrow(
+            () ->
+                new IllegalStateException(
+                    "No transformer found for resource: " + resource.getResourceName()));
   }
 
   private static void handleUnexpectedError(
       final String resourceName, final RuntimeException exception, final StringBuilder errors) {
     LOG.error("Unexpected error while processing resource '{}'", resourceName, exception);
     errors.append("\n'").append(resourceName).append("': ").append(exception.getMessage());
-  }
-
-  private static final class UnknownResourceTransformer implements DeploymentResourceTransformer {
-
-    @Override
-    public Either<Failure, Void> createMetadata(
-        final DeploymentResource resource,
-        final DeploymentRecord deployment,
-        final DeploymentResourceContext context) {
-      final var failureMessage =
-          String.format("%n'%s': unknown resource type", resource.getResourceName());
-      return Either.left(new Failure(failureMessage));
-    }
-
-    @Override
-    public void writeRecords(
-        final DeploymentResource resource, final DeploymentRecord deployment) {}
   }
 
   private record BpmnResource(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DmnResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DmnResourceTransformer.java
@@ -77,6 +77,11 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
   }
 
   @Override
+  public boolean canTransform(final DeploymentResource resource) {
+    return resource.getResourceName().endsWith(".dmn");
+  }
+
+  @Override
   public Either<Failure, Void> createMetadata(
       final DeploymentResource resource,
       final DeploymentRecord deployment,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/FormResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/FormResourceTransformer.java
@@ -52,6 +52,11 @@ public final class FormResourceTransformer implements DeploymentResourceTransfor
   }
 
   @Override
+  public boolean canTransform(final DeploymentResource resource) {
+    return resource.getResourceName().endsWith(".form");
+  }
+
+  @Override
   public Either<Failure, Void> createMetadata(
       final DeploymentResource resource,
       final DeploymentRecord deployment,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/RpaTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/RpaTransformer.java
@@ -14,142 +14,36 @@ import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.ChecksumGenerator;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.state.immutable.ResourceState;
-import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentResource;
-import io.camunda.zeebe.protocol.impl.record.value.deployment.ResourceMetadataRecord;
-import io.camunda.zeebe.protocol.impl.record.value.deployment.ResourceRecord;
-import io.camunda.zeebe.protocol.record.intent.ResourceIntent;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.Either;
 import java.io.IOException;
 import java.util.Optional;
-import java.util.function.LongSupplier;
-import org.agrona.DirectBuffer;
 
-public class RpaTransformer implements DeploymentResourceTransformer {
-  private static final int INITIAL_VERSION = 1;
+public class RpaTransformer extends DefaultResourceTransformer {
+
   private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
-
-  private final KeyGenerator keyGenerator;
-  private final StateWriter stateWriter;
-  private final ChecksumGenerator checksumGenerator;
-  private final ResourceState resourceState;
 
   public RpaTransformer(
       final KeyGenerator keyGenerator,
       final StateWriter stateWriter,
       final ChecksumGenerator checksumGenerator,
       final ResourceState resourceState) {
-    this.keyGenerator = keyGenerator;
-    this.stateWriter = stateWriter;
-    this.checksumGenerator = checksumGenerator;
-    this.resourceState = resourceState;
+    super(keyGenerator, stateWriter, checksumGenerator, resourceState);
   }
 
   @Override
-  public Either<Failure, Void> createMetadata(
-      final DeploymentResource deploymentResource,
-      final DeploymentRecord deployment,
-      final DeploymentResourceContext context) {
-    return parseResource(deploymentResource)
-        .flatMap(
-            resource ->
-                checkForDuplicateResourceId(resource.id, deploymentResource, deployment)
-                    .map(
-                        noDuplicates -> {
-                          final ResourceMetadataRecord resourceMetadataRecord =
-                              deployment.resourceMetadata().add();
-                          appendMetadataToResourceRecord(
-                              resourceMetadataRecord, resource, deploymentResource, deployment);
-                          return null;
-                        }));
+  public boolean canTransform(final DeploymentResource resource) {
+    return resource.getResourceName().endsWith(".rpa");
   }
 
   @Override
-  public void writeRecords(final DeploymentResource resource, final DeploymentRecord deployment) {
-    if (deployment.hasDuplicatesOnly()) {
-      return;
-    }
-    final var checksum = checksumGenerator.checksum(resource.getResourceBuffer());
-    deployment.resourceMetadata().stream()
-        .filter(metadata -> checksum.equals(metadata.getChecksumBuffer()))
-        .findFirst()
-        .ifPresent(
-            metadata -> {
-              var key = metadata.getResourceKey();
-              if (metadata.isDuplicate()) {
-                key = keyGenerator.nextKey();
-                metadata
-                    .setResourceKey(key)
-                    .setVersion(
-                        resourceState.getNextResourceVersion(
-                            metadata.getResourceId(), metadata.getTenantId()))
-                    .setDuplicate(false)
-                    .setDeploymentKey(deployment.getDeploymentKey());
-              }
-              writeResourceRecord(metadata, resource);
-            });
-  }
-
-  private void writeResourceRecord(
-      final ResourceMetadataRecord resourceMetadataRecord, final DeploymentResource resource) {
-    stateWriter.appendFollowUpEvent(
-        resourceMetadataRecord.getResourceKey(),
-        ResourceIntent.CREATED,
-        new ResourceRecord().wrap(resourceMetadataRecord, resource.getResource()));
-  }
-
-  private void appendMetadataToResourceRecord(
-      final ResourceMetadataRecord resourceMetadataRecord,
-      final Resource resource,
-      final DeploymentResource deploymentResource,
-      final DeploymentRecord deploymentRecord) {
-    final LongSupplier newResourceKey = keyGenerator::nextKey;
-    final DirectBuffer checksum =
-        checksumGenerator.checksum(deploymentResource.getResourceBuffer());
-    final String tenantId = deploymentRecord.getTenantId();
-
-    resourceMetadataRecord.setResourceId(resource.id);
-    resourceMetadataRecord.setChecksum(checksum);
-    resourceMetadataRecord.setResourceName(deploymentResource.getResourceName());
-    resourceMetadataRecord.setTenantId(tenantId);
-    Optional.ofNullable(resource.versionTag).ifPresent(resourceMetadataRecord::setVersionTag);
-
-    resourceState
-        .findLatestResourceById(resourceMetadataRecord.getResourceId(), tenantId)
-        .ifPresentOrElse(
-            latestResource -> {
-              final boolean isDuplicate =
-                  latestResource.getChecksum().equals(resourceMetadataRecord.getChecksumBuffer())
-                      && latestResource
-                          .getResourceName()
-                          .equals(resourceMetadataRecord.getResourceNameBuffer());
-
-              if (isDuplicate) {
-                final int latestVersion = latestResource.getVersion();
-                resourceMetadataRecord
-                    .setResourceKey(latestResource.getResourceKey())
-                    .setVersion(latestVersion)
-                    .setDeploymentKey(latestResource.getDeploymentKey())
-                    .setDuplicate(true);
-              } else {
-                resourceMetadataRecord
-                    .setResourceKey(newResourceKey.getAsLong())
-                    .setVersion(resourceState.getNextResourceVersion(resource.id, tenantId))
-                    .setDeploymentKey(deploymentRecord.getDeploymentKey());
-              }
-            },
-            () ->
-                resourceMetadataRecord
-                    .setResourceKey(newResourceKey.getAsLong())
-                    .setVersion(INITIAL_VERSION)
-                    .setDeploymentKey(deploymentRecord.getDeploymentKey()));
-  }
-
-  private Either<Failure, Resource> parseResource(final DeploymentResource resource) {
+  protected Either<Failure, ResourceInfo> parseResourceInfo(final DeploymentResource resource) {
     try {
-      final var res = JSON_MAPPER.readValue(resource.getResource(), Resource.class);
-      return validateResource(res);
+      final var rpaResource =
+          JSON_MAPPER.readValue(resource.getResource(), ParsedRpaResource.class);
+      return validateRpaResource(rpaResource)
+          .map(valid -> ResourceInfo.of(valid.id, valid.versionTag));
     } catch (final JsonProcessingException e) {
       final var failureMessage =
           String.format(
@@ -169,7 +63,7 @@ public class RpaTransformer implements DeploymentResourceTransformer {
         .orElse(exception.getMessage());
   }
 
-  private Either<Failure, Resource> validateResource(final Resource res) {
+  private Either<Failure, ParsedRpaResource> validateRpaResource(final ParsedRpaResource res) {
     if (res.id == null) {
       return Either.left(new Failure("Expected the resource id to be present, but none given"));
     }
@@ -179,23 +73,6 @@ public class RpaTransformer implements DeploymentResourceTransformer {
     return Either.right(res);
   }
 
-  private Either<Failure, ?> checkForDuplicateResourceId(
-      final String resourceId, final DeploymentResource resource, final DeploymentRecord record) {
-    return record.getResourceMetadata().stream()
-        .filter(metadata -> metadata.getResourceId().equals(resourceId))
-        .findFirst()
-        .map(
-            dupeResource -> {
-              final var failureMessage =
-                  String.format(
-                      "Expected the resource ids to be unique within a deployment"
-                          + " but found a duplicated id '%s' in the resources '%s' and '%s'.",
-                      resourceId, dupeResource.getResourceName(), resource.getResourceName());
-              return Either.left(new Failure(failureMessage));
-            })
-        .orElse(Either.right(null));
-  }
-
   @JsonIgnoreProperties(ignoreUnknown = true)
-  private record Resource(String id, String versionTag) {}
+  private record ParsedRpaResource(String id, String versionTag) {}
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedForm.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedForm.java
@@ -119,4 +119,8 @@ public final class PersistedForm extends UnpackedObject implements DbValue {
     deploymentKeyProp.setValue(record.getDeploymentKey());
     versionTagProp.setValue(record.getVersionTag());
   }
+
+  public boolean isDuplicateOf(final DirectBuffer resourceName, final DirectBuffer checksum) {
+    return getResourceName().equals(resourceName) && getChecksum().equals(checksum);
+  }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedResource.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedResource.java
@@ -107,4 +107,8 @@ public class PersistedResource extends UnpackedObject implements DbValue {
     versionTagProp.setValue(record.getVersionTag());
     resourceProp.setValue(record.getResourceProp());
   }
+
+  public boolean isDuplicateOf(final DirectBuffer resourceName, final DirectBuffer checksum) {
+    return getResourceName().equals(resourceName) && getChecksum().equals(checksum);
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.engine.processing.deployment;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
@@ -141,24 +140,6 @@ public class DeploymentRejectionTest {
         .hasIntent(DeploymentIntent.CREATE)
         .hasRejectionType(RejectionType.INVALID_ARGUMENT)
         .hasRejectionReason("Expected to deploy at least one resource, but none given");
-  }
-
-  @Test
-  public void shouldRejectDeploymentIfNotParsable() {
-    // when
-    final Record<DeploymentRecordValue> rejectedDeployment =
-        ENGINE
-            .deployment()
-            .withXmlResource("not a process".getBytes(UTF_8))
-            .expectRejection()
-            .deploy();
-
-    // then
-    Assertions.assertThat(rejectedDeployment)
-        .hasKey(ExecuteCommandResponseDecoder.keyNullValue())
-        .hasRecordType(RecordType.COMMAND_REJECTION)
-        .hasIntent(DeploymentIntent.CREATE)
-        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/GenericResourceDeploymentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/GenericResourceDeploymentTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collection;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class GenericResourceDeploymentTest {
+
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+
+  @Parameter(0)
+  public String resourceName;
+
+  @Parameter(1)
+  public String content;
+
+  @Parameters(name = "{0}")
+  public static Collection<Object[]> fileTypes() {
+    return Arrays.asList(
+        new Object[][] {
+          {"my-script.txt", "echo 'Hello World'"},
+          {"runbook.md", "# Runbook\n\n## Steps\n\n1. Check logs"},
+          {"config.yml", "server:\n  port: 8080\n  host: localhost"},
+          {"pipeline.yaml", "stages:\n  - name: build\n    script: mvn package"},
+          {"settings.json", "{\"timeout\": 30, \"retries\": 3, \"mode\": \"production\"}"},
+        });
+  }
+
+  @Test
+  public void shouldDeployGenericResource() {
+    // when
+    final var deploymentEvent =
+        engine
+            .deployment()
+            .withJsonResource(content.getBytes(StandardCharsets.UTF_8), resourceName)
+            .deploy();
+
+    // then
+    Assertions.assertThat(deploymentEvent)
+        .hasIntent(DeploymentIntent.CREATED)
+        .hasValueType(ValueType.DEPLOYMENT)
+        .hasRecordType(RecordType.EVENT);
+    assertThat(deploymentEvent.getValue().getResourceMetadata())
+        .singleElement()
+        .satisfies(
+            resourceMetadata ->
+                Assertions.assertThat(resourceMetadata)
+                    .hasResourceId(resourceName)
+                    .hasVersion(1)
+                    .hasResourceName(resourceName)
+                    .isNotDuplicate()
+                    .hasDeploymentKey(deploymentEvent.getKey()));
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/ResourceDeploymentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/ResourceDeploymentTest.java
@@ -42,6 +42,9 @@ public class ResourceDeploymentTest {
   private static final String TEST_RESOURCE_WITH_BLANK_ID = "/resource/test-rpa_with_blank_id.rpa";
   private static final String TEST_RESOURCE_1_ID = "Rpa_0w7r08e";
   private static final String TEST_RESOURCE_2_ID = "Rpa_6s1b76p";
+  private static final String TEST_GENERIC_RESOURCE_1 = "/resource/test-generic-1.txt";
+  private static final String TEST_GENERIC_RESOURCE_2 = "/resource/test-generic-2.txt";
+  private static final String TEST_GENERIC_XML_CONFIG = "/resource/test-generic-config.xml";
 
   @Rule public final EngineRule engine = EngineRule.singlePartition();
 
@@ -523,6 +526,226 @@ public class ResourceDeploymentTest {
         .describedAs("Resources are created for correct tenants")
         .containsExactly(
             tuple(TEST_RESOURCE_1_ID, 1, tenant1), tuple(TEST_RESOURCE_1_ID, 1, tenant2));
+  }
+
+  // --- Generic resource tests ---
+
+  @Test
+  public void shouldDeployGenericResource() {
+    // when
+    final var deploymentEvent =
+        engine.deployment().withJsonClasspathResource(TEST_GENERIC_RESOURCE_1).deploy();
+
+    // then
+    Assertions.assertThat(deploymentEvent)
+        .hasIntent(DeploymentIntent.CREATED)
+        .hasValueType(ValueType.DEPLOYMENT)
+        .hasRecordType(RecordType.EVENT);
+    assertThat(deploymentEvent.getValue().getResourceMetadata())
+        .singleElement()
+        .satisfies(
+            resourceMetadata ->
+                Assertions.assertThat(resourceMetadata)
+                    .hasResourceId(TEST_GENERIC_RESOURCE_1)
+                    .hasVersion(1)
+                    .hasVersionTag("")
+                    .hasResourceName(TEST_GENERIC_RESOURCE_1)
+                    .hasChecksum(getChecksum(TEST_GENERIC_RESOURCE_1))
+                    .isNotDuplicate()
+                    .hasDeploymentKey(deploymentEvent.getKey()));
+  }
+
+  @Test
+  public void shouldWriteResourceRecordForGenericResource() {
+    // when
+    final var deployment =
+        engine.deployment().withJsonClasspathResource(TEST_GENERIC_RESOURCE_1).deploy();
+
+    // then
+    final Record<Resource> record = RecordingExporter.resourceRecords().getFirst();
+
+    Assertions.assertThat(record)
+        .hasIntent(ResourceIntent.CREATED)
+        .hasValueType(ValueType.RESOURCE)
+        .hasRecordType(RecordType.EVENT);
+
+    final Resource resourceRecord = record.getValue();
+    Assertions.assertThat(resourceRecord)
+        .hasResourceId(TEST_GENERIC_RESOURCE_1)
+        .hasResourceName(TEST_GENERIC_RESOURCE_1)
+        .hasVersion(1)
+        .hasVersionTag("")
+        .hasDeploymentKey(deployment.getKey());
+
+    assertThat(resourceRecord.getResourceKey()).isPositive();
+    assertThat(resourceRecord.isDuplicate()).isFalse();
+  }
+
+  @Test
+  public void shouldDeployNonBpmnXmlFileAsGenericResource() {
+    // when
+    final var deploymentEvent =
+        engine.deployment().withXmlClasspathResource(TEST_GENERIC_XML_CONFIG).deploy();
+
+    // then - it should be deployed as a generic resource, not fail as invalid BPMN
+    Assertions.assertThat(deploymentEvent)
+        .hasIntent(DeploymentIntent.CREATED)
+        .hasValueType(ValueType.DEPLOYMENT)
+        .hasRecordType(RecordType.EVENT);
+
+    assertThat(deploymentEvent.getValue().getResourceMetadata())
+        .singleElement()
+        .satisfies(
+            resourceMetadata ->
+                Assertions.assertThat(resourceMetadata)
+                    .hasResourceId(TEST_GENERIC_XML_CONFIG)
+                    .hasVersion(1)
+                    .hasResourceName(TEST_GENERIC_XML_CONFIG)
+                    .hasChecksum(getChecksum(TEST_GENERIC_XML_CONFIG))
+                    .isNotDuplicate()
+                    .hasDeploymentKey(deploymentEvent.getKey()));
+
+    // Verify resource record was created
+    final Record<Resource> record = RecordingExporter.resourceRecords().getFirst();
+    Assertions.assertThat(record)
+        .hasIntent(ResourceIntent.CREATED)
+        .hasValueType(ValueType.RESOURCE)
+        .hasRecordType(RecordType.EVENT);
+    Assertions.assertThat(record.getValue())
+        .hasResourceId(TEST_GENERIC_XML_CONFIG)
+        .hasVersion(1)
+        .hasResourceName(TEST_GENERIC_XML_CONFIG)
+        .hasChecksum(getChecksum(TEST_GENERIC_XML_CONFIG));
+  }
+
+  @Test
+  public void shouldDeployGenericResourceDuplicateInSeparateCommand() {
+    // given
+    final var firstDeployment =
+        engine.deployment().withJsonClasspathResource(TEST_GENERIC_RESOURCE_1).deploy();
+    final var resourceV1 = firstDeployment.getValue().getResourceMetadata().get(0);
+
+    // when
+    final var secondDeployment =
+        engine.deployment().withJsonClasspathResource(TEST_GENERIC_RESOURCE_1).deploy();
+
+    // then
+    assertThat(secondDeployment.getValue().getResourceMetadata()).hasSize(1);
+    final var resourceMetadata = secondDeployment.getValue().getResourceMetadata().get(0);
+    Assertions.assertThat(resourceMetadata)
+        .hasVersion(1)
+        .hasResourceKey(resourceV1.getResourceKey())
+        .isDuplicate();
+  }
+
+  @Test
+  public void shouldIncreaseVersionForGenericResourceWithChangedContent() {
+    // given
+    engine.deployment().withJsonClasspathResource(TEST_GENERIC_RESOURCE_1).deploy();
+
+    // when
+    final var secondDeployment =
+        engine
+            .deployment()
+            .withJsonResource(readResource(TEST_GENERIC_RESOURCE_2), TEST_GENERIC_RESOURCE_1)
+            .deploy();
+
+    // then
+    assertThat(secondDeployment.getValue().getResourceMetadata())
+        .extracting(ResourceMetadataValue::getVersion)
+        .describedAs("Expect that the resource version is increased")
+        .containsExactly(2);
+  }
+
+  @Test
+  public void shouldCreateNewResourceWhenGenericResourceIsRenamed() {
+    // given
+    final var firstDeployment =
+        engine.deployment().withJsonClasspathResource(TEST_GENERIC_RESOURCE_1).deploy();
+    final var resourceV1 = firstDeployment.getValue().getResourceMetadata().get(0);
+
+    // when - same content deployed under a different filename
+    final var secondDeployment =
+        engine
+            .deployment()
+            .withJsonResource(
+                readResource(TEST_GENERIC_RESOURCE_1), "/resource/renamed-generic-1.txt")
+            .deploy();
+
+    // then - a new, separate resource is created because the filename (= resource ID) changed
+    assertThat(secondDeployment.getValue().getResourceMetadata())
+        .singleElement()
+        .satisfies(
+            resourceMetadata ->
+                Assertions.assertThat(resourceMetadata)
+                    .hasResourceId("/resource/renamed-generic-1.txt")
+                    .hasResourceName("/resource/renamed-generic-1.txt")
+                    .hasVersion(1)
+                    .isNotDuplicate());
+
+    assertThat(resourceV1)
+        .satisfies(
+            metadata ->
+                Assertions.assertThat(metadata)
+                    .hasResourceId(TEST_GENERIC_RESOURCE_1)
+                    .hasVersion(1));
+  }
+
+  @Test
+  public void shouldRejectGenericDeploymentWithDuplicateResourceName() {
+    // given
+    final var resource = readResource(TEST_GENERIC_RESOURCE_1);
+
+    // when
+    final var deploymentEvent =
+        engine
+            .deployment()
+            .withJsonResource(resource, TEST_GENERIC_RESOURCE_1)
+            .withJsonResource(resource, TEST_GENERIC_RESOURCE_1)
+            .expectRejection()
+            .deploy();
+
+    // then
+    Assertions.assertThat(deploymentEvent)
+        .hasIntent(DeploymentIntent.CREATE)
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+
+    assertThat(deploymentEvent.getRejectionReason())
+        .contains(
+            String.format(
+                "Expected the resource ids to be unique within a deployment"
+                    + " but found a duplicated id '%s' in the resources '%s' and '%s'.",
+                TEST_GENERIC_RESOURCE_1, TEST_GENERIC_RESOURCE_1, TEST_GENERIC_RESOURCE_1));
+  }
+
+  @Test
+  public void shouldRejectGenericDeploymentWithSameNameButDifferentContent() {
+    // given
+    final var resource1 = readResource(TEST_GENERIC_RESOURCE_1);
+    final var resource2 = readResource(TEST_GENERIC_RESOURCE_2);
+
+    // when - two different files deployed under the same name
+    final var deploymentEvent =
+        engine
+            .deployment()
+            .withJsonResource(resource1, TEST_GENERIC_RESOURCE_1)
+            .withJsonResource(resource2, TEST_GENERIC_RESOURCE_1)
+            .expectRejection()
+            .deploy();
+
+    // then
+    Assertions.assertThat(deploymentEvent)
+        .hasIntent(DeploymentIntent.CREATE)
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+
+    assertThat(deploymentEvent.getRejectionReason())
+        .contains(
+            String.format(
+                "Expected the resource ids to be unique within a deployment"
+                    + " but found a duplicated id '%s' in the resources '%s' and '%s'.",
+                TEST_GENERIC_RESOURCE_1, TEST_GENERIC_RESOURCE_1, TEST_GENERIC_RESOURCE_1));
   }
 
   private byte[] readResource(final String resourceName) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/ResourceDeploymentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/ResourceDeploymentTest.java
@@ -529,33 +529,6 @@ public class ResourceDeploymentTest {
   }
 
   @Test
-  public void shouldDeployGenericTxtResource() {
-    assertGenericResourceDeployment("my-script.txt", "echo 'Hello World'");
-  }
-
-  @Test
-  public void shouldDeployGenericMdResource() {
-    assertGenericResourceDeployment("runbook.md", "# Runbook\n\n## Steps\n\n1. Check logs");
-  }
-
-  @Test
-  public void shouldDeployGenericYmlResource() {
-    assertGenericResourceDeployment("config.yml", "server:\n  port: 8080\n  host: localhost");
-  }
-
-  @Test
-  public void shouldDeployGenericYamlResource() {
-    assertGenericResourceDeployment(
-        "pipeline.yaml", "stages:\n  - name: build\n    script: mvn package");
-  }
-
-  @Test
-  public void shouldDeployGenericJsonResource() {
-    assertGenericResourceDeployment(
-        "settings.json", "{\"timeout\": 30, \"retries\": 3, \"mode\": \"production\"}");
-  }
-
-  @Test
   public void shouldWriteResourceRecordForGenericResource() {
     // when
     final var deployment =
@@ -587,7 +560,7 @@ public class ResourceDeploymentTest {
     final var deploymentEvent =
         engine.deployment().withXmlClasspathResource(TEST_GENERIC_XML_CONFIG).deploy();
 
-    // then - it should be deployed as a generic resource, not fail as invalid BPMN
+    // then
     Assertions.assertThat(deploymentEvent)
         .hasIntent(DeploymentIntent.CREATED)
         .hasValueType(ValueType.DEPLOYMENT)
@@ -605,7 +578,6 @@ public class ResourceDeploymentTest {
                     .isNotDuplicate()
                     .hasDeploymentKey(deploymentEvent.getKey()));
 
-    // Verify resource record was created
     final Record<Resource> record = RecordingExporter.resourceRecords().getFirst();
     Assertions.assertThat(record)
         .hasIntent(ResourceIntent.CREATED)
@@ -619,7 +591,7 @@ public class ResourceDeploymentTest {
   }
 
   @Test
-  public void shouldDeployGenericResourceDuplicateInSeparateCommand() {
+  public void shouldDetectGenericResourceDuplicateInSeparateCommand() {
     // given
     final var firstDeployment =
         engine.deployment().withJsonClasspathResource(TEST_GENERIC_RESOURCE_1).deploy();
@@ -653,7 +625,6 @@ public class ResourceDeploymentTest {
     // then
     assertThat(secondDeployment.getValue().getResourceMetadata())
         .extracting(ResourceMetadataValue::getVersion)
-        .describedAs("Expect that the resource version is increased")
         .containsExactly(2);
   }
 
@@ -664,7 +635,7 @@ public class ResourceDeploymentTest {
         engine.deployment().withJsonClasspathResource(TEST_GENERIC_RESOURCE_1).deploy();
     final var resourceV1 = firstDeployment.getValue().getResourceMetadata().get(0);
 
-    // when - same content deployed under a different filename
+    // when
     final var secondDeployment =
         engine
             .deployment()
@@ -672,7 +643,7 @@ public class ResourceDeploymentTest {
                 readResource(TEST_GENERIC_RESOURCE_1), "/resource/renamed-generic-1.txt")
             .deploy();
 
-    // then - a new, separate resource is created because the filename (= resource ID) changed
+    // then - filename is the resource ID for generic resources, so rename = new resource
     assertThat(secondDeployment.getValue().getResourceMetadata())
         .singleElement()
         .satisfies(
@@ -725,7 +696,7 @@ public class ResourceDeploymentTest {
     final var resource1 = readResource(TEST_GENERIC_RESOURCE_1);
     final var resource2 = readResource(TEST_GENERIC_RESOURCE_2);
 
-    // when - two different files deployed under the same name
+    // when
     final var deploymentEvent =
         engine
             .deployment()
@@ -746,32 +717,6 @@ public class ResourceDeploymentTest {
                 "Expected the resource ids to be unique within a deployment"
                     + " but found a duplicated id '%s' in the resources '%s' and '%s'.",
                 TEST_GENERIC_RESOURCE_1, TEST_GENERIC_RESOURCE_1, TEST_GENERIC_RESOURCE_1));
-  }
-
-  private void assertGenericResourceDeployment(final String resourceName, final String content) {
-
-    // when
-    final var deploymentEvent =
-        engine
-            .deployment()
-            .withJsonResource(content.getBytes(StandardCharsets.UTF_8), resourceName)
-            .deploy();
-
-    // then
-    Assertions.assertThat(deploymentEvent)
-        .hasIntent(DeploymentIntent.CREATED)
-        .hasValueType(ValueType.DEPLOYMENT)
-        .hasRecordType(RecordType.EVENT);
-    assertThat(deploymentEvent.getValue().getResourceMetadata())
-        .singleElement()
-        .satisfies(
-            resourceMetadata ->
-                Assertions.assertThat(resourceMetadata)
-                    .hasResourceId(resourceName)
-                    .hasVersion(1)
-                    .hasResourceName(resourceName)
-                    .isNotDuplicate()
-                    .hasDeploymentKey(deploymentEvent.getKey()));
   }
 
   private byte[] readResource(final String resourceName) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/ResourceDeploymentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/ResourceDeploymentTest.java
@@ -528,31 +528,31 @@ public class ResourceDeploymentTest {
             tuple(TEST_RESOURCE_1_ID, 1, tenant1), tuple(TEST_RESOURCE_1_ID, 1, tenant2));
   }
 
-  // --- Generic resource tests ---
+  @Test
+  public void shouldDeployGenericTxtResource() {
+    assertGenericResourceDeployment("my-script.txt", "echo 'Hello World'");
+  }
 
   @Test
-  public void shouldDeployGenericResource() {
-    // when
-    final var deploymentEvent =
-        engine.deployment().withJsonClasspathResource(TEST_GENERIC_RESOURCE_1).deploy();
+  public void shouldDeployGenericMdResource() {
+    assertGenericResourceDeployment("runbook.md", "# Runbook\n\n## Steps\n\n1. Check logs");
+  }
 
-    // then
-    Assertions.assertThat(deploymentEvent)
-        .hasIntent(DeploymentIntent.CREATED)
-        .hasValueType(ValueType.DEPLOYMENT)
-        .hasRecordType(RecordType.EVENT);
-    assertThat(deploymentEvent.getValue().getResourceMetadata())
-        .singleElement()
-        .satisfies(
-            resourceMetadata ->
-                Assertions.assertThat(resourceMetadata)
-                    .hasResourceId(TEST_GENERIC_RESOURCE_1)
-                    .hasVersion(1)
-                    .hasVersionTag("")
-                    .hasResourceName(TEST_GENERIC_RESOURCE_1)
-                    .hasChecksum(getChecksum(TEST_GENERIC_RESOURCE_1))
-                    .isNotDuplicate()
-                    .hasDeploymentKey(deploymentEvent.getKey()));
+  @Test
+  public void shouldDeployGenericYmlResource() {
+    assertGenericResourceDeployment("config.yml", "server:\n  port: 8080\n  host: localhost");
+  }
+
+  @Test
+  public void shouldDeployGenericYamlResource() {
+    assertGenericResourceDeployment(
+        "pipeline.yaml", "stages:\n  - name: build\n    script: mvn package");
+  }
+
+  @Test
+  public void shouldDeployGenericJsonResource() {
+    assertGenericResourceDeployment(
+        "settings.json", "{\"timeout\": 30, \"retries\": 3, \"mode\": \"production\"}");
   }
 
   @Test
@@ -746,6 +746,32 @@ public class ResourceDeploymentTest {
                 "Expected the resource ids to be unique within a deployment"
                     + " but found a duplicated id '%s' in the resources '%s' and '%s'.",
                 TEST_GENERIC_RESOURCE_1, TEST_GENERIC_RESOURCE_1, TEST_GENERIC_RESOURCE_1));
+  }
+
+  private void assertGenericResourceDeployment(final String resourceName, final String content) {
+
+    // when
+    final var deploymentEvent =
+        engine
+            .deployment()
+            .withJsonResource(content.getBytes(StandardCharsets.UTF_8), resourceName)
+            .deploy();
+
+    // then
+    Assertions.assertThat(deploymentEvent)
+        .hasIntent(DeploymentIntent.CREATED)
+        .hasValueType(ValueType.DEPLOYMENT)
+        .hasRecordType(RecordType.EVENT);
+    assertThat(deploymentEvent.getValue().getResourceMetadata())
+        .singleElement()
+        .satisfies(
+            resourceMetadata ->
+                Assertions.assertThat(resourceMetadata)
+                    .hasResourceId(resourceName)
+                    .hasVersion(1)
+                    .hasResourceName(resourceName)
+                    .isNotDuplicate()
+                    .hasDeploymentKey(deploymentEvent.getKey()));
   }
 
   private byte[] readResource(final String resourceName) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceFetchTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceFetchTest.java
@@ -89,6 +89,39 @@ public class ResourceFetchTest {
   }
 
   @Test
+  public void shouldFetchGenericResource() throws Exception {
+    // Generic resources use the filename as their resource ID (no structured content to parse).
+    // The resource can be fetched by key via GET /v2/resources/{key}/content once deployed.
+    final var resourceContent = "Hello, generic resource!".getBytes();
+    final var resourceName = "my-script.txt";
+    final var deployment =
+        engine.deployment().withJsonResource(resourceContent, resourceName).deploy();
+    final var resourceMetadata = deployment.getValue().getResourceMetadata().getFirst();
+    final var resourceKey = resourceMetadata.getResourceKey();
+
+    // when
+    final var record =
+        engine
+            .resourceFetch()
+            .withResourceKey(resourceKey)
+            .withRequestStreamId(10)
+            .withRequestId(123456789L)
+            .fetch();
+
+    // then - resourceId equals the filename for generic resources
+    ResourceAssert.assertThat(record.getValue())
+        .isNotNull()
+        .hasResourceProp(new String(resourceContent))
+        .hasResourceKey(resourceKey)
+        .hasResourceId(resourceName)
+        .hasResourceName(resourceName)
+        .hasVersion(1)
+        .hasVersionTag("")
+        .hasDeploymentKey(deployment.getKey())
+        .hasChecksum(resourceMetadata.getChecksum());
+  }
+
+  @Test
   public void shouldRejectIfResourceNotFound() {
     // given
     final var unknownResourceKey = 123456789L;

--- a/zeebe/engine/src/test/resources/resource/test-generic-1.txt
+++ b/zeebe/engine/src/test/resources/resource/test-generic-1.txt
@@ -1,0 +1,1 @@
+Hello, I am a generic resource.

--- a/zeebe/engine/src/test/resources/resource/test-generic-2.txt
+++ b/zeebe/engine/src/test/resources/resource/test-generic-2.txt
@@ -1,0 +1,1 @@
+Hello, I am a different generic resource.

--- a/zeebe/engine/src/test/resources/resource/test-generic-config.xml
+++ b/zeebe/engine/src/test/resources/resource/test-generic-config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <setting name="timeout" value="30"/>
+  <setting name="retries" value="3"/>
+  <setting name="mode" value="production"/>
+  <features>
+    <feature name="logging" enabled="true"/>
+    <feature name="monitoring" enabled="false"/>
+  </features>
+</configuration>

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentRecord.java
@@ -247,9 +247,9 @@ public final class DeploymentRecord extends UnifiedRecordValue implements Deploy
   }
 
   /**
-   * Returns {@code true} if every resource in this deployment is a duplicate of an already-deployed
-   * version (i.e. its content and filename have not changed since the last deployment), {@code
-   * false} if at least one resource is new or changed.
+   * Returns {@code true} if every metadata entry in this deployment record has its {@code
+   * duplicate} flag set, {@code false} if at least one entry is marked as new or changed. The
+   * duplicate flag is set during metadata creation by the individual resource transformers.
    */
   public boolean hasDuplicatesOnly() {
     return processesMetadata().stream().allMatch(ProcessMetadata::isDuplicate)

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentRecord.java
@@ -246,6 +246,11 @@ public final class DeploymentRecord extends UnifiedRecordValue implements Deploy
         .anyMatch(x -> x.endsWith(".rpa"));
   }
 
+  /**
+   * Returns {@code true} if every resource in this deployment is a duplicate of an already-deployed
+   * version (i.e. its content and filename have not changed since the last deployment), {@code
+   * false} if at least one resource is new or changed.
+   */
   public boolean hasDuplicatesOnly() {
     return processesMetadata().stream().allMatch(ProcessMetadata::isDuplicate)
         && decisionRequirementsMetadata().stream()


### PR DESCRIPTION
## Summary

Adds support for deploying arbitrary file types (not just BPMN, DMN, Form, RPA) as generic resources. Unknown file types now go through a `DefaultResourceTransformer` that uses the filename as the resource ID.

### Key changes

- Add `canTransform()` to `DeploymentResourceTransformer` interface for content-based dispatch
- Switch `DeploymentTransformer` from extension-map to ordered list-based transformer selection
- Create `DefaultResourceTransformer` as fallback for unrecognized file types
- `BpmnResourceTransformer` now sniffs `.xml` content to distinguish BPMN from generic XML
- `RpaTransformer` extends `DefaultResourceTransformer`, eliminating ~130 lines of duplicated versioning/record-writing logic
- Add `isDuplicateOf()` helpers to `PersistedForm` and `PersistedResource`

### Duplicate detection semantics

Duplicate detection is a two-step process: the latest deployed version is looked up by resource ID, then compared using both filename and checksum. For generic resources, the filename *is* the resource ID — renaming creates a new independently versioned resource.

## Test plan

- [x] Parameterized `GenericResourceDeploymentTest` covering `.txt`, `.md`, `.yml`, `.yaml`, `.json` with realistic content
- [x] Non-BPMN `.xml` deployed as generic resource
- [x] Generic resource record writing, duplicate detection, versioning, rename semantics
- [x] Duplicate resource ID rejection within same deployment
- [x] Generic resource fetch via `ResourceFetchTest`

Closes #50900

🤖 Generated with [Claude Code](https://claude.com/claude-code)