### PR TITLE
fix: handle legacy ZeebeWorkerValueCustomizer without dynamic bean registration

### DIFF
--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/annotation/customizer/LegacyJobWorkerValueCustomizerBeanDefinitionRegistryPostProcessor.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/annotation/customizer/LegacyJobWorkerValueCustomizerBeanDefinitionRegistryPostProcessor.java
@@ -20,7 +20,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanDefinition;
-import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
 
@@ -42,11 +41,6 @@ public class LegacyJobWorkerValueCustomizerBeanDefinitionRegistryPostProcessor
         LOG.warn(
             "Bean '{}' is implementing deprecated interface ZeebeWorkerValueCustomizer, please migrate to JobWorkerValueCustomizer",
             beanDefinitionName);
-        final BeanDefinitionBuilder beanDefinitionBuilder =
-            BeanDefinitionBuilder.genericBeanDefinition(JobWorkerValueCustomizerCompat.class)
-                .addConstructorArgReference(beanDefinitionName);
-        registry.registerBeanDefinition(
-            beanDefinitionName + "_Compat", beanDefinitionBuilder.getBeanDefinition());
       }
     }
   }

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/AnnotationProcessorConfiguration.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/AnnotationProcessorConfiguration.java
@@ -18,11 +18,15 @@ package io.camunda.client.spring.configuration;
 import io.camunda.client.annotation.customizer.JobWorkerValueCustomizer;
 import io.camunda.client.jobhandling.JobWorkerManager;
 import io.camunda.client.lifecycle.CamundaClientLifecycleAware;
+import io.camunda.client.spring.annotation.customizer.JobWorkerValueCustomizerCompat;
 import io.camunda.client.spring.annotation.processor.DeploymentAnnotationProcessor;
 import io.camunda.client.spring.annotation.processor.JobWorkerAnnotationProcessor;
 import io.camunda.client.spring.event.CamundaClientEventListener;
+import io.camunda.zeebe.spring.client.annotation.customizer.ZeebeWorkerValueCustomizer;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
@@ -45,7 +49,15 @@ public class AnnotationProcessorConfiguration {
   @Bean
   public JobWorkerAnnotationProcessor jobWorkerPostProcessor(
       final JobWorkerManager jobWorkerManager,
-      final List<JobWorkerValueCustomizer> jobWorkerValueCustomizers) {
-    return new JobWorkerAnnotationProcessor(jobWorkerManager, jobWorkerValueCustomizers);
+      final List<JobWorkerValueCustomizer> jobWorkerValueCustomizers,
+      @Autowired(required = false) final List<ZeebeWorkerValueCustomizer> legacyCustomizers) {
+    final List<JobWorkerValueCustomizer> allCustomizers =
+        new ArrayList<>(jobWorkerValueCustomizers);
+    if (legacyCustomizers != null) {
+      legacyCustomizers.stream()
+          .map(JobWorkerValueCustomizerCompat::new)
+          .forEach(allCustomizers::add);
+    }
+    return new JobWorkerAnnotationProcessor(jobWorkerManager, allCustomizers);
   }
 }

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/annotation/customizer/JobWorkerValueCustomizerCompatTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/annotation/customizer/JobWorkerValueCustomizerCompatTest.java
@@ -17,12 +17,9 @@ package io.camunda.client.spring.annotation.customizer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.client.annotation.customizer.JobWorkerValueCustomizer;
 import io.camunda.client.spring.configuration.CamundaBeanPostProcessorConfiguration;
