### PR TITLE
build: update Dockerfile to fix known CVEs

### DIFF
--- a/optimize.Dockerfile
+++ b/optimize.Dockerfile
@@ -1,13 +1,13 @@
 # hadolint global ignore=DL3006
 ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base-compat:21-dev"
-ARG BASE_DIGEST="sha256:42225e68749d492e62d348bbebdf3605de6e744ffe08f0424cc23d2b967b0bee"
+ARG BASE_DIGEST="sha256:642e4a1ee31f95b307833477049aca67a3a4b094148691bc3768db2e072a8eca"
 ARG WAITFORIT_CHECKSUM="b7a04f38de1e51e7455ecf63151c8c7e405bd2d45a2d4e16f6419db737a125d6"
 
 # If you don't have access to Minimus hardened base images, you can use public
 # base images like this instead on your own risk.
 # Simply pass `--build-arg BASE=public` in order to build with Alpine.
-ARG BASE_IMAGE_PUBLIC="alpine:3.23.0"
-ARG BASE_DIGEST_PUBLIC="sha256:51183f2cfa6320055da30872f211093f9ff1d3cf06f39a0bdb212314c5dc7375"
+ARG BASE_IMAGE_PUBLIC="alpine:3.23.3"
+ARG BASE_DIGEST_PUBLIC="sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659"
 ARG BASE="hardened"
 
 ### Download wait-for-it.sh ###


### PR DESCRIPTION
## Description

Example CVEs
- https://cve-registry.infosec.camunda-it.rocks/team/1/finding/2423
- https://cve-registry.infosec.camunda-it.rocks/team/1/finding/2366

Used images that `stable/8.8` uses to fix known CVEs 

@szpraat Is there a specific reason why we’re not consistently using the latest hardened base image version for all supported minor versions, or is this simply something we haven’t standardized yet ❓
If there’s already guidance or a decision documented somewhere, I’d appreciate a pointer.

## Related issues
Not affected, but avoid scanning these

- CVE-2026-3784
- CVE-2026-27171
