### PR TITLE
fix: strip Swagger `##default` sentinel from MCP tool schemas

### DIFF
--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/schema/CamundaJsonSchemaGenerator.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/schema/CamundaJsonSchemaGenerator.java
@@ -96,13 +96,35 @@ public class CamundaJsonSchemaGenerator {
             : new SpringAiSchemaModule(
                 SpringAiSchemaModule.Option.PROPERTY_REQUIRED_FALSE_BY_DEFAULT);
 
-    return new SchemaGeneratorConfigBuilder(objectMapper, SCHEMA_VERSION, OptionPreset.PLAIN_JSON)
-        .with(jacksonModule)
-        .with(openApiModule)
-        .with(springAiSchemaModule)
-        .with(Option.EXTRA_OPEN_API_FORMAT_VALUES)
-        .with(Option.STANDARD_FORMATS)
-        .with(Option.INLINE_ALL_SCHEMAS);
+    final var builder =
+        new SchemaGeneratorConfigBuilder(objectMapper, SCHEMA_VERSION, OptionPreset.PLAIN_JSON)
+            .with(jacksonModule)
+            .with(openApiModule)
+            .with(springAiSchemaModule)
+            .with(Option.EXTRA_OPEN_API_FORMAT_VALUES)
+            .with(Option.STANDARD_FORMATS)
+            .with(Option.INLINE_ALL_SCHEMAS);
+
+    // The Swagger2Module reads @Schema.defaultValue() and emits it into the JSON Schema "default"
+    // field. When defaultValue is not explicitly set, the annotation returns the sentinel
+    // "##default" (Schema.DEFAULT_SENTINEL), which leaks into the generated schema. Strip it.
+    builder
+        .forFields()
+        .withInstanceAttributeOverride((node, field, context) -> removeDefaultSentinel(node));
+    builder
+        .forMethods()
+        .withInstanceAttributeOverride((node, method, context) -> removeDefaultSentinel(node));
+
+    return builder;
+  }
+
+  private static void removeDefaultSentinel(final ObjectNode node) {
+    final var defaultNode = node.get("default");
+    if (defaultNode != null
+        && defaultNode.isTextual()
+        && Schema.DEFAULT_SENTINEL.equals(defaultNode.asText())) {
+      node.remove("default");
+    }
   }
 
   public String generateForMethodInput(final Method method) {

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/schema/CamundaJsonSchemaGenerator.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/schema/CamundaJsonSchemaGenerator.java
@@ -108,6 +108,8 @@ public class CamundaJsonSchemaGenerator {
     // The Swagger2Module reads @Schema.defaultValue() and emits it into the JSON Schema "default"
     // field. When defaultValue is not explicitly set, the annotation returns the sentinel
     // "##default" (Schema.DEFAULT_SENTINEL), which leaks into the generated schema. Strip it.
+    // Can be removed when upstream is fixed:
+    // https://github.com/victools/jsonschema-generator/issues/573
     builder
         .forFields()
         .withInstanceAttributeOverride((node, field, context) -> removeDefaultSentinel(node));

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/config/schema/CamundaJsonSchemaGeneratorTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/config/schema/CamundaJsonSchemaGeneratorTest.java
@@ -11,6 +11,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.gateway.mcp.config.tool.McpToolParamsUnwrapped;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import jakarta.validation.Valid;
 import java.lang.reflect.Method;
 import org.junit.jupiter.api.Test;
@@ -79,6 +81,32 @@ class CamundaJsonSchemaGeneratorTest {
   }
 
   @Test
+  void shouldNotIncludeSwaggerDefaultSentinelInSchema() throws Exception {
+    // given — a method parameter type annotated with @Schema (like the generated API models)
+    final JsonNode schema =
+        generateMethodSchema("withSwaggerAnnotatedParam", SwaggerAnnotatedDto.class);
+
+    // when — inspecting properties that don't have an explicit defaultValue
+    final JsonNode properties = schema.get("properties");
+
+    // then — no "default": "##default" sentinel should leak into the schema
+    final JsonNode dtoProperties = properties.get("dto").get("properties");
+    assertThat(dtoProperties.get("name").has("default")).isFalse();
+    assertThat(dtoProperties.get("description").has("default")).isFalse();
+  }
+
+  @Test
+  void shouldPreserveExplicitDefaultValue() throws Exception {
+    // given — a method parameter type with an explicit @Schema(defaultValue = "active")
+    final JsonNode schema =
+        generateMethodSchema("withSwaggerAnnotatedParam", SwaggerAnnotatedDto.class);
+
+    // then — the explicitly set default is preserved
+    final JsonNode dtoProperties = schema.get("properties").get("dto").get("properties");
+    assertThat(dtoProperties.get("status").get("default").asText()).isEqualTo("active");
+  }
+
+  @Test
   void shouldExcludeFrameworkParamsFromMcpToolParamsSchema() throws Exception {
     final JsonNode schema =
         generateMethodSchema(
@@ -118,6 +146,37 @@ class CamundaJsonSchemaGeneratorTest {
 
   public record DtoWithRepeatedTypes(Address homeAddress, Address workAddress) {}
 
+  /** Mimics the generated API model classes that use @Schema without explicit defaultValue. */
+  public static class SwaggerAnnotatedDto {
+    @Schema(name = "name", description = "The name.", requiredMode = RequiredMode.NOT_REQUIRED)
+    private String name;
+
+    @Schema(
+        name = "description",
+        description = "The description.",
+        requiredMode = RequiredMode.NOT_REQUIRED)
+    private String description;
+
+    @Schema(
+        name = "status",
+        description = "The status.",
+        defaultValue = "active",
+        requiredMode = RequiredMode.NOT_REQUIRED)
+    private String status;
+
+    public String getName() {
+      return name;
+    }
+
+    public String getDescription() {
+      return description;
+    }
+
+    public String getStatus() {
+      return status;
+    }
+  }
+
   public static class TestToolMethods {
     public void withOnlyFrameworkParams(final CallToolRequest request) {}
 
@@ -130,5 +189,7 @@ class CamundaJsonSchemaGeneratorTest {
 
     public void withMcpToolParamsAndContext(
         @McpToolParamsUnwrapped @Valid final TaskDto dto, final McpSyncRequestContext context) {}
+
+    public void withSwaggerAnnotatedParam(final SwaggerAnnotatedDto dto) {}
   }
 }

--- a/gateways/gateway-mcp/src/test/resources/schema/tools-schema-snapshot.json
+++ b/gateways/gateway-mcp/src/test/resources/schema/tools-schema-snapshot.json
@@ -88,13 +88,11 @@
                     "description": "Filter up to this time (exclusive). RFC 3339 format (e.g., '2024-12-17T10:30:00Z' or '2024-12-17T10:30:00+01:00')."
                   }
                 },
-                "description": "Date of incident creation.",
-                "default": "##default"
+                "description": "Date of incident creation."
               },
               "elementId": {
                 "type": "string",
-                "description": "The element ID associated to this incident.",
-                "default": "##default"
+                "description": "The element ID associated to this incident."
               },
               "errorType": {
                 "type": "string",
@@ -116,23 +114,19 @@
                   "UNKNOWN",
                   "UNSPECIFIED"
                 ],
-                "description": "Incident error type with a defined set of values.",
-                "default": "##default"
+                "description": "Incident error type with a defined set of values."
               },
               "processDefinitionId": {
                 "type": "string",
-                "description": "The process definition ID associated to this incident.",
-                "default": "##default"
+                "description": "The process definition ID associated to this incident."
               },
               "processDefinitionKey": {
                 "type": "string",
-                "description": "The process definition key associated to this incident.",
-                "default": "##default"
+                "description": "The process definition key associated to this incident."
               },
               "processInstanceKey": {
                 "type": "string",
-                "description": "The process instance key associated to this incident.",
-                "default": "##default"
+                "description": "The process instance key associated to this incident."
               },
               "state": {
                 "type": "string",
@@ -143,45 +137,37 @@
                   "RESOLVED",
                   "UNKNOWN"
                 ],
-                "description": "State of this incident with a defined set of values.",
-                "default": "##default"
+                "description": "State of this incident with a defined set of values."
               }
             },
