### PR TITLE
fix: skip fully-cached shards and harden cache lookup in version compatibility workflow

### DIFF
--- a/.github/workflows/zeebe-version-compatibility.yml
+++ b/.github/workflows/zeebe-version-compatibility.yml
@@ -39,12 +39,22 @@ jobs:
       - name: Find previous report
         id: get-last-run-id
         run: |
-          runs=$(gh api /repos/${{ github.repository }}/actions/workflows/zeebe-version-compatibility.yml/runs)
-          last_run_id=$(echo "$runs" | jq 'first(.workflow_runs[] | select(.status=="completed").id)')
-          echo "last_run_id=$last_run_id" >> "$GITHUB_OUTPUT"
+          run_ids=$(gh api '/repos/${{ github.repository }}/actions/workflows/zeebe-version-compatibility.yml/runs?branch=main' \
+            | jq -r '[.workflow_runs[] | select(.status=="completed" and .conclusion!="cancelled").id] | .[:10] | .[]')
+          for run_id in $run_ids; do
+            has_artifact=$(gh api "/repos/${{ github.repository }}/actions/runs/${run_id}/artifacts" \
+              | jq '[.artifacts[] | select(.name=="zeebe-version-compatibility")] | length')
+            if [ "$has_artifact" -gt 0 ]; then
+              echo "Found report artifact in run $run_id"
+              echo "last_run_id=$run_id" >> "$GITHUB_OUTPUT"
+              break
+            fi
+            echo "Run $run_id has no report artifact, trying next..."
+          done
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Download previous report
+        if: steps.get-last-run-id.outputs.last_run_id != ''
         uses: actions/download-artifact@v8
         continue-on-error: true
         with:

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/VersionCompatibilityMatrix.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/VersionCompatibilityMatrix.java
@@ -25,6 +25,7 @@ import java.net.http.HttpResponse.BodyHandlers;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -35,7 +36,9 @@ import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -260,7 +263,78 @@ final class VersionCompatibilityMatrix {
         Optional.ofNullable(System.getenv("ZEEBE_CI_CHECK_VERSION_COMPATIBILITY_TOTAL"))
             .map(Integer::parseInt)
             .orElse(1);
-    return shard(combinations, index, total);
+    final var shardedCombinations = shard(combinations, index, total).toList();
+
+    if (isFullyCached(shardedCombinations)) {
+      LOG.info(
+          "All {} version pairs in shard {}/{} are fully cached, skipping to avoid"
+              + " unnecessary resource usage",
+          shardedCombinations.size(),
+          index,
+          total);
+      return Stream.empty();
+    }
+
+    return shardedCombinations.stream();
+  }
+
+  /**
+   * Checks if all version pairs are fully cached by reading the cache file referenced by the {@code
+   * ZEEBE_CI_CHECK_VERSION_COMPATIBILITY_REPORT} environment variable. The expected number of test
+   * methods per pair is derived reflectively from {@link RollingUpdateTest} to ensure that newly
+   * added test methods are not silently skipped.
+   *
+   * <p>Returns {@code false} if the cache file is missing, empty, or cannot be read — in those
+   * cases the shard should run normally.
+   */
+  private static boolean isFullyCached(final List<Arguments> combinations) {
+    final var reportPath =
+        Optional.ofNullable(System.getenv("ZEEBE_CI_CHECK_VERSION_COMPATIBILITY_REPORT"))
+            .map(Path::of)
+            .orElse(null);
+    final var expectedMethods = countVersionMatrixTestMethods(RollingUpdateTest.class);
+    return isFullyCached(combinations, reportPath, expectedMethods);
+  }
+
+  @VisibleForTesting
+  static boolean isFullyCached(
+      final List<Arguments> combinations, final Path reportPath, final long expectedMethods) {
+    if (reportPath == null || !Files.exists(reportPath) || expectedMethods <= 0) {
+      return false;
+    }
+
+    try {
+      final var methodCountPerPair =
+          Files.readAllLines(reportPath).stream()
+              .filter(line -> line.contains(","))
+              .collect(
+                  Collectors.groupingBy(
+                      line -> line.substring(line.indexOf(',') + 1), Collectors.counting()));
+
+      return combinations.stream()
+          .map(args -> args.get()[0] + "->" + args.get()[1])
+          .allMatch(pair -> methodCountPerPair.getOrDefault(pair, 0L) >= expectedMethods);
+    } catch (final IOException e) {
+      LOG.warn("Failed to read cache file at {}, proceeding with full shard", reportPath, e);
+      return false;
+    }
+  }
+
+  /**
+   * Counts the number of {@link ParameterizedTest} methods in the given test class that use
+   * {@code @MethodSource("versionMatrix")}. This is the authoritative source for how many test
+   * methods each version pair must have cached to be considered fully tested.
+   */
+  @VisibleForTesting
+  static long countVersionMatrixTestMethods(final Class<?> testClass) {
+    return Arrays.stream(testClass.getDeclaredMethods())
+        .filter(m -> m.isAnnotationPresent(ParameterizedTest.class))
+        .filter(
+            m -> {
+              final var source = m.getAnnotation(MethodSource.class);
+              return source != null && Arrays.asList(source.value()).contains("versionMatrix");
+            })
+        .count();
   }
 
   @VisibleForTesting

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/VersionCompatibilityMatrixTest.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/VersionCompatibilityMatrixTest.java
@@ -327,6 +327,145 @@ class VersionCompatibilityMatrixTest {
   }
 
   @Nested
