### PR TITLE
refactor: centralize db version properties for CI reuse

### DIFF
--- a/.ci/db-versions.yml
+++ b/.ci/db-versions.yml
@@ -1,0 +1,59 @@
+# Database versions
+#
+# Single source of truth for all database versions tested in CI and deployed to SaaS.
+# Versions are specified as Docker image tags. Earlier versions *must* be listed before
+# later versions so that the last entry in each list resolves to the newest supported minor.
+#
+# ── How to use this file in CI workflows ────────────────────────────────────────
+#   CI workflows read versions from this file via the reusable action:
+#     .github/actions/read-db-versions
+#
+# ── SaaS version ────────────────────────────────────────────────────────────────
+#   The `saas` field under elasticsearch identifies which version is recommended to be deployed to
+#   SaaS environments. It must always reference one of the listed es8 versions via
+#   a YAML anchor so that the SaaS version cannot drift from what is tested in CI.
+# ────────────────────────────────────────────────────────────────────────────────
+
+elasticsearch:
+  es8:
+    - &saas "8.19.13"
+  es9:
+    - "9.2.0"
+    - "9.3.0"
+  saas: *saas
+
+opensearch:
+  os2:
+    - "2.19.4"
+  os3:
+    - "3.4.0"
+    - "3.5.0"
+
+# ── RDBMS databases ─────────────────────────────────────────────────────────────
+# Each entry is a Docker image tag representing one supported major version.
+# All listed versions are actively tested in CI.
+# See: .github/workflows/zeebe-rdbms-integration-tests.yml
+
+postgresql:
+  - "14-alpine"
+  - "15-alpine"
+  - "16-alpine"
+  - "17-alpine"
+  - "18-alpine"
+
+mysql:
+  - "8.4"
+
+mariadb:
+  - "10.11"
+  - "11.4"
+  - "11.8"
+
+mssql:
+  - "2019-latest"
+  - "2022-latest"
+  - "2025-latest"
+
+oracle:
+  - "21-slim-faststart"
+  - "23-slim-faststart"

--- a/.github/actions/read-db-versions/action.yml
+++ b/.github/actions/read-db-versions/action.yml
@@ -1,0 +1,59 @@
+name: Read DB Versions
+description: |
+  Parses .ci/db-versions.yml and exposes every database version as a named output.
+  The repository must already be checked out before this action is called.
+
+outputs:
+  # ── Single-version outputs ────────────────────────────────────────────────────
+  # Resolves to the last (i.e. newest) entry in the corresponding list in
+  # db-versions.yml. Use these wherever a single representative version is needed
+  # for a major series — e.g. service container images, docker checks, optimize
+  # and identity workflow jobs that run against one version at a time.
+  elasticsearch-8:
+    value: ${{ steps.parse.outputs.elasticsearch-8 }}
+  elasticsearch-9:
+    value: ${{ steps.parse.outputs.elasticsearch-9 }}
+  opensearch-2:
+    value: ${{ steps.parse.outputs.opensearch-2 }}
+  opensearch-3:
+    value: ${{ steps.parse.outputs.opensearch-3 }}
+
+  # ── SaaS version ─────────────────────────────────────────────────────────────
+  # The Elasticsearch version recommended for SaaS deployments, as declared by
+  # the `saas` field in db-versions.yml. Always resolves to one of the es8 entries
+  # (enforced via a YAML anchor in the source file).
+  saas:
+    value: ${{ steps.parse.outputs.saas }}
+
+  # ── Matrix outputs ────────────────────────────────────────────────────────────
+  # Each is a JSON object ({ include: [...] }) ready for strategy.matrix via fromJSON().
+  # rdbms-matrix:   one entry per version of PostgreSQL, MySQL, MariaDB, MSSQL, Oracle.
+  #                 Fields: database-name, database-type, database-image-version, it-database-type.
+  #                 Used by zeebe-rdbms-integration-tests.yml.
+  # es-os-matrix:   min and max entries per supported major series of ES8, ES9, OS2, OS3.
+  #                 Fields: database-name, database-type, database-container, database-image-version, it-database-type.
+  #                 Used by zeebe-search-integration-tests.yml.
+  # ci-database-matrix: one entry per ES/OS major series (latest minor) plus H2.
+  #                 Fields: name, database-type, database-name, it-database-type, database-image-version (H2 omits this).
+  #                 Used by ci.yml (database-integration-tests, history-tests, identity-tests).
+  rdbms-matrix:
+    value: ${{ steps.parse.outputs.rdbms-matrix }}
+  es-os-matrix:
+    value: ${{ steps.parse.outputs.es-os-matrix }}
+  ci-database-matrix:
+    value: ${{ steps.parse.outputs.ci-database-matrix }}
+
+runs:
+  using: composite
+  steps:
+    - name: Python setup
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: "3.x"
+    - name: Install Python dependencies
+      shell: bash
+      run: python3 -m pip install -q --disable-pip-version-check pyyaml==6.0.2
+    - name: Parse DB versions
+      id: parse
+      shell: bash
+      run: python3 .github/actions/read-db-versions/generate-db-versions.py >> "$GITHUB_OUTPUT"