-            "description": "The incident search filters.",
-            "default": "##default"
+            "description": "The incident search filters."
           },
           "page": {
             "type": "object",
             "properties": {
               "after": {
                 "type": "string",
-                "description": "Use the `endCursor` value from the previous response to fetch the next page of results.",
-                "default": "##default"
+                "description": "Use the `endCursor` value from the previous response to fetch the next page of results."
               },
               "before": {
                 "type": "string",
-                "description": "Use the `startCursor` value from the previous response to fetch the previous page of results.",
-                "default": "##default"
+                "description": "Use the `startCursor` value from the previous response to fetch the previous page of results."
               },
               "from": {
                 "type": "integer",
                 "format": "int32",
-                "description": "The index of items to start searching from.",
-                "default": "##default"
+                "description": "The index of items to start searching from."
               },
               "limit": {
                 "type": "integer",
                 "format": "int32",
-                "description": "The maximum number of items to return in one request.",
-                "default": "##default"
+                "description": "The maximum number of items to return in one request."
               }
             },
-            "description": "Pagination criteria.",
-            "default": "##default"
+            "description": "Pagination criteria."
           },
           "sort": {
             "description": "Sort field criteria.",
-            "default": "##default",
             "type": "array",
             "items": {
               "type": "object",
@@ -201,16 +187,14 @@
                     "jobKey",
                     "tenantId"
                   ],
-                  "description": "The field to sort by.",
-                  "default": "##default"
+                  "description": "The field to sort by."
                 },
                 "order": {
                   "type": "string",
                   "enum": [
                     "ASC",
                     "DESC"
-                  ],
-                  "default": "##default"
+                  ]
                 }
               },
               "required": [
@@ -279,81 +263,66 @@
             "properties": {
               "hasStartForm": {
                 "type": "boolean",
-                "description": "Indicates whether the start event of the process has an associated Form Key.",
-                "default": "##default"
+                "description": "Indicates whether the start event of the process has an associated Form Key."
               },
               "isLatestVersion": {
                 "type": "boolean",
-                "description": "Whether to only return the latest version of each process definition. When using this filter, pagination functionality is limited, you can only paginate forward using `after` and `limit`. The response contains no `startCursor` in the `page`, and requests ignore the `from` and `before` in the `page`. When using this filter, sorting is limited to `processDefinitionId` and `tenantId` fields only. ",
-                "default": "##default"
+                "description": "Whether to only return the latest version of each process definition. When using this filter, pagination functionality is limited, you can only paginate forward using `after` and `limit`. The response contains no `startCursor` in the `page`, and requests ignore the `from` and `before` in the `page`. When using this filter, sorting is limited to `processDefinitionId` and `tenantId` fields only. "
               },
               "name": {
                 "type": "string",
-                "description": "Name of this process definition.",
-                "default": "##default"
+                "description": "Name of this process definition."
               },
               "processDefinitionId": {
                 "type": "string",
-                "description": "Process definition ID of this process definition.",
-                "default": "##default"
+                "description": "Process definition ID of this process definition."
               },
               "processDefinitionKey": {
                 "type": "string",
-                "description": "The key for this process definition.",
-                "default": "##default"
+                "description": "The key for this process definition."
               },
               "resourceName": {
                 "type": "string",
-                "description": "Resource name of this process definition.",
-                "default": "##default"
+                "description": "Resource name of this process definition."
               },
               "version": {
                 "type": "integer",
                 "format": "int32",
-                "description": "Version of this process definition.",
-                "default": "##default"
+                "description": "Version of this process definition."
               },
               "versionTag": {
                 "type": "string",
-                "description": "Version tag of this process definition.",
-                "default": "##default"
+                "description": "Version tag of this process definition."
               }
             },
-            "description": "The process definition search filters.",
-            "default": "##default"
+            "description": "The process definition search filters."
           },
           "page": {
             "type": "object",
             "properties": {
               "after": {
                 "type": "string",
-                "description": "Use the `endCursor` value from the previous response to fetch the next page of results.",
-                "default": "##default"
+                "description": "Use the `endCursor` value from the previous response to fetch the next page of results."
               },
               "before": {
                 "type": "string",
-                "description": "Use the `startCursor` value from the previous response to fetch the previous page of results.",
-                "default": "##default"
+                "description": "Use the `startCursor` value from the previous response to fetch the previous page of results."
               },
               "from": {
                 "type": "integer",
                 "format": "int32",
-                "description": "The index of items to start searching from.",
-                "default": "##default"
+                "description": "The index of items to start searching from."
               },
               "limit": {
                 "type": "integer",
                 "format": "int32",
-                "description": "The maximum number of items to return in one request.",
-                "default": "##default"
+                "description": "The maximum number of items to return in one request."
               }
             },
-            "description": "Pagination criteria.",
-            "default": "##default"
+            "description": "Pagination criteria."
           },
           "sort": {
             "description": "Sort field criteria.",
-            "default": "##default",
             "type": "array",
             "items": {
               "type": "object",
@@ -369,16 +338,14 @@
                     "processDefinitionId",
                     "tenantId"
                   ],
-                  "description": "The field to sort by.",
-                  "default": "##default"
+                  "description": "The field to sort by."
                 },
                 "order": {
                   "type": "string",
                   "enum": [
                     "ASC",
                     "DESC"
-                  ],
-                  "default": "##default"
+                  ]
                 }
               },
               "required": [
@@ -402,17 +369,14 @@
         "properties": {
           "awaitCompletion": {
             "type": "boolean",
-            "description": "Wait for the process instance to complete. If the process instance does not complete within the request timeout limit, a 504 response status will be returned. The process instance will continue to run in the background regardless of the timeout. Disabled by default. ",
-            "default": "##default"
+            "description": "Wait for the process instance to complete. If the process instance does not complete within the request timeout limit, a 504 response status will be returned. The process instance will continue to run in the background regardless of the timeout. Disabled by default. "
           },
           "businessId": {
             "type": "string",
-            "description": "An optional, user-defined string identifier that identifies the process instance within the scope of a process definition (scoped by tenant). If provided and uniqueness enforcement is enabled, the engine will reject creation if another root process instance with the same business id is already active for the same process definition. Note that any active child process instances with the same business id are not taken into account. ",
-            "default": "##default"
+            "description": "An optional, user-defined string identifier that identifies the process instance within the scope of a process definition (scoped by tenant). If provided and uniqueness enforcement is enabled, the engine will reject creation if another root process instance with the same business id is already active for the same process definition. Note that any active child process instances with the same business id are not taken into account. "
           },
           "fetchVariables": {
             "description": "List of variables by name to be included in the response when awaitCompletion is set to true. If empty, all visible variables in the root scope will be returned. ",
-            "default": "##default",
             "type": "array",
             "items": {
               "type": "string"
@@ -420,29 +384,24 @@
           },
           "processDefinitionId": {
             "type": "string",
-            "description": "The BPMN process id of the process definition to start an instance of. ",
-            "default": "##default"
+            "description": "The BPMN process id of the process definition to start an instance of. "
           },
           "processDefinitionKey": {
             "type": "string",
-            "description": "The unique key identifying the process definition, for example, returned for a process in the deploy resources endpoint. ",
-            "default": "##default"
+            "description": "The unique key identifying the process definition, for example, returned for a process in the deploy resources endpoint. "
           },
           "processDefinitionVersion": {
             "type": "integer",
             "format": "int32",
-            "description": "The version of the process. By default, the latest version of the process is used. ",
-            "default": "##default"
+            "description": "The version of the process. By default, the latest version of the process is used. "
           },
           "requestTimeout": {
             "type": "integer",
             "format": "int64",
-            "description": "Timeout (in ms) the request waits for the process to complete. By default or when set to 0, the generic request timeout configured in the cluster is applied. ",
-            "default": "##default"
+            "description": "Timeout (in ms) the request waits for the process to complete. By default or when set to 0, the generic request timeout configured in the cluster is applied. "
           },
           "tags": {
-            "description": "List of tags. Tags need to start with a letter; then alphanumerics, `_`, `-`, `:`, or `.`; length ≤ 100.",
-            "default": "##default",
+            "description": "List of tags. Tags need to start with a letter; then alphanumerics, `_`, `-`, `:`, or `.`; length \u2264 100.",
             "type": "array",
             "items": {
               "type": "string"
@@ -450,13 +409,11 @@
           },
           "tenantId": {
             "type": "string",
-            "description": "The tenant id of the process definition. If multi-tenancy is enabled, provide the tenant id of the process definition to start a process instance of. If multi-tenancy is disabled, don't provide this parameter. ",
-            "default": "##default"
+            "description": "The tenant id of the process definition. If multi-tenancy is enabled, provide the tenant id of the process definition to start a process instance of. If multi-tenancy is disabled, don't provide this parameter. "
           },
           "variables": {
             "type": "object",
-            "description": "JSON object that will instantiate the variables for the root variable scope of the process instance. ",
-            "default": "##default"
+            "description": "JSON object that will instantiate the variables for the root variable scope of the process instance. "
           }
         },
         "required": []
@@ -496,8 +453,7 @@
             "properties": {
               "businessId": {
                 "type": "string",
-                "description": "The business id associated with the process instance.",
-                "default": "##default"
+                "description": "The business id associated with the process instance."
               },
               "endDate": {
                 "type": "object",
@@ -511,39 +467,32 @@
                     "description": "Filter up to this time (exclusive). RFC 3339 format (e.g., '2024-12-17T10:30:00Z' or '2024-12-17T10:30:00+01:00')."
                   }
                 },
-                "description": "The end date.",
-                "default": "##default"
+                "description": "The end date."
               },
               "hasIncident": {
                 "type": "boolean",
-                "description": "Whether this process instance has a related incident or not.",
-                "default": "##default"
+                "description": "Whether this process instance has a related incident or not."
               },
               "processDefinitionId": {
                 "type": "string",
-                "description": "The process definition id.",
-                "default": "##default"
+                "description": "The process definition id."
               },
               "processDefinitionKey": {
                 "type": "string",
-                "description": "The process definition key.",
-                "default": "##default"
+                "description": "The process definition key."
               },
               "processDefinitionName": {
                 "type": "string",
-                "description": "The process definition name.",
-                "default": "##default"
+                "description": "The process definition name."
               },
               "processDefinitionVersion": {
                 "type": "integer",
                 "format": "int32",
-                "description": "The process definition version.",
-                "default": "##default"
+                "description": "The process definition version."
               },
               "processInstanceKey": {
                 "type": "string",
-                "description": "The key of this process instance.",
-                "default": "##default"
+                "description": "The key of this process instance."
               },
               "startDate": {
                 "type": "object",
@@ -557,8 +506,7 @@
                     "description": "Filter up to this time (exclusive). RFC 3339 format (e.g., '2024-12-17T10:30:00Z' or '2024-12-17T10:30:00+01:00')."
                   }
                 },
-                "description": "The start date.",
-                "default": "##default"
+                "description": "The start date."
               },
               "state": {
                 "type": "string",
@@ -567,12 +515,10 @@
                   "COMPLETED",
                   "TERMINATED"
                 ],
