### PR TITLE
feat: validate deployment bindings for linked resources

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/BpmnDeploymentBindingValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/BpmnDeploymentBindingValidator.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.engine.processing.deployment.transform.ValidationErrorFo
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledDecision;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledElement;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeFormDefinition;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeLinkedResource;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import java.io.StringWriter;
 import java.util.List;
@@ -25,11 +26,13 @@ public class BpmnDeploymentBindingValidator {
   private final ZeebeCalledElementDeploymentBindingValidator calledElementValidator;
   private final ZeebeCalledDecisionDeploymentBindingValidator calledDecisionValidator;
   private final ZeebeFormDefinitionDeploymentBindingValidator formDefinitionValidator;
+  private final ZeebeLinkedResourceDeploymentBindingValidator linkedResourceValidator;
 
   public BpmnDeploymentBindingValidator(final DeploymentRecord deployment) {
     calledElementValidator = new ZeebeCalledElementDeploymentBindingValidator(deployment);
     calledDecisionValidator = new ZeebeCalledDecisionDeploymentBindingValidator(deployment);
     formDefinitionValidator = new ZeebeFormDefinitionDeploymentBindingValidator(deployment);
+    linkedResourceValidator = new ZeebeLinkedResourceDeploymentBindingValidator(deployment);
   }
 
   public String validate(final BpmnElementsWithDeploymentBinding elements) {
@@ -38,6 +41,7 @@ public class BpmnDeploymentBindingValidator {
     validateCalledElements(elements.getCalledElements(), resultsCollector);
     validateCalledDecisions(elements.getCalledDecisions(), resultsCollector);
     validateFormDefinitions(elements.getFormDefinitions(), resultsCollector);
+    validateLinkedResources(elements.getLinkedResources(), resultsCollector);
 
     final var validationResults = resultsCollector.getResults();
 
@@ -71,6 +75,16 @@ public class BpmnDeploymentBindingValidator {
         element -> {
           collector.setCurrentElement(element);
           formDefinitionValidator.validate(element, collector);
+        });
+  }
+
+  private void validateLinkedResources(
+      final List<ZeebeLinkedResource> linkedResources,
+      final ValidationResultsCollectorImpl collector) {
+    linkedResources.forEach(
+        element -> {
+          collector.setCurrentElement(element);
+          linkedResourceValidator.validate(element, collector);
         });
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeLinkedResourceDeploymentBindingValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeLinkedResourceDeploymentBindingValidator.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.validation;
+
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeLinkedResource;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.record.value.deployment.ResourceMetadataValue;
+import java.util.List;
+import org.camunda.bpm.model.xml.validation.ModelElementValidator;
+import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
+
+public class ZeebeLinkedResourceDeploymentBindingValidator
+    implements ModelElementValidator<ZeebeLinkedResource> {
+
+  private final List<ResourceMetadataValue> resourceMetadata;
+
+  public ZeebeLinkedResourceDeploymentBindingValidator(final DeploymentRecord deployment) {
+    resourceMetadata = deployment.getResourceMetadata();
+  }
+
+  @Override
+  public Class<ZeebeLinkedResource> getElementType() {
+    return ZeebeLinkedResource.class;
+  }
+
+  @Override
+  public void validate(
+      final ZeebeLinkedResource linkedResource,
+      final ValidationResultCollector validationResultCollector) {
+    final var resourceId = linkedResource.getResourceId();
+    if (resourceId == null || resourceId.isBlank()) {
+      return;
+    }
+
+    if (resourceMetadata.stream().noneMatch(r -> resourceId.equals(r.getResourceId()))) {
+      validationResultCollector.addError(
+          0,
+          "Expected to find resource with id '%s' in current deployment, but not found."
+              .formatted(resourceId));
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnElementsWithDeploymentBinding.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnElementsWithDeploymentBinding.java
@@ -9,12 +9,15 @@ package io.camunda.zeebe.engine.processing.deployment.transform;
 
 import io.camunda.zeebe.model.bpmn.instance.BusinessRuleTask;
 import io.camunda.zeebe.model.bpmn.instance.CallActivity;
+import io.camunda.zeebe.model.bpmn.instance.FlowElement;
 import io.camunda.zeebe.model.bpmn.instance.Process;
 import io.camunda.zeebe.model.bpmn.instance.UserTask;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledDecision;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledElement;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeFormDefinition;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeLinkedResource;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeLinkedResources;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -24,6 +27,7 @@ public class BpmnElementsWithDeploymentBinding implements DeploymentResourceCont
   private final List<ZeebeCalledElement> calledElements = new ArrayList<>();
   private final List<ZeebeCalledDecision> calledDecisions = new ArrayList<>();
   private final List<ZeebeFormDefinition> formDefinitions = new ArrayList<>();
+  private final List<ZeebeLinkedResource> linkedResources = new ArrayList<>();
 
   public void addFromProcess(final Process process) {
     process
@@ -36,6 +40,7 @@ public class BpmnElementsWithDeploymentBinding implements DeploymentResourceCont
                 case final UserTask task -> handleUserTask(task);
                 default -> {}
               }
+              handleLinkedResources(element);
             });
   }
 
@@ -49,6 +54,10 @@ public class BpmnElementsWithDeploymentBinding implements DeploymentResourceCont
 
   public List<ZeebeFormDefinition> getFormDefinitions() {
     return formDefinitions;
+  }
+
+  public List<ZeebeLinkedResource> getLinkedResources() {
+    return linkedResources;
   }
 
   private void handleCallActivity(final CallActivity callActivity) {
@@ -78,7 +87,17 @@ public class BpmnElementsWithDeploymentBinding implements DeploymentResourceCont
         .ifPresent(formDefinitions::add);
   }
 
+  private void handleLinkedResources(final FlowElement element) {
+    Optional.ofNullable(element.getSingleExtensionElement(ZeebeLinkedResources.class))
+        .ifPresent(
+            resources ->
+                resources.getLinkedResources().stream()
+                    .filter(r -> r.getBindingType() == ZeebeBindingType.deployment)
+                    .filter(r -> isNotExpression(r.getResourceId()))
+                    .forEach(linkedResources::add));
+  }
+
   private boolean isNotExpression(final String s) {
-    return !s.startsWith("=");
+    return s != null && !s.startsWith("=");
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/ServiceTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/ServiceTaskTest.java
@@ -282,6 +282,79 @@ public class ServiceTaskTest {
   }
 
   @Test
+  public void shouldCreateJobWithLinkedGenericResourceDeploymentBinding()
+      throws JsonProcessingException {
+    // Generic resources use the filename as their resource ID.
+    // A job worker can link a generic resource by using the filename as resourceId in BPMN.
+    // After the job is created, the worker reads the resolved resource key from the
+    // "linkedResources" custom header and fetches the content via GET /v2/resources/{key}/content.
+    final var genericResourceContent = "My script content".getBytes(StandardCharsets.UTF_8);
+    final var genericResourceName = "my-generic-script.txt";
+
+    final BpmnModelInstance modelInstance =
+        Bpmn.createExecutableProcess("genericResourceProcess")
+            .startEvent()
+            .serviceTask(
+                "my_linked_resource",
+                t ->
+                    t.zeebeLinkedResources(
+                            l ->
+                                l.resourceId(genericResourceName)
+                                    .resourceType("GenericScript")
+                                    .bindingType(ZeebeBindingType.deployment)
+                                    .linkName("my_generic_link"))
+                        .zeebeJobType("type"))
+            .endEvent()
+            .done();
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withJsonResource(genericResourceContent, genericResourceName)
+            .withXmlResource(modelInstance)
+            .deploy();
+
+    // Deploy a second version of the generic resource (should not be used — deployment binding
+    // pins to the version deployed alongside the process definition)
+    ENGINE
+        .deployment()
+        .withJsonResource("Updated content".getBytes(StandardCharsets.UTF_8), genericResourceName)
+        .deploy();
+
+    // when
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId("genericResourceProcess").create();
+
+    // then
+    final Record<JobRecordValue> jobCreated =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    assertThat(jobCreated.getValue().getCustomHeaders()).containsKey("linkedResources");
+    final List<LinkedResourceProps> resourcePropsList =
+        MAPPER.readValue(
+            jobCreated.getValue().getCustomHeaders().get("linkedResources"),
+            new TypeReference<>() {});
+
+    assertThat(resourcePropsList).hasSize(1);
+    final LinkedResourceProps resourceProps = resourcePropsList.get(0);
+    assertThat(resourceProps)
+        .hasFieldOrPropertyWithValue("resourceType", "GenericScript")
+        .hasFieldOrPropertyWithValue("linkName", "my_generic_link");
+
+    // The resource key should refer to the version deployed WITH the process (deployment binding),
+    // not the later version
+    final var expectedResourceKey =
+        deployment.getValue().getResourceMetadata().stream()
+            .filter(metadata -> genericResourceName.equals(metadata.getResourceName()))
+            .findFirst()
+            .orElseThrow()
+            .getResourceKey();
+    assertThat(resourceProps.getResourceKey()).isEqualTo(String.valueOf(expectedResourceKey));
+  }
+
+  @Test
   public void shouldHandleNotFoundVersionTagBinding() {
     final BpmnModelInstance modelInstance =
         Bpmn.createExecutableProcess("process")
@@ -317,45 +390,6 @@ public class ServiceTaskTest {
             ErrorType.RESOURCE_NOT_FOUND,
             String.format(
                 BpmnJobBehavior.FIND_RESOURCE_BY_ID_AND_VERSION_TAG_FAILED_MESSAGE, "2", "1v"));
-  }
-
-  @Test
-  public void shouldHandleNotFoundDeploymentBinding() {
-    final BpmnModelInstance modelInstance =
-        Bpmn.createExecutableProcess("process")
-            .startEvent()
-            .serviceTask(
-                "my_linked_resource",
-                t ->
-                    t.zeebeLinkedResources(
-                            l ->
-                                l.resourceId("2")
-                                    .resourceType("RPA")
-                                    .bindingType(ZeebeBindingType.deployment)
-                                    .versionTag("1v")
-                                    .linkName("my_link"))
-                        .zeebeJobType("type"))
-            .endEvent()
-            .done();
-
-    final var deployment = ENGINE.deployment().withXmlResource(modelInstance).deploy();
-
-    // when
-    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
-
-    // then
-    final IncidentRecordValue incidentRecordValue =
-        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
-            .withProcessInstanceKey(processInstanceKey)
-            .getFirst()
-            .getValue();
-    assertThat(incidentRecordValue.getErrorType()).isEqualTo(ErrorType.RESOURCE_NOT_FOUND);
-    assertThat(incidentRecordValue.getErrorMessage())
-        .isEqualTo(
-            String.format(
-                BpmnJobBehavior.FIND_RESOURCE_BY_ID_IN_SAME_DEPLOYMENT_FAILED_MESSAGE,
-                "2",
-                deployment.getKey()));
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/LinkedResourceDeploymentBindingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/LinkedResourceDeploymentBindingTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.ExecuteCommandResponseDecoder;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class LinkedResourceDeploymentBindingTest {
+
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+
+  @Test
+  public void shouldRejectDeploymentIfLinkedResourceNotIncluded() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask(
+                "serviceTask",
+                builder ->
+                    builder
+                        .zeebeLinkedResources(
+                            l ->
+                                l.resourceId("test-rpa-resource")
+                                    .resourceType("RPA")
+                                    .bindingType(ZeebeBindingType.deployment))
+                        .zeebeJobType("type"))
+            .endEvent()
+            .done();
+
+    // when
+    final var rejectedDeployment =
+        engine.deployment().withXmlResource("process.bpmn", process).expectRejection().deploy();
+
+    // then
+    Assertions.assertThat(rejectedDeployment)
+        .hasKey(ExecuteCommandResponseDecoder.keyNullValue())
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasIntent(DeploymentIntent.CREATE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejectedDeployment.getRejectionReason())
+        .isEqualTo(
+            """
+            Expected to deploy new resources, but encountered the following errors:
+            'process.bpmn':
+            - Element: serviceTask > extensionElements > linkedResources > linkedResource
+                - ERROR: Expected to find resource with id 'test-rpa-resource' in current deployment, but not found.
+            """);
+  }
+
+  @Test
+  public void shouldDeploySuccessfullyIfLinkedResourceIncluded() {
+    // given
+    final var rpaResource =
+        """
+        {
+          "id": "test-rpa-resource",
+          "resourceType": "RPA"
+        }
+        """;
+    final var process =
+        Bpmn.createExecutableProcess("process-linked-resource-success")
+            .startEvent()
+            .serviceTask(
+                "serviceTask",
+                builder ->
+                    builder
+                        .zeebeLinkedResources(
+                            l ->
+                                l.resourceId("test-rpa-resource")
+                                    .resourceType("RPA")
+                                    .bindingType(ZeebeBindingType.deployment))
+                        .zeebeJobType("type"))
+            .endEvent()
+            .done();
+
+    // when
+    final var deployment =
+        engine
+            .deployment()
+            .withXmlResource("process.bpmn", process)
+            .withJsonResource(rpaResource.getBytes(UTF_8), "resource.rpa")
+            .deploy();
+
+    // then
+    Assertions.assertThat(deployment)
+        .hasRecordType(RecordType.EVENT)
+        .hasValueType(ValueType.DEPLOYMENT)
+        .hasIntent(DeploymentIntent.CREATED);
+  }
+
+  @Test
+  public void shouldRejectIfLinkedResourceIdNotFoundInDeployment() {
+    // given - a BPMN process referencing a resource ID that is not in the deployment
+    final var process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask(
+                "my_linked_resource",
+                t ->
+                    t.zeebeLinkedResources(
+                            l ->
+                                l.resourceId("2")
+                                    .resourceType("RPA")
+                                    .bindingType(ZeebeBindingType.deployment)
+                                    .versionTag("1v")
+                                    .linkName("my_link"))
+                        .zeebeJobType("type"))
+            .endEvent()
+            .done();
+
+    // when
+    final var rejection = engine.deployment().withXmlResource(process).expectRejection().deploy();
+
+    // then - rejected at deploy time (not a runtime incident)
+    Assertions.assertThat(rejection).hasRejectionType(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejection.getRejectionReason())
+        .contains("Expected to find resource with id '2' in current deployment, but not found.");
+  }
+}


### PR DESCRIPTION
## Summary

BPMN processes referencing generic resources via `zeebe:linkedResource` with `bindingType=deployment` are now validated at deploy time. If a referenced resource is not included in the same deployment, the deployment is rejected immediately — rather than failing at runtime with an incident.

### Key changes

- Add `ZeebeLinkedResourceDeploymentBindingValidator` to validate linked resource presence in deployment
- Extend `BpmnElementsWithDeploymentBinding` to collect `zeebe:linkedResource` elements with deployment binding
- Wire linked resource validation into `BpmnDeploymentBindingValidator`

### Behavior change ⚠️ ⚠️ ⚠️ 

Previously, deploying a BPMN process with a `zeebe:linkedResource` (`bindingType=deployment`) referencing a resource ID not present in the deployment would succeed. The error would only surface at runtime as a `RESOURCE_NOT_FOUND` incident when the job was created.

After this change, the deployment is **rejected** with `INVALID_ARGUMENT` if the referenced resource is missing from the deployment. This gives faster, more actionable feedback.

**Note:** This only applies to static resource IDs. Expression-based resource IDs (starting with `=`) are still resolved at runtime and are not affected by this change.

## Test plan

- [x] `LinkedResourceDeploymentBindingTest` — dedicated test class for binding validation
  - Deployment rejected when linked resource not included
  - Deployment succeeds when linked resource is included
  - Rejection when referenced resource ID not found in deployment
- [x] `ServiceTaskTest` — generic resource deployment binding with job creation resolves correct version

Closes #50901

🤖 Generated with [Claude Code](https://claude.com/claude-code)