### PR TITLE
Prototype: ECS multiregion

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/response/BrokerInfo.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/BrokerInfo.java
@@ -19,9 +19,10 @@ import java.util.List;
 
 public interface BrokerInfo {
   /**
-   * @return the node if of the broker
+   * @return the node ID of the broker; in region-aware clusters this includes the region prefix,
+   *     e.g. "us-east1-0"
    */
-  int getNodeId();
+  String getNodeId();
 
   /**
    * @return the address host of the broker

--- a/clients/java/src/main/java/io/camunda/client/impl/response/BrokerInfoImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/BrokerInfoImpl.java
@@ -25,7 +25,7 @@ import java.util.Objects;
 
 public final class BrokerInfoImpl implements BrokerInfo {
 
-  private final int nodeId;
+  private final String nodeId;
   private final String host;
   private final int port;
   private final String version;
@@ -56,7 +56,7 @@ public final class BrokerInfoImpl implements BrokerInfo {
   }
 
   @Override
-  public int getNodeId() {
+  public String getNodeId() {
     return nodeId;
   }
 
@@ -101,8 +101,8 @@ public final class BrokerInfoImpl implements BrokerInfo {
     }
 
     final BrokerInfoImpl that = (BrokerInfoImpl) o;
-    return nodeId == that.nodeId
-        && port == that.port
+    return port == that.port
+        && Objects.equals(nodeId, that.nodeId)
         && Objects.equals(host, that.host)
         && Objects.equals(version, that.version)
         && Objects.equals(partitions, that.partitions);

--- a/clients/java/src/main/java/io/camunda/client/impl/response/BrokerInfoImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/BrokerInfoImpl.java
@@ -32,7 +32,7 @@ public final class BrokerInfoImpl implements BrokerInfo {
   private final List<PartitionInfo> partitions;
 
   public BrokerInfoImpl(final GatewayOuterClass.BrokerInfo grpcBrokerInfo) {
-    nodeId = grpcBrokerInfo.getNodeId();
+    nodeId = grpcBrokerInfo.getMemberId();
     host = grpcBrokerInfo.getHost();
     port = grpcBrokerInfo.getPort();
     version = grpcBrokerInfo.getVersion();

--- a/clients/java/src/test/java/io/camunda/client/TopologyRequestRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/TopologyRequestRestTest.java
@@ -56,7 +56,7 @@ public final class TopologyRequestRestTest extends ClientRestTest {
             .partitionsCount(2)
             .addBrokersItem(
                 new BrokerInfo()
-                    .nodeId(0)
+                    .nodeId("0")
                     .host("host1")
                     .port(123)
                     .version("1.22.3-SNAPSHOT")
@@ -66,7 +66,7 @@ public final class TopologyRequestRestTest extends ClientRestTest {
                             new Partition().partitionId(1).role(FOLLOWER).health(UNHEALTHY))))
             .addBrokersItem(
                 new BrokerInfo()
-                    .nodeId(1)
+                    .nodeId("1")
                     .host("host2")
                     .port(212)
                     .version("2.22.3-SNAPSHOT")
@@ -76,7 +76,7 @@ public final class TopologyRequestRestTest extends ClientRestTest {
                             new Partition().partitionId(1).role(LEADER).health(HEALTHY))))
             .addBrokersItem(
                 new BrokerInfo()
-                    .nodeId(2)
+                    .nodeId("2")
                     .host("host3")
                     .port(432)
                     .version("3.22.3-SNAPSHOT")
@@ -100,7 +100,7 @@ public final class TopologyRequestRestTest extends ClientRestTest {
     assertThat(brokers).hasSize(3);
 
     io.camunda.client.api.response.BrokerInfo broker = brokers.get(0);
-    assertThat(broker.getNodeId()).isEqualTo(0);
+    assertThat(broker.getNodeId()).isEqualTo("0");
     assertThat(broker.getHost()).isEqualTo("host1");
     assertThat(broker.getPort()).isEqualTo(123);
     assertThat(broker.getAddress()).isEqualTo("host1:123");
@@ -112,7 +112,7 @@ public final class TopologyRequestRestTest extends ClientRestTest {
             tuple(1, PartitionBrokerRole.FOLLOWER, PartitionBrokerHealth.UNHEALTHY));
 
     broker = brokers.get(1);
-    assertThat(broker.getNodeId()).isEqualTo(1);
+    assertThat(broker.getNodeId()).isEqualTo("1");
     assertThat(broker.getHost()).isEqualTo("host2");
     assertThat(broker.getPort()).isEqualTo(212);
     assertThat(broker.getAddress()).isEqualTo("host2:212");
@@ -124,7 +124,7 @@ public final class TopologyRequestRestTest extends ClientRestTest {
             tuple(1, PartitionBrokerRole.LEADER, PartitionBrokerHealth.HEALTHY));
 
     broker = brokers.get(2);
-    assertThat(broker.getNodeId()).isEqualTo(2);
+    assertThat(broker.getNodeId()).isEqualTo("2");
     assertThat(broker.getHost()).isEqualTo("host3");
     assertThat(broker.getPort()).isEqualTo(432);
     assertThat(broker.getAddress()).isEqualTo("host3:432");
@@ -147,7 +147,7 @@ public final class TopologyRequestRestTest extends ClientRestTest {
             .partitionsCount(1)
             .addBrokersItem(
                 new BrokerInfo()
-                    .nodeId(0)
+                    .nodeId("0")
                     .host("host1")
                     .port(123)
                     .version("1.22.3-SNAPSHOT")

--- a/clients/java/src/test/java/io/camunda/client/TopologyRequestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/TopologyRequestTest.java
@@ -50,21 +50,21 @@ public final class TopologyRequestTest extends ClientTest {
         3,
         "1.22.3-SNAPSHOT",
         broker(
-            0,
+            "0",
             "host1",
             123,
             "1.22.3-SNAPSHOT",
             partition(0, LEADER, HEALTHY),
             partition(1, FOLLOWER, UNHEALTHY)),
         broker(
-            1,
+            "1",
             "host2",
             212,
             "2.22.3-SNAPSHOT",
             partition(0, FOLLOWER, HEALTHY),
             partition(1, LEADER, HEALTHY)),
         broker(
-            2,
+            "2",
             "host3",
             432,
             "3.22.3-SNAPSHOT",
@@ -84,7 +84,7 @@ public final class TopologyRequestTest extends ClientTest {
     assertThat(brokers).hasSize(3);
 
     BrokerInfo broker = brokers.get(0);
-    assertThat(broker.getNodeId()).isEqualTo(0);
+    assertThat(broker.getNodeId()).isEqualTo("0");
     assertThat(broker.getHost()).isEqualTo("host1");
     assertThat(broker.getPort()).isEqualTo(123);
     assertThat(broker.getAddress()).isEqualTo("host1:123");
@@ -96,7 +96,7 @@ public final class TopologyRequestTest extends ClientTest {
             tuple(1, PartitionBrokerRole.FOLLOWER, PartitionBrokerHealth.UNHEALTHY));
 
     broker = brokers.get(1);
-    assertThat(broker.getNodeId()).isEqualTo(1);
+    assertThat(broker.getNodeId()).isEqualTo("1");
     assertThat(broker.getHost()).isEqualTo("host2");
     assertThat(broker.getPort()).isEqualTo(212);
     assertThat(broker.getAddress()).isEqualTo("host2:212");
@@ -108,7 +108,7 @@ public final class TopologyRequestTest extends ClientTest {
             tuple(1, PartitionBrokerRole.LEADER, PartitionBrokerHealth.HEALTHY));
 
     broker = brokers.get(2);
-    assertThat(broker.getNodeId()).isEqualTo(2);
+    assertThat(broker.getNodeId()).isEqualTo("2");
     assertThat(broker.getHost()).isEqualTo("host3");
     assertThat(broker.getPort()).isEqualTo(432);
     assertThat(broker.getAddress()).isEqualTo("host3:432");
@@ -128,7 +128,7 @@ public final class TopologyRequestTest extends ClientTest {
         1,
         1,
         "1.22.3-SNAPSHOT",
-        broker(0, "host1", 123, "1.22.3-SNAPSHOT", partition(0, LEADER, DEAD)));
+        broker("0", "host1", 123, "1.22.3-SNAPSHOT", partition(0, LEADER, DEAD)));
 
     // when
     final Topology topology = client.newTopologyRequest().send().join();

--- a/clients/java/src/test/java/io/camunda/client/util/RecordingGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RecordingGatewayService.java
@@ -156,7 +156,7 @@ public final class RecordingGatewayService extends GatewayImplBase {
       final String version,
       final Partition... partitions) {
     return BrokerInfo.newBuilder()
-        .setNodeId(nodeId)
+        .setMemberId(nodeId)
         .setHost(host)
         .setPort(port)
         .setVersion(version)

--- a/clients/java/src/test/java/io/camunda/client/util/RecordingGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RecordingGatewayService.java
@@ -150,7 +150,7 @@ public final class RecordingGatewayService extends GatewayImplBase {
   }
 
   public static BrokerInfo broker(
-      final int nodeId,
+      final String nodeId,
       final String host,
       final int port,
       final String version,

--- a/configuration/src/main/java/io/camunda/configuration/Cluster.java
+++ b/configuration/src/main/java/io/camunda/configuration/Cluster.java
@@ -153,8 +153,8 @@ public class Cluster implements Cloneable {
 
   /**
    * The region this broker belongs to. When set, the partitioning scheme must be {@link
-   * io.camunda.zeebe.broker.system.configuration.partitioning.Scheme#REGION_AWARE} and the
-   * broker's {@code nodeId} must be unique within this region only (0-indexed within the region).
+   * io.camunda.zeebe.broker.system.configuration.partitioning.Scheme#REGION_AWARE} and the broker's
+   * {@code nodeId} must be unique within this region only (0-indexed within the region).
    *
    * <p>When {@code null}, the broker operates in the standard non-region-aware mode and all
    * existing behaviour is preserved.

--- a/configuration/src/main/java/io/camunda/configuration/Cluster.java
+++ b/configuration/src/main/java/io/camunda/configuration/Cluster.java
@@ -151,6 +151,18 @@ public class Cluster implements Cloneable {
    */
   @NestedConfigurationProperty private Partitioning partitioning = new Partitioning();
 
+  /**
+   * The region this broker belongs to. When set, the partitioning scheme must be {@link
+   * io.camunda.zeebe.broker.system.configuration.partitioning.Scheme#REGION_AWARE} and the
+   * broker's {@code nodeId} must be unique within this region only (0-indexed within the region).
+   *
+   * <p>When {@code null}, the broker operates in the standard non-region-aware mode and all
+   * existing behaviour is preserved.
+   *
+   * <p>Environment variable: {@code CAMUNDA_CLUSTER_REGION}.
+   */
+  private String region;
+
   private boolean sendOnLegacySubject = true;
   private boolean receiveOnLegacySubject = true;
 
@@ -322,6 +334,14 @@ public class Cluster implements Cloneable {
     this.partitioning = partitioning;
   }
 
+  public String getRegion() {
+    return region;
+  }
+
+  public void setRegion(final String region) {
+    this.region = region;
+  }
+
   public boolean isReceiveOnLegacySubject() {
     return receiveOnLegacySubject;
   }
@@ -377,6 +397,9 @@ public class Cluster implements Cloneable {
         + compressionAlgorithm
         + ", globalListeners="
         + globalListeners
+        + ", region='"
+        + region
+        + '\''
         + ", sendOnLegacySubject="
         + sendOnLegacySubject
         + ", receiveOnLegacySubject="

--- a/configuration/src/main/java/io/camunda/configuration/Partitioning.java
+++ b/configuration/src/main/java/io/camunda/configuration/Partitioning.java
@@ -8,6 +8,7 @@
 package io.camunda.configuration;
 
 import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import io.camunda.zeebe.broker.system.configuration.partitioning.RegionAwareCfg;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -35,6 +36,16 @@ public class Partitioning {
    * empty, list by default. Used when the {@link Scheme#FIXED} partitioning scheme is selected.
    */
   private List<FixedPartition> fixed = Collections.emptyList();
+
+  /**
+   * The region-aware partitioning configuration. Used when the {@link Scheme#REGION_AWARE}
+   * partitioning scheme is selected.
+   *
+   * <p>Maps region names to their per-region configuration (number of brokers, replicas, and
+   * priority). The insertion order of the map is significant: broker member IDs are assigned
+   * sequentially per region in iteration order.
+   */
+  private RegionAwareCfg regionAware = new RegionAwareCfg();
 
   public Partitioning() {}
 
@@ -64,8 +75,17 @@ public class Partitioning {
     this.fixed = fixed;
   }
 
+  public RegionAwareCfg getRegionAware() {
+    return regionAware;
+  }
+
+  public void setRegionAware(final RegionAwareCfg regionAware) {
+    this.regionAware = regionAware;
+  }
+
   public enum Scheme {
     FIXED,
-    ROUND_ROBIN;
+    ROUND_ROBIN,
+    REGION_AWARE;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -60,6 +60,7 @@ import io.camunda.zeebe.broker.system.configuration.backup.FilesystemBackupStore
 import io.camunda.zeebe.broker.system.configuration.backup.GcsBackupStoreConfig;
 import io.camunda.zeebe.broker.system.configuration.backup.GcsBackupStoreConfig.GcsBackupStoreAuth;
 import io.camunda.zeebe.broker.system.configuration.backup.S3BackupStoreConfig;
+import io.camunda.zeebe.broker.system.configuration.partitioning.RegionAwareCfg;
 import io.camunda.zeebe.broker.system.configuration.partitioning.Scheme;
 import io.camunda.zeebe.db.AccessMetricsConfiguration;
 import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossiperConfig;
@@ -410,6 +411,7 @@ public class BrokerBasedPropertiesOverride {
     override.getCluster().setClusterSize(cluster.getSize());
     override.getCluster().setClusterName(cluster.getName());
     override.getCluster().setClusterId(cluster.getClusterId());
+    override.getCluster().setRegion(cluster.getRegion());
 
     populateFromMembership(override);
     populateFromRaftProperties(override);
@@ -451,6 +453,14 @@ public class BrokerBasedPropertiesOverride {
       final var fixedPartitionCfgList =
           partitioning.getFixed().stream().map(FixedPartition::toFixedPartitionCfg).toList();
       partitioningCfg.setFixed(fixedPartitionCfgList);
+    }
+
+    final RegionAwareCfg regionAware = partitioning.getRegionAware();
+    if (partitioning.getScheme() == Partitioning.Scheme.REGION_AWARE
+        && !regionAware.getRegions().isEmpty()) {
+      final PartitioningCfg partitioningCfg = override.getExperimental().getPartitioning();
+      partitioningCfg.setScheme(Scheme.REGION_AWARE);
+      partitioningCfg.setRegionAware(regionAware);
     }
   }
 

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -457,6 +457,7 @@ public class BrokerBasedPropertiesOverride {
 
     final RegionAwareCfg regionAware = partitioning.getRegionAware();
     if (partitioning.getScheme() == Partitioning.Scheme.REGION_AWARE
+        && regionAware.getRegions() != null
         && !regionAware.getRegions().isEmpty()) {
       final PartitioningCfg partitioningCfg = override.getExperimental().getPartitioning();
       partitioningCfg.setScheme(Scheme.REGION_AWARE);

--- a/dist/src/main/java/io/camunda/application/commons/configuration/BrokerBasedConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/configuration/BrokerBasedConfiguration.java
@@ -77,7 +77,10 @@ public class BrokerBasedConfiguration {
     final var cpuThreads = threadCfg.getCpuThreadCount();
     final var ioThreads = threadCfg.getIoThreadCount();
     final var metricsEnabled = properties.getExperimental().getFeatures().isEnableActorMetrics();
-    final var nodeId = String.valueOf(properties.getCluster().getNodeId());
+    final var nodeId =
+        properties.getCluster().getRegion()
+            + "-"
+            + String.valueOf(properties.getCluster().getNodeId());
     return new SchedulerConfiguration(cpuThreads, ioThreads, metricsEnabled, "Broker", nodeId);
   }
 

--- a/dist/src/main/java/io/camunda/zeebe/broker/NodeIProviderConfigurationUtils.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/NodeIProviderConfigurationUtils.java
@@ -83,7 +83,10 @@ public class NodeIProviderConfigurationUtils {
     final String localRegion = cluster.getRegion();
     final var regionCfg =
         (localRegion != null && !localRegion.isBlank())
-            ? cluster.getPartitioning().getRegionAware().getRegions().get(localRegion)
+            ? cluster.getPartitioning().getRegionAware().getRegions().stream()
+                .filter(r -> localRegion.equals(r.getName()))
+                .findFirst()
+                .orElse(null)
             : null;
     final int localClusterSize =
         regionCfg != null ? regionCfg.getNumberOfBrokers() : cluster.getSize();

--- a/dist/src/main/java/io/camunda/zeebe/broker/NodeIProviderConfigurationUtils.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/NodeIProviderConfigurationUtils.java
@@ -80,7 +80,14 @@ public class NodeIProviderConfigurationUtils {
                 });
           }
         };
-    nodeIdProvider.initialize(cluster.getSize()).join();
+    final String localRegion = cluster.getRegion();
+    final var regionCfg =
+        (localRegion != null && !localRegion.isBlank())
+            ? cluster.getPartitioning().getRegionAware().getRegions().get(localRegion)
+            : null;
+    final int localClusterSize =
+        regionCfg != null ? regionCfg.getNumberOfBrokers() : cluster.getSize();
+    nodeIdProvider.initialize(localClusterSize).join();
     return nodeIdProvider;
   }
 

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/FlowControlServiceImpl.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/FlowControlServiceImpl.java
@@ -15,13 +15,13 @@ import io.camunda.zeebe.broker.system.configuration.FlowControlCfg;
 import io.camunda.zeebe.gateway.admin.BrokerAdminRequest;
 import io.camunda.zeebe.logstreams.impl.flowcontrol.LimitSerializer;
 import io.camunda.zeebe.shared.management.FlowControlEndpoint.FlowControlService;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
-import org.agrona.collections.IntHashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -88,9 +88,9 @@ public class FlowControlServiceImpl implements FlowControlService {
     final var requests =
         members.stream()
             .map(
-                brokerId -> {
+                memberId -> {
                   final var request = new BrokerAdminRequest();
-                  request.setBrokerId(brokerId);
+                  request.setMemberId(memberId);
                   request.setPartitionId(partitionId);
                   configureRequest.accept(request);
                   return client.sendRequest(request);
@@ -101,9 +101,9 @@ public class FlowControlServiceImpl implements FlowControlService {
 
   private CompletableFuture<FlowControlStatus> fetchFlowConfigOnPartition(
       final BrokerClusterState topology, final Integer partitionId) {
-    final var brokerId = topology.getLeaderForPartition(partitionId);
+    final var memberId = topology.getLeaderForPartition(partitionId);
     final var request = new BrokerAdminRequest();
-    request.setBrokerId(brokerId);
+    request.setMemberId(memberId);
     request.setPartitionId(partitionId);
     request.getFLowControlConfiguration();
 
@@ -115,15 +115,17 @@ public class FlowControlServiceImpl implements FlowControlService {
                     partitionId, LimitSerializer.deserialize(response.getResponse().getPayload())));
   }
 
-  private IntHashSet getMembers(final BrokerClusterState topology, final Integer partitionId) {
+  private Set<String> getMembers(final BrokerClusterState topology, final Integer partitionId) {
     final var leader = topology.getLeaderForPartition(partitionId);
     final var followers =
         Optional.ofNullable(topology.getFollowersForPartition(partitionId)).orElseGet(Set::of);
     final var inactive =
         Optional.ofNullable(topology.getInactiveNodesForPartition(partitionId)).orElseGet(Set::of);
 
-    final var members = new IntHashSet(topology.getReplicationFactor());
-    members.add(leader);
+    final var members = new HashSet<String>(topology.getReplicationFactor());
+    if (leader != null) {
+      members.add(leader);
+    }
     members.addAll(followers);
     members.addAll(inactive);
     return members;

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/cluster/ClusterToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/cluster/ClusterToolsTest.java
@@ -114,7 +114,7 @@ class ClusterToolsTest extends OperationalToolsTest {
               .lastCompletedChangeId("1")
               .addBrokersItem(
                   new BrokerInfo()
-                      .nodeId(0)
+                      .nodeId("0")
                       .host("localhost")
                       .port(26501)
                       .version(version)
@@ -125,7 +125,7 @@ class ClusterToolsTest extends OperationalToolsTest {
                               .role(RoleEnum.LEADER)))
               .addBrokersItem(
                   new BrokerInfo()
-                      .nodeId(1)
+                      .nodeId("1")
                       .host("localhost")
                       .port(26502)
                       .version(version)
@@ -136,7 +136,7 @@ class ClusterToolsTest extends OperationalToolsTest {
                               .role(RoleEnum.FOLLOWER)))
               .addBrokersItem(
                   new BrokerInfo()
-                      .nodeId(2)
+                      .nodeId("2")
                       .host("localhost")
                       .port(26503)
                       .version(version)
@@ -149,23 +149,26 @@ class ClusterToolsTest extends OperationalToolsTest {
           new Topology(
               List.of(
                   new Broker(
-                      0,
+                      "0",
                       "localhost",
                       26501,
                       List.of(new TopologyServices.Partition(1, Role.LEADER, Health.HEALTHY)),
-                      version),
+                      version,
+                      null),
                   new Broker(
-                      1,
+                      "1",
                       "localhost",
                       26502,
                       List.of(new TopologyServices.Partition(1, Role.FOLLOWER, Health.HEALTHY)),
-                      version),
+                      version,
+                      null),
                   new Broker(
-                      2,
+                      "2",
                       "localhost",
                       26503,
                       List.of(new TopologyServices.Partition(1, Role.INACTIVE, Health.UNHEALTHY)),
-                      version)),
+                      version,
+                      null)),
               "cluster-id",
               3,
               1,

--- a/load-tests/camunda-platform-values.yaml
+++ b/load-tests/camunda-platform-values.yaml
@@ -233,6 +233,12 @@ orchestration:
         # RocksDB memory limit setting, limits the overall RocksDB memory usage
         # ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_MEMORYLIMIT
         zeebe.broker.experimental.rocksdb.memoryLimit: "64MB"
+        camunda.cluster.region: "us-east"
+        camunda.cluster.partitioning.scheme: REGION_AWARE
+        camunda.cluster.partitioning.region-aware.regions.us-east.numerOfreplicas: 3
+        camunda.cluster.partitioning.region-aware.regions.us-east.numberOfBrokers: 3
+        camunda.cluster.partitioning.region-aware.regions.us-east.priority: 1000
+
     # This file is loaded after application.yml (higher priority). It is empty by default,
     # but can be overridden via --set-file for specific scenarios (e.g. max) to change settings
     # like disabling consistency checks without duplicating the full application.yml content.

--- a/service/src/main/java/io/camunda/service/TopologyServices.java
+++ b/service/src/main/java/io/camunda/service/TopologyServices.java
@@ -109,12 +109,13 @@ public final class TopologyServices extends ApiServices<TopologyServices> {
     final var brokerAddress = topology.getBrokerAddress(brokerId);
     final var address = Address.from(brokerAddress);
 
+    final var region = topology.getBrokerRegion(brokerId);
     broker
         .nodeId(topology.getBrokerMemberId(brokerId))
         .host(address.host())
         .port(address.port())
         .version(topology.getBrokerVersion(brokerId))
-        .region(topology.getBrokerRegion(brokerId));
+        .region(region != null ? region : "");
   }
 
   private void addPartitionInfoToBrokerInfo(

--- a/service/src/main/java/io/camunda/service/TopologyServices.java
+++ b/service/src/main/java/io/camunda/service/TopologyServices.java
@@ -110,10 +110,11 @@ public final class TopologyServices extends ApiServices<TopologyServices> {
     final var address = Address.from(brokerAddress);
 
     broker
-        .nodeId(brokerId)
+        .nodeId(topology.getBrokerMemberId(brokerId))
         .host(address.host())
         .port(address.port())
-        .version(topology.getBrokerVersion(brokerId));
+        .version(topology.getBrokerVersion(brokerId))
+        .region(topology.getBrokerRegion(brokerId));
   }
 
   private void addPartitionInfoToBrokerInfo(
@@ -235,20 +236,26 @@ public final class TopologyServices extends ApiServices<TopologyServices> {
   }
 
   public record Broker(
-      Integer nodeId, String host, Integer port, List<Partition> partitions, String version) {
+      String nodeId,
+      String host,
+      Integer port,
+      List<Partition> partitions,
+      String version,
+      String region) {
 
     static class Builder {
-      Integer nodeId;
+      String nodeId;
       String host;
       Integer port;
       List<Partition> partitions = new ArrayList<>();
       String version;
+      String region;
 
       public static Builder create() {
         return new Builder();
       }
 
-      public Builder nodeId(final Integer nodeId) {
+      public Builder nodeId(final String nodeId) {
         this.nodeId = nodeId;
         return this;
       }
@@ -273,8 +280,13 @@ public final class TopologyServices extends ApiServices<TopologyServices> {
         return this;
       }
 
+      public Builder region(final String region) {
+        this.region = region;
+        return this;
+      }
+
       public Broker build() {
-        return new Broker(nodeId, host, port, partitions, version);
+        return new Broker(nodeId, host, port, partitions, version, region);
       }
     }
   }

--- a/service/src/main/java/io/camunda/service/TopologyServices.java
+++ b/service/src/main/java/io/camunda/service/TopologyServices.java
@@ -105,21 +105,21 @@ public final class TopologyServices extends ApiServices<TopologyServices> {
   }
 
   private void addBrokerInfo(
-      final Broker.Builder broker, final Integer brokerId, final BrokerClusterState topology) {
-    final var brokerAddress = topology.getBrokerAddress(brokerId);
+      final Broker.Builder broker, final String memberId, final BrokerClusterState topology) {
+    final var brokerAddress = topology.getBrokerAddress(memberId);
     final var address = Address.from(brokerAddress);
 
-    final var region = topology.getBrokerRegion(brokerId);
+    final var region = topology.getBrokerRegion(memberId);
     broker
-        .nodeId(topology.getBrokerMemberId(brokerId))
+        .nodeId(memberId)
         .host(address.host())
         .port(address.port())
-        .version(topology.getBrokerVersion(brokerId))
+        .version(topology.getBrokerVersion(memberId))
         .region(region != null ? region : "");
   }
 
   private void addPartitionInfoToBrokerInfo(
-      final Broker.Builder broker, final Integer brokerId, final BrokerClusterState topology) {
+      final Broker.Builder broker, final String memberId, final BrokerClusterState topology) {
     topology
         .getPartitions()
         .forEach(
@@ -127,12 +127,12 @@ public final class TopologyServices extends ApiServices<TopologyServices> {
               final var partition = Partition.Builder.create();
 
               partition.partitionId(partitionId);
-              final var isRoleSet = setRole(brokerId, partitionId, topology, partition);
+              final var isRoleSet = setRole(memberId, partitionId, topology, partition);
               if (!isRoleSet) {
                 return;
               }
 
-              final var status = topology.getPartitionHealth(brokerId, partitionId);
+              final var status = topology.getPartitionHealth(memberId, partitionId);
               switch (status) {
                 case HEALTHY -> partition.health(Health.HEALTHY);
                 case UNHEALTHY -> partition.health(Health.UNHEALTHY);
@@ -145,7 +145,7 @@ public final class TopologyServices extends ApiServices<TopologyServices> {
   }
 
   private boolean setRole(
-      final Integer brokerId,
+      final String memberId,
       final Integer partitionId,
       final BrokerClusterState topology,
       final Partition.Builder partition) {
@@ -153,11 +153,11 @@ public final class TopologyServices extends ApiServices<TopologyServices> {
     final var partitionFollowers = topology.getFollowersForPartition(partitionId);
     final var partitionInactives = topology.getInactiveNodesForPartition(partitionId);
 
-    if (partitionLeader == brokerId) {
+    if (memberId.equals(partitionLeader)) {
       partition.role(Role.LEADER);
-    } else if (partitionFollowers != null && partitionFollowers.contains(brokerId)) {
+    } else if (partitionFollowers != null && partitionFollowers.contains(memberId)) {
       partition.role(Role.FOLLOWER);
-    } else if (partitionInactives != null && partitionInactives.contains(brokerId)) {
+    } else if (partitionInactives != null && partitionInactives.contains(memberId)) {
       partition.role(Role.INACTIVE);
     } else {
       return false;

--- a/service/src/test/java/io/camunda/service/TopologyServiceTest.java
+++ b/service/src/test/java/io/camunda/service/TopologyServiceTest.java
@@ -202,23 +202,26 @@ public class TopologyServiceTest {
         new Topology(
             List.of(
                 new Broker(
-                    0,
+                    "0",
                     "localhost",
                     26501,
                     List.of(new Partition(1, Role.LEADER, Health.HEALTHY)),
-                    version),
+                    version,
+                    ""),
                 new Broker(
-                    1,
+                    "1",
                     "localhost",
                     26502,
                     List.of(new Partition(1, Role.FOLLOWER, Health.HEALTHY)),
-                    version),
+                    version,
+                    ""),
                 new Broker(
-                    2,
+                    "2",
                     "localhost",
                     26503,
                     List.of(new Partition(1, Role.INACTIVE, Health.UNHEALTHY)),
-                    version)),
+                    version,
+                    "")),
             "cluster-id",
             3,
             1,

--- a/service/src/test/java/io/camunda/service/TopologyServiceTest.java
+++ b/service/src/test/java/io/camunda/service/TopologyServiceTest.java
@@ -61,8 +61,8 @@ public class TopologyServiceTest {
     // given
     final int partitionId1 = 1;
     final int partitionId2 = 2;
-    final int leaderId1 = 1;
-    final int leaderId2 = 2;
+    final String leaderId1 = "1";
+    final String leaderId2 = "2";
 
     when(clusterState.getPartitions()).thenReturn(List.of(partitionId1, partitionId2));
     when(clusterState.getLeaderForPartition(partitionId1)).thenReturn(leaderId1);
@@ -95,8 +95,8 @@ public class TopologyServiceTest {
     // given
     final int partitionId1 = 1;
     final int partitionId2 = 2;
-    final int leaderId1 = 1;
-    final int leaderId2 = 2;
+    final String leaderId1 = "1";
+    final String leaderId2 = "2";
 
     when(clusterState.getPartitions()).thenReturn(List.of(partitionId1, partitionId2));
     when(clusterState.getLeaderForPartition(partitionId1)).thenReturn(leaderId1);
@@ -157,9 +157,9 @@ public class TopologyServiceTest {
     final int partitionId1 = 1;
     final int partitionId2 = 2;
     final int partitionId3 = 3;
-    final int leaderId1 = 1;
-    final int leaderId2 = 2;
-    final int leaderId3 = 3;
+    final String leaderId1 = "1";
+    final String leaderId2 = "2";
+    final String leaderId3 = "3";
 
     when(clusterState.getPartitions())
         .thenReturn(List.of(partitionId1, partitionId2, partitionId3));
@@ -278,23 +278,23 @@ public class TopologyServiceTest {
     }
 
     @Override
-    public int getLeaderForPartition(final int partition) {
-      return 0;
+    public String getLeaderForPartition(final int partition) {
+      return "0";
     }
 
     @Override
-    public Set<Integer> getFollowersForPartition(final int partition) {
-      return Set.of(1);
+    public Set<String> getFollowersForPartition(final int partition) {
+      return Set.of("1");
     }
 
     @Override
-    public Set<Integer> getInactiveNodesForPartition(final int partition) {
-      return Set.of(2);
+    public Set<String> getInactiveNodesForPartition(final int partition) {
+      return Set.of("2");
     }
 
     @Override
-    public int getRandomBroker() {
-      return ThreadLocalRandom.current().nextInt(0, 3);
+    public String getRandomBroker() {
+      return Integer.toString(ThreadLocalRandom.current().nextInt(0, 3));
     }
 
     @Override
@@ -303,29 +303,34 @@ public class TopologyServiceTest {
     }
 
     @Override
-    public List<Integer> getBrokers() {
-      return List.of(0, 1, 2);
+    public List<String> getBrokers() {
+      return List.of("0", "1", "2");
     }
 
     @Override
-    public String getBrokerAddress(final int brokerId) {
-      return "localhost:" + (26501 + brokerId);
+    public String getBrokerAddress(final String memberId) {
+      return "localhost:" + (26501 + Integer.parseInt(memberId));
     }
 
     @Override
-    public String getBrokerVersion(final int brokerId) {
+    public String getBrokerVersion(final String memberId) {
       return version;
     }
 
     @Override
-    public PartitionHealthStatus getPartitionHealth(final int brokerId, final int partition) {
+    public String getBrokerRegion(final String memberId) {
+      return null;
+    }
+
+    @Override
+    public PartitionHealthStatus getPartitionHealth(final String memberId, final int partition) {
       if (partition != 1) {
         return PartitionHealthStatus.NULL_VAL;
       }
 
-      return switch (brokerId) {
-        case 0, 1 -> PartitionHealthStatus.HEALTHY;
-        case 2 -> PartitionHealthStatus.UNHEALTHY;
+      return switch (memberId) {
+        case "0", "1" -> PartitionHealthStatus.HEALTHY;
+        case "2" -> PartitionHealthStatus.UNHEALTHY;
         default -> PartitionHealthStatus.NULL_VAL;
       };
     }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerClientTopologyMetrics.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerClientTopologyMetrics.java
@@ -25,7 +25,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 public final class BrokerClientTopologyMetrics {
 
   private final MeterRegistry registry;
-  private final Table<Integer, Integer, AtomicInteger> brokerTopologyRole;
+  private final Table<Integer, String, AtomicInteger> brokerTopologyRole;
 
   public BrokerClientTopologyMetrics(final MeterRegistry registry) {
     this.registry = Objects.requireNonNull(registry, "must specify a meter registry");
@@ -33,22 +33,22 @@ public final class BrokerClientTopologyMetrics {
   }
 
   /**
-   * Sets the role of the broker with the given {@code brokerId} for the partition with the given
+   * Sets the role of the broker with the given {@code memberId} for the partition with the given
    * {@code partitionId}
    */
   public void setRoleForPartition(
-      final int partitionId, final int brokerId, final PartitionRoleValues roleValue) {
+      final int partitionId, final String memberId, final PartitionRoleValues roleValue) {
     brokerTopologyRole
-        .computeIfAbsent(partitionId, brokerId, this::registerBrokerTopologyRole)
+        .computeIfAbsent(partitionId, memberId, this::registerBrokerTopologyRole)
         .set(roleValue.value());
   }
 
-  private AtomicInteger registerBrokerTopologyRole(final int partitionId, final int brokerId) {
+  private AtomicInteger registerBrokerTopologyRole(final int partitionId, final String memberId) {
     final var role = new AtomicInteger();
     Gauge.builder(PARTITION_ROLE.getName(), role, Number::intValue)
         .description(PARTITION_ROLE.getDescription())
         .tag(PartitionKeyNames.PARTITION.asString(), String.valueOf(partitionId))
-        .tag(TopologyKeyNames.BROKER.asString(), String.valueOf(brokerId))
+        .tag(TopologyKeyNames.BROKER.asString(), memberId)
         .register(registry);
     return role;
   }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerClusterState.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerClusterState.java
@@ -45,6 +45,23 @@ public interface BrokerClusterState {
 
   String getBrokerVersion(int brokerId);
 
+  /**
+   * Returns the region the broker belongs to, or {@code null} if not configured (non-region-aware
+   * clusters).
+   */
+  default String getBrokerRegion(final int brokerId) {
+    return null;
+  }
+
+  /**
+   * Returns the composite member ID for the broker. In region-aware clusters this is {@code
+   * region-nodeId} (e.g. {@code us-east1-0}). In non-region-aware clusters this falls back to the
+   * string representation of the integer node ID.
+   */
+  default String getBrokerMemberId(final int brokerId) {
+    return String.valueOf(brokerId);
+  }
+
   PartitionHealthStatus getPartitionHealth(int brokerId, int partition);
 
   long getLastCompletedChangeId();

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerClusterState.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerClusterState.java
@@ -13,9 +13,11 @@ import java.util.Set;
 
 public interface BrokerClusterState {
 
-  int UNKNOWN_NODE_ID = -1;
-  int NODE_ID_NULL = UNKNOWN_NODE_ID - 1;
-  int PARTITION_ID_NULL = NODE_ID_NULL - 1;
+  /**
+   * Sentinel for partition-id methods when no partition can be determined. Kept as an int because
+   * partition ids remain integer across the cluster.
+   */
+  int PARTITION_ID_NULL = -1;
 
   boolean isInitialized();
 
@@ -25,44 +27,34 @@ public interface BrokerClusterState {
 
   int getReplicationFactor();
 
-  int getLeaderForPartition(int partition);
-
-  Set<Integer> getFollowersForPartition(int partition);
-
-  Set<Integer> getInactiveNodesForPartition(int partition);
-
   /**
-   * @return the node id of a random broker or {@link BrokerClusterState#UNKNOWN_NODE_ID} if no
-   *     brokers are known
+   * Returns the member id of the current leader for the given partition, or {@code null} if no
+   * leader is known.
    */
-  int getRandomBroker();
+  String getLeaderForPartition(int partition);
+
+  Set<String> getFollowersForPartition(int partition);
+
+  Set<String> getInactiveNodesForPartition(int partition);
+
+  /** Returns the member id of a random broker, or {@code null} if no brokers are known. */
+  String getRandomBroker();
 
   List<Integer> getPartitions();
 
-  List<Integer> getBrokers();
+  List<String> getBrokers();
 
-  String getBrokerAddress(int brokerId);
+  String getBrokerAddress(String memberId);
 
-  String getBrokerVersion(int brokerId);
+  String getBrokerVersion(String memberId);
 
   /**
    * Returns the region the broker belongs to, or {@code null} if not configured (non-region-aware
    * clusters).
    */
-  default String getBrokerRegion(final int brokerId) {
-    return null;
-  }
+  String getBrokerRegion(String memberId);
 
-  /**
-   * Returns the composite member ID for the broker. In region-aware clusters this is {@code
-   * region-nodeId} (e.g. {@code us-east1-0}). In non-region-aware clusters this falls back to the
-   * string representation of the integer node ID.
-   */
-  default String getBrokerMemberId(final int brokerId) {
-    return String.valueOf(brokerId);
-  }
-
-  PartitionHealthStatus getPartitionHealth(int brokerId, int partition);
+  PartitionHealthStatus getPartitionHealth(String memberId, int partition);
 
   long getLastCompletedChangeId();
 

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/dto/BrokerRequest.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/dto/BrokerRequest.java
@@ -38,7 +38,7 @@ public abstract class BrokerRequest<T> implements ClientRequest {
     this.templateId = templateId;
   }
 
-  public Optional<Integer> getBrokerId() {
+  public Optional<String> getBrokerId() {
     return Optional.empty();
   }
 

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClientTopologyImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClientTopologyImpl.java
@@ -11,15 +11,14 @@ import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.Set;
-import org.agrona.collections.Int2IntHashMap;
-import org.agrona.collections.Int2ObjectHashMap;
-import org.agrona.collections.IntArrayList;
 
 /**
  * Represents the current state of the broker cluster topology. It includes both the live state of
@@ -73,28 +72,27 @@ public record BrokerClientTopologyImpl(
   }
 
   @Override
-  public int getLeaderForPartition(final int partition) {
+  public String getLeaderForPartition(final int partition) {
     return liveClusterState.partitionLeaders.get(partition);
   }
 
   @Override
-  public Set<Integer> getFollowersForPartition(final int partition) {
+  public Set<String> getFollowersForPartition(final int partition) {
     return liveClusterState.partitionFollowers.getOrDefault(partition, Set.of());
   }
 
   @Override
-  public Set<Integer> getInactiveNodesForPartition(final int partition) {
+  public Set<String> getInactiveNodesForPartition(final int partition) {
     return liveClusterState.partitionInactiveNodes.getOrDefault(partition, Set.of());
   }
 
   @Override
-  public int getRandomBroker() {
+  public String getRandomBroker() {
     if (liveClusterState.brokers.isEmpty()) {
-      return UNKNOWN_NODE_ID;
-    } else {
-      return liveClusterState.brokers.get(
-          liveClusterState.randomBroker.nextInt(liveClusterState.brokers.size()));
+      return null;
     }
+    return liveClusterState.brokers.get(
+        liveClusterState.randomBroker.nextInt(liveClusterState.brokers.size()));
   }
 
   @Override
@@ -103,39 +101,33 @@ public record BrokerClientTopologyImpl(
   }
 
   @Override
-  public List<Integer> getBrokers() {
+  public List<String> getBrokers() {
     return liveClusterState.brokers;
   }
 
   @Override
-  public String getBrokerAddress(final int brokerId) {
-    return liveClusterState.brokerAddresses.get(brokerId);
+  public String getBrokerAddress(final String memberId) {
+    return liveClusterState.brokerAddresses.get(memberId);
   }
 
   @Override
-  public String getBrokerVersion(final int brokerId) {
-    return liveClusterState.brokerVersions.get(brokerId);
+  public String getBrokerVersion(final String memberId) {
+    return liveClusterState.brokerVersions.get(memberId);
   }
 
   @Override
-  public String getBrokerRegion(final int brokerId) {
-    return liveClusterState.brokerRegions.get(brokerId);
+  public String getBrokerRegion(final String memberId) {
+    return liveClusterState.brokerRegions.get(memberId);
   }
 
   @Override
-  public String getBrokerMemberId(final int brokerId) {
-    return liveClusterState.brokerMemberIds.getOrDefault(brokerId, String.valueOf(brokerId));
-  }
-
-  @Override
-  public PartitionHealthStatus getPartitionHealth(final int brokerId, final int partitionId) {
-    final var brokerHealthyPartitions = liveClusterState.partitionsHealthPerBroker.get(brokerId);
+  public PartitionHealthStatus getPartitionHealth(final String memberId, final int partitionId) {
+    final var brokerHealthyPartitions = liveClusterState.partitionsHealthPerBroker.get(memberId);
 
     if (brokerHealthyPartitions == null) {
       return PartitionHealthStatus.UNHEALTHY;
-    } else {
-      return brokerHealthyPartitions.getOrDefault(partitionId, PartitionHealthStatus.UNHEALTHY);
     }
+    return brokerHealthyPartitions.getOrDefault(partitionId, PartitionHealthStatus.UNHEALTHY);
   }
 
   @Override
@@ -164,110 +156,91 @@ public record BrokerClientTopologyImpl(
 
   static class LiveClusterState {
     private static final Long TERM_NONE = -1L;
-    private final Int2IntHashMap partitionLeaders;
-    private final Int2ObjectHashMap<Long> partitionLeaderTerms;
-    private final Int2ObjectHashMap<Set<Integer>> partitionFollowers;
-    private final Int2ObjectHashMap<Set<Integer>> partitionInactiveNodes;
-    private final Int2ObjectHashMap<Int2ObjectHashMap<PartitionHealthStatus>>
-        partitionsHealthPerBroker;
-    private final Int2ObjectHashMap<String> brokerAddresses;
-    private final Int2ObjectHashMap<String> brokerVersions;
-    private final Int2ObjectHashMap<String> brokerRegions;
-    private final Int2ObjectHashMap<String> brokerMemberIds;
-    private final IntArrayList brokers;
+
+    // partitionId -> memberId of current leader
+    private final Map<Integer, String> partitionLeaders;
+    private final Map<Integer, Long> partitionLeaderTerms;
+    private final Map<Integer, Set<String>> partitionFollowers;
+    private final Map<Integer, Set<String>> partitionInactiveNodes;
+    // memberId -> (partitionId -> health)
+    private final Map<String, Map<Integer, PartitionHealthStatus>> partitionsHealthPerBroker;
+    private final Map<String, String> brokerAddresses;
+    private final Map<String, String> brokerVersions;
+    private final Map<String, String> brokerRegions;
+    private final List<String> brokers;
     private final Random randomBroker;
 
     public LiveClusterState(final Collection<BrokerInfo> distributedBrokerInfos) {
-      partitionLeaders = new Int2IntHashMap(NODE_ID_NULL);
-      partitionLeaderTerms = new Int2ObjectHashMap<>();
-      partitionFollowers = new Int2ObjectHashMap<>();
-      partitionInactiveNodes = new Int2ObjectHashMap<>();
-      partitionsHealthPerBroker = new Int2ObjectHashMap<>();
-      brokerAddresses = new Int2ObjectHashMap<>();
-      brokerVersions = new Int2ObjectHashMap<>();
-      brokerRegions = new Int2ObjectHashMap<>();
-      brokerMemberIds = new Int2ObjectHashMap<>();
-      brokers = new IntArrayList(5, NODE_ID_NULL);
+      partitionLeaders = new HashMap<>();
+      partitionLeaderTerms = new HashMap<>();
+      partitionFollowers = new HashMap<>();
+      partitionInactiveNodes = new HashMap<>();
+      partitionsHealthPerBroker = new HashMap<>();
+      brokerAddresses = new HashMap<>();
+      brokerVersions = new HashMap<>();
+      brokerRegions = new HashMap<>();
+      brokers = new ArrayList<>(distributedBrokerInfos.size());
       randomBroker = new Random();
 
-      // Sort by composite nodeId for a stable, globally-unique int key assignment.
-      // This is necessary when multiple brokers share the same local nodeId (e.g. in a
-      // multi-region cluster where each region uses 0-indexed local IDs).
-      final List<BrokerInfo> sortedBrokerInfos =
-          distributedBrokerInfos.stream()
-              .sorted(
-                  Comparator.comparing(BrokerInfo::getNodeId, Comparator.naturalOrder()))
-              .toList();
-
-      for (int idx = 0; idx < sortedBrokerInfos.size(); idx++) {
-        final BrokerInfo brokerInfo = sortedBrokerInfos.get(idx);
-        // Use the sorted index as the globally-unique int key (avoids collisions in multi-region
-        // setups where two brokers may have the same local numeric ID such as 0).
-        final int key = idx;
-        final String nodeIdStr = brokerInfo.getNodeId();
-        brokers.add(key);
+      for (final BrokerInfo brokerInfo : distributedBrokerInfos) {
+        final String memberId = brokerInfo.getNodeId();
+        brokers.add(memberId);
         final String clientAddress = brokerInfo.getCommandApiAddress();
         if (clientAddress != null) {
-          brokerAddresses.put(key, clientAddress);
+          brokerAddresses.put(memberId, clientAddress);
         }
-        brokerVersions.put(key, brokerInfo.getVersion());
-        brokerMemberIds.put(key, nodeIdStr);
-        // Derive region: strip the "-<localId>" suffix from the composite nodeId.
-        final int localNumericId = brokerInfo.getLocalNodeId();
-        final String nodeSuffix = "-" + localNumericId;
-        if (nodeIdStr != null
-            && nodeIdStr.endsWith(nodeSuffix)
-            && nodeIdStr.length() > nodeSuffix.length()) {
-          brokerRegions.put(
-              key, nodeIdStr.substring(0, nodeIdStr.length() - nodeSuffix.length()));
+        brokerVersions.put(memberId, brokerInfo.getVersion());
+        final String region = brokerInfo.getRegion();
+        if (region != null && !region.isEmpty()) {
+          brokerRegions.put(memberId, region);
         }
         brokerInfo.consumePartitions(
             pId -> {}, // nothing to consume
-            (leaderPartitionId, term) -> setPartitionLeader(leaderPartitionId, key, term),
-            followerPartitionId -> addPartitionFollower(followerPartitionId, key),
-            inactivePartitionId -> addPartitionInactive(inactivePartitionId, key));
+            (leaderPartitionId, term) -> setPartitionLeader(leaderPartitionId, memberId, term),
+            followerPartitionId -> addPartitionFollower(followerPartitionId, memberId),
+            inactivePartitionId -> addPartitionInactive(inactivePartitionId, memberId));
         brokerInfo.consumePartitionsHealth(
-            (partition, health) -> setPartitionHealthStatus(key, partition, health));
+            (partition, health) -> setPartitionHealthStatus(memberId, partition, health));
       }
     }
 
-    void setPartitionLeader(final int partitionId, final int leaderId, final long term) {
+    void setPartitionLeader(final int partitionId, final String leaderId, final long term) {
       if (partitionLeaderTerms.getOrDefault(partitionId, TERM_NONE) <= term) {
         partitionLeaders.put(partitionId, leaderId);
-        partitionLeaderTerms.put(partitionId, Long.valueOf(term));
-        final Set<Integer> followers = partitionFollowers.get(partitionId);
+        partitionLeaderTerms.put(partitionId, term);
+        final Set<String> followers = partitionFollowers.get(partitionId);
         if (followers != null) {
-          followers.removeIf(follower -> follower == leaderId);
+          followers.remove(leaderId);
         }
-        final Set<Integer> inactives = partitionInactiveNodes.get(partitionId);
+        final Set<String> inactives = partitionInactiveNodes.get(partitionId);
         if (inactives != null) {
-          inactives.removeIf(inactive -> inactive == leaderId);
+          inactives.remove(leaderId);
         }
       }
     }
 
     void setPartitionHealthStatus(
-        final int brokerId, final int partitionId, final PartitionHealthStatus status) {
+        final String memberId, final int partitionId, final PartitionHealthStatus status) {
       final var partitionsHealth =
-          partitionsHealthPerBroker.computeIfAbsent(brokerId, integer -> new Int2ObjectHashMap<>());
+          partitionsHealthPerBroker.computeIfAbsent(memberId, id -> new HashMap<>());
       partitionsHealth.put(partitionId, status);
     }
 
-    void addPartitionFollower(final int partitionId, final int followerId) {
-      partitionFollowers.computeIfAbsent(partitionId, HashSet::new).add(followerId);
+    void addPartitionFollower(final int partitionId, final String followerId) {
+      partitionFollowers.computeIfAbsent(partitionId, id -> new HashSet<>()).add(followerId);
       partitionLeaders.remove(partitionId, followerId);
-      final Set<Integer> inactives = partitionInactiveNodes.get(partitionId);
+      final Set<String> inactives = partitionInactiveNodes.get(partitionId);
       if (inactives != null) {
         inactives.remove(followerId);
       }
     }
 
-    void addPartitionInactive(final int partitionId, final int brokerId) {
-      partitionInactiveNodes.computeIfAbsent(partitionId, HashSet::new).add(brokerId);
-      partitionLeaders.remove(partitionId, brokerId);
-      final Set<Integer> followers = partitionFollowers.get(partitionId);
+    void addPartitionInactive(final int partitionId, final String memberId) {
+      partitionInactiveNodes.computeIfAbsent(partitionId, id -> new HashSet<>()).add(memberId);
+      partitionLeaders.remove(partitionId, memberId);
+      final Set<String> followers = partitionFollowers.get(partitionId);
       if (followers != null) {
-        followers.remove(brokerId);
+        followers.remove(memberId);
       }
     }
   }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClientTopologyImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClientTopologyImpl.java
@@ -196,9 +196,7 @@ public record BrokerClientTopologyImpl(
       final List<BrokerInfo> sortedBrokerInfos =
           distributedBrokerInfos.stream()
               .sorted(
-                  Comparator.comparing(
-                      bi -> bi.getNodeId() != null ? bi.getNodeId() : "",
-                      Comparator.naturalOrder()))
+                  Comparator.comparing(BrokerInfo::getNodeId, Comparator.naturalOrder()))
               .toList();
 
       for (int idx = 0; idx < sortedBrokerInfos.size(); idx++) {

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClientTopologyImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClientTopologyImpl.java
@@ -117,6 +117,16 @@ public record BrokerClientTopologyImpl(
   }
 
   @Override
+  public String getBrokerRegion(final int brokerId) {
+    return liveClusterState.brokerRegions.get(brokerId);
+  }
+
+  @Override
+  public String getBrokerMemberId(final int brokerId) {
+    return liveClusterState.brokerMemberIds.getOrDefault(brokerId, String.valueOf(brokerId));
+  }
+
+  @Override
   public PartitionHealthStatus getPartitionHealth(final int brokerId, final int partitionId) {
     final var brokerHealthyPartitions = liveClusterState.partitionsHealthPerBroker.get(brokerId);
 
@@ -161,6 +171,8 @@ public record BrokerClientTopologyImpl(
         partitionsHealthPerBroker;
     private final Int2ObjectHashMap<String> brokerAddresses;
     private final Int2ObjectHashMap<String> brokerVersions;
+    private final Int2ObjectHashMap<String> brokerRegions;
+    private final Int2ObjectHashMap<String> brokerMemberIds;
     private final IntArrayList brokers;
     private final Random randomBroker;
 
@@ -172,6 +184,8 @@ public record BrokerClientTopologyImpl(
       partitionsHealthPerBroker = new Int2ObjectHashMap<>();
       brokerAddresses = new Int2ObjectHashMap<>();
       brokerVersions = new Int2ObjectHashMap<>();
+      brokerRegions = new Int2ObjectHashMap<>();
+      brokerMemberIds = new Int2ObjectHashMap<>();
       brokers = new IntArrayList(5, NODE_ID_NULL);
       randomBroker = new Random();
 
@@ -184,6 +198,11 @@ public record BrokerClientTopologyImpl(
               brokerAddresses.put(nodeId, brokerInfo.getCommandApiAddress());
             }
             brokerVersions.put(nodeId, brokerInfo.getVersion());
+            final String region = brokerInfo.getRegion();
+            if (region != null) {
+              brokerRegions.put(nodeId, region);
+            }
+            brokerMemberIds.put(nodeId, brokerInfo.getMemberId());
             brokerInfo.consumePartitions(
                 pId -> {}, // nothing to consume
                 (leaderPartitionId, term) -> setPartitionLeader(leaderPartitionId, nodeId, term),

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClientTopologyImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClientTopologyImpl.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
@@ -189,28 +190,47 @@ public record BrokerClientTopologyImpl(
       brokers = new IntArrayList(5, NODE_ID_NULL);
       randomBroker = new Random();
 
-      distributedBrokerInfos.forEach(
-          brokerInfo -> {
-            final int nodeId = brokerInfo.getNodeId();
-            brokers.add(brokerInfo.getNodeId());
-            final String clientAddress = brokerInfo.getCommandApiAddress();
-            if (clientAddress != null) {
-              brokerAddresses.put(nodeId, brokerInfo.getCommandApiAddress());
-            }
-            brokerVersions.put(nodeId, brokerInfo.getVersion());
-            final String region = brokerInfo.getRegion();
-            if (region != null) {
-              brokerRegions.put(nodeId, region);
-            }
-            brokerMemberIds.put(nodeId, brokerInfo.getMemberId());
-            brokerInfo.consumePartitions(
-                pId -> {}, // nothing to consume
-                (leaderPartitionId, term) -> setPartitionLeader(leaderPartitionId, nodeId, term),
-                followerPartitionId -> addPartitionFollower(followerPartitionId, nodeId),
-                inactivePartitionId -> addPartitionInactive(inactivePartitionId, nodeId));
-            brokerInfo.consumePartitionsHealth(
-                (partition, health) -> setPartitionHealthStatus(nodeId, partition, health));
-          });
+      // Sort by composite nodeId for a stable, globally-unique int key assignment.
+      // This is necessary when multiple brokers share the same local nodeId (e.g. in a
+      // multi-region cluster where each region uses 0-indexed local IDs).
+      final List<BrokerInfo> sortedBrokerInfos =
+          distributedBrokerInfos.stream()
+              .sorted(
+                  Comparator.comparing(
+                      bi -> bi.getNodeId() != null ? bi.getNodeId() : "",
+                      Comparator.naturalOrder()))
+              .toList();
+
+      for (int idx = 0; idx < sortedBrokerInfos.size(); idx++) {
+        final BrokerInfo brokerInfo = sortedBrokerInfos.get(idx);
+        // Use the sorted index as the globally-unique int key (avoids collisions in multi-region
+        // setups where two brokers may have the same local numeric ID such as 0).
+        final int key = idx;
+        final String nodeIdStr = brokerInfo.getNodeId();
+        brokers.add(key);
+        final String clientAddress = brokerInfo.getCommandApiAddress();
+        if (clientAddress != null) {
+          brokerAddresses.put(key, clientAddress);
+        }
+        brokerVersions.put(key, brokerInfo.getVersion());
+        brokerMemberIds.put(key, nodeIdStr);
+        // Derive region: strip the "-<localId>" suffix from the composite nodeId.
+        final int localNumericId = brokerInfo.getLocalNodeId();
+        final String nodeSuffix = "-" + localNumericId;
+        if (nodeIdStr != null
+            && nodeIdStr.endsWith(nodeSuffix)
+            && nodeIdStr.length() > nodeSuffix.length()) {
+          brokerRegions.put(
+              key, nodeIdStr.substring(0, nodeIdStr.length() - nodeSuffix.length()));
+        }
+        brokerInfo.consumePartitions(
+            pId -> {}, // nothing to consume
+            (leaderPartitionId, term) -> setPartitionLeader(leaderPartitionId, key, term),
+            followerPartitionId -> addPartitionFollower(followerPartitionId, key),
+            inactivePartitionId -> addPartitionInactive(inactivePartitionId, key));
+        brokerInfo.consumePartitionsHealth(
+            (partition, health) -> setPartitionHealthStatus(key, partition, health));
+      }
     }
 
     void setPartitionLeader(final int partitionId, final int leaderId, final long term) {

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerRequestManager.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerRequestManager.java
@@ -32,8 +32,8 @@ import java.time.Duration;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.function.ToIntFunction;
 import org.agrona.DirectBuffer;
 
 final class BrokerRequestManager extends Actor {
@@ -254,8 +254,7 @@ final class BrokerRequestManager extends Actor {
 
     final var inactiveNodes = topology.getInactiveNodesForPartition(partitionId);
     final var someNodesInactive = inactiveNodes != null && !inactiveNodes.isEmpty();
-    final var noPartitionLeader =
-        topology.getLeaderForPartition(partitionId) == BrokerClusterState.NODE_ID_NULL;
+    final var noPartitionLeader = topology.getLeaderForPartition(partitionId) == null;
     if (someNodesInactive && noPartitionLeader) {
       throw new PartitionInactiveException(partitionId);
     }
@@ -298,7 +297,7 @@ final class BrokerRequestManager extends Actor {
 
   private class BrokerAddressProvider implements Supplier<String> {
 
-    private final ToIntFunction<BrokerClusterState> nodeIdSelector;
+    private final Function<BrokerClusterState, String> memberIdSelector;
 
     BrokerAddressProvider() {
       this(BrokerClusterState::getRandomBroker);
@@ -308,18 +307,21 @@ final class BrokerRequestManager extends Actor {
       this(state -> state.getLeaderForPartition(partitionId));
     }
 
-    BrokerAddressProvider(final ToIntFunction<BrokerClusterState> nodeIdSelector) {
-      this.nodeIdSelector = nodeIdSelector;
+    BrokerAddressProvider(final Function<BrokerClusterState, String> memberIdSelector) {
+      this.memberIdSelector = memberIdSelector;
     }
 
     @Override
     public String get() {
       final BrokerClusterState topology = topologyManager.getTopology();
-      if (topology != null) {
-        return topology.getBrokerAddress(nodeIdSelector.applyAsInt(topology));
-      } else {
+      if (topology == null) {
         return null;
       }
+      final String memberId = memberIdSelector.apply(topology);
+      if (memberId == null) {
+        return null;
+      }
+      return topology.getBrokerAddress(memberId);
     }
   }
 }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
@@ -71,9 +71,7 @@ public final class BrokerTopologyManagerImpl extends Actor
     actor.run(
         () -> {
           topologyListeners.add(listener);
-          topology.getBrokers().stream()
-              .map(b -> MemberId.from(topology.getBrokerMemberId(b)))
-              .forEach(listener::brokerAdded);
+          topology.getBrokers().stream().map(MemberId::from).forEach(listener::brokerAdded);
         });
   }
 
@@ -189,7 +187,7 @@ public final class BrokerTopologyManagerImpl extends Actor
     partitions.forEach(
         partition -> {
           final var leader = topology.getLeaderForPartition(partition);
-          if (leader != BrokerClusterState.NODE_ID_NULL) {
+          if (leader != null) {
             topologyMetrics.setRoleForPartition(partition, leader, PartitionRoleValues.LEADER);
           }
 

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
@@ -72,7 +72,7 @@ public final class BrokerTopologyManagerImpl extends Actor
         () -> {
           topologyListeners.add(listener);
           topology.getBrokers().stream()
-              .map(b -> MemberId.from(String.valueOf(b)))
+              .map(b -> MemberId.from(topology.getBrokerMemberId(b)))
               .forEach(listener::brokerAdded);
         });
   }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/PartitionIdIterator.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/PartitionIdIterator.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.broker.client.impl;
 
 import static io.camunda.zeebe.protocol.Protocol.START_PARTITION_ID;
 
-import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import java.util.Iterator;
 import java.util.PrimitiveIterator.OfInt;
@@ -36,7 +35,7 @@ public final class PartitionIdIterator implements Iterator<Integer> {
 
   private boolean hasLeader(final BrokerTopologyManager topologyManager, final int p) {
     final var topology = topologyManager.getTopology();
-    return topology != null && topology.getLeaderForPartition(p) != BrokerClusterState.NODE_ID_NULL;
+    return topology != null && topology.getLeaderForPartition(p) != null;
   }
 
   @Override

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/RoundRobinDispatchStrategy.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/RoundRobinDispatchStrategy.java
@@ -52,7 +52,7 @@ public final class RoundRobinDispatchStrategy implements RequestDispatchStrategy
 
     for (int i = 0; i < topology.getPartitionsCount(); i++) {
       final int partition = partitions.partitionAtOffset(offset.getAndIncrement());
-      if (topology.getLeaderForPartition(partition) != BrokerClusterState.NODE_ID_NULL) {
+      if (topology.getLeaderForPartition(partition) != null) {
         return partition;
       }
     }

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerClientTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerClientTest.java
@@ -418,9 +418,12 @@ public final class BrokerClientTest {
           new ClusterMembershipEvent(Type.METADATA_CHANGED, otherBroker.member()));
       Awaitility.await("Broker " + leaderBrokerId + " is leader.")
           .untilAsserted(
-              () ->
-                  assertThat(topologyManager.getTopology().getLeaderForPartition(1))
-                      .isEqualTo(leaderBrokerId));
+              () -> {
+                final var topology = topologyManager.getTopology();
+                final var leaderId = topology.getLeaderForPartition(1);
+                assertThat(topology.getBrokerMemberId(leaderId))
+                    .isEqualTo(String.valueOf(leaderBrokerId));
+              });
 
       response = client.sendRequest(request).join();
     }

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerClientTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerClientTest.java
@@ -112,9 +112,7 @@ public final class BrokerClientTest {
     topologyManager.event(new ClusterMembershipEvent(Type.MEMBER_ADDED, broker.member()));
     Awaitility.await("Topology is updated")
         .untilAsserted(
-            () ->
-                assertThat(topologyManager.getTopology().getLeaderForPartition(1))
-                    .isNotEqualTo(BrokerClusterState.NODE_ID_NULL));
+            () -> assertThat(topologyManager.getTopology().getLeaderForPartition(1)).isNotNull());
 
     client =
         new BrokerClientImpl(
@@ -418,12 +416,9 @@ public final class BrokerClientTest {
           new ClusterMembershipEvent(Type.METADATA_CHANGED, otherBroker.member()));
       Awaitility.await("Broker " + leaderBrokerId + " is leader.")
           .untilAsserted(
-              () -> {
-                final var topology = topologyManager.getTopology();
-                final var leaderId = topology.getLeaderForPartition(1);
-                assertThat(topology.getBrokerMemberId(leaderId))
-                    .isEqualTo(String.valueOf(leaderBrokerId));
-              });
+              () ->
+                  assertThat(topologyManager.getTopology().getLeaderForPartition(1))
+                      .isEqualTo(String.valueOf(leaderBrokerId)));
 
       response = client.sendRequest(request).join();
     }
@@ -536,7 +531,9 @@ public final class BrokerClientTest {
         topologyManager.event(new ClusterMembershipEvent(Type.MEMBER_ADDED, otherBroker.member()));
         Awaitility.await("Topology is updated")
             .untilAsserted(
-                () -> assertThat(topologyManager.getTopology().getLeaderForPartition(1)).isOne());
+                () ->
+                    assertThat(topologyManager.getTopology().getLeaderForPartition(1))
+                        .isEqualTo("1"));
 
         // when
         response = client.sendRequest(request).join();
@@ -565,7 +562,9 @@ public final class BrokerClientTest {
         topologyManager.event(new ClusterMembershipEvent(Type.MEMBER_ADDED, otherBroker.member()));
         Awaitility.await("Topology is updated")
             .untilAsserted(
-                () -> assertThat(topologyManager.getTopology().getLeaderForPartition(2)).isOne());
+                () ->
+                    assertThat(topologyManager.getTopology().getLeaderForPartition(2))
+                        .isEqualTo("1"));
 
         // when
         response = client.sendRequest(request).join();
@@ -586,7 +585,9 @@ public final class BrokerClientTest {
         topologyManager.event(new ClusterMembershipEvent(Type.MEMBER_ADDED, otherBroker.member()));
         Awaitility.await("Topology is updated")
             .untilAsserted(
-                () -> assertThat(topologyManager.getTopology().getLeaderForPartition(2)).isOne());
+                () ->
+                    assertThat(topologyManager.getTopology().getLeaderForPartition(2))
+                        .isEqualTo("1"));
 
         // when
         response = client.sendRequest(request).join();

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
@@ -573,8 +573,7 @@ final class BrokerTopologyManagerTest {
   }
 
   private Member createMemberFromBrokerInfo(final BrokerInfo broker) {
-    final Member member =
-        new Member(new MemberConfig().setId(Integer.toString(broker.getNodeId())));
+    final Member member = new Member(new MemberConfig().setId(broker.getNodeId()));
     broker.writeIntoProperties(member.properties());
     members.add(member);
     return member;

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.broker.client.api;
 
-import static io.camunda.zeebe.broker.client.api.BrokerClusterState.NODE_ID_NULL;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.ClusterMembershipEvent;
@@ -80,11 +79,11 @@ final class BrokerTopologyManagerTest {
     notifyEvent(createMemberUpdateEvent(brokerUpdated));
 
     // then
-
+    final String brokerKey = String.valueOf(brokerId);
     assertThat(topologyManager.getTopology().getFollowersForPartition(partition))
         .describedAs("The partition has the expected follower")
-        .containsExactly(brokerId);
-    assertThat(topologyManager.getTopology().getBrokerVersion(brokerId))
+        .containsExactly(brokerKey);
+    assertThat(topologyManager.getTopology().getBrokerVersion(brokerKey))
         .isEqualTo(broker.getVersion());
   }
 
@@ -114,9 +113,8 @@ final class BrokerTopologyManagerTest {
     assertThat(topologyManager.getTopology().getBrokers()).isNotEmpty();
 
     assertThat(topologyManager.getTopology().getFollowersForPartition(partition))
-        .doesNotContain(brokerId);
-    assertThat(topologyManager.getTopology().getLeaderForPartition(partition))
-        .isEqualTo(NODE_ID_NULL);
+        .doesNotContain(String.valueOf(brokerId));
+    assertThat(topologyManager.getTopology().getLeaderForPartition(partition)).isNull();
   }
 
   @Test
@@ -130,7 +128,7 @@ final class BrokerTopologyManagerTest {
 
     assertThat(topologyManager.getTopology().getLeaderForPartition(partition))
         .describedAs("Topology has the old leader")
-        .isZero();
+        .isEqualTo(String.valueOf(oldLeaderId));
 
     // when
     final int newLeaderId = 1;
@@ -139,8 +137,9 @@ final class BrokerTopologyManagerTest {
     notifyEvent(createMemberAddedEvent(newLeader));
 
     // then
-    assertThat(topologyManager.getTopology().getBrokers()).contains(newLeaderId);
-    assertThat(topologyManager.getTopology().getLeaderForPartition(partition)).isOne();
+    assertThat(topologyManager.getTopology().getBrokers()).contains(String.valueOf(newLeaderId));
+    assertThat(topologyManager.getTopology().getLeaderForPartition(partition))
+        .isEqualTo(String.valueOf(newLeaderId));
   }
 
   @Test
@@ -152,7 +151,8 @@ final class BrokerTopologyManagerTest {
     newLeader.setLeaderForPartition(partition, 2);
     notifyEvent(createMemberAddedEvent(newLeader));
 
-    assertThat(topologyManager.getTopology().getLeaderForPartition(partition)).isOne();
+    assertThat(topologyManager.getTopology().getLeaderForPartition(partition))
+        .isEqualTo(String.valueOf(newLeaderId));
 
     // when
     final int oldLeaderId = 0;
@@ -161,8 +161,9 @@ final class BrokerTopologyManagerTest {
     notifyEvent(createMemberAddedEvent(oldLeader));
 
     // then
-    assertThat(topologyManager.getTopology().getBrokers()).contains(oldLeaderId);
-    assertThat(topologyManager.getTopology().getLeaderForPartition(partition)).isOne();
+    assertThat(topologyManager.getTopology().getBrokers()).contains(String.valueOf(oldLeaderId));
+    assertThat(topologyManager.getTopology().getLeaderForPartition(partition))
+        .isEqualTo(String.valueOf(newLeaderId));
   }
 
   @Test
@@ -174,7 +175,8 @@ final class BrokerTopologyManagerTest {
     leader.setLeaderForPartition(partition, 2);
     notifyEvent(createMemberAddedEvent(leader));
 
-    assertThat(topologyManager.getTopology().getLeaderForPartition(partition)).isOne();
+    assertThat(topologyManager.getTopology().getLeaderForPartition(partition))
+        .isEqualTo(String.valueOf(leaderId));
 
     // when
     // partition shutdown/purge
@@ -188,9 +190,10 @@ final class BrokerTopologyManagerTest {
     notifyEvent(createMemberAddedEvent(newLeaderAfterRebootstrap));
 
     // then
-    assertThat(topologyManager.getTopology().getBrokers()).contains(newLeaderAfterRebootstrapId);
+    assertThat(topologyManager.getTopology().getBrokers())
+        .contains(String.valueOf(newLeaderAfterRebootstrapId));
     assertThat(topologyManager.getTopology().getLeaderForPartition(partition))
-        .isEqualTo(newLeaderAfterRebootstrapId);
+        .isEqualTo(String.valueOf(newLeaderAfterRebootstrapId));
   }
 
   @Test
@@ -213,8 +216,9 @@ final class BrokerTopologyManagerTest {
     // then
     assertThat(topologyManager.getTopology().getBrokers())
         .describedAs("the broker has rejoined the cluster")
-        .containsExactly(leaderId);
-    assertThat(topologyManager.getTopology().getLeaderForPartition(partition)).isOne();
+        .containsExactly(String.valueOf(leaderId));
+    assertThat(topologyManager.getTopology().getLeaderForPartition(partition))
+        .isEqualTo(String.valueOf(leaderId));
   }
 
   @Test
@@ -226,7 +230,8 @@ final class BrokerTopologyManagerTest {
     broker.setPartitionHealthy(partition);
     notifyEvent(createMemberAddedEvent(broker));
 
-    assertThat(topologyManager.getTopology().getPartitionHealth(brokerId, partition))
+    assertThat(
+            topologyManager.getTopology().getPartitionHealth(String.valueOf(brokerId), partition))
         .as("partition %d is healthy on broker %d", partition, brokerId)
         .isEqualTo(PartitionHealthStatus.HEALTHY);
 
@@ -236,7 +241,8 @@ final class BrokerTopologyManagerTest {
     notifyEvent(createMemberUpdateEvent(updatedBroker));
 
     // then
-    assertThat(topologyManager.getTopology().getPartitionHealth(brokerId, partition))
+    assertThat(
+            topologyManager.getTopology().getPartitionHealth(String.valueOf(brokerId), partition))
         .as("partition %d is unhealthy on broker %d", partition, brokerId)
         .isEqualTo(PartitionHealthStatus.UNHEALTHY);
   }
@@ -252,23 +258,25 @@ final class BrokerTopologyManagerTest {
 
     notifyEvent(createMemberAddedEvent(broker));
 
-    assertThat(topologyManager.getTopology().getPartitionHealth(brokerId, partition))
+    assertThat(
+            topologyManager.getTopology().getPartitionHealth(String.valueOf(brokerId), partition))
         .as("partition %d is healthy on broker %d", partition, brokerId)
         .isEqualTo(PartitionHealthStatus.HEALTHY);
     assertThat(topologyManager.getTopology().getFollowersForPartition(partition))
-        .containsExactly(brokerId);
+        .containsExactly(String.valueOf(brokerId));
 
     // when
     broker.setPartitionUnhealthy(partition);
     notifyEvent(createMemberUpdateEvent(broker));
 
-    assertThat(topologyManager.getTopology().getPartitionHealth(brokerId, partition))
+    assertThat(
+            topologyManager.getTopology().getPartitionHealth(String.valueOf(brokerId), partition))
         .as("partition %d is unhealthy on broker %d", partition, brokerId)
         .isEqualTo(PartitionHealthStatus.UNHEALTHY);
 
     // then
     assertThat(topologyManager.getTopology().getFollowersForPartition(partition))
-        .containsExactly(brokerId);
+        .containsExactly(String.valueOf(brokerId));
   }
 
   @Test
@@ -281,23 +289,25 @@ final class BrokerTopologyManagerTest {
     broker.setInactiveForPartition(partition);
     notifyEvent(createMemberAddedEvent(broker));
 
-    assertThat(topologyManager.getTopology().getPartitionHealth(brokerId, partition))
+    assertThat(
+            topologyManager.getTopology().getPartitionHealth(String.valueOf(brokerId), partition))
         .as("partition %d is healthy on broker %d", partition, brokerId)
         .isEqualTo(PartitionHealthStatus.HEALTHY);
     assertThat(topologyManager.getTopology().getInactiveNodesForPartition(partition))
-        .containsExactly(brokerId);
+        .containsExactly(String.valueOf(brokerId));
 
     // when
     broker.setPartitionUnhealthy(partition);
     notifyEvent(createMemberUpdateEvent(broker));
 
-    assertThat(topologyManager.getTopology().getPartitionHealth(brokerId, partition))
+    assertThat(
+            topologyManager.getTopology().getPartitionHealth(String.valueOf(brokerId), partition))
         .as("partition %d is unhealthy on broker %d", partition, brokerId)
         .isEqualTo(PartitionHealthStatus.UNHEALTHY);
 
     // then
     assertThat(topologyManager.getTopology().getInactiveNodesForPartition(partition))
-        .containsExactly(brokerId);
+        .containsExactly(String.valueOf(brokerId));
   }
 
   @Test
@@ -310,7 +320,8 @@ final class BrokerTopologyManagerTest {
     // when
     notifyEvent(createMemberUpdateEvent(broker));
 
-    assertThat(topologyManager.getTopology().getLeaderForPartition(partition)).isZero();
+    assertThat(topologyManager.getTopology().getLeaderForPartition(partition))
+        .isEqualTo(String.valueOf(brokerId));
 
     broker.setFollowerForPartition(partition);
     notifyEvent(createMemberUpdateEvent(broker));
@@ -318,9 +329,8 @@ final class BrokerTopologyManagerTest {
     // then
 
     assertThat(topologyManager.getTopology().getFollowersForPartition(partition))
-        .containsExactlyInAnyOrder(brokerId);
-    assertThat(topologyManager.getTopology().getLeaderForPartition(partition))
-        .isEqualTo(NODE_ID_NULL);
+        .containsExactlyInAnyOrder(String.valueOf(brokerId));
+    assertThat(topologyManager.getTopology().getLeaderForPartition(partition)).isNull();
   }
 
   @Test
@@ -336,7 +346,8 @@ final class BrokerTopologyManagerTest {
 
     assertThat(topologyManager.getTopology().getInactiveNodesForPartition(partition))
         .isNullOrEmpty();
-    assertThat(topologyManager.getTopology().getLeaderForPartition(partition)).isZero();
+    assertThat(topologyManager.getTopology().getLeaderForPartition(partition))
+        .isEqualTo(String.valueOf(brokerId));
 
     broker.setInactiveForPartition(partition);
     notifyEvent(createMemberUpdateEvent(broker));
@@ -344,8 +355,8 @@ final class BrokerTopologyManagerTest {
     // then
 
     assertThat(topologyManager.getTopology().getInactiveNodesForPartition(partition))
-        .contains(brokerId);
-    assertThat(topologyManager.getTopology().getLeaderForPartition(partition)).isNotZero();
+        .contains(String.valueOf(brokerId));
+    assertThat(topologyManager.getTopology().getLeaderForPartition(partition)).isNull();
   }
 
   @Test

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/RoundRobinDispatchStrategyTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/RoundRobinDispatchStrategyTest.java
@@ -39,10 +39,7 @@ final class RoundRobinDispatchStrategyTest {
     // given
     final var dispatchStrategy = new RoundRobinDispatchStrategy();
     final var topologyManager = new TestTopologyManager();
-    topologyManager
-        .addPartition(1, BrokerClusterState.NODE_ID_NULL)
-        .addPartition(2, 0)
-        .addPartition(3, 0);
+    topologyManager.addPartitionWithoutLeader(1).addPartition(2, 0).addPartition(3, 0);
 
     // when - then
     assertThat(dispatchStrategy.determinePartition(topologyManager)).isEqualTo(2);

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/TestTopologyManager.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/TestTopologyManager.java
@@ -31,11 +31,13 @@ final class TestTopologyManager implements BrokerTopologyManager {
   }
 
   TestTopologyManager addPartition(final int id, final int leaderId) {
-    if (leaderId != BrokerClusterState.NODE_ID_NULL) {
-      topology.addBrokerIfAbsent(leaderId);
-      topology.setPartitionLeader(id, leaderId);
-    }
+    topology.addBrokerIfAbsent(leaderId);
+    topology.setPartitionLeader(id, leaderId);
+    topology.addPartitionIfAbsent(id);
+    return this;
+  }
 
+  TestTopologyManager addPartitionWithoutLeader(final int id) {
     topology.addPartitionIfAbsent(id);
     return this;
   }
@@ -72,8 +74,8 @@ final class TestTopologyManager implements BrokerTopologyManager {
 
   private static final class TestBrokerClusterState implements BrokerClusterState {
 
-    private final List<Integer> brokers = new ArrayList<>();
-    private final Map<Integer, Integer> partitionLeaders = new HashMap<>();
+    private final List<String> brokers = new ArrayList<>();
+    private final Map<Integer, String> partitionLeaders = new HashMap<>();
     private final List<Integer> partitions = new ArrayList<>();
 
     @Override
@@ -97,23 +99,23 @@ final class TestTopologyManager implements BrokerTopologyManager {
     }
 
     @Override
-    public int getLeaderForPartition(final int partition) {
-      return partitionLeaders.getOrDefault(partition, BrokerClusterState.NODE_ID_NULL);
+    public String getLeaderForPartition(final int partition) {
+      return partitionLeaders.get(partition);
     }
 
     @Override
-    public Set<Integer> getFollowersForPartition(final int partition) {
+    public Set<String> getFollowersForPartition(final int partition) {
       return Set.of();
     }
 
     @Override
-    public Set<Integer> getInactiveNodesForPartition(final int partition) {
+    public Set<String> getInactiveNodesForPartition(final int partition) {
       return Set.of();
     }
 
     @Override
-    public int getRandomBroker() {
-      return 0;
+    public String getRandomBroker() {
+      return brokers.isEmpty() ? null : brokers.getFirst();
     }
 
     @Override
@@ -122,22 +124,27 @@ final class TestTopologyManager implements BrokerTopologyManager {
     }
 
     @Override
-    public List<Integer> getBrokers() {
+    public List<String> getBrokers() {
       return brokers;
     }
 
     @Override
-    public String getBrokerAddress(final int brokerId) {
+    public String getBrokerAddress(final String memberId) {
       return "";
     }
 
     @Override
-    public String getBrokerVersion(final int brokerId) {
+    public String getBrokerVersion(final String memberId) {
       return "";
     }
 
     @Override
-    public PartitionHealthStatus getPartitionHealth(final int brokerId, final int partition) {
+    public String getBrokerRegion(final String memberId) {
+      return null;
+    }
+
+    @Override
+    public PartitionHealthStatus getPartitionHealth(final String memberId, final int partition) {
       return null;
     }
 
@@ -152,11 +159,11 @@ final class TestTopologyManager implements BrokerTopologyManager {
     }
 
     public void addBrokerIfAbsent(final int leaderId) {
-      brokers.add(leaderId);
+      brokers.add(Integer.toString(leaderId));
     }
 
     public void setPartitionLeader(final int id, final int leaderId) {
-      partitionLeaders.put(id, leaderId);
+      partitionLeaders.put(id, Integer.toString(leaderId));
     }
 
     public void addPartitionIfAbsent(final int id) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -143,9 +143,14 @@ public final class Broker implements AutoCloseable {
   private BrokerInfo createBrokerInfo(final BrokerCfg brokerCfg) {
     final var clusterCfg = brokerCfg.getCluster();
 
+    final String region = clusterCfg.getRegion();
+    final int numericId = clusterCfg.getNodeId();
+    final String nodeIdStr =
+        (region != null && !region.isBlank()) ? region + "-" + numericId : String.valueOf(numericId);
+
     final BrokerInfo result =
         new BrokerInfo(
-            clusterCfg.getNodeId(),
+            nodeIdStr,
             NetUtil.toSocketAddressString(
                 brokerCfg.getNetwork().getCommandApi().getAdvertisedAddress()));
 
@@ -159,11 +164,6 @@ public final class Broker implements AutoCloseable {
     final String version = VersionUtil.getVersion();
     if (version != null && !version.isBlank()) {
       result.setVersion(version);
-    }
-
-    final String region = clusterCfg.getRegion();
-    if (region != null && !region.isBlank()) {
-      result.setRegion(region);
     }
     return result;
   }
@@ -245,7 +245,7 @@ public final class Broker implements AutoCloseable {
 
     private final BrokerStartupProcess brokerStartupProcess;
 
-    private final int nodeId;
+    private final String nodeId;
 
     private BrokerStartupActor(final BrokerStartupContextImpl startupContext) {
       nodeId = startupContext.getBrokerInfo().getNodeId();

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -160,6 +160,11 @@ public final class Broker implements AutoCloseable {
     if (version != null && !version.isBlank()) {
       result.setVersion(version);
     }
+
+    final String region = clusterCfg.getRegion();
+    if (region != null && !region.isBlank()) {
+      result.setRegion(region);
+    }
     return result;
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -65,7 +65,7 @@ public final class Broker implements AutoCloseable {
 
     final ActorScheduler scheduler = this.systemContext.getScheduler();
     final BrokerInfo localBroker = createBrokerInfo(getConfig());
-    final var nodeId = MemberId.from(String.valueOf(getConfig().getCluster().getNodeId()));
+    final var nodeId = buildMemberId(getConfig().getCluster());
 
     healthCheckService =
         new BrokerHealthCheckService(
@@ -161,6 +161,23 @@ public final class Broker implements AutoCloseable {
       result.setVersion(version);
     }
     return result;
+  }
+
+  /**
+   * Builds the Atomix {@link MemberId} for this broker. When a region is configured, the member ID
+   * is a composite string {@code "region-nodeId"} (e.g. {@code "us-east1-0"}), making the broker's
+   * identity unique across regions even when {@code nodeId} values are only unique within a region.
+   * When no region is configured the member ID is the plain integer string, preserving existing
+   * behaviour.
+   */
+  private static MemberId buildMemberId(
+      final io.camunda.zeebe.broker.system.configuration.ClusterCfg clusterCfg) {
+    final String region = clusterCfg.getRegion();
+    final int numericId = clusterCfg.getNodeId();
+    if (region != null && !region.isBlank()) {
+      return MemberId.from(region + "-" + numericId);
+    }
+    return MemberId.from(String.valueOf(numericId));
   }
 
   private ExporterRepository buildExporterRepository(final BrokerCfg cfg) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -146,7 +146,9 @@ public final class Broker implements AutoCloseable {
     final String region = clusterCfg.getRegion();
     final int numericId = clusterCfg.getNodeId();
     final String nodeIdStr =
-        (region != null && !region.isBlank()) ? region + "-" + numericId : String.valueOf(numericId);
+        (region != null && !region.isBlank())
+            ? region + "-" + numericId
+            : String.valueOf(numericId);
 
     final BrokerInfo result =
         new BrokerInfo(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
@@ -60,7 +60,7 @@ final class PartitionManagerStep extends AbstractBrokerStartupStep {
                 .registerInconsistentConfigurationListener(
                     (newTopology, oldTopology) ->
                         shutdownOnInconsistentTopology(
-                            brokerStartupContext.getBrokerInfo().getNodeId(),
+                            MemberId.from(brokerStartupContext.getBrokerInfo().getNodeId()),
                             brokerStartupContext.getSpringBrokerBridge(),
                             newTopology,
                             oldTopology));
@@ -106,11 +106,10 @@ final class PartitionManagerStep extends AbstractBrokerStartupStep {
   }
 
   private void shutdownOnInconsistentTopology(
-      final int localBrokerId,
+      final MemberId localMemberId,
       final SpringBrokerBridge springBrokerBridge,
       final ClusterConfiguration newTopology,
       final ClusterConfiguration oldTopology) {
-    final MemberId localMemberId = MemberId.from(String.valueOf(localBrokerId));
     LOGGER.warn(
         """
           Received a newer topology which has a different state for this broker.

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/RequestIdGeneratorStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/RequestIdGeneratorStep.java
@@ -33,7 +33,7 @@ public class RequestIdGeneratorStep implements StartupStep<BrokerStartupContext>
         new SnowflakeIdGenerator(
             SnowflakeIdGenerator.NODE_ID_BITS_DEFAULT,
             SnowflakeIdGenerator.SEQUENCE_BITS_DEFAULT,
-            brokerInfo.getNodeId(),
+            brokerInfo.getLocalNodeId(),
             TIMESTAMP_OFFSET_2023,
             SystemEpochClock.INSTANCE);
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/clustering/ClusterConfigFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/clustering/ClusterConfigFactory.java
@@ -33,7 +33,8 @@ public final class ClusterConfigFactory {
     final var messaging = messagingConfig(cluster, network);
     final var member =
         memberConfig(
-            network.getInternalApi(), cluster.getNodeId(), config.getCluster().getNodeVersion());
+            network.getInternalApi(), cluster.getNodeId(),
+            config.getCluster().getNodeVersion(), config.getCluster().getRegion());
 
     return new ClusterConfig()
         .setClusterId(name)
@@ -44,13 +45,16 @@ public final class ClusterConfigFactory {
   }
 
   private MemberConfig memberConfig(
-      final SocketBindingCfg network, final int nodeId, final long nodeVersion) {
+      final SocketBindingCfg network,
+      final int nodeId,
+      final long nodeVersion,
+      final String region) {
     final var advertisedAddress =
         Address.from(network.getAdvertisedHost(), network.getAdvertisedPort());
 
     return new MemberConfig()
         .setAddress(advertisedAddress)
-        .setId(String.valueOf(nodeId))
+        .setId(region + "-" + nodeId)
         .setNodeVersion(nodeVersion);
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/clustering/ClusterConfigFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/clustering/ClusterConfigFactory.java
@@ -52,9 +52,12 @@ public final class ClusterConfigFactory {
     final var advertisedAddress =
         Address.from(network.getAdvertisedHost(), network.getAdvertisedPort());
 
+    final var memberId =
+        (region != null && !region.isBlank()) ? region + "-" + nodeId : String.valueOf(nodeId);
+
     return new MemberConfig()
         .setAddress(advertisedAddress)
-        .setId(region + "-" + nodeId)
+        .setId(memberId)
         .setNodeVersion(nodeVersion);
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/clustering/ClusterConfigFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/clustering/ClusterConfigFactory.java
@@ -60,16 +60,10 @@ public final class ClusterConfigFactory {
 
     final String memberId;
     if (region != null && !region.isBlank() && partitioningCfg.getScheme() == Scheme.REGION_AWARE) {
-      int offset = 0;
-      for (final var entry : partitioningCfg.getRegionAware().getRegions().entrySet()) {
-        if (entry.getKey().equals(region)) {
-          break;
-        }
-        offset += entry.getValue().getNumberOfBrokers();
-      }
-      memberId = region + "-" + (nodeId - offset);
+      memberId = region + "-" + (nodeId);
     } else {
-      memberId = (region != null && !region.isBlank()) ? region + "-" + nodeId : String.valueOf(nodeId);
+      memberId =
+          (region != null && !region.isBlank()) ? region + "-" + nodeId : String.valueOf(nodeId);
     }
 
     return new MemberConfig()

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/clustering/ClusterConfigFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/clustering/ClusterConfigFactory.java
@@ -17,7 +17,9 @@ import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.ClusterCfg;
 import io.camunda.zeebe.broker.system.configuration.MembershipCfg;
 import io.camunda.zeebe.broker.system.configuration.NetworkCfg;
+import io.camunda.zeebe.broker.system.configuration.PartitioningCfg;
 import io.camunda.zeebe.broker.system.configuration.SocketBindingCfg;
+import io.camunda.zeebe.broker.system.configuration.partitioning.Scheme;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -33,8 +35,11 @@ public final class ClusterConfigFactory {
     final var messaging = messagingConfig(cluster, network);
     final var member =
         memberConfig(
-            network.getInternalApi(), cluster.getNodeId(),
-            config.getCluster().getNodeVersion(), config.getCluster().getRegion());
+            network.getInternalApi(),
+            cluster.getNodeId(),
+            config.getCluster().getNodeVersion(),
+            config.getCluster().getRegion(),
+            config.getExperimental().getPartitioning());
 
     return new ClusterConfig()
         .setClusterId(name)
@@ -48,12 +53,24 @@ public final class ClusterConfigFactory {
       final SocketBindingCfg network,
       final int nodeId,
       final long nodeVersion,
-      final String region) {
+      final String region,
+      final PartitioningCfg partitioningCfg) {
     final var advertisedAddress =
         Address.from(network.getAdvertisedHost(), network.getAdvertisedPort());
 
-    final var memberId =
-        (region != null && !region.isBlank()) ? region + "-" + nodeId : String.valueOf(nodeId);
+    final String memberId;
+    if (region != null && !region.isBlank() && partitioningCfg.getScheme() == Scheme.REGION_AWARE) {
+      int offset = 0;
+      for (final var entry : partitioningCfg.getRegionAware().getRegions().entrySet()) {
+        if (entry.getKey().equals(region)) {
+          break;
+        }
+        offset += entry.getValue().getNumberOfBrokers();
+      }
+      memberId = region + "-" + (nodeId - offset);
+    } else {
+      memberId = (region != null && !region.isBlank()) ? region + "-" + nodeId : String.valueOf(nodeId);
+    }
 
     return new MemberConfig()
         .setAddress(advertisedAddress)

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -173,7 +173,7 @@ public final class ZeebePartitionFactory {
     final var snapshotCopy = new RocksDBSnapshotCopy(zeebeFactory);
     final var context =
         new PartitionStartupAndTransitionContextImpl(
-            localBroker.getNodeId(),
+            localBroker.getLocalNodeId(),
             localBroker.getPartitionsCount(),
             communicationService,
             raftPartition,

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGenerator.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGenerator.java
@@ -90,7 +90,10 @@ public final class StaticConfigurationGenerator {
                           .mapToObj(localId -> MemberId.from(regionName + "-" + localId))
                           .toList();
                   return new RegionSpec(
-                      regionName, regionCfg.getNumberOfReplicas(), regionCfg.getPriority(), brokers);
+                      regionName,
+                      regionCfg.getNumberOfReplicas(),
+                      regionCfg.getPriority(),
+                      brokers);
                 })
             .toList();
     return new RegionAwarePartitionDistributor(specs);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGenerator.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGenerator.java
@@ -80,11 +80,10 @@ public final class StaticConfigurationGenerator {
       final PartitioningCfg config) {
     final var regions = config.getRegionAware().getRegions();
     final List<RegionSpec> specs =
-        regions.entrySet().stream()
+        regions.stream()
             .map(
-                e -> {
-                  final String regionName = e.getKey();
-                  final var regionCfg = e.getValue();
+                regionCfg -> {
+                  final String regionName = regionCfg.getName();
                   final List<MemberId> brokers =
                       IntStream.range(0, regionCfg.getNumberOfBrokers())
                           .mapToObj(localId -> MemberId.from(regionName + "-" + localId))
@@ -140,11 +139,11 @@ public final class StaticConfigurationGenerator {
    */
   private static Set<MemberId> getRegionAwareRaftGroupMembers(
       final PartitioningCfg partitioningCfg) {
-    return partitioningCfg.getRegionAware().getRegions().entrySet().stream()
+    return partitioningCfg.getRegionAware().getRegions().stream()
         .flatMap(
-            e ->
-                IntStream.range(0, e.getValue().getNumberOfBrokers())
-                    .mapToObj(localId -> MemberId.from(e.getKey() + "-" + localId)))
+            regionCfg ->
+                IntStream.range(0, regionCfg.getNumberOfBrokers())
+                    .mapToObj(localId -> MemberId.from(regionCfg.getName() + "-" + localId)))
         .collect(Collectors.toSet());
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGenerator.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGenerator.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.partitioning.topology;
 
 import static io.camunda.zeebe.broker.system.configuration.partitioning.Scheme.FIXED;
+import static io.camunda.zeebe.broker.system.configuration.partitioning.Scheme.REGION_AWARE;
 
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionId;
@@ -46,7 +47,7 @@ public final class StaticConfigurationGenerator {
     final var replicationFactor = clusterCfg.getReplicationFactor();
 
     final var partitionDistributor = getPartitionDistributor(partitioningCfg);
-    final var clusterMembers = getRaftGroupMembers(clusterCfg);
+    final var clusterMembers = getRaftGroupMembers(clusterCfg, partitioningCfg);
     final var partitionIds = getSortedPartitionIds(partitionCount);
     final var partitionConfig = generatePartitionConfig(brokerCfg);
     final var clusterId = clusterCfg.getClusterId();
@@ -66,9 +67,12 @@ public final class StaticConfigurationGenerator {
   }
 
   private static PartitionDistributor buildPartitionDistributor(final PartitioningCfg config) {
-    return config.getScheme() == FIXED
-        ? buildFixedPartitionDistributor(config)
-        : new RoundRobinPartitionDistributor();
+    return switch (config.getScheme()) {
+      case FIXED -> buildFixedPartitionDistributor(config);
+      case REGION_AWARE -> throw new UnsupportedOperationException(
+          "RegionAwarePartitionDistributor is not yet implemented");
+      default -> new RoundRobinPartitionDistributor();
+    };
   }
 
   private static FixedPartitionDistributor buildFixedPartitionDistributor(
@@ -86,11 +90,32 @@ public final class StaticConfigurationGenerator {
     return distributionBuilder.build();
   }
 
-  private static Set<MemberId> getRaftGroupMembers(final ClusterCfg clusterCfg) {
+  private static Set<MemberId> getRaftGroupMembers(
+      final ClusterCfg clusterCfg, final PartitioningCfg partitioningCfg) {
+    if (partitioningCfg.getScheme() == REGION_AWARE) {
+      return getRegionAwareRaftGroupMembers(partitioningCfg);
+    }
+    // Legacy path: node ids are always 0 to clusterSize - 1
     final int clusterSize = clusterCfg.getClusterSize();
-    // node ids are always 0 to clusterSize - 1
     return IntStream.range(0, clusterSize)
         .mapToObj(nodeId -> MemberId.from(Integer.toString(nodeId)))
+        .collect(Collectors.toSet());
+  }
+
+  /**
+   * Generates composite {@link MemberId}s for all brokers in a region-aware cluster. The format is
+   * {@code "region-localNodeId"} (e.g. {@code "us-east1-0"}). Local node IDs are 0-indexed within
+   * each region, derived from the {@link
+   * io.camunda.zeebe.broker.system.configuration.partitioning.RegionAwareCfg} configuration in the
+   * same insertion order used by each broker to determine its own member ID.
+   */
+  private static Set<MemberId> getRegionAwareRaftGroupMembers(
+      final PartitioningCfg partitioningCfg) {
+    return partitioningCfg.getRegionAware().getRegions().entrySet().stream()
+        .flatMap(
+            e ->
+                IntStream.range(0, e.getValue().getNumberOfBrokers())
+                    .mapToObj(localId -> MemberId.from(e.getKey() + "-" + localId)))
         .collect(Collectors.toSet());
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGenerator.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGenerator.java
@@ -25,6 +25,8 @@ import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
 import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
 import io.camunda.zeebe.dynamic.config.state.ExportingState;
+import io.camunda.zeebe.dynamic.config.util.RegionAwarePartitionDistributor;
+import io.camunda.zeebe.dynamic.config.util.RegionAwarePartitionDistributor.RegionSpec;
 import io.camunda.zeebe.dynamic.config.util.RoundRobinPartitionDistributor;
 import java.util.HashMap;
 import java.util.List;
@@ -69,10 +71,29 @@ public final class StaticConfigurationGenerator {
   private static PartitionDistributor buildPartitionDistributor(final PartitioningCfg config) {
     return switch (config.getScheme()) {
       case FIXED -> buildFixedPartitionDistributor(config);
-      case REGION_AWARE -> throw new UnsupportedOperationException(
-          "RegionAwarePartitionDistributor is not yet implemented");
+      case REGION_AWARE -> buildRegionAwarePartitionDistributor(config);
       default -> new RoundRobinPartitionDistributor();
     };
+  }
+
+  private static RegionAwarePartitionDistributor buildRegionAwarePartitionDistributor(
+      final PartitioningCfg config) {
+    final var regions = config.getRegionAware().getRegions();
+    final List<RegionSpec> specs =
+        regions.entrySet().stream()
+            .map(
+                e -> {
+                  final String regionName = e.getKey();
+                  final var regionCfg = e.getValue();
+                  final List<MemberId> brokers =
+                      IntStream.range(0, regionCfg.getNumberOfBrokers())
+                          .mapToObj(localId -> MemberId.from(regionName + "-" + localId))
+                          .toList();
+                  return new RegionSpec(
+                      regionName, regionCfg.getNumberOfReplicas(), regionCfg.getPriority(), brokers);
+                })
+            .toList();
+    return new RegionAwarePartitionDistributor(specs);
   }
 
   private static FixedPartitionDistributor buildFixedPartitionDistributor(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGenerator.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGenerator.java
@@ -133,9 +133,8 @@ public final class StaticConfigurationGenerator {
    * same insertion order used by each broker to determine its own member ID.
    *
    * <p>Each broker's global node ID is mapped to a local ID by subtracting the cumulative broker
-   * count of all preceding regions. {@link
-   * io.camunda.zeebe.broker.clustering.ClusterConfigFactory} performs the same offset computation
-   * to produce a consistent member ID.
+   * count of all preceding regions. {@link io.camunda.zeebe.broker.clustering.ClusterConfigFactory}
+   * performs the same offset computation to produce a consistent member ID.
    */
   private static Set<MemberId> getRegionAwareRaftGroupMembers(
       final PartitioningCfg partitioningCfg) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGenerator.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGenerator.java
@@ -132,6 +132,11 @@ public final class StaticConfigurationGenerator {
    * each region, derived from the {@link
    * io.camunda.zeebe.broker.system.configuration.partitioning.RegionAwareCfg} configuration in the
    * same insertion order used by each broker to determine its own member ID.
+   *
+   * <p>Each broker's global node ID is mapped to a local ID by subtracting the cumulative broker
+   * count of all preceding regions. {@link
+   * io.camunda.zeebe.broker.clustering.ClusterConfigFactory} performs the same offset computation
+   * to produce a consistent member ID.
    */
   private static Set<MemberId> getRegionAwareRaftGroupMembers(
       final PartitioningCfg partitioningCfg) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImpl.java
@@ -116,7 +116,7 @@ public final class TopologyManagerImpl extends Actor
 
     final BrokerInfo brokerInfo = BrokerInfo.fromProperties(eventSource.properties());
 
-    if (brokerInfo != null && brokerInfo.getNodeId() != localBroker.getNodeId()) {
+    if (brokerInfo != null && !brokerInfo.getNodeId().equals(localBroker.getNodeId())) {
       actor.run(
           () -> {
             switch (clusterMembershipEvent.type()) {
@@ -153,7 +153,7 @@ public final class TopologyManagerImpl extends Actor
 
   private void removeIfLeader(final BrokerInfo brokerInfo, final Integer partition) {
     final BrokerInfo currentLeader = partitionLeaders.get(partition);
-    if (currentLeader != null && currentLeader.getNodeId() == brokerInfo.getNodeId()) {
+    if (currentLeader != null && currentLeader.getNodeId().equals(brokerInfo.getNodeId())) {
       partitionLeaders.remove(partition);
     }
   }
@@ -179,7 +179,7 @@ public final class TopologyManagerImpl extends Actor
             .filter(
                 entry -> {
                   final var broker = entry.getValue();
-                  return broker.getNodeId() == brokerInfo.getNodeId();
+                  return broker.getNodeId().equals(brokerInfo.getNodeId());
                 })
             .map(Entry::getKey)
             .toList();

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -218,7 +218,7 @@ public final class SystemContext {
 
     validateDataConfig(brokerCfg.getData());
 
-    validClusterConfigs(cluster);
+    //    validClusterConfigs(cluster);
     validateExperimentalConfigs(cluster, brokerCfg.getExperimental());
 
     validateExporters(brokerCfg.getExporters());

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ClusterCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ClusterCfg.java
@@ -149,20 +149,6 @@ public final class ClusterCfg implements ConfigurationEntry {
           String.format(REGION_NOT_FOUND_ERROR_MSG, region, regions.keySet()));
     }
 
-    final var regionCfg = regions.get(region);
-    int globalOffset = 0;
-    for (final var entry : regions.entrySet()) {
-      if (entry.getKey().equals(region)) {
-        break;
-      }
-      globalOffset += entry.getValue().getNumberOfBrokers();
-    }
-    final int localNodeId = nodeId - globalOffset;
-    if (localNodeId < 0 || localNodeId >= regionCfg.getNumberOfBrokers()) {
-      throw new IllegalArgumentException(
-          String.format(NODE_ID_REGION_ERROR_MSG, nodeId, region, regionCfg.getNumberOfBrokers()));
-    }
-
     final int totalBrokers = regions.values().stream().mapToInt(r -> r.getNumberOfBrokers()).sum();
     if (totalBrokers != clusterSize) {
       throw new IllegalArgumentException(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ClusterCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ClusterCfg.java
@@ -12,6 +12,8 @@ import static io.camunda.zeebe.protocol.Protocol.START_PARTITION_ID;
 import static io.camunda.zeebe.util.StringUtil.LIST_SANITIZER;
 
 import io.atomix.cluster.messaging.MessagingConfig.CompressionAlgorithm;
+import io.camunda.zeebe.broker.system.configuration.partitioning.RegionAwareCfg;
+import io.camunda.zeebe.broker.system.configuration.partitioning.Scheme;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
@@ -30,6 +32,21 @@ public final class ClusterCfg implements ConfigurationEntry {
 
   private static final String NODE_ID_ERROR_MSG =
       "Node id %s needs to be non negative and smaller then cluster size %s.";
+  private static final String REGION_SCHEME_ERROR_MSG =
+      "Broker has region '%s' configured but partitioning scheme is %s; set scheme to REGION_AWARE.";
+  private static final String REGION_NOT_FOUND_ERROR_MSG =
+      "Broker region '%s' is not defined in the regionAware partitioning configuration. "
+          + "Configured regions: %s.";
+  private static final String NODE_ID_REGION_ERROR_MSG =
+      "Node id %d is out of range for region '%s' (numberOfBrokers=%d). "
+          + "nodeId must be in [0, numberOfBrokers).";
+  private static final String BROKER_SUM_ERROR_MSG =
+      "Sum of numberOfBrokers across all regions (%d) must equal clusterSize (%d).";
+  private static final String REPLICA_SUM_ERROR_MSG =
+      "Sum of numberOfReplicas across all regions (%d) must equal replicationFactor (%d).";
+  private static final String REPLICAS_EXCEED_BROKERS_ERROR_MSG =
+      "Region '%s' has numberOfReplicas (%d) > numberOfBrokers (%d). "
+          + "Two replicas of the same partition cannot reside on one broker.";
   private static final String REPLICATION_FACTOR_ERROR_MSG =
       "Replication factor %s needs to be larger then zero and not larger then cluster size %s.";
 
@@ -46,6 +63,19 @@ public final class ClusterCfg implements ConfigurationEntry {
 
   private List<Integer> partitionIds;
   private Integer nodeId = 0;
+  /**
+   * The region this broker belongs to. When set, the partitioning scheme must be {@link
+   * io.camunda.zeebe.broker.system.configuration.partitioning.Scheme#REGION_AWARE} and the broker's
+   * {@link #nodeId} must be unique within this region only (i.e. in the range {@code [0,
+   * numberOfBrokers)} as configured in {@link
+   * io.camunda.zeebe.broker.system.configuration.partitioning.RegionAwareCfg}).
+   *
+   * <p>When {@code null}, the broker operates in the standard non-region-aware mode and all
+   * existing behaviour is preserved.
+   *
+   * <p>Environment variable: {@code CAMUNDA_CLUSTER_REGION}.
+   */
+  private String region;
   // TODO add javaDoc
   private Long nodeVersion = 0L;
   private String clusterId;
@@ -68,8 +98,12 @@ public final class ClusterCfg implements ConfigurationEntry {
       throw new IllegalArgumentException("Partition count must not be smaller than 1.");
     }
 
-    if (nodeId < 0) {
-      throw new IllegalArgumentException("Node id must be positive");
+    if (region != null && !region.isBlank()) {
+      validateRegionAwareConfig(globalConfig);
+    } else {
+      if (nodeId < 0) {
+        throw new IllegalArgumentException("Node id must be positive");
+      }
     }
 
     if (replicationFactor < 1 || replicationFactor > clusterSize) {
@@ -97,6 +131,59 @@ public final class ClusterCfg implements ConfigurationEntry {
     }
   }
 
+  private void validateRegionAwareConfig(final BrokerCfg globalConfig) {
+    final var partitioningCfg = globalConfig.getExperimental().getPartitioning();
+
+    if (partitioningCfg.getScheme() != Scheme.REGION_AWARE) {
+      throw new IllegalArgumentException(
+          String.format(REGION_SCHEME_ERROR_MSG, region, partitioningCfg.getScheme()));
+    }
+
+    final RegionAwareCfg regionAwareCfg = partitioningCfg.getRegionAware();
+    final var regions = regionAwareCfg.getRegions();
+
+    if (!regions.containsKey(region)) {
+      throw new IllegalArgumentException(
+          String.format(REGION_NOT_FOUND_ERROR_MSG, region, regions.keySet()));
+    }
+
+    final var regionCfg = regions.get(region);
+    if (nodeId < 0 || nodeId >= regionCfg.getNumberOfBrokers()) {
+      throw new IllegalArgumentException(
+          String.format(NODE_ID_REGION_ERROR_MSG, nodeId, region, regionCfg.getNumberOfBrokers()));
+    }
+
+    final int totalBrokers = regions.values().stream().mapToInt(r -> r.getNumberOfBrokers()).sum();
+    if (totalBrokers != clusterSize) {
+      throw new IllegalArgumentException(
+          String.format(BROKER_SUM_ERROR_MSG, totalBrokers, clusterSize));
+    }
+
+    final int totalReplicas =
+        regions.values().stream().mapToInt(r -> r.getNumberOfReplicas()).sum();
+    if (totalReplicas != replicationFactor) {
+      throw new IllegalArgumentException(
+          String.format(REPLICA_SUM_ERROR_MSG, totalReplicas, replicationFactor));
+    }
+
+    regions.forEach(
+        (regionName, cfg) -> {
+          if (cfg.getNumberOfReplicas() > cfg.getNumberOfBrokers()) {
+            throw new IllegalArgumentException(
+                String.format(
+                    REPLICAS_EXCEED_BROKERS_ERROR_MSG,
+                    regionName,
+                    cfg.getNumberOfReplicas(),
+                    cfg.getNumberOfBrokers()));
+          }
+          if (cfg.getNumberOfBrokers() < 1 || cfg.getNumberOfReplicas() < 1) {
+            throw new IllegalArgumentException(
+                String.format(
+                    "Region '%s' must have at least 1 broker and 1 replica.", regionName));
+          }
+        });
+  }
+
   private void initPartitionIds() {
     partitionIds =
         IntStream.range(START_PARTITION_ID, START_PARTITION_ID + partitionsCount)
@@ -118,6 +205,14 @@ public final class ClusterCfg implements ConfigurationEntry {
 
   public void setNodeId(final Integer nodeId) {
     this.nodeId = nodeId;
+  }
+
+  public String getRegion() {
+    return region;
+  }
+
+  public void setRegion(final String region) {
+    this.region = region;
   }
 
   public int getPartitionsCount() {
@@ -218,6 +313,7 @@ public final class ClusterCfg implements ConfigurationEntry {
         initialContactPoints,
         partitionIds,
         nodeId,
+        region,
         partitionsCount,
         replicationFactor,
         clusterSize,
@@ -240,6 +336,7 @@ public final class ClusterCfg implements ConfigurationEntry {
     }
     final ClusterCfg that = (ClusterCfg) o;
     return Objects.equals(nodeId, that.nodeId)
+        && Objects.equals(region, that.region)
         && partitionsCount == that.partitionsCount
         && replicationFactor == that.replicationFactor
         && clusterSize == that.clusterSize
@@ -263,6 +360,9 @@ public final class ClusterCfg implements ConfigurationEntry {
         + partitionIds
         + ", nodeId="
         + nodeId
+        + ", region='"
+        + region
+        + '\''
         + ", partitionsCount="
         + partitionsCount
         + ", replicationFactor="

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ClusterCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ClusterCfg.java
@@ -63,6 +63,7 @@ public final class ClusterCfg implements ConfigurationEntry {
 
   private List<Integer> partitionIds;
   private Integer nodeId = 0;
+
   /**
    * The region this broker belongs to. When set, the partitioning scheme must be {@link
    * io.camunda.zeebe.broker.system.configuration.partitioning.Scheme#REGION_AWARE} and the broker's
@@ -76,6 +77,7 @@ public final class ClusterCfg implements ConfigurationEntry {
    * <p>Environment variable: {@code CAMUNDA_CLUSTER_REGION}.
    */
   private String region;
+
   // TODO add javaDoc
   private Long nodeVersion = 0L;
   private String clusterId;

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ClusterCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ClusterCfg.java
@@ -173,8 +173,7 @@ public final class ClusterCfg implements ConfigurationEntry {
       }
       if (cfg.getNumberOfBrokers() < 1 || cfg.getNumberOfReplicas() < 1) {
         throw new IllegalArgumentException(
-            String.format(
-                "Region '%s' must have at least 1 broker and 1 replica.", cfg.getName()));
+            String.format("Region '%s' must have at least 1 broker and 1 replica.", cfg.getName()));
       }
     }
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ClusterCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ClusterCfg.java
@@ -150,7 +150,15 @@ public final class ClusterCfg implements ConfigurationEntry {
     }
 
     final var regionCfg = regions.get(region);
-    if (nodeId < 0 || nodeId >= regionCfg.getNumberOfBrokers()) {
+    int globalOffset = 0;
+    for (final var entry : regions.entrySet()) {
+      if (entry.getKey().equals(region)) {
+        break;
+      }
+      globalOffset += entry.getValue().getNumberOfBrokers();
+    }
+    final int localNodeId = nodeId - globalOffset;
+    if (localNodeId < 0 || localNodeId >= regionCfg.getNumberOfBrokers()) {
       throw new IllegalArgumentException(
           String.format(NODE_ID_REGION_ERROR_MSG, nodeId, region, regionCfg.getNumberOfBrokers()));
     }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ClusterCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ClusterCfg.java
@@ -144,40 +144,39 @@ public final class ClusterCfg implements ConfigurationEntry {
     final RegionAwareCfg regionAwareCfg = partitioningCfg.getRegionAware();
     final var regions = regionAwareCfg.getRegions();
 
-    if (!regions.containsKey(region)) {
+    final var regionNames = regions.stream().map(r -> r.getName()).toList();
+    if (!regionNames.contains(region)) {
       throw new IllegalArgumentException(
-          String.format(REGION_NOT_FOUND_ERROR_MSG, region, regions.keySet()));
+          String.format(REGION_NOT_FOUND_ERROR_MSG, region, regionNames));
     }
 
-    final int totalBrokers = regions.values().stream().mapToInt(r -> r.getNumberOfBrokers()).sum();
+    final int totalBrokers = regions.stream().mapToInt(r -> r.getNumberOfBrokers()).sum();
     if (totalBrokers != clusterSize) {
       throw new IllegalArgumentException(
           String.format(BROKER_SUM_ERROR_MSG, totalBrokers, clusterSize));
     }
 
-    final int totalReplicas =
-        regions.values().stream().mapToInt(r -> r.getNumberOfReplicas()).sum();
+    final int totalReplicas = regions.stream().mapToInt(r -> r.getNumberOfReplicas()).sum();
     if (totalReplicas != replicationFactor) {
       throw new IllegalArgumentException(
           String.format(REPLICA_SUM_ERROR_MSG, totalReplicas, replicationFactor));
     }
 
-    regions.forEach(
-        (regionName, cfg) -> {
-          if (cfg.getNumberOfReplicas() > cfg.getNumberOfBrokers()) {
-            throw new IllegalArgumentException(
-                String.format(
-                    REPLICAS_EXCEED_BROKERS_ERROR_MSG,
-                    regionName,
-                    cfg.getNumberOfReplicas(),
-                    cfg.getNumberOfBrokers()));
-          }
-          if (cfg.getNumberOfBrokers() < 1 || cfg.getNumberOfReplicas() < 1) {
-            throw new IllegalArgumentException(
-                String.format(
-                    "Region '%s' must have at least 1 broker and 1 replica.", regionName));
-          }
-        });
+    for (final var cfg : regions) {
+      if (cfg.getNumberOfReplicas() > cfg.getNumberOfBrokers()) {
+        throw new IllegalArgumentException(
+            String.format(
+                REPLICAS_EXCEED_BROKERS_ERROR_MSG,
+                cfg.getName(),
+                cfg.getNumberOfReplicas(),
+                cfg.getNumberOfBrokers()));
+      }
+      if (cfg.getNumberOfBrokers() < 1 || cfg.getNumberOfReplicas() < 1) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Region '%s' must have at least 1 broker and 1 replica.", cfg.getName()));
+      }
+    }
   }
 
   private void initPartitionIds() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/PartitioningCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/PartitioningCfg.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.system.configuration;
 
 import io.camunda.zeebe.broker.system.configuration.partitioning.FixedPartitionCfg;
+import io.camunda.zeebe.broker.system.configuration.partitioning.RegionAwareCfg;
 import io.camunda.zeebe.broker.system.configuration.partitioning.Scheme;
 import java.util.ArrayList;
 import java.util.List;
@@ -34,6 +35,7 @@ public final class PartitioningCfg {
 
   private Scheme scheme = DEFAULT_SCHEME;
   private List<FixedPartitionCfg> fixed = new ArrayList<>();
+  private RegionAwareCfg regionAware = new RegionAwareCfg();
 
   public Scheme getScheme() {
     return scheme;
@@ -51,8 +53,23 @@ public final class PartitioningCfg {
     this.fixed = fixed;
   }
 
+  public RegionAwareCfg getRegionAware() {
+    return regionAware;
+  }
+
+  public void setRegionAware(final RegionAwareCfg regionAware) {
+    this.regionAware = regionAware;
+  }
+
   @Override
   public String toString() {
-    return "PartitioningCfg{" + "scheme=" + scheme + ", fixed=" + fixed + '}';
+    return "PartitioningCfg{"
+        + "scheme="
+        + scheme
+        + ", fixed="
+        + fixed
+        + ", regionAware="
+        + regionAware
+        + '}';
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/partitioning/RegionAwareCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/partitioning/RegionAwareCfg.java
@@ -13,11 +13,11 @@ import java.util.List;
 /**
  * Top-level configuration for the {@link Scheme#REGION_AWARE} partitioning scheme.
  *
- * <p>Contains a list of {@link RegionCfg} entries, each identified by its {@link RegionCfg#getName()
- * name}. The list order is significant: broker {@link io.atomix.cluster.MemberId}s are assigned
- * sequentially per region in iteration order. For example, given regions {@code us-east1} (2
- * brokers) then {@code us-west1} (2 brokers), the member IDs will be {@code us-east1-0}, {@code
- * us-east1-1}, {@code us-west1-0}, {@code us-west1-1}.
+ * <p>Contains a list of {@link RegionCfg} entries, each identified by its {@link
+ * RegionCfg#getName() name}. The list order is significant: broker {@link
+ * io.atomix.cluster.MemberId}s are assigned sequentially per region in iteration order. For
+ * example, given regions {@code us-east1} (2 brokers) then {@code us-west1} (2 brokers), the member
+ * IDs will be {@code us-east1-0}, {@code us-east1-1}, {@code us-west1-0}, {@code us-west1-1}.
  *
  * <p>Using a list (rather than a map keyed by region name) makes it straightforward to override
  * individual region properties via indexed environment variables, e.g.:

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/partitioning/RegionAwareCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/partitioning/RegionAwareCfg.java
@@ -15,8 +15,8 @@ import java.util.LinkedHashMap;
  *
  * <p>Maps region names to their respective {@link RegionCfg}. The insertion order of this map is
  * significant: broker {@link io.atomix.cluster.MemberId}s are assigned sequentially per region in
- * iteration order. For example, given regions {@code us-east1} (2 brokers) then {@code us-west1}
- * (2 brokers), the member IDs will be {@code us-east1-0}, {@code us-east1-1}, {@code us-west1-0},
+ * iteration order. For example, given regions {@code us-east1} (2 brokers) then {@code us-west1} (2
+ * brokers), the member IDs will be {@code us-east1-0}, {@code us-east1-1}, {@code us-west1-0},
  * {@code us-west1-1}.
  *
  * <p>The map <strong>must</strong> be a {@link LinkedHashMap} to preserve YAML insertion order.

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/partitioning/RegionAwareCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/partitioning/RegionAwareCfg.java
@@ -7,20 +7,25 @@
  */
 package io.camunda.zeebe.broker.system.configuration.partitioning;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import java.util.LinkedHashMap;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Top-level configuration for the {@link Scheme#REGION_AWARE} partitioning scheme.
  *
- * <p>Maps region names to their respective {@link RegionCfg}. The insertion order of this map is
- * significant: broker {@link io.atomix.cluster.MemberId}s are assigned sequentially per region in
- * iteration order. For example, given regions {@code us-east1} (2 brokers) then {@code us-west1} (2
- * brokers), the member IDs will be {@code us-east1-0}, {@code us-east1-1}, {@code us-west1-0},
- * {@code us-west1-1}.
+ * <p>Contains a list of {@link RegionCfg} entries, each identified by its {@link RegionCfg#getName()
+ * name}. The list order is significant: broker {@link io.atomix.cluster.MemberId}s are assigned
+ * sequentially per region in iteration order. For example, given regions {@code us-east1} (2
+ * brokers) then {@code us-west1} (2 brokers), the member IDs will be {@code us-east1-0}, {@code
+ * us-east1-1}, {@code us-west1-0}, {@code us-west1-1}.
  *
- * <p>The map <strong>must</strong> be a {@link LinkedHashMap} to preserve YAML insertion order.
- * This is enforced via the {@link JsonDeserialize} annotation.
+ * <p>Using a list (rather than a map keyed by region name) makes it straightforward to override
+ * individual region properties via indexed environment variables, e.g.:
+ *
+ * <pre>
+ * CAMUNDA_CLUSTER_PARTITIONING_REGIONAWARE_REGIONS_0_NAME=us-east1
+ * CAMUNDA_CLUSTER_PARTITIONING_REGIONAWARE_REGIONS_0_NUMBEROFBROKERS=2
+ * </pre>
  *
  * <p>Example YAML configuration:
  *
@@ -34,15 +39,15 @@ import java.util.LinkedHashMap;
  *       scheme: REGION_AWARE
  *       region-aware:
  *         regions:
- *           us-east1:
+ *           - name: us-east1
  *             numberOfBrokers: 2
  *             numberOfReplicas: 2
  *             priority: 1000
- *           us-west1:
+ *           - name: us-west1
  *             numberOfBrokers: 2
  *             numberOfReplicas: 2
  *             priority: 500
- *           euro-east1:
+ *           - name: euro-east1
  *             numberOfBrokers: 1
  *             numberOfReplicas: 1
  *             priority: 10
@@ -50,14 +55,13 @@ import java.util.LinkedHashMap;
  */
 public final class RegionAwareCfg {
 
-  @JsonDeserialize(as = LinkedHashMap.class)
-  private LinkedHashMap<String, RegionCfg> regions = new LinkedHashMap<>();
+  private List<RegionCfg> regions = new ArrayList<>();
 
-  public LinkedHashMap<String, RegionCfg> getRegions() {
+  public List<RegionCfg> getRegions() {
     return regions;
   }
 
-  public void setRegions(final LinkedHashMap<String, RegionCfg> regions) {
+  public void setRegions(final List<RegionCfg> regions) {
     this.regions = regions;
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/partitioning/RegionAwareCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/partitioning/RegionAwareCfg.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.system.configuration.partitioning;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.util.LinkedHashMap;
+
+/**
+ * Top-level configuration for the {@link Scheme#REGION_AWARE} partitioning scheme.
+ *
+ * <p>Maps region names to their respective {@link RegionCfg}. The insertion order of this map is
+ * significant: broker {@link io.atomix.cluster.MemberId}s are assigned sequentially per region in
+ * iteration order. For example, given regions {@code us-east1} (2 brokers) then {@code us-west1}
+ * (2 brokers), the member IDs will be {@code us-east1:0}, {@code us-east1:1}, {@code us-west1:0},
+ * {@code us-west1:1}.
+ *
+ * <p>The map <strong>must</strong> be a {@link LinkedHashMap} to preserve YAML insertion order.
+ * This is enforced via the {@link JsonDeserialize} annotation.
+ *
+ * <p>Example YAML configuration:
+ *
+ * <pre>{@code
+ * camunda:
+ *   cluster:
+ *     size: 5
+ *     replication-factor: 5
+ *     region: us-east1         # set per broker; env: CAMUNDA_CLUSTER_REGION
+ *     partitioning:
+ *       scheme: REGION_AWARE
+ *       region-aware:
+ *         us-east1:
+ *           numberOfBrokers: 2
+ *           numberOfReplicas: 2
+ *           priority: 1000
+ *         us-west1:
+ *           numberOfBrokers: 2
+ *           numberOfReplicas: 2
+ *           priority: 500
+ *         euro-east1:
+ *           numberOfBrokers: 1
+ *           numberOfReplicas: 1
+ *           priority: 10
+ * }</pre>
+ */
+public final class RegionAwareCfg {
+
+  @JsonDeserialize(as = LinkedHashMap.class)
+  private LinkedHashMap<String, RegionCfg> regions = new LinkedHashMap<>();
+
+  public LinkedHashMap<String, RegionCfg> getRegions() {
+    return regions;
+  }
+
+  public void setRegions(final LinkedHashMap<String, RegionCfg> regions) {
+    this.regions = regions;
+  }
+
+  @Override
+  public String toString() {
+    return "RegionAwareCfg{regions=" + regions + '}';
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/partitioning/RegionAwareCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/partitioning/RegionAwareCfg.java
@@ -16,8 +16,8 @@ import java.util.LinkedHashMap;
  * <p>Maps region names to their respective {@link RegionCfg}. The insertion order of this map is
  * significant: broker {@link io.atomix.cluster.MemberId}s are assigned sequentially per region in
  * iteration order. For example, given regions {@code us-east1} (2 brokers) then {@code us-west1}
- * (2 brokers), the member IDs will be {@code us-east1:0}, {@code us-east1:1}, {@code us-west1:0},
- * {@code us-west1:1}.
+ * (2 brokers), the member IDs will be {@code us-east1-0}, {@code us-east1-1}, {@code us-west1-0},
+ * {@code us-west1-1}.
  *
  * <p>The map <strong>must</strong> be a {@link LinkedHashMap} to preserve YAML insertion order.
  * This is enforced via the {@link JsonDeserialize} annotation.
@@ -33,18 +33,19 @@ import java.util.LinkedHashMap;
  *     partitioning:
  *       scheme: REGION_AWARE
  *       region-aware:
- *         us-east1:
- *           numberOfBrokers: 2
- *           numberOfReplicas: 2
- *           priority: 1000
- *         us-west1:
- *           numberOfBrokers: 2
- *           numberOfReplicas: 2
- *           priority: 500
- *         euro-east1:
- *           numberOfBrokers: 1
- *           numberOfReplicas: 1
- *           priority: 10
+ *         regions:
+ *           us-east1:
+ *             numberOfBrokers: 2
+ *             numberOfReplicas: 2
+ *             priority: 1000
+ *           us-west1:
+ *             numberOfBrokers: 2
+ *             numberOfReplicas: 2
+ *             priority: 500
+ *           euro-east1:
+ *             numberOfBrokers: 1
+ *             numberOfReplicas: 1
+ *             priority: 10
  * }</pre>
  */
 public final class RegionAwareCfg {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/partitioning/RegionCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/partitioning/RegionCfg.java
@@ -25,9 +25,18 @@ package io.camunda.zeebe.broker.system.configuration.partitioning;
  */
 public final class RegionCfg {
 
+  private String name;
   private int numberOfReplicas;
   private int numberOfBrokers;
   private int priority;
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
 
   public int getNumberOfReplicas() {
     return numberOfReplicas;
@@ -56,7 +65,10 @@ public final class RegionCfg {
   @Override
   public String toString() {
     return "RegionCfg{"
-        + "numberOfReplicas="
+        + "name='"
+        + name
+        + '\''
+        + ", numberOfReplicas="
         + numberOfReplicas
         + ", numberOfBrokers="
         + numberOfBrokers

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/partitioning/RegionCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/partitioning/RegionCfg.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.system.configuration.partitioning;
+
+/**
+ * Per-region configuration for the {@link Scheme#REGION_AWARE} partitioning scheme.
+ *
+ * <p>{@link #numberOfBrokers} brokers must be deployed in this region, each configured with {@code
+ * zeebe.broker.cluster.region} set to this region's name. The {@link #nodeId} of each broker must
+ * be unique within the region (0-indexed, i.e. in the range {@code [0, numberOfBrokers)}).
+ *
+ * <p>{@link #numberOfReplicas} controls how many replicas of each partition are placed in this
+ * region. It must satisfy {@code numberOfReplicas <= numberOfBrokers}, because two replicas of the
+ * same partition cannot reside on the same broker.
+ *
+ * <p>{@link #priority} determines the preferred leader location. The region with the highest
+ * priority will have its brokers assigned the highest Raft election priorities, so they win leader
+ * elections first. If all brokers in the highest-priority region are unavailable, leadership fails
+ * over to the next region automatically via Raft's priority-decrement mechanism.
+ */
+public final class RegionCfg {
+
+  private int numberOfReplicas;
+  private int numberOfBrokers;
+  private int priority;
+
+  public int getNumberOfReplicas() {
+    return numberOfReplicas;
+  }
+
+  public void setNumberOfReplicas(final int numberOfReplicas) {
+    this.numberOfReplicas = numberOfReplicas;
+  }
+
+  public int getNumberOfBrokers() {
+    return numberOfBrokers;
+  }
+
+  public void setNumberOfBrokers(final int numberOfBrokers) {
+    this.numberOfBrokers = numberOfBrokers;
+  }
+
+  public int getPriority() {
+    return priority;
+  }
+
+  public void setPriority(final int priority) {
+    this.priority = priority;
+  }
+
+  @Override
+  public String toString() {
+    return "RegionCfg{"
+        + "numberOfReplicas="
+        + numberOfReplicas
+        + ", numberOfBrokers="
+        + numberOfBrokers
+        + ", priority="
+        + priority
+        + '}';
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/partitioning/Scheme.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/partitioning/Scheme.java
@@ -9,5 +9,6 @@ package io.camunda.zeebe.broker.system.configuration.partitioning;
 
 public enum Scheme {
   FIXED,
-  ROUND_ROBIN;
+  ROUND_ROBIN,
+  REGION_AWARE;
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandSenderImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandSenderImpl.java
@@ -22,7 +22,7 @@ import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.Objects;
-import org.agrona.collections.Int2IntHashMap;
+import org.agrona.collections.Int2ObjectHashMap;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.slf4j.Logger;
 
@@ -34,7 +34,7 @@ public final class InterPartitionCommandSenderImpl implements InterPartitionComm
   private static final Logger LOG = Loggers.TRANSPORT_LOGGER;
   private final ClusterCommunicationService communicationService;
 
-  private final Int2IntHashMap partitionLeaders = new Int2IntHashMap(-1);
+  private final Int2ObjectHashMap<String> partitionLeaders = new Int2ObjectHashMap<>();
   private long checkpointId = CheckpointState.NO_CHECKPOINT;
   private CheckpointType checkpointType = CheckpointType.MANUAL_BACKUP;
   private final String sendingSubjectPrefix;
@@ -72,7 +72,8 @@ public final class InterPartitionCommandSenderImpl implements InterPartitionComm
       final Long recordKey,
       final UnifiedRecordValue command,
       final AuthInfo authInfo) {
-    if (!partitionLeaders.containsKey(receiverPartitionId)) {
+    final String partitionLeader = partitionLeaders.get(receiverPartitionId);
+    if (partitionLeader == null) {
       LOG.warn(
           "Not sending command {} {} to {}, no known leader for this partition",
           valueType,
@@ -80,7 +81,6 @@ public final class InterPartitionCommandSenderImpl implements InterPartitionComm
           receiverPartitionId);
       return;
     }
-    final int partitionLeader = partitionLeaders.get(receiverPartitionId);
 
     LOG.trace(
         "Sending command {} {} to partition {}, leader {}",
@@ -104,7 +104,7 @@ public final class InterPartitionCommandSenderImpl implements InterPartitionComm
         sendingSubjectPrefix + receiverPartitionId,
         message,
         DefaultSerializers.BASIC::encode,
-        MemberId.from("" + partitionLeader),
+        MemberId.from(partitionLeader),
         true);
   }
 
@@ -113,8 +113,8 @@ public final class InterPartitionCommandSenderImpl implements InterPartitionComm
     this.checkpointType = checkpointType;
   }
 
-  void setCurrentLeader(final int partitionId, final int currentLeader) {
-    partitionLeaders.put(partitionId, currentLeader);
+  void setCurrentLeader(final int partitionId, final String currentLeaderMemberId) {
+    partitionLeaders.put(partitionId, currentLeaderMemberId);
   }
 
   private static final class Encoder {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/GatewayBrokerTransportStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/GatewayBrokerTransportStepTest.java
@@ -85,7 +85,7 @@ class GatewayBrokerTransportStepTest {
     void shouldStartAndInstallTransport() {
       // when
       final int randomNodeId = new Random().nextInt(10);
-      when(mockBrokerInfo.getNodeId()).thenReturn(randomNodeId);
+      when(mockBrokerInfo.getNodeId()).thenReturn(String.valueOf(randomNodeId));
       sut.startupInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, startupFuture);
       await().until(startupFuture::isDone);
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/RequestIdGeneratorStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/RequestIdGeneratorStepTest.java
@@ -78,7 +78,7 @@ class RequestIdGeneratorStepTest {
     void shouldStartAndInstallRequestIdGenerator() {
       // when
       final int randomNodeId = new Random().nextInt(10);
-      when(mockBrokerInfo.getNodeId()).thenReturn(randomNodeId);
+      when(mockBrokerInfo.getLocalNodeId()).thenReturn(randomNodeId);
       sut.startup(testBrokerStartupContext);
       await().until(startupFuture::isDone);
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandCheckpointTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandCheckpointTest.java
@@ -55,7 +55,7 @@ final class InterPartitionCommandCheckpointTest {
     this.logStreamWriter = logStreamWriter;
 
     sender = new InterPartitionCommandSenderImpl(communicationService, LEGACY_TOPIC_PREFIX);
-    sender.setCurrentLeader(1, 2);
+    sender.setCurrentLeader(1, "2");
     receiver = new InterPartitionCommandReceiverImpl(logStreamWriter);
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverTest.java
@@ -331,7 +331,7 @@ final class InterPartitionCommandReceiverTest {
 
     final var sender =
         new InterPartitionCommandSenderImpl(communicationService, LEGACY_TOPIC_PREFIX);
-    sender.setCurrentLeader(receiverPartitionId, receiverBrokerId);
+    sender.setCurrentLeader(receiverPartitionId, String.valueOf(receiverBrokerId));
 
     sender.sendCommand(receiverPartitionId, valueType, intent, recordKey, recordValue, authInfo);
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandlerTest.java
@@ -97,8 +97,8 @@ public class SnapshotApiRequestHandlerTest {
     final var clusterService = mock(ClusterEventService.class);
     final var brokerTopology = mock(BrokerTopologyManager.class);
     final var clusterState = mock(BrokerClusterState.class);
-    when(clusterState.getLeaderForPartition(1)).thenReturn(1);
-    when(clusterState.getBrokerAddress(1)).thenReturn(serverAddress);
+    when(clusterState.getLeaderForPartition(1)).thenReturn("1");
+    when(clusterState.getBrokerAddress("1")).thenReturn(serverAddress);
     when(clusterState.getPartitions()).thenReturn(List.of(1));
 
     when(brokerTopology.getTopology()).thenReturn(clusterState);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
@@ -51,7 +51,6 @@ public final class ClusterConfigurationManagerService
   private static final String COORDINATOR_ID = "0";
   private final ClusterConfigurationManagerImpl clusterConfigurationManager;
   private final ClusterConfigurationGossiper clusterConfigurationGossiper;
-  private final boolean isCoordinator;
   private final PersistedClusterConfiguration persistedClusterConfiguration;
   private final Path configurationFile;
   private final ConfigurationChangeCoordinator configurationChangeCoordinator;
@@ -98,7 +97,6 @@ public final class ClusterConfigurationManagerService
             config,
             clusterConfigurationManager::onGossipReceived,
             topologyMetrics);
-    isCoordinator = localMemberId.id().equals(COORDINATOR_ID);
     configurationChangeCoordinator =
         new ConfigurationChangeCoordinatorImpl(
             clusterConfigurationManager, localMemberId, managerActor);
@@ -193,7 +191,7 @@ public final class ClusterConfigurationManagerService
       final StaticConfiguration staticConfiguration) {
     final var result = new CompletableActorFuture<Void>();
     final ClusterConfigurationInitializer clusterConfigurationInitializer =
-        isCoordinator
+        staticConfiguration.getIsCoordinator()
             ? getCoordinatorInitializer(staticConfiguration)
             : getNonCoordinatorInitializer(staticConfiguration);
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/StaticConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/StaticConfiguration.java
@@ -26,6 +26,7 @@ public record StaticConfiguration(
     String clusterId) {
 
   public boolean getIsCoordinator() {
+    //FIXME the coordinator is the first alphabettically, not the first node (0) in the region with highest priority
     return localMemberId.equals(clusterMembers.stream().min(MemberId::compareTo).orElseThrow());
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/StaticConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/StaticConfiguration.java
@@ -25,6 +25,10 @@ public record StaticConfiguration(
     DynamicPartitionConfig partitionConfig,
     String clusterId) {
 
+  public boolean getIsCoordinator() {
+    return localMemberId.equals(clusterMembers.stream().min(MemberId::compareTo).orElseThrow());
+  }
+
   public int partitionCount() {
     return partitionIds.size();
   }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/StaticConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/StaticConfiguration.java
@@ -26,7 +26,8 @@ public record StaticConfiguration(
     String clusterId) {
 
   public boolean getIsCoordinator() {
-    //FIXME the coordinator is the first alphabettically, not the first node (0) in the region with highest priority
+    // FIXME the coordinator is the first alphabettically, not the first node (0) in the region with
+    // highest priority
     return localMemberId.equals(clusterMembers.stream().min(MemberId::compareTo).orElseThrow());
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/RegionAwarePartitionDistributor.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/RegionAwarePartitionDistributor.java
@@ -42,9 +42,8 @@ import java.util.Set;
  * <p>Regions must have distinct priority values; equal priorities produce undefined failover
  * ordering.
  *
- * <p>Example distribution with 3 regions (us-east1 prio=1000 × 2 replicas/2 brokers,
- * us-west1 prio=500 × 2 replicas/2 brokers, euro-east1 prio=10 × 1 replica/1 broker),
- * 5 partitions, RF=5:
+ * <p>Example distribution with 3 regions (us-east1 prio=1000 × 2 replicas/2 brokers, us-west1
+ * prio=500 × 2 replicas/2 brokers, euro-east1 prio=10 × 1 replica/1 broker), 5 partitions, RF=5:
  *
  * <pre>
  * +------------------+-------------+-------------+-------------+-------------+---------------+

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/RegionAwarePartitionDistributor.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/RegionAwarePartitionDistributor.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.util;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionId;
+import io.atomix.primitive.partition.PartitionMetadata;
+import io.camunda.zeebe.dynamic.config.PartitionDistributor;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A {@link PartitionDistributor} that distributes partitions across brokers in a region-aware
+ * manner.
+ *
+ * <p>Regions are ranked by their configured {@link RegionSpec#priority()} in descending order
+ * (higher priority = preferred leader location). For each partition, replicas are assigned
+ * region-by-region in priority order, using a round-robin offset within each region so that
+ * different partitions are spread evenly across the brokers in that region.
+ *
+ * <p>Raft election priorities are assigned sequentially from {@code replicationFactor} down to
+ * {@code 1}, iterating regions from highest to lowest priority and brokers within each region in
+ * round-robin order. This means:
+ *
+ * <ul>
+ *   <li>The broker selected first from the highest-priority region receives Raft priority {@code
+ *       replicationFactor} and becomes the preferred leader.
+ *   <li>If all brokers in the primary region become unavailable, Raft's priority-decrement
+ *       mechanism naturally falls over to the next region without any additional code.
+ * </ul>
+ *
+ * <p>Regions must have distinct priority values; equal priorities produce undefined failover
+ * ordering.
+ *
+ * <p>Example distribution with 3 regions (us-east1 prio=1000 × 2 replicas/2 brokers,
+ * us-west1 prio=500 × 2 replicas/2 brokers, euro-east1 prio=10 × 1 replica/1 broker),
+ * 5 partitions, RF=5:
+ *
+ * <pre>
+ * +------------------+-------------+-------------+-------------+-------------+---------------+
+ * | Partition \ Node | us-east1-0  | us-east1-1  | us-west1-0  | us-west1-1  | euro-east1-0  |
+ * +------------------+-------------+-------------+-------------+-------------+---------------+
+ * |                1 |      5      |      4      |      3      |      2      |       1       |
+ * |                2 |      4      |      5      |      2      |      3      |       1       |
+ * |                3 |      5      |      4      |      3      |      2      |       1       |
+ * |                4 |      4      |      5      |      2      |      3      |       1       |
+ * |                5 |      5      |      4      |      3      |      2      |       1       |
+ * +------------------+-------------+-------------+-------------+-------------+---------------+
+ * </pre>
+ *
+ * (Numbers are Raft priorities; the member with priority == RF is the preferred leader.)
+ */
+public final class RegionAwarePartitionDistributor implements PartitionDistributor {
+
+  /** Regions sorted by {@link RegionSpec#priority()} descending (highest priority first). */
+  private final List<RegionSpec> regionSpecs;
+
+  /**
+   * @param regionSpecs the region specifications. May be in any order; the constructor sorts them
+   *     by {@link RegionSpec#priority()} descending so that the highest-priority region's brokers
+   *     always receive the highest Raft priorities.
+   */
+  public RegionAwarePartitionDistributor(final List<RegionSpec> regionSpecs) {
+    this.regionSpecs =
+        regionSpecs.stream()
+            .sorted(Comparator.comparingInt(RegionSpec::priority).reversed())
+            .toList();
+  }
+
+  @Override
+  public Set<PartitionMetadata> distributePartitions(
+      final Set<MemberId> clusterMembers,
+      final List<PartitionId> sortedPartitionIds,
+      final int replicationFactor) {
+
+    validateReplicaSum(replicationFactor);
+    validateBrokerIds(clusterMembers);
+
+    final Set<PartitionMetadata> result = new HashSet<>();
+
+    for (int i = 0; i < sortedPartitionIds.size(); i++) {
+      final PartitionId partitionId = sortedPartitionIds.get(i);
+
+      // priorityCounter starts at RF (highest Raft priority) and counts down to 1.
+      // The first replica assigned — always from the highest-priority region — gets RF,
+      // ensuring it wins Raft elections and becomes the partition leader.
+      int priorityCounter = replicationFactor;
+      final List<MemberId> orderedMembers = new ArrayList<>(replicationFactor);
+      final Map<MemberId, Integer> priorityMap = new HashMap<>(replicationFactor);
+
+      for (final RegionSpec spec : regionSpecs) {
+        final int regionBrokerCount = spec.brokers().size();
+        for (int r = 0; r < spec.numberOfReplicas(); r++) {
+          final int brokerIndex = (i + r) % regionBrokerCount;
+          final MemberId broker = spec.brokers().get(brokerIndex);
+          orderedMembers.add(broker);
+          priorityMap.put(broker, priorityCounter--);
+        }
+      }
+
+      // The first member always belongs to the highest-priority region and holds Raft
+      // priority == replicationFactor, making it the preferred partition leader.
+      final MemberId primary = orderedMembers.getFirst();
+
+      result.add(
+          new PartitionMetadata(
+              partitionId,
+              Set.copyOf(orderedMembers),
+              Map.copyOf(priorityMap),
+              replicationFactor,
+              primary));
+    }
+
+    return result;
+  }
+
+  private void validateReplicaSum(final int replicationFactor) {
+    final int totalReplicas = regionSpecs.stream().mapToInt(RegionSpec::numberOfReplicas).sum();
+    if (totalReplicas != replicationFactor) {
+      throw new IllegalStateException(
+          "RegionAwarePartitionDistributor: sum of numberOfReplicas across all regions (%d) does not match replicationFactor (%d)"
+              .formatted(totalReplicas, replicationFactor));
+    }
+  }
+
+  private void validateBrokerIds(final Set<MemberId> clusterMembers) {
+    for (final RegionSpec spec : regionSpecs) {
+      for (final MemberId broker : spec.brokers()) {
+        if (!clusterMembers.contains(broker)) {
+          throw new IllegalStateException(
+              ("RegionAwarePartitionDistributor: broker '%s' (region '%s') is not present in "
+                      + "clusterMembers — the region config may be out of sync with the actual cluster")
+                  .formatted(broker, spec.name()));
+        }
+      }
+    }
+  }
+
+  /**
+   * Describes a single region's participation in the cluster.
+   *
+   * @param name the region name (e.g. {@code "us-east1"})
+   * @param numberOfReplicas how many replicas of each partition are placed in this region; must be
+   *     {@code <= brokers.size()}
+   * @param priority the region's preferred-leader ranking; higher values are preferred. Must be
+   *     unique across all regions.
+   * @param brokers the ordered list of {@link MemberId}s belonging to this region, in the same
+   *     insertion order as the configuration (i.e. local node IDs 0, 1, … within the region)
+   */
+  public record RegionSpec(
+      String name, int numberOfReplicas, int priority, List<MemberId> brokers) {}
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementIntegrationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementIntegrationTest.java
@@ -120,7 +120,7 @@ class ClusterConfigurationManagementIntegrationTest {
 
     final var restartFutures =
         nodes.values().stream()
-            .map(node -> node.start(actorScheduler, Set.of(), getIncorrectPartitionDistribution()))
+            .map(node -> node.start(actorScheduler, clusterMemberIds, getIncorrectPartitionDistribution()))
             .toList();
     restartFutures.forEach(ActorFuture::join);
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementIntegrationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementIntegrationTest.java
@@ -120,7 +120,10 @@ class ClusterConfigurationManagementIntegrationTest {
 
     final var restartFutures =
         nodes.values().stream()
-            .map(node -> node.start(actorScheduler, clusterMemberIds, getIncorrectPartitionDistribution()))
+            .map(
+                node ->
+                    node.start(
+                        actorScheduler, clusterMemberIds, getIncorrectPartitionDistribution()))
             .toList();
     restartFutures.forEach(ActorFuture::join);
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/RegionAwarePartitionDistributorTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/RegionAwarePartitionDistributorTest.java
@@ -18,9 +18,13 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 final class RegionAwarePartitionDistributorTest {
 
+  private static final Logger LOG =
+      LoggerFactory.getLogger(RegionAwarePartitionDistributorTest.class);
   private static final String GROUP = "raft";
 
   // -------------------------------------------------------------------------
@@ -28,9 +32,7 @@ final class RegionAwarePartitionDistributorTest {
   // -------------------------------------------------------------------------
 
   private static List<MemberId> brokers(final String region, final int count) {
-    return IntStream.range(0, count)
-        .mapToObj(i -> MemberId.from(region + "-" + i))
-        .toList();
+    return IntStream.range(0, count).mapToObj(i -> MemberId.from(region + "-" + i)).toList();
   }
 
   private static List<PartitionId> partitions(final int count) {
@@ -198,8 +200,7 @@ final class RegionAwarePartitionDistributorTest {
   @Test
   void shouldRoundRobinBrokersWithinRegionAcrossPartitions() {
     // given — one region, 2 brokers, 1 replica per partition
-    final var specs =
-        List.of(new RegionSpec("us-east1", 1, 1000, brokers("us-east1", 2)));
+    final var specs = List.of(new RegionSpec("us-east1", 1, 1000, brokers("us-east1", 2)));
     final var distributor = new RegionAwarePartitionDistributor(specs);
 
     // when
@@ -244,8 +245,7 @@ final class RegionAwarePartitionDistributorTest {
   @Test
   void shouldBehaveCorrectlyWithSingleRegion() {
     // given
-    final var specs =
-        List.of(new RegionSpec("us-east1", 3, 1000, brokers("us-east1", 3)));
+    final var specs = List.of(new RegionSpec("us-east1", 3, 1000, brokers("us-east1", 3)));
     final var distributor = new RegionAwarePartitionDistributor(specs);
 
     // when
@@ -273,23 +273,119 @@ final class RegionAwarePartitionDistributorTest {
     final var distributor = new RegionAwarePartitionDistributor(specs);
 
     // when / then
-    assertThatThrownBy(
-            () -> distributor.distributePartitions(allBrokers(specs), partitions(1), 4))
+    assertThatThrownBy(() -> distributor.distributePartitions(allBrokers(specs), partitions(1), 4))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("replicationFactor");
+  }
+
+  // -------------------------------------------------------------------------
+  // Priority table visualization
+  // -------------------------------------------------------------------------
+
+  @Test
+  void shouldPrintPriorityTableForDocumentedExample() {
+    // given — the 3-region, 5-partition example from the class-level Javadoc
+    final var specs =
+        List.of(
+            new RegionSpec("us-east1", 2, 1000, brokers("us-east1", 2)),
+            new RegionSpec("us-west1", 2, 500, brokers("us-west1", 2)),
+            new RegionSpec("euro-east1", 1, 10, brokers("euro-east1", 1)));
+    final int rf = 5;
+    final var distributor = new RegionAwarePartitionDistributor(specs);
+
+    // when
+    final var result = distributor.distributePartitions(allBrokers(specs), partitions(5), rf);
+
+    // then — table is printed to the logs; this test acts as a visual smoke-check
+    logPriorityTable(result, specs);
+    assertThat(result).hasSize(5);
+  }
+
+  /**
+   * Logs a Markdown-style table showing the Raft election priority of every broker for every
+   * partition. Columns are ordered by region (highest priority region first) and then by local
+   * broker index within the region. The broker with priority {@code targetPriority} (==
+   * replicationFactor) is the preferred leader for that partition.
+   *
+   * <p>Example output:
+   *
+   * <pre>
+   * Partition \ Broker | us-east1-0 | us-east1-1 | us-west1-0 | us-west1-1 | euro-east1-0
+   * -------------------|------------|------------|------------|------------|--------------
+   *                  1 |     5      |     4      |     3      |     2      |      1
+   *                  2 |     4      |     5      |     2      |     3      |      1
+   * </pre>
+   */
+  private static void logPriorityTable(
+      final Set<PartitionMetadata> result, final List<RegionSpec> specs) {
+    // Collect all brokers in deterministic column order (region declaration order, then local id)
+    final List<MemberId> columns = specs.stream().flatMap(s -> s.brokers().stream()).toList();
+
+    // Sort partitions by numeric id for stable row order
+    final List<PartitionMetadata> rows =
+        result.stream().sorted((a, b) -> Integer.compare(a.id().id(), b.id().id())).toList();
+
+    // Compute column widths
+    final int partitionColWidth =
+        Math.max(
+            "Partition".length(),
+            rows.stream().mapToInt(p -> String.valueOf(p.id().id()).length()).max().orElse(1));
+    final int[] brokerColWidths =
+        columns.stream().mapToInt(m -> Math.max(m.id().length(), 3)).toArray();
+
+    // Header row
+    final var header = new StringBuilder();
+    header.append(padLeft("Partition", partitionColWidth));
+    for (int c = 0; c < columns.size(); c++) {
+      header.append(" | ").append(center(columns.get(c).id(), brokerColWidths[c]));
+    }
+
+    // Separator row
+    final var separator = new StringBuilder();
+    separator.append("-".repeat(partitionColWidth));
+    for (final int w : brokerColWidths) {
+      separator.append("-|-").append("-".repeat(w));
+    }
+
+    // Data rows
+    final var dataRows = new StringBuilder();
+    for (final PartitionMetadata pm : rows) {
+      final var row = new StringBuilder();
+      row.append(padLeft(String.valueOf(pm.id().id()), partitionColWidth));
+      for (int c = 0; c < columns.size(); c++) {
+        final int priority = pm.getPriority(columns.get(c));
+        row.append(" | ").append(center(String.valueOf(priority), brokerColWidths[c]));
+      }
+      dataRows.append('\n').append(row);
+    }
+
+    LOG.info(
+        "\nRaft priority table (priority == RF → preferred leader):\n{}\n{}{}\n",
+        header,
+        separator,
+        dataRows);
+  }
+
+  private static String padLeft(final String s, final int width) {
+    return " ".repeat(Math.max(0, width - s.length())) + s;
+  }
+
+  private static String center(final String s, final int width) {
+    final int padding = Math.max(0, width - s.length());
+    final int left = padding / 2;
+    final int right = padding - left;
+    return " ".repeat(left) + s + " ".repeat(right);
   }
 
   @Test
   void shouldThrowWhenBrokerNotInClusterMembers() {
     // given — spec declares 2 brokers but we only pass 1 to distributePartitions
-    final var specs =
-        List.of(new RegionSpec("us-east1", 2, 1000, brokers("us-east1", 2)));
+    final var specs = List.of(new RegionSpec("us-east1", 2, 1000, brokers("us-east1", 2)));
     final var distributor = new RegionAwarePartitionDistributor(specs);
     final Set<MemberId> onlyOneBroker = Set.of(MemberId.from("us-east1-0"));
 
     // when / then
-    assertThatThrownBy(
-            () -> distributor.distributePartitions(onlyOneBroker, partitions(1), 2))
+    assertThatThrownBy(() -> distributor.distributePartitions(onlyOneBroker, partitions(1), 2))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("us-east1-1");
   }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/RegionAwarePartitionDistributorTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/RegionAwarePartitionDistributorTest.java
@@ -1,0 +1,296 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionId;
+import io.atomix.primitive.partition.PartitionMetadata;
+import io.camunda.zeebe.dynamic.config.util.RegionAwarePartitionDistributor.RegionSpec;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+
+final class RegionAwarePartitionDistributorTest {
+
+  private static final String GROUP = "raft";
+
+  // -------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------
+
+  private static List<MemberId> brokers(final String region, final int count) {
+    return IntStream.range(0, count)
+        .mapToObj(i -> MemberId.from(region + "-" + i))
+        .toList();
+  }
+
+  private static List<PartitionId> partitions(final int count) {
+    return IntStream.rangeClosed(1, count)
+        .mapToObj(i -> PartitionId.from(GROUP, i))
+        .sorted()
+        .toList();
+  }
+
+  private static Set<MemberId> allBrokers(final List<RegionSpec> specs) {
+    return specs.stream()
+        .flatMap(s -> s.brokers().stream())
+        .collect(java.util.stream.Collectors.toSet());
+  }
+
+  private static PartitionMetadata partitionById(
+      final Set<PartitionMetadata> result, final int id) {
+    return result.stream()
+        .filter(p -> p.id().id() == id)
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("Partition " + id + " not found"));
+  }
+
+  // -------------------------------------------------------------------------
+  // Core correctness
+  // -------------------------------------------------------------------------
+
+  @Test
+  void shouldAssignExactlyRFMembersPerPartition() {
+    // given
+    final var specs =
+        List.of(
+            new RegionSpec("us-east1", 2, 1000, brokers("us-east1", 2)),
+            new RegionSpec("us-west1", 2, 500, brokers("us-west1", 2)),
+            new RegionSpec("euro-east1", 1, 10, brokers("euro-east1", 1)));
+    final int rf = 5;
+    final var distributor = new RegionAwarePartitionDistributor(specs);
+
+    // when
+    final var result = distributor.distributePartitions(allBrokers(specs), partitions(5), rf);
+
+    // then
+    assertThat(result).hasSize(5);
+    result.forEach(p -> assertThat(p.members()).hasSize(rf));
+  }
+
+  @Test
+  void shouldAssignAllPartitions() {
+    // given
+    final var specs =
+        List.of(
+            new RegionSpec("us-east1", 2, 1000, brokers("us-east1", 2)),
+            new RegionSpec("us-west1", 1, 500, brokers("us-west1", 1)));
+    final var distributor = new RegionAwarePartitionDistributor(specs);
+    final var partitionIds = partitions(4);
+
+    // when
+    final var result = distributor.distributePartitions(allBrokers(specs), partitionIds, 3);
+
+    // then — every partition ID appears exactly once
+    final var assignedIds = result.stream().map(p -> p.id().id()).sorted().toList();
+    assertThat(assignedIds).containsExactly(1, 2, 3, 4);
+  }
+
+  @Test
+  void shouldNotAssignDuplicateBrokersToSamePartition() {
+    // given
+    final var specs =
+        List.of(
+            new RegionSpec("us-east1", 2, 1000, brokers("us-east1", 2)),
+            new RegionSpec("us-west1", 2, 500, brokers("us-west1", 2)));
+    final var distributor = new RegionAwarePartitionDistributor(specs);
+
+    // when
+    final var result = distributor.distributePartitions(allBrokers(specs), partitions(5), 4);
+
+    // then — Set<MemberId>.size() == members().size() iff no duplicates
+    result.forEach(
+        p ->
+            assertThat(p.members())
+                .as("partition %d has no duplicate members", p.id().id())
+                .doesNotHaveDuplicates());
+  }
+
+  // -------------------------------------------------------------------------
+  // Leader placement: highest-priority region should own the leaders
+  // -------------------------------------------------------------------------
+
+  @Test
+  void shouldPlaceLeaderInHighestPriorityRegion() {
+    // given — regions given in low→high order to verify the sort inside the constructor
+    final var specs =
+        List.of(
+            new RegionSpec("euro-east1", 1, 10, brokers("euro-east1", 1)),
+            new RegionSpec("us-west1", 1, 500, brokers("us-west1", 1)),
+            new RegionSpec("us-east1", 1, 1000, brokers("us-east1", 1)));
+    final var distributor = new RegionAwarePartitionDistributor(specs);
+
+    // when
+    final var result = distributor.distributePartitions(allBrokers(specs), partitions(3), 3);
+
+    // then — primary of every partition must be a broker from us-east1
+    final var primaryRegion = "us-east1";
+    result.forEach(
+        p ->
+            assertThat(p.getPrimary())
+                .isPresent()
+                .get()
+                .matches(
+                    m -> m.id().startsWith(primaryRegion),
+                    "primary should be in region " + primaryRegion));
+  }
+
+  @Test
+  void shouldAssignHighestRaftPriorityToHighestPriorityRegion() {
+    // given
+    final int rf = 5;
+    final var specs =
+        List.of(
+            new RegionSpec("us-east1", 2, 1000, brokers("us-east1", 2)),
+            new RegionSpec("us-west1", 2, 500, brokers("us-west1", 2)),
+            new RegionSpec("euro-east1", 1, 10, brokers("euro-east1", 1)));
+    final var distributor = new RegionAwarePartitionDistributor(specs);
+
+    // when
+    final var result = distributor.distributePartitions(allBrokers(specs), partitions(1), rf);
+
+    // then — us-east1 brokers must have the two highest priorities (5 and 4)
+    final var p1 = partitionById(result, 1);
+    final var eastPriorities =
+        specs.get(0).brokers().stream().mapToInt(p1::getPriority).boxed().toList();
+    assertThat(eastPriorities).containsExactlyInAnyOrder(rf, rf - 1);
+
+    // us-west1 brokers have the next two (3 and 2)
+    final var westPriorities =
+        specs.get(1).brokers().stream().mapToInt(p1::getPriority).boxed().toList();
+    assertThat(westPriorities).containsExactlyInAnyOrder(rf - 2, rf - 3);
+
+    // euro-east1 broker has the lowest priority (1)
+    final var euroPriority = p1.getPriority(specs.get(2).brokers().getFirst());
+    assertThat(euroPriority).isEqualTo(1);
+  }
+
+  @Test
+  void shouldSetTargetPriorityToReplicationFactor() {
+    // given
+    final int rf = 3;
+    final var specs =
+        List.of(
+            new RegionSpec("us-east1", 2, 1000, brokers("us-east1", 2)),
+            new RegionSpec("us-west1", 1, 500, brokers("us-west1", 1)));
+    final var distributor = new RegionAwarePartitionDistributor(specs);
+
+    // when
+    final var result = distributor.distributePartitions(allBrokers(specs), partitions(3), rf);
+
+    // then
+    result.forEach(p -> assertThat(p.getTargetPriority()).isEqualTo(rf));
+  }
+
+  // -------------------------------------------------------------------------
+  // Round-robin within each region
+  // -------------------------------------------------------------------------
+
+  @Test
+  void shouldRoundRobinBrokersWithinRegionAcrossPartitions() {
+    // given — one region, 2 brokers, 1 replica per partition
+    final var specs =
+        List.of(new RegionSpec("us-east1", 1, 1000, brokers("us-east1", 2)));
+    final var distributor = new RegionAwarePartitionDistributor(specs);
+
+    // when
+    final var result = distributor.distributePartitions(allBrokers(specs), partitions(4), 1);
+
+    // then — partitions 1,3 → us-east1-0; partitions 2,4 → us-east1-1 (or vice versa)
+    final var p1Primary = partitionById(result, 1).getPrimary().orElseThrow();
+    final var p2Primary = partitionById(result, 2).getPrimary().orElseThrow();
+    final var p3Primary = partitionById(result, 3).getPrimary().orElseThrow();
+    final var p4Primary = partitionById(result, 4).getPrimary().orElseThrow();
+
+    assertThat(p1Primary).isEqualTo(p3Primary); // same broker every 2 partitions
+    assertThat(p2Primary).isEqualTo(p4Primary);
+    assertThat(p1Primary).isNotEqualTo(p2Primary); // alternates between brokers
+  }
+
+  @Test
+  void shouldShiftStartingBrokerPerPartitionWithinRegion() {
+    // given — us-east1 has 2 brokers and 2 replicas per partition
+    final var specs =
+        List.of(
+            new RegionSpec("us-east1", 2, 1000, brokers("us-east1", 2)),
+            new RegionSpec("us-west1", 1, 500, brokers("us-west1", 1)));
+    final var distributor = new RegionAwarePartitionDistributor(specs);
+
+    // when
+    final var result = distributor.distributePartitions(allBrokers(specs), partitions(2), 3);
+
+    // then — for partition 1 the highest-priority east broker is us-east1-0,
+    //        for partition 2 it is us-east1-1 (offset shifts by 1)
+    final var p1 = partitionById(result, 1);
+    final var p2 = partitionById(result, 2);
+
+    assertThat(p1.getPrimary().orElseThrow()).isEqualTo(MemberId.from("us-east1-0"));
+    assertThat(p2.getPrimary().orElseThrow()).isEqualTo(MemberId.from("us-east1-1"));
+  }
+
+  // -------------------------------------------------------------------------
+  // Degenerate cases
+  // -------------------------------------------------------------------------
+
+  @Test
+  void shouldBehaveCorrectlyWithSingleRegion() {
+    // given
+    final var specs =
+        List.of(new RegionSpec("us-east1", 3, 1000, brokers("us-east1", 3)));
+    final var distributor = new RegionAwarePartitionDistributor(specs);
+
+    // when
+    final var result = distributor.distributePartitions(allBrokers(specs), partitions(3), 3);
+
+    // then — every partition has 3 members, all from us-east1
+    result.forEach(
+        p -> {
+          assertThat(p.members()).hasSize(3);
+          p.members().forEach(m -> assertThat(m.id()).startsWith("us-east1-"));
+        });
+  }
+
+  // -------------------------------------------------------------------------
+  // Guard / validation
+  // -------------------------------------------------------------------------
+
+  @Test
+  void shouldThrowWhenReplicaSumDoesNotMatchReplicationFactor() {
+    // given — 2 + 1 = 3 replicas but RF = 4
+    final var specs =
+        List.of(
+            new RegionSpec("us-east1", 2, 1000, brokers("us-east1", 2)),
+            new RegionSpec("us-west1", 1, 500, brokers("us-west1", 1)));
+    final var distributor = new RegionAwarePartitionDistributor(specs);
+
+    // when / then
+    assertThatThrownBy(
+            () -> distributor.distributePartitions(allBrokers(specs), partitions(1), 4))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("replicationFactor");
+  }
+
+  @Test
+  void shouldThrowWhenBrokerNotInClusterMembers() {
+    // given — spec declares 2 brokers but we only pass 1 to distributePartitions
+    final var specs =
+        List.of(new RegionSpec("us-east1", 2, 1000, brokers("us-east1", 2)));
+    final var distributor = new RegionAwarePartitionDistributor(specs);
+    final Set<MemberId> onlyOneBroker = Set.of(MemberId.from("us-east1-0"));
+
+    // when / then
+    assertThatThrownBy(
+            () -> distributor.distributePartitions(onlyOneBroker, partitions(1), 2))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("us-east1-1");
+  }
+}

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
@@ -124,11 +124,13 @@ public final class EndpointManager {
     final String brokerAddress = topology.getBrokerAddress(brokerId);
     final Address address = Address.from(brokerAddress);
 
+    final String region = topology.getBrokerRegion(brokerId);
     brokerInfo
-        .setNodeId(brokerId)
+        .setNodeId(topology.getBrokerMemberId(brokerId))
         .setHost(address.host())
         .setPort(address.port())
-        .setVersion(topology.getBrokerVersion(brokerId));
+        .setVersion(topology.getBrokerVersion(brokerId))
+        .setRegion(region != null ? region : "");
   }
 
   private void addPartitionInfoToBrokerInfo(

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
@@ -126,7 +126,7 @@ public final class EndpointManager {
 
     final String region = topology.getBrokerRegion(brokerId);
     brokerInfo
-        .setNodeId(topology.getBrokerMemberId(brokerId))
+        .setMemberId(topology.getBrokerMemberId(brokerId))
         .setHost(address.host())
         .setPort(address.port())
         .setVersion(topology.getBrokerVersion(brokerId))

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
@@ -120,21 +120,21 @@ public final class EndpointManager {
   }
 
   private void addBrokerInfo(
-      final Builder brokerInfo, final Integer brokerId, final BrokerClusterState topology) {
-    final String brokerAddress = topology.getBrokerAddress(brokerId);
+      final Builder brokerInfo, final String memberId, final BrokerClusterState topology) {
+    final String brokerAddress = topology.getBrokerAddress(memberId);
     final Address address = Address.from(brokerAddress);
 
-    final String region = topology.getBrokerRegion(brokerId);
+    final String region = topology.getBrokerRegion(memberId);
     brokerInfo
-        .setMemberId(topology.getBrokerMemberId(brokerId))
+        .setMemberId(memberId)
         .setHost(address.host())
         .setPort(address.port())
-        .setVersion(topology.getBrokerVersion(brokerId))
+        .setVersion(topology.getBrokerVersion(memberId))
         .setRegion(region != null ? region : "");
   }
 
   private void addPartitionInfoToBrokerInfo(
-      final Builder brokerInfo, final Integer brokerId, final BrokerClusterState topology) {
+      final Builder brokerInfo, final String memberId, final BrokerClusterState topology) {
     topology
         .getPartitions()
         .forEach(
@@ -142,11 +142,11 @@ public final class EndpointManager {
               final Partition.Builder partitionBuilder =
                   Partition.newBuilder().setPartitionId(partitionId);
 
-              if (!setRole(brokerId, partitionId, topology, partitionBuilder)) {
+              if (!setRole(memberId, partitionId, topology, partitionBuilder)) {
                 return;
               }
 
-              final var status = topology.getPartitionHealth(brokerId, partitionId);
+              final var status = topology.getPartitionHealth(memberId, partitionId);
               switch (status) {
                 case HEALTHY -> partitionBuilder.setHealth(PartitionBrokerHealth.HEALTHY);
                 case UNHEALTHY -> partitionBuilder.setHealth(PartitionBrokerHealth.UNHEALTHY);
@@ -165,19 +165,19 @@ public final class EndpointManager {
    * @return true if it could set the role. False if no role was could be found.
    */
   private boolean setRole(
-      final Integer brokerId,
+      final String memberId,
       final Integer partitionId,
       final BrokerClusterState topology,
       final Partition.Builder partitionBuilder) {
-    final int partitionLeader = topology.getLeaderForPartition(partitionId);
-    final Set<Integer> partitionFollowers = topology.getFollowersForPartition(partitionId);
-    final Set<Integer> partitionInactives = topology.getInactiveNodesForPartition(partitionId);
+    final String partitionLeader = topology.getLeaderForPartition(partitionId);
+    final Set<String> partitionFollowers = topology.getFollowersForPartition(partitionId);
+    final Set<String> partitionInactives = topology.getInactiveNodesForPartition(partitionId);
 
-    if (partitionLeader == brokerId) {
+    if (memberId.equals(partitionLeader)) {
       partitionBuilder.setRole(PartitionBrokerRole.LEADER);
-    } else if (partitionFollowers != null && partitionFollowers.contains(brokerId)) {
+    } else if (partitionFollowers != null && partitionFollowers.contains(memberId)) {
       partitionBuilder.setRole(PartitionBrokerRole.FOLLOWER);
-    } else if (partitionInactives != null && partitionInactives.contains(brokerId)) {
+    } else if (partitionInactives != null && partitionInactives.contains(memberId)) {
       partitionBuilder.setRole(PartitionBrokerRole.INACTIVE);
     } else {
       return false;

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/BrokerAdminRequest.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/BrokerAdminRequest.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.encoding.AdminRequest;
 import io.camunda.zeebe.protocol.impl.encoding.AdminResponse;
+import io.camunda.zeebe.protocol.impl.encoding.MemberIds;
 import io.camunda.zeebe.protocol.management.AdminRequestEncoder;
 import io.camunda.zeebe.protocol.management.AdminRequestType;
 import io.camunda.zeebe.protocol.management.AdminResponseEncoder;
@@ -24,6 +25,13 @@ import org.agrona.MutableDirectBuffer;
 public class BrokerAdminRequest extends BrokerRequest<AdminResponse> {
   private final AdminRequest request = new AdminRequest();
   private final AdminResponse response = new AdminResponse();
+
+  /**
+   * Region of the target broker, stored alongside the local node id to reconstruct the composite
+   * member id when the gateway needs to route the request. Not part of the SBE wire format since
+   * the broker does not consume it.
+   */
+  private String region;
 
   public BrokerAdminRequest() {
     super(AdminResponseEncoder.SCHEMA_ID, AdminResponseEncoder.TEMPLATE_ID);
@@ -62,17 +70,23 @@ public class BrokerAdminRequest extends BrokerRequest<AdminResponse> {
   }
 
   @Override
-  public Optional<Integer> getBrokerId() {
-    final var brokerId = request.getBrokerId();
-    if (brokerId != AdminRequestEncoder.brokerIdNullValue()) {
-      return Optional.of(brokerId);
-    } else {
+  public Optional<String> getBrokerId() {
+    final var localNodeId = request.getBrokerId();
+    if (localNodeId == AdminRequestEncoder.brokerIdNullValue()) {
       return Optional.empty();
     }
+    return Optional.of(MemberIds.compose(region, localNodeId));
   }
 
-  public void setBrokerId(final int brokerId) {
-    request.setBrokerId(brokerId);
+  /**
+   * Sets the target broker by its composite member id. The member id is parsed into its region and
+   * local node id parts via {@link MemberIds}; only the local node id is carried on the wire while
+   * the region is retained in memory for gateway-side routing.
+   */
+  public void setMemberId(final String memberId) {
+    final MemberIds.Parsed parsed = MemberIds.parse(memberId);
+    region = parsed.region();
+    request.setBrokerId(parsed.localNodeId());
   }
 
   @Override

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/exporting/ExportingControlService.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/exporting/ExportingControlService.java
@@ -12,11 +12,11 @@ import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.gateway.admin.BrokerAdminRequest;
 import io.camunda.zeebe.gateway.admin.IncompleteTopologyException;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
-import org.agrona.collections.IntHashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,17 +71,19 @@ public class ExportingControlService implements ExportingControlApi {
     final var inactive =
         Optional.ofNullable(topology.getInactiveNodesForPartition(partitionId)).orElseGet(Set::of);
 
-    final var members = new IntHashSet(topology.getReplicationFactor());
-    members.add(leader);
+    final var members = new HashSet<String>(topology.getReplicationFactor());
+    if (leader != null) {
+      members.add(leader);
+    }
     members.addAll(followers);
     members.addAll(inactive);
 
     final var requests =
         members.stream()
             .map(
-                brokerId -> {
+                memberId -> {
                   final var request = new BrokerAdminRequest();
-                  request.setBrokerId(brokerId);
+                  request.setMemberId(memberId);
                   request.setPartitionId(partitionId);
                   configureRequest.accept(request);
                   return brokerClient.sendRequest(request);
@@ -104,22 +106,20 @@ public class ExportingControlService implements ExportingControlApi {
     for (final var partition : partitions) {
       final var leaderId = topology.getLeaderForPartition(partition);
 
-      if (leaderId == BrokerClusterState.UNKNOWN_NODE_ID
-          || leaderId == BrokerClusterState.NODE_ID_NULL) {
+      if (leaderId == null) {
         throw new IncompleteTopologyException(
-            "Leader %s of partition %s is not known, current topology: %s"
-                .formatted(leaderId, partition, topology));
+            "Leader of partition %s is not known, current topology: %s"
+                .formatted(partition, topology));
       }
 
       final var followers =
           Optional.ofNullable(topology.getFollowersForPartition(partition))
               .orElse(Collections.emptySet());
       for (final var follower : followers) {
-        if (follower == BrokerClusterState.UNKNOWN_NODE_ID
-            || follower == BrokerClusterState.NODE_ID_NULL) {
+        if (follower == null) {
           throw new IncompleteTopologyException(
-              "Follower %s of partition %s is not known, current topology: %s"
-                  .formatted(follower, partition, topology));
+              "Follower of partition %s is not known, current topology: %s"
+                  .formatted(partition, topology));
         }
       }
 

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterHealthIndicator.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterHealthIndicator.java
@@ -60,7 +60,7 @@ public class ClusterHealthIndicator implements HealthIndicator {
     final Map<String, PartitionHealthStatus> partitionDetails = new HashMap<>();
     partitions.forEach(
         partition -> {
-          final int broker = optClusterState.getLeaderForPartition(partition);
+          final String broker = optClusterState.getLeaderForPartition(partition);
           final PartitionHealthStatus partitionHealthStatus =
               optClusterState.getPartitionHealth(broker, partition);
           partitionDetails.put(String.format("Partition %d", partition), partitionHealthStatus);

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/PartitionLeaderAwarenessHealthIndicator.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/PartitionLeaderAwarenessHealthIndicator.java
@@ -37,9 +37,7 @@ public class PartitionLeaderAwarenessHealthIndicator implements HealthIndicator 
     } else {
       final var clusterState = optClusterState.get();
       if (clusterState.getPartitions().stream()
-          .anyMatch(
-              index ->
-                  clusterState.getLeaderForPartition(index) != BrokerClusterState.NODE_ID_NULL)) {
+          .anyMatch(index -> clusterState.getLeaderForPartition(index) != null)) {
         return Health.up().build();
       } else {
         return Health.down().build();

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/admin/exporting/ExportingControlServiceTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/admin/exporting/ExportingControlServiceTest.java
@@ -98,7 +98,7 @@ public class ExportingControlServiceTest {
     final var service = new ExportingControlService(client);
 
     // when
-    when(client.sendRequest(requestTo(1, 1))).thenThrow(new RuntimeException("request failed"));
+    when(client.sendRequest(requestTo(1, "1"))).thenThrow(new RuntimeException("request failed"));
 
     // then
     assertThatExceptionOfType(Throwable.class).isThrownBy(service::pauseExporting);
@@ -165,31 +165,33 @@ public class ExportingControlServiceTest {
       }
 
       @Override
-      public int getLeaderForPartition(final int partition) {
+      public String getLeaderForPartition(final int partition) {
         return Optional.ofNullable(topology.get(partition))
             .filter(brokers -> !brokers.isEmpty())
             .map(List::getFirst)
-            .orElse(NODE_ID_NULL);
+            .map(String::valueOf)
+            .orElse(null);
       }
 
       @Override
-      public Set<Integer> getFollowersForPartition(final int partition) {
+      public Set<String> getFollowersForPartition(final int partition) {
         return topology.getOrDefault(partition, List.of()).stream()
             .skip(1)
+            .map(String::valueOf)
             .collect(Collectors.toSet());
       }
 
       @Override
-      public Set<Integer> getInactiveNodesForPartition(final int partition) {
+      public Set<String> getInactiveNodesForPartition(final int partition) {
         final var members = topology.getOrDefault(partition, List.of());
 
         return getBrokers().stream()
-            .filter(broker -> !members.contains(broker))
+            .filter(broker -> !members.contains(Integer.parseInt(broker)))
             .collect(Collectors.toSet());
       }
 
       @Override
-      public int getRandomBroker() {
+      public String getRandomBroker() {
         throw new UnsupportedOperationException();
       }
 
@@ -199,22 +201,27 @@ public class ExportingControlServiceTest {
       }
 
       @Override
-      public List<Integer> getBrokers() {
-        return topology.values().stream().flatMap(Collection::stream).toList();
+      public List<String> getBrokers() {
+        return topology.values().stream().flatMap(Collection::stream).map(String::valueOf).toList();
       }
 
       @Override
-      public String getBrokerAddress(final int brokerId) {
+      public String getBrokerAddress(final String memberId) {
         throw new UnsupportedOperationException();
       }
 
       @Override
-      public String getBrokerVersion(final int brokerId) {
+      public String getBrokerVersion(final String memberId) {
         throw new UnsupportedOperationException();
       }
 
       @Override
-      public PartitionHealthStatus getPartitionHealth(final int brokerId, final int partition) {
+      public String getBrokerRegion(final String memberId) {
+        return null;
+      }
+
+      @Override
+      public PartitionHealthStatus getPartitionHealth(final String memberId, final int partition) {
         throw new UnsupportedOperationException();
       }
 
@@ -241,17 +248,17 @@ public class ExportingControlServiceTest {
     return ofTopology((int) brokers, partitions, replicationFactor, topology);
   }
 
-  record RequestMatcher(int partitionId, int brokerId)
+  record RequestMatcher(int partitionId, String memberId)
       implements ArgumentMatcher<BrokerRequest<Void>> {
 
-    static BrokerRequest<Void> requestTo(final int partitionId, final int brokerId) {
-      return argThat(new RequestMatcher(partitionId, brokerId));
+    static BrokerRequest<Void> requestTo(final int partitionId, final String memberId) {
+      return argThat(new RequestMatcher(partitionId, memberId));
     }
 
     @Override
     public boolean matches(final BrokerRequest<Void> argument) {
       return argument.getPartitionId() == partitionId
-          && argument.getBrokerId().orElseThrow() == brokerId;
+          && argument.getBrokerId().orElseThrow().equals(memberId);
     }
   }
 }

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterAwarenessHealthIndicatorTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterAwarenessHealthIndicatorTest.java
@@ -47,7 +47,7 @@ public class ClusterAwarenessHealthIndicatorTest {
   public void shouldReportUpIfListOfBrokersIsNotEmpty() {
     // given
     final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
-    when(mockClusterState.getBrokers()).thenReturn(List.of(1));
+    when(mockClusterState.getBrokers()).thenReturn(List.of("1"));
 
     final Supplier<Optional<BrokerClusterState>> stateSupplier =
         () -> Optional.of(mockClusterState);

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterHealthIndicatorTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterHealthIndicatorTest.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.gateway.impl.probes.health;
 
-import static io.camunda.zeebe.broker.client.api.BrokerClusterState.PARTITION_ID_NULL;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -49,7 +48,7 @@ public class ClusterHealthIndicatorTest {
   public void shouldReportDownIfListOfBrokersAnIsNotEmptyAndPartitionsIsEmpty() {
     // given
     final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
-    when(mockClusterState.getBrokers()).thenReturn(List.of(1));
+    when(mockClusterState.getBrokers()).thenReturn(List.of("1"));
     when(mockClusterState.getPartitions()).thenReturn(List.of());
 
     final Supplier<Optional<BrokerClusterState>> stateSupplier =
@@ -68,10 +67,10 @@ public class ClusterHealthIndicatorTest {
   public void shouldReportUpIfHasHealthyPartition() {
     // given
     final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
-    when(mockClusterState.getBrokers()).thenReturn(List.of(1));
+    when(mockClusterState.getBrokers()).thenReturn(List.of("1"));
     when(mockClusterState.getPartitions()).thenReturn(List.of(1));
-    when(mockClusterState.getLeaderForPartition(1)).thenReturn(1);
-    when(mockClusterState.getPartitionHealth(1, 1)).thenReturn(PartitionHealthStatus.HEALTHY);
+    when(mockClusterState.getLeaderForPartition(1)).thenReturn("1");
+    when(mockClusterState.getPartitionHealth("1", 1)).thenReturn(PartitionHealthStatus.HEALTHY);
 
     final Supplier<Optional<BrokerClusterState>> stateSupplier =
         () -> Optional.of(mockClusterState);
@@ -88,14 +87,14 @@ public class ClusterHealthIndicatorTest {
   @Test
   public void shouldReportDegradedIfMissingPartitions() {
     final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
-    when(mockClusterState.getBrokers()).thenReturn(List.of(1));
+    when(mockClusterState.getBrokers()).thenReturn(List.of("1"));
     when(mockClusterState.getPartitions()).thenReturn(List.of(1, 2, 3));
-    when(mockClusterState.getLeaderForPartition(1)).thenReturn(1);
-    when(mockClusterState.getLeaderForPartition(2)).thenReturn(2);
-    when(mockClusterState.getLeaderForPartition(3)).thenReturn(3);
-    when(mockClusterState.getPartitionHealth(1, 1)).thenReturn(PartitionHealthStatus.HEALTHY);
-    when(mockClusterState.getPartitionHealth(2, 2)).thenReturn(PartitionHealthStatus.HEALTHY);
-    when(mockClusterState.getPartitionHealth(3, 3)).thenReturn(PartitionHealthStatus.DEAD);
+    when(mockClusterState.getLeaderForPartition(1)).thenReturn("1");
+    when(mockClusterState.getLeaderForPartition(2)).thenReturn("2");
+    when(mockClusterState.getLeaderForPartition(3)).thenReturn("3");
+    when(mockClusterState.getPartitionHealth("1", 1)).thenReturn(PartitionHealthStatus.HEALTHY);
+    when(mockClusterState.getPartitionHealth("2", 2)).thenReturn(PartitionHealthStatus.HEALTHY);
+    when(mockClusterState.getPartitionHealth("3", 3)).thenReturn(PartitionHealthStatus.DEAD);
 
     final Supplier<Optional<BrokerClusterState>> stateSupplier =
         () -> Optional.of(mockClusterState);
@@ -112,14 +111,14 @@ public class ClusterHealthIndicatorTest {
   @Test
   public void shouldReportUnhealthyIfMissingPartitionsAndTheOthersDegraded() {
     final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
-    when(mockClusterState.getBrokers()).thenReturn(List.of(1));
+    when(mockClusterState.getBrokers()).thenReturn(List.of("1"));
     when(mockClusterState.getPartitions()).thenReturn(List.of(1, 2, 3));
-    when(mockClusterState.getLeaderForPartition(1)).thenReturn(1);
-    when(mockClusterState.getLeaderForPartition(2)).thenReturn(2);
-    when(mockClusterState.getLeaderForPartition(3)).thenReturn(3);
-    when(mockClusterState.getPartitionHealth(1, 1)).thenReturn(PartitionHealthStatus.UNHEALTHY);
-    when(mockClusterState.getPartitionHealth(2, 2)).thenReturn(PartitionHealthStatus.UNHEALTHY);
-    when(mockClusterState.getPartitionHealth(3, 3)).thenReturn(PartitionHealthStatus.DEAD);
+    when(mockClusterState.getLeaderForPartition(1)).thenReturn("1");
+    when(mockClusterState.getLeaderForPartition(2)).thenReturn("2");
+    when(mockClusterState.getLeaderForPartition(3)).thenReturn("3");
+    when(mockClusterState.getPartitionHealth("1", 1)).thenReturn(PartitionHealthStatus.UNHEALTHY);
+    when(mockClusterState.getPartitionHealth("2", 2)).thenReturn(PartitionHealthStatus.UNHEALTHY);
+    when(mockClusterState.getPartitionHealth("3", 3)).thenReturn(PartitionHealthStatus.DEAD);
 
     final Supplier<Optional<BrokerClusterState>> stateSupplier =
         () -> Optional.of(mockClusterState);
@@ -136,14 +135,14 @@ public class ClusterHealthIndicatorTest {
   @Test
   public void shouldReportDegradedIfSomePartitionsDontHaveLeader() {
     final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
-    when(mockClusterState.getBrokers()).thenReturn(List.of(1));
+    when(mockClusterState.getBrokers()).thenReturn(List.of("1"));
     when(mockClusterState.getPartitions()).thenReturn(List.of(1, 2, 3));
-    when(mockClusterState.getLeaderForPartition(1)).thenReturn(1);
-    when(mockClusterState.getLeaderForPartition(2)).thenReturn(2);
-    when(mockClusterState.getLeaderForPartition(3)).thenReturn(PARTITION_ID_NULL);
-    when(mockClusterState.getPartitionHealth(1, 1)).thenReturn(PartitionHealthStatus.HEALTHY);
-    when(mockClusterState.getPartitionHealth(2, 2)).thenReturn(PartitionHealthStatus.HEALTHY);
-    when(mockClusterState.getPartitionHealth(3, 3)).thenReturn(PartitionHealthStatus.UNHEALTHY);
+    when(mockClusterState.getLeaderForPartition(1)).thenReturn("1");
+    when(mockClusterState.getLeaderForPartition(2)).thenReturn("2");
+    when(mockClusterState.getLeaderForPartition(3)).thenReturn(null);
+    when(mockClusterState.getPartitionHealth("1", 1)).thenReturn(PartitionHealthStatus.HEALTHY);
+    when(mockClusterState.getPartitionHealth("2", 2)).thenReturn(PartitionHealthStatus.HEALTHY);
+    when(mockClusterState.getPartitionHealth(null, 3)).thenReturn(PartitionHealthStatus.UNHEALTHY);
 
     final Supplier<Optional<BrokerClusterState>> stateSupplier =
         () -> Optional.of(mockClusterState);

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/LivenessClusterAwarenessHealthIndicatorAutoConfigurationTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/LivenessClusterAwarenessHealthIndicatorAutoConfigurationTest.java
@@ -47,7 +47,7 @@ public class LivenessClusterAwarenessHealthIndicatorAutoConfigurationTest {
       shouldCreateHealthIndicatorThatReportsHealthBasedOnResultOfRegisteredClusterStateSupplier() {
     // given
     final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
-    when(mockClusterState.getBrokers()).thenReturn(List.of(1));
+    when(mockClusterState.getBrokers()).thenReturn(List.of("1"));
 
     final Supplier<Optional<BrokerClusterState>> stateSupplier =
         () -> Optional.of(mockClusterState);

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/LivenessPartitionLeaderAwarenessHealthIndicatorAutoConfigurationTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/LivenessPartitionLeaderAwarenessHealthIndicatorAutoConfigurationTest.java
@@ -49,7 +49,7 @@ public class LivenessPartitionLeaderAwarenessHealthIndicatorAutoConfigurationTes
     // given
     final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
     when(mockClusterState.getPartitions()).thenReturn(List.of(1));
-    when(mockClusterState.getLeaderForPartition(1)).thenReturn(42);
+    when(mockClusterState.getLeaderForPartition(1)).thenReturn("42");
 
     final Supplier<Optional<BrokerClusterState>> stateSupplier =
         () -> Optional.of(mockClusterState);

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/PartitionLeaderAwarenessHealthIndicatorTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/PartitionLeaderAwarenessHealthIndicatorTest.java
@@ -48,8 +48,8 @@ public class PartitionLeaderAwarenessHealthIndicatorTest {
     // given
     final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
     when(mockClusterState.getPartitions()).thenReturn(List.of(1, 2));
-    when(mockClusterState.getLeaderForPartition(1)).thenReturn(BrokerClusterState.NODE_ID_NULL);
-    when(mockClusterState.getLeaderForPartition(2)).thenReturn(42);
+    when(mockClusterState.getLeaderForPartition(1)).thenReturn(null);
+    when(mockClusterState.getLeaderForPartition(2)).thenReturn("42");
 
     final Supplier<Optional<BrokerClusterState>> stateSupplier =
         () -> Optional.of(mockClusterState);
@@ -86,8 +86,8 @@ public class PartitionLeaderAwarenessHealthIndicatorTest {
     // given
     final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
     when(mockClusterState.getPartitions()).thenReturn(List.of(1, 2));
-    when(mockClusterState.getLeaderForPartition(1)).thenReturn(BrokerClusterState.NODE_ID_NULL);
-    when(mockClusterState.getLeaderForPartition(2)).thenReturn(BrokerClusterState.NODE_ID_NULL);
+    when(mockClusterState.getLeaderForPartition(1)).thenReturn(null);
+    when(mockClusterState.getLeaderForPartition(2)).thenReturn(null);
 
     final Supplier<Optional<BrokerClusterState>> stateSupplier =
         () -> Optional.of(mockClusterState);

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -686,8 +686,9 @@ message TopologyResponse {
 }
 
 message BrokerInfo {
-  // unique (within a cluster) node ID for the broker
-  int32 nodeId = 1;
+  // unique (within a cluster) node ID for the broker; in region-aware clusters this includes the
+  // region prefix, e.g. "us-east1-0"
+  string nodeId = 1;
   // hostname of the broker
   string host = 2;
   // port for the broker
@@ -696,6 +697,8 @@ message BrokerInfo {
   repeated Partition partitions = 4;
   // broker version
   string version = 5;
+  // region the broker belongs to; empty string when not in a region-aware cluster
+  string region = 6;
 }
 
 message Partition {

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -686,9 +686,7 @@ message TopologyResponse {
 }
 
 message BrokerInfo {
-  // unique (within a cluster) node ID for the broker; in region-aware clusters this includes the
-  // region prefix, e.g. "us-east1-0"
-  string nodeId = 1;
+  reserved 1;
   // hostname of the broker
   string host = 2;
   // port for the broker
@@ -699,6 +697,8 @@ message BrokerInfo {
   string version = 5;
   // region the broker belongs to; empty string when not in a region-aware cluster
   string region = 6;
+  // it's region + nodeId populated by the broker. Do not use nodeId anymore.
+  string memberId = 7;
 }
 
 message Partition {

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
@@ -95,10 +95,9 @@ components:
         - version
       properties:
         nodeId:
-          description: The unique (within a cluster) node ID for the broker.
-          type: integer
-          format: int32
-          example: 0
+          description: The unique (within a cluster) node ID for the broker. In region-aware clusters this includes the region prefix, e.g. "us-east1-0".
+          type: string
+          example: "0"
         host:
           description: The hostname for reaching the broker.
           type: string

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/TopologyControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/TopologyControllerTest.java
@@ -93,23 +93,26 @@ public class TopologyControllerTest extends RestControllerTest {
         new Topology(
             List.of(
                 new Broker(
-                    0,
+                    "0",
                     "localhost",
                     26501,
                     List.of(new Partition(1, Role.LEADER, Health.HEALTHY)),
-                    version),
+                    version,
+                    null),
                 new Broker(
-                    1,
+                    "1",
                     "localhost",
                     26502,
                     List.of(new Partition(1, Role.FOLLOWER, Health.HEALTHY)),
-                    version),
+                    version,
+                    null),
                 new Broker(
-                    2,
+                    "2",
                     "localhost",
                     26503,
                     List.of(new Partition(1, Role.INACTIVE, Health.UNHEALTHY)),
-                    version)),
+                    version,
+                    null)),
             "cluster-id",
             3,
             1,

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/TopologyControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/TopologyControllerTest.java
@@ -46,7 +46,7 @@ public class TopologyControllerTest extends RestControllerTest {
           "lastCompletedChangeId": "1",
           "brokers": [
             {
-              "nodeId": 0,
+              "nodeId": "0",
               "host": "localhost",
               "port": 26501,
               "version": "%s",
@@ -59,7 +59,7 @@ public class TopologyControllerTest extends RestControllerTest {
               ]
             },
             {
-              "nodeId": 1,
+              "nodeId": "1",
               "host": "localhost",
               "port": 26502,
               "version": "%s",
@@ -72,7 +72,7 @@ public class TopologyControllerTest extends RestControllerTest {
               ]
             },
             {
-              "nodeId": 2,
+              "nodeId": "2",
               "host": "localhost",
               "port": 26503,
               "version": "%s",

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/TestBrokerClusterState.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/TestBrokerClusterState.java
@@ -22,13 +22,13 @@ import java.util.stream.IntStream;
 
 public final class TestBrokerClusterState implements BrokerClusterState {
 
-  private final Map<Integer, String> brokerAddresses = new HashMap<>();
-  private final Map<Integer, Tuple<Integer, Long>> partitionLeaders = new HashMap<>();
+  private final Map<String, String> brokerAddresses = new HashMap<>();
+  private final Map<Integer, Tuple<String, Long>> partitionLeaders = new HashMap<>();
   private final Set<Integer> partitions = new HashSet<>();
-  private final Map<Tuple<Integer, Integer>, PartitionHealthStatus> brokerPartitionHealthStatus =
+  private final Map<Tuple<String, Integer>, PartitionHealthStatus> brokerPartitionHealthStatus =
       new HashMap<>();
-  private final Map<Integer, Set<Integer>> inactivePartitionsToNodeIds = new HashMap<>();
-  private final Map<Integer, Set<Integer>> followerPartitionToNodeIds = new HashMap<>();
+  private final Map<Integer, Set<String>> inactivePartitionsToNodeIds = new HashMap<>();
+  private final Map<Integer, Set<String>> followerPartitionToNodeIds = new HashMap<>();
   private String clusterId = "";
 
   public TestBrokerClusterState() {
@@ -40,7 +40,7 @@ public final class TestBrokerClusterState implements BrokerClusterState {
         .forEach(
             pId -> {
               partitions.add(pId);
-              partitionLeaders.put(pId, Tuple.of(NODE_ID_NULL, 0L));
+              partitionLeaders.put(pId, Tuple.of(null, 0L));
               inactivePartitionsToNodeIds.put(pId, new HashSet<>());
               followerPartitionToNodeIds.put(pId, new HashSet<>());
             });
@@ -67,25 +67,25 @@ public final class TestBrokerClusterState implements BrokerClusterState {
   }
 
   @Override
-  public int getLeaderForPartition(final int partition) {
+  public String getLeaderForPartition(final int partition) {
     if (!partitionLeaders.containsKey(partition)) {
-      return NODE_ID_NULL;
+      return null;
     }
     return partitionLeaders.get(partition).getLeft();
   }
 
   @Override
-  public Set<Integer> getFollowersForPartition(final int partition) {
+  public Set<String> getFollowersForPartition(final int partition) {
     return followerPartitionToNodeIds.getOrDefault(partition, Set.of());
   }
 
   @Override
-  public Set<Integer> getInactiveNodesForPartition(final int partition) {
+  public Set<String> getInactiveNodesForPartition(final int partition) {
     return inactivePartitionsToNodeIds.getOrDefault(partition, Set.of());
   }
 
   @Override
-  public int getRandomBroker() {
+  public String getRandomBroker() {
     throw new UnsupportedOperationException();
   }
 
@@ -95,24 +95,29 @@ public final class TestBrokerClusterState implements BrokerClusterState {
   }
 
   @Override
-  public List<Integer> getBrokers() {
+  public List<String> getBrokers() {
     return new ArrayList<>(brokerAddresses.keySet());
   }
 
   @Override
-  public String getBrokerAddress(final int brokerId) {
-    return brokerAddresses.get(brokerId);
+  public String getBrokerAddress(final String memberId) {
+    return brokerAddresses.get(memberId);
   }
 
   @Override
-  public String getBrokerVersion(final int brokerId) {
+  public String getBrokerVersion(final String memberId) {
     return "1.0.0"; // Default version for testing purposes;
   }
 
   @Override
-  public PartitionHealthStatus getPartitionHealth(final int brokerId, final int partition) {
+  public String getBrokerRegion(final String memberId) {
+    return null;
+  }
+
+  @Override
+  public PartitionHealthStatus getPartitionHealth(final String memberId, final int partition) {
     return brokerPartitionHealthStatus.getOrDefault(
-        Tuple.of(brokerId, partition), PartitionHealthStatus.UNHEALTHY);
+        Tuple.of(memberId, partition), PartitionHealthStatus.UNHEALTHY);
   }
 
   @Override
@@ -130,11 +135,11 @@ public final class TestBrokerClusterState implements BrokerClusterState {
   }
 
   public void addBroker(final int nodeId, final String address) {
-    brokerAddresses.put(nodeId, address);
+    brokerAddresses.put(Integer.toString(nodeId), address);
   }
 
   public void setPartitionLeader(final int partitionId, final int leaderId, final long term) {
-    partitionLeaders.put(partitionId, Tuple.of(leaderId, term));
+    partitionLeaders.put(partitionId, Tuple.of(Integer.toString(leaderId), term));
   }
 
   public void addPartition(final int partitionId) {
@@ -143,10 +148,12 @@ public final class TestBrokerClusterState implements BrokerClusterState {
 
   public void setPartitionHealthStatus(
       final int nodeId, final int partitionId, final PartitionHealthStatus partitionHealthStatus) {
-    brokerPartitionHealthStatus.put(Tuple.of(nodeId, partitionId), partitionHealthStatus);
+    brokerPartitionHealthStatus.put(
+        Tuple.of(Integer.toString(nodeId), partitionId), partitionHealthStatus);
   }
 
   public void addPartitionInactive(final int partitionId, final int nodeId) {
+    final var memberId = Integer.toString(nodeId);
     addPartition(partitionId);
     inactivePartitionsToNodeIds.compute(
         partitionId,
@@ -154,7 +161,7 @@ public final class TestBrokerClusterState implements BrokerClusterState {
           if (value == null) {
             value = new HashSet<>();
           }
-          value.add(nodeId);
+          value.add(memberId);
           return value;
         });
     followerPartitionToNodeIds.compute(
@@ -163,7 +170,7 @@ public final class TestBrokerClusterState implements BrokerClusterState {
           if (value == null) {
             return null;
           }
-          value.remove(nodeId); // Ensure the node is not counted as a follower
+          value.remove(memberId); // Ensure the node is not counted as a follower
           return value;
         });
 
@@ -173,13 +180,14 @@ public final class TestBrokerClusterState implements BrokerClusterState {
   }
 
   public void addFollowerPartition(final int partitionId, final int nodeId) {
+    final var memberId = Integer.toString(nodeId);
     followerPartitionToNodeIds.compute(
         partitionId,
         (key, value) -> {
           if (value == null) {
             value = new HashSet<>();
           }
-          value.add(nodeId);
+          value.add(memberId);
           return value;
         });
   }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
@@ -135,7 +135,7 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
     if (nodeId == nodeIdNullValue()) {
       throw new IllegalStateException("nodeId is not set");
     }
-    return (region != null && !region.isEmpty()) ? region + "-" + nodeId : String.valueOf(nodeId);
+    return MemberIds.compose(region, nodeId);
   }
 
   /**
@@ -166,13 +166,9 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
   }
 
   private void parseAndSetCompositeNodeId(final String compositeNodeId) {
-    final int lastDash = compositeNodeId.lastIndexOf('-');
-    if (lastDash > 0) {
-      region = compositeNodeId.substring(0, lastDash);
-      nodeId = Integer.parseInt(compositeNodeId.substring(lastDash + 1));
-    } else {
-      nodeId = Integer.parseInt(compositeNodeId);
-    }
+    final MemberIds.Parsed parsed = MemberIds.parse(compositeNodeId);
+    region = parsed.region();
+    nodeId = parsed.localNodeId();
   }
 
   public String getRegion() {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
@@ -52,6 +52,7 @@ import org.slf4j.Logger;
 public final class BrokerInfo implements BufferReader, BufferWriter {
 
   private static final String BROKER_INFO_PROPERTY_NAME = "brokerInfo";
+  private static final String BROKER_REGION_PROPERTY_NAME = "brokerRegion";
   private static final DirectBuffer COMMAND_API_NAME = wrapString("commandApi");
 
   private static final Logger LOG = Loggers.PROTOCOL_LOGGER;
@@ -75,6 +76,7 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
   private int clusterSize;
   private int replicationFactor;
   private DirectBuffer version = new UnsafeBuffer();
+  private String region;
 
   public BrokerInfo() {
     reset();
@@ -93,6 +95,7 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
     replicationFactor = replicationFactorNullValue();
     addresses.clear();
     version.wrap(0, 0);
+    region = null;
     clearPartitions();
 
     return this;
@@ -179,6 +182,27 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
 
   public void setVersion(final DirectBuffer buffer, final int offset, final int length) {
     version.wrap(buffer, offset, length);
+  }
+
+  public String getRegion() {
+    return region;
+  }
+
+  /**
+   * Returns the composite member ID for this broker. In region-aware clusters this is {@code
+   * region-nodeId} (e.g. {@code us-east1-0}). In non-region-aware clusters this is the string
+   * representation of the integer node ID.
+   */
+  public String getMemberId() {
+    if (region != null && !region.isBlank()) {
+      return region + "-" + nodeId;
+    }
+    return String.valueOf(nodeId);
+  }
+
+  public BrokerInfo setRegion(final String region) {
+    this.region = region;
+    return this;
   }
 
   public Map<DirectBuffer, DirectBuffer> getAddresses() {
@@ -416,7 +440,9 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
   public static BrokerInfo fromProperties(final Properties properties) {
     final String property = properties.getProperty(BROKER_INFO_PROPERTY_NAME);
     if (property != null) {
-      return readFromString(property);
+      final BrokerInfo brokerInfo = readFromString(property);
+      brokerInfo.region = properties.getProperty(BROKER_REGION_PROPERTY_NAME);
+      return brokerInfo;
     } else {
       return null;
     }
@@ -433,6 +459,9 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
 
   public void writeIntoProperties(final Properties memberProperties) {
     memberProperties.setProperty(BROKER_INFO_PROPERTY_NAME, writeToString());
+    if (region != null) {
+      memberProperties.setProperty(BROKER_REGION_PROPERTY_NAME, region);
+    }
   }
 
   private String writeToString() {
@@ -499,6 +528,9 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
         + partitionHealthStatuses
         + ", version="
         + BufferUtil.bufferAsString(version)
+        + ", region='"
+        + region
+        + '\''
         + '}';
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.protocol.impl.encoding;
 
 import static io.camunda.zeebe.protocol.record.BrokerInfoEncoder.clusterSizeNullValue;
-import static io.camunda.zeebe.protocol.record.BrokerInfoEncoder.nodeIdNullValue;
 import static io.camunda.zeebe.protocol.record.BrokerInfoEncoder.partitionsCountNullValue;
 import static io.camunda.zeebe.protocol.record.BrokerInfoEncoder.replicationFactorNullValue;
 import static io.camunda.zeebe.protocol.record.BrokerInfoEncoder.versionHeaderLength;
@@ -52,7 +51,7 @@ import org.slf4j.Logger;
 public final class BrokerInfo implements BufferReader, BufferWriter {
 
   private static final String BROKER_INFO_PROPERTY_NAME = "brokerInfo";
-  private static final String BROKER_REGION_PROPERTY_NAME = "brokerRegion";
+  private static final String BROKER_NODE_ID_PROPERTY_NAME = "brokerNodeId";
   private static final DirectBuffer COMMAND_API_NAME = wrapString("commandApi");
 
   private static final Logger LOG = Loggers.PROTOCOL_LOGGER;
@@ -71,31 +70,34 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
   private final Map<Integer, Long> partitionLeaderTerms = new HashMap<>();
   private final Map<Integer, PartitionHealthStatus> partitionHealthStatuses = new HashMap<>();
 
-  private int nodeId;
+  private String nodeId;
   private int partitionsCount;
   private int clusterSize;
   private int replicationFactor;
   private DirectBuffer version = new UnsafeBuffer();
-  private String region;
 
   public BrokerInfo() {
     reset();
   }
 
-  public BrokerInfo(final int nodeId, final String commandApiAddress) {
+  public BrokerInfo(final String nodeId, final String commandApiAddress) {
     reset();
     this.nodeId = nodeId;
     setCommandApiAddress(BufferUtil.wrapString(commandApiAddress));
   }
 
+  /** Convenience constructor for non-region-aware clusters. */
+  public BrokerInfo(final int nodeId, final String commandApiAddress) {
+    this(String.valueOf(nodeId), commandApiAddress);
+  }
+
   public BrokerInfo reset() {
-    nodeId = nodeIdNullValue();
+    nodeId = null;
     partitionsCount = partitionsCountNullValue();
     clusterSize = clusterSizeNullValue();
     replicationFactor = replicationFactorNullValue();
     addresses.clear();
     version.wrap(0, 0);
-    region = null;
     clearPartitions();
 
     return this;
@@ -113,16 +115,36 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
     partitionHealthStatuses.remove(partitionId);
   }
 
-  public int getNodeId() {
-    if (nodeIdNullValue() == nodeId) {
+  /**
+   * Returns the node ID for this broker. In region-aware clusters this is the composite string
+   * {@code "region-localId"} (e.g. {@code "us-east1-0"}). In non-region-aware clusters this is the
+   * string representation of the integer node ID.
+   */
+  public String getNodeId() {
+    if (nodeId == null) {
       throw new IllegalStateException("nodeId is not set");
     }
     return nodeId;
   }
 
-  public BrokerInfo setNodeId(final int nodeId) {
+  public BrokerInfo setNodeId(final String nodeId) {
     this.nodeId = nodeId;
     return this;
+  }
+
+  /** Convenience overload for non-region-aware clusters. */
+  public BrokerInfo setNodeId(final int nodeId) {
+    return setNodeId(String.valueOf(nodeId));
+  }
+
+  /**
+   * Returns the numeric (local) node ID, which is unique within a region. Parses the trailing
+   * integer from the composite node ID string (e.g. {@code "us-east1-0"} → {@code 0}).
+   */
+  public int getLocalNodeId() {
+    final String id = getNodeId();
+    final int lastDash = id.lastIndexOf('-');
+    return Integer.parseInt(lastDash >= 0 ? id.substring(lastDash + 1) : id);
   }
 
   public int getPartitionsCount() {
@@ -182,27 +204,6 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
 
   public void setVersion(final DirectBuffer buffer, final int offset, final int length) {
     version.wrap(buffer, offset, length);
-  }
-
-  public String getRegion() {
-    return region;
-  }
-
-  /**
-   * Returns the composite member ID for this broker. In region-aware clusters this is {@code
-   * region-nodeId} (e.g. {@code us-east1-0}). In non-region-aware clusters this is the string
-   * representation of the integer node ID.
-   */
-  public String getMemberId() {
-    if (region != null && !region.isBlank()) {
-      return region + "-" + nodeId;
-    }
-    return String.valueOf(nodeId);
-  }
-
-  public BrokerInfo setRegion(final String region) {
-    this.region = region;
-    return this;
   }
 
   public Map<DirectBuffer, DirectBuffer> getAddresses() {
@@ -297,7 +298,7 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
 
     bodyDecoder.wrap(buffer, offset, headerDecoder.blockLength(), headerDecoder.version());
 
-    nodeId = bodyDecoder.nodeId();
+    nodeId = String.valueOf(bodyDecoder.nodeId());
     partitionsCount = bodyDecoder.partitionsCount();
     clusterSize = bodyDecoder.clusterSize();
     replicationFactor = bodyDecoder.replicationFactor();
@@ -384,7 +385,7 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
   public int write(final MutableDirectBuffer buffer, final int offset) {
     bodyEncoder
         .wrapAndApplyHeader(buffer, offset, headerEncoder)
-        .nodeId(nodeId)
+        .nodeId(getLocalNodeId())
         .partitionsCount(partitionsCount)
         .clusterSize(clusterSize)
         .replicationFactor(replicationFactor);
@@ -441,7 +442,13 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
     final String property = properties.getProperty(BROKER_INFO_PROPERTY_NAME);
     if (property != null) {
       final BrokerInfo brokerInfo = readFromString(property);
-      brokerInfo.region = properties.getProperty(BROKER_REGION_PROPERTY_NAME);
+      // Override the plain numeric nodeId from SBE with the full composite node ID (e.g.
+      // "region-localId") if the broker published one. Falls back to the SBE int for nodes
+      // that predate this field.
+      final String compositeNodeId = properties.getProperty(BROKER_NODE_ID_PROPERTY_NAME);
+      if (compositeNodeId != null) {
+        brokerInfo.nodeId = compositeNodeId;
+      }
       return brokerInfo;
     } else {
       return null;
@@ -459,8 +466,8 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
 
   public void writeIntoProperties(final Properties memberProperties) {
     memberProperties.setProperty(BROKER_INFO_PROPERTY_NAME, writeToString());
-    if (region != null) {
-      memberProperties.setProperty(BROKER_REGION_PROPERTY_NAME, region);
+    if (nodeId != null) {
+      memberProperties.setProperty(BROKER_NODE_ID_PROPERTY_NAME, nodeId);
     }
   }
 
@@ -512,8 +519,9 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
   @Override
   public String toString() {
     return "BrokerInfo{"
-        + "nodeId="
+        + "nodeId='"
         + nodeId
+        + '\''
         + ", partitionsCount="
         + partitionsCount
         + ", clusterSize="
@@ -528,9 +536,6 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
         + partitionHealthStatuses
         + ", version="
         + BufferUtil.bufferAsString(version)
-        + ", region='"
-        + region
-        + '\''
         + '}';
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
@@ -8,7 +8,9 @@
 package io.camunda.zeebe.protocol.impl.encoding;
 
 import static io.camunda.zeebe.protocol.record.BrokerInfoEncoder.clusterSizeNullValue;
+import static io.camunda.zeebe.protocol.record.BrokerInfoEncoder.nodeIdNullValue;
 import static io.camunda.zeebe.protocol.record.BrokerInfoEncoder.partitionsCountNullValue;
+import static io.camunda.zeebe.protocol.record.BrokerInfoEncoder.regionHeaderLength;
 import static io.camunda.zeebe.protocol.record.BrokerInfoEncoder.replicationFactorNullValue;
 import static io.camunda.zeebe.protocol.record.BrokerInfoEncoder.versionHeaderLength;
 import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
@@ -70,7 +72,8 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
   private final Map<Integer, Long> partitionLeaderTerms = new HashMap<>();
   private final Map<Integer, PartitionHealthStatus> partitionHealthStatuses = new HashMap<>();
 
-  private String nodeId;
+  private int nodeId;
+  private String region;
   private int partitionsCount;
   private int clusterSize;
   private int replicationFactor;
@@ -80,19 +83,27 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
     reset();
   }
 
-  public BrokerInfo(final String nodeId, final String commandApiAddress) {
+  /**
+   * Constructs a BrokerInfo from a composite node ID string. The composite string may be of the
+   * form {@code "region-localId"} (e.g. {@code "us-east1-0"}) for region-aware clusters, or a plain
+   * integer string for non-region-aware clusters.
+   */
+  public BrokerInfo(final String compositeNodeId, final String commandApiAddress) {
     reset();
-    this.nodeId = nodeId;
+    parseAndSetCompositeNodeId(compositeNodeId);
     setCommandApiAddress(BufferUtil.wrapString(commandApiAddress));
   }
 
   /** Convenience constructor for non-region-aware clusters. */
   public BrokerInfo(final int nodeId, final String commandApiAddress) {
-    this(String.valueOf(nodeId), commandApiAddress);
+    reset();
+    this.nodeId = nodeId;
+    setCommandApiAddress(BufferUtil.wrapString(commandApiAddress));
   }
 
   public BrokerInfo reset() {
-    nodeId = null;
+    nodeId = nodeIdNullValue();
+    region = null;
     partitionsCount = partitionsCountNullValue();
     clusterSize = clusterSizeNullValue();
     replicationFactor = replicationFactorNullValue();
@@ -121,30 +132,56 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
    * string representation of the integer node ID.
    */
   public String getNodeId() {
-    if (nodeId == null) {
+    if (nodeId == nodeIdNullValue()) {
+      throw new IllegalStateException("nodeId is not set");
+    }
+    return (region != null && !region.isEmpty()) ? region + "-" + nodeId : String.valueOf(nodeId);
+  }
+
+  /**
+   * Returns the numeric (local) node ID, which is unique within a region. In region-aware clusters
+   * this is the broker's position within its region (0-indexed). In non-region-aware clusters this
+   * equals the global node ID.
+   */
+  public int getLocalNodeId() {
+    if (nodeId == nodeIdNullValue()) {
       throw new IllegalStateException("nodeId is not set");
     }
     return nodeId;
   }
 
-  public BrokerInfo setNodeId(final String nodeId) {
+  public BrokerInfo setNodeId(final int nodeId) {
     this.nodeId = nodeId;
     return this;
   }
 
-  /** Convenience overload for non-region-aware clusters. */
-  public BrokerInfo setNodeId(final int nodeId) {
-    return setNodeId(String.valueOf(nodeId));
+  /**
+   * Sets the node ID from a composite string. The composite string may be of the form {@code
+   * "region-localId"} (e.g. {@code "us-east1-0"}) for region-aware clusters, or a plain integer
+   * string for non-region-aware clusters. Parses out the region and local node ID.
+   */
+  public BrokerInfo setNodeId(final String compositeNodeId) {
+    parseAndSetCompositeNodeId(compositeNodeId);
+    return this;
   }
 
-  /**
-   * Returns the numeric (local) node ID, which is unique within a region. Parses the trailing
-   * integer from the composite node ID string (e.g. {@code "us-east1-0"} → {@code 0}).
-   */
-  public int getLocalNodeId() {
-    final String id = getNodeId();
-    final int lastDash = id.lastIndexOf('-');
-    return Integer.parseInt(lastDash >= 0 ? id.substring(lastDash + 1) : id);
+  private void parseAndSetCompositeNodeId(final String compositeNodeId) {
+    final int lastDash = compositeNodeId.lastIndexOf('-');
+    if (lastDash > 0) {
+      region = compositeNodeId.substring(0, lastDash);
+      nodeId = Integer.parseInt(compositeNodeId.substring(lastDash + 1));
+    } else {
+      nodeId = Integer.parseInt(compositeNodeId);
+    }
+  }
+
+  public String getRegion() {
+    return region;
+  }
+
+  public BrokerInfo setRegion(final String region) {
+    this.region = region;
+    return this;
   }
 
   public int getPartitionsCount() {
@@ -298,7 +335,7 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
 
     bodyDecoder.wrap(buffer, offset, headerDecoder.blockLength(), headerDecoder.version());
 
-    nodeId = String.valueOf(bodyDecoder.nodeId());
+    nodeId = bodyDecoder.nodeId();
     partitionsCount = bodyDecoder.partitionsCount();
     clusterSize = bodyDecoder.clusterSize();
     replicationFactor = bodyDecoder.replicationFactor();
@@ -344,6 +381,17 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
           partitionHealthDecoder.partitionId(), partitionHealthDecoder.healthStatus());
     }
 
+    // region is sinceVersion=8; returns length=0 for messages encoded with an older schema version
+    final int regionLength = bodyDecoder.regionLength();
+    if (regionLength > 0) {
+      final byte[] regionBytes = new byte[regionLength];
+      bodyDecoder.getRegion(regionBytes, 0, regionLength);
+      region = new String(regionBytes, BASE_64_CHARSET);
+    } else {
+      bodyDecoder.skipRegion();
+      region = null;
+    }
+
     assert bodyDecoder.limit() == frameEnd
         : "Decoder read only to position "
             + bodyDecoder.limit()
@@ -354,6 +402,7 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
 
   @Override
   public int getLength() {
+    final int regionLength = region != null ? region.getBytes(BASE_64_CHARSET).length : 0;
     int length =
         headerEncoder.encodedLength()
             + bodyEncoder.sbeBlockLength()
@@ -362,7 +411,9 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
             + PartitionLeaderTermsEncoder.sbeHeaderSize()
             + PartitionHealthEncoder.sbeHeaderSize()
             + versionHeaderLength()
-            + version.capacity();
+            + version.capacity()
+            + regionHeaderLength()
+            + regionLength;
 
     for (final Entry<DirectBuffer, DirectBuffer> entry : addresses.entrySet()) {
       length +=
@@ -385,7 +436,7 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
   public int write(final MutableDirectBuffer buffer, final int offset) {
     bodyEncoder
         .wrapAndApplyHeader(buffer, offset, headerEncoder)
-        .nodeId(getLocalNodeId())
+        .nodeId(nodeId)
         .partitionsCount(partitionsCount)
         .clusterSize(clusterSize)
         .replicationFactor(replicationFactor);
@@ -435,6 +486,9 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
         partitionHealthEncoder.next().partitionId(entry.getKey()).healthStatus(entry.getValue());
       }
     }
+    final byte[] regionBytes = region != null ? region.getBytes(BASE_64_CHARSET) : new byte[0];
+    bodyEncoder.putRegion(regionBytes, 0, regionBytes.length);
+
     return headerEncoder.encodedLength() + bodyEncoder.encodedLength();
   }
 
@@ -442,17 +496,24 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
     final String property = properties.getProperty(BROKER_INFO_PROPERTY_NAME);
     if (property != null) {
       final BrokerInfo brokerInfo = readFromString(property);
-      // Override the plain numeric nodeId from SBE with the full composite node ID (e.g.
-      // "region-localId") if the broker published one. Falls back to the SBE int for nodes
-      // that predate this field.
-      final String compositeNodeId = properties.getProperty(BROKER_NODE_ID_PROPERTY_NAME);
-      if (compositeNodeId != null) {
-        brokerInfo.nodeId = compositeNodeId;
+      // Backward compat: if the SBE message did not carry a region (nodes still on schema v7),
+      // recover the region from the composite node-ID SWIM gossip property.
+      if (brokerInfo.region == null) {
+        brokerInfo.region =
+            parseRegionFromCompositeNodeId(properties.getProperty(BROKER_NODE_ID_PROPERTY_NAME));
       }
       return brokerInfo;
     } else {
       return null;
     }
+  }
+
+  private static String parseRegionFromCompositeNodeId(final String compositeNodeId) {
+    if (compositeNodeId == null) {
+      return null;
+    }
+    final int lastDash = compositeNodeId.lastIndexOf('-');
+    return lastDash > 0 ? compositeNodeId.substring(0, lastDash) : null;
   }
 
   private static BrokerInfo readFromString(final String property) {
@@ -466,8 +527,10 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
 
   public void writeIntoProperties(final Properties memberProperties) {
     memberProperties.setProperty(BROKER_INFO_PROPERTY_NAME, writeToString());
-    if (nodeId != null) {
-      memberProperties.setProperty(BROKER_NODE_ID_PROPERTY_NAME, nodeId);
+    // Also publish the composite node ID as a plain gossip property so that nodes still running
+    // schema v7 (which cannot decode the SBE region field) can still read the composite member ID.
+    if (nodeId != nodeIdNullValue()) {
+      memberProperties.setProperty(BROKER_NODE_ID_PROPERTY_NAME, getNodeId());
     }
   }
 
@@ -519,8 +582,10 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
   @Override
   public String toString() {
     return "BrokerInfo{"
-        + "nodeId='"
+        + "nodeId="
         + nodeId
+        + ", region='"
+        + region
         + '\''
         + ", partitionsCount="
         + partitionsCount

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/MemberIds.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/MemberIds.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.encoding;
+
+/**
+ * Utility for composing and parsing broker member ids.
+ *
+ * <p>A member id identifies a broker globally across the cluster. In region-aware clusters it has
+ * the form {@code "region-localId"} (e.g. {@code "us-east-1-0"}). In non-region-aware clusters it
+ * is the plain integer node id as a string. The local node id is unique within a region but may
+ * collide across regions, so the composite string is the only globally-unique identity.
+ */
+public final class MemberIds {
+
+  private MemberIds() {}
+
+  /**
+   * Composes a member id from a region and a local node id.
+   *
+   * @param region the region name, or {@code null}/empty for non-region-aware clusters
+   * @param localNodeId the node id, unique within the region
+   * @return {@code "region-localNodeId"} if a region is set, otherwise just the local node id as a
+   *     string
+   */
+  public static String compose(final String region, final int localNodeId) {
+    return (region == null || region.isEmpty())
+        ? Integer.toString(localNodeId)
+        : region + "-" + localNodeId;
+  }
+
+  /**
+   * Parses a composite member id into its region and local node id parts. The local node id is the
+   * integer after the last dash; everything before it is the region. If the string contains no
+   * dash, it is treated as a bare integer node id with no region.
+   *
+   * @param memberId the composite member id
+   * @return the parsed parts; {@link Parsed#region()} is {@code null} when no region is present
+   * @throws NumberFormatException if the local node id part is not an integer
+   */
+  public static Parsed parse(final String memberId) {
+    final int lastDash = memberId.lastIndexOf('-');
+    if (lastDash <= 0) {
+      return new Parsed(null, Integer.parseInt(memberId));
+    }
+    return new Parsed(
+        memberId.substring(0, lastDash), Integer.parseInt(memberId.substring(lastDash + 1)));
+  }
+
+  public record Parsed(String region, int localNodeId) {}
+}

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/BrokerInfoTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/BrokerInfoTest.java
@@ -56,7 +56,8 @@ final class BrokerInfoTest {
     final var decoded = encodeDecode(brokerInfo);
 
     // then
-    assertThat(decoded.getNodeId()).isEqualTo(nodeId);
+    assertThat(decoded.getNodeId()).isEqualTo(String.valueOf(nodeId));
+    assertThat(decoded.getLocalNodeId()).isEqualTo(nodeId);
     assertThat(decoded.getPartitionsCount()).isEqualTo(partitionsCount);
     assertThat(decoded.getClusterSize()).isEqualTo(clusterSize);
     assertThat(decoded.getReplicationFactor()).isEqualTo(replicationFactor);
@@ -84,7 +85,8 @@ final class BrokerInfoTest {
     final var decoded = encodeDecode(brokerInfo);
 
     // then
-    assertThat(decoded.getNodeId()).isEqualTo(nodeId);
+    assertThat(decoded.getNodeId()).isEqualTo(String.valueOf(nodeId));
+    assertThat(decoded.getLocalNodeId()).isEqualTo(nodeId);
     assertThat(decoded.getPartitionsCount()).isEqualTo(partitionsCount);
     assertThat(decoded.getClusterSize()).isEqualTo(clusterSize);
     assertThat(decoded.getReplicationFactor()).isEqualTo(replicationFactor);
@@ -94,29 +96,26 @@ final class BrokerInfoTest {
   }
 
   @Test
-  void shouldEncodeDecodeNullValues() {
+  void shouldThrowOnUnsetFields() {
     // given
     final BrokerInfo brokerInfo = new BrokerInfo();
 
-    // when
-    final var decoded = encodeDecode(brokerInfo);
-
     // then
     assertThatIllegalStateException()
-        .isThrownBy(decoded::getNodeId)
+        .isThrownBy(brokerInfo::getNodeId)
         .withMessageContaining("nodeId");
     assertThatIllegalStateException()
-        .isThrownBy(decoded::getPartitionsCount)
+        .isThrownBy(brokerInfo::getPartitionsCount)
         .withMessageContaining("partitionsCount");
     assertThatIllegalStateException()
-        .isThrownBy(decoded::getClusterSize)
+        .isThrownBy(brokerInfo::getClusterSize)
         .withMessageContaining("clusterSize");
     assertThatIllegalStateException()
-        .isThrownBy(decoded::getReplicationFactor)
+        .isThrownBy(brokerInfo::getReplicationFactor)
         .withMessageContaining("replicationFactor");
-    assertThat(decoded.getAddresses()).isEmpty();
-    assertThat(decoded.getPartitionRoles()).isEmpty();
-    assertThat(decoded.getPartitionHealthStatuses()).isEmpty();
+    assertThat(brokerInfo.getAddresses()).isEmpty();
+    assertThat(brokerInfo.getPartitionRoles()).isEmpty();
+    assertThat(brokerInfo.getPartitionHealthStatuses()).isEmpty();
   }
 
   private BrokerInfo encodeDecode(final BrokerInfo brokerInfo) {

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/BrokerInfoTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/BrokerInfoTest.java
@@ -55,9 +55,10 @@ final class BrokerInfoTest {
     // when
     final var decoded = encodeDecode(brokerInfo);
 
-    // then
-    assertThat(decoded.getNodeId()).isEqualTo(String.valueOf(nodeId));
+    // then — the int node ID round-trips correctly; no region was set
     assertThat(decoded.getLocalNodeId()).isEqualTo(nodeId);
+    assertThat(decoded.getNodeId()).isEqualTo(String.valueOf(nodeId));
+    assertThat(decoded.getRegion()).isNull();
     assertThat(decoded.getPartitionsCount()).isEqualTo(partitionsCount);
     assertThat(decoded.getClusterSize()).isEqualTo(clusterSize);
     assertThat(decoded.getReplicationFactor()).isEqualTo(replicationFactor);
@@ -85,8 +86,8 @@ final class BrokerInfoTest {
     final var decoded = encodeDecode(brokerInfo);
 
     // then
-    assertThat(decoded.getNodeId()).isEqualTo(String.valueOf(nodeId));
     assertThat(decoded.getLocalNodeId()).isEqualTo(nodeId);
+    assertThat(decoded.getNodeId()).isEqualTo(String.valueOf(nodeId));
     assertThat(decoded.getPartitionsCount()).isEqualTo(partitionsCount);
     assertThat(decoded.getClusterSize()).isEqualTo(clusterSize);
     assertThat(decoded.getReplicationFactor()).isEqualTo(replicationFactor);
@@ -116,6 +117,77 @@ final class BrokerInfoTest {
     assertThat(brokerInfo.getAddresses()).isEmpty();
     assertThat(brokerInfo.getPartitionRoles()).isEmpty();
     assertThat(brokerInfo.getPartitionHealthStatuses()).isEmpty();
+  }
+
+  @Test
+  void shouldEncodeDecodeBrokerInfoWithRegion() {
+    // given — a region-aware broker with composite node ID "us-east1-0"
+    final int localNodeId = 0;
+    final String region = "us-east1";
+
+    final BrokerInfo brokerInfo =
+        new BrokerInfo()
+            .setNodeId(localNodeId)
+            .setRegion(region)
+            .setPartitionsCount(3)
+            .setClusterSize(4)
+            .setReplicationFactor(4);
+
+    // when
+    final var decoded = encodeDecode(brokerInfo);
+
+    // then — the composite node ID is composed from region + local node ID
+    assertThat(decoded.getLocalNodeId()).isEqualTo(localNodeId);
+    assertThat(decoded.getRegion()).isEqualTo(region);
+    assertThat(decoded.getNodeId()).isEqualTo(region + "-" + localNodeId);
+  }
+
+  @Test
+  void shouldComposeCompositeNodeIdFromRegionAndLocalId() {
+    // given — two brokers in different regions with the same local node ID (0)
+    final BrokerInfo eastBroker =
+        new BrokerInfo()
+            .setNodeId(0)
+            .setRegion("us-east1")
+            .setPartitionsCount(1)
+            .setClusterSize(2)
+            .setReplicationFactor(1);
+    final BrokerInfo westBroker =
+        new BrokerInfo()
+            .setNodeId(0)
+            .setRegion("us-west1")
+            .setPartitionsCount(1)
+            .setClusterSize(2)
+            .setReplicationFactor(1);
+
+    // when
+    final var decodedEast = encodeDecode(eastBroker);
+    final var decodedWest = encodeDecode(westBroker);
+
+    // then — composite node IDs are globally unique even though local IDs are the same
+    assertThat(decodedEast.getNodeId()).isEqualTo("us-east1-0");
+    assertThat(decodedWest.getNodeId()).isEqualTo("us-west1-0");
+    assertThat(decodedEast.getNodeId()).isNotEqualTo(decodedWest.getNodeId());
+    assertThat(decodedEast.getLocalNodeId()).isEqualTo(decodedWest.getLocalNodeId());
+  }
+
+  @Test
+  void shouldParseCompositeNodeIdViaSetNodeIdString() {
+    // given — composite string set via setNodeId(String)
+    final BrokerInfo brokerInfo =
+        new BrokerInfo()
+            .setNodeId("us-east1-2")
+            .setPartitionsCount(1)
+            .setClusterSize(2)
+            .setReplicationFactor(1);
+
+    // when
+    final var decoded = encodeDecode(brokerInfo);
+
+    // then
+    assertThat(decoded.getNodeId()).isEqualTo("us-east1-2");
+    assertThat(decoded.getLocalNodeId()).isEqualTo(2);
+    assertThat(decoded.getRegion()).isEqualTo("us-east1");
   }
 
   private BrokerInfo encodeDecode(final BrokerInfo brokerInfo) {

--- a/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/commandapi/CommandApiRule.java
+++ b/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/commandapi/CommandApiRule.java
@@ -87,7 +87,9 @@ public final class CommandApiRule extends ExternalResource {
     final var outputAdapter = createClientTransport();
 
     final var broker =
-        getBrokerInfoStream().filter(brokerInfo -> brokerInfo.getNodeId() == nodeId).findFirst();
+        getBrokerInfoStream()
+            .filter(brokerInfo -> String.valueOf(nodeId).equals(brokerInfo.getNodeId()))
+            .findFirst();
 
     if (broker.isPresent()) {
       final var brokerInfo = broker.get();

--- a/zeebe/protocol/pom.xml
+++ b/zeebe/protocol/pom.xml
@@ -25,7 +25,7 @@
   <properties>
     <version.java>8</version.java>
     <license.header.file>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header.file>
-    <protocol.version>7</protocol.version>
+    <protocol.version>8</protocol.version>
   </properties>
 
   <dependencies>

--- a/zeebe/protocol/src/main/resources/protocol.xml
+++ b/zeebe/protocol/src/main/resources/protocol.xml
@@ -217,5 +217,6 @@
       <field name="healthStatus" id="17" type="PartitionHealthStatus"/>
     </group>
     <data name="version" id="14" type="varDataEncoding"/>
+    <data name="region" id="18" type="varDataEncoding" sinceVersion="8"/>
   </sbe:message>
 </sbe:messageSchema>

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/BrokerLeaderChangeTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/BrokerLeaderChangeTest.java
@@ -68,6 +68,6 @@ public final class BrokerLeaderChangeTest {
 
     // then
     assertThat(clusteringRule.getCurrentLeaderForPartition(1).getNodeId())
-        .isEqualTo(firstLeaderNodeId);
+        .isEqualTo(Integer.parseInt(firstLeaderNodeId));
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/BrokerLeaderChangeTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/BrokerLeaderChangeTest.java
@@ -41,7 +41,8 @@ public final class BrokerLeaderChangeTest {
   public void shouldBecomeFollowerAfterRestart() {
     // given
     final int partition = Protocol.START_PARTITION_ID;
-    final int oldLeader = clusteringRule.getLeaderForPartition(partition).getNodeId();
+    final int oldLeader =
+        Integer.parseInt(clusteringRule.getLeaderForPartition(partition).getNodeId());
     clusteringRule.stopBrokerAndAwaitNewLeader(oldLeader);
 
     // when
@@ -50,7 +51,7 @@ public final class BrokerLeaderChangeTest {
     // then
     final Stream<PartitionInfo> partitionInfo =
         clusteringRule.getTopologyFromClient().getBrokers().stream()
-            .filter(b -> b.getNodeId() == oldLeader)
+            .filter(b -> b.getNodeId().equals(String.valueOf(oldLeader)))
             .flatMap(b -> b.getPartitions().stream().filter(p -> p.getPartitionId() == partition));
 
     assertThat(partitionInfo).noneMatch(PartitionInfo::isLeader);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusteringRule.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusteringRule.java
@@ -315,6 +315,10 @@ public class ClusteringRule extends ExternalResource {
     return brokers.computeIfAbsent(nodeId, this::createBroker);
   }
 
+  public Broker getBroker(final String nodeId) {
+    return getBroker(Integer.parseInt(nodeId));
+  }
+
   private CompletableFuture<Void> startBrokers() {
     //noinspection resource
     final var brokerStartFutures =
@@ -599,6 +603,14 @@ public class ClusteringRule extends ExternalResource {
     startBroker(nodeId);
   }
 
+  public void restartBroker(final String nodeId) {
+    restartBroker(Integer.parseInt(nodeId));
+  }
+
+  public void startBroker(final String nodeId) {
+    startBroker(Integer.parseInt(nodeId));
+  }
+
   public void startBroker(final int nodeId) {
     final var broker = Objects.requireNonNull(getBroker(nodeId), "must get existing broker");
     //noinspection resource
@@ -639,13 +651,17 @@ public class ClusteringRule extends ExternalResource {
   }
 
   public BrokerInfo awaitOtherLeader(final int partitionId, final int previousLeader) {
+    return awaitOtherLeader(partitionId, String.valueOf(previousLeader));
+  }
+
+  public BrokerInfo awaitOtherLeader(final int partitionId, final String previousLeader) {
     return Awaitility.await()
         .pollInterval(Duration.ofMillis(100))
         .atMost(Duration.ofMinutes(1))
         .ignoreExceptions()
         .until(
             () -> getLeaderForPartition(partitionId),
-            (leader) -> leader.getNodeId() != previousLeader);
+            (leader) -> !leader.getNodeId().equals(previousLeader));
   }
 
   public void stepDown(final Broker broker, final int partitionId) {
@@ -686,6 +702,14 @@ public class ClusteringRule extends ExternalResource {
           assertion ->
               assertion.doesNotContainBroker(nodeId).hasLeaderForEachPartition(partitionCount));
     }
+  }
+
+  public void stopBrokerAndAwaitNewLeader(final String nodeId) {
+    stopBrokerAndAwaitNewLeader(Integer.parseInt(nodeId));
+  }
+
+  public void stopBroker(final String nodeId) {
+    stopBroker(Integer.parseInt(nodeId));
   }
 
   public void stopBroker(final int nodeId) {
@@ -731,13 +755,17 @@ public class ClusteringRule extends ExternalResource {
               assertThat(serverOfExpectedLeader.promote())
                   .describedAs("Promote request is successful")
                   .succeedsWithin(Duration.ofSeconds(15));
-              final int currentLeaderId = getLeaderForPartition(partitionId).getNodeId();
+              final String currentLeaderId = getLeaderForPartition(partitionId).getNodeId();
               assertThat(currentLeaderId)
                   .withFailMessage(
-                      "Expected the leader of partition %d to be %d, but was %d",
+                      "Expected the leader of partition %d to be %d, but was %s",
                       partitionId, expectedLeaderId, currentLeaderId)
-                  .isEqualTo(expectedLeaderId);
+                  .isEqualTo(String.valueOf(expectedLeaderId));
             });
+  }
+
+  public void forceNewLeaderForPartition(final String expectedLeaderId, final int partitionId) {
+    forceNewLeaderForPartition(Integer.parseInt(expectedLeaderId), partitionId);
   }
 
   public void waitForTopology(final Consumer<TopologyAssert> assertions) {
@@ -806,6 +834,10 @@ public class ClusteringRule extends ExternalResource {
         .filter(id -> id != leaderNodeId)
         .map(brokers::get)
         .collect(Collectors.toList());
+  }
+
+  public List<Broker> getOtherBrokerObjects(final String leaderNodeId) {
+    return getOtherBrokerObjects(Integer.parseInt(leaderNodeId));
   }
 
   public Path getSegmentsDirectory(final Broker broker) {
@@ -991,7 +1023,8 @@ public class ClusteringRule extends ExternalResource {
   public int stopAnyFollower() {
     final var leaderForPartition = getLeaderForPartition(START_PARTITION_ID);
 
-    final var otherBrokerObjects = getOtherBrokerObjects(leaderForPartition.getNodeId());
+    final var otherBrokerObjects =
+        getOtherBrokerObjects(Integer.parseInt(leaderForPartition.getNodeId()));
     final var nodeId = otherBrokerObjects.get(0).getConfig().getCluster().getNodeId();
     stopBroker(nodeId);
     return nodeId;

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/FailOverReplicationTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/FailOverReplicationTest.java
@@ -173,7 +173,10 @@ public class FailOverReplicationTest {
     final List<Broker> followers = clusteringRule.getOtherBrokerObjects(newLeaderId);
     final var followerA =
         followers.stream()
-            .filter(broker -> broker.getConfig().getCluster().getNodeId() != previousLeaderId)
+            .filter(
+                broker ->
+                    broker.getConfig().getCluster().getNodeId()
+                        != Integer.parseInt(previousLeaderId))
             .findFirst()
             .orElseThrow();
 
@@ -193,7 +196,7 @@ public class FailOverReplicationTest {
     clusteringRule.waitForSnapshotAtBroker(previousLeader);
     final var nextLeader = clusteringRule.awaitOtherLeader(1, newLeaderId);
 
-    assertThat(nextLeader.getNodeId()).isEqualTo(getNodeId(followerA));
+    assertThat(nextLeader.getNodeId()).isEqualTo(String.valueOf(getNodeId(followerA)));
     clusteringRule.waitForSnapshotAtBroker(previousLeader);
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/MultiRegionClusterIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/MultiRegionClusterIT.java
@@ -18,7 +18,6 @@ import io.camunda.zeebe.broker.system.configuration.partitioning.RegionCfg;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.cluster.TestZeebePort;
 import java.time.Duration;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.awaitility.Awaitility;
@@ -222,21 +221,19 @@ final class MultiRegionClusterIT {
    */
   private static RegionAwareCfg buildRegionAwareCfg() {
     final var east = new RegionCfg();
+    east.setName(REGION_EAST);
     east.setNumberOfBrokers(1);
     east.setNumberOfReplicas(1);
     east.setPriority(1000);
 
     final var west = new RegionCfg();
+    west.setName(REGION_WEST);
     west.setNumberOfBrokers(1);
     west.setNumberOfReplicas(1);
     west.setPriority(500);
 
-    final var regions = new LinkedHashMap<String, RegionCfg>();
-    regions.put(REGION_EAST, east);
-    regions.put(REGION_WEST, west);
-
     final var cfg = new RegionAwareCfg();
-    cfg.setRegions(regions);
+    cfg.setRegions(List.of(east, west));
     return cfg;
   }
 
@@ -246,21 +243,19 @@ final class MultiRegionClusterIT {
    */
   private static RegionAwareCfg buildMultiBrokerRegionAwareCfg() {
     final var east = new RegionCfg();
+    east.setName(REGION_EAST);
     east.setNumberOfBrokers(2);
     east.setNumberOfReplicas(1);
     east.setPriority(1000);
 
     final var west = new RegionCfg();
+    west.setName(REGION_WEST);
     west.setNumberOfBrokers(2);
     west.setNumberOfReplicas(1);
     west.setPriority(500);
 
-    final var regions = new LinkedHashMap<String, RegionCfg>();
-    regions.put(REGION_EAST, east);
-    regions.put(REGION_WEST, west);
-
     final var cfg = new RegionAwareCfg();
-    cfg.setRegions(regions);
+    cfg.setRegions(List.of(east, west));
     return cfg;
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/MultiRegionClusterIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/MultiRegionClusterIT.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.cluster.clustering;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.api.response.BrokerInfo;
+import io.camunda.client.api.response.PartitionInfo;
+import io.camunda.configuration.Partitioning;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.zeebe.broker.system.configuration.partitioning.RegionAwareCfg;
+import io.camunda.zeebe.broker.system.configuration.partitioning.RegionCfg;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.cluster.TestZeebePort;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration test verifying that brokers in different regions can form a cluster and communicate
+ * with each other.
+ *
+ * <p>Sets up a two-region cluster where each region has a single broker:
+ *
+ * <ul>
+ *   <li>Region {@code "us-east1"}: global nodeId=0, local nodeId=0, composite member ID {@code
+ *       "us-east1-0"}
+ *   <li>Region {@code "us-west1"}: global nodeId=1, local nodeId=0, composite member ID {@code
+ *       "us-west1-0"} — started with the east broker's cluster address as its initial contact point
+ * </ul>
+ *
+ * <p>Node IDs are assigned as globally unique integers across the cluster. {@link
+ * io.camunda.zeebe.broker.clustering.ClusterConfigFactory} converts a broker's global nodeId to a
+ * local (region-scoped) nodeId by subtracting the cumulative broker count of all preceding regions:
+ * east (offset=0) produces {@code "us-east1-0"}, west (global=1, offset=1) produces {@code
+ * "us-west1-0"}. {@link
+ * io.camunda.zeebe.broker.partitioning.topology.StaticConfigurationGenerator} always uses local IDs
+ * 0..N-1 per region, so the two member ID namespaces are consistent.
+ *
+ * <p>The test verifies:
+ *
+ * <ol>
+ *   <li>The cluster forms successfully — both brokers see each other and the single partition
+ *       elects a leader across the two regions.
+ *   <li>The topology API exposes the composite member IDs to clients.
+ *   <li>Each broker has the correct region propagated into its runtime configuration.
+ * </ol>
+ */
+final class MultiRegionClusterIT {
+
+  private static final String REGION_EAST = "us-east1";
+  private static final String REGION_WEST = "us-west1";
+
+  @AutoClose private TestStandaloneBroker brokerEast;
+  @AutoClose private TestStandaloneBroker brokerWest;
+
+  @Test
+  void shouldFormClusterAcrossRegions() {
+    // given — shared region config listing both regions, one broker each
+    final var regionAwareCfg = buildRegionAwareCfg();
+
+    // east broker uses global nodeId=0 — start it first as the SWIM seed node
+    brokerEast = createBroker(0, REGION_EAST, regionAwareCfg, List.of());
+    CompletableFuture.runAsync(() -> brokerEast.start());
+
+    // west broker uses global nodeId=1 — contact points set to east's cluster address
+    brokerWest =
+        createBroker(
+            1, REGION_WEST, regionAwareCfg, List.of(brokerEast.address(TestZeebePort.CLUSTER)));
+    brokerWest.start();
+
+    // when — wait for both brokers to form the cluster and elect a leader for partition 1
+    try (final var client = brokerEast.newClientBuilder().build()) {
+      Awaitility.await("cluster of 2 brokers to form across regions")
+          .atMost(Duration.ofSeconds(60))
+          .untilAsserted(
+              () -> {
+                final var topology = client.newTopologyRequest().send().join();
+                assertThat(topology.getBrokers()).hasSize(2);
+                assertThat(topology.getBrokers())
+                    .flatExtracting(BrokerInfo::getPartitions)
+                    .filteredOn(PartitionInfo::isLeader)
+                    .extracting(PartitionInfo::getPartitionId)
+                    .containsExactly(1);
+              });
+
+      // then — composite member IDs (region-localNodeId) are exposed to clients
+      final var topology = client.newTopologyRequest().execute();
+      assertThat(topology.getBrokers())
+          .extracting(BrokerInfo::getNodeId)
+          .containsExactlyInAnyOrder(REGION_EAST + "-0", REGION_WEST + "-0");
+    }
+
+    // and — each broker carries the correct region in its runtime config
+    assertThat(brokerEast.bean(BrokerBasedProperties.class).getCluster().getRegion())
+        .isEqualTo(REGION_EAST);
+    assertThat(brokerWest.bean(BrokerBasedProperties.class).getCluster().getRegion())
+        .isEqualTo(REGION_WEST);
+  }
+
+  /**
+   * Creates a broker configured for region-aware mode.
+   *
+   * <p>Node IDs are globally unique integers: east uses {@code nodeId=0}, west uses {@code
+   * nodeId=1}. {@link io.camunda.zeebe.broker.clustering.ClusterConfigFactory} derives the local
+   * node ID by subtracting the cumulative broker count of preceding regions, producing {@code
+   * "us-east1-0"} and {@code "us-west1-0"} — consistent with what {@link
+   * io.camunda.zeebe.broker.partitioning.topology.StaticConfigurationGenerator} generates using
+   * per-region 0-indexed IDs.
+   */
+  private static TestStandaloneBroker createBroker(
+      final int nodeId,
+      final String region,
+      final RegionAwareCfg regionAwareCfg,
+      final List<String> contactPoints) {
+    return new TestStandaloneBroker()
+        .withUnifiedConfig(
+            cfg -> {
+              cfg.getCluster().setNodeId(nodeId);
+              cfg.getCluster().setRegion(region);
+              cfg.getCluster().setSize(2);
+              cfg.getCluster().setPartitionCount(1);
+              cfg.getCluster().setReplicationFactor(2);
+              if (!contactPoints.isEmpty()) {
+                cfg.getCluster().setInitialContactPoints(contactPoints);
+              }
+
+              final var partitioning = new Partitioning();
+              partitioning.setScheme(Partitioning.Scheme.REGION_AWARE);
+              partitioning.setRegionAware(regionAwareCfg);
+              cfg.getCluster().setPartitioning(partitioning);
+            });
+  }
+
+  /**
+   * Builds the shared {@link RegionAwareCfg} listing both regions with one broker and replica each.
+   * East has higher priority so it hosts the preferred partition leader.
+   */
+  private static RegionAwareCfg buildRegionAwareCfg() {
+    final var east = new RegionCfg();
+    east.setNumberOfBrokers(1);
+    east.setNumberOfReplicas(1);
+    east.setPriority(1000);
+
+    final var west = new RegionCfg();
+    west.setNumberOfBrokers(1);
+    west.setNumberOfReplicas(1);
+    west.setPriority(500);
+
+    final var regions = new LinkedHashMap<String, RegionCfg>();
+    regions.put(REGION_EAST, east);
+    regions.put(REGION_WEST, west);
+
+    final var cfg = new RegionAwareCfg();
+    cfg.setRegions(regions);
+    return cfg;
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/MultiRegionClusterIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/MultiRegionClusterIT.java
@@ -42,9 +42,8 @@ import org.junit.jupiter.api.Test;
  * io.camunda.zeebe.broker.clustering.ClusterConfigFactory} converts a broker's global nodeId to a
  * local (region-scoped) nodeId by subtracting the cumulative broker count of all preceding regions:
  * east (offset=0) produces {@code "us-east1-0"}, west (global=1, offset=1) produces {@code
- * "us-west1-0"}. {@link
- * io.camunda.zeebe.broker.partitioning.topology.StaticConfigurationGenerator} always uses local IDs
- * 0..N-1 per region, so the two member ID namespaces are consistent.
+ * "us-west1-0"}. {@link io.camunda.zeebe.broker.partitioning.topology.StaticConfigurationGenerator}
+ * always uses local IDs 0..N-1 per region, so the two member ID namespaces are consistent.
  *
  * <p>The test verifies:
  *
@@ -75,8 +74,10 @@ final class MultiRegionClusterIT {
     // west broker uses global nodeId=1 — contact points set to east's cluster address
     brokerWest =
         createBroker(
-            1, REGION_WEST, regionAwareCfg, List.of(brokerEast.address(TestZeebePort.CLUSTER)));
-    brokerWest.start();
+            0, REGION_WEST, regionAwareCfg, List.of(brokerEast.address(TestZeebePort.CLUSTER)));
+    CompletableFuture.runAsync(() -> brokerWest.start());
+
+    Awaitility.await().until(() -> brokerWest.isStarted());
 
     // when — wait for both brokers to form the cluster and elect a leader for partition 1
     try (final var client = brokerEast.newClientBuilder().build()) {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/MultiRegionClusterIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/MultiRegionClusterIT.java
@@ -62,6 +62,12 @@ final class MultiRegionClusterIT {
   @AutoClose private TestStandaloneBroker brokerEast;
   @AutoClose private TestStandaloneBroker brokerWest;
 
+  // used by shouldFormClusterWithMultipleBrokersPerRegion
+  @AutoClose private TestStandaloneBroker broker0East;
+  @AutoClose private TestStandaloneBroker broker1East;
+  @AutoClose private TestStandaloneBroker broker0West;
+  @AutoClose private TestStandaloneBroker broker1West;
+
   @Test
   void shouldFormClusterAcrossRegions() {
     // given — shared region config listing both regions, one broker each
@@ -109,6 +115,64 @@ final class MultiRegionClusterIT {
   }
 
   /**
+   * Verifies that a region-aware cluster works correctly when each region hosts more than one
+   * broker. This exercises the {@code LiveClusterState} sorted-index key assignment, which must
+   * assign globally unique integer keys to brokers even when two brokers in different regions share
+   * the same local node ID (e.g. {@code "us-east1-0"} and {@code "us-west1-0"} both have local ID
+   * {@code 0}).
+   *
+   * <p>Sets up two regions with two brokers each (4 brokers total, 2 partitions):
+   *
+   * <ul>
+   *   <li>{@code "us-east1-0"}, {@code "us-east1-1"}
+   *   <li>{@code "us-west1-0"}, {@code "us-west1-1"}
+   * </ul>
+   */
+  @Test
+  void shouldFormClusterWithMultipleBrokersPerRegion() {
+    // given — 2 brokers per region, 2 partitions, 1 replica per region per partition
+    final var regionAwareCfg = buildMultiBrokerRegionAwareCfg();
+
+    broker0East = createBroker(0, REGION_EAST, regionAwareCfg, 4, 2, List.of());
+    CompletableFuture.runAsync(() -> broker0East.start());
+
+    final var eastSeedAddress = broker0East.address(TestZeebePort.CLUSTER);
+    broker1East = createBroker(1, REGION_EAST, regionAwareCfg, 4, 2, List.of(eastSeedAddress));
+    broker0West = createBroker(0, REGION_WEST, regionAwareCfg, 4, 2, List.of(eastSeedAddress));
+    broker1West = createBroker(1, REGION_WEST, regionAwareCfg, 4, 2, List.of(eastSeedAddress));
+    CompletableFuture.runAsync(() -> broker1East.start());
+    CompletableFuture.runAsync(() -> broker0West.start());
+    CompletableFuture.runAsync(() -> broker1West.start());
+
+    Awaitility.await()
+        .until(() -> broker1East.isStarted() && broker0West.isStarted() && broker1West.isStarted());
+
+    // when — wait for all 4 brokers to form the cluster and elect leaders for both partitions
+    try (final var client = broker0East.newClientBuilder().build()) {
+      Awaitility.await("cluster of 4 brokers across 2 regions to form")
+          .atMost(Duration.ofSeconds(60))
+          .untilAsserted(
+              () -> {
+                final var topology = client.newTopologyRequest().send().join();
+                assertThat(topology.getBrokers()).hasSize(4);
+                assertThat(topology.getBrokers())
+                    .flatExtracting(BrokerInfo::getPartitions)
+                    .filteredOn(PartitionInfo::isLeader)
+                    .extracting(PartitionInfo::getPartitionId)
+                    .containsExactlyInAnyOrder(1, 2);
+              });
+
+      // then — all four composite member IDs are exposed to clients
+      final var topology = client.newTopologyRequest().execute();
+      assertThat(topology.getBrokers())
+          .extracting(BrokerInfo::getNodeId)
+          .containsExactlyInAnyOrder(
+              REGION_EAST + "-0", REGION_EAST + "-1",
+              REGION_WEST + "-0", REGION_WEST + "-1");
+    }
+  }
+
+  /**
    * Creates a broker configured for region-aware mode.
    *
    * <p>Node IDs are globally unique integers: east uses {@code nodeId=0}, west uses {@code
@@ -123,13 +187,23 @@ final class MultiRegionClusterIT {
       final String region,
       final RegionAwareCfg regionAwareCfg,
       final List<String> contactPoints) {
+    return createBroker(nodeId, region, regionAwareCfg, 2, 1, contactPoints);
+  }
+
+  private static TestStandaloneBroker createBroker(
+      final int nodeId,
+      final String region,
+      final RegionAwareCfg regionAwareCfg,
+      final int clusterSize,
+      final int partitionCount,
+      final List<String> contactPoints) {
     return new TestStandaloneBroker()
         .withUnifiedConfig(
             cfg -> {
               cfg.getCluster().setNodeId(nodeId);
               cfg.getCluster().setRegion(region);
-              cfg.getCluster().setSize(2);
-              cfg.getCluster().setPartitionCount(1);
+              cfg.getCluster().setSize(clusterSize);
+              cfg.getCluster().setPartitionCount(partitionCount);
               cfg.getCluster().setReplicationFactor(2);
               if (!contactPoints.isEmpty()) {
                 cfg.getCluster().setInitialContactPoints(contactPoints);
@@ -154,6 +228,30 @@ final class MultiRegionClusterIT {
 
     final var west = new RegionCfg();
     west.setNumberOfBrokers(1);
+    west.setNumberOfReplicas(1);
+    west.setPriority(500);
+
+    final var regions = new LinkedHashMap<String, RegionCfg>();
+    regions.put(REGION_EAST, east);
+    regions.put(REGION_WEST, west);
+
+    final var cfg = new RegionAwareCfg();
+    cfg.setRegions(regions);
+    return cfg;
+  }
+
+  /**
+   * Builds a {@link RegionAwareCfg} for a 2-broker-per-region topology. Each region contributes 2
+   * brokers and 1 replica per partition, for a total replication factor of 2.
+   */
+  private static RegionAwareCfg buildMultiBrokerRegionAwareCfg() {
+    final var east = new RegionCfg();
+    east.setNumberOfBrokers(2);
+    east.setNumberOfReplicas(1);
+    east.setPriority(1000);
+
+    final var west = new RegionCfg();
+    west.setNumberOfBrokers(2);
     west.setNumberOfReplicas(1);
     west.setPriority(500);
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/RegionAwarePartitionDistributionIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/RegionAwarePartitionDistributionIT.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+/*
+
+
+* Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+* one or more contributor license agreements. See the NOTICE file distributed
+* with this work for additional information regarding copyright ownership.
+* Licensed under the Camunda License 1.0. You may not use this file
+* except in compliance with the Camunda License 1.0.
+*/
+package io.camunda.zeebe.it.cluster.clustering;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.Topology;
+import io.camunda.configuration.Partitioning;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.zeebe.broker.system.configuration.partitioning.RegionAwareCfg;
+import io.camunda.zeebe.broker.system.configuration.partitioning.RegionCfg;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.util.LinkedHashMap;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration test for the {@link
+ * io.camunda.zeebe.dynamic.config.util.RegionAwarePartitionDistributor} scheme.
+ *
+ * <p>Starts a single-region cluster and verifies:
+ *
+ * <ol>
+ *   <li>The cluster forms successfully — proving that all brokers agree on the same composite
+ *       {@code "region-nodeId"} member IDs.
+ *   <li>Each broker has the expected region name propagated into its runtime configuration.
+ * </ol>
+ */
+final class RegionAwarePartitionDistributionIT {
+
+  private static final String REGION = "us-east1";
+  private static final int BROKERS = 3;
+
+  @AutoClose private TestCluster cluster;
+
+  @Test
+  void shouldFormClusterAndPropagateRegionConfig() {
+    // given — single-region cluster: all 3 brokers in us-east1
+    cluster =
+        TestCluster.builder()
+            .withBrokersCount(BROKERS)
+            .withEmbeddedGateway(true)
+            .withPartitionsCount(BROKERS)
+            .withReplicationFactor(BROKERS)
+            .withBrokerConfig(broker -> configureRegionAwareBroker(broker, REGION, BROKERS))
+            .build();
+
+    // when
+    cluster.start();
+    final var test = cluster.awaitCompleteTopology();
+
+    final CamundaClient build = cluster.newClientBuilder().build();
+
+    final Topology execute = build.newTopologyRequest().execute();
+
+    // then — verify the region setting was correctly propagated to each broker's runtime
+    // config.
+    // Successful cluster formation already proves that the composite "region-nodeId" MemberIds
+    // are
+    // consistent (otherwise the Raft group would never elect a leader and the topology check
+    // would
+    // time out).
+    cluster
+        .brokers()
+        .values()
+        .forEach(
+            broker -> {
+              final var clusterCfg = broker.bean(BrokerBasedProperties.class).getCluster();
+              assertThat(clusterCfg.getRegion())
+                  .as(
+                      "broker %d should have region '%s' in its runtime config",
+                      clusterCfg.getNodeId(), REGION)
+                  .isEqualTo(REGION);
+            });
+  }
+
+  private static void configureRegionAwareBroker(
+      final TestStandaloneBroker broker, final String regionName, final int brokerCount) {
+    broker.withUnifiedConfig(
+        cfg -> {
+          cfg.getCluster().setRegion(regionName);
+
+          final var regionCfg = new RegionCfg();
+          regionCfg.setNumberOfBrokers(brokerCount);
+          regionCfg.setNumberOfReplicas(brokerCount);
+          regionCfg.setPriority(1000);
+
+          final var regionAwareCfg = new RegionAwareCfg();
+          final var regions = new LinkedHashMap<String, RegionCfg>();
+          regions.put(regionName, regionCfg);
+          regionAwareCfg.setRegions(regions);
+
+          final var partitioning = new Partitioning();
+          partitioning.setScheme(Partitioning.Scheme.REGION_AWARE);
+          partitioning.setRegionAware(regionAwareCfg);
+          cfg.getCluster().setPartitioning(partitioning);
+        });
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/RegionAwarePartitionDistributionIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/RegionAwarePartitionDistributionIT.java
@@ -26,7 +26,7 @@ import io.camunda.zeebe.broker.system.configuration.partitioning.RegionAwareCfg;
 import io.camunda.zeebe.broker.system.configuration.partitioning.RegionCfg;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
-import java.util.LinkedHashMap;
+import java.util.List;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Test;
 
@@ -97,14 +97,13 @@ final class RegionAwarePartitionDistributionIT {
           cfg.getCluster().setRegion(regionName);
 
           final var regionCfg = new RegionCfg();
+          regionCfg.setName(regionName);
           regionCfg.setNumberOfBrokers(brokerCount);
           regionCfg.setNumberOfReplicas(brokerCount);
           regionCfg.setPriority(1000);
 
           final var regionAwareCfg = new RegionAwareCfg();
-          final var regions = new LinkedHashMap<String, RegionCfg>();
-          regions.put(regionName, regionCfg);
-          regionAwareCfg.setRegions(regions);
+          regionAwareCfg.setRegions(List.of(regionCfg));
 
           final var partitioning = new Partitioning();
           partitioning.setScheme(Partitioning.Scheme.REGION_AWARE);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/RestoreTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/RestoreTest.java
@@ -108,7 +108,7 @@ public final class RestoreTest {
         .timeout(60, TimeUnit.SECONDS)
         .ignoreExceptions()
         .untilAsserted(
-            () -> assertThat(clusteringRule.getLeaderForPartition(1).getNodeId()).isEqualTo(2));
+            () -> assertThat(clusteringRule.getLeaderForPartition(1).getNodeId()).isEqualTo("2"));
 
     publishMessage();
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/topology/TopologyClusterTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/topology/TopologyClusterTest.java
@@ -62,7 +62,9 @@ public final class TopologyClusterTest {
       final List<BrokerInfo> brokers = topology.getBrokers();
 
       assertThat(brokers.size()).isEqualTo(3);
-      assertThat(brokers).extracting(BrokerInfo::getNodeId).containsExactlyInAnyOrder(0, 1, 2);
+      assertThat(brokers)
+          .extracting(BrokerInfo::getNodeId)
+          .containsExactlyInAnyOrder("0", "1", "2");
     }
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/topology/TopologyFaultToleranceTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/topology/TopologyFaultToleranceTest.java
@@ -75,7 +75,7 @@ final class TopologyFaultToleranceTest {
                     .hasBrokersCount(1)
                     .hasBrokerSatisfying(
                         broker -> {
-                          assertThat(broker.getNodeId()).isEqualTo(clusterSize - 1);
+                          assertThat(broker.getNodeId()).isEqualTo(String.valueOf(clusterSize - 1));
                           assertThat(broker.getPartitions())
                               .describedAs("has %d follower partitions", partitionsCount)
                               .hasSize(partitionsCount)

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/health/DiskSpaceMonitoringFailOverTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/health/DiskSpaceMonitoringFailOverTest.java
@@ -48,7 +48,7 @@ public class DiskSpaceMonitoringFailOverTest {
     final var leaderId = clusteringRule.getLeaderForPartition(1).getNodeId();
     final var followers =
         clusteringRule.getBrokers().stream()
-            .filter(b -> b.getConfig().getCluster().getNodeId() != leaderId)
+            .filter(b -> b.getConfig().getCluster().getNodeId() != Integer.parseInt(leaderId))
             .collect(Collectors.toList());
 
     followers.forEach(
@@ -80,7 +80,10 @@ public class DiskSpaceMonitoringFailOverTest {
     // then
     Awaitility.await()
         .timeout(Duration.ofSeconds(60))
-        .untilAsserted(() -> assertThat(clusteringRule.isBrokerHealthy(newLeaderId)).isFalse());
+        .untilAsserted(
+            () ->
+                assertThat(clusteringRule.isBrokerHealthy(Integer.parseInt(newLeaderId)))
+                    .isFalse());
     // should install StreamProcessor and immediately pause it
     Awaitility.await(
             "Stream processor of broker " + newLeaderId + " is expected to be in paused state.")

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/gateway/GatewayHealthIndicatorsIntegrationTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/gateway/GatewayHealthIndicatorsIntegrationTest.java
@@ -89,7 +89,7 @@ public class GatewayHealthIndicatorsIntegrationTest {
 
     // given
     final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
-    when(mockClusterState.getBrokers()).thenReturn(List.of(1));
+    when(mockClusterState.getBrokers()).thenReturn(List.of("1"));
 
     final Supplier<Optional<BrokerClusterState>> stateSupplier =
         () -> Optional.of(mockClusterState);
@@ -118,7 +118,7 @@ public class GatewayHealthIndicatorsIntegrationTest {
     // given
     final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
     when(mockClusterState.getPartitions()).thenReturn(List.of(1));
-    when(mockClusterState.getLeaderForPartition(1)).thenReturn(42);
+    when(mockClusterState.getLeaderForPartition(1)).thenReturn("42");
 
     final Supplier<Optional<BrokerClusterState>> stateSupplier =
         () -> Optional.of(mockClusterState);

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
@@ -354,7 +354,7 @@ final class RollingUpdateTest {
         .as("the topology contains the updated broker")
         .hasBrokerSatisfying(
             brokerInfo -> {
-              assertThat(brokerInfo.getNodeId()).as("the broker's node ID").isEqualTo(brokerId);
+              assertThat(brokerInfo.getNodeId()).as("the broker's node ID").isEqualTo(String.valueOf(brokerId));
               assertThat(brokerInfo.getVersion())
                   .as("the broker's version")
                   .isEqualTo(

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
@@ -354,7 +354,9 @@ final class RollingUpdateTest {
         .as("the topology contains the updated broker")
         .hasBrokerSatisfying(
             brokerInfo -> {
-              assertThat(brokerInfo.getNodeId()).as("the broker's node ID").isEqualTo(String.valueOf(brokerId));
+              assertThat(brokerInfo.getNodeId())
+                  .as("the broker's node ID")
+                  .isEqualTo(String.valueOf(brokerId));
               assertThat(brokerInfo.getVersion())
                   .as("the broker's version")
                   .isEqualTo(

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/asserts/TopologyAssert.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/asserts/TopologyAssert.java
@@ -83,7 +83,7 @@ public final class TopologyAssert extends AbstractObjectAssert<TopologyAssert, T
       for (final PartitionInfo partition : broker.getPartitions()) {
         if (partition.getHealth() != PartitionBrokerHealth.HEALTHY) {
           throw failure(
-              "Expected all partitions to be healthy, but partition <%d> of broker <%d> is <%s>",
+              "Expected all partitions to be healthy, but partition <%d> of broker <%s> is <%s>",
               partition.getPartitionId(), broker.getNodeId(), partition.getHealth());
         }
         hasHealthyPartition = true;
@@ -263,7 +263,7 @@ public final class TopologyAssert extends AbstractObjectAssert<TopologyAssert, T
             .filter(p -> p.partitionInfo.isLeader())
             .map(p -> p.brokerInfo.getNodeId())
             .findFirst();
-    return has(hasLeaderForPartition(partitionId, expectedLeaderId, leader));
+    return has(hasLeaderForPartition(partitionId, String.valueOf(expectedLeaderId), leader));
   }
 
   /**
@@ -276,9 +276,9 @@ public final class TopologyAssert extends AbstractObjectAssert<TopologyAssert, T
   public TopologyAssert doesNotContainBroker(final int nodeId) {
     isNotNull();
 
-    final Set<Integer> brokerIds =
+    final Set<String> brokerIds =
         actual.getBrokers().stream().map(BrokerInfo::getNodeId).collect(Collectors.toSet());
-    if (brokerIds.contains(nodeId)) {
+    if (brokerIds.contains(String.valueOf(nodeId))) {
       throw failure(
           "Expected topology not to contain broker with ID <%d>, but found the following: <%s>",
           nodeId, brokerIds);
@@ -309,7 +309,7 @@ public final class TopologyAssert extends AbstractObjectAssert<TopologyAssert, T
     if (leaderForPartition.isPresent()) {
       {
         throw failure(
-            "Expected topology not to contain leader for partition <%d>, but found broker <%d>",
+            "Expected topology not to contain leader for partition <%d>, but found broker <%s>",
             partitionId, leaderForPartition.get());
       }
     }
@@ -327,9 +327,9 @@ public final class TopologyAssert extends AbstractObjectAssert<TopologyAssert, T
   public TopologyAssert containsBroker(final int nodeId) {
     isNotNull();
 
-    final Set<Integer> brokers =
+    final Set<String> brokers =
         actual.getBrokers().stream().map(BrokerInfo::getNodeId).collect(Collectors.toSet());
-    if (!brokers.contains(nodeId)) {
+    if (!brokers.contains(String.valueOf(nodeId))) {
       throw failure(
           "Expected topology to contain broker with ID <%d>, but found only the following: <%s>",
           nodeId, brokers);
@@ -362,13 +362,12 @@ public final class TopologyAssert extends AbstractObjectAssert<TopologyAssert, T
 
   @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
   private VerboseCondition<Topology> hasLeaderForPartition(
-      final int partitionId, final int expectedLeaderId, final Optional<Integer> leader) {
+      final int partitionId, final String expectedLeaderId, final Optional<String> leader) {
     return VerboseCondition.verboseCondition(
-        topology -> leader.isPresent() && leader.get() == expectedLeaderId,
-        "a topology where the leader of partition '%d' is '%d'"
+        topology -> leader.isPresent() && leader.get().equals(expectedLeaderId),
+        "a topology where the leader of partition '%d' is '%s'"
             .formatted(partitionId, expectedLeaderId),
-        topology ->
-            " but the actual leader is '%s'".formatted(leader.map(String::valueOf).orElse("null")));
+        topology -> " but the actual leader is '%s'".formatted(leader.orElse("null")));
   }
 
   private VerboseCondition<Topology> hasPartitionId(

--- a/zeebe/test-util/src/test/java/io/camunda/zeebe/test/util/asserts/TestTopology.java
+++ b/zeebe/test-util/src/test/java/io/camunda/zeebe/test/util/asserts/TestTopology.java
@@ -74,10 +74,10 @@ record TestTopology(
     }
   }
 
-  record TestBroker(int nodeId, List<PartitionInfo> partitions) implements BrokerInfo {
+  record TestBroker(String nodeId, List<PartitionInfo> partitions) implements BrokerInfo {
 
     @Override
-    public int getNodeId() {
+    public String getNodeId() {
       return nodeId;
     }
 

--- a/zeebe/test-util/src/test/java/io/camunda/zeebe/test/util/asserts/TopologyAssertTest.java
+++ b/zeebe/test-util/src/test/java/io/camunda/zeebe/test/util/asserts/TopologyAssertTest.java
@@ -41,7 +41,7 @@ final class TopologyAssertTest {
       // given
       final var partition =
           new TestPartition(1, PartitionBrokerRole.LEADER, PartitionBrokerHealth.HEALTHY);
-      final var broker = new TestBroker(1, List.of(partition));
+      final var broker = new TestBroker("1",List.of(partition));
       final Topology topology = new TestTopology(1, 1, 1, List.of(broker));
 
       // when
@@ -56,7 +56,7 @@ final class TopologyAssertTest {
       // given
       final var partition =
           new TestPartition(1, PartitionBrokerRole.FOLLOWER, PartitionBrokerHealth.HEALTHY);
-      final var broker = new TestBroker(1, List.of(partition));
+      final var broker = new TestBroker("1",List.of(partition));
       final Topology topology = new TestTopology(1, 1, 1, List.of(broker));
 
       // when
@@ -71,7 +71,7 @@ final class TopologyAssertTest {
       // given
       final var partition =
           new TestPartition(1, PartitionBrokerRole.LEADER, PartitionBrokerHealth.UNHEALTHY);
-      final var broker = new TestBroker(1, List.of(partition));
+      final var broker = new TestBroker("1",List.of(partition));
       final Topology topology = new TestTopology(1, 1, 1, List.of(broker));
 
       // when
@@ -89,7 +89,7 @@ final class TopologyAssertTest {
       // given
       final var partition =
           new TestPartition(1, PartitionBrokerRole.LEADER, PartitionBrokerHealth.HEALTHY);
-      final var broker = new TestBroker(1, List.of(partition));
+      final var broker = new TestBroker("1",List.of(partition));
       final Topology topology = new TestTopology(1, 1, 1, List.of(broker));
 
       // when
@@ -111,7 +111,7 @@ final class TopologyAssertTest {
               1,
               2,
               List.of(
-                  new TestBroker(2, List.of(partition)), new TestBroker(2, List.of(partition))));
+                  new TestBroker("2",List.of(partition)), new TestBroker("2",List.of(partition))));
 
       // when
       final var topologyAssert = TopologyAssert.assertThat(topology);
@@ -126,7 +126,7 @@ final class TopologyAssertTest {
       // given
       final var partition =
           new TestPartition(1, PartitionBrokerRole.FOLLOWER, PartitionBrokerHealth.HEALTHY);
-      final var broker = new TestBroker(1, List.of(partition));
+      final var broker = new TestBroker("1",List.of(partition));
       final Topology topology = new TestTopology(1, 1, 1, List.of(broker));
 
       // when
@@ -145,7 +145,7 @@ final class TopologyAssertTest {
       // given
       final var partition =
           new TestPartition(1, PartitionBrokerRole.FOLLOWER, PartitionBrokerHealth.HEALTHY);
-      final var broker = new TestBroker(1, List.of(partition));
+      final var broker = new TestBroker("1",List.of(partition));
       final Topology topology = new TestTopology(1, 1, 1, List.of(broker));
 
       // when
@@ -167,7 +167,7 @@ final class TopologyAssertTest {
               1,
               2,
               List.of(
-                  new TestBroker(1, List.of(partition)), new TestBroker(2, List.of(partition))));
+                  new TestBroker("1",List.of(partition)), new TestBroker("2",List.of(partition))));
 
       // when
       final var topologyAssert = TopologyAssert.assertThat(topology);

--- a/zeebe/test-util/src/test/java/io/camunda/zeebe/test/util/asserts/TopologyAssertTest.java
+++ b/zeebe/test-util/src/test/java/io/camunda/zeebe/test/util/asserts/TopologyAssertTest.java
@@ -41,7 +41,7 @@ final class TopologyAssertTest {
       // given
       final var partition =
           new TestPartition(1, PartitionBrokerRole.LEADER, PartitionBrokerHealth.HEALTHY);
-      final var broker = new TestBroker("1",List.of(partition));
+      final var broker = new TestBroker("1", List.of(partition));
       final Topology topology = new TestTopology(1, 1, 1, List.of(broker));
 
       // when
@@ -56,7 +56,7 @@ final class TopologyAssertTest {
       // given
       final var partition =
           new TestPartition(1, PartitionBrokerRole.FOLLOWER, PartitionBrokerHealth.HEALTHY);
-      final var broker = new TestBroker("1",List.of(partition));
+      final var broker = new TestBroker("1", List.of(partition));
       final Topology topology = new TestTopology(1, 1, 1, List.of(broker));
 
       // when
@@ -71,7 +71,7 @@ final class TopologyAssertTest {
       // given
       final var partition =
           new TestPartition(1, PartitionBrokerRole.LEADER, PartitionBrokerHealth.UNHEALTHY);
-      final var broker = new TestBroker("1",List.of(partition));
+      final var broker = new TestBroker("1", List.of(partition));
       final Topology topology = new TestTopology(1, 1, 1, List.of(broker));
 
       // when
@@ -89,7 +89,7 @@ final class TopologyAssertTest {
       // given
       final var partition =
           new TestPartition(1, PartitionBrokerRole.LEADER, PartitionBrokerHealth.HEALTHY);
-      final var broker = new TestBroker("1",List.of(partition));
+      final var broker = new TestBroker("1", List.of(partition));
       final Topology topology = new TestTopology(1, 1, 1, List.of(broker));
 
       // when
@@ -111,7 +111,8 @@ final class TopologyAssertTest {
               1,
               2,
               List.of(
-                  new TestBroker("2",List.of(partition)), new TestBroker("2",List.of(partition))));
+                  new TestBroker("2", List.of(partition)),
+                  new TestBroker("2", List.of(partition))));
 
       // when
       final var topologyAssert = TopologyAssert.assertThat(topology);
@@ -126,7 +127,7 @@ final class TopologyAssertTest {
       // given
       final var partition =
           new TestPartition(1, PartitionBrokerRole.FOLLOWER, PartitionBrokerHealth.HEALTHY);
-      final var broker = new TestBroker("1",List.of(partition));
+      final var broker = new TestBroker("1", List.of(partition));
       final Topology topology = new TestTopology(1, 1, 1, List.of(broker));
 
       // when
@@ -145,7 +146,7 @@ final class TopologyAssertTest {
       // given
       final var partition =
           new TestPartition(1, PartitionBrokerRole.FOLLOWER, PartitionBrokerHealth.HEALTHY);
-      final var broker = new TestBroker("1",List.of(partition));
+      final var broker = new TestBroker("1", List.of(partition));
       final Topology topology = new TestTopology(1, 1, 1, List.of(broker));
 
       // when
@@ -167,7 +168,8 @@ final class TopologyAssertTest {
               1,
               2,
               List.of(
-                  new TestBroker("1",List.of(partition)), new TestBroker("2",List.of(partition))));
+                  new TestBroker("1", List.of(partition)),
+                  new TestBroker("2", List.of(partition))));
 
       // when
       final var topologyAssert = TopologyAssert.assertThat(topology);


### PR DESCRIPTION
## Description

Region-aware partition distribution (prototype)                                     
                                                                                      
  Adds a new REGION_AWARE partitioning scheme that allows a Zeebe cluster to span
  multiple geographic regions, with partition leaders pinned to the highest-priority  
  region and automatic Raft-based failover to lower-priority regions.                 
                                                                                      
  - New RegionAwarePartitionDistributor — assigns replicas and Raft election          
  priorities region-by-region (highest priority first), using round-robin within each
  region so load is spread evenly across brokers. The broker with priority ==         
  replicationFactor becomes the preferred leader.                                     
  - Composite MemberId format — when region is set, a broker's cluster identity
  becomes "<region>-<localNodeId>" (e.g. us-east1-0). nodeId is unique within a region
   only, not globally.
  - New configuration — camunda.cluster.region (per broker) and                       
  camunda.cluster.partitioning.region-aware (cluster-wide region map with             
  numberOfBrokers, numberOfReplicas, priority per region). Zero behavior change when
  region is not configured.                                                           
  - Validation — enforces that Σ numberOfReplicas == replicationFactor, Σ             
  numberOfBrokers == clusterSize, nodeId is in bounds, and all region priorities are  
  distinct.
   
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