+  class FullyCachedTest {
+
+    @Test
+    void shouldReturnFalseWhenCacheFileDoesNotExist(
+        @org.junit.jupiter.api.io.TempDir final Path tempDir) {
+      // given
+      final var combinations =
+          List.of(Arguments.of("8.7.0", "8.7.11"), Arguments.of("8.7.11", "8.7.12"));
+
+      // when / then
+      assertThat(
+              VersionCompatibilityMatrix.isFullyCached(combinations, tempDir.resolve("missing"), 3))
+          .isFalse();
+    }
+
+    @Test
+    void shouldReturnFalseWhenCachePathIsNull() {
+      // given
+      final var combinations = List.of(Arguments.of("8.7.0", "8.7.11"));
+
+      // when / then
+      assertThat(VersionCompatibilityMatrix.isFullyCached(combinations, null, 3)).isFalse();
+    }
+
+    @Test
+    void shouldReturnTrueWhenAllPairsFullyCached(
+        @org.junit.jupiter.api.io.TempDir final Path tempDir) throws Exception {
+      // given
+      final var cacheFile = tempDir.resolve("cache");
+      Files.writeString(
+          cacheFile,
+          """
+          methodA,8.7.0->8.7.11
+          methodB,8.7.0->8.7.11
+          methodC,8.7.0->8.7.11
+          methodA,8.7.11->8.7.12
+          methodB,8.7.11->8.7.12
+          methodC,8.7.11->8.7.12
+          """);
+      final var combinations =
+          List.of(Arguments.of("8.7.0", "8.7.11"), Arguments.of("8.7.11", "8.7.12"));
+
+      // when / then
+      assertThat(VersionCompatibilityMatrix.isFullyCached(combinations, cacheFile, 3)).isTrue();
+    }
+
+    @Test
+    void shouldReturnFalseWhenSomePairsMissingFromCache(
+        @org.junit.jupiter.api.io.TempDir final Path tempDir) throws Exception {
+      // given
+      final var cacheFile = tempDir.resolve("cache");
+      Files.writeString(
+          cacheFile,
+          """
+          methodA,8.7.0->8.7.11
+          methodB,8.7.0->8.7.11
+          methodC,8.7.0->8.7.11
+          """);
+      final var combinations =
+          List.of(Arguments.of("8.7.0", "8.7.11"), Arguments.of("8.7.11", "8.7.12"));
+
+      // when / then
+      assertThat(VersionCompatibilityMatrix.isFullyCached(combinations, cacheFile, 3)).isFalse();
+    }
+
+    @Test
+    void shouldReturnFalseWhenPairPartiallyCached(
+        @org.junit.jupiter.api.io.TempDir final Path tempDir) throws Exception {
+      // given \u2014 pair 8.7.0->8.7.11 only has 2 of 3 methods cached
+      final var cacheFile = tempDir.resolve("cache");
+      Files.writeString(
+          cacheFile,
+          """
+          methodA,8.7.0->8.7.11
+          methodB,8.7.0->8.7.11
+          methodA,8.7.11->8.7.12
+          methodB,8.7.11->8.7.12
+          methodC,8.7.11->8.7.12
+          """);
+      final var combinations =
+          List.of(Arguments.of("8.7.0", "8.7.11"), Arguments.of("8.7.11", "8.7.12"));
+
+      // when / then
+      assertThat(VersionCompatibilityMatrix.isFullyCached(combinations, cacheFile, 3)).isFalse();
+    }
+
+    @Test
+    void shouldReturnFalseWhenCacheFileIsEmpty(@org.junit.jupiter.api.io.TempDir final Path tempDir)
+        throws Exception {
+      // given
+      final var cacheFile = tempDir.resolve("cache");
+      Files.writeString(cacheFile, "");
+      final var combinations = List.of(Arguments.of("8.7.0", "8.7.11"));
+
+      // when / then
+      assertThat(VersionCompatibilityMatrix.isFullyCached(combinations, cacheFile, 3)).isFalse();
+    }
+  }
+
+  @Nested
+  class CountVersionMatrixTestMethodsTest {
+
+    @Test
+    void shouldCountOnlyVersionMatrixParameterizedMethods() {
+      // when / then — DummyTestClass has exactly 2 @ParameterizedTest methods
+      // with @MethodSource("versionMatrix")
+      assertThat(VersionCompatibilityMatrix.countVersionMatrixTestMethods(DummyTestClass.class))
+          .isEqualTo(2);
+    }
+
+    @Test
+    void shouldReturnZeroForClassWithNoMatchingMethods() {
+      // when / then
+      assertThat(
+              VersionCompatibilityMatrix.countVersionMatrixTestMethods(
+                  VersionCompatibilityMatrixTest.class))
+          .isZero();
+    }
+
+    @SuppressWarnings("unused")
+    static class DummyTestClass {
+      @ParameterizedTest
+      @MethodSource("versionMatrix")
+      void matchingMethodA() {}
+
+      @ParameterizedTest
+      @MethodSource("versionMatrix")
+      void matchingMethodB() {}
+
+      @ParameterizedTest
+      @MethodSource("otherSource")
+      void nonMatchingParameterized() {}
+
+      @Test
+      void plainTest() {}
+    }
+  }
+
+  @Nested
   class VersionInfoTest {
 
     @Test


### PR DESCRIPTION
## Description

The zeebe-version-compatibility workflow had three cache lookup bugs causing shards to lose their cached test results and time out at 300 minutes:

1. The gh API query returned runs from all branches, including backport branches with broken YAML that uploaded zero artifacts — wiping the cache on download.
2. Cancelled runs (status=completed, conclusion=cancelled) were matched despite having no artifacts.
3. When no valid run was found, jq output "null" and the download step silently failed under continue-on-error, giving no indication of cache loss.

Additionally, fully-cached shards (where every version pair already has results for all test methods) kept the forked JVM alive for the full 300-minute timeout due to Testcontainers/Ryuk initialization with no actual work to do.

Changes:
- Scope API query to main branch only (?branch=main)
- Filter out cancelled runs (conclusion!="cancelled")
- Add null safety (jq -r + // empty) and skip download when no run found
- Add isFullyCached() check that returns an empty test stream when all pairs in a shard are already cached, allowing the JVM to exit immediately

## Related issues

related to https://camunda.slack.com/archives/C0AR2M2M3SL
