### PR TITLE
fix: allow opting into ID-token-backed claims in OIDC user converter

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -644,7 +644,8 @@ public class WebSecurityConfig {
           oidcAccessTokenDecoderFactory,
           tokenClaimsConverter,
           request,
-          buildAdditionalJwkSetUrisByIssuer(oidcProviderRepository));
+          buildAdditionalJwkSetUrisByIssuer(oidcProviderRepository),
+          buildPreferIdTokenClaimsByRegistrationId(oidcProviderRepository));
     }
 
     @Bean
@@ -796,6 +797,13 @@ public class WebSecurityConfig {
                     }
                     return a;
                   }));
+    }
+
+    private Map<String, Boolean> buildPreferIdTokenClaimsByRegistrationId(
+        final OidcAuthenticationConfigurationRepository oidcProviderRepository) {
+      return oidcProviderRepository.getOidcAuthenticationConfigurations().entrySet().stream()
+          .filter(entry -> entry.getValue().isPreferIdTokenClaims())
+          .collect(toMap(Map.Entry::getKey, entry -> Boolean.TRUE));
     }
 
     @Bean

--- a/authentication/src/main/java/io/camunda/authentication/converter/OidcUserAuthenticationConverter.java
+++ b/authentication/src/main/java/io/camunda/authentication/converter/OidcUserAuthenticationConverter.java
@@ -41,6 +41,7 @@ public class OidcUserAuthenticationConverter
   private final HttpServletRequest request;
   private final Map<String, JwtDecoder> jwtDecoders;
   private final Map<String, List<String>> additionalJwkSetUrisByIssuer;
+  private final Map<String, Boolean> preferIdTokenClaimsByRegistrationId;
 
   public OidcUserAuthenticationConverter(
       final OAuth2AuthorizedClientRepository authorizedClientRepository,
@@ -52,6 +53,7 @@ public class OidcUserAuthenticationConverter
         accessTokenDecoderFactory,
         tokenClaimsConverter,
         request,
+        Collections.emptyMap(),
         Collections.emptyMap());
   }
 
@@ -61,6 +63,22 @@ public class OidcUserAuthenticationConverter
       final TokenClaimsConverter tokenClaimsConverter,
       final HttpServletRequest request,
       final Map<String, List<String>> additionalJwkSetUrisByIssuer) {
+    this(
+        authorizedClientRepository,
+        accessTokenDecoderFactory,
+        tokenClaimsConverter,
+        request,
+        additionalJwkSetUrisByIssuer,
+        Collections.emptyMap());
+  }
+
+  public OidcUserAuthenticationConverter(
+      final OAuth2AuthorizedClientRepository authorizedClientRepository,
+      final OidcAccessTokenDecoderFactory accessTokenDecoderFactory,
+      final TokenClaimsConverter tokenClaimsConverter,
+      final HttpServletRequest request,
+      final Map<String, List<String>> additionalJwkSetUrisByIssuer,
+      final Map<String, Boolean> preferIdTokenClaimsByRegistrationId) {
     this.authorizedClientRepository = authorizedClientRepository;
     this.accessTokenDecoderFactory = accessTokenDecoderFactory;
     this.tokenClaimsConverter = tokenClaimsConverter;
@@ -70,6 +88,10 @@ public class OidcUserAuthenticationConverter
             ? additionalJwkSetUrisByIssuer.entrySet().stream()
                 .collect(
                     Collectors.toUnmodifiableMap(Map.Entry::getKey, e -> List.copyOf(e.getValue())))
+            : Collections.emptyMap();
+    this.preferIdTokenClaimsByRegistrationId =
+        preferIdTokenClaimsByRegistrationId != null
+            ? Map.copyOf(preferIdTokenClaimsByRegistrationId)
             : Collections.emptyMap();
     jwtDecoders = new ConcurrentHashMap<>();
   }