-                "description": "The process instance state.",
-                "default": "##default"
+                "description": "The process instance state."
               },
               "tags": {
-                "description": "List of tags. Tags need to start with a letter; then alphanumerics, `_`, `-`, `:`, or `.`; length ≤ 100.",
-                "default": "##default",
+                "description": "List of tags. Tags need to start with a letter; then alphanumerics, `_`, `-`, `:`, or `.`; length \u2264 100.",
                 "type": "array",
                 "items": {
                   "type": "string"
@@ -580,20 +526,17 @@
               },
               "variables": {
                 "description": "The process instance variables.",
-                "default": "##default",
                 "type": "array",
                 "items": {
                   "type": "object",
                   "properties": {
                     "name": {
                       "type": "string",
-                      "description": "Name of the variable.",
-                      "default": "##default"
+                      "description": "Name of the variable."
                     },
                     "value": {
                       "type": "string",
-                      "description": "The value of the variable. Variable values in filters need to be in serialized JSON format. For example, a variable with string value `myValue` can be found with the filter value `\"myValue\"`. Consider appropriate escaping for special characters in JSON strings when constructing filter values. ",
-                      "default": "##default"
+                      "description": "The value of the variable. Variable values in filters need to be in serialized JSON format. For example, a variable with string value `myValue` can be found with the filter value `\"myValue\"`. Consider appropriate escaping for special characters in JSON strings when constructing filter values. "
                     }
                   },
                   "required": [
@@ -603,41 +546,34 @@
                 }
               }
             },
-            "description": "The process instance search filters.",
-            "default": "##default"
+            "description": "The process instance search filters."
           },
           "page": {
             "type": "object",
             "properties": {
               "after": {
                 "type": "string",
-                "description": "Use the `endCursor` value from the previous response to fetch the next page of results.",
-                "default": "##default"
+                "description": "Use the `endCursor` value from the previous response to fetch the next page of results."
               },
               "before": {
                 "type": "string",
-                "description": "Use the `startCursor` value from the previous response to fetch the previous page of results.",
-                "default": "##default"
+                "description": "Use the `startCursor` value from the previous response to fetch the previous page of results."
               },
               "from": {
                 "type": "integer",
                 "format": "int32",
-                "description": "The index of items to start searching from.",
-                "default": "##default"
+                "description": "The index of items to start searching from."
               },
               "limit": {
                 "type": "integer",
                 "format": "int32",
-                "description": "The maximum number of items to return in one request.",
-                "default": "##default"
+                "description": "The maximum number of items to return in one request."
               }
             },
-            "description": "Pagination criteria.",
-            "default": "##default"
+            "description": "Pagination criteria."
           },
           "sort": {
             "description": "Sort field criteria.",
-            "default": "##default",
             "type": "array",
             "items": {
               "type": "object",
@@ -660,16 +596,14 @@
                     "tenantId",
                     "businessId"
                   ],
-                  "description": "The field to sort by.",
-                  "default": "##default"
+                  "description": "The field to sort by."
                 },
                 "order": {
                   "type": "string",
                   "enum": [
                     "ASC",
                     "DESC"
-                  ],
-                  "default": "##default"
+                  ]
                 }
               },
               "required": [
@@ -705,13 +639,11 @@
             "properties": {
               "action": {
                 "type": "string",
-                "description": "A custom action value that will be accessible from user task events resulting from this endpoint invocation. If not provided, it will default to \"assign\". ",
-                "default": "##default"
+                "description": "A custom action value that will be accessible from user task events resulting from this endpoint invocation. If not provided, it will default to \"assign\". "
               },
               "allowOverride": {
                 "type": "boolean",
-                "description": "By default, the task is reassigned if it was already assigned. Set this to `false` to return an error in such cases. The task must then first be unassigned to be assigned again. Use this when you have users picking from group task queues to prevent race conditions. ",
-                "default": "##default"
+                "description": "By default, the task is reassigned if it was already assigned. Set this to `false` to return an error in such cases. The task must then first be unassigned to be assigned again. Use this when you have users picking from group task queues to prevent race conditions. "
               }
             },
             "description": "Assignment options."
@@ -761,8 +693,7 @@
             "properties": {
               "name": {
                 "type": "string",
-                "description": "Name of the variable.",
-                "default": "##default"
+                "description": "Name of the variable."
               }
             },
             "description": "Filter search by the given fields"
@@ -782,16 +713,14 @@
                     "scopeKey",
                     "processInstanceKey"
                   ],
