### PR TITLE
ci: add optimize-8.7 branch for renovate patches

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,6 +7,7 @@
   "commitMessagePrefix": "deps:",
   "baseBranchPatterns": [
     "/^stable\\/8\\.([7-9]|[1-9][0-9])/",
+    "stable/optimize-8.7",
     "main"
   ],
   "dependencyDashboard": true,
@@ -59,13 +60,15 @@
       "description": "Enable separateMinorPatch so updates to latest patch are not ignored in maintenance branches.",
       "separateMinorPatch": true,
       "matchBaseBranches": [
-        "/^stable\\/8\\..*/"
+        "/^stable\\/8\\..*/",
+        "stable/optimize-8.7"
       ]
     },
     {
       "description": "Only patch updates for our maintenance branches to avoid breaking changes.",
       "matchBaseBranches": [
-        "/^stable\\/8\\..*/"
+        "/^stable\\/8\\..*/",
+        "stable/optimize-8.7"
       ],
       "matchUpdateTypes": [
         "minor",
@@ -356,7 +359,8 @@
         "maven"
       ],
       "matchBaseBranches": [
-        "/^stable\\/8\\..*/"
+        "/^stable\\/8\\..*/",
+        "stable/optimize-8.7"
       ],
       "matchPackageNames": [
         "/^io\\.camunda:.+/"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -184,7 +184,8 @@
     {
       "description": "Skip lucene minor and patch in stable branches to avoid breaking changes.",
       "matchBaseBranches": [
-        "/^stable\\/8\\.[6-8]/"
+        "/^stable\\/8\\.[6-8]/",
+        "stable/optimize-8.7"
       ],
       "matchManagers": [
         "maven"


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Adding the stable/optimize-8.7 branch so that it also receives patch updates.

Motivation: having to manually fix base image digests that get automatically updated in any other maintenance branch (https://github.com/camunda/camunda/pull/51046)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