@@ -94,12 +116,29 @@ public class OidcUserAuthenticationConverter
   }
 
   protected Map<String, Object> getClaims(final OAuth2AuthenticationToken authenticationToken) {
+    // When prefer-id-token-claims is enabled for the current registration we short-circuit the
+    // access-token decode path entirely and use the OidcUser principal attributes (which Spring
+    // populates with the ID-token and userInfo merged claims). This lets operators opt in to
+    // sourcing authorisation-relevant claims from userInfo in setups where the access token is
+    // signed by a key set that Camunda cannot reach, or lacks claims Camunda needs.
+    if (shouldPreferIdTokenClaims(authenticationToken)) {
+      return getIdTokenClaims(authenticationToken);
+    }
     return Optional.ofNullable(getAccessTokenClaims(authenticationToken))
         .orElseGet(
             () -> {
               LOGGER.warn("Falling back to ID Token claims");
               return getIdTokenClaims(authenticationToken);
             });
+  }
+
+  private boolean shouldPreferIdTokenClaims(final OAuth2AuthenticationToken authenticationToken) {
+    if (preferIdTokenClaimsByRegistrationId.isEmpty()) {
+      return false;
+    }
+    final var registrationId = authenticationToken.getAuthorizedClientRegistrationId();
+    return registrationId != null
+        && Boolean.TRUE.equals(preferIdTokenClaimsByRegistrationId.get(registrationId));
   }
 
   protected Map<String, Object> getAccessTokenClaims(

--- a/authentication/src/test/java/io/camunda/authentication/config/JWSKeySelectorFactoryTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/JWSKeySelectorFactoryTest.java
@@ -235,11 +235,11 @@ final class JWSKeySelectorFactoryTest {
   }
 
   @Test
-  void shouldResolveDisjointKeysFromCorrectSourcesLikeWalmartScenario() throws Exception {
-    // given — simulates the Walmart/PingFederate scenario:
-    // Primary JWKS (standard) has kid="web-ui-kid" for Web UI tokens
-    // Additional JWKS (custom) has kid="m2m-kid" for M2M tokens
-    // The key sets are disjoint (different kids at each endpoint).
+  void shouldResolveDisjointKeysFromCorrectSources() throws Exception {
+    // given — primary JWKS and additional JWKS hold disjoint key sets:
+    // primary has kid="web-ui-kid" for Web UI tokens, additional has
+    // kid="m2m-kid" for M2M tokens. The composite source must route each
+    // token to the correct JWKS.
     final var webUiKey =
         new RSAKeyGenerator(2048)
             .keyID("web-ui-kid")

--- a/authentication/src/test/java/io/camunda/authentication/converter/OidcUserAuthenticationConverterIntegrationTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/converter/OidcUserAuthenticationConverterIntegrationTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.converter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import io.camunda.authentication.config.AbstractWebSecurityConfigTest;
+import io.camunda.authentication.config.WebSecurityConfig;
+import io.camunda.authentication.config.controllers.WebSecurityConfigTestContext;
+import io.camunda.authentication.config.controllers.WebSecurityOidcTestContext;
+import io.camunda.security.auth.CamundaAuthentication;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+/**
+ * Integration test covering the {@code prefer-id-token-claims} opt-in for an OIDC setup where a
+ * specific claim only found in the userInfo response is required for mapping-rule evaluation.
+ *
+ * <p>When the flag is enabled, {@link OidcUserAuthenticationConverter} must short-circuit the
+ * access-token decode path entirely and source claims from {@link OidcUser#getAttributes()} (which
+ * Spring populates with the merged ID-token + userInfo claims during the authorisation-code flow).
+ * This test exercises the full Spring bean graph (real converter, real {@link WebSecurityConfig}
+ * wiring from the property through to the converter bean) to verify the flag propagates end-to-end.
+ */
+@SuppressWarnings("SpringBootApplicationProperties")
+@SpringBootTest(
+    classes = {
+      WebSecurityConfigTestContext.class,
+      WebSecurityOidcTestContext.class,
+      WebSecurityConfig.class
+    },
+    properties = {
+      "camunda.security.authentication.unprotected-api=false",
+      "camunda.security.authentication.method=oidc",
+      "camunda.security.authentication.oidc.client-id=example",
+      "camunda.security.authentication.oidc.redirect-uri=redirect.example.com",
+      "camunda.security.authentication.oidc.authorization-uri=authorization.example.com",
+      "camunda.security.authentication.oidc.token-uri=token.example.com",
+      "camunda.security.authentication.oidc.prefer-id-token-claims=true",
+    })
+public class OidcUserAuthenticationConverterIntegrationTest extends AbstractWebSecurityConfigTest {
+
+  @RegisterExtension
+  static WireMockExtension wireMock =
+      WireMockExtension.newInstance().configureStaticDsl(true).build();
+
+  private static final String CLIENT_REGISTRATION_ID = "oidc";
+
+  @Autowired private OidcUserAuthenticationConverter converter;
+
+  @MockitoBean private TokenClaimsConverter tokenClaimsConverter;
+
+  @DynamicPropertySource
+  static void registerWireMockProperties(final DynamicPropertyRegistry registry) {
+    final var issuerUri = "http://localhost:" + wireMock.getPort() + "/issuer";
+    registry.add("camunda.security.authentication.oidc.issuer-uri", () -> issuerUri);
+    registry.add(
+        "camunda.security.authentication.oidc.jwk-set-uri",
+        () -> "http://localhost:" + wireMock.getPort() + "/id-token/jwks");
+
+    // Spring resolves the issuer's .well-known configuration during context startup; mock it so
+    // the client registration can be built. No JWKS fetch happens in this test because the
+    // prefer-id-token-claims flag short-circuits the access-token decode path entirely.
+    final var openidConfig =
+        "{\"issuer\": \""
+            + issuerUri
+            + "\","
+            + "\"token_endpoint\": \"token.example.com\","
+            + "\"jwks_uri\": \"http://localhost:"
+            + wireMock.getPort()
+            + "/id-token/jwks\","
+            + "\"subject_types_supported\": [\"public\"]"
+            + "}";
+    wireMock
+        .getRuntimeInfo()
+        .getWireMock()
+        .register(
+            WireMock.get(WireMock.urlMatching(".*/issuer/.well-known/openid-configuration"))
+                .willReturn(WireMock.jsonResponse(openidConfig, HttpStatus.OK.value())));
+  }
+
+  @Test
+  void shouldUseIdTokenAndUserInfoClaimsWhenPreferIdTokenClaimsIsEnabled() {
+    // given — a logged-in OidcUser whose principal attributes carry the ID-token + userInfo
+    // merged claims (which is where a userInfo-only claim lives once Spring fetches userInfo
+    // during the authorisation-code flow).
+    final var oidcUser = Mockito.mock(OidcUser.class);
+    Mockito.when(oidcUser.getAttributes())
+        .thenReturn(Map.of("sub", "alice", "groups", List.of("group-a")));
+
+    final var authentication =
+        new OAuth2AuthenticationToken(oidcUser, List.of(), CLIENT_REGISTRATION_ID);
+
+    // the converter's request-scoped HttpServletRequest proxy resolves via RequestContextHolder;
+    // bind a mock request for the duration of the call.
+    final var request = new MockHttpServletRequest();
+    final var response = new MockHttpServletResponse();
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request, response));
+
+    Mockito.when(tokenClaimsConverter.convert(Mockito.any()))
+        .thenReturn(CamundaAuthentication.of(b -> b.user("alice")));
+
+    try {
+      // when — the converter runs through the real WebSecurityConfig bean graph. With
+      // prefer-id-token-claims=true, it must skip access-token decoding and return the
+      // principal attributes directly.
+      converter.convert(authentication);
+    } finally {
+      RequestContextHolder.resetRequestAttributes();
+    }
+
+    // then — TokenClaimsConverter receives the userInfo-merged principal attributes,
+    // including the userInfo-only claim that mapping rules need to match against.
+    @SuppressWarnings("unchecked")
+    final ArgumentCaptor<Map<String, Object>> claimsCaptor = ArgumentCaptor.forClass(Map.class);
+    Mockito.verify(tokenClaimsConverter).convert(claimsCaptor.capture());
+    assertThat(claimsCaptor.getValue())
+        .containsEntry("sub", "alice")
+        .containsEntry("groups", List.of("group-a"));
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/converter/OidcUserAuthenticationConverterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/converter/OidcUserAuthenticationConverterTest.java
@@ -13,6 +13,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -20,6 +21,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.authentication.config.OidcAccessTokenDecoderFactory;
 import io.camunda.security.auth.CamundaAuthentication;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -435,5 +437,102 @@ public class OidcUserAuthenticationConverterTest {
     // then — null passed because empty map has no entry for this issuer
     verify(oidcAccessTokenDecoderFactory)
         .createAccessTokenDecoder(eq(clientRegistration), isNull());
+  }
+
+  @Test
+  public void shouldUseIdTokenClaimsWhenPreferIdTokenClaimsIsEnabled() {
+    // given — converter configured with prefer-id-token-claims=true for the current registration
+    final var registrationId = "pingfed";
+    final var converter =
+        new OidcUserAuthenticationConverter(
+            authorizedClientRepository,
+            oidcAccessTokenDecoderFactory,
+            tokenClaimsConverter,
+            request,
+            Collections.emptyMap(),
+            Map.of(registrationId, true));
+
+    // OidcUser attributes carry the ID-token + userInfo merged claims (including the
+    // userInfo-only claim)
+    final var oidcUser = mock(OidcUser.class);
+    final Map<String, Object> principalAttributes =
+        Map.of("sub", "alice", "groups", List.of("group-a"));
+    when(oidcUser.getAttributes()).thenReturn(principalAttributes);
+
+    final var authentication = mock(OAuth2AuthenticationToken.class);
+    when(authentication.getPrincipal()).thenReturn(oidcUser);
+    when(authentication.getAuthorizedClientRegistrationId()).thenReturn(registrationId);
+
+    when(tokenClaimsConverter.convert(any()))
+        .thenReturn(CamundaAuthentication.of(b -> b.user("alice")));
+
+    // when
+    converter.convert(authentication);
+
+    // then — TokenClaimsConverter receives the principal attributes verbatim
+    @SuppressWarnings("unchecked")
+    final ArgumentCaptor<Map<String, Object>> claimsCaptor = ArgumentCaptor.forClass(Map.class);
+    verify(tokenClaimsConverter).convert(claimsCaptor.capture());
+    assertThat(claimsCaptor.getValue())
+        .containsEntry("sub", "alice")
+        .containsEntry("groups", List.of("group-a"));
+
+    // and — the access token is NOT decoded and the authorised client repository is NOT hit
+    verify(jwtDecoder, never()).decode(any());
+    verify(oidcAccessTokenDecoderFactory, never()).createAccessTokenDecoder(any(), any());
+    verify(authorizedClientRepository, never()).loadAuthorizedClient(any(), any(), any());
+  }
+
+  @Test
+  public void shouldDecodeAccessTokenWhenPreferIdTokenClaimsIsDisabledForRegistration() {
+    // given — converter configured with prefer-id-token-claims=true for a DIFFERENT registration
+    // than the one the authentication is for. The flag must only apply when the current
+    // registration is explicitly opted in.
+    final var converter =
+        new OidcUserAuthenticationConverter(
+            authorizedClientRepository,
+            oidcAccessTokenDecoderFactory,
+            tokenClaimsConverter,
+            request,
+            Collections.emptyMap(),
+            Map.of("other-reg", true));
+
+    final var oidcUser = mock(OidcUser.class);
+    when(oidcUser.getAttributes()).thenReturn(Map.of("sub", "alice", "groups", List.of("group-a")));
+
+    final var authentication = mock(OAuth2AuthenticationToken.class);
+    when(authentication.getPrincipal()).thenReturn(oidcUser);
+    when(authentication.getAuthorizedClientRegistrationId()).thenReturn("current-reg");
+
+    final var accessTokenValue = "test-access-token";
+    final var accessToken = mock(OAuth2AccessToken.class);
+    when(accessToken.getTokenValue()).thenReturn(accessTokenValue);
+
+    final var providerDetails = mock(ClientRegistration.ProviderDetails.class);
+    when(providerDetails.getIssuerUri()).thenReturn("https://issuer.example.com");
+    final var clientRegistration = mock(ClientRegistration.class);
+    when(clientRegistration.getRegistrationId()).thenReturn("current-reg");
+    when(clientRegistration.getProviderDetails()).thenReturn(providerDetails);
+
+    final var authorizedClient = mock(OAuth2AuthorizedClient.class);
+    when(authorizedClient.getAccessToken()).thenReturn(accessToken);
+    when(authorizedClient.getClientRegistration()).thenReturn(clientRegistration);
+    when(authorizedClientRepository.loadAuthorizedClient(any(), any(), any()))
+        .thenReturn(authorizedClient);
+
+    final Map<String, Object> accessTokenClaims = Map.of("sub", "alice");
+    final var jwt = mock(Jwt.class);
+    when(jwtDecoder.decode(eq(accessTokenValue))).thenReturn(jwt);
+    when(jwt.getClaims()).thenReturn(accessTokenClaims);
+
+    when(tokenClaimsConverter.convert(any()))
+        .thenReturn(CamundaAuthentication.of(b -> b.user("alice")));
+
+    // when
+    converter.convert(authentication);
+
+    // then — the access token is decoded and its claims are used (default behaviour)
+    verify(jwtDecoder).decode(eq(accessTokenValue));
+    verify(tokenClaimsConverter).convert(eq(accessTokenClaims));
   }
 }

--- a/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
@@ -50,6 +50,7 @@ public class OidcAuthenticationConfiguration {
   private String clientIdClaim;
   private String groupsClaim;
   private boolean preferUsernameClaim;
+  private boolean preferIdTokenClaims;
   private String organizationId;
   private List<String> resource;
   private String clientAuthenticationMethod = CLIENT_AUTHENTICATION_METHOD_CLIENT_SECRET_BASIC;
@@ -237,6 +238,14 @@ public class OidcAuthenticationConfiguration {
     this.preferUsernameClaim = preferUsernameClaim;
   }
 
+  public boolean isPreferIdTokenClaims() {
+    return preferIdTokenClaims;
+  }
+
+  public void setPreferIdTokenClaims(final boolean preferIdTokenClaims) {
+    this.preferIdTokenClaims = preferIdTokenClaims;
+  }
+
   public String getClientAuthenticationMethod() {
     return clientAuthenticationMethod;
   }
@@ -298,6 +307,7 @@ public class OidcAuthenticationConfiguration {
         || clientIdClaim != null
         || groupsClaim != null
         || preferUsernameClaim
+        || preferIdTokenClaims
         || organizationId != null
         || !CLIENT_AUTHENTICATION_METHOD_CLIENT_SECRET_BASIC.equals(clientAuthenticationMethod)
         || assertionConfiguration.getKeystore().getPath() != null
@@ -336,6 +346,7 @@ public class OidcAuthenticationConfiguration {
     private String clientIdClaim;
     private String groupsClaim;
     private boolean preferUsernameClaim;
+    private boolean preferIdTokenClaims;
     private String organizationId;
     private String clientAuthenticationMethod = CLIENT_AUTHENTICATION_METHOD_CLIENT_SECRET_BASIC;
     private AssertionConfiguration assertionConfiguration = new AssertionConfiguration();
@@ -440,6 +451,11 @@ public class OidcAuthenticationConfiguration {
       return this;
     }
 
+    public Builder preferIdTokenClaims(final boolean preferIdTokenClaims) {
+      this.preferIdTokenClaims = preferIdTokenClaims;
+      return this;
+    }
+
     public Builder organizationId(final String organizationId) {
       this.organizationId = organizationId;
       return this;
@@ -491,6 +507,7 @@ public class OidcAuthenticationConfiguration {
       config.setClientIdClaim(clientIdClaim);
       config.setGroupsClaim(groupsClaim);
       config.setPreferUsernameClaim(preferUsernameClaim);
+      config.setPreferIdTokenClaims(preferIdTokenClaims);
       config.setOrganizationId(organizationId);
       config.setClientAuthenticationMethod(clientAuthenticationMethod);
       config.setAssertion(assertionConfiguration);


### PR DESCRIPTION
## Issue

Users could not log in after enabling `additional-jwk-set-uris` in an OIDC setup with the following shape:

- **Primary `jwk-set-uri`** (from `.well-known/openid-configuration`) — signs ID tokens only.
- **Access tokens (including m2m)** — signed by keys from a separate JWKS endpoint.
- **Mapping rules** — keyed on a specific claim only found in the userInfo response (not in the access token or ID token).

Before adding the additional JWKS:
- User tokens failed to decode (access-token `kid` not in primary) → `OidcUserAuthenticationConverter` caught `JwtException` → fell back to `OidcUser#getAttributes()` (ID token + userInfo merged by Spring) → the userInfo-only claim was present → mapping rules matched → users logged in.
- Clients failed to decode for the same reason → no fallback on the resource-server path → clients rejected.

After adding `additional-jwk-set-uris` pointing at the access-token JWKS:
- Clients started working (composite source resolves the `kid`).
- **Users broke**, because their access tokens now also decoded successfully via the composite source. The converter returned the access-token claims and never consulted the principal attributes, silently dropping the userInfo-only claim. Downstream mapping-rule evaluation had nothing to match on and the user was rejected.

The IdP serves both user access tokens and m2m tokens from the same secondary JWKS endpoint, so this cannot be worked around with JWKS-scoping configuration alone.

## Root cause

`OidcUserAuthenticationConverter.getClaims` treated principal attributes as a fallback that only fires on `JwtException`. That assumption is fragile: any change that makes a previously-undecodable access token decodable will silently drop authorisation-relevant claims that live only at userInfo. The new multi-JWKS feature exposes that fragility, but the underlying design weakness predates it.

## Fix

Introduce a new per-provider OIDC configuration flag `prefer-id-token-claims` (default `false`, mirroring the shape of `prefer-username-claim`). When enabled, `OidcUserAuthenticationConverter.getClaims` short-circuits the access-token decode path entirely and returns the `OidcUser` principal attributes directly — which Spring populates with the merged ID-token + userInfo claims during the authorisation-code flow.

```java
protected Map<String, Object> getClaims(final OAuth2AuthenticationToken authenticationToken) {
  if (shouldPreferIdTokenClaims(authenticationToken)) {
    return getIdTokenClaims(authenticationToken);
  }
  return Optional.ofNullable(getAccessTokenClaims(authenticationToken))
      .orElseGet(() -> {
        LOGGER.warn("Falling back to ID Token claims");
        return getIdTokenClaims(authenticationToken);
      });
}
```

**The flag is off by default, so existing customers see no behavioural change.** Operators with the userInfo-only-claim shape can opt in per OIDC provider in their Camunda configuration:

```yaml
camunda:
  security:
    authentication:
      oidc:
        prefer-id-token-claims: true
```

When enabled, the flag also sidesteps the need to configure `additional-jwk-set-uris` for user access tokens entirely — the converter never attempts to decode the access token in that path, so an unreachable access-token JWKS endpoint is no longer a problem for the user login flow.

### Naming note

`prefer-id-token-claims` is strictly a slight misnomer — the source is `OidcUser#getAttributes()`, which Spring populates with both the ID-token claims **and** the userInfo response (unless `user-info-enabled=false`). The name matches the `prefer-*` pattern for discoverability; happy to rename to something like `prefer-userinfo-claims` or `prefer-principal-claims` if reviewers feel the former is too vague.

## Commits

1. **`fix: allow opting into ID-token-backed claims in OIDC user converter`** — adds the `preferIdTokenClaims` config field, wires it through `WebSecurityConfig` as a per-registration-id map, updates `OidcUserAuthenticationConverter.getClaims` with the short-circuit, and adds two unit tests covering both flag states.
2. **`test: add integration test for prefer-id-token-claims opt-in`** — full Spring bean graph test (`@SpringBootTest` + WireMock for the OIDC discovery endpoint) that sets `prefer-id-token-claims=true` via property and verifies the flag propagates end-to-end from config → repository → converter.
3. **`test: remove customer-specific identifier from disjoint-keys test`** — unrelated cleanup of a pre-existing test comment that named a customer and IdP vendor.

## Verification

- [x] RED/GREEN cycle on the unit tests: `shouldUseIdTokenClaimsWhenPreferIdTokenClaimsIsEnabled` fails to compile without the constructor overload; passes once the converter logic is in place. `shouldDecodeAccessTokenWhenPreferIdTokenClaimsIsDisabledForRegistration` verifies the default flag-off path is unchanged.
- [x] Integration test runs against the real Spring context with the property set, captures the claims passed to a `@MockitoBean TokenClaimsConverter`, and asserts the userInfo-only claim is present.
- [x] `OidcUserAuthenticationConverterTest` suite: 12 tests, 0 failures.
- [x] `./mvnw checkstyle:check -pl authentication` → 0 violations.
- [x] `./mvnw license:format spotless:apply -pl authentication` clean.
- [ ] Manual verification in the affected environment once merged.

## Notes for reviewers

- The flag is keyed by client registration ID (not issuer URI) because the converter looks it up via `authenticationToken.getAuthorizedClientRegistrationId()` directly — no issuer-URI extraction needed. This differs from `additionalJwkSetUrisByIssuer`, which is keyed by issuer URI because the decoder looks it up from the JWT `iss` claim. Different lookup contexts, different keys.
- When the flag is enabled, the authorised-client repository is not consulted and no JWKS fetch is triggered — the access token is never touched by this code path.
- The existing `"Falling back to ID Token claims"` WARN log is preserved for the default-off path (when access-token decoding fails at runtime). Operators who opt into the new flag won't see it.