-                  "description": "The field to sort by.",
-                  "default": "##default"
+                  "description": "The field to sort by."
                 },
                 "order": {
                   "type": "string",
                   "enum": [
                     "ASC",
                     "DESC"
-                  ],
-                  "default": "##default"
+                  ]
                 }
               },
               "required": [
@@ -806,14 +735,12 @@
               "from": {
                 "type": "integer",
                 "format": "int32",
-                "description": "The index of items to start searching from.",
-                "default": "##default"
+                "description": "The index of items to start searching from."
               },
               "limit": {
                 "type": "integer",
                 "format": "int32",
-                "description": "The maximum number of items to return in one request.",
-                "default": "##default"
+                "description": "The maximum number of items to return in one request."
               }
             },
             "description": "Pagination criteria"
@@ -843,8 +770,7 @@
             "properties": {
               "assignee": {
                 "type": "string",
-                "description": "The assignee of the user task.",
-                "default": "##default"
+                "description": "The assignee of the user task."
               },
               "completionDate": {
                 "type": "object",
@@ -858,8 +784,7 @@
                     "description": "Filter up to this time (exclusive). RFC 3339 format (e.g., '2024-12-17T10:30:00Z' or '2024-12-17T10:30:00+01:00')."
                   }
                 },
-                "description": "The user task completion date.",
-                "default": "##default"
+                "description": "The user task completion date."
               },
               "creationDate": {
                 "type": "object",
@@ -873,8 +798,7 @@
                     "description": "Filter up to this time (exclusive). RFC 3339 format (e.g., '2024-12-17T10:30:00Z' or '2024-12-17T10:30:00+01:00')."
                   }
                 },
