### PR TITLE
fix: Remove Unwanted Plugins from LoadTest OpenSearch

### DIFF
--- a/load-tests/camunda-platform-values-opensearch.yaml
+++ b/load-tests/camunda-platform-values-opensearch.yaml
@@ -52,15 +52,56 @@ config:
   opensearch.yml: |
     cluster.name: opensearch
     network.host: 0.0.0.0
-    plugins.security.disabled: true
     # Disable deprecation logging to avoid filling up the logs with warnings about deprecated features that we might be using in our tests
     logger.org.opensearch.deprecation: "OFF"
 
 extraEnvs:
   - name: OPENSEARCH_INITIAL_ADMIN_PASSWORD
     value: "yourStrongPassword123!"
+  - name: DISABLE_INSTALL_DEMO_CONFIG
+    value: "true"
 
 opensearchJavaOpts: "-Xms3g -Xmx3g"
+
+# Remove bundled plugins that are not needed for Camunda.
+# OpenSearch ships with 24 plugins by default (vs 0 for Elasticsearch).
+# These consume ~15-20% extra RAM and 40+ additional thread pools, causing
+# write throughput degradation and cascading backpressure on the Zeebe exporters.
+# We keep only opensearch-index-management (ISM/retention) and its dependency
+# opensearch-job-scheduler.
+extraVolumes:
+  - name: plugins-dir
+    emptyDir: {}
+
+extraVolumeMounts:
+  - name: plugins-dir
+    mountPath: /usr/share/opensearch/plugins
+
+extraInitContainers:
+  - name: copy-and-prune-plugins
+    image: opensearchproject/opensearch:2.19.0
+    command:
+      - sh
+      - -c
+      - |
+        # Copy all plugins from the image to the shared emptyDir volume
+        cp -a /usr/share/opensearch/plugins/* /target/
+
+        # Remove all plugins except index-management and job-scheduler
+        PLUGINS_TO_REMOVE="opensearch-alerting opensearch-anomaly-detection opensearch-asynchronous-search opensearch-cross-cluster-replication opensearch-custom-codecs opensearch-flow-framework opensearch-geospatial opensearch-knn opensearch-ltr opensearch-ml opensearch-neural-search opensearch-notifications opensearch-notifications-core opensearch-observability opensearch-performance-analyzer opensearch-reports-scheduler opensearch-security opensearch-security-analytics opensearch-skills opensearch-sql opensearch-system-templates query-insights"
+
+        for plugin in $PLUGINS_TO_REMOVE; do
+          if [ -d "/target/$plugin" ]; then
+            echo "Removing plugin: $plugin"
+            rm -rf "/target/$plugin"
+          fi
+        done
+
+        echo "Remaining plugins:"
+        ls /target/
+    volumeMounts:
+      - name: plugins-dir
+        mountPath: /target
 
 sysctlInit:
   enabled: true

--- a/operate/common/src/main/java/io/camunda/operate/connect/OpensearchConnector.java
+++ b/operate/common/src/main/java/io/camunda/operate/connect/OpensearchConnector.java
@@ -348,6 +348,11 @@ public class OpensearchConnector {
       final OpensearchProperties osConfig,
       final HttpRequestInterceptor... requestInterceptors) {
     httpAsyncClientBuilder.disableContentCompression();
+    // Strip Accept-Encoding header to prevent OS <3.5.0 from sending gzip responses
+    // that httpclient5 can't decompress (disableContentCompression remove the decompressor)
+    httpAsyncClientBuilder.addRequestInterceptorLast(
+        (request, entity, context) -> request.removeHeaders("Accept-Encoding"));
+
     setupAuthentication(httpAsyncClientBuilder, osConfig);
 
     LOGGER.trace("Attempt to load interceptor plugins");

--- a/operate/common/src/main/java/io/camunda/operate/connect/OpensearchConnector.java
+++ b/operate/common/src/main/java/io/camunda/operate/connect/OpensearchConnector.java
@@ -152,6 +152,8 @@ public class OpensearchConnector {
           return requestConfigBuilder;
         });
 
+    builder.setCompressionEnabled(true);
+
     final JacksonJsonpMapper jsonpMapper = new JacksonJsonpMapper(objectMapper);
     builder.setMapper(jsonpMapper);
 

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/upgrade/os/OpenSearchClientBuilder.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/upgrade/os/OpenSearchClientBuilder.java
@@ -171,6 +171,8 @@ public class OpenSearchClientBuilder {
           return requestConfigBuilder;
         });
 
+    builder.setCompressionEnabled(true);
+
     if (StringUtils.isNotBlank(configurationService.getOpenSearchConfiguration().getPathPrefix())) {
       builder.setPathPrefix(configurationService.getOpenSearchConfiguration().getPathPrefix());
     }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/upgrade/os/OpenSearchClientBuilder.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/upgrade/os/OpenSearchClientBuilder.java
@@ -398,6 +398,10 @@ public class OpenSearchClientBuilder {
       final ConfigurationService configurationService,
       final HttpRequestInterceptor... requestInterceptors) {
     httpAsyncClientBuilder.disableContentCompression();
+    // Strip Accept-Encoding header to prevent OS <3.5.0 from sending gzip responses
+    // that httpclient5 can't decompress (disableContentCompression remove the decompressor)
+    httpAsyncClientBuilder.addRequestInterceptorLast(
+        (request, entity, context) -> request.removeHeaders("Accept-Encoding"));
     setupAuthentication(httpAsyncClientBuilder, configurationService);
 
     for (final HttpRequestInterceptor interceptor : requestInterceptors) {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -83,7 +83,7 @@
     <version.netty>4.2.12.Final</version.netty>
     <version.objenesis>3.5</version.objenesis>
     <version.opensearch>2.17.0</version.opensearch>
-    <version.opensearch-java>3.4.0</version.opensearch-java>
+    <version.opensearch-java>3.6.0</version.opensearch-java>
     <version.opensearch.testcontainers>4.1.0</version.opensearch.testcontainers>
     <version.prometheus>1.3.5</version.prometheus>
     <version.protobuf>4.34.1</version.protobuf>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/document/OSClient.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/document/OSClient.java
@@ -47,6 +47,7 @@ public class OSClient implements DocumentClient {
                     httpClientBuilder.disableContentCompression();
                     return httpClientBuilder;
                   })
+              .setCompressionEnabled(true)
               .setMapper(new JacksonJsonpMapper())
               .build();
       opensearchClient = new OpenSearchClient(transport);

--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/os/OpensearchConnector.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/os/OpensearchConnector.java
@@ -133,6 +133,8 @@ public final class OpensearchConnector {
           return requestConfigBuilder;
         });
 
+    builder.setCompressionEnabled(true);
+
     final var jsonpMapper = new SearchRequestJacksonJsonpMapperWrapper(objectMapper);
     builder.setMapper(jsonpMapper);
 

--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/os/OpensearchConnector.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/os/OpensearchConnector.java
@@ -188,6 +188,11 @@ public final class OpensearchConnector {
       final ConnectConfiguration osConfig,
       final HttpRequestInterceptor... interceptors) {
     httpAsyncClientBuilder.disableContentCompression();
+    // Strip Accept-Encoding header to prevent OS <3.5.0 from sending gzip responses
+    // that httpclient5 can't decompress (disableContentCompression remove the decompressor)
+    httpAsyncClientBuilder.addRequestInterceptorLast(
+        (request, entity, context) -> request.removeHeaders("Accept-Encoding"));
+
     setupAuthentication(httpAsyncClientBuilder, osConfig);
 
     for (final HttpRequestInterceptor interceptor : interceptors) {

--- a/tasklist/common/src/main/java/io/camunda/tasklist/os/OpenSearchConnector.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/os/OpenSearchConnector.java
@@ -277,6 +277,10 @@ public class OpenSearchConnector {
       final OpenSearchProperties osConfig,
       final org.apache.hc.core5.http.HttpRequestInterceptor... httpRequestInterceptors) {
     httpAsyncClientBuilder.disableContentCompression();
+    // Strip Accept-Encoding header to prevent OS <3.5.0 from sending gzip responses
+    // that httpclient5 can't decompress (disableContentCompression remove the decompressor)
+    httpAsyncClientBuilder.addRequestInterceptorLast(
+        (request, entity, context) -> request.removeHeaders("Accept-Encoding"));
     setupAuthentication(httpAsyncClientBuilder, osConfig);
 
     LOGGER.trace("Attempt to load interceptor plugins");

--- a/tasklist/common/src/main/java/io/camunda/tasklist/os/OpenSearchConnector.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/os/OpenSearchConnector.java
@@ -131,6 +131,8 @@ public class OpenSearchConnector {
           return requestConfigBuilder;
         });
 
+    builder.setCompressionEnabled(true);
+
     final JacksonJsonpMapper jsonpMapper = new JacksonJsonpMapper(tasklistObjectMapper);
     builder.setMapper(jsonpMapper);
 

--- a/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/BackupRestoreTest.java
+++ b/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/BackupRestoreTest.java
@@ -148,6 +148,8 @@ public class BackupRestoreTest {
     builder.setHttpClientConfigCallback(
         httpClientBuilder -> {
           httpClientBuilder.disableContentCompression();
+          httpClientBuilder.addRequestInterceptorLast(
+              (request, entity, context) -> request.removeHeaders("Accept-Encoding"));
           return httpClientBuilder;
         });
 

--- a/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/BackupRestoreTest.java
+++ b/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/BackupRestoreTest.java
@@ -151,6 +151,8 @@ public class BackupRestoreTest {
           return httpClientBuilder;
         });
 
+    builder.setCompressionEnabled(true);
+
     final org.opensearch.client.json.jackson.JacksonJsonpMapper jsonpMapper =
         new org.opensearch.client.json.jackson.JacksonJsonpMapper(CommonUtils.OBJECT_MAPPER);
     builder.setMapper(jsonpMapper);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -1569,6 +1569,8 @@ final class OpenSearchArchiverRepositoryIT {
           .setHttpClientConfigCallback(
               httpClientBuilder -> {
                 httpClientBuilder.disableContentCompression();
+                httpClientBuilder.addRequestInterceptorLast(
+                    (request, entity, context) -> request.removeHeaders("Accept-Encoding"));
                 return httpClientBuilder;
               })
           .setCompressionEnabled(true)

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -1571,6 +1571,7 @@ final class OpenSearchArchiverRepositoryIT {
                 httpClientBuilder.disableContentCompression();
                 return httpClientBuilder;
               })
+          .setCompressionEnabled(true)
           .setMapper(new JacksonJsonpMapper())
           .build();
     } catch (final Exception e) {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpensearchAuditLogArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpensearchAuditLogArchiverRepositoryIT.java
@@ -453,6 +453,7 @@ final class OpensearchAuditLogArchiverRepositoryIT {
                 httpClientBuilder.disableContentCompression();
                 return httpClientBuilder;
               })
+          .setCompressionEnabled(true)
           .setMapper(new JacksonJsonpMapper())
           .build();
     } catch (final Exception e) {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpensearchAuditLogArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpensearchAuditLogArchiverRepositoryIT.java
@@ -451,6 +451,8 @@ final class OpensearchAuditLogArchiverRepositoryIT {
           .setHttpClientConfigCallback(
               httpClientBuilder -> {
                 httpClientBuilder.disableContentCompression();
+                httpClientBuilder.addRequestInterceptorLast(
+                    (request, entity, context) -> request.removeHeaders("Accept-Encoding"));
                 return httpClientBuilder;
               })
           .setCompressionEnabled(true)

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/OpensearchIncidentUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/OpensearchIncidentUpdateRepositoryIT.java
@@ -81,6 +81,7 @@ final class OpensearchIncidentUpdateRepositoryIT extends IncidentUpdateRepositor
                 httpClientBuilder.disableContentCompression();
                 return httpClientBuilder;
               })
+          .setCompressionEnabled(true)
           .setMapper(new JacksonJsonpMapper())
           .build();
     } catch (final Exception e) {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/OpensearchIncidentUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/OpensearchIncidentUpdateRepositoryIT.java
@@ -79,6 +79,8 @@ final class OpensearchIncidentUpdateRepositoryIT extends IncidentUpdateRepositor
           .setHttpClientConfigCallback(
               httpClientBuilder -> {
                 httpClientBuilder.disableContentCompression();
+                httpClientBuilder.addRequestInterceptorLast(
+                    (request, entity, context) -> request.removeHeaders("Accept-Encoding"));
                 return httpClientBuilder;
               })
           .setCompressionEnabled(true)

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchConnector.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchConnector.java
@@ -179,6 +179,10 @@ public final class OpensearchConnector {
       final OpensearchExporterConfiguration osConfig,
       final HttpRequestInterceptor... interceptors) {
     httpAsyncClientBuilder.disableContentCompression();
+    // Strip Accept-Encoding header to prevent OS <3.5.0 from sending gzip responses
+    // that httpclient5 can't decompress (disableContentCompression removed its decompressor)
+    httpAsyncClientBuilder.addRequestInterceptorLast(
+        (request, entity, context) -> request.removeHeaders("Accept-Encoding"));
     setupAuthentication(httpAsyncClientBuilder, osConfig.getAuthentication());
 
     for (final HttpRequestInterceptor interceptor : interceptors) {

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchConnector.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchConnector.java
@@ -126,6 +126,8 @@ public final class OpensearchConnector {
           return requestConfigBuilder;
         });
 
+    builder.setCompressionEnabled(true);
+
     builder.setMapper(new JacksonJsonpMapper(objectMapper));
 
     return builder.build();


### PR DESCRIPTION

## Description

There are lots of plugins defined in OpenSearch compared to Elasticsearch and some it seems are not relevant. Adding an init container to get rid of them and test perf.

NOTE: This is to determine if these plugins actually impact performance

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
