### PR TITLE
ci: parameterize docker tag in e2e workflow

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-e2e-api-test-branch-on-demand.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-api-test-branch-on-demand.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Build Docker image from branch
         id: docker-tag
         run: |
-          DOCKER_TAG="${{ needs.utils-get-snapshot-docker-tag.outputs.snapshot_tag != '' && needs.utils-get-snapshot-docker-tag.outputs.snapshot_tag || needs.utils-get-snapshot-docker-tag.outputs.version_tag }}"
+          DOCKER_TAG="${{ needs.utils-get-snapshot-docker-tag.outputs.version_tag }}"
           docker build \
             -f camunda.Dockerfile \
             --target app \

--- a/.github/workflows/c8-orchestration-cluster-e2e-api-test-branch-on-demand.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-api-test-branch-on-demand.yml
@@ -95,7 +95,10 @@ jobs:
       - name: Build Docker image from branch
         id: docker-tag
         run: |
-          DOCKER_TAG="${{ needs.utils-get-snapshot-docker-tag.outputs.version_tag }}"
+          VERSION_TAG="${{ needs.utils-get-snapshot-docker-tag.outputs.version_tag }}"
+          SNAPSHOT_TAG="${{ needs.utils-get-snapshot-docker-tag.outputs.snapshot_tag }}"
+          # Prefer version_tag for reproducibility; fall back to snapshot_tag if needed
+          DOCKER_TAG="${VERSION_TAG:-${SNAPSHOT_TAG:-local-build}}"
           docker build \
             -f camunda.Dockerfile \
             --target app \

--- a/.github/workflows/c8-orchestration-cluster-e2e-api-test-branch-on-demand.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-api-test-branch-on-demand.yml
@@ -119,12 +119,13 @@ jobs:
 
       - name: Start Camunda
         run: |
+          CAMUNDA_DOCKER_IMAGE="camunda/camunda:${{ steps.docker-tag.outputs.docker_tag }}"
           if [[ "$NON_STANDALONE" == "true" ]]; then
             echo "Using single services for older branches (8.6/8.7)"
-            CAMUNDA_DOCKER_IMAGE="camunda/camunda:${{ steps.docker-tag.outputs.docker_tag }}" DATABASE=elasticsearch docker compose up -d operate tasklist
+            CAMUNDA_DOCKER_IMAGE="$CAMUNDA_DOCKER_IMAGE" DATABASE=elasticsearch docker compose up -d operate tasklist
           else
             echo "Using standalone camunda container"
-            CAMUNDA_DOCKER_IMAGE="camunda/camunda:${{ steps.docker-tag.outputs.docker_tag }}" DATABASE=elasticsearch docker compose up -d camunda
+            CAMUNDA_DOCKER_IMAGE="$CAMUNDA_DOCKER_IMAGE" DATABASE=elasticsearch docker compose up -d camunda
           fi
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
 

--- a/.github/workflows/c8-orchestration-cluster-e2e-api-test-branch-on-demand.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-api-test-branch-on-demand.yml
@@ -22,6 +22,12 @@ defaults:
     shell: bash
 
 jobs:
+  utils-get-snapshot-docker-tag:
+    uses: ./.github/workflows/generate-snapshot-docker-tag.yml
+    secrets: inherit
+    permissions:
+      contents: read
+
   validate-branch:
     runs-on: ubuntu-latest
     outputs:
@@ -60,7 +66,7 @@ jobs:
 
   c8-orchestration-cluster-api-tests-es:
     name: C8 Orchestration Cluster API Tests (ES)
-    needs: validate-branch
+    needs: [utils-get-snapshot-docker-tag, validate-branch]
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -90,7 +96,7 @@ jobs:
             --target app \
             --build-arg BASE=public \
             --build-arg DISTBALL="dist/target/camunda-zeebe-*.tar.gz" \
-            -t "camunda/camunda:SNAPSHOT" \
+            -t "camunda/camunda:${{ needs.utils-get-snapshot-docker-tag.outputs.snapshot_tag != '' && needs.utils-get-snapshot-docker-tag.outputs.snapshot_tag || needs.utils-get-snapshot-docker-tag.outputs.version_tag }}" \
             .
 
       - name: Set NON_STANDALONE variable

--- a/.github/workflows/c8-orchestration-cluster-e2e-api-test-branch-on-demand.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-api-test-branch-on-demand.yml
@@ -22,12 +22,6 @@ defaults:
     shell: bash
 
 jobs:
-  utils-get-snapshot-docker-tag:
-    uses: ./.github/workflows/generate-snapshot-docker-tag.yml
-    secrets: inherit
-    permissions:
-      contents: read
-
   validate-branch:
     runs-on: ubuntu-latest
     outputs:
@@ -64,6 +58,15 @@ jobs:
           echo "Detected base branch: $base"
           echo "base=$base" >> "$GITHUB_OUTPUT"
 
+  utils-get-snapshot-docker-tag:
+    needs: validate-branch
+    uses: ./.github/workflows/generate-snapshot-docker-tag.yml
+    with:
+      target_branch: ${{ needs.validate-branch.outputs.base }}
+    secrets: inherit
+    permissions:
+      contents: read
+
   c8-orchestration-cluster-api-tests-es:
     name: C8 Orchestration Cluster API Tests (ES)
     needs: [utils-get-snapshot-docker-tag, validate-branch]
@@ -90,14 +93,17 @@ jobs:
         run: ./mvnw install -Dquickly -T1C
 
       - name: Build Docker image from branch
+        id: docker-tag
         run: |
+          DOCKER_TAG="${{ needs.utils-get-snapshot-docker-tag.outputs.snapshot_tag != '' && needs.utils-get-snapshot-docker-tag.outputs.snapshot_tag || needs.utils-get-snapshot-docker-tag.outputs.version_tag }}"
           docker build \
             -f camunda.Dockerfile \
             --target app \
             --build-arg BASE=public \
             --build-arg DISTBALL="dist/target/camunda-zeebe-*.tar.gz" \
-            -t "camunda/camunda:${{ needs.utils-get-snapshot-docker-tag.outputs.snapshot_tag != '' && needs.utils-get-snapshot-docker-tag.outputs.snapshot_tag || needs.utils-get-snapshot-docker-tag.outputs.version_tag }}" \
+            -t "camunda/camunda:${DOCKER_TAG}" \
             .
+          echo "docker_tag=${DOCKER_TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Set NON_STANDALONE variable
         run: |
@@ -112,10 +118,10 @@ jobs:
         run: |
           if [[ "$NON_STANDALONE" == "true" ]]; then
             echo "Using single services for older branches (8.6/8.7)"
-            DATABASE=elasticsearch docker compose up -d operate tasklist
+            CAMUNDA_DOCKER_IMAGE="camunda/camunda:${{ steps.docker-tag.outputs.docker_tag }}" DATABASE=elasticsearch docker compose up -d operate tasklist
           else
             echo "Using standalone camunda container"
-            DATABASE=elasticsearch docker compose up -d camunda
+            CAMUNDA_DOCKER_IMAGE="camunda/camunda:${{ steps.docker-tag.outputs.docker_tag }}" DATABASE=elasticsearch docker compose up -d camunda
           fi
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
 


### PR DESCRIPTION
## Summary
- Replace hardcoded 'camunda/camunda:SNAPSHOT' tag with dynamically generated tag
- Uses the shared `generate-snapshot-docker-tag.yml` workflow to compute proper version tags
- Allows CI workflow to use actual version tags instead of static SNAPSHOT placeholder

## Test plan
- Verify the e2e-api-test workflow runs successfully with the new parameterized tag
- Confirm the docker image is built with the correct tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)