### PR TITLE
Fix: typing blocked in other inputs after leaving InlineJsonEditor

### DIFF
--- a/operate/client/src/modules/components/InlineJsonEditor/index.tsx
+++ b/operate/client/src/modules/components/InlineJsonEditor/index.tsx
@@ -119,9 +119,15 @@ const InlineJsonEditor: React.FC<Props> = observer(
     }, [onFocus]);
 
     const handleBlur = useCallback(() => {
-      setIsEditing(false);
-      setEditingValue(null);
       onBlur?.();
+      // Monaco's FocusTracker debounces blur via setTimeout(0). Synchronously
+      // calling setIsEditing(false) would dispose the editor before that timer
+      // fires, leaving editorHasFocus=true and blocking keyboard input in other
+      // elements. Deferring here ensures Monaco cleans up first.
+      setTimeout(() => {
+        setIsEditing(false);
+        setEditingValue(null);
+      }, 0);
     }, [onBlur]);
 
     useEffect(() => {


### PR DESCRIPTION
## Problem
After editing a variable value in the InlineJsonEditor and clicking back into the variable name input, the name input appeared focused (focus ring visible) but all keystrokes were silently swallowed.

## Root cause
Monaco's FocusTracker intentionally debounces its internal blur handling via window.setTimeout(0) — this lets it ignore focus shifts between Monaco's own sub-elements. When handleBlur on the EditorWrapper fired, it called setIsEditing(false) synchronously, which caused React to unmount the editor (and call editor.dispose()) before Monaco's debounce timer had a chance to run. The editorHasFocus context key was left stuck at true, so Monaco's global keydown listener on document kept intercepting all subsequent keystrokes even though the editor was gone.

## Fix
Defer setIsEditing(false) / setEditingValue(null) inside a setTimeout(0) in handleBlur. Because Monaco's own debounce was queued first (it runs in the same blur event handler), our timer fires second — after editorHasFocus is correctly set to false — so the editor is disposed in a clean state.