### PR TITLE
ci: pin load test workloads to a specific availability zone on stable/8.7

### DIFF
--- a/zeebe/benchmarks/camunda-platform-values.yaml
+++ b/zeebe/benchmarks/camunda-platform-values.yaml
@@ -23,15 +23,7 @@ global:
     ## @param global.image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
     pullSecrets:
       - name: harbor-registry
-  # Identity authentication enabled for Optimize and Zeebe gateway
 
-  # Default node configuration for all the components, unless specific
-  # reconfigured.
-  nodeSelector:
-    component: benchmark-n2-standard-4
-    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
-
-  # By default, we run without Identity
   identity:
     auth:
       enabled: true
@@ -66,6 +58,8 @@ identity:
   firstUser:
     existingSecret: camunda-credentials
     existingSecretKey: identity-firstuser-password
+  nodeSelector:
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
   tolerations:
     - key: nodepool
       operator: Equal
@@ -79,6 +73,8 @@ identityKeycloak:
     adminUser: admin
     existingSecret: camunda-credentials
     passwordSecretKey: identity-keycloak-admin-password
+  nodeSelector:
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
   tolerations:
     - key: nodepool
       operator: Equal
@@ -107,6 +103,8 @@ optimize:
       historyCleanup:
         cronTrigger: '0 1 * * *'
         ttl: 'P1D'
+  nodeSelector:
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
   tolerations:
     - key: nodepool
       operator: Equal
@@ -127,6 +125,8 @@ operate:
   retention:
     enabled: true
     minimumAge: 1d
+  nodeSelector:
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
   tolerations:
     - key: nodepool
       operator: Equal
@@ -146,6 +146,8 @@ tasklist:
   # Retention can be used to define the data in Elasticsearch (ILM).
   retention:
     enabled: true
+  nodeSelector:
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
   tolerations:
     - key: nodepool
       operator: Equal
@@ -162,6 +164,8 @@ connectors:
     limits:
       cpu: 2
       memory: 2Gi
+  nodeSelector:
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
   tolerations:
     - key: nodepool
       operator: Equal
@@ -283,6 +287,8 @@ zeebe:
     requests:
       cpu: 3000m
       memory: 2Gi
+  nodeSelector:
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
   tolerations:
     - key: nodepool
       operator: Equal

--- a/zeebe/benchmarks/setup/default/values-stable.yaml
+++ b/zeebe/benchmarks/setup/default/values-stable.yaml
@@ -1,4 +1,15 @@
-# Additional values file to run Zeebe on stable VMs
+# Additional values file to run on stable VMs
+elasticsearch:
+  master:
+    nodeSelector:
+      component: benchmark-n2-standard-8
+      topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+    tolerations:
+      - key: nodepool
+        operator: Equal
+        value: n2-standard-8-stable
+        effect: NoSchedule
+
 zeebe:
   # Require n2-standard-4-stable to ensure the broker is the only application running on its node
   nodeSelector:


### PR DESCRIPTION
## Description

The global configuration is not understood by the 8.7 Camunda Platform Helm Chart, so we have to specify each component separately.

Example with Operate:

* https://github.com/camunda/camunda-platform-helm/blob/31e237b2ed972927ddcff77cfb7eac555400d6be/charts/camunda-platform-8.7/templates/operate/deployment.yaml#L379-L382

This is done on top of the stable/8.7 branch directly, let me know if it should not.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

* https://github.com/camunda/camunda/issues/50877
