### PR TITLE
feat: enhance advanced filtering for Tasklist `user-tasks` V2 API

### DIFF
--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -329,6 +329,7 @@
             <typeMapping>FormKeyFilterProperty=BasicStringFilterProperty</typeMapping>
             <typeMapping>JobKeyFilterProperty=BasicStringFilterProperty</typeMapping>
             <typeMapping>MessageSubscriptionKeyFilterProperty=BasicStringFilterProperty</typeMapping>
+            <typeMapping>ProcessDefinitionIdFilterProperty=StringFilterProperty</typeMapping>
             <typeMapping>ProcessDefinitionKeyFilterProperty=BasicStringFilterProperty</typeMapping>
             <typeMapping>ProcessInstanceKeyFilterProperty=BasicStringFilterProperty</typeMapping>
             <typeMapping>ResourceKeyFilterProperty=BasicStringFilterProperty</typeMapping>

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/UserTaskFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/UserTaskFilter.java
@@ -207,6 +207,15 @@ public interface UserTaskFilter extends SearchRequestFilter {
   UserTaskFilter bpmnProcessId(final String bpmnProcessId);
 
   /**
+   * Filters user tasks by the specified Process Definition Id using {@link StringProperty}
+   * consumer.
+   *
+   * @param fn the Process Definition Id {@link StringProperty} consumer of the user task
+   * @return the updated filter
+   */
+  UserTaskFilter bpmnProcessId(final Consumer<StringProperty> fn);
+
+  /**
    * Filters user tasks by specified Process Instance Variables.
    *
    * @param variableValueFilters from the task

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/UserTaskFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/UserTaskFilter.java
@@ -16,6 +16,7 @@
 package io.camunda.client.api.search.filter;
 
 import io.camunda.client.api.search.enums.UserTaskState;
+import io.camunda.client.api.search.filter.builder.BasicLongProperty;
 import io.camunda.client.api.search.filter.builder.DateTimeProperty;
 import io.camunda.client.api.search.filter.builder.IntegerProperty;
 import io.camunda.client.api.search.filter.builder.StringProperty;
@@ -175,12 +176,30 @@ public interface UserTaskFilter extends SearchRequestFilter {
   UserTaskFilter processDefinitionKey(final Long processDefinitionKey);
 
   /**
+   * Filters user tasks by the specified process definition key using {@link BasicLongProperty}
+   * consumer.
+   *
+   * @param fn the process definition key {@link BasicLongProperty} consumer of the user task
+   * @return the updated filter
+   */
+  UserTaskFilter processDefinitionKey(final Consumer<BasicLongProperty> fn);
+
+  /**
    * Filters user tasks by the specified process instance key.
    *
    * @param processInstanceKey the process instance key of the user task
    * @return the updated filter
    */
   UserTaskFilter processInstanceKey(final Long processInstanceKey);
+
+  /**
+   * Filters user tasks by the specified process instance key using {@link BasicLongProperty}
+   * consumer.
+   *
+   * @param fn the process instance key {@link BasicLongProperty} consumer of the user task
+   * @return the updated filter
+   */
+  UserTaskFilter processInstanceKey(final Consumer<BasicLongProperty> fn);
 
   /**
    * Filters user tasks by the specified tenant ID.

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/UserTaskFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/UserTaskFilterImpl.java
@@ -180,7 +180,10 @@ public class UserTaskFilterImpl
 
   @Override
   public UserTaskFilter bpmnProcessId(final String bpmnProcessId) {
-    filter.processDefinitionId(bpmnProcessId);
+    final Consumer<StringProperty> fn = b -> b.eq(bpmnProcessId);
+    final StringProperty property = new StringPropertyImpl();
+    fn.accept(property);
+    filter.setProcessDefinitionId(provideSearchRequestProperty(property));
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/UserTaskFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/UserTaskFilterImpl.java
@@ -18,10 +18,12 @@ package io.camunda.client.impl.search.filter;
 import io.camunda.client.api.search.enums.UserTaskState;
 import io.camunda.client.api.search.filter.UserTaskFilter;
 import io.camunda.client.api.search.filter.VariableValueFilter;
+import io.camunda.client.api.search.filter.builder.BasicStringProperty;
 import io.camunda.client.api.search.filter.builder.DateTimeProperty;
 import io.camunda.client.api.search.filter.builder.IntegerProperty;
 import io.camunda.client.api.search.filter.builder.StringProperty;
 import io.camunda.client.api.search.filter.builder.UserTaskStateProperty;
+import io.camunda.client.impl.search.filter.builder.BasicStringPropertyImpl;
 import io.camunda.client.impl.search.filter.builder.DateTimePropertyImpl;
 import io.camunda.client.impl.search.filter.builder.IntegerPropertyImpl;
 import io.camunda.client.impl.search.filter.builder.StringPropertyImpl;
@@ -155,7 +157,10 @@ public class UserTaskFilterImpl
 
   @Override
   public UserTaskFilter processDefinitionKey(final Long processDefinitionKey) {
-    filter.setProcessDefinitionKey(ParseUtil.keyToString(processDefinitionKey));
+    final Consumer<BasicStringProperty> fn = b -> b.eq(ParseUtil.keyToString(processDefinitionKey));
+    final BasicStringProperty property = new BasicStringPropertyImpl();
+    fn.accept(property);
+    filter.setProcessDefinitionKey(provideSearchRequestProperty(property));
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/UserTaskFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/UserTaskFilterImpl.java
@@ -185,7 +185,12 @@ public class UserTaskFilterImpl
 
   @Override
   public UserTaskFilter bpmnProcessId(final String bpmnProcessId) {
-    final Consumer<StringProperty> fn = b -> b.eq(bpmnProcessId);
+    bpmnProcessId(b -> b.eq(bpmnProcessId))
+    return this;
+  }
+
+  @Override
+  public UserTaskFilter bpmnProcessId(final Consumer<StringProperty> fn) {
     final StringProperty property = new StringPropertyImpl();
     fn.accept(property);
     filter.setProcessDefinitionId(provideSearchRequestProperty(property));

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/UserTaskFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/UserTaskFilterImpl.java
@@ -185,7 +185,7 @@ public class UserTaskFilterImpl
 
   @Override
   public UserTaskFilter bpmnProcessId(final String bpmnProcessId) {
-    bpmnProcessId(b -> b.eq(bpmnProcessId))
+    bpmnProcessId(b -> b.eq(bpmnProcessId));
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/UserTaskFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/UserTaskFilterImpl.java
@@ -18,12 +18,12 @@ package io.camunda.client.impl.search.filter;
 import io.camunda.client.api.search.enums.UserTaskState;
 import io.camunda.client.api.search.filter.UserTaskFilter;
 import io.camunda.client.api.search.filter.VariableValueFilter;
-import io.camunda.client.api.search.filter.builder.BasicStringProperty;
+import io.camunda.client.api.search.filter.builder.BasicLongProperty;
 import io.camunda.client.api.search.filter.builder.DateTimeProperty;
 import io.camunda.client.api.search.filter.builder.IntegerProperty;
 import io.camunda.client.api.search.filter.builder.StringProperty;
 import io.camunda.client.api.search.filter.builder.UserTaskStateProperty;
-import io.camunda.client.impl.search.filter.builder.BasicStringPropertyImpl;
+import io.camunda.client.impl.search.filter.builder.BasicLongPropertyImpl;
 import io.camunda.client.impl.search.filter.builder.DateTimePropertyImpl;
 import io.camunda.client.impl.search.filter.builder.IntegerPropertyImpl;
 import io.camunda.client.impl.search.filter.builder.StringPropertyImpl;
@@ -157,8 +157,13 @@ public class UserTaskFilterImpl
 
   @Override
   public UserTaskFilter processDefinitionKey(final Long processDefinitionKey) {
-    final Consumer<BasicStringProperty> fn = b -> b.eq(ParseUtil.keyToString(processDefinitionKey));
-    final BasicStringProperty property = new BasicStringPropertyImpl();
+    processDefinitionKey(b -> b.eq(processDefinitionKey));
+    return this;
+  }
+
+  @Override
+  public UserTaskFilter processDefinitionKey(final Consumer<BasicLongProperty> fn) {
+    final BasicLongProperty property = new BasicLongPropertyImpl();
     fn.accept(property);
     filter.setProcessDefinitionKey(provideSearchRequestProperty(property));
     return this;
@@ -166,7 +171,15 @@ public class UserTaskFilterImpl
 
   @Override
   public UserTaskFilter processInstanceKey(final Long processInstanceKey) {
-    filter.setProcessInstanceKey(ParseUtil.keyToString(processInstanceKey));
+    processInstanceKey(b -> b.eq(processInstanceKey));
+    return this;
+  }
+
+  @Override
+  public UserTaskFilter processInstanceKey(final Consumer<BasicLongProperty> fn) {
+    final BasicLongProperty property = new BasicLongPropertyImpl();
+    fn.accept(property);
+    filter.setProcessInstanceKey(provideSearchRequestProperty(property));
     return this;
   }
 

--- a/clients/java/src/test/java/io/camunda/client/usertask/SearchUserTaskTest.java
+++ b/clients/java/src/test/java/io/camunda/client/usertask/SearchUserTaskTest.java
@@ -20,7 +20,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.client.api.search.enums.UserTaskState;
+import io.camunda.client.api.search.filter.builder.BasicLongProperty;
+import io.camunda.client.api.search.filter.builder.StringProperty;
 import io.camunda.client.api.search.filter.builder.UserTaskStateProperty;
+import io.camunda.client.protocol.rest.BasicStringFilterProperty;
 import io.camunda.client.protocol.rest.FormResult;
 import io.camunda.client.protocol.rest.IntegerFilterProperty;
 import io.camunda.client.protocol.rest.StringFilterProperty;
@@ -195,6 +198,50 @@ public final class SearchUserTaskTest extends ClientRestTest {
     assertThat(request.getFilter().getCandidateUser().get$Eq()).isEqualTo("user1");
   }
 
+  static Stream<Arguments> provideBpmnProcessIdFilters() {
+    return Stream.of(
+        stringFilterCase(
+            "eq:my-process",
+            b -> b.eq("my-process"),
+            f -> assertThat(f.get$Eq()).isEqualTo("my-process")),
+        stringFilterCase(
+            "neq:my-process",
+            b -> b.neq("my-process"),
+            f -> assertThat(f.get$Neq()).isEqualTo("my-process")),
+        stringFilterCase(
+            "exists:true", b -> b.exists(true), f -> assertThat(f.get$Exists()).isTrue()),
+        stringFilterCase(
+            "exists:false", b -> b.exists(false), f -> assertThat(f.get$Exists()).isFalse()),
+        stringFilterCase(
+            "in:[proc-a,proc-b]",
+            b -> b.in("proc-a", "proc-b"),
+            f -> assertThat(f.get$In()).containsExactly("proc-a", "proc-b")),
+        stringFilterCase(
+            "like:my-proc*",
+            b -> b.like("my-proc*"),
+            f -> assertThat(f.get$Like()).isEqualTo("my-proc*")));
+  }
+
+  private static Arguments stringFilterCase(
+      final String label,
+      final Consumer<StringProperty> filter,
+      final Consumer<StringFilterProperty> assertion) {
+    return Arguments.of(Named.of(label, filter), Named.of("assert " + label, assertion));
+  }
+
+  @ParameterizedTest(name = "[{index}] should apply {0}")
+  @MethodSource("provideBpmnProcessIdFilters")
+  @DisplayName("Should search user tasks by bpmnProcessId using advanced filters")
+  void shouldSearchUserTasksByBpmnProcessIdUsingAdvancedFilter(
+      final Consumer<StringProperty> filter, final Consumer<StringFilterProperty> assertion) {
+    // when
+    client.newUserTaskSearchRequest().filter(f -> f.bpmnProcessId(filter)).send().join();
+
+    // then
+    final UserTaskSearchQuery request = gatewayService.getLastRequest(UserTaskSearchQuery.class);
+    assertThat(request.getFilter().getProcessDefinitionId()).isNotNull().satisfies(assertion);
+  }
+
   @Test
   void shouldSearchUserTaskByBpmnProcessId() {
     // when
@@ -223,6 +270,60 @@ public final class SearchUserTaskTest extends ClientRestTest {
     // then
     final UserTaskSearchQuery request = gatewayService.getLastRequest(UserTaskSearchQuery.class);
     assertThat(request.getFilter().getProcessInstanceKey().get$Eq()).isEqualTo("456");
+  }
+
+  static Stream<Arguments> provideKeyFilters() {
+    return Stream.of(
+        longKeyFilterCase("eq:123", b -> b.eq(123L), f -> assertThat(f.get$Eq()).isEqualTo("123")),
+        longKeyFilterCase(
+            "neq:123", b -> b.neq(123L), f -> assertThat(f.get$Neq()).isEqualTo("123")),
+        longKeyFilterCase(
+            "exists:true", b -> b.exists(true), f -> assertThat(f.get$Exists()).isTrue()),
+        longKeyFilterCase(
+            "exists:false", b -> b.exists(false), f -> assertThat(f.get$Exists()).isFalse()),
+        longKeyFilterCase(
+            "in:[123,456]",
+            b -> b.in(123L, 456L),
+            f -> assertThat(f.get$In()).containsExactly("123", "456")),
+        longKeyFilterCase(
+            "notIn:[123,456]",
+            b -> b.notIn(123L, 456L),
+            f -> assertThat(f.get$NotIn()).containsExactly("123", "456")));
+  }
+
+  private static Arguments longKeyFilterCase(
+      final String label,
+      final Consumer<BasicLongProperty> filter,
+      final Consumer<BasicStringFilterProperty> assertion) {
+    return Arguments.of(Named.of(label, filter), Named.of("assert " + label, assertion));
+  }
+
+  @ParameterizedTest(name = "[{index}] should apply {0}")
+  @MethodSource("provideKeyFilters")
+  @DisplayName("Should search user tasks by processDefinitionKey using advanced filters")
+  void shouldSearchUserTasksByProcessDefinitionKeyUsingAdvancedFilter(
+      final Consumer<BasicLongProperty> filter,
+      final Consumer<BasicStringFilterProperty> assertion) {
+    // when
+    client.newUserTaskSearchRequest().filter(f -> f.processDefinitionKey(filter)).send().join();
+
+    // then
+    final UserTaskSearchQuery request = gatewayService.getLastRequest(UserTaskSearchQuery.class);
+    assertThat(request.getFilter().getProcessDefinitionKey()).isNotNull().satisfies(assertion);
+  }
+
+  @ParameterizedTest(name = "[{index}] should apply {0}")
+  @MethodSource("provideKeyFilters")
+  @DisplayName("Should search user tasks by processInstanceKey using advanced filters")
+  void shouldSearchUserTasksByProcessInstanceKeyUsingAdvancedFilter(
+      final Consumer<BasicLongProperty> filter,
+      final Consumer<BasicStringFilterProperty> assertion) {
+    // when
+    client.newUserTaskSearchRequest().filter(f -> f.processInstanceKey(filter)).send().join();
+
+    // then
+    final UserTaskSearchQuery request = gatewayService.getLastRequest(UserTaskSearchQuery.class);
+    assertThat(request.getFilter().getProcessInstanceKey()).isNotNull().satisfies(assertion);
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/usertask/SearchUserTaskTest.java
+++ b/clients/java/src/test/java/io/camunda/client/usertask/SearchUserTaskTest.java
@@ -196,6 +196,16 @@ public final class SearchUserTaskTest extends ClientRestTest {
   }
 
   @Test
+  void shouldSearchUserTaskByBpmnProcessId() {
+    // when
+    client.newUserTaskSearchRequest().filter(f -> f.bpmnProcessId("my-process")).send().join();
+
+    // then
+    final UserTaskSearchQuery request = gatewayService.getLastRequest(UserTaskSearchQuery.class);
+    assertThat(request.getFilter().getProcessDefinitionId().get$Eq()).isEqualTo("my-process");
+  }
+
+  @Test
   void shouldSearchUserTaskByProcessDefinitionKey() {
     // when
     client.newUserTaskSearchRequest().filter(f -> f.processDefinitionKey(123L)).send().join();
@@ -212,7 +222,7 @@ public final class SearchUserTaskTest extends ClientRestTest {
 
     // then
     final UserTaskSearchQuery request = gatewayService.getLastRequest(UserTaskSearchQuery.class);
-    assertThat(request.getFilter().getProcessInstanceKey()).isEqualTo("456");
+    assertThat(request.getFilter().getProcessInstanceKey().get$Eq()).isEqualTo("456");
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/usertask/SearchUserTaskTest.java
+++ b/clients/java/src/test/java/io/camunda/client/usertask/SearchUserTaskTest.java
@@ -202,7 +202,7 @@ public final class SearchUserTaskTest extends ClientRestTest {
 
     // then
     final UserTaskSearchQuery request = gatewayService.getLastRequest(UserTaskSearchQuery.class);
-    assertThat(request.getFilter().getProcessDefinitionKey()).isEqualTo("123");
+    assertThat(request.getFilter().getProcessDefinitionKey().get$Eq()).isEqualTo("123");
   }
 
   @Test

--- a/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
@@ -282,14 +282,14 @@
       <if
         test="filter.processInstanceKeyOperations != null and !filter.processInstanceKeyOperations.isEmpty()">
         <foreach collection="filter.processInstanceKeyOperations" item="operation">
-          AND PROCESS_INSTANCE_KEY
+          AND ut.PROCESS_INSTANCE_KEY
           <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
         </foreach>
       </if>
       <if
         test="filter.processDefinitionKeyOperations != null and !filter.processDefinitionKeyOperations.isEmpty()">
         <foreach collection="filter.processDefinitionKeyOperations" item="operation">
-          AND PROCESS_DEFINITION_KEY
+          AND ut.PROCESS_DEFINITION_KEY
           <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
         </foreach>
       </if>

--- a/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
@@ -254,6 +254,13 @@
           separator=", ">#{value}
         </foreach>
       </if>
+      <if
+        test="filter.processDefinitionIdOperations != null and !filter.processDefinitionIdOperations.isEmpty()">
+        <foreach collection="filter.processDefinitionIdOperations" item="operation">
+          AND ut.PROCESS_DEFINITION_ID
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
       <if test="filter.assigneeOperations != null and !filter.assigneeOperations.isEmpty()">
         <foreach collection="filter.assigneeOperations" item="operation">
           AND ut.ASSIGNEE
@@ -282,13 +289,6 @@
         test="filter.processDefinitionKeyOperations != null and !filter.processDefinitionKeyOperations.isEmpty()">
         <foreach collection="filter.processDefinitionKeyOperations" item="operation">
           AND PROCESS_DEFINITION_KEY
-          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
-        </foreach>
-      </if>
-      <if
-        test="filter.processDefinitionIdOperations != null and !filter.processDefinitionIdOperations.isEmpty()">
-        <foreach collection="filter.processDefinitionIdOperations" item="operation">
-          AND ut.PROCESS_DEFINITION_ID
           <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
         </foreach>
       </if>

--- a/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
@@ -279,10 +279,11 @@
           <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
         </foreach>
       </if>
-      <if test="filter.processInstanceKeys != null and !filter.processInstanceKeys.isEmpty()">
-        AND ut.PROCESS_INSTANCE_KEY IN
-        <foreach close=")" collection="filter.processInstanceKeys" item="value" open="("
-          separator=", ">#{value}
+      <if
+        test="filter.processInstanceKeyOperations != null and !filter.processInstanceKeyOperations.isEmpty()">
+        <foreach collection="filter.pprocessInstanceKeyOperations" item="operation">
+          AND PROCESS_INSTANCE_KEY
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
         </foreach>
       </if>
       <if

--- a/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
@@ -254,12 +254,6 @@
           separator=", ">#{value}
         </foreach>
       </if>
-      <if test="filter.bpmnProcessIds != null and !filter.bpmnProcessIds.isEmpty()">
-        AND ut.PROCESS_DEFINITION_ID IN
-        <foreach close=")" collection="filter.bpmnProcessIds" item="value" open="("
-          separator=", ">#{value}
-        </foreach>
-      </if>
       <if test="filter.assigneeOperations != null and !filter.assigneeOperations.isEmpty()">
         <foreach collection="filter.assigneeOperations" item="operation">
           AND ut.ASSIGNEE
@@ -288,6 +282,13 @@
         AND ut.PROCESS_DEFINITION_KEY IN
         <foreach close=")" collection="filter.processDefinitionKeys" item="value" open="("
           separator=", ">#{value}
+        </foreach>
+      </if>
+      <if
+        test="filter.processDefinitionIdOperations != null and !filter.processDefinitionIdOperations.isEmpty()">
+        <foreach collection="filter.processDefinitionIdOperations" item="operation">
+          AND ut.PROCESS_DEFINITION_ID
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
         </foreach>
       </if>
       <if test="filter.tenantIdOperations != null and !filter.tenantIdOperations.isEmpty()">

--- a/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
@@ -281,7 +281,7 @@
       </if>
       <if
         test="filter.processInstanceKeyOperations != null and !filter.processInstanceKeyOperations.isEmpty()">
-        <foreach collection="filter.pprocessInstanceKeyOperations" item="operation">
+        <foreach collection="filter.processInstanceKeyOperations" item="operation">
           AND PROCESS_INSTANCE_KEY
           <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
         </foreach>

--- a/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
@@ -278,10 +278,11 @@
           separator=", ">#{value}
         </foreach>
       </if>
-      <if test="filter.processDefinitionKeys != null and !filter.processDefinitionKeys.isEmpty()">
-        AND ut.PROCESS_DEFINITION_KEY IN
-        <foreach close=")" collection="filter.processDefinitionKeys" item="value" open="("
-          separator=", ">#{value}
+      <if
+        test="filter.processDefinitionKeyOperations != null and !filter.processDefinitionKeyOperations.isEmpty()">
+        <foreach collection="filter.processDefinitionKeyOperations" item="operation">
+          AND PROCESS_DEFINITION_KEY
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
         </foreach>
       </if>
       <if

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -905,8 +905,8 @@ public class SearchQueryFilterMapper {
           .map(mapToKeyOperations("processDefinitionKey", validationErrors))
           .ifPresent(builder::processDefinitionKeyOperations);
       Optional.ofNullable(filter.getProcessInstanceKey())
-          .map(mapKeyToLong("processInstanceKey", validationErrors))
-          .ifPresent(builder::processInstanceKeys);
+          .map(mapToKeyOperations("processInstanceKey", validationErrors))
+          .ifPresent(builder::processInstanceKeyOperations);
       Optional.ofNullable(filter.getTenantId())
           .map(mapToStringOperations())
           .ifPresent(builder::tenantIdOperations);

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -902,8 +902,8 @@ public class SearchQueryFilterMapper {
           .map(mapToStringOperations())
           .ifPresent(builder::candidateUserOperations);
       Optional.ofNullable(filter.getProcessDefinitionKey())
-          .map(mapKeyToLong("processDefinitionKey", validationErrors))
-          .ifPresent(builder::processDefinitionKeys);
+          .map(mapToKeyOperations("processDefinitionKey", validationErrors))
+          .ifPresent(builder::processDefinitionKeyOperations);
       Optional.ofNullable(filter.getProcessInstanceKey())
           .map(mapKeyToLong("processInstanceKey", validationErrors))
           .ifPresent(builder::processInstanceKeys);

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -882,7 +882,7 @@ public class SearchQueryFilterMapper {
       Optional.ofNullable(filter.getState())
           .map(mapToStringOperations())
           .ifPresent(builder::stateOperations);
-      ofNullable(filter.getProcessDefinitionId())
+      Optional.ofNullable(filter.getProcessDefinitionId())
           .map(mapToStringOperations())
           .ifPresent(builder::processDefinitionIdOperations);
       Optional.ofNullable(filter.getElementId()).ifPresent(builder::elementIds);

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -882,7 +882,9 @@ public class SearchQueryFilterMapper {
       Optional.ofNullable(filter.getState())
           .map(mapToStringOperations())
           .ifPresent(builder::stateOperations);
-      Optional.ofNullable(filter.getProcessDefinitionId()).ifPresent(builder::bpmnProcessIds);
+      ofNullable(filter.getProcessDefinitionId())
+          .map(mapToStringOperations())
+          .ifPresent(builder::processDefinitionIdOperations);
       Optional.ofNullable(filter.getElementId()).ifPresent(builder::elementIds);
       Optional.ofNullable(filter.getName())
           .map(mapToStringOperations())

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SimpleSearchQueryMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SimpleSearchQueryMapper.java
@@ -380,7 +380,9 @@ public class SimpleSearchQueryMapper {
       ofNullable(filter.getProcessDefinitionKey())
           .map(SimpleSearchQueryMapper::getBasicStringFilter)
           .ifPresent(filterModel::processDefinitionKey);
-      ofNullable(filter.getProcessInstanceKey()).ifPresent(filterModel::processInstanceKey);
+      ofNullable(filter.getProcessInstanceKey())
+          .map(SimpleSearchQueryMapper::getBasicStringFilter)
+          .ifPresent(filterModel::processInstanceKey);
       ofNullable(filter.getElementInstanceKey()).ifPresent(filterModel::elementInstanceKey);
       ofNullable(filter.getTags()).ifPresent(filterModel::tags);
     }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SimpleSearchQueryMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SimpleSearchQueryMapper.java
@@ -355,7 +355,9 @@ public class SimpleSearchQueryMapper {
       ofNullable(filter.getTenantId())
           .map(SimpleSearchQueryMapper::getStringFilter)
           .ifPresent(filterModel::tenantId);
-      ofNullable(filter.getProcessDefinitionId()).ifPresent(filterModel::processDefinitionId);
+      ofNullable(filter.getProcessDefinitionId())
+          .map(SimpleSearchQueryMapper::getStringFilter)
+          .ifPresent(filterModel::processDefinitionId);
       ofNullable(filter.getCreationDate())
           .map(SimpleSearchQueryMapper::getDateTimeFilter)
           .ifPresent(filterModel::creationDate);

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SimpleSearchQueryMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SimpleSearchQueryMapper.java
@@ -377,7 +377,9 @@ public class SimpleSearchQueryMapper {
           .map(SimpleSearchQueryMapper::mapVariableValueFilterProperties)
           .ifPresent(filterModel::localVariables);
       ofNullable(filter.getUserTaskKey()).ifPresent(filterModel::userTaskKey);
-      ofNullable(filter.getProcessDefinitionKey()).ifPresent(filterModel::processDefinitionKey);
+      ofNullable(filter.getProcessDefinitionKey())
+          .map(SimpleSearchQueryMapper::getBasicStringFilter)
+          .ifPresent(filterModel::processDefinitionKey);
       ofNullable(filter.getProcessInstanceKey()).ifPresent(filterModel::processInstanceKey);
       ofNullable(filter.getElementInstanceKey()).ifPresent(filterModel::elementInstanceKey);
       ofNullable(filter.getTags()).ifPresent(filterModel::tags);

--- a/gateways/gateway-model/pom.xml
+++ b/gateways/gateway-model/pom.xml
@@ -105,6 +105,7 @@
                 <typeMapping>FormKeyFilterProperty=BasicStringFilterProperty</typeMapping>
                 <typeMapping>JobKeyFilterProperty=BasicStringFilterProperty</typeMapping>
                 <typeMapping>MessageSubscriptionKeyFilterProperty=BasicStringFilterProperty</typeMapping>
+                <typeMapping>ProcessDefinitionIdFilterProperty=StringFilterProperty</typeMapping>
                 <typeMapping>ProcessDefinitionKeyFilterProperty=BasicStringFilterProperty</typeMapping>
                 <typeMapping>ProcessInstanceKeyFilterProperty=BasicStringFilterProperty</typeMapping>
                 <typeMapping>ResourceKeyFilterProperty=BasicStringFilterProperty</typeMapping>
@@ -167,6 +168,7 @@
                 <typeMapping>IntegerFilterProperty=Integer</typeMapping>
                 <typeMapping>JobKeyFilterProperty=String</typeMapping>
                 <typeMapping>MessageSubscriptionKeyFilterProperty=String</typeMapping>
+                <typeMapping>ProcessDefinitionIdFilterProperty=String</typeMapping>
                 <typeMapping>ProcessDefinitionKeyFilterProperty=String</typeMapping>
                 <typeMapping>ProcessInstanceKeyFilterProperty=String</typeMapping>
                 <typeMapping>ResourceKeyFilterProperty=String</typeMapping>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UserTaskSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UserTaskSearchIT.java
@@ -495,7 +495,7 @@ class UserTaskSearchIT {
   }
 
   @Test
-  public void shouldRetrieveTaskByBpmnDefinitionId() {
+  public void shouldRetrieveTaskByBpmnProcessId() {
     final var result =
         camundaClient
             .newUserTaskSearchRequest()
@@ -504,50 +504,6 @@ class UserTaskSearchIT {
             .join();
     assertThat(result.items()).hasSize(2);
     result.items().forEach(item -> assertThat(item.getBpmnProcessId()).isEqualTo("process"));
-  }
-
-  @Test
-  void shouldRetrieveTaskByProcessDefinitionKey() {
-    // given - use a process with exactly one task to get an unambiguous processDefinitionKey
-    final var taskSearch =
-        camundaClient
-            .newUserTaskSearchRequest()
-            .filter(f -> f.bpmnProcessId("process-2"))
-            .send()
-            .join();
-    assertThat(taskSearch.items()).hasSize(1);
-    final var processDefinitionKey = taskSearch.items().getFirst().getProcessDefinitionKey();
-
-    // when
-    final var result =
-        camundaClient
-            .newUserTaskSearchRequest()
-            .filter(f -> f.processDefinitionKey(processDefinitionKey))
-            .send()
-            .join();
-
-    // then
-    assertThat(result.items()).hasSize(1);
-    result
-        .items()
-        .forEach(
-            item -> assertThat(item.getProcessDefinitionKey()).isEqualTo(processDefinitionKey));
-  }
-
-  @Test
-  void shouldRetrieveTaskByProcessInstanceKey() {
-    // when - childProcessInstanceKey has exactly one user task
-    final var result =
-        camundaClient
-            .newUserTaskSearchRequest()
-            .filter(f -> f.processInstanceKey(childProcessInstanceKey))
-            .send()
-            .join();
-
-    // then
-    assertThat(result.items()).hasSize(1);
-    assertThat(result.items().getFirst().getProcessInstanceKey())
-        .isEqualTo(childProcessInstanceKey);
   }
 
   @Test
@@ -582,6 +538,117 @@ class UserTaskSearchIT {
     // then
     assertThat(result.items()).hasSize(2);
     result.items().forEach(item -> assertThat(item.getBpmnProcessId()).startsWith("process-"));
+  }
+
+  @Test
+  void shouldRetrieveTaskByProcessDefinitionKey() {
+    // given - use a process with exactly one task to get an unambiguous processDefinitionKey
+    final var taskSearch =
+        camundaClient
+            .newUserTaskSearchRequest()
+            .filter(f -> f.bpmnProcessId("process-2"))
+            .send()
+            .join();
+    assertThat(taskSearch.items()).hasSize(1);
+    final var processDefinitionKey = taskSearch.items().getFirst().getProcessDefinitionKey();
+
+    // when
+    final var result =
+        camundaClient
+            .newUserTaskSearchRequest()
+            .filter(f -> f.processDefinitionKey(processDefinitionKey))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    result
+        .items()
+        .forEach(
+            item -> assertThat(item.getProcessDefinitionKey()).isEqualTo(processDefinitionKey));
+  }
+
+  @Test
+  void shouldRetrieveTaskByProcessDefinitionKeyIn() {
+    // given - "process-2" and "process-3" each have exactly one task
+    final var key2 =
+        camundaClient
+            .newUserTaskSearchRequest()
+            .filter(f -> f.bpmnProcessId("process-2"))
+            .send()
+            .join()
+            .items()
+            .getFirst()
+            .getProcessDefinitionKey();
+    final var key3 =
+        camundaClient
+            .newUserTaskSearchRequest()
+            .filter(f -> f.bpmnProcessId("process-3"))
+            .send()
+            .join()
+            .items()
+            .getFirst()
+            .getProcessDefinitionKey();
+
+    // when
+    final var result =
+        camundaClient
+            .newUserTaskSearchRequest()
+            .filter(f -> f.processDefinitionKey(b -> b.in(key2, key3)))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).hasSize(2);
+    result.items().forEach(item -> assertThat(item.getProcessDefinitionKey()).isIn(key2, key3));
+  }
+
+  @Test
+  void shouldRetrieveTaskByProcessInstanceKey() {
+    // when - childProcessInstanceKey has exactly one user task
+    final var result =
+        camundaClient
+            .newUserTaskSearchRequest()
+            .filter(f -> f.processInstanceKey(childProcessInstanceKey))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().getFirst().getProcessInstanceKey())
+        .isEqualTo(childProcessInstanceKey);
+  }
+
+  @Test
+  void shouldRetrieveTaskByProcessInstanceKeyIn() {
+    // given - "process-2" has exactly one task; childProcessInstanceKey also has exactly one task
+    final var process2InstanceKey =
+        camundaClient
+            .newUserTaskSearchRequest()
+            .filter(f -> f.bpmnProcessId("process-2"))
+            .send()
+            .join()
+            .items()
+            .getFirst()
+            .getProcessInstanceKey();
+
+    // when
+    final var result =
+        camundaClient
+            .newUserTaskSearchRequest()
+            .filter(
+                f -> f.processInstanceKey(b -> b.in(childProcessInstanceKey, process2InstanceKey)))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).hasSize(2);
+    result
+        .items()
+        .forEach(
+            item ->
+                assertThat(item.getProcessInstanceKey())
+                    .isIn(childProcessInstanceKey, process2InstanceKey));
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UserTaskSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UserTaskSearchIT.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOf
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.search.enums.UserTaskState;
+import io.camunda.client.api.search.filter.builder.StringProperty;
 import io.camunda.client.api.search.response.UserTask;
 import io.camunda.client.api.search.response.Variable;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
@@ -33,6 +34,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.function.Consumer;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -502,6 +504,84 @@ class UserTaskSearchIT {
             .join();
     assertThat(result.items()).hasSize(2);
     result.items().forEach(item -> assertThat(item.getBpmnProcessId()).isEqualTo("process"));
+  }
+
+  @Test
+  void shouldRetrieveTaskByProcessDefinitionKey() {
+    // given - use a process with exactly one task to get an unambiguous processDefinitionKey
+    final var taskSearch =
+        camundaClient
+            .newUserTaskSearchRequest()
+            .filter(f -> f.bpmnProcessId("process-2"))
+            .send()
+            .join();
+    assertThat(taskSearch.items()).hasSize(1);
+    final var processDefinitionKey = taskSearch.items().getFirst().getProcessDefinitionKey();
+
+    // when
+    final var result =
+        camundaClient
+            .newUserTaskSearchRequest()
+            .filter(f -> f.processDefinitionKey(processDefinitionKey))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    result
+        .items()
+        .forEach(
+            item -> assertThat(item.getProcessDefinitionKey()).isEqualTo(processDefinitionKey));
+  }
+
+  @Test
+  void shouldRetrieveTaskByProcessInstanceKey() {
+    // when - childProcessInstanceKey has exactly one user task
+    final var result =
+        camundaClient
+            .newUserTaskSearchRequest()
+            .filter(f -> f.processInstanceKey(childProcessInstanceKey))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().getFirst().getProcessInstanceKey())
+        .isEqualTo(childProcessInstanceKey);
+  }
+
+  @Test
+  void shouldRetrieveTaskByBpmnProcessIdIn() {
+    // when - "process-2" and "process-3" each have exactly one task
+    final Consumer<StringProperty> inFilter = b -> b.in("process-2", "process-3");
+    final var result =
+        camundaClient
+            .newUserTaskSearchRequest()
+            .filter(f -> f.bpmnProcessId(inFilter))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).hasSize(2);
+    result
+        .items()
+        .forEach(item -> assertThat(item.getBpmnProcessId()).isIn("process-2", "process-3"));
+  }
+
+  @Test
+  void shouldRetrieveTaskByBpmnProcessIdLike() {
+    // when - "process-?" matches "process-2" and "process-3" (single char after dash)
+    final Consumer<StringProperty> likeFilter = b -> b.like("process-?");
+    final var result =
+        camundaClient
+            .newUserTaskSearchRequest()
+            .filter(f -> f.bpmnProcessId(likeFilter))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).hasSize(2);
+    result.items().forEach(item -> assertThat(item.getBpmnProcessId()).startsWith("process-"));
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/usertask/UserTaskIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/usertask/UserTaskIT.java
@@ -308,7 +308,7 @@ public class UserTaskIT {
             .search(
                 new UserTaskQuery(
                     new UserTaskFilter.Builder()
-                        .processDefinitionIdOperations(Operation.like(prefix + "%"))
+                        .processDefinitionIdOperations(Operation.like(prefix + "*"))
                         .build(),
                     UserTaskSort.of(b -> b),
                     SearchQueryPage.of(b -> b.from(0).size(10))));

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/usertask/UserTaskIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/usertask/UserTaskIT.java
@@ -228,6 +228,227 @@ public class UserTaskIT {
   }
 
   @TestTemplate
+  public void shouldFindUserTaskByProcessDefinitionIdEq(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final String processDefinitionId = generateRandomString("processDefinitionId");
+    final UserTaskDbModel userTask =
+        UserTaskFixtures.createRandomized(b -> b.processDefinitionId(processDefinitionId));
+    createAndSaveUserTask(rdbmsService, userTask);
+
+    // when
+    final var searchResult =
+        rdbmsService
+            .getUserTaskReader()
+            .search(
+                new UserTaskQuery(
+                    new UserTaskFilter.Builder()
+                        .processDefinitionIdOperations(Operation.eq(processDefinitionId))
+                        .build(),
+                    UserTaskSort.of(b -> b),
+                    SearchQueryPage.of(b -> b.from(0).size(10))));
+
+    // then
+    assertThat(searchResult.total()).isEqualTo(1);
+    assertThat(searchResult.items()).hasSize(1);
+    assertUserTaskEntity(searchResult.items().getFirst(), userTask);
+  }
+
+  @TestTemplate
+  public void shouldFindUserTaskByProcessDefinitionIdNeq(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final String tenantId = generateRandomString("tenant");
+    final String processDefinitionIdA = generateRandomString("proc-a");
+    final String processDefinitionIdB = generateRandomString("proc-b");
+    final UserTaskDbModel taskA =
+        UserTaskFixtures.createRandomized(
+            b -> b.tenantId(tenantId).processDefinitionId(processDefinitionIdA));
+    final UserTaskDbModel taskB =
+        UserTaskFixtures.createRandomized(
+            b -> b.tenantId(tenantId).processDefinitionId(processDefinitionIdB));
+    createAndSaveUserTask(rdbmsService, taskA);
+    createAndSaveUserTask(rdbmsService, taskB);
+
+    // when
+    final var searchResult =
+        rdbmsService
+            .getUserTaskReader()
+            .search(
+                new UserTaskQuery(
+                    new UserTaskFilter.Builder()
+                        .tenantIds(tenantId)
+                        .processDefinitionIdOperations(Operation.neq(processDefinitionIdA))
+                        .build(),
+                    UserTaskSort.of(b -> b),
+                    SearchQueryPage.of(b -> b.from(0).size(10))));
+
+    // then
+    assertThat(searchResult.total()).isEqualTo(1);
+    assertThat(searchResult.items()).hasSize(1);
+    assertUserTaskEntity(searchResult.items().getFirst(), taskB);
+  }
+
+  @TestTemplate
+  public void shouldFindUserTaskByProcessDefinitionIdLike(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final String prefix = generateRandomString("order-process");
+    final UserTaskDbModel userTask =
+        UserTaskFixtures.createRandomized(b -> b.processDefinitionId(prefix + "-v1"));
+    createAndSaveUserTask(rdbmsService, userTask);
+
+    // when
+    final var searchResult =
+        rdbmsService
+            .getUserTaskReader()
+            .search(
+                new UserTaskQuery(
+                    new UserTaskFilter.Builder()
+                        .processDefinitionIdOperations(Operation.like(prefix + "%"))
+                        .build(),
+                    UserTaskSort.of(b -> b),
+                    SearchQueryPage.of(b -> b.from(0).size(10))));
+
+    // then
+    assertThat(searchResult.total()).isEqualTo(1);
+    assertThat(searchResult.items()).hasSize(1);
+    assertUserTaskEntity(searchResult.items().getFirst(), userTask);
+  }
+
+  @TestTemplate
+  public void shouldFindUserTaskByProcessDefinitionKeyNeq(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final String tenantId = generateRandomString("tenant");
+    final UserTaskDbModel taskA = UserTaskFixtures.createRandomized(b -> b.tenantId(tenantId));
+    final UserTaskDbModel taskB = UserTaskFixtures.createRandomized(b -> b.tenantId(tenantId));
+    createAndSaveUserTask(rdbmsService, taskA);
+    createAndSaveUserTask(rdbmsService, taskB);
+
+    // when
+    final var searchResult =
+        rdbmsService
+            .getUserTaskReader()
+            .search(
+                new UserTaskQuery(
+                    new UserTaskFilter.Builder()
+                        .tenantIds(tenantId)
+                        .processDefinitionKeyOperations(Operation.neq(taskA.processDefinitionKey()))
+                        .build(),
+                    UserTaskSort.of(b -> b),
+                    SearchQueryPage.of(b -> b.from(0).size(10))));
+
+    // then
+    assertThat(searchResult.total()).isEqualTo(1);
+    assertThat(searchResult.items()).hasSize(1);
+    assertUserTaskEntity(searchResult.items().getFirst(), taskB);
+  }
+
+  @TestTemplate
+  public void shouldFindUserTaskByProcessDefinitionKeyIn(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final String tenantId = generateRandomString("tenant");
+    final UserTaskDbModel taskA = UserTaskFixtures.createRandomized(b -> b.tenantId(tenantId));
+    final UserTaskDbModel taskB = UserTaskFixtures.createRandomized(b -> b.tenantId(tenantId));
+    final UserTaskDbModel taskC = UserTaskFixtures.createRandomized(b -> b.tenantId(tenantId));
+    createAndSaveUserTask(rdbmsService, taskA);
+    createAndSaveUserTask(rdbmsService, taskB);
+    createAndSaveUserTask(rdbmsService, taskC);
+
+    // when
+    final var searchResult =
+        rdbmsService
+            .getUserTaskReader()
+            .search(
+                new UserTaskQuery(
+                    new UserTaskFilter.Builder()
+                        .tenantIds(tenantId)
+                        .processDefinitionKeyOperations(
+                            Operation.in(
+                                taskA.processDefinitionKey(), taskB.processDefinitionKey()))
+                        .build(),
+                    UserTaskSort.of(b -> b),
+                    SearchQueryPage.of(b -> b.from(0).size(10))));
+
+    // then
+    assertThat(searchResult.total()).isEqualTo(2);
+    assertThat(searchResult.items()).hasSize(2);
+    assertThat(searchResult.items().stream().map(UserTaskEntity::userTaskKey))
+        .containsExactlyInAnyOrder(taskA.userTaskKey(), taskB.userTaskKey());
+  }
+
+  @TestTemplate
+  public void shouldFindUserTaskByProcessInstanceKeyNeq(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final String tenantId = generateRandomString("tenant");
+    final UserTaskDbModel taskA = UserTaskFixtures.createRandomized(b -> b.tenantId(tenantId));
+    final UserTaskDbModel taskB = UserTaskFixtures.createRandomized(b -> b.tenantId(tenantId));
+    createAndSaveUserTask(rdbmsService, taskA);
+    createAndSaveUserTask(rdbmsService, taskB);
+
+    // when
+    final var searchResult =
+        rdbmsService
+            .getUserTaskReader()
+            .search(
+                new UserTaskQuery(
+                    new UserTaskFilter.Builder()
+                        .tenantIds(tenantId)
+                        .processInstanceKeyOperations(Operation.neq(taskA.processInstanceKey()))
+                        .build(),
+                    UserTaskSort.of(b -> b),
+                    SearchQueryPage.of(b -> b.from(0).size(10))));
+
+    // then
+    assertThat(searchResult.total()).isEqualTo(1);
+    assertThat(searchResult.items()).hasSize(1);
+    assertUserTaskEntity(searchResult.items().getFirst(), taskB);
+  }
+
+  @TestTemplate
+  public void shouldFindUserTaskByProcessInstanceKeyIn(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final String tenantId = generateRandomString("tenant");
+    final UserTaskDbModel taskA = UserTaskFixtures.createRandomized(b -> b.tenantId(tenantId));
+    final UserTaskDbModel taskB = UserTaskFixtures.createRandomized(b -> b.tenantId(tenantId));
+    final UserTaskDbModel taskC = UserTaskFixtures.createRandomized(b -> b.tenantId(tenantId));
+    createAndSaveUserTask(rdbmsService, taskA);
+    createAndSaveUserTask(rdbmsService, taskB);
+    createAndSaveUserTask(rdbmsService, taskC);
+
+    // when
+    final var searchResult =
+        rdbmsService
+            .getUserTaskReader()
+            .search(
+                new UserTaskQuery(
+                    new UserTaskFilter.Builder()
+                        .tenantIds(tenantId)
+                        .processInstanceKeyOperations(
+                            Operation.in(taskA.processInstanceKey(), taskB.processInstanceKey()))
+                        .build(),
+                    UserTaskSort.of(b -> b),
+                    SearchQueryPage.of(b -> b.from(0).size(10))));
+
+    // then
+    assertThat(searchResult.total()).isEqualTo(2);
+    assertThat(searchResult.items()).hasSize(2);
+    assertThat(searchResult.items().stream().map(UserTaskEntity::userTaskKey))
+        .containsExactlyInAnyOrder(taskA.userTaskKey(), taskB.userTaskKey());
+  }
+
+  @TestTemplate
   public void shouldFindUserTaskByAuthorizedResourceId(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/usertask/UserTaskIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/usertask/UserTaskIT.java
@@ -192,7 +192,7 @@ public class UserTaskIT {
             .getUserTaskReader()
             .search(
                 new UserTaskQuery(
-                    new UserTaskFilter.Builder().bpmnProcessIds(processDefinitionId).build(),
+                    new UserTaskFilter.Builder().processDefinitionIds(processDefinitionId).build(),
                     UserTaskSort.of(b -> b),
                     SearchQueryPage.of(b -> b.from(0).size(5))));
 
@@ -1114,7 +1114,7 @@ public class UserTaskIT {
             .getUserTaskReader()
             .search(
                 new UserTaskQuery(
-                    new UserTaskFilter.Builder().bpmnProcessIds(processDefinitionId).build(),
+                    new UserTaskFilter.Builder().processDefinitionIds(processDefinitionId).build(),
                     UserTaskSort.of(b -> b),
                     SearchQueryPage.of(b -> b.from(0).size(5))));
 
@@ -1136,7 +1136,7 @@ public class UserTaskIT {
             .getUserTaskReader()
             .search(
                 new UserTaskQuery(
-                    new UserTaskFilter.Builder().bpmnProcessIds(processDefinitionId).build(),
+                    new UserTaskFilter.Builder().processDefinitionIds(processDefinitionId).build(),
                     UserTaskSort.of(b -> b),
                     SearchQueryPage.of(b -> b.from(null).size(null))));
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/usertask/UserTaskSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/usertask/UserTaskSortIT.java
@@ -127,7 +127,7 @@ public class UserTaskSortIT {
         reader
             .search(
                 new UserTaskQuery(
-                    new UserTaskFilter.Builder().bpmnProcessIds(processDefinitionId).build(),
+                    new UserTaskFilter.Builder().processDefinitionIds(processDefinitionId).build(),
                     UserTaskSort.of(sortBuilder),
                     SearchQueryPage.of(b -> b)))
             .items();

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserTaskFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserTaskFilterTransformer.java
@@ -13,13 +13,16 @@ import static io.camunda.search.clients.query.SearchQueryBuilders.exists;
 import static io.camunda.search.clients.query.SearchQueryBuilders.hasChildQuery;
 import static io.camunda.search.clients.query.SearchQueryBuilders.hasParentQuery;
 import static io.camunda.search.clients.query.SearchQueryBuilders.intOperations;
+import static io.camunda.search.clients.query.SearchQueryBuilders.longOperations;
 import static io.camunda.search.clients.query.SearchQueryBuilders.longTerms;
 import static io.camunda.search.clients.query.SearchQueryBuilders.matchNone;
 import static io.camunda.search.clients.query.SearchQueryBuilders.or;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringOperations;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
 import static io.camunda.search.clients.query.SearchQueryBuilders.term;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.PROCESS_DEFINITION_KEY;
 import static io.camunda.webapps.schema.descriptors.template.TaskTemplate.*;
+import static java.util.Optional.of;
 import static java.util.Optional.ofNullable;
 
 import io.camunda.search.clients.query.SearchQuery;
@@ -59,8 +62,7 @@ public class UserTaskFilterTransformer extends IndexFilterTransformer<UserTaskFi
     final var queries = new ArrayList<SearchQuery>();
     ofNullable(getUserTaskKeysQuery(filter.userTaskKeys())).ifPresent(queries::add);
     ofNullable(getProcessInstanceKeysQuery(filter.processInstanceKeys())).ifPresent(queries::add);
-    ofNullable(getProcessDefinitionKeyQuery(filter.processDefinitionKeys()))
-        .ifPresent(queries::add);
+    queries.addAll(getProcessDefinitionKeyQuery(filter.processDefinitionKeyOperations()));
     ofNullable(getElementIdQuery(filter.elementIds())).ifPresent(queries::add);
     queries.addAll(getNameQuery(filter.nameOperations()));
     queries.addAll(getProcessDefinitionIdsQuery(filter.processDefinitionIdOperations()));
@@ -172,9 +174,10 @@ public class UserTaskFilterTransformer extends IndexFilterTransformer<UserTaskFi
     return longTerms(PROCESS_INSTANCE_ID, processInstanceKeys);
   }
 
-  private SearchQuery getProcessDefinitionKeyQuery(final List<Long> processDefinitionIds) {
+  private List<SearchQuery> getProcessDefinitionKeyQuery(
+      final List<Operation<Long>> processDefinitionKeys) {
     // In ElasticSearch, "processDefinitionKey" is stored in field "processDefinitionId"
-    return longTerms(PROCESS_DEFINITION_ID, processDefinitionIds);
+    return longOperations(PROCESS_DEFINITION_ID, processDefinitionKeys);
   }
 
   private SearchQuery getUserTaskKeysQuery(final List<Long> userTaskKeys) {

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserTaskFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserTaskFilterTransformer.java
@@ -61,9 +61,9 @@ public class UserTaskFilterTransformer extends IndexFilterTransformer<UserTaskFi
     ofNullable(getUserTaskKeysQuery(filter.userTaskKeys())).ifPresent(queries::add);
     queries.addAll(getProcessInstanceKeyQuery(filter.processInstanceKeyOperations()));
     queries.addAll(getProcessDefinitionKeyQuery(filter.processDefinitionKeyOperations()));
+    queries.addAll(getProcessDefinitionIdsQuery(filter.processDefinitionIdOperations()));
     ofNullable(getElementIdQuery(filter.elementIds())).ifPresent(queries::add);
     queries.addAll(getNameQuery(filter.nameOperations()));
-    queries.addAll(getProcessDefinitionIdsQuery(filter.processDefinitionIdOperations()));
     queries.addAll(getCandidateUsersQuery(filter.candidateUserOperations()));
     queries.addAll(getCandidateGroupsQuery(filter.candidateGroupOperations()));
     queries.addAll(getAssigneesQuery(filter.assigneeOperations()));
@@ -183,12 +183,6 @@ public class UserTaskFilterTransformer extends IndexFilterTransformer<UserTaskFi
     return longTerms(KEY, userTaskKeys);
   }
 
-  private List<SearchQuery> getProcessDefinitionIdsQuery(
-      final List<Operation<String>> processDefinitionIds) {
-    // In ElasticSearch, "processDefinitionId" is stored in field "bpmnProcessId"
-    return stringOperations(BPMN_PROCESS_ID, processDefinitionIds);
-  }
-
   private List<SearchQuery> getCandidateUsersQuery(final List<Operation<String>> candidateUsers) {
     return stringOperations(CANDIDATE_USERS, candidateUsers);
   }
@@ -230,6 +224,12 @@ public class UserTaskFilterTransformer extends IndexFilterTransformer<UserTaskFi
 
   private List<SearchQuery> getTenantQuery(final List<Operation<String>> tenant) {
     return stringOperations(TENANT_ID, tenant);
+  }
+
+  private List<SearchQuery> getProcessDefinitionIdsQuery(
+      final List<Operation<String>> processDefinitionIds) {
+    // In ElasticSearch, "processDefinitionId" is stored in field "bpmnProcessId"
+    return stringOperations(BPMN_PROCESS_ID, processDefinitionIds);
   }
 
   private SearchQuery getElementInstanceKeyQuery(final List<Long> elementInstanceKeys) {

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserTaskFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserTaskFilterTransformer.java
@@ -20,9 +20,7 @@ import static io.camunda.search.clients.query.SearchQueryBuilders.or;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringOperations;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
 import static io.camunda.search.clients.query.SearchQueryBuilders.term;
-import static io.camunda.webapps.schema.descriptors.template.JobTemplate.PROCESS_DEFINITION_KEY;
 import static io.camunda.webapps.schema.descriptors.template.TaskTemplate.*;
-import static java.util.Optional.of;
 import static java.util.Optional.ofNullable;
 
 import io.camunda.search.clients.query.SearchQuery;

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserTaskFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserTaskFilterTransformer.java
@@ -181,7 +181,8 @@ public class UserTaskFilterTransformer extends IndexFilterTransformer<UserTaskFi
     return longTerms(KEY, userTaskKeys);
   }
 
-  private List<SearchQuery> getProcessDefinitionIdsQuery(final List<Operation<String>> processDefinitionIds) {
+  private List<SearchQuery> getProcessDefinitionIdsQuery(
+      final List<Operation<String>> processDefinitionIds) {
     // In ElasticSearch, "processDefinitionId" is stored in field "bpmnProcessId"
     return stringOperations(BPMN_PROCESS_ID, processDefinitionIds);
   }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserTaskFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserTaskFilterTransformer.java
@@ -61,9 +61,9 @@ public class UserTaskFilterTransformer extends IndexFilterTransformer<UserTaskFi
     ofNullable(getProcessInstanceKeysQuery(filter.processInstanceKeys())).ifPresent(queries::add);
     ofNullable(getProcessDefinitionKeyQuery(filter.processDefinitionKeys()))
         .ifPresent(queries::add);
-    ofNullable(getBpmnProcessIdQuery(filter.bpmnProcessIds())).ifPresent(queries::add);
     ofNullable(getElementIdQuery(filter.elementIds())).ifPresent(queries::add);
     queries.addAll(getNameQuery(filter.nameOperations()));
+    queries.addAll(getProcessDefinitionIdsQuery(filter.processDefinitionIdOperations()));
     queries.addAll(getCandidateUsersQuery(filter.candidateUserOperations()));
     queries.addAll(getCandidateGroupsQuery(filter.candidateGroupOperations()));
     queries.addAll(getAssigneesQuery(filter.assigneeOperations()));
@@ -173,11 +173,17 @@ public class UserTaskFilterTransformer extends IndexFilterTransformer<UserTaskFi
   }
 
   private SearchQuery getProcessDefinitionKeyQuery(final List<Long> processDefinitionIds) {
+    // In ElasticSearch, "processDefinitionKey" is stored in field "processDefinitionId"
     return longTerms(PROCESS_DEFINITION_ID, processDefinitionIds);
   }
 
   private SearchQuery getUserTaskKeysQuery(final List<Long> userTaskKeys) {
     return longTerms(KEY, userTaskKeys);
+  }
+
+  private List<SearchQuery> getProcessDefinitionIdsQuery(final List<Operation<String>> processDefinitionIds) {
+    // In ElasticSearch, "processDefinitionId" is stored in field "bpmnProcessId"
+    return stringOperations(BPMN_PROCESS_ID, processDefinitionIds);
   }
 
   private List<SearchQuery> getCandidateUsersQuery(final List<Operation<String>> candidateUsers) {
@@ -221,10 +227,6 @@ public class UserTaskFilterTransformer extends IndexFilterTransformer<UserTaskFi
 
   private List<SearchQuery> getTenantQuery(final List<Operation<String>> tenant) {
     return stringOperations(TENANT_ID, tenant);
-  }
-
-  private SearchQuery getBpmnProcessIdQuery(final List<String> bpmnProcessId) {
-    return stringTerms(BPMN_PROCESS_ID, bpmnProcessId);
   }
 
   private SearchQuery getElementInstanceKeyQuery(final List<Long> elementInstanceKeys) {

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserTaskFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserTaskFilterTransformer.java
@@ -59,7 +59,7 @@ public class UserTaskFilterTransformer extends IndexFilterTransformer<UserTaskFi
   public SearchQuery toSearchQuery(final UserTaskFilter filter) {
     final var queries = new ArrayList<SearchQuery>();
     ofNullable(getUserTaskKeysQuery(filter.userTaskKeys())).ifPresent(queries::add);
-    ofNullable(getProcessInstanceKeysQuery(filter.processInstanceKeys())).ifPresent(queries::add);
+    queries.addAll(getProcessInstanceKeyQuery(filter.processInstanceKeyOperations()));
     queries.addAll(getProcessDefinitionKeyQuery(filter.processDefinitionKeyOperations()));
     ofNullable(getElementIdQuery(filter.elementIds())).ifPresent(queries::add);
     queries.addAll(getNameQuery(filter.nameOperations()));
@@ -168,8 +168,9 @@ public class UserTaskFilterTransformer extends IndexFilterTransformer<UserTaskFi
     return or(queries);
   }
 
-  private SearchQuery getProcessInstanceKeysQuery(final List<Long> processInstanceKeys) {
-    return longTerms(PROCESS_INSTANCE_ID, processInstanceKeys);
+  private List<SearchQuery> getProcessInstanceKeyQuery(
+      final List<Operation<Long>> processInstanceKeys) {
+    return longOperations(PROCESS_INSTANCE_ID, processInstanceKeys);
   }
 
   private List<SearchQuery> getProcessDefinitionKeyQuery(

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/UserTaskQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/UserTaskQueryTransformerTest.java
@@ -347,6 +347,243 @@ public class UserTaskQueryTransformerTest extends AbstractTransformerTest {
             });
   }
 
+  static Stream<Arguments> provideProcessDefinitionIdOperations() {
+    return Stream.of(
+        processDefinitionIdCase(
+            Operation.eq("proc-1"),
+            query -> assertSearchTermQuery(query, "bpmnProcessId", "proc-1")),
+        processDefinitionIdCase(
+            Operation.neq("proc-1"),
+            query ->
+                assertThat(query)
+                    .isInstanceOfSatisfying(
+                        SearchBoolQuery.class,
+                        boolQuery ->
+                            assertThat(boolQuery.mustNot())
+                                .singleElement()
+                                .extracting(SearchQuery::queryOption)
+                                .satisfies(
+                                    mustNotQuery ->
+                                        assertSearchTermQuery(
+                                            mustNotQuery, "bpmnProcessId", "proc-1")))),
+        processDefinitionIdCase(
+            Operation.exists(true), query -> assertExistsQuery(query, "bpmnProcessId")),
+        processDefinitionIdCase(
+            Operation.exists(false),
+            query ->
+                assertThat(query)
+                    .isInstanceOfSatisfying(
+                        SearchBoolQuery.class,
+                        boolQuery ->
+                            assertThat(boolQuery.mustNot())
+                                .singleElement()
+                                .extracting(SearchQuery::queryOption)
+                                .satisfies(
+                                    mustNotQuery ->
+                                        assertExistsQuery(mustNotQuery, "bpmnProcessId")))),
+        processDefinitionIdCase(
+            Operation.in("proc-1", "proc-2"),
+            query -> assertSearchTermsQuery(query, "bpmnProcessId", "proc-1", "proc-2")),
+        processDefinitionIdCase(
+            Operation.notIn("proc-1", "proc-2"),
+            query ->
+                assertThat(query)
+                    .isInstanceOfSatisfying(
+                        SearchBoolQuery.class,
+                        boolQuery ->
+                            assertThat(boolQuery.mustNot())
+                                .singleElement()
+                                .extracting(SearchQuery::queryOption)
+                                .satisfies(
+                                    mustNotQuery ->
+                                        assertSearchTermsQuery(
+                                            mustNotQuery, "bpmnProcessId", "proc-1", "proc-2")))),
+        processDefinitionIdCase(
+            Operation.like("proc*"),
+            query ->
+                assertThat(query)
+                    .isInstanceOfSatisfying(
+                        SearchWildcardQuery.class,
+                        wildcardQuery -> {
+                          assertThat(wildcardQuery.field()).isEqualTo("bpmnProcessId");
+                          assertThat(wildcardQuery.value()).isEqualTo("proc*");
+                        })));
+  }
+
+  private static Arguments processDefinitionIdCase(
+      final Operation<String> operation, final Consumer<SearchQueryOption> queryAssertion) {
+    return Arguments.of(operation, queryAssertion);
+  }
+
+  @ParameterizedTest(name = "[{index}] should map {0}")
+  @MethodSource("provideProcessDefinitionIdOperations")
+  @DisplayName("Should transform processDefinitionId operations into correct search query")
+  void shouldTransformProcessDefinitionIdOperationsToSearchQuery(
+      final Operation<String> operation, final Consumer<SearchQueryOption> queryAssertion) {
+    // given
+    final var filter = FilterBuilders.userTask(f -> f.processDefinitionIdOperations(operation));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    assertThat(searchRequest.queryOption())
+        .isInstanceOfSatisfying(
+            SearchBoolQuery.class,
+            boolQuery -> queryAssertion.accept(boolQuery.must().getFirst().queryOption()));
+  }
+
+  static Stream<Arguments> provideProcessDefinitionKeyOperations() {
+    return Stream.of(
+        processDefinitionKeyCase(
+            Operation.eq(123L), query -> assertSearchTermQuery(query, "processDefinitionId", 123L)),
+        processDefinitionKeyCase(
+            Operation.neq(456L),
+            query ->
+                assertThat(query)
+                    .isInstanceOfSatisfying(
+                        SearchBoolQuery.class,
+                        boolQuery ->
+                            assertThat(boolQuery.mustNot())
+                                .singleElement()
+                                .extracting(SearchQuery::queryOption)
+                                .satisfies(
+                                    mustNotQuery ->
+                                        assertSearchTermQuery(
+                                            mustNotQuery, "processDefinitionId", 456L)))),
+        processDefinitionKeyCase(
+            Operation.exists(true), query -> assertExistsQuery(query, "processDefinitionId")),
+        processDefinitionKeyCase(
+            Operation.exists(false),
+            query ->
+                assertThat(query)
+                    .isInstanceOfSatisfying(
+                        SearchBoolQuery.class,
+                        boolQuery ->
+                            assertThat(boolQuery.mustNot())
+                                .singleElement()
+                                .extracting(SearchQuery::queryOption)
+                                .satisfies(
+                                    mustNotQuery ->
+                                        assertExistsQuery(mustNotQuery, "processDefinitionId")))),
+        processDefinitionKeyCase(
+            Operation.in(123L, 456L),
+            query -> assertSearchTermsQuery(query, "processDefinitionId", 123L, 456L)),
+        processDefinitionKeyCase(
+            Operation.notIn(123L, 456L),
+            query ->
+                assertThat(query)
+                    .isInstanceOfSatisfying(
+                        SearchBoolQuery.class,
+                        boolQuery ->
+                            assertThat(boolQuery.mustNot())
+                                .singleElement()
+                                .extracting(SearchQuery::queryOption)
+                                .satisfies(
+                                    mustNotQuery ->
+                                        assertSearchTermsQuery(
+                                            mustNotQuery, "processDefinitionId", 123L, 456L)))));
+  }
+
+  private static Arguments processDefinitionKeyCase(
+      final Operation<Long> operation, final Consumer<SearchQueryOption> queryAssertion) {
+    return Arguments.of(operation, queryAssertion);
+  }
+
+  @ParameterizedTest(name = "[{index}] should map {0}")
+  @MethodSource("provideProcessDefinitionKeyOperations")
+  @DisplayName("Should transform processDefinitionKey operations into correct search query")
+  void shouldTransformProcessDefinitionKeyOperationsToSearchQuery(
+      final Operation<Long> operation, final Consumer<SearchQueryOption> queryAssertion) {
+    // given
+    final var filter = FilterBuilders.userTask(f -> f.processDefinitionKeyOperations(operation));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    assertThat(searchRequest.queryOption())
+        .isInstanceOfSatisfying(
+            SearchBoolQuery.class,
+            boolQuery -> queryAssertion.accept(boolQuery.must().getFirst().queryOption()));
+  }
+
+  static Stream<Arguments> provideProcessInstanceKeyOperations() {
+    return Stream.of(
+        processInstanceKeyCase(
+            Operation.eq(12345L),
+            query -> assertSearchTermQuery(query, "processInstanceId", 12345L)),
+        processInstanceKeyCase(
+            Operation.neq(67890L),
+            query ->
+                assertThat(query)
+                    .isInstanceOfSatisfying(
+                        SearchBoolQuery.class,
+                        boolQuery ->
+                            assertThat(boolQuery.mustNot())
+                                .singleElement()
+                                .extracting(SearchQuery::queryOption)
+                                .satisfies(
+                                    mustNotQuery ->
+                                        assertSearchTermQuery(
+                                            mustNotQuery, "processInstanceId", 67890L)))),
+        processInstanceKeyCase(
+            Operation.exists(true), query -> assertExistsQuery(query, "processInstanceId")),
+        processInstanceKeyCase(
+            Operation.exists(false),
+            query ->
+                assertThat(query)
+                    .isInstanceOfSatisfying(
+                        SearchBoolQuery.class,
+                        boolQuery ->
+                            assertThat(boolQuery.mustNot())
+                                .singleElement()
+                                .extracting(SearchQuery::queryOption)
+                                .satisfies(
+                                    mustNotQuery ->
+                                        assertExistsQuery(mustNotQuery, "processInstanceId")))),
+        processInstanceKeyCase(
+            Operation.in(12345L, 67890L),
+            query -> assertSearchTermsQuery(query, "processInstanceId", 12345L, 67890L)),
+        processInstanceKeyCase(
+            Operation.notIn(12345L, 67890L),
+            query ->
+                assertThat(query)
+                    .isInstanceOfSatisfying(
+                        SearchBoolQuery.class,
+                        boolQuery ->
+                            assertThat(boolQuery.mustNot())
+                                .singleElement()
+                                .extracting(SearchQuery::queryOption)
+                                .satisfies(
+                                    mustNotQuery ->
+                                        assertSearchTermsQuery(
+                                            mustNotQuery, "processInstanceId", 12345L, 67890L)))));
+  }
+
+  private static Arguments processInstanceKeyCase(
+      final Operation<Long> operation, final Consumer<SearchQueryOption> queryAssertion) {
+    return Arguments.of(operation, queryAssertion);
+  }
+
+  @ParameterizedTest(name = "[{index}] should map {0}")
+  @MethodSource("provideProcessInstanceKeyOperations")
+  @DisplayName("Should transform processInstanceKey operations into correct search query")
+  void shouldTransformProcessInstanceKeyOperationsToSearchQuery(
+      final Operation<Long> operation, final Consumer<SearchQueryOption> queryAssertion) {
+    // given
+    final var filter = FilterBuilders.userTask(f -> f.processInstanceKeyOperations(operation));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    assertThat(searchRequest.queryOption())
+        .isInstanceOfSatisfying(
+            SearchBoolQuery.class,
+            boolQuery -> queryAssertion.accept(boolQuery.must().getFirst().queryOption()));
+  }
+
   @Test
   public void shouldQueryByCandidateUsers() {
     // given

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/UserTaskQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/UserTaskQueryTransformerTest.java
@@ -329,9 +329,9 @@ public class UserTaskQueryTransformerTest extends AbstractTransformerTest {
   }
 
   @Test
-  public void shouldQueryByBpmnProcessId() {
+  public void shouldQueryByProcessDefinitionIds() {
     // given
-    final var filter = FilterBuilders.userTask((f) -> f.bpmnProcessIds("bpmnProcess1"));
+    final var filter = FilterBuilders.userTask((f) -> f.processDefinitionIds("bpmnProcess1"));
 
     // when
     final var searchRequest = transformQuery(filter);

--- a/search/search-domain/src/main/java/io/camunda/search/filter/UserTaskFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/UserTaskFilter.java
@@ -30,6 +30,7 @@ public record UserTaskFilter(
     List<Operation<String>> stateOperations,
     List<Long> processInstanceKeys,
     List<Long> processDefinitionKeys,
+    List<Operation<String>> processDefinitionIdOperations,
     List<Operation<String>> candidateUserOperations,
     List<Operation<String>> candidateGroupOperations,
     List<Operation<String>> tenantIdOperations,
@@ -55,6 +56,7 @@ public record UserTaskFilter(
     private List<Operation<String>> stateOperations;
     private List<Long> processInstanceKeys;
     private List<Long> processDefinitionKeys;
+    private List<Operation<String>> processDefinitionIdOperations;
     private List<Operation<String>> candidateUserOperations;
     private List<Operation<String>> candidateGroupOperations;
     private List<Operation<String>> tenantIdOperations;
@@ -175,6 +177,22 @@ public record UserTaskFilter(
     public Builder processDefinitionKeys(final List<Long> values) {
       processDefinitionKeys = addValuesToList(processDefinitionKeys, values);
       return this;
+    }
+
+    public UserTaskFilter.Builder processDefinitionIdOperations(
+        final List<Operation<String>> operations) {
+      processDefinitionIdOperations = addValuesToList(processDefinitionIdOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final UserTaskFilter.Builder processDefinitionIdOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return processDefinitionIdOperations(collectValues(operation, operations));
+    }
+
+    public UserTaskFilter.Builder processDefinitionIds(final String value, final String... values) {
+      return processDefinitionIdOperations(FilterUtil.mapDefaultToOperation(value, values));
     }
 
     public Builder candidateUserOperations(final List<Operation<String>> operations) {
@@ -307,6 +325,7 @@ public record UserTaskFilter(
           Objects.requireNonNullElse(stateOperations, Collections.emptyList()),
           Objects.requireNonNullElse(processInstanceKeys, Collections.emptyList()),
           Objects.requireNonNullElse(processDefinitionKeys, Collections.emptyList()),
+          Objects.requireNonNullElse(processDefinitionIdOperations, Collections.emptyList()),
           Objects.requireNonNullElse(candidateUserOperations, Collections.emptyList()),
           Objects.requireNonNullElse(candidateGroupOperations, Collections.emptyList()),
           Objects.requireNonNullElse(tenantIdOperations, Collections.emptyList()),

--- a/search/search-domain/src/main/java/io/camunda/search/filter/UserTaskFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/UserTaskFilter.java
@@ -11,7 +11,6 @@ import static io.camunda.util.CollectionUtil.addValuesToList;
 import static io.camunda.util.CollectionUtil.collectValues;
 import static io.camunda.util.CollectionUtil.collectValuesAsList;
 
-import io.camunda.search.filter.ProcessInstanceFilter.Builder;
 import io.camunda.util.FilterUtil;
 import io.camunda.util.ObjectBuilder;
 import java.time.OffsetDateTime;
@@ -28,7 +27,7 @@ public record UserTaskFilter(
     List<Operation<Integer>> priorityOperations,
     List<Operation<String>> stateOperations,
     List<Long> processInstanceKeys,
-    List<Long> processDefinitionKeys,
+    List<Operation<Long>> processDefinitionKeyOperations,
     List<Operation<String>> processDefinitionIdOperations,
     List<Operation<String>> candidateUserOperations,
     List<Operation<String>> candidateGroupOperations,
@@ -53,7 +52,7 @@ public record UserTaskFilter(
     private List<Operation<Integer>> priorityOperations;
     private List<Operation<String>> stateOperations;
     private List<Long> processInstanceKeys;
-    private List<Long> processDefinitionKeys;
+    private List<Operation<Long>> processDefinitionKeyOperations;
     private List<Operation<String>> processDefinitionIdOperations;
     private List<Operation<String>> candidateUserOperations;
     private List<Operation<String>> candidateGroupOperations;
@@ -159,13 +158,19 @@ public record UserTaskFilter(
       return this;
     }
 
-    public Builder processDefinitionKeys(final Long... values) {
-      return processDefinitionKeys(collectValuesAsList(values));
+    public Builder processDefinitionKeyOperations(final List<Operation<Long>> operations) {
+      processDefinitionKeyOperations = addValuesToList(processDefinitionKeyOperations, operations);
+      return this;
     }
 
-    public Builder processDefinitionKeys(final List<Long> values) {
-      processDefinitionKeys = addValuesToList(processDefinitionKeys, values);
-      return this;
+    @SafeVarargs
+    public final Builder processDefinitionKeyOperations(
+        final Operation<Long> operation, final Operation<Long>... operations) {
+      return processDefinitionKeyOperations(collectValues(operation, operations));
+    }
+
+    public Builder processDefinitionKeys(final Long value, final Long... values) {
+      return processDefinitionKeyOperations(FilterUtil.mapDefaultToOperation(value, values));
     }
 
     public Builder processDefinitionIdOperations(final List<Operation<String>> operations) {
@@ -311,7 +316,7 @@ public record UserTaskFilter(
           Objects.requireNonNullElse(priorityOperations, Collections.emptyList()),
           Objects.requireNonNullElse(stateOperations, Collections.emptyList()),
           Objects.requireNonNullElse(processInstanceKeys, Collections.emptyList()),
-          Objects.requireNonNullElse(processDefinitionKeys, Collections.emptyList()),
+          Objects.requireNonNullElse(processDefinitionKeyOperations, Collections.emptyList()),
           Objects.requireNonNullElse(processDefinitionIdOperations, Collections.emptyList()),
           Objects.requireNonNullElse(candidateUserOperations, Collections.emptyList()),
           Objects.requireNonNullElse(candidateGroupOperations, Collections.emptyList()),

--- a/search/search-domain/src/main/java/io/camunda/search/filter/UserTaskFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/UserTaskFilter.java
@@ -23,12 +23,12 @@ public record UserTaskFilter(
     List<Long> userTaskKeys,
     List<String> elementIds,
     List<Operation<String>> nameOperations,
+    List<Operation<String>> processDefinitionIdOperations,
     List<Operation<String>> assigneeOperations,
     List<Operation<Integer>> priorityOperations,
     List<Operation<String>> stateOperations,
     List<Long> processInstanceKeys,
     List<Operation<Long>> processDefinitionKeyOperations,
-    List<Operation<String>> processDefinitionIdOperations,
     List<Operation<String>> candidateUserOperations,
     List<Operation<String>> candidateGroupOperations,
     List<Operation<String>> tenantIdOperations,
@@ -48,12 +48,12 @@ public record UserTaskFilter(
     private List<Long> userTaskKeys;
     private List<String> elementIds;
     private List<Operation<String>> nameOperations;
+    private List<Operation<String>> processDefinitionIdOperations;
     private List<Operation<String>> assigneeOperations;
     private List<Operation<Integer>> priorityOperations;
     private List<Operation<String>> stateOperations;
     private List<Long> processInstanceKeys;
     private List<Operation<Long>> processDefinitionKeyOperations;
-    private List<Operation<String>> processDefinitionIdOperations;
     private List<Operation<String>> candidateUserOperations;
     private List<Operation<String>> candidateGroupOperations;
     private List<Operation<String>> tenantIdOperations;
@@ -98,6 +98,21 @@ public record UserTaskFilter(
     public final Builder nameOperations(
         final Operation<String> operation, final Operation<String>... operations) {
       return nameOperations(collectValues(operation, operations));
+    }
+
+    public Builder processDefinitionIdOperations(final List<Operation<String>> operations) {
+      processDefinitionIdOperations = addValuesToList(processDefinitionIdOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder processDefinitionIdOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return processDefinitionIdOperations(collectValues(operation, operations));
+    }
+
+    public Builder processDefinitionIds(final String value, final String... values) {
+      return processDefinitionIdOperations(FilterUtil.mapDefaultToOperation(value, values));
     }
 
     public Builder assigneeOperations(final List<Operation<String>> operations) {
@@ -171,21 +186,6 @@ public record UserTaskFilter(
 
     public Builder processDefinitionKeys(final Long value, final Long... values) {
       return processDefinitionKeyOperations(FilterUtil.mapDefaultToOperation(value, values));
-    }
-
-    public Builder processDefinitionIdOperations(final List<Operation<String>> operations) {
-      processDefinitionIdOperations = addValuesToList(processDefinitionIdOperations, operations);
-      return this;
-    }
-
-    @SafeVarargs
-    public final Builder processDefinitionIdOperations(
-        final Operation<String> operation, final Operation<String>... operations) {
-      return processDefinitionIdOperations(collectValues(operation, operations));
-    }
-
-    public Builder processDefinitionIds(final String value, final String... values) {
-      return processDefinitionIdOperations(FilterUtil.mapDefaultToOperation(value, values));
     }
 
     public Builder candidateUserOperations(final List<Operation<String>> operations) {
@@ -312,12 +312,12 @@ public record UserTaskFilter(
           Objects.requireNonNullElse(userTaskKeys, Collections.emptyList()),
           Objects.requireNonNullElse(elementIds, Collections.emptyList()),
           Objects.requireNonNullElse(nameOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(processDefinitionIdOperations, Collections.emptyList()),
           Objects.requireNonNullElse(assigneeOperations, Collections.emptyList()),
           Objects.requireNonNullElse(priorityOperations, Collections.emptyList()),
           Objects.requireNonNullElse(stateOperations, Collections.emptyList()),
           Objects.requireNonNullElse(processInstanceKeys, Collections.emptyList()),
           Objects.requireNonNullElse(processDefinitionKeyOperations, Collections.emptyList()),
-          Objects.requireNonNullElse(processDefinitionIdOperations, Collections.emptyList()),
           Objects.requireNonNullElse(candidateUserOperations, Collections.emptyList()),
           Objects.requireNonNullElse(candidateGroupOperations, Collections.emptyList()),
           Objects.requireNonNullElse(tenantIdOperations, Collections.emptyList()),

--- a/search/search-domain/src/main/java/io/camunda/search/filter/UserTaskFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/UserTaskFilter.java
@@ -27,7 +27,7 @@ public record UserTaskFilter(
     List<Operation<String>> assigneeOperations,
     List<Operation<Integer>> priorityOperations,
     List<Operation<String>> stateOperations,
-    List<Long> processInstanceKeys,
+    List<Operation<Long>> processInstanceKeyOperations,
     List<Operation<Long>> processDefinitionKeyOperations,
     List<Operation<String>> candidateUserOperations,
     List<Operation<String>> candidateGroupOperations,
@@ -52,7 +52,7 @@ public record UserTaskFilter(
     private List<Operation<String>> assigneeOperations;
     private List<Operation<Integer>> priorityOperations;
     private List<Operation<String>> stateOperations;
-    private List<Long> processInstanceKeys;
+    private List<Operation<Long>> processInstanceKeyOperations;
     private List<Operation<Long>> processDefinitionKeyOperations;
     private List<Operation<String>> candidateUserOperations;
     private List<Operation<String>> candidateGroupOperations;
@@ -164,13 +164,19 @@ public record UserTaskFilter(
       return stateOperations(FilterUtil.mapDefaultToOperation(values));
     }
 
-    public Builder processInstanceKeys(final Long... values) {
-      return processInstanceKeys(collectValuesAsList(values));
+    public Builder processInstanceKeyOperations(final List<Operation<Long>> operations) {
+      processInstanceKeyOperations = addValuesToList(processInstanceKeyOperations, operations);
+      return this;
     }
 
-    public Builder processInstanceKeys(final List<Long> values) {
-      processInstanceKeys = addValuesToList(processInstanceKeys, values);
-      return this;
+    @SafeVarargs
+    public final Builder processInstanceKeyOperations(
+        final Operation<Long> operation, final Operation<Long>... operations) {
+      return processInstanceKeyOperations(collectValues(operation, operations));
+    }
+
+    public Builder processInstanceKeys(final Long value, final Long... values) {
+      return processInstanceKeyOperations(FilterUtil.mapDefaultToOperation(value, values));
     }
 
     public Builder processDefinitionKeyOperations(final List<Operation<Long>> operations) {
@@ -316,7 +322,7 @@ public record UserTaskFilter(
           Objects.requireNonNullElse(assigneeOperations, Collections.emptyList()),
           Objects.requireNonNullElse(priorityOperations, Collections.emptyList()),
           Objects.requireNonNullElse(stateOperations, Collections.emptyList()),
-          Objects.requireNonNullElse(processInstanceKeys, Collections.emptyList()),
+          Objects.requireNonNullElse(processInstanceKeyOperations, Collections.emptyList()),
           Objects.requireNonNullElse(processDefinitionKeyOperations, Collections.emptyList()),
           Objects.requireNonNullElse(candidateUserOperations, Collections.emptyList()),
           Objects.requireNonNullElse(candidateGroupOperations, Collections.emptyList()),

--- a/search/search-domain/src/main/java/io/camunda/search/filter/UserTaskFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/UserTaskFilter.java
@@ -168,8 +168,7 @@ public record UserTaskFilter(
       return this;
     }
 
-    public Builder processDefinitionIdOperations(
-        final List<Operation<String>> operations) {
+    public Builder processDefinitionIdOperations(final List<Operation<String>> operations) {
       processDefinitionIdOperations = addValuesToList(processDefinitionIdOperations, operations);
       return this;
     }

--- a/search/search-domain/src/main/java/io/camunda/search/filter/UserTaskFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/UserTaskFilter.java
@@ -24,7 +24,6 @@ public record UserTaskFilter(
     List<Long> userTaskKeys,
     List<String> elementIds,
     List<Operation<String>> nameOperations,
-    List<String> bpmnProcessIds,
     List<Operation<String>> assigneeOperations,
     List<Operation<Integer>> priorityOperations,
     List<Operation<String>> stateOperations,
@@ -50,7 +49,6 @@ public record UserTaskFilter(
     private List<Long> userTaskKeys;
     private List<String> elementIds;
     private List<Operation<String>> nameOperations;
-    private List<String> bpmnProcessIds;
     private List<Operation<String>> assigneeOperations;
     private List<Operation<Integer>> priorityOperations;
     private List<Operation<String>> stateOperations;
@@ -101,15 +99,6 @@ public record UserTaskFilter(
     public final Builder nameOperations(
         final Operation<String> operation, final Operation<String>... operations) {
       return nameOperations(collectValues(operation, operations));
-    }
-
-    public Builder bpmnProcessIds(final String... values) {
-      return bpmnProcessIds(collectValuesAsList(values));
-    }
-
-    public Builder bpmnProcessIds(final List<String> values) {
-      bpmnProcessIds = addValuesToList(bpmnProcessIds, values);
-      return this;
     }
 
     public Builder assigneeOperations(final List<Operation<String>> operations) {
@@ -179,19 +168,19 @@ public record UserTaskFilter(
       return this;
     }
 
-    public UserTaskFilter.Builder processDefinitionIdOperations(
+    public Builder processDefinitionIdOperations(
         final List<Operation<String>> operations) {
       processDefinitionIdOperations = addValuesToList(processDefinitionIdOperations, operations);
       return this;
     }
 
     @SafeVarargs
-    public final UserTaskFilter.Builder processDefinitionIdOperations(
+    public final Builder processDefinitionIdOperations(
         final Operation<String> operation, final Operation<String>... operations) {
       return processDefinitionIdOperations(collectValues(operation, operations));
     }
 
-    public UserTaskFilter.Builder processDefinitionIds(final String value, final String... values) {
+    public Builder processDefinitionIds(final String value, final String... values) {
       return processDefinitionIdOperations(FilterUtil.mapDefaultToOperation(value, values));
     }
 
@@ -319,7 +308,6 @@ public record UserTaskFilter(
           Objects.requireNonNullElse(userTaskKeys, Collections.emptyList()),
           Objects.requireNonNullElse(elementIds, Collections.emptyList()),
           Objects.requireNonNullElse(nameOperations, Collections.emptyList()),
-          Objects.requireNonNullElse(bpmnProcessIds, Collections.emptyList()),
           Objects.requireNonNullElse(assigneeOperations, Collections.emptyList()),
           Objects.requireNonNullElse(priorityOperations, Collections.emptyList()),
           Objects.requireNonNullElse(stateOperations, Collections.emptyList()),

--- a/zeebe/gateway-protocol/src/main/proto/v2/identifiers.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/identifiers.yaml
@@ -137,3 +137,42 @@ components:
             $ref: '#/components/schemas/ElementId'
         $like:
           $ref: 'filters.yaml#/components/schemas/LikeFilter'
+
+    ProcessDefinitionIdFilterProperty:
+      description: ProcessDefinitionId property with full advanced search capabilities.
+      oneOf:
+        - type: string
+          title: Exact match
+          description: Matches the value exactly.
+          allOf:
+            - $ref: '#/components/schemas/ProcessDefinitionId'
+        - $ref: '#/components/schemas/AdvancedProcessDefinitionIdFilter'
+
+    AdvancedProcessDefinitionIdFilter:
+      title: Advanced filter
+      description: Advanced ProcessDefinitionId filter.
+      type: object
+      properties:
+        $eq:
+          description: Checks for equality with the provided value.
+          allOf:
+            - $ref: '#/components/schemas/ProcessDefinitionId'
+        $neq:
+          description: Checks for inequality with the provided value.
+          allOf:
+            - $ref: '#/components/schemas/ProcessDefinitionId'
+        $exists:
+          description: Checks if the current property exists.
+          type: boolean
+        $in:
+          description: Checks if the property matches any of the provided values.
+          type: array
+          items:
+            $ref: '#/components/schemas/ProcessDefinitionId'
+        $notIn:
+          description: Checks if the property matches none of the provided values.
+          type: array
+          items:
+            $ref: '#/components/schemas/ProcessDefinitionId'
+        $like:
+          $ref: 'filters.yaml#/components/schemas/LikeFilter'

--- a/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
@@ -521,7 +521,7 @@ components:
           description: Tenant ID of this user task.
         processDefinitionId:
           allOf:
-            - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
+            - $ref: 'identifiers.yaml#/components/schemas/ProcessDefinitionIdFilterProperty'
           description: The ID of the process definition.
         creationDate:
           allOf:

--- a/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
@@ -520,9 +520,9 @@ components:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
           description: Tenant ID of this user task.
         processDefinitionId:
-          allOf:
-            - $ref: 'identifiers.yaml#/components/schemas/ProcessDefinitionId'
           description: The ID of the process definition.
+          allOf:
+            - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
         creationDate:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/DateTimeFilterProperty'

--- a/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
@@ -520,9 +520,9 @@ components:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
           description: Tenant ID of this user task.
         processDefinitionId:
-          description: The ID of the process definition.
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
+          description: The ID of the process definition.
         creationDate:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/DateTimeFilterProperty'
@@ -555,7 +555,7 @@ components:
           description: The key for this user task.
         processDefinitionKey:
           allOf:
-            - $ref: 'keys.yaml#/components/schemas/ProcessDefinitionKey'
+            - $ref: 'keys.yaml#/components/schemas/ProcessDefinitionKeyFilterProperty'
           description: The key of the process definition.
         processInstanceKey:
           allOf:

--- a/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
@@ -559,7 +559,7 @@ components:
           description: The key of the process definition.
         processInstanceKey:
           allOf:
-            - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
+            - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKeyFilterProperty'
           description: The key of the process instance.
         elementInstanceKey:
           allOf:


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

For endpoint `v2/user-tasks`, this PR adds advanced filtering for the following properties:

- `processDefinitionId`:  
   Can now be queried as a `StringFilterProperty`, boiling down to `StringProperty`
- `processDefinitionKey`:  
   Can now be queried as a `ProcessDefinitionKeyFilterProperty`, boiling down to `LongProperty`
- `processInstanceKey`:  
   Can now be queried as a `ProcessInstanceKeyFilterProperty`, boiling down to `LongProperty`

### Changes to `camunda-client-java`
The advanced filtering is added to `camunda-client-java` ([Javadoc](https://javadoc.io/doc/io.camunda/camunda-client-java/latest/io/camunda/client/impl/search/filter/UserTaskFilterImpl.html)). The change is non-breaking, as it only adds an additional interface for each property and does not change existing ones.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #50122 
