### PR TITLE
test: use controllable clock for shouldScheduleInitialFlushAtConfiguredDelay

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
@@ -228,6 +228,8 @@ final class CamundaExporterTest {
     @Test
     void shouldScheduleInitialFlushAtConfiguredDelay() {
       // given
+      final var clock = new MutableClock(1000);
+      testContext.setClock(clock);
       configuration.getBulk().setDelay(5);
       exporter =
           new CamundaExporter(


### PR DESCRIPTION
so we get a consistent time back, which makes verifying the initial scheduled flush less flakey.