-                "description": "The user task creation date.",
-                "default": "##default"
+                "description": "The user task creation date."
               },
               "dueDate": {
                 "type": "object",
@@ -888,18 +812,15 @@
                     "description": "Filter up to this time (exclusive). RFC 3339 format (e.g., '2024-12-17T10:30:00Z' or '2024-12-17T10:30:00+01:00')."
                   }
                 },
-                "description": "The user task due date.",
-                "default": "##default"
+                "description": "The user task due date."
               },
               "elementId": {
                 "type": "string",
-                "description": "The element ID of the user task.",
-                "default": "##default"
+                "description": "The element ID of the user task."
               },
               "elementInstanceKey": {
                 "type": "string",
-                "description": "The key of the element instance.",
-                "default": "##default"
+                "description": "The key of the element instance."
               },
               "followUpDate": {
                 "type": "object",
@@ -913,25 +834,21 @@
                     "description": "Filter up to this time (exclusive). RFC 3339 format (e.g., '2024-12-17T10:30:00Z' or '2024-12-17T10:30:00+01:00')."
                   }
                 },
-                "description": "The user task follow-up date.",
-                "default": "##default"
+                "description": "The user task follow-up date."
               },
               "localVariables": {
                 "description": "The local variables of the user task.",
-                "default": "##default",
                 "type": "array",
                 "items": {
                   "type": "object",
                   "properties": {
                     "name": {
                       "type": "string",
-                      "description": "Name of the variable.",
-                      "default": "##default"
+                      "description": "Name of the variable."
                     },
                     "value": {
                       "type": "string",
-                      "description": "The value of the variable. Variable values in filters need to be in serialized JSON format. For example, a variable with string value `myValue` can be found with the filter value `\"myValue\"`. Consider appropriate escaping for special characters in JSON strings when constructing filter values. ",
-                      "default": "##default"
+                      "description": "The value of the variable. Variable values in filters need to be in serialized JSON format. For example, a variable with string value `myValue` can be found with the filter value `\"myValue\"`. Consider appropriate escaping for special characters in JSON strings when constructing filter values. "
                     }
                   },
                   "required": [
@@ -942,46 +859,38 @@
               },
               "name": {
                 "type": "string",
-                "description": "The task name. This only works for data created with 8.8 and onwards. Instances from prior versions don't contain this data and cannot be found. ",
-                "default": "##default"
+                "description": "The task name. This only works for data created with 8.8 and onwards. Instances from prior versions don't contain this data and cannot be found. "
               },
               "priority": {
                 "type": "integer",
                 "format": "int32",
-                "description": "The priority of the user task.",
-                "default": "##default"
+                "description": "The priority of the user task."
               },
               "processDefinitionId": {
                 "type": "string",
-                "description": "The ID of the process definition.",
-                "default": "##default"
+                "description": "The ID of the process definition."
               },
               "processDefinitionKey": {
                 "type": "string",
-                "description": "The key of the process definition.",
-                "default": "##default"
+                "description": "The key of the process definition."
               },
               "processInstanceKey": {
                 "type": "string",
-                "description": "The key of the process instance.",
-                "default": "##default"
+                "description": "The key of the process instance."
               },
               "processInstanceVariables": {
                 "description": "The variables of the process instance.",
-                "default": "##default",
                 "type": "array",
                 "items": {
                   "type": "object",
                   "properties": {
                     "name": {
                       "type": "string",
-                      "description": "Name of the variable.",
-                      "default": "##default"
+                      "description": "Name of the variable."
                     },
                     "value": {
                       "type": "string",
-                      "description": "The value of the variable. Variable values in filters need to be in serialized JSON format. For example, a variable with string value `myValue` can be found with the filter value `\"myValue\"`. Consider appropriate escaping for special characters in JSON strings when constructing filter values. ",
-                      "default": "##default"
+                      "description": "The value of the variable. Variable values in filters need to be in serialized JSON format. For example, a variable with string value `myValue` can be found with the filter value `\"myValue\"`. Consider appropriate escaping for special characters in JSON strings when constructing filter values. "
                     }
                   },
                   "required": [
@@ -1003,12 +912,10 @@
                   "CANCELED",
                   "FAILED"
                 ],
-                "description": "The user task state.",
-                "default": "##default"
+                "description": "The user task state."
               },
               "tags": {
-                "description": "List of tags. Tags need to start with a letter; then alphanumerics, `_`, `-`, `:`, or `.`; length ≤ 100.",
-                "default": "##default",
+                "description": "List of tags. Tags need to start with a letter; then alphanumerics, `_`, `-`, `:`, or `.`; length \u2264 100.",
                 "type": "array",
                 "items": {
                   "type": "string"
@@ -1016,45 +923,37 @@
               },
               "userTaskKey": {
                 "type": "string",
-                "description": "The key for this user task.",
-                "default": "##default"
+                "description": "The key for this user task."
               }
             },
-            "description": "The user task search filters.",
-            "default": "##default"
+            "description": "The user task search filters."
           },
           "page": {
             "type": "object",
             "properties": {
               "after": {
                 "type": "string",
-                "description": "Use the `endCursor` value from the previous response to fetch the next page of results.",
-                "default": "##default"
+                "description": "Use the `endCursor` value from the previous response to fetch the next page of results."
               },
               "before": {
                 "type": "string",
-                "description": "Use the `startCursor` value from the previous response to fetch the previous page of results.",
-                "default": "##default"
+                "description": "Use the `startCursor` value from the previous response to fetch the previous page of results."
               },
               "from": {
                 "type": "integer",
                 "format": "int32",
-                "description": "The index of items to start searching from.",
-                "default": "##default"
+                "description": "The index of items to start searching from."
               },
               "limit": {
                 "type": "integer",
                 "format": "int32",
-                "description": "The maximum number of items to return in one request.",
-                "default": "##default"
+                "description": "The maximum number of items to return in one request."
               }
             },
-            "description": "Pagination criteria.",
-            "default": "##default"
+            "description": "Pagination criteria."
           },
           "sort": {
             "description": "Sort field criteria.",
-            "default": "##default",
             "type": "array",
             "items": {
               "type": "object",
@@ -1069,16 +968,14 @@
                     "priority",
                     "name"
                   ],
-                  "description": "The field to sort by.",
-                  "default": "##default"
+                  "description": "The field to sort by."
                 },
                 "order": {
                   "type": "string",
                   "enum": [
                     "ASC",
                     "DESC"
-                  ],
-                  "default": "##default"
+                  ]
                 }
               },
               "required": [
@@ -1126,33 +1023,27 @@
             "properties": {
               "isTruncated": {
                 "type": "boolean",
-                "description": "Whether the value is truncated or not.",
-                "default": "##default"
+                "description": "Whether the value is truncated or not."
               },
               "name": {
                 "type": "string",
-                "description": "Name of the variable.",
-                "default": "##default"
+                "description": "Name of the variable."
               },
               "processInstanceKey": {
                 "type": "string",
-                "description": "The key of the process instance of this variable.",
-                "default": "##default"
+                "description": "The key of the process instance of this variable."
               },
               "scopeKey": {
                 "type": "string",
-                "description": "The key of the scope that defines where this variable is directly defined. This can be a process instance key (for process-level variables) or an element instance key (for local variables scoped to tasks, subprocesses, gateways, events, etc.). Use this filter to find variables directly defined in specific scopes. Note that this does not include variables from parent scopes that would be visible through the scope hierarchy. ",
-                "default": "##default"
+                "description": "The key of the scope that defines where this variable is directly defined. This can be a process instance key (for process-level variables) or an element instance key (for local variables scoped to tasks, subprocesses, gateways, events, etc.). Use this filter to find variables directly defined in specific scopes. Note that this does not include variables from parent scopes that would be visible through the scope hierarchy. "
               },
               "value": {
                 "type": "string",
-                "description": "The value of the variable. Variable values in filters need to be in serialized JSON format. For example, a variable with string value `myValue` can be found with the filter value `\"myValue\"`. Consider appropriate escaping for special characters in JSON strings when constructing filter values. ",
-                "default": "##default"
+                "description": "The value of the variable. Variable values in filters need to be in serialized JSON format. For example, a variable with string value `myValue` can be found with the filter value `\"myValue\"`. Consider appropriate escaping for special characters in JSON strings when constructing filter values. "
               },
               "variableKey": {
                 "type": "string",
-                "description": "The key for this variable.",
-                "default": "##default"
+                "description": "The key for this variable."
               }
             },
             "description": "Filter search by the given fields"
@@ -1172,16 +1063,14 @@
                     "scopeKey",
                     "processInstanceKey"
                   ],
