### PR TITLE
ci: enhance dual tagging documentation

### DIFF
--- a/.github/workflows/generate-snapshot-docker-tag.yml
+++ b/.github/workflows/generate-snapshot-docker-tag.yml
@@ -1,4 +1,26 @@
 # description: Generate Docker snapshot tags based on branch and project version.
+#
+# Produces two Docker tag outputs so that images built from `main` are
+# discoverable in two complementary ways:
+#
+#   version_tag  – A versioned snapshot tag derived from the project's
+#                  major.minor version (e.g. "8.10-SNAPSHOT").  Always set
+#                  for both `main` and `stable/*` branches.
+#
+#   snapshot_tag – A generic, un-versioned "SNAPSHOT" tag.  Only set when
+#                  building from `main`; empty for stable branches.
+#
+# Why dual tagging on main?
+#   • `SNAPSHOT` (snapshot_tag) provides a stable, version-agnostic pointer
+#     so consumers that always want "the latest development build" never need
+#     to update references when the project bumps its minor version.
+#   • `8.10-SNAPSHOT` (version_tag) lets consumers pin to a specific version
+#     stream, which matters when main and a recent stable branch coexist and
+#     images for each must be independently addressable.
+#
+# On stable branches only version_tag is produced (e.g. "8.8-SNAPSHOT")
+# because each stable branch maps to exactly one version.
+#
 # type: CI
 # owner: @camunda/monorepo-devops-team
 name: Generate Docker Snapshot Tag
@@ -16,10 +38,15 @@ on:
         type: string
     outputs:
       version_tag:
-        description: "Generated Docker version tag"
+        description: >-
+          Versioned snapshot tag (e.g. "8.10-SNAPSHOT" on main, "8.8-SNAPSHOT"
+          on stable/8.8). Always set when the job runs.
         value: ${{ jobs.get-snapshot-docker-version-tag.outputs.tag }}
       snapshot_tag:
-        description: "Generated Docker SNAPSHOT tag for main branch"
+        description: >-
+          Generic un-versioned "SNAPSHOT" tag. Only set on main so that
+          consumers can reference the latest development build without
+          hard-coding a version number. Empty on stable branches.
         value: ${{ jobs.get-snapshot-docker-version-tag.outputs.snapshot_tag }}
 
 env:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -35,6 +35,8 @@
 /.github/workflows/commitlint.yml                        @camunda/monorepo-devops-team
 /.github/workflows/dispatch-release*                     @camunda/monorepo-devops-team
 /.github/workflows/docs*                                 @camunda/monorepo-devops-team
+/.github/workflows/generate-concurrency-group.yml        @camunda/monorepo-devops-team
+/.github/workflows/generate-snapshot-docker-tag.yml      @camunda/monorepo-devops-team
 /.github/workflows/issue-add-support-label.yml           @camunda/monorepo-devops-team
 /.github/workflows/labeler.yml                           @camunda/monorepo-devops-team
 /.github/workflows/preview-env*                          @camunda/monorepo-devops-team


### PR DESCRIPTION
## Description

This pull request improves documentation and ownership assignment of the Docker snapshot tag generation workflow. The main focus is on clarifying how Docker tags are produced for different branches, ensuring consumers can reliably reference development builds, and assigning proper ownership for new workflow files, in alignment with what was discussed [here](https://github.com/camunda/camunda/pull/50460/changes#r3086454678).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
