### PR TITLE
Return meaningful message when end_session_endpoint is unavailable

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/CamundaOidcLogoutSuccessHandler.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/CamundaOidcLogoutSuccessHandler.java
@@ -37,6 +37,8 @@ import org.springframework.web.util.UriComponentsBuilder;
  */
 public class CamundaOidcLogoutSuccessHandler extends OidcClientInitiatedLogoutSuccessHandler {
 
+  public static final String LOGOUT_MESSAGE_ATTRIBUTE =
+      CamundaOidcLogoutSuccessHandler.class.getName() + ".LOGOUT_MESSAGE";
   private static final Logger LOG = LoggerFactory.getLogger(CamundaOidcLogoutSuccessHandler.class);
   private final ClientRegistrationRepository clientRegistrationRepository;
 
@@ -65,8 +67,13 @@ public class CamundaOidcLogoutSuccessHandler extends OidcClientInitiatedLogoutSu
       LOG.trace(
 """
 Unable to determine end-session endpoint for OIDC logout. \
+The local session has been terminated, but the IdP session will still be active. \
 Falling back to '{}' without logout hint.""",
           baseLogoutUrl);
+      request.setAttribute(
+          LOGOUT_MESSAGE_ATTRIBUTE,
+          "The identity provider's end_session_endpoint is not available. "
+              + "The local session has been terminated, but the IdP session will still be active.");
       return baseLogoutUrl;
     }
 

--- a/authentication/src/main/java/io/camunda/authentication/config/CamundaOidcLogoutSuccessHandler.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/CamundaOidcLogoutSuccessHandler.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.authentication.config;
 
+import static io.camunda.authentication.config.WebappRedirectStrategy.REDIRECT_MESSAGE_ATTRIBUTE;
 import static io.camunda.authentication.controller.PostLogoutController.POST_LOGOUT_REDIRECT_ATTRIBUTE;
 import static io.camunda.authentication.utils.RequestValidationUtils.isAllowedRedirect;
 