-import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
@@ -34,17 +31,9 @@ import org.springframework.boot.test.system.OutputCaptureExtension;
     })
 @ExtendWith(OutputCaptureExtension.class)
 public class JobWorkerValueCustomizerCompatTest {
-  @Autowired Set<JobWorkerValueCustomizer> jobWorkerValueCustomizers;
 
   @Test
-  void shouldPostProcessBean(final CapturedOutput capturedOutput) {
-    assertThat(jobWorkerValueCustomizers).hasSize(1);
-    final JobWorkerValueCustomizer jobWorkerValueCustomizer =
-        jobWorkerValueCustomizers.iterator().next();
-    assertThat(jobWorkerValueCustomizer).isInstanceOf(JobWorkerValueCustomizerCompat.class);
-    final JobWorkerValueCustomizerCompat customizer =
-        (JobWorkerValueCustomizerCompat) jobWorkerValueCustomizer;
-    assertThat(customizer.getCustomizer()).isNotNull();
+  void shouldLogDeprecationWarningForLegacyBean(final CapturedOutput capturedOutput) {
     assertThat(capturedOutput)
         .contains(
             "Bean 'testZeebeWorkerValueCustomizer' is implementing deprecated interface ZeebeWorkerValueCustomizer, please migrate to JobWorkerValueCustomizer");

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/config/LegacyZeebeWorkerCustomizerAotCompatibilityTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/config/LegacyZeebeWorkerCustomizerAotCompatibilityTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.spring.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.annotation.JobWorker;
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.client.jobhandling.JobWorkerManager;
+import io.camunda.client.spring.configuration.AnnotationProcessorConfiguration;
+import io.camunda.client.spring.event.CamundaClientCreatedSpringEvent;
+import io.camunda.client.spring.event.CamundaClientEventListener;
+import io.camunda.zeebe.spring.client.annotation.customizer.ZeebeWorkerValueCustomizer;
+import io.camunda.zeebe.spring.client.annotation.value.ZeebeWorkerValue;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+/**
+ * Regression test for https://github.com/camunda/camunda/issues/49131.
+ *
+ * <p>Verifies that a legacy {@link ZeebeWorkerValueCustomizer} bean is applied to job workers even
+ * when {@code LegacyJobWorkerValueCustomizerBeanDefinitionRegistryPostProcessor} does not register
+ * the compat wrapper as a bean — which is the scenario that occurs with Spring AOT, where the
+ * dynamic {@code BeanDefinitionRegistryPostProcessor} bean registration produces a null-customizer
+ * {@code JobWorkerValueCustomizerCompat} due to an unresolved {@code RuntimeBeanReference}.
+ */
+@SpringBootTest(
+    classes = {
+      AnnotationProcessorConfiguration.class,
+      LegacyZeebeWorkerCustomizerAotCompatibilityTest.TestConfig.class
+    })
+class LegacyZeebeWorkerCustomizerAotCompatibilityTest {
+
+  // No CamundaBeanPostProcessorConfiguration — simulates the AOT scenario where the
+  // BeanDefinitionRegistryPostProcessor does not register compat beans.
+  @MockitoBean JobWorkerManager jobWorkerManager;
+  @MockitoBean CamundaClient camundaClient;
+
+  @Autowired CamundaClientEventListener camundaClientEventListener;
+  @Autowired TestConfig.TrackingZeebeCustomizer trackingCustomizer;
+
+  @Test
+  void shouldApplyLegacyZeebeWorkerValueCustomizerWhenPostProcessorIsAbsent() {
+    // when
+    camundaClientEventListener.handleStart(
+        new CamundaClientCreatedSpringEvent(this, mock(CamundaClient.class)));
+
+    // then — the legacy customizer must have been invoked via the compat wrapper,
+    // proving AnnotationProcessorConfiguration handles it directly
+    assertThat(trackingCustomizer.wasCalled()).isTrue();
+  }
+
+  @Configuration
+  static class TestConfig {
+
+    @Bean
+    public TrackingZeebeCustomizer legacyZeebeCustomizer() {
+      return new TrackingZeebeCustomizer();
+    }
+
+    @Bean
+    public WorkerBean workerBean() {
+      return new WorkerBean();
+    }
+
+    static class TrackingZeebeCustomizer implements ZeebeWorkerValueCustomizer {
+      private boolean called = false;
+
+      @Override
+      public void customize(final ZeebeWorkerValue worker) {
+        called = true;
+      }
+
+      public boolean wasCalled() {
+        return called;
+      }
+    }
+
+    static class WorkerBean {
+      @JobWorker(type = "test-type")
+      public void handle(final ActivatedJob job) {}
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Spring Boot applications using `ZeebeWorkerValueCustomizer` (deprecated) fail to start when Spring AOT is enabled (`-Dspring.aot.enabled=true`).

- `LegacyJobWorkerValueCustomizerBeanDefinitionRegistryPostProcessor` used `addConstructorArgReference()` to register `JobWorkerValueCustomizerCompat` beans dynamically. Spring AOT does not correctly serialize `RuntimeBeanReference` constructor args from `BeanDefinitionRegistryPostProcessor`-registered beans into AOT-generated code, resulting in a null `customizer` field and NPE at runtime.
- Fix moves the compat wrapping into `AnnotationProcessorConfiguration.jobWorkerPostProcessor()` using `@Autowired(required=false) List<ZeebeWorkerValueCustomizer>` — a pattern Spring AOT handles correctly.
- The post-processor is retained for its deprecation warning only.

closes #49131 