-                  "description": "The field to sort by.",
-                  "default": "##default"
+                  "description": "The field to sort by."
                 },
                 "order": {
                   "type": "string",
                   "enum": [
                     "ASC",
                     "DESC"
-                  ],
-                  "default": "##default"
+                  ]
                 }
               },
               "required": [
@@ -1195,25 +1084,21 @@
             "properties": {
               "after": {
                 "type": "string",
-                "description": "Use the `endCursor` value from the previous response to fetch the next page of results.",
-                "default": "##default"
+                "description": "Use the `endCursor` value from the previous response to fetch the next page of results."
               },
               "before": {
                 "type": "string",
-                "description": "Use the `startCursor` value from the previous response to fetch the previous page of results.",
-                "default": "##default"
+                "description": "Use the `startCursor` value from the previous response to fetch the previous page of results."
               },
               "from": {
                 "type": "integer",
                 "format": "int32",
-                "description": "The index of items to start searching from.",
-                "default": "##default"
+                "description": "The index of items to start searching from."
               },
               "limit": {
                 "type": "integer",
                 "format": "int32",
-                "description": "The maximum number of items to return in one request.",
-                "default": "##default"
+                "description": "The maximum number of items to return in one request."
               }
             },
             "description": "Pagination criteria"


### PR DESCRIPTION
## Description

The Swagger2Module reads @Schema.defaultValue() and emits it into the JSON Schema "default" field. Since Swagger 2.2.44, unset defaultValue returns "##default" (Schema.DEFAULT_SENTINEL) instead of "", and the victools module does not filter it out (victools/jsonschema-generator#573).

Add a withInstanceAttributeOverride to CamundaJsonSchemaGenerator that removes the sentinel from generated schemas.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #50934
