### PR TITLE
fix: adjust partition iteration to include last partition in multi-partition tests

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/CreateAuthorizationMultipartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/CreateAuthorizationMultipartitionTest.java
@@ -97,7 +97,7 @@ public class CreateAuthorizationMultipartitionTest {
             tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 3))
         .endsWith(tuple(CommandDistributionIntent.FINISHED, RecordType.EVENT, 1));
 
-    for (int partitionId = 2; partitionId < PARTITION_COUNT; partitionId++) {
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
       assertThat(
               RecordingExporter.authorizationRecords()
                   .withAuthorizationKey(authorizationKey)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/DeleteAuthorizationMultipartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/DeleteAuthorizationMultipartitionTest.java
@@ -102,7 +102,7 @@ public class DeleteAuthorizationMultipartitionTest {
             tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 3))
         .endsWith(tuple(CommandDistributionIntent.FINISHED, RecordType.EVENT, 1));
 
-    for (int partitionId = 2; partitionId < PARTITION_COUNT; partitionId++) {
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
       assertThat(
               RecordingExporter.records()
                   .withPartitionId(partitionId)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/UpdateAuthorizationMultipartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/UpdateAuthorizationMultipartitionTest.java
@@ -109,7 +109,7 @@ public class UpdateAuthorizationMultipartitionTest {
             tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 3))
         .endsWith(tuple(CommandDistributionIntent.FINISHED, RecordType.EVENT, 1));
 
-    for (int partitionId = 2; partitionId < PARTITION_COUNT; partitionId++) {
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
       assertThat(
               RecordingExporter.records()
                   .withPartitionId(partitionId)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/AddEntityGroupMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/AddEntityGroupMultiPartitionTest.java
@@ -90,7 +90,7 @@ public class AddEntityGroupMultiPartitionTest {
             tuple(CommandDistributionIntent.ACKNOWLEDGE, RecordType.COMMAND, 3),
             tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 3))
         .endsWith(tuple(CommandDistributionIntent.FINISHED, RecordType.EVENT, 1));
-    for (int partitionId = 2; partitionId < PARTITION_COUNT; partitionId++) {
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
       assertThat(
               RecordingExporter.groupRecords()
                   .withPartitionId(partitionId)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/CreateGroupMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/CreateGroupMultiPartitionTest.java
@@ -71,7 +71,7 @@ public class CreateGroupMultiPartitionTest {
             tuple(CommandDistributionIntent.ACKNOWLEDGE, RecordType.COMMAND, 3),
             tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 3))
         .endsWith(tuple(CommandDistributionIntent.FINISHED, RecordType.EVENT, 1));
-    for (int partitionId = 2; partitionId < PARTITION_COUNT; partitionId++) {
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
       assertThat(
               RecordingExporter.groupRecords()
                   .withPartitionId(partitionId)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/DeleteGroupMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/DeleteGroupMultiPartitionTest.java
@@ -77,7 +77,7 @@ public class DeleteGroupMultiPartitionTest {
             tuple(CommandDistributionIntent.ACKNOWLEDGE, RecordType.COMMAND, 3),
             tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 3))
         .endsWith(tuple(CommandDistributionIntent.FINISHED, RecordType.EVENT, 1));
-    for (int partitionId = 2; partitionId < PARTITION_COUNT; partitionId++) {
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
       assertThat(
               RecordingExporter.groupRecords()
                   .withPartitionId(partitionId)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/RemoveEntityGroupMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/RemoveEntityGroupMultiPartitionTest.java
@@ -95,7 +95,7 @@ public class RemoveEntityGroupMultiPartitionTest {
             tuple(CommandDistributionIntent.ACKNOWLEDGE, RecordType.COMMAND, 3),
             tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 3))
         .endsWith(tuple(CommandDistributionIntent.FINISHED, RecordType.EVENT, 1));
-    for (int partitionId = 2; partitionId < PARTITION_COUNT; partitionId++) {
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
       assertThat(
               RecordingExporter.groupRecords()
                   .withPartitionId(partitionId)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/UpdateGroupMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/UpdateGroupMultiPartitionTest.java
@@ -79,7 +79,7 @@ public class UpdateGroupMultiPartitionTest {
             tuple(CommandDistributionIntent.ACKNOWLEDGE, RecordType.COMMAND, 3),
             tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 3))
         .endsWith(tuple(CommandDistributionIntent.FINISHED, RecordType.EVENT, 1));
-    for (int partitionId = 2; partitionId < PARTITION_COUNT; partitionId++) {
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
       assertThat(
               RecordingExporter.groupRecords()
                   .withPartitionId(partitionId)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mappingrule/CreateMappingRuleMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mappingrule/CreateMappingRuleMultiPartitionTest.java
@@ -79,7 +79,7 @@ public class CreateMappingRuleMultiPartitionTest {
             tuple(CommandDistributionIntent.ACKNOWLEDGE, RecordType.COMMAND, 3),
             tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 3))
         .endsWith(tuple(CommandDistributionIntent.FINISHED, RecordType.EVENT, 1));
-    for (int partitionId = 2; partitionId < PARTITION_COUNT; partitionId++) {
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
       assertThat(
               RecordingExporter.mappingRuleRecords()
                   .withPartitionId(partitionId)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mappingrule/DeleteMappingRuleMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mappingrule/DeleteMappingRuleMultiPartitionTest.java
@@ -81,7 +81,7 @@ public class DeleteMappingRuleMultiPartitionTest {
             tuple(CommandDistributionIntent.ACKNOWLEDGE, RecordType.COMMAND, 3),
             tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 3))
         .endsWith(tuple(CommandDistributionIntent.FINISHED, RecordType.EVENT, 1));
-    for (int partitionId = 2; partitionId < PARTITION_COUNT; partitionId++) {
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
       assertThat(
               RecordingExporter.mappingRuleRecords()
                   .withPartitionId(partitionId)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mappingrule/UpdateMappingRuleMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mappingrule/UpdateMappingRuleMultiPartitionTest.java
@@ -55,7 +55,7 @@ public class UpdateMappingRuleMultiPartitionTest {
         .withName(name + "New")
         .update();
 
-    for (int partitionId = 2; partitionId < PARTITION_COUNT; partitionId++) {
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
       assertThat(
               RecordingExporter.mappingRuleRecords()
                   .withPartitionId(partitionId)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionMultiPartitionTest.java
@@ -87,7 +87,7 @@ public class ResourceDeletionMultiPartitionTest {
             tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 3))
         .endsWith(tuple(CommandDistributionIntent.FINISHED, RecordType.EVENT, 1));
 
-    for (int partitionId = 2; partitionId < PARTITION_COUNT; partitionId++) {
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
       assertThat(
               RecordingExporter.records()
                   .withPartitionId(partitionId)
@@ -152,7 +152,7 @@ public class ResourceDeletionMultiPartitionTest {
             tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 3))
         .endsWith(tuple(CommandDistributionIntent.FINISHED, RecordType.EVENT, 1));
 
-    for (int partitionId = 2; partitionId < PARTITION_COUNT; partitionId++) {
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
       assertThat(
               RecordingExporter.records()
                   .withPartitionId(partitionId)
@@ -215,7 +215,7 @@ public class ResourceDeletionMultiPartitionTest {
             tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 3))
         .endsWith(tuple(CommandDistributionIntent.FINISHED, RecordType.EVENT, 1));
 
-    for (int partitionId = 2; partitionId < PARTITION_COUNT; partitionId++) {
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
       assertThat(
               RecordingExporter.records()
                   .withPartitionId(partitionId)
@@ -277,7 +277,7 @@ public class ResourceDeletionMultiPartitionTest {
             tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 3))
         .endsWith(tuple(CommandDistributionIntent.FINISHED, RecordType.EVENT, 1));
 
-    for (int partitionId = 2; partitionId < PARTITION_COUNT; partitionId++) {
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
       assertThat(
               RecordingExporter.records()
                   .withPartitionId(partitionId)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/AddEntityRoleMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/AddEntityRoleMultiPartitionTest.java
@@ -87,7 +87,7 @@ public class AddEntityRoleMultiPartitionTest {
             tuple(CommandDistributionIntent.ACKNOWLEDGE, RecordType.COMMAND, 3),
             tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 3))
         .endsWith(tuple(CommandDistributionIntent.FINISHED, RecordType.EVENT, 1));
-    for (int partitionId = 2; partitionId < PARTITION_COUNT; partitionId++) {
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
       assertThat(
               RecordingExporter.roleRecords()
                   .withPartitionId(partitionId)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/CreateRoleMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/CreateRoleMultiPartitionTest.java
@@ -70,7 +70,7 @@ public class CreateRoleMultiPartitionTest {
             tuple(CommandDistributionIntent.ACKNOWLEDGE, RecordType.COMMAND, 3),
             tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 3))
         .endsWith(tuple(CommandDistributionIntent.FINISHED, RecordType.EVENT, 1));
-    for (int partitionId = 2; partitionId < PARTITION_COUNT; partitionId++) {
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
       assertThat(
               RecordingExporter.roleRecords()
                   .withRoleId(roleId)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/DeleteRoleMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/DeleteRoleMultiPartitionTest.java
@@ -79,7 +79,7 @@ public class DeleteRoleMultiPartitionTest {
             tuple(CommandDistributionIntent.ACKNOWLEDGE, RecordType.COMMAND, 3),
             tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 3))
         .endsWith(tuple(CommandDistributionIntent.FINISHED, RecordType.EVENT, 1));
-    for (int partitionId = 2; partitionId < PARTITION_COUNT; partitionId++) {
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
       assertThat(
               RecordingExporter.roleRecords()
                   .withPartitionId(partitionId)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/RemoveEntityRoleMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/RemoveEntityRoleMultiPartitionTest.java
@@ -93,7 +93,7 @@ public class RemoveEntityRoleMultiPartitionTest {
             tuple(CommandDistributionIntent.ACKNOWLEDGE, RecordType.COMMAND, 3),
             tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 3))
         .endsWith(tuple(CommandDistributionIntent.FINISHED, RecordType.EVENT, 1));
-    for (int partitionId = 2; partitionId < PARTITION_COUNT; partitionId++) {
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
       assertThat(
               RecordingExporter.roleRecords()
                   .withPartitionId(partitionId)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/UpdateRoleMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/UpdateRoleMultiPartitionTest.java
@@ -78,7 +78,7 @@ public class UpdateRoleMultiPartitionTest {
             tuple(CommandDistributionIntent.ACKNOWLEDGE, RecordType.COMMAND, 3),
             tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 3))
         .endsWith(tuple(CommandDistributionIntent.FINISHED, RecordType.EVENT, 1));
-    for (int partitionId = 2; partitionId < PARTITION_COUNT; partitionId++) {
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
       assertThat(
               RecordingExporter.roleRecords()
                   .withPartitionId(partitionId)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/DeleteTenantMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/DeleteTenantMultiPartitionTest.java
@@ -72,7 +72,7 @@ public class DeleteTenantMultiPartitionTest {
             tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 3))
         .endsWith(tuple(CommandDistributionIntent.FINISHED, RecordType.EVENT, 1));
 
-    for (int partitionId = 2; partitionId < PARTITION_COUNT; partitionId++) {
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
       assertThat(
               RecordingExporter.tenantRecords()
                   .withPartitionId(partitionId)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/RemoveEntityTenantMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/RemoveEntityTenantMultiPartitionTest.java
@@ -100,7 +100,7 @@ public class RemoveEntityTenantMultiPartitionTest {
             tuple(CommandDistributionIntent.ACKNOWLEDGE, RecordType.COMMAND, 3),
             tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 3))
         .endsWith(tuple(CommandDistributionIntent.FINISHED, RecordType.EVENT, 1));
-    for (int partitionId = 2; partitionId < PARTITION_COUNT; partitionId++) {
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
       assertThat(
               RecordingExporter.tenantRecords()
                   .withPartitionId(partitionId)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/UpdateTenantMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/UpdateTenantMultiPartitionTest.java
@@ -88,7 +88,7 @@ public class UpdateTenantMultiPartitionTest {
             tuple(CommandDistributionIntent.ACKNOWLEDGE, RecordType.COMMAND, 3),
             tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 3))
         .endsWith(tuple(CommandDistributionIntent.FINISHED, RecordType.EVENT, 1));
-    for (int partitionId = 2; partitionId < PARTITION_COUNT; partitionId++) {
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
       assertThat(
               RecordingExporter.tenantRecords()
                   .withPartitionId(partitionId)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/CreateUserMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/CreateUserMultiPartitionTest.java
@@ -80,7 +80,7 @@ public class CreateUserMultiPartitionTest {
             tuple(CommandDistributionIntent.ACKNOWLEDGE, RecordType.COMMAND, 3),
             tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 3))
         .endsWith(tuple(CommandDistributionIntent.FINISHED, RecordType.EVENT, 1));
-    for (int partitionId = 2; partitionId < PARTITION_COUNT; partitionId++) {
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
       assertThat(
               RecordingExporter.userRecords()
                   .withUsername(username)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/DeleteUserMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/DeleteUserMultiPartitionTest.java
@@ -96,7 +96,7 @@ public class DeleteUserMultiPartitionTest {
             tuple(CommandDistributionIntent.ACKNOWLEDGE, RecordType.COMMAND, 3),
             tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 3))
         .endsWith(tuple(CommandDistributionIntent.FINISHED, RecordType.EVENT, 1));
-    for (int partitionId = 2; partitionId < PARTITION_COUNT; partitionId++) {
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
       assertThat(
               RecordingExporter.records()
                   .withPartitionId(partitionId)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/UpdateUserMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/UpdateUserMultiPartitionTest.java
@@ -95,7 +95,7 @@ public class UpdateUserMultiPartitionTest {
             tuple(CommandDistributionIntent.ACKNOWLEDGE, RecordType.COMMAND, 3),
             tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 3))
         .endsWith(tuple(CommandDistributionIntent.FINISHED, RecordType.EVENT, 1));
-    for (int partitionId = 2; partitionId < PARTITION_COUNT; partitionId++) {
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
       assertThat(
               RecordingExporter.userRecords()
                   .withUsername(username)


### PR DESCRIPTION

## Description

- Updated loop conditions in various multi-partition tests to ensure all partitions, including the last (PARTITION_COUNT), are covered.
- Adjusted assertions accordingly.

## Related issues

related to https://github.com/camunda/camunda/issues/42049
