### PR TITLE
fix: close auditLogArchiverRepository in CamundaBackgroundTaskManager

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/CamundaBackgroundTaskManager.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/CamundaBackgroundTaskManager.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.tasks;
 
 import io.camunda.exporter.tasks.archiver.ArchiverRepository;
+import io.camunda.exporter.tasks.archiver.AuditLogArchiverRepository;
 import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateRepository;
 import io.camunda.exporter.tasks.historydeletion.HistoryDeletionRepository;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository;
@@ -30,6 +31,7 @@ import org.slf4j.Logger;
 public final class CamundaBackgroundTaskManager implements CloseableSilently {
   private final int partitionId;
   private final ArchiverRepository archiverRepository;
+  private final AuditLogArchiverRepository auditLogArchiverRepository;
   private final IncidentUpdateRepository incidentRepository;
   private final BatchOperationUpdateRepository batchOperationUpdateRepository;
   private final HistoryDeletionRepository historyDeletionRepository;
@@ -39,6 +41,7 @@ public final class CamundaBackgroundTaskManager implements CloseableSilently {
   CamundaBackgroundTaskManager(
       final int partitionId,
       final @WillCloseWhenClosed ArchiverRepository archiverRepository,
+      final @WillCloseWhenClosed AuditLogArchiverRepository auditLogArchiverRepository,
       final @WillCloseWhenClosed IncidentUpdateRepository incidentRepository,
       final @WillCloseWhenClosed BatchOperationUpdateRepository batchOperationUpdateRepository,
       final @WillCloseWhenClosed HistoryDeletionRepository historyDeletionRepository,
@@ -49,6 +52,9 @@ public final class CamundaBackgroundTaskManager implements CloseableSilently {
     this.partitionId = partitionId;
     this.archiverRepository =
         Objects.requireNonNull(archiverRepository, "must specify an archiver repository");
+    this.auditLogArchiverRepository =
+        Objects.requireNonNull(
+            auditLogArchiverRepository, "must specify an audit log archiver repository");
     this.incidentRepository =
         Objects.requireNonNull(incidentRepository, "must specify an incident repository");
     this.batchOperationUpdateRepository =
@@ -70,6 +76,7 @@ public final class CamundaBackgroundTaskManager implements CloseableSilently {
     CloseHelper.closeAll(
         error -> logger.warn("Failed to close resource for partition {}", partitionId, error),
         archiverRepository,
+        auditLogArchiverRepository,
         incidentRepository,
         batchOperationUpdateRepository,
         historyDeletionRepository);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/CamundaBackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/CamundaBackgroundTaskManagerFactory.java
@@ -148,6 +148,7 @@ public final class CamundaBackgroundTaskManagerFactory {
     return new CamundaBackgroundTaskManager(
         partitionId,
         archiverRepository,
+        auditLogArchiverRepository,
         incidentRepository,
         batchOperationUpdateRepository,
         historyDeletionRepository,

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/CamundaBackgroundTaskManagerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/CamundaBackgroundTaskManagerTest.java
@@ -10,11 +10,14 @@ package io.camunda.exporter.tasks;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
+import io.camunda.exporter.tasks.archiver.ArchiveBatch.AuditLogCleanupBatch;
+import io.camunda.exporter.tasks.archiver.AuditLogArchiverRepository;
 import io.camunda.exporter.tasks.archiver.NoopArchiverRepository;
 import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateRepository.NoopBatchOperationUpdateRepository;
 import io.camunda.exporter.tasks.historydeletion.HistoryDeletionRepository.NoopHistoryDeletionRepository;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.NoopIncidentUpdateRepository;
 import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Nested;
@@ -31,6 +34,8 @@ final class CamundaBackgroundTaskManagerTest {
   final class CloseTest {
     private final CloseableArchiverRepository archiverRepository =
         new CloseableArchiverRepository();
+    private final CloseableAuditLogArchiverRepository auditLogArchiverRepository =
+        new CloseableAuditLogArchiverRepository();
     private final CloseableIncidentRepository incidentRepository =
         new CloseableIncidentRepository();
     private final CloseableBatchOperationUpdateRepository batchOperationUpdateRepository =
@@ -41,6 +46,7 @@ final class CamundaBackgroundTaskManagerTest {
         new CamundaBackgroundTaskManager(
             1,
             archiverRepository,
+            auditLogArchiverRepository,
             incidentRepository,
             batchOperationUpdateRepository,
             historyDeletionRepository,
@@ -60,6 +66,7 @@ final class CamundaBackgroundTaskManagerTest {
 
       // then
       assertThat(archiverRepository.isClosed).isTrue();
+      assertThat(auditLogArchiverRepository.isClosed).isTrue();
       assertThat(incidentRepository.isClosed).isTrue();
       assertThat(batchOperationUpdateRepository.isClosed).isTrue();
       assertThat(historyDeletionRepository.isClosed).isTrue();
@@ -69,6 +76,15 @@ final class CamundaBackgroundTaskManagerTest {
     void shouldNotThrowOnArchiverRepositoryCloseError() {
       // given
       archiverRepository.exception = new RuntimeException("foo");
+
+      // when
+      assertThatCode(taskManager::close).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldNotThrowOnAuditLogArchiverRepositoryCloseError() {
+      // given
+      auditLogArchiverRepository.exception = new RuntimeException("foo");
 
       // when
       assertThatCode(taskManager::close).doesNotThrowAnyException();
@@ -99,6 +115,33 @@ final class CamundaBackgroundTaskManagerTest {
 
       // when
       assertThatCode(taskManager::close).doesNotThrowAnyException();
+    }
+
+    private static final class CloseableAuditLogArchiverRepository
+        implements AuditLogArchiverRepository {
+      private boolean isClosed;
+      private Exception exception;
+
+      @Override
+      public CompletableFuture<AuditLogCleanupBatch> getNextBatch() {
+        return CompletableFuture.completedFuture(
+            new AuditLogCleanupBatch(null, java.util.List.of(), java.util.List.of()));
+      }
+
+      @Override
+      public CompletableFuture<Integer> deleteAuditLogCleanupMetadata(
+          final AuditLogCleanupBatch batch) {
+        return CompletableFuture.completedFuture(0);
+      }
+
+      @Override
+      public void close() throws Exception {
+        if (exception != null) {
+          throw exception;
+        }
+
+        isClosed = true;
+      }
     }
 
     private static final class CloseableArchiverRepository extends NoopArchiverRepository {


### PR DESCRIPTION
## Summary

- `auditLogArchiverRepository` was created by `CamundaBackgroundTaskManagerFactory` but never passed to `CamundaBackgroundTaskManager`, so it was not closed on shutdown
- Added it to the constructor and `CloseHelper.closeAll()` alongside the other repositories
- Added corresponding test coverage