@@ -37,8 +38,6 @@ import org.springframework.web.util.UriComponentsBuilder;
  */
 public class CamundaOidcLogoutSuccessHandler extends OidcClientInitiatedLogoutSuccessHandler {
 
-  public static final String LOGOUT_MESSAGE_ATTRIBUTE =
-      CamundaOidcLogoutSuccessHandler.class.getName() + ".LOGOUT_MESSAGE";
   private static final Logger LOG = LoggerFactory.getLogger(CamundaOidcLogoutSuccessHandler.class);
   private final ClientRegistrationRepository clientRegistrationRepository;
 
@@ -71,7 +70,7 @@ The local session has been terminated, but the IdP session will still be active.
 Falling back to '{}' without logout hint.""",
           baseLogoutUrl);
       request.setAttribute(
-          LOGOUT_MESSAGE_ATTRIBUTE,
+          REDIRECT_MESSAGE_ATTRIBUTE,
           "The identity provider's end_session_endpoint is not available. "
               + "The local session has been terminated, but the IdP session will still be active.");
       return baseLogoutUrl;

--- a/authentication/src/main/java/io/camunda/authentication/config/WebappRedirectStrategy.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebappRedirectStrategy.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.authentication.config;
 
+import static io.camunda.authentication.config.CamundaOidcLogoutSuccessHandler.LOGOUT_MESSAGE_ATTRIBUTE;
 import static org.springframework.http.HttpStatus.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -42,7 +43,11 @@ public class WebappRedirectStrategy implements RedirectStrategy {
       throws IOException {
 
     if (url == null || DEFAULT_REDIRECT_URL.equals(url)) {
+      final String message = (String) request.getAttribute(LOGOUT_MESSAGE_ATTRIBUTE);
       response.setStatus(NO_CONTENT.value());
+      if (message != null) {
+        response.setHeader("X-Logout-Message", message);
+      }
       return;
     }
 

--- a/authentication/src/main/java/io/camunda/authentication/config/WebappRedirectStrategy.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebappRedirectStrategy.java
@@ -29,6 +29,12 @@ import org.springframework.security.web.RedirectStrategy;
  *       redirect destination.
  * </ul>
  *
+ * <p>On a {@code 204} response, an {@code X-Logout-Message} header may be included to convey a
+ * human-readable diagnostic message to the frontend. This happens when the OIDC identity provider's
+ * {@code end_session_endpoint} is not available: the local session is terminated successfully, but
+ * the IdP session cannot be ended. The header allows the frontend to display an appropriate warning
+ * to the user.
+ *
  * <p>This allows a JavaScript client to decide how to handle navigation based on the returned
  * response.
  */

--- a/authentication/src/main/java/io/camunda/authentication/config/WebappRedirectStrategy.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebappRedirectStrategy.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.authentication.config;
 
-import static io.camunda.authentication.config.CamundaOidcLogoutSuccessHandler.LOGOUT_MESSAGE_ATTRIBUTE;
 import static org.springframework.http.HttpStatus.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -40,6 +39,16 @@ import org.springframework.security.web.RedirectStrategy;
  */
 public class WebappRedirectStrategy implements RedirectStrategy {
 
+  /**
+   * Request attribute key used to pass a human-readable message to the redirect response. When set
+   * on a {@code 204 No Content} response, the value is sent as an {@code X-Logout-Message} header.
+   *
+   * <p>Any component that needs to communicate a diagnostic message through the redirect response
+   * can set this attribute on the {@link HttpServletRequest} before the redirect is executed.
+   */
+  public static final String REDIRECT_MESSAGE_ATTRIBUTE =
+      WebappRedirectStrategy.class.getName() + ".REDIRECT_MESSAGE";
+
   private static final String DEFAULT_REDIRECT_URL = "/";
   private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -49,7 +58,7 @@ public class WebappRedirectStrategy implements RedirectStrategy {
       throws IOException {
 
     if (url == null || DEFAULT_REDIRECT_URL.equals(url)) {
-      final String message = (String) request.getAttribute(LOGOUT_MESSAGE_ATTRIBUTE);
+      final String message = (String) request.getAttribute(REDIRECT_MESSAGE_ATTRIBUTE);
       response.setStatus(NO_CONTENT.value());
       if (message != null) {
         response.setHeader("X-Logout-Message", message);

--- a/authentication/src/test/java/io/camunda/authentication/config/CamundaOidcLogoutSuccessHandlerTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/CamundaOidcLogoutSuccessHandlerTest.java
@@ -153,6 +153,26 @@ public class CamundaOidcLogoutSuccessHandlerTest {
     assertThat(targetUrl).doesNotContain("logout_hint=");
   }
 
+  @Test
+  void shouldSetLogoutMessageAttributeWhenEndSessionEndpointNotAvailable() {
+    // given
+    final MockHttpServletRequest request = buildMockHttpServletRequestWithReferer(ALLOWED_REFERER);
+    final MockHttpServletResponse response = new MockHttpServletResponse();
+    final OAuth2AuthenticationToken authentication = createAuthentication("user@camunda.com");
+
+    // when
+    when(clientRegistrationRepository.findByRegistrationId("client"))
+        .thenReturn(clientRegistrationWithoutEndSessionEndpoint());
+
+    handler.determineTargetUrl(request, response, authentication);
+
+    // then
+    assertThat(request.getAttribute(CamundaOidcLogoutSuccessHandler.LOGOUT_MESSAGE_ATTRIBUTE))
+        .isEqualTo(
+            "The identity provider's end_session_endpoint is not available. "
+                + "The local session has been terminated, but the IdP session will still be active.");
+  }
+
   private static MockHttpServletRequest buildMockHttpServletRequestWithReferer(
       final String referer) {
     final MockHttpServletRequest request = new MockHttpServletRequest();
@@ -188,6 +208,17 @@ public class CamundaOidcLogoutSuccessHandlerTest {
         new DefaultOAuth2User(List.of(new SimpleGrantedAuthority("ROLE_USER")), attributes, "sub");
 
     return new OAuth2AuthenticationToken(user, user.getAuthorities(), "client");
+  }
+
+  private ClientRegistration clientRegistrationWithoutEndSessionEndpoint() {
+    return ClientRegistration.withRegistrationId("client")
+        .clientId("client-id")
+        .clientSecret("client-secret")
+        .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+        .redirectUri("{baseUrl}/login/oauth2/code/{registrationId}")
+        .authorizationUri("https://idp.com/oauth2/v1/authorize")
+        .tokenUri("https://idp.com/oauth2/v1/token")
+        .build();
   }
 
   private ClientRegistration clientRegistration() {

--- a/authentication/src/test/java/io/camunda/authentication/config/CamundaOidcLogoutSuccessHandlerTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/CamundaOidcLogoutSuccessHandlerTest.java
@@ -167,7 +167,7 @@ public class CamundaOidcLogoutSuccessHandlerTest {
     handler.determineTargetUrl(request, response, authentication);
 
     // then
-    assertThat(request.getAttribute(CamundaOidcLogoutSuccessHandler.LOGOUT_MESSAGE_ATTRIBUTE))
+    assertThat(request.getAttribute(WebappRedirectStrategy.REDIRECT_MESSAGE_ATTRIBUTE))
         .isEqualTo(
             "The identity provider's end_session_endpoint is not available. "
                 + "The local session has been terminated, but the IdP session will still be active.");

--- a/authentication/src/test/java/io/camunda/authentication/config/WebappRedirectStrategyTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/WebappRedirectStrategyTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.authentication.config;
 
+import static io.camunda.authentication.config.CamundaOidcLogoutSuccessHandler.*;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -63,6 +64,22 @@ public class WebappRedirectStrategyTest {
 
     assertThat(OBJECT_MAPPER.readTree(response.getContentAsString()).get("url").asText())
         .isEqualTo(url);
+  }
+
+  @Test
+  void shouldReturnNoContentWithLogoutMessageHeaderWhenAttributeIsPresent() throws Exception {
+    // given
+    final MockHttpServletRequest request = new MockHttpServletRequest();
+    final MockHttpServletResponse response = new MockHttpServletResponse();
+    final String message = "The identity provider's end_session_endpoint is not available.";
+    request.setAttribute(LOGOUT_MESSAGE_ATTRIBUTE, message);
+
+    // when
+    redirectStrategy.sendRedirect(request, response, "/");
+
+    // then
+    assertThat(response.getStatus()).isEqualTo(NO_CONTENT.value());
+    assertThat(response.getHeader("X-Logout-Message")).isEqualTo(message);
   }
 
   @Test

--- a/authentication/src/test/java/io/camunda/authentication/config/WebappRedirectStrategyTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/WebappRedirectStrategyTest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.authentication.config;
 
-import static io.camunda.authentication.config.CamundaOidcLogoutSuccessHandler.*;
+import static io.camunda.authentication.config.WebappRedirectStrategy.REDIRECT_MESSAGE_ATTRIBUTE;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -72,7 +72,7 @@ public class WebappRedirectStrategyTest {
     final MockHttpServletRequest request = new MockHttpServletRequest();
     final MockHttpServletResponse response = new MockHttpServletResponse();
     final String message = "The identity provider's end_session_endpoint is not available.";
-    request.setAttribute(LOGOUT_MESSAGE_ATTRIBUTE, message);
+    request.setAttribute(REDIRECT_MESSAGE_ATTRIBUTE, message);
 
     // when
     redirectStrategy.sendRedirect(request, response, "/");


### PR DESCRIPTION
When the OIDC provider does not expose an `end_session_endpoint`, the logout response now includes an `X-Logout-Message` header explaining what happens.

We already return 204 and we log the below message (trace level), so no changes here.

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #44486
