### PR TITLE
feat: Enable auto-merge workflow for release-to-stable PRs

### DIFF
--- a/.github/workflows/auto-merge-back-to-stable.yml
+++ b/.github/workflows/auto-merge-back-to-stable.yml
@@ -28,7 +28,7 @@ jobs:
         shell: bash
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      DRY_RUN: ${{ vars.AUTO_MERGE_DRY_RUN || 'true' }}
+      DRY_RUN: ${{ vars.AUTO_MERGE_DRY_RUN || 'false' }}
       MERGE_QUEUE_TIMEOUT_MINUTES: ${{ vars.MERGE_QUEUE_TIMEOUT_MINUTES || '180' }}
     
     steps:


### PR DESCRIPTION
## Description

Changes the default `DRY_RUN` mode of the auto-merge-back-to-stable workflow from `true` to `false`.

Previously, the workflow defaulted to dry-run mode when the `AUTO_MERGE_DRY_RUN` repository variable was not set, meaning it would only log what it *would* do without actually approving or merging release PRs. This change flips the default so the workflow is **live by default** — it will automatically approve, merge, and report the result for release-to-stable PRs.

## What changes
- `DRY_RUN` default: `'true'` → `'false'`