### PR TITLE
Ensure proper keys are set when using a start instruction to activate a process at the root

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementActivationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementActivationBehavior.java
@@ -401,12 +401,24 @@ public final class ElementActivationBehavior {
       final AbstractFlowElement elementToActivate,
       final long flowScopeKey) {
 
-    final var elementInstanceKey = keyGenerator.nextKey();
+    final long elementInstanceKey;
+    final long elementFlowScopeKey;
+
+    // If the instruction directly activates the process itself we must ensure we don't override the
+    // process instance key, and we remove the flow scope key. If we don't the flow scope key would
+    // be set to the process instance key and the element instance key would be newly generated.
+    if (isProcess(elementToActivate)) {
+      elementInstanceKey = processInstanceRecord.getProcessInstanceKey();
+      elementFlowScopeKey = -1L;
+    } else {
+      elementInstanceKey = keyGenerator.nextKey();
+      elementFlowScopeKey = flowScopeKey;
+    }
+
     final var elementRecord =
-        createElementRecord(processInstanceRecord, elementToActivate, flowScopeKey);
+        createElementRecord(processInstanceRecord, elementToActivate, elementFlowScopeKey);
     commandWriter.appendFollowUpCommand(
         elementInstanceKey, ProcessInstanceIntent.ACTIVATE_ELEMENT, elementRecord);
-
     return elementInstanceKey;
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceAnywhereTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CreateProcessInstanceAnywhereTest.java
@@ -1172,6 +1172,52 @@ public class CreateProcessInstanceAnywhereTest {
             tuple(BpmnElementType.START_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED));
   }
 
+  @Test
+  public void shouldActivateAtProcessInstance() {
+    // Given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID).startEvent().endEvent("end").done())
+        .deploy();
+
+    // When
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withStartInstruction(PROCESS_ID)
+            .create();
+
+    // Then
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(record -> record.getValue().getBpmnElementType(), Record::getIntent)
+        .describedAs("Expected to start process instance at the root")
+        .containsSequence(
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.START_EVENT, ProcessInstanceIntent.ACTIVATE_ELEMENT))
+        .containsSubsequence(
+            tuple(BpmnElementType.END_EVENT, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.END_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
+
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.PROCESS)
+                .getFirst())
+        .extracting(
+            Record::getKey,
+            r -> r.getValue().getProcessInstanceKey(),
+            r -> r.getValue().getFlowScopeKey(),
+            r -> r.getValue().getBpmnElementType())
+        .containsExactly(processInstanceKey, processInstanceKey, -1L, BpmnElementType.PROCESS);
+  }
+
   private void completeJob(
       final String jobType,
       final boolean completionConditionFulfilled,


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

The activation behavior could not deal with an activation of the process at the root. When this happened it would activate it any other element. This means it'd regenerate an element instance key, even though we have already generated a process instance key. It sets the flow scope to the process instance key. This is wrong, as the flow scope of the process instance itself should be -1.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #26755 
