### PR TITLE
fix: allow configuration of max concurrent HTTP Connections in deprec…

### DIFF
--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientConfigurationImpl.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientConfigurationImpl.java
@@ -182,6 +182,11 @@ public class ZeebeClientConfigurationImpl implements ZeebeClientConfiguration {
   }
 
   @Override
+  public int getMaxHttpConnections() {
+    return camundaClientConfiguration.getMaxHttpConnections();
+  }
+
+  @Override
   public String toString() {
     return "ZeebeClientConfigurationImpl{"
         + "camundaClientConfiguration="

--- a/clients/java-deprecated/src/main/java/io/camunda/zeebe/client/ClientProperties.java
+++ b/clients/java-deprecated/src/main/java/io/camunda/zeebe/client/ClientProperties.java
@@ -49,6 +49,11 @@ public final class ClientProperties {
   public static final String PREFER_REST_OVER_GRPC = "zeebe.client.gateway.preferRestOverGrpc";
 
   /**
+   * @see ZeebeClientBuilder#maxHttpConnections(int)
+   */
+  public static final String MAX_HTTP_CONNECTIONS = "zeebe.client.gateway.maxHttpConnections";
+
+  /**
    * @see ZeebeClientBuilder#restAddress(URI)
    */
   public static final String REST_ADDRESS = "zeebe.client.gateway.rest.address";

--- a/clients/java-deprecated/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
+++ b/clients/java-deprecated/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
@@ -245,11 +245,14 @@ public interface ZeebeClientBuilder {
    * The default value is {@code false} (gRPC is preferred).
    *
    * <p>NOTE: not all calls can be done over REST (or HTTP/1) yet, this is also subject to change.
-   *
-   * @param preferRestOverGrpc if true, the client will use REST instead of gRPC whenever possible
-   * @return this builder for chaining
    */
   ZeebeClientBuilder preferRestOverGrpc(final boolean preferRestOverGrpc);
+
+  /**
+   * Sets the maximum number of HTTP connections to maintain in the connection pool. This affects
+   * the number of concurrent REST API calls that can be made.
+   */
+  ZeebeClientBuilder maxHttpConnections(int maxConnections);
 
   /**
    * @return a new {@link ZeebeClient} with the provided configuration options.

--- a/clients/java-deprecated/src/main/java/io/camunda/zeebe/client/ZeebeClientConfiguration.java
+++ b/clients/java-deprecated/src/main/java/io/camunda/zeebe/client/ZeebeClientConfiguration.java
@@ -174,4 +174,9 @@ public interface ZeebeClientConfiguration {
    * @see ZeebeClientBuilder#preferRestOverGrpc(boolean)
    */
   boolean preferRestOverGrpc();
+
+  /**
+   * @see ZeebeClientBuilder#maxHttpConnections(int)
+   */
+  int getMaxHttpConnections();
 }

--- a/clients/java-deprecated/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
+++ b/clients/java-deprecated/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
@@ -299,6 +299,12 @@ public class ZeebeClientCloudBuilderImpl
   }
 
   @Override
+  public ZeebeClientBuilder maxHttpConnections(final int maxConnections) {
+    innerBuilder.maxHttpConnections(maxConnections);
+    return this;
+  }
+
+  @Override
   public ZeebeClient build() {
     innerBuilder.grpcAddress(determineGrpcAddress());
     innerBuilder.restAddress(determineRestAddress());

--- a/clients/java-deprecated/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientEnvironmentVariables.java
+++ b/clients/java-deprecated/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientEnvironmentVariables.java
@@ -29,6 +29,7 @@ public final class ZeebeClientEnvironmentVariables {
   public static final String DEFAULT_JOB_WORKER_TENANT_IDS_VAR =
       "ZEEBE_DEFAULT_JOB_WORKER_TENANT_IDS";
   public static final String USE_DEFAULT_RETRY_POLICY_VAR = "ZEEBE_CLIENT_USE_DEFAULT_RETRY_POLICY";
+  public static final String MAX_HTTP_CONNECTIONS = "ZEEBE_MAX_HTTP_CONNECTIONS";
 
   /** OAuth Environment Variables */
   public static final String OAUTH_ENV_CLIENT_ID = "ZEEBE_CLIENT_ID";

--- a/clients/java-deprecated/src/main/java/io/camunda/zeebe/client/impl/http/HttpClientFactory.java
+++ b/clients/java-deprecated/src/main/java/io/camunda/zeebe/client/impl/http/HttpClientFactory.java
@@ -61,6 +61,7 @@ import org.apache.hc.core5.http.config.CharCodingConfig;
 import org.apache.hc.core5.http.message.BasicHeader;
 import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
 import org.apache.hc.core5.net.URIBuilder;
+import org.apache.hc.core5.pool.PoolConcurrencyPolicy;
 import org.apache.hc.core5.ssl.SSLContexts;
 import org.apache.hc.core5.util.TimeValue;
 import org.apache.hc.core5.util.Timeout;
@@ -142,7 +143,11 @@ public class HttpClientFactory {
             .setHostnameVerifier(hostnameVerifier)
             .build();
     final PoolingAsyncClientConnectionManager connectionManager =
-        PoolingAsyncClientConnectionManagerBuilder.create().setTlsStrategy(tlsStrategy).build();
+        PoolingAsyncClientConnectionManagerBuilder.create()
+            .setTlsStrategy(tlsStrategy)
+            .setPoolConcurrencyPolicy(PoolConcurrencyPolicy.LAX)
+            .setMaxConnPerRoute(config.getMaxHttpConnections())
+            .build();
 
     final HttpAsyncClientBuilder builder =
         HttpAsyncClients.custom()

--- a/clients/java-deprecated/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
+++ b/clients/java-deprecated/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
@@ -21,6 +21,7 @@ import static io.camunda.zeebe.client.ClientProperties.DEFAULT_REQUEST_TIMEOUT;
 import static io.camunda.zeebe.client.ClientProperties.DEFAULT_REQUEST_TIMEOUT_OFFSET;
 import static io.camunda.zeebe.client.ClientProperties.DEFAULT_TENANT_ID;
 import static io.camunda.zeebe.client.ClientProperties.GRPC_ADDRESS;
+import static io.camunda.zeebe.client.ClientProperties.MAX_HTTP_CONNECTIONS;
 import static io.camunda.zeebe.client.ClientProperties.MAX_MESSAGE_SIZE;
 import static io.camunda.zeebe.client.ClientProperties.MAX_METADATA_SIZE;
 import static io.camunda.zeebe.client.ClientProperties.PREFER_REST_OVER_GRPC;
@@ -30,6 +31,7 @@ import static io.camunda.zeebe.client.ClientProperties.USE_DEFAULT_RETRY_POLICY;
 import static io.camunda.zeebe.client.ClientProperties.USE_PLAINTEXT_CONNECTION;
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_GATEWAY_ADDRESS;
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_GRPC_ADDRESS;
+import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_MAX_HTTP_CONNECTIONS;
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_MESSAGE_TTL;
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_REST_ADDRESS;
 import static io.camunda.zeebe.client.impl.ZeebeClientEnvironmentVariables.CA_CERTIFICATE_VAR;
@@ -57,6 +59,7 @@ import io.camunda.zeebe.client.api.worker.JobWorker;
 import io.camunda.zeebe.client.impl.NoopCredentialsProvider;
 import io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl;
 import io.camunda.zeebe.client.impl.ZeebeClientCloudBuilderImpl;
+import io.camunda.zeebe.client.impl.ZeebeClientEnvironmentVariables;
 import io.camunda.zeebe.client.impl.oauth.OAuthCredentialsProvider;
 import io.camunda.zeebe.client.impl.util.Environment;
 import io.camunda.zeebe.client.impl.util.EnvironmentRule;
@@ -113,6 +116,7 @@ public final class ZeebeClientTest extends ClientTest {
       assertThat(configuration.getDefaultJobWorkerTenantIds())
           .containsExactly(CommandWithTenantStep.DEFAULT_TENANT_IDENTIFIER);
       assertThat(configuration.preferRestOverGrpc()).isFalse();
+      assertThat(configuration.getMaxHttpConnections()).isEqualTo(DEFAULT_MAX_HTTP_CONNECTIONS);
     }
   }
 
@@ -1014,5 +1018,46 @@ public final class ZeebeClientTest extends ClientTest {
 
     // then
     assertThat(builder.getDefaultRequestTimeoutOffset()).isEqualTo(Duration.ofMillis(100));
+  }
+
+  @Test
+  public void shouldSetMaxHttpConnections() {
+    // given
+    final ZeebeClientBuilderImpl builder = new ZeebeClientBuilderImpl();
+    builder.maxHttpConnections(1234);
+
+    // when
+    builder.build();
+
+    // then
+    assertThat(builder.getMaxHttpConnections()).isEqualTo(1234);
+  }
+
+  @Test
+  public void shouldSetMaxHttpConnectionsWithProperty() {
+    // given
+    final Properties properties = new Properties();
+    final ZeebeClientBuilderImpl builder = new ZeebeClientBuilderImpl();
+    properties.setProperty(MAX_HTTP_CONNECTIONS, "1234");
+    builder.withProperties(properties);
+
+    // when
+    builder.build();
+
+    // then
+    assertThat(builder.getMaxHttpConnections()).isEqualTo(1234);
+  }
+
+  @Test
+  public void shouldSetMaxHttpConnectionsWithEnv() {
+    // given
+    final ZeebeClientBuilderImpl builder = new ZeebeClientBuilderImpl();
+    Environment.system().put(ZeebeClientEnvironmentVariables.MAX_HTTP_CONNECTIONS, "1234");
+
+    // when
+    builder.build();
+
+    // then
+    assertThat(builder.getMaxHttpConnections()).isEqualTo(1234);
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/LegacyZeebeClientProperties.java
+++ b/clients/java/src/main/java/io/camunda/client/LegacyZeebeClientProperties.java
@@ -31,6 +31,8 @@ public final class LegacyZeebeClientProperties {
 
   public static final String PREFER_REST_OVER_GRPC = "zeebe.client.gateway.preferRestOverGrpc";
 
+  public static final String MAX_HTTP_CONNECTIONS = "zeebe.client.gateway.maxHttpConnections";
+
   public static final String REST_ADDRESS = "zeebe.client.gateway.rest.address";
 
   public static final String GRPC_ADDRESS = "zeebe.client.gateway.grpc.address";

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientBuilderImpl.java
@@ -344,7 +344,8 @@ public final class CamundaClientBuilderImpl
     BuilderUtils.applyPropertyValueIfNotNull(
         properties,
         value -> maxHttpConnections(Integer.parseInt(value)),
-        ClientProperties.MAX_HTTP_CONNECTIONS);
+        ClientProperties.MAX_HTTP_CONNECTIONS,
+        LegacyZeebeClientProperties.MAX_HTTP_CONNECTIONS);
 
     BuilderUtils.applyPropertyValueIfNotNull(
         properties,
@@ -717,7 +718,9 @@ public final class CamundaClientBuilderImpl
         PREFER_REST_VAR,
         LegacyZeebeClientEnvironmentVariables.PREFER_REST_VAR);
     applyEnvironmentValueIfNotNull(
-        value -> maxHttpConnections(Integer.parseInt(value)), MAX_HTTP_CONNECTIONS);
+        value -> maxHttpConnections(Integer.parseInt(value)),
+        MAX_HTTP_CONNECTIONS,
+        LegacyZeebeClientEnvironmentVariables.MAX_HTTP_CONNECTIONS);
     applyEnvironmentValueIfNotNull(
         this::defaultTenantId,
         DEFAULT_TENANT_ID_VAR,

--- a/clients/java/src/main/java/io/camunda/client/impl/LegacyZeebeClientEnvironmentVariables.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/LegacyZeebeClientEnvironmentVariables.java
@@ -36,6 +36,7 @@ public final class LegacyZeebeClientEnvironmentVariables {
   public static final String DEFAULT_JOB_WORKER_TENANT_IDS_VAR =
       "ZEEBE_DEFAULT_JOB_WORKER_TENANT_IDS";
   public static final String USE_DEFAULT_RETRY_POLICY_VAR = "ZEEBE_CLIENT_USE_DEFAULT_RETRY_POLICY";
+  public static final String MAX_HTTP_CONNECTIONS = "ZEEBE_MAX_HTTP_CONNECTIONS";
 
   /** OAuth Environment Variables */
   public static final String OAUTH_ENV_CLIENT_ID = "ZEEBE_CLIENT_ID";

--- a/clients/java/src/test/java/io/camunda/client/CamundaClientTest.java
+++ b/clients/java/src/test/java/io/camunda/client/CamundaClientTest.java
@@ -1395,7 +1395,7 @@ public final class CamundaClientTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {MAX_HTTP_CONNECTIONS})
+  @ValueSource(strings = {MAX_HTTP_CONNECTIONS, LegacyZeebeClientProperties.MAX_HTTP_CONNECTIONS})
   public void shouldSetMaxHttpConnectionsWithProperty(final String propertyName) {
     // given
     final Properties properties = new Properties();
@@ -1411,7 +1411,11 @@ public final class CamundaClientTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {CamundaClientEnvironmentVariables.MAX_HTTP_CONNECTIONS})
+  @ValueSource(
+      strings = {
+        CamundaClientEnvironmentVariables.MAX_HTTP_CONNECTIONS,
+        LegacyZeebeClientEnvironmentVariables.MAX_HTTP_CONNECTIONS
+      })
   public void shouldSetMaxHttpConnectionsWithEnv(final String envName) {
     // given
     final CamundaClientBuilderImpl builder = new CamundaClientBuilderImpl();


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This is the same change as done to the camunda client with 7ada88c (PR https://github.com/camunda/camunda/pull/40596). We need to backport this code to the deprecated Zeebe client to ensure backward compatibility since this code is already present in the deprecated Zeebe client in version 8.8.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates to https://github.com/camunda/camunda/issues/40576
