### PR TITLE
fix issues with data availability checks under heavy load

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/http/HttpClientFactory.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/http/HttpClientFactory.java
@@ -117,6 +117,7 @@ public class HttpClientFactory {
         PoolingAsyncClientConnectionManagerBuilder.create()
             .setTlsStrategy(tlsStrategy)
             .setPoolConcurrencyPolicy(PoolConcurrencyPolicy.LAX)
+            .setMaxConnTotal(config.getMaxHttpConnections())
             .setMaxConnPerRoute(config.getMaxHttpConnections());
 
     if (config.useClientSideLoadBalancing()) {

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/App.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/App.java
@@ -23,11 +23,14 @@ import io.grpc.ClientInterceptor;
 import io.grpc.Status.Code;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.binder.grpc.MetricCollectingClientInterceptor;
+import io.micrometer.core.instrument.binder.httpcomponents.hc5.ObservationExecChainHandler;
 import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
+import io.micrometer.core.instrument.observation.DefaultMeterObservationHandler;
+import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.prometheusmetrics.PrometheusConfig;
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 import io.micrometer.prometheusmetrics.PrometheusRenameFilter;
@@ -54,6 +57,7 @@ abstract class App implements Runnable {
   protected final AppCfg config;
   protected PrometheusMeterRegistry registry;
   protected ClientInterceptor monitoringInterceptor;
+  protected ObservationExecChainHandler observationExecChainHandler;
   private final AtomicInteger connected = new AtomicInteger(0);
 
   private HTTPServer monitoringServer;
@@ -104,6 +108,11 @@ abstract class App implements Runnable {
     Gauge.builder(AppMetricsDoc.CONNECTED.getName(), connected, AtomicInteger::get)
         .description(AppMetricsDoc.CONNECTED.getDescription())
         .register(registry);
+    final var observationRegistry = ObservationRegistry.create();
+    observationRegistry
+        .observationConfig()
+        .observationHandler(new DefaultMeterObservationHandler(registry));
+    observationExecChainHandler = new ObservationExecChainHandler(observationRegistry);
     registerDefaultInstrumentation();
   }
 
@@ -176,6 +185,7 @@ abstract class App implements Runnable {
             .preferRestOverGrpc(config.isPreferRest())
             .withProperties(System.getProperties())
             .withInterceptors(monitoringInterceptor)
+            .withChainHandlers(observationExecChainHandler)
             .useClientSideLoadBalancing(config.isClientSideLoadBalancing());
 
     final var auth = config.getAuth();

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/App.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/App.java
@@ -58,6 +58,7 @@ abstract class App implements Runnable {
   protected PrometheusMeterRegistry registry;
   protected ClientInterceptor monitoringInterceptor;
   protected ObservationExecChainHandler observationExecChainHandler;
+  protected ConcurrentConnectionsMetric concurrentConnectionsMetric;
   private final AtomicInteger connected = new AtomicInteger(0);
 
   private HTTPServer monitoringServer;
@@ -113,6 +114,7 @@ abstract class App implements Runnable {
         .observationConfig()
         .observationHandler(new DefaultMeterObservationHandler(registry));
     observationExecChainHandler = new ObservationExecChainHandler(observationRegistry);
+    concurrentConnectionsMetric = new ConcurrentConnectionsMetric(registry);
     registerDefaultInstrumentation();
   }
 
@@ -185,7 +187,7 @@ abstract class App implements Runnable {
             .preferRestOverGrpc(config.isPreferRest())
             .withProperties(System.getProperties())
             .withInterceptors(monitoringInterceptor)
-            .withChainHandlers(observationExecChainHandler)
+            .withChainHandlers(observationExecChainHandler, concurrentConnectionsMetric)
             .useClientSideLoadBalancing(config.isClientSideLoadBalancing());
 
     final var auth = config.getAuth();

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/ConcurrentConnectionsMetric.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/ConcurrentConnectionsMetric.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe;
+
+import com.google.common.base.Suppliers;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.hc.client5.http.async.AsyncExecCallback;
+import org.apache.hc.client5.http.async.AsyncExecChain;
+import org.apache.hc.client5.http.async.AsyncExecChain.Scope;
+import org.apache.hc.client5.http.async.AsyncExecChainHandler;
+import org.apache.hc.core5.http.EntityDetails;
+import org.apache.hc.core5.http.HttpException;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.nio.AsyncDataConsumer;
+import org.apache.hc.core5.http.nio.AsyncEntityProducer;
+
+public class ConcurrentConnectionsMetric implements AsyncExecChainHandler {
+  private final AtomicInteger concurrentConnections = new AtomicInteger();
+
+  public ConcurrentConnectionsMetric(final MeterRegistry registry) {
+    Gauge.builder("starter.http.concurrent.connections", concurrentConnections, AtomicInteger::get)
+        .description("Number of concurrent HTTP connections to the broker")
+        .register(registry);
+  }
+
+  @Override
+  public void execute(
+      final HttpRequest request,
+      final AsyncEntityProducer entityProducer,
+      final Scope scope,
+      final AsyncExecChain chain,
+      final AsyncExecCallback asyncExecCallback)
+      throws HttpException, IOException {
+    concurrentConnections.incrementAndGet();
+    final var done = Suppliers.memoize(concurrentConnections::decrementAndGet);
+    chain.proceed(
+        request,
+        entityProducer,
+        scope,
+        new AsyncExecCallback() {
+          @Override
+          public AsyncDataConsumer handleResponse(
+              final HttpResponse response, final EntityDetails entityDetails)
+              throws HttpException, IOException {
+            return asyncExecCallback.handleResponse(response, entityDetails);
+          }
+
+          @Override
+          public void handleInformationResponse(final HttpResponse response)
+              throws HttpException, IOException {
+            asyncExecCallback.handleInformationResponse(response);
+          }
+
+          @Override
+          public void completed() {
+            done.get();
+            asyncExecCallback.completed();
+          }
+
+          @Override
+          public void failed(final Exception cause) {
+            done.get();
+            asyncExecCallback.failed(cause);
+          }
+        });
+  }
+}

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/ProcessInstanceStartMeter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/ProcessInstanceStartMeter.java
@@ -85,26 +85,22 @@ public class ProcessInstanceStartMeter implements AutoCloseable {
     }
 
     LOG.debug("Current instances awaiting {}", startedInstances.size());
+    final List<Long> availableInstances;
     final var startQueryTime = clock.getNanos();
-    availabilityChecker
-        .findAvailableInstances(List.copyOf(startedInstances.keySet()))
-        .whenCompleteAsync(
-            (availableInstances, error) -> {
-              final var endQueryTime = clock.getNanos();
-              dataAvailabilityQueryDurationTimer.record(
-                  endQueryTime - startQueryTime, TimeUnit.NANOSECONDS);
-
-              if (error != null) {
-                LOG.error("Error while checking for available process instances", error);
-                cleanUpStaleInstances();
-                return;
-              }
-
-              LOG.debug("Available process instances items: {}", availableInstances.size());
-              processAvailableInstances(availableInstances);
-              cleanUpStaleInstances();
-            },
-            piCheckExecutorService);
+    try {
+      availableInstances =
+          availabilityChecker
+              .findAvailableInstances(List.copyOf(startedInstances.keySet()))
+              .toCompletableFuture()
+              .join();
+    } finally {
+      final var endQueryTime = clock.getNanos();
+      dataAvailabilityQueryDurationTimer.record(
+          endQueryTime - startQueryTime, TimeUnit.NANOSECONDS);
+    }
+    LOG.debug("Available process instances items: {}", availableInstances.size());
+    processAvailableInstances(availableInstances);
+    cleanUpStaleInstances();
   }
 
   private void cleanUpStaleInstances() {

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/ProcessInstanceStartMeter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/ProcessInstanceStartMeter.java
@@ -25,7 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ProcessInstanceStartMeter implements AutoCloseable {
-  private static final long MAX_DURATION = Duration.ofSeconds(90).toNanos();
+  private static final int MAX_PENDING_INSTANCES = 1000;
   private static final Logger LOG = LoggerFactory.getLogger(ProcessInstanceStartMeter.class);
   private final ConcurrentHashMap<Integer, Timer> partitionToTimerMap;
   private final Map<Long, PiCreationResult> startedInstances;
@@ -106,25 +106,6 @@ public class ProcessInstanceStartMeter implements AutoCloseable {
     }
     LOG.debug("Available process instances items: {}", availableInstances.size());
     processAvailableInstances(availableInstances);
-    cleanUpStaleInstances();
-  }
-
-  private void cleanUpStaleInstances() {
-    // clean up stale instances which exceeded the max duration - to save memory
-    final long nanoTime = clock.getNanos();
-    final var instancesWhereTimeExceededDeadline =
-        startedInstances.values().stream()
-            .filter(piCreationResult -> nanoTime - piCreationResult.startTimeNanos > MAX_DURATION)
-            .toList();
-    instancesWhereTimeExceededDeadline.forEach(
-        piResults -> {
-          final long durationNanos = clock.getNanos() - piResults.startTimeNanos;
-          LOG.debug(
-              "Process instance {} was not retrieved after {} ms, removing it from the awaiting list.",
-              piResults.processInstanceKey,
-              TimeUnit.NANOSECONDS.toMillis(durationNanos));
-          recordInstanceAvailable(piResults, durationNanos);
-        });
   }
 
   private void processAvailableInstances(final List<Long> availableInstances) {
@@ -157,8 +138,14 @@ public class ProcessInstanceStartMeter implements AutoCloseable {
   }
 
   public void recordProcessInstanceStart(final long processInstanceKey, final long startTimeNanos) {
-    startedInstances.put(
-        processInstanceKey, new PiCreationResult(processInstanceKey, startTimeNanos));
+    // under load we'll drop new instances as we might as well
+    // focus on what we're already checking (and more instances will arrive pretty quickly anyway)
+    // otherwise with a max benchmark we can easily end up with 20 thousand instances to check
+    // within a minute or two
+    if (startedInstances.size() < MAX_PENDING_INSTANCES) {
+      startedInstances.put(
+          processInstanceKey, new PiCreationResult(processInstanceKey, startTimeNanos));
+    }
   }
 
   private record PiCreationResult(long processInstanceKey, long startTimeNanos) {}

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/ProcessInstanceStartMeter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/ProcessInstanceStartMeter.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe;
 import io.camunda.zeebe.StarterLatencyMetricsDoc.StarterMetricKeyNames;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.util.micrometer.MicrometerUtil;
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import java.time.Duration;
@@ -51,6 +52,11 @@ public class ProcessInstanceStartMeter implements AutoCloseable {
             .register(registry);
     this.availabilityCheckInterval = availabilityCheckInterval;
     this.availabilityChecker = availabilityChecker;
+    Gauge.builder(
+            "starter.data.availability.pending.process.instances", startedInstances, Map::size)
+        .description(
+            "Number of process instances started that we have not yet confirmed as available")
+        .register(registry);
   }
 
   /** Starts the periodic checking for process instance availability. */

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/Starter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/Starter.java
@@ -18,6 +18,7 @@ import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.client.api.search.response.ProcessInstance;
 import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.client.api.search.sort.ProcessInstanceSort;
+import io.camunda.client.impl.CamundaClientBuilderImpl;
 import io.camunda.zeebe.config.AppCfg;
 import io.camunda.zeebe.config.StarterCfg;
 import io.camunda.zeebe.read.DataReadMeter;
@@ -320,7 +321,17 @@ public class Starter extends App {
   }
 
   private CamundaClient createCamundaClient() {
-    return newClientBuilder().numJobWorkerExecutionThreads(0).build();
+    return newClientBuilder()
+        .numJobWorkerExecutionThreads(0)
+        .maxHttpConnections(maxHttpConnections())
+        .build();
+  }
+
+  private int maxHttpConnections() {
+    // ensure we can create enough concurrent requests to actually
+    // keep up with the rate (with a little extra to spare for other availability checks)
+    final var perSecond = starterCfg.getRatePerSecond();
+    return Math.min(CamundaClientBuilderImpl.DEFAULT_MAX_HTTP_CONNECTIONS, (int) (perSecond + 100));
   }
 
   private void deployProcess(final CamundaClient client, final StarterCfg starterCfg) {

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/Starter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/Starter.java
@@ -153,7 +153,7 @@ public class Starter extends App {
             Executors.newScheduledThreadPool(1),
             config.getMonitorDataAvailabilityInterval(),
             (listOfStartedInstances) -> {
-              final var limit = 100;
+              final var limit = 1000;
               final var instanceIds = listOfStartedInstances.stream().limit(limit).toList();
               final CamundaFuture<SearchResponse<ProcessInstance>> send =
                   client

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/Starter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/Starter.java
@@ -153,12 +153,14 @@ public class Starter extends App {
             Executors.newScheduledThreadPool(1),
             config.getMonitorDataAvailabilityInterval(),
             (listOfStartedInstances) -> {
+              final var limit = 100;
+              final var instanceIds = listOfStartedInstances.stream().limit(limit).toList();
               final CamundaFuture<SearchResponse<ProcessInstance>> send =
                   client
                       .newProcessInstanceSearchRequest()
-                      .filter((f) -> f.processInstanceKey(key -> key.in(listOfStartedInstances)))
+                      .filter((f) -> f.processInstanceKey(key -> key.in(instanceIds)))
                       .sort(ProcessInstanceSort::startDate)
-                      .page(p -> p.limit(100))
+                      .page(p -> p.limit(limit))
                       .send();
 
               return send.thenApply(

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/Starter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/Starter.java
@@ -325,7 +325,7 @@ public class Starter extends App {
   private CamundaClient createCamundaClient() {
     return newClientBuilder()
         .numJobWorkerExecutionThreads(0)
-        .maxHttpConnections(maxHttpConnections())
+        .maxHttpConnections(500 /*maxHttpConnections()*/)
         .build();
   }
 

--- a/load-tests/load-tester/src/test/java/io/camunda/zeebe/ProcessInstanceStartMeterTest.java
+++ b/load-tests/load-tester/src/test/java/io/camunda/zeebe/ProcessInstanceStartMeterTest.java
@@ -215,7 +215,7 @@ public class ProcessInstanceStartMeterTest {
                 .get(StarterLatencyMetricsDoc.DATA_AVAILABILITY_QUERY_DURATION.getName())
                 .timer()
                 .totalTime(TimeUnit.MILLISECONDS))
-        .isGreaterThan(1);
+        .isGreaterThan(0.0);
   }
 
   @Test


### PR DESCRIPTION
In the starter (when running `max` benchmarks) I was seeing a lot of errors like:
```
13:14:01.505 [pool-5-thread-1] ERROR io.camunda.zeebe.ProcessInstanceStartMeter - Error while checking for available process instances
java.util.concurrent.CompletionException: io.camunda.client.api.command.ClientException: org.apache.hc.core5.util.DeadlineTimeoutException: Deadline: 2026-04-15T13:14:01.502+0000, -2 MILLISECONDS overdue
	at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:332)
	at java.base/java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:347)
	at java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:636)
	at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510
```
Which usually happens when the http connection pool is exhausted.

In addition the _observed_ client side request times to search for process instances was very high (in the minutes), but server side times where still only seconds at most.

This PR fixes a few things:

* only allow one PI search request at a time (previously they could stack up if things weren't running fast enough)
* increase the allowed number http connections based on the rate
* get the http client to actually set the max connections (was only setting the max per route one)
* request more PIs per call

Plus also adds a gauge to track how many PIs we're currently waiting for.

I think the fact the max connections was not getting increased might have been a big factor here - as it would make the http client wait much longer before starting a request (when under load).