--- a/.github/actions/read-db-versions/generate-db-versions.py
+++ b/.github/actions/read-db-versions/generate-db-versions.py
@@ -1,0 +1,189 @@
+"""
+Reads .ci/db-versions.yml and writes every database version as a key=value
+line to stdout, ready to be appended to $GITHUB_OUTPUT.
+
+Run manually for testing:
+    python3 .github/actions/read-db-versions/generate-db-versions.py
+"""
+
+import json
+import sys
+import yaml
+
+
+def set_output(name, value):
+    print(f"{name}={value}")
+
+
+with open(".ci/db-versions.yml") as f:
+    versions = yaml.safe_load(f)
+
+# ── Search database versions ──────────────────────────────────────────────────
+es8_versions = versions["elasticsearch"]["es8"]
+es9_versions = versions["elasticsearch"]["es9"]
+os2_versions = versions["opensearch"]["os2"]
+os3_versions = versions["opensearch"]["os3"]
+
+# Single-version outputs: last entry = newest supported minor version.
+set_output("elasticsearch-8", es8_versions[-1])
+set_output("elasticsearch-9", es9_versions[-1])
+set_output("opensearch-2",    os2_versions[-1])
+set_output("opensearch-3",    os3_versions[-1])
+set_output("saas",            versions["elasticsearch"]["saas"])
+
+
+# ── ES/OS matrix (zeebe-search-integration-tests.yml) ────────────────────────
+# Min and max of each major series — oldest supported minor to catch regressions,
+# newest to validate against the latest release. Intermediate versions are skipped
+# to keep CI costs proportional to the number of supported minors.
+# database-type encodes both the DB family and the version for test filtering.
+def version_slug(v):
+    return v.replace(".", "_").replace("-", "_")
+
+
+def min_max(versions):
+    """Return [first, last], deduplicated (single-entry lists return one item)."""
+    return list(dict.fromkeys([versions[0], versions[-1]]))
+
+
+es_os_matrix = {"include": []}
+
+for v in min_max(es8_versions):
+    es_os_matrix["include"].append({
+        "database-name":          f"Elasticsearch {v}",
+        "database-type":          f"elasticsearch8_{version_slug(v)}",
+        "database-container":     "elasticsearch",
+        "database-image-version": v,
+        "it-database-type":       "es",
+    })
+
+for v in min_max(es9_versions):
+    es_os_matrix["include"].append({
+        "database-name":          f"Elasticsearch {v}",
+        "database-type":          f"elasticsearch9_{version_slug(v)}",
+        "database-container":     "elasticsearch",
+        "database-image-version": v,
+        "it-database-type":       "es",
+    })
+
+for v in min_max(os2_versions):
+    es_os_matrix["include"].append({
+        "database-name":          f"OpenSearch {v}",
+        "database-type":          f"opensearch2_{version_slug(v)}",
+        "database-container":     "opensearch",
+        "database-image-version": v,
+        "it-database-type":       "os",
+    })
+
+for v in min_max(os3_versions):
+    es_os_matrix["include"].append({
+        "database-name":          f"OpenSearch {v}",
+        "database-type":          f"opensearch3_{version_slug(v)}",
+        "database-container":     "opensearch",
+        "database-image-version": v,
+        "it-database-type":       "os",
+    })
+
+set_output("es-os-matrix", json.dumps(es_os_matrix))
+
+# ── CI database integration test matrix (ci.yml) ─────────────────────────────
+# One entry per major series using the latest supported minor, plus a static
+# H2 entry. H2 is an embedded database with no Docker image version to track.
+ci_db_matrix = {"include": [
+    {
+        "name":                   "Elasticsearch 8",
+        "database-type":          "elasticsearch",
+        "database-image-version": es8_versions[-1],
+        "database-name":          "Elasticsearch 8",
+        "it-database-type":       "es",
+    },
+    {
+        "name":                   "Elasticsearch 9",
+        "database-type":          "elasticsearch9",
+        "database-container":     "elasticsearch",
+        "database-image-version": es9_versions[-1],
+        "database-name":          "Elasticsearch 9",
+        "it-database-type":       "es",
+    },
+    {
+        "name":                   "Opensearch 2",
+        "database-type":          "opensearch2",
+        "database-container":     "opensearch",
+        "database-image-version": os2_versions[-1],
+        "database-name":          "OpenSearch 2",
+        "it-database-type":       "os",
+    },
+    {
+        "name":                   "Opensearch 3",
+        "database-type":          "opensearch3",
+        "database-container":     "opensearch",
+        "database-image-version": os3_versions[-1],
+        "database-name":          "OpenSearch 3",
+        "it-database-type":       "os",
+    },
+    {
+        "name":             "RDBMS H2",
+        "database-type":    "h2",
+        "database-name":    "H2",
+        "it-database-type": "rdbms_h2",
+    },
+]}
+
+set_output("ci-database-matrix", json.dumps(ci_db_matrix))
+
+# ── RDBMS matrix (zeebe-rdbms-integration-tests.yml) ─────────────────────────
+# Maps the first segment of an Oracle image tag to its display name and
+# database-type. Oracle versions use non-numeric suffixes (21c, 23ai) that
+# cannot be derived mechanically from the version number alone.
+oracle_meta = {
+    "23": {"name": "Oracle 23ai", "type": "oracle"},
+    "21": {"name": "Oracle 21c",  "type": "oracle-21"},
+}
+
+rdbms_matrix = {"include": []}
+
+for v in versions["postgresql"]:
+    major = v.split("-")[0]
+    rdbms_matrix["include"].append({
+        "database-name":          f"Postgres {major}",
+        "database-type":          "postgres",
+        "database-image-version": v,
+        "it-database-type":       "rdbms_postgres",
+    })
+
+for v in versions["mysql"]:
+    rdbms_matrix["include"].append({
+        "database-name":          f"MySQL {v}",
+        "database-type":          "mysql",
+        "database-image-version": v,
+        "it-database-type":       "rdbms_mysql",
+    })
+
+for v in versions["mariadb"]:
+    rdbms_matrix["include"].append({
+        "database-name":          f"MariaDB {v}",
+        "database-type":          "mariadb",
+        "database-image-version": v,
+        "it-database-type":       "rdbms_mariadb",
+    })
+
+for v in versions["mssql"]:
+    year = v.split("-")[0]
+    rdbms_matrix["include"].append({
+        "database-name":          f"MSSQL {year}",
+        "database-type":          "mssql",
+        "database-image-version": v,
+        "it-database-type":       "rdbms_mssql",
+    })
+
+for v in versions["oracle"]:
+    major = v.split("-")[0]
+    meta  = oracle_meta.get(major, {"name": f"Oracle {major}", "type": "oracle"})
+    rdbms_matrix["include"].append({
+        "database-name":          meta["name"],
+        "database-type":          meta["type"],
+        "database-image-version": v,
+        "it-database-type":       "rdbms_oracle",
+    })
+
+set_output("rdbms-matrix", json.dumps(rdbms_matrix))

