### PR TITLE
fix: Job error stats should not include CANCELED jobs

### DIFF
--- a/db/rdbms/src/main/resources/mapper/JobMetricsBatchMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/JobMetricsBatchMapper.xml
@@ -269,7 +269,7 @@
   </select>
 
   <sql id="jobErrorStatisticsFilter">
-    WHERE STATE IN ('ERROR_THROWN', 'FAILED', 'CANCELED', 'TIMED_OUT')
+    WHERE STATE IN ('ERROR_THROWN', 'FAILED', 'TIMED_OUT')
     <if test="authorizedTenantIds != null and !authorizedTenantIds.isEmpty()">
       AND TENANT_ID IN
       <foreach collection="authorizedTenantIds" item="tenantId" open="(" separator="," close=")">


### PR DESCRIPTION
## Description

This pull request makes a small change to the job error statistics query filter. The change removes the `CANCELED` state from the list of error states considered in the `jobErrorStatisticsFilter` SQL snippet.

* Removed `CANCELED` from the list of job states treated as errors in the `jobErrorStatisticsFilter` in `JobMetricsBatchMapper.xml`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