--- a/.github/conftest-unified-ci-rules.rego
+++ b/.github/conftest-unified-ci-rules.rego
@@ -168,6 +168,7 @@ get_jobs_without_cihealth(jobInput) = jobs_without_cihealth {
         job_id != "utils-flaky-tests-summary"
         job_id != "fe-unit-tests-merge"
         job_id != "operate-fe-visual-regression-merge"
+        job_id != "generate-db-versions"
         # temporary for docker-build-helm-integration.yml workflow from alwaysgreen
         job_id != "format-identifier"
         job_id != "should-run"

--- a/.github/workflows/check-saas-version.yml
+++ b/.github/workflows/check-saas-version.yml
@@ -1,0 +1,73 @@
+---
+# Guards against accidentally downgrading the SaaS Elasticsearch version in
+# .ci/db-versions.yml. The saas field drives which image is deployed to SaaS,
+# so it should only ever move forward. Downgrades can go unnoticed until a
+# production deployment and are difficult to roll back safely.
+#
+# Only triggers on pull_request events so the escape-hatch label (see below)
+# is accessible via github.event.pull_request.labels. Labels are not available
+# in the merge_group context, and the check has already been enforced on the
+# PR before it enters the queue, so it intentionally does not run there.
+#
+# To enforce this as a merge requirement, add "Check SaaS version / Check SaaS
+# version does not decrease" to the required status checks in branch protection.
+
+name: Check SaaS version
+
+on:
+  pull_request:
+    paths:
+      - .ci/db-versions.yml
+
+jobs:
+  check-saas-version:
+    name: Check SaaS version does not decrease
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Install Python dependencies
+        run: python3 -m pip install -q --disable-pip-version-check pyyaml==6.0.2
+      - name: Compare SaaS version against main
+        env:
+          # Add the label ci:allow-saas-downgrade to the PR to bypass this
+          # check. Use only when intentionally downgrading — e.g. to retract
+          # a version that contains a security vulnerability. Remove the label
+          # once the PR is merged.
+          SKIP_LABEL: "ci:allow-saas-downgrade"
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        shell: bash
+        run: |
+          if echo "$PR_LABELS" | python3 -c "import json,sys; sys.exit(0 if '$SKIP_LABEL' in json.load(sys.stdin) else 1)"; then
+            echo "Label '$SKIP_LABEL' is set — skipping version check."
+            exit 0
+          fi
+
+          PR_VERSION=$(python3 -c "import yaml; print(yaml.safe_load(open('.ci/db-versions.yml'))['elasticsearch']['saas'])")
+          git fetch origin main --depth=1
+          MAIN_VERSION=$(git show origin/main:.ci/db-versions.yml | python3 -c "import yaml,sys; print(yaml.safe_load(sys.stdin)['elasticsearch']['saas'])")
+
+          echo "SaaS version on main:    $MAIN_VERSION"
+          echo "SaaS version on this PR: $PR_VERSION"
+
+          python3 - <<EOF
+          import sys
+
+          def parse(v):
+              return tuple(int(x) for x in v.split("."))
+
+          pr   = parse("$PR_VERSION")
+          main = parse("$MAIN_VERSION")
+
+          if pr < main:
+              print(f"::error::SaaS version decreased: {main} -> {pr}.")
+              print(f"::error::If this is intentional (e.g. security fix), add the label '$SKIP_LABEL' to the PR.")
+              sys.exit(1)
+
+          print(f"OK: {main} -> {pr}")
+          EOF

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -836,41 +836,29 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
+  generate-db-versions:
+    name: "Generate DB versions"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [ detect-changes ]
+    permissions:
+      contents: read
+    outputs:
+      ci-database-matrix: ${{ steps.db-versions.outputs.ci-database-matrix }}
+      elasticsearch-8: ${{ steps.db-versions.outputs.elasticsearch-8 }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Read DB versions
+        id: db-versions
+        uses: ./.github/actions/read-db-versions
+
   database-integration-tests:
     name: "Database Integration Tests / ${{ matrix.name }}"
     if: needs.detect-changes.outputs.java-code-changes == 'true'
-    needs: [ detect-changes ]
+    needs: [ detect-changes, generate-db-versions ]
     strategy:
       fail-fast: false
-      matrix: &database-matrix
-        include:
-          - name: "Elasticsearch 8"
-            database-type: "elasticsearch"
-            database-image-version: "8.19.11"
-            database-name: "Elasticsearch 8"
-            it-database-type: "es"
-          - name: "Elasticsearch 9"
-            database-type: "elasticsearch9"
-            database-container: "elasticsearch"
-            database-image-version: "9.2.5"
-            database-name: "Elasticsearch 9"
-            it-database-type: "es"
-          - name: "Opensearch 2"
-            database-type: "opensearch2"
-            database-container: "opensearch"
-            database-image-version: "2.19.4"
-            database-name: "OpenSearch 2"
-            it-database-type: "os"
-          - name: "Opensearch 3"
-            database-type: "opensearch3"
-            database-container: "opensearch"
-            database-image-version: "3.4.0"
-            database-name: "OpenSearch 3"
-            it-database-type: "os"
-          - name: "RDBMS H2"
-            database-type: "h2"
-            database-name: "H2"
-            it-database-type: "rdbms_h2"
+      matrix: ${{ fromJSON(needs.generate-db-versions.outputs.ci-database-matrix) }}
     uses: ./.github/workflows/ci-database-integration-tests-reusable.yml
     secrets: inherit
     with:
@@ -883,10 +871,10 @@ jobs:
   history-tests:
     name: "History Integration Tests / ${{ matrix.name }}"
     if: needs.detect-changes.outputs.java-code-changes == 'true'
-    needs: [ detect-changes ]
+    needs: [ detect-changes, generate-db-versions ]
     strategy:
       fail-fast: false
-      matrix: *database-matrix
+      matrix: ${{ fromJSON(needs.generate-db-versions.outputs.ci-database-matrix) }}
     uses: ./.github/workflows/ci-database-integration-tests-reusable.yml
     secrets: inherit
     with:
@@ -903,10 +891,10 @@ jobs:
   identity-tests:
     name: "Identity Integration Tests / ${{ matrix.name }}"
     if: needs.detect-changes.outputs.java-code-changes == 'true'
-    needs: [ detect-changes ]
+    needs: [ detect-changes, generate-db-versions ]
     strategy:
       fail-fast: false
-      matrix: *database-matrix
+      matrix: ${{ fromJSON(needs.generate-db-versions.outputs.ci-database-matrix) }}
     uses: ./.github/workflows/ci-database-integration-tests-reusable.yml
     secrets: inherit
     with:
@@ -1198,7 +1186,7 @@ jobs:
   docker-checks:
     if: needs.detect-changes.outputs.camunda-docker-tests == 'true'
     name: "Docker / Tool / Checks"
-    needs: [ detect-changes ]
+    needs: [ detect-changes, generate-db-versions ]
     runs-on: ubuntu-latest
     outputs:
       flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
@@ -1213,7 +1201,7 @@ jobs:
           - 5000:5000
     env:
       LOCAL_DOCKER_IMAGE: localhost:5000/camunda/camunda
-      TEST_ELASTICSEARCH_IMAGE: docker.elastic.co/elasticsearch/elasticsearch:8.19.11
+      TEST_ELASTICSEARCH_IMAGE: docker.elastic.co/elasticsearch/elasticsearch:${{ needs.generate-db-versions.outputs.elasticsearch-8 }}
       DOCKER_PLATFORMS: "linux/arm64,linux/amd64" # build AMD64 last so it gets picked up by the test
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -1824,6 +1812,7 @@ jobs:
       - detect-new-flaky-tests
       - docker-checks
       - general-unit-tests
+      - generate-db-versions
       - history-tests
       - identity-frontend-sbom-snyk
       - identity-frontend-tests

--- a/.github/workflows/identity-e2e-tests.yml
+++ b/.github/workflows/identity-e2e-tests.yml
@@ -44,12 +44,25 @@ permissions:
   contents: read # for git clone
 
 jobs:
+  read-versions:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      elasticsearch-8: ${{ steps.db-versions.outputs.elasticsearch-8 }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Read DB versions
+        id: db-versions
+        uses: ./.github/actions/read-db-versions
+
   test:
+    needs: [ read-versions ]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     services:
       elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:8.19.13
+        image: docker.elastic.co/elasticsearch/elasticsearch:${{ needs.read-versions.outputs.elasticsearch-8 }}
         env:
           discovery.type: single-node
           cluster.name: docker-cluster

--- a/.github/workflows/identity-regression-test.yml
+++ b/.github/workflows/identity-regression-test.yml
@@ -35,6 +35,18 @@ permissions:
   statuses: write
 
 jobs:
+  read-versions:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      elasticsearch-8: ${{ steps.db-versions.outputs.elasticsearch-8 }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Read DB versions
+        id: db-versions
+        uses: ./.github/actions/read-db-versions
+
   build-and-package:
     name: Build and Package Camunda
     runs-on: ubuntu-latest
@@ -68,7 +80,7 @@ jobs:
 
   run-http-regression-tests:
     name: Run Regression Tests
-    needs: build-and-package
+    needs: [ build-and-package, read-versions ]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     if: ${{ github.event_name == 'workflow_dispatch' }}
@@ -109,7 +121,7 @@ jobs:
 
     services:
       elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:8.19.13
+        image: docker.elastic.co/elasticsearch/elasticsearch:${{ needs.read-versions.outputs.elasticsearch-8 }}
         env:
           discovery.type: single-node
           cluster.name: "ci-${{ matrix.case }}"

--- a/.github/workflows/optimize-ci-core-features.yml
+++ b/.github/workflows/optimize-ci-core-features.yml
@@ -90,15 +90,9 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
 
-      - name: "Read Java / Version Info"
-        id: "pom-info"
-        uses: YunaBraska/java-info-action@575e99f42f2915cc62410c7917fef5558257042c # 3.0.1
-        with:
-          work-dir: ./optimize
-
-      - name: Expose Parsed Elastic Version
-        run: |
-          echo "ELASTIC_VERSION=${{ steps.pom-info.outputs.x_elasticsearch_test_version }}" >> "$GITHUB_ENV"
+      - name: Read DB versions
+        id: db-versions
+        uses: ./.github/actions/read-db-versions
 
       - name: Start Elasticsearch
         uses: ./.github/actions/compose
@@ -106,7 +100,7 @@ jobs:
           compose_file: .github/actions/compose/docker-compose.elasticsearch.yml
           project_name: elasticsearch
         env:
-          ELASTIC_VERSION: ${{ env.ELASTIC_VERSION }}
+          ELASTIC_VERSION: ${{ steps.db-versions.outputs.elasticsearch-8 }}
           ELASTIC_JVM_MEMORY: 16
           ELASTIC_HTTP_PORT: 9200
 
@@ -174,14 +168,9 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
 
-      - name: "Read Java / Version Info"
-        id: "pom-info"
-        uses: YunaBraska/java-info-action@575e99f42f2915cc62410c7917fef5558257042c # 3.0.1
-        with:
-          work-dir: ./optimize
-
-      - name: Expose Parsed OpenSearch Version
-        run: echo "OPENSEARCH_VERSION=${{ steps.pom-info.outputs.x_opensearch_test_version }}" >> "$GITHUB_ENV"
+      - name: Read DB versions
+        id: db-versions
+        uses: ./.github/actions/read-db-versions
 
       - name: Start OpenSearch
         uses: ./.github/actions/compose
@@ -189,7 +178,7 @@ jobs:
           compose_file: .github/actions/compose/docker-compose.opensearch.yml
           project_name: opensearch
         env:
-          OPENSEARCH_VERSION: ${{ env.OPENSEARCH_VERSION }}
+          OPENSEARCH_VERSION: ${{ steps.db-versions.outputs.opensearch-2 }}
           OPENSEARCH_JVM_MEMORY: 16
           OPENSEARCH_HTTP_PORT: 9200
 

--- a/.github/workflows/optimize-ci-data-layer.yml
+++ b/.github/workflows/optimize-ci-data-layer.yml
@@ -77,16 +77,19 @@ jobs:
       - name: Read Java/version info
         id: "pom-info"
         uses: YunaBraska/java-info-action@575e99f42f2915cc62410c7917fef5558257042c # 3.0.1
+      - name: Read DB versions
+        id: db-versions
+        uses: ./.github/actions/read-db-versions
       - name: Start Database
         uses: ./.github/actions/compose
         with:
           compose_file: .github/actions/compose/docker-compose.${{ matrix.database }}.yml
           project_name: ${{ matrix.database }}
         env:
-          ELASTIC_VERSION: ${{ steps.pom-info.outputs.x_elasticsearch_test_version }}
+          ELASTIC_VERSION: ${{ steps.db-versions.outputs.elasticsearch-8 }}
           ELASTIC_JVM_MEMORY: 1
           ELASTIC_HTTP_PORT: ${{ steps.pom-info.outputs.x_new_elasticsearch_port }}
-          OPENSEARCH_VERSION: ${{ steps.pom-info.outputs.x_opensearch_test_version }}
+          OPENSEARCH_VERSION: ${{ steps.db-versions.outputs.opensearch-2 }}
           OPENSEARCH_JVM_MEMORY: 1
           OPENSEARCH_HTTP_PORT: ${{ steps.pom-info.outputs.x_new_elasticsearch_port }}
 

--- a/.github/workflows/optimize-deploy-artifacts.yml
+++ b/.github/workflows/optimize-deploy-artifacts.yml
@@ -41,6 +41,9 @@ jobs:
       uses: YunaBraska/java-info-action@575e99f42f2915cc62410c7917fef5558257042c # 3.0.1
       with:
         work-dir: ./optimize
+    - name: Read DB versions
+      id: db-versions
+      uses: ./.github/actions/read-db-versions
     - name: Expose common variables as Env
       run: |
         {
@@ -99,7 +102,7 @@ jobs:
         project_name: smoketest
       env:
         OPTIMIZE_IMAGE_TAG: ${{ env.DOCKER_TAG }}
-        ELASTIC_VERSION: ${{ steps.pom-info.outputs.x_elasticsearch_test_version }}
+        ELASTIC_VERSION: ${{ steps.db-versions.outputs.elasticsearch-8 }}
         ZEEBE_VERSION: ${{ env.ZEEBE_VERSION }}
         IDENTITY_VERSION: ${{ env.IDENTITY_VERSION }}
 

--- a/.github/workflows/optimize-e2e-test-cloud.yml
+++ b/.github/workflows/optimize-e2e-test-cloud.yml
@@ -62,13 +62,16 @@ jobs:
         uses: YunaBraska/java-info-action@575e99f42f2915cc62410c7917fef5558257042c # 3.0.1
         with:
           work-dir: ./optimize
+      - name: Read DB versions
+        id: db-versions
+        uses: ./.github/actions/read-db-versions
       - name: Start Elastic search
         uses: ./.github/actions/compose
         with:
           compose_file: .github/actions/compose/docker-compose.elasticsearch.yml
           project_name: elasticsearch
         env:
-          ELASTIC_VERSION: ${{ steps.pom-info.outputs.x_elasticsearch_test_version }}
+          ELASTIC_VERSION: ${{ steps.db-versions.outputs.elasticsearch-8 }}
           ELASTIC_JVM_MEMORY: 1
           ELASTIC_HTTP_PORT: ${{ steps.pom-info.outputs.x_new_database_port }}
       - name: Build frontend

--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -229,6 +229,10 @@ jobs:
         with:
           work-dir: ./optimize
 
+      - name: Read DB versions
+        id: db-versions
+        uses: ./.github/actions/read-db-versions
+
       - name: Clean release
         run: |
           ./mvnw release:clean
@@ -367,7 +371,7 @@ jobs:
           project_name: smoketest
         env:
           OPTIMIZE_IMAGE_TAG: ${{ env.RELEASE_VERSION }}
-          ELASTIC_VERSION: ${{ steps.pom-info.outputs.x_elasticsearch_test_version }}
+          ELASTIC_VERSION: ${{ steps.db-versions.outputs.elasticsearch-8 }}
           ZEEBE_VERSION: ${{ steps.pom-info.outputs.x_zeebe_docker_version }}
           IDENTITY_VERSION: ${{ steps.pom-info.outputs.x_identity_version }}
 

--- a/.github/workflows/zeebe-rdbms-integration-tests.yml
+++ b/.github/workflows/zeebe-rdbms-integration-tests.yml
@@ -9,6 +9,8 @@ on:
   workflow_call:
   pull_request:
     paths:
+      - ".ci/db-versions.yml"
+      - ".github/actions/read-db-versions/**"
       - ".github/workflows/zeebe-rdbms-integration-tests.yml"
   schedule:
     - cron: "0 5 * * Mon-Fri"
@@ -23,76 +25,40 @@ defaults:
     shell: bash
 
 jobs:
+  # Reads all supported RDBMS versions from .ci/db-versions.yml and generates
+  # the test matrix. Add or remove versions there — this workflow updates automatically.
+  generate-matrix:
+    name: "Generate RDBMS matrix"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      matrix: ${{ steps.read-versions.outputs.rdbms-matrix }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Read DB versions
+        id: read-versions
+        uses: ./.github/actions/read-db-versions
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+
   rdbms-integration-tests:
     name: "RDBMS ${{ matrix.database-name }}"
+    needs: [ generate-matrix ]
     permissions:
       actions: write
       contents: read
     strategy:
       fail-fast: false
-      matrix: &database-matrix
-        include:
-          # PostgreSQL - Supported versions: 14, 15, 16, 17, 18
-          - database-name: "Postgres 14"
-            database-type: "postgres"
-            database-image-version: "14-alpine"
-            it-database-type: "rdbms_postgres"
-          - database-name: "Postgres 15"
-            database-type: "postgres"
-            database-image-version: "15-alpine"
-            it-database-type: "rdbms_postgres"
-          - database-name: "Postgres 16"
-            database-type: "postgres"
-            database-image-version: "16-alpine"
-            it-database-type: "rdbms_postgres"
-          - database-name: "Postgres 17"
-            database-type: "postgres"
-            database-image-version: "17-alpine"
-            it-database-type: "rdbms_postgres"
-          - database-name: "Postgres 18"
-            database-type: "postgres"
-            database-image-version: "18-alpine"
-            it-database-type: "rdbms_postgres"
-          # MySQL - Supported version: 8.4
-          - database-name: "MySQL 8.4"
-            database-type: "mysql"
-            database-image-version: "8.4"
-            it-database-type: "rdbms_mysql"
-          # MariaDB - Supported versions: 10.11, 11.4, 11.8
-          - database-name: "MariaDB 10.11"
-            database-type: "mariadb"
-            database-image-version: "10.11"
-            it-database-type: "rdbms_mariadb"
-          - database-name: "MariaDB 11.4"
-            database-type: "mariadb"
-            database-image-version: "11.4"
-            it-database-type: "rdbms_mariadb"
-          - database-name: "MariaDB 11.8"
-            database-type: "mariadb"
-            database-image-version: "11.8"
-            it-database-type: "rdbms_mariadb"
-          # Microsoft SQL Server - Supported versions: 2019, 2022, 2025
-          - database-name: "MSSQL 2019"
-            database-type: "mssql"
-            database-image-version: "2019-latest"
-            it-database-type: "rdbms_mssql"
-          - database-name: "MSSQL 2022"
-            database-type: "mssql"
-            database-image-version: "2022-latest"
-            it-database-type: "rdbms_mssql"
-          - database-name: "MSSQL 2025"
-            database-type: "mssql"
-            database-image-version: "2025-latest"
-            it-database-type: "rdbms_mssql"
-          # Oracle - Supported version: 21c, 23ai (19c not available as Docker image)
-          - database-name: "Oracle 23ai"
-            database-type: "oracle"
-            database-image-version: "23-slim-faststart"
-            it-database-type: "rdbms_oracle"
-          - database-name: "Oracle 21c"
-            database-type: "oracle-21"
-            database-image-version: "21-slim-faststart"
-            it-database-type: "rdbms_oracle"
+      matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
     uses: ./.github/workflows/ci-database-integration-tests-reusable.yml
     secrets: inherit
     with:
@@ -104,12 +70,13 @@ jobs:
 
   rdbms-history-tests:
     name: "RDBMS History Tests / ${{ matrix.database-name }}"
+    needs: [ generate-matrix ]
     permissions:
       actions: write
       contents: read
     strategy:
       fail-fast: false
-      matrix: *database-matrix
+      matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
     uses: ./.github/workflows/ci-database-integration-tests-reusable.yml
     secrets: inherit
     with:
@@ -125,12 +92,13 @@ jobs:
 
   rdbms-identity-tests:
     name: "RDBMS Identity Tests / ${{ matrix.database-name }}"
+    needs: [ generate-matrix ]
     permissions:
       actions: write
       contents: read
     strategy:
       fail-fast: false
-      matrix: *database-matrix
+      matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
     uses: ./.github/workflows/ci-database-integration-tests-reusable.yml
     secrets: inherit
     with:

--- a/.github/workflows/zeebe-search-integration-tests.yml
+++ b/.github/workflows/zeebe-search-integration-tests.yml
@@ -1,4 +1,4 @@
-# description: Runs Integration tests on min/max supported versions of Elasticsearch and OpenSearch
+# description: Runs Integration tests on min and max versions of each supported major series of Elasticsearch and OpenSearch
 # test location: /qa/acceptance-tests
 # type: CI
 # owner: @camunda/core-features, @camunda/data-layer
@@ -8,6 +8,8 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
+      - ".ci/db-versions.yml"
+      - ".github/actions/read-db-versions/**"
       - ".github/workflows/zeebe-search-integration-tests.yml"
   schedule:
     - cron: "0 5 * * Mon-Fri"
@@ -22,59 +24,40 @@ defaults:
     shell: bash
 
 jobs:
+  # Reads search DB versions from .ci/db-versions.yml and generates a min/max matrix.
+  # Add or remove versions there — this workflow updates automatically.
+  generate-matrix:
+    name: "Generate search DB matrix"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      matrix: ${{ steps.read-versions.outputs.es-os-matrix }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Read DB versions
+        id: read-versions
+        uses: ./.github/actions/read-db-versions
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+
   search-integration-tests:
     name: "Search ${{ matrix.database-name }}"
+    needs: [ generate-matrix ]
     permissions:
       actions: write
       contents: read
     strategy:
       fail-fast: false
-      matrix: &database-matrix
-        include:
-          # Elasticsearch 8 - Supported versions: 8.19.0 (min) to 8.19.11 (max)
-          - database-name: "Elasticsearch 8.19.0"
-            database-type: "elasticsearch8_19_0"
-            database-container: "elasticsearch"
-            database-image-version: "8.19.0"
-            it-database-type: "es"
-          - database-name: "Elasticsearch 8.19.11"
-            database-type: "elasticsearch8_19_11"
-            database-container: "elasticsearch"
-            database-image-version: "8.19.11"
-            it-database-type: "es"
-          # Elasticsearch 9 - Supported versions: 9.2.0 (min) to 9.3.0 (max)
-          - database-name: "Elasticsearch 9.2.0"
-            database-type: "elasticsearch9_2_0"
-            database-container: "elasticsearch"
-            database-image-version: "9.2.0"
-            it-database-type: "es"
-          - database-name: "Elasticsearch 9.3.0"
-            database-type: "elasticsearch9_3_0"
-            database-container: "elasticsearch"
-            database-image-version: "9.3.0"
-            it-database-type: "es"
-          # OpenSearch 2 - Supported versions: 2.19.0 (min) to 2.19.4 (max)
-          - database-name: "OpenSearch 2.19.0"
-            database-type: "opensearch2_19_0"
-            database-container: "opensearch"
-            database-image-version: "2.19.0"
-            it-database-type: "os"
-          - database-name: "OpenSearch 2.19.4"
-            database-type: "opensearch2_19"
-            database-container: "opensearch"
-            database-image-version: "2.19.4"
-            it-database-type: "os"
-          # OpenSearch 3 - Supported versions: 3.4.0 (min) to 3.5.0 (max)
-          - database-name: "OpenSearch 3.4.0"
-            database-type: "opensearch3_4_0"
-            database-container: "opensearch"
-            database-image-version: "3.4.0"
-            it-database-type: "os"
-          - database-name: "OpenSearch 3.5.0"
-            database-type: "opensearch3_5_0"
-            database-container: "opensearch"
-            database-image-version: "3.5.0"
-            it-database-type: "os"
+      matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
     uses: ./.github/workflows/ci-database-integration-tests-reusable.yml
     secrets: inherit
     with:
@@ -87,12 +70,13 @@ jobs:
 
   search-history-tests:
     name: "Search History Tests / ${{ matrix.database-name }}"
+    needs: [ generate-matrix ]
     permissions:
       actions: write
       contents: read
     strategy:
       fail-fast: false
-      matrix: *database-matrix
+      matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
     uses: ./.github/workflows/ci-database-integration-tests-reusable.yml
     secrets: inherit
     with:
@@ -109,12 +93,13 @@ jobs:
 
   search-identity-tests:
     name: "Search Identity Tests / ${{ matrix.database-name }}"
+    needs: [ generate-matrix ]
     permissions:
       actions: write
       contents: read
     strategy:
       fail-fast: false
-      matrix: *database-matrix
+      matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
     uses: ./.github/workflows/ci-database-integration-tests-reusable.yml
     secrets: inherit
     with:

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -62,14 +62,12 @@
     <version.elasticsearch-java-client>8.19.14</version.elasticsearch-java-client>
     <!-- The least supported elasticsearch version we should test against-->
     <elasticsearch.test.version>8.19.11</elasticsearch.test.version>
+    <!-- The least supported opensearch version we should test against-->
+    <opensearch.test.version>2.19.4</opensearch.test.version>
     <!-- The ElasticSearch version of the previous Optimize version -->
     <previous.optimize.elasticsearch.version>8.16.6</previous.optimize.elasticsearch.version>
     <!-- https://www.elastic.co/guide/en/elasticsearch/client/java-api/6.5/_using_another_logger.html -->
     <elasticsearch.log4j.version>2.24.2</elasticsearch.log4j.version>
-    <!-- The least supported opensearch version we should test against-->
-    <opensearch.test.version>2.19.4</opensearch.test.version>
-    <!-- the opensearch version of the previous Optimize version -->
-    <previous.optimize.opensearch.version>2.17.0</previous.optimize.opensearch.version>
     <apache.http5-client.version>5.4</apache.http5-client.version>
     <quartz.version>2.5.2</quartz.version>
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Centralizes DB properties for:
- Consistent version usage across CI
- SSOT for which version to use in SaaS

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #46966
