### PR TITLE
Restore legacy ci workflows

### DIFF
--- a/.codeowners
+++ b/.codeowners
@@ -268,7 +268,12 @@ optimize.Dockerfile         @camunda/core-features
 /.github/actions/run-maven/ @camunda/core-features
 /.github/optimize/scripts/ @camunda/core-features
 /.github/workflows/assign-urgency-to-issue* @camunda/core-features
+/.github/workflows/operate-ci-build-reusable.yml @camunda/core-features
+/.github/workflows/operate-ci.yml @camunda/core-features
+/.github/workflows/operate-ci-test-reusable.yml @camunda/core-features
+/.github/workflows/operate-e2e-tests.yml @camunda/core-features
 /.github/workflows/operate-playwright.yml @camunda/core-features
+/.github/workflows/operate-docker-tests.yml @camunda/core-features
 /.github/workflows/operate-release-*.yml @camunda/core-features
 /.github/workflows/ci-operate.yml @camunda/core-features
 /.github/workflows/ci-tasklist.yml @camunda/core-features

--- a/.github/workflows/operate-ci-build-reusable.yml
+++ b/.github/workflows/operate-ci-build-reusable.yml
@@ -1,0 +1,162 @@
+# This GitHub Actions workflow automates the CI build process for the 'operate' service.
+# It triggers on a `workflow_call` event and accepts inputs for branch name[required], Java version[optional]
+#
+# It consists of a several steps:
+# 1. Setup: It checks out the specified branch, sets up Java and Maven with the provided inputs, and imports secrets from Vault.
+# 2. Build: Then it builds the Maven artifacts and Docker images
+# 3. Upload: Deploys SNAPSHOT Docker image and mvn artifacts
+#
+# Environment variables are used to define the image tags used for Docker builds.
+# This workflow is designed to provide a comprehensive, automated CI process that ensures code quality, handles secrets securely,
+# and enables detailed reporting of test results.
+# description: Automates the build process for operate workflows
+# called by: operate-ci.yml, preview-env-build-and-deploy.yml
+# test location:
+# type: CI
+# owner: @camunda/core-features
+---
+name: Operate CI Reusable
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        description: "The branch name to be used for the workflow"
+        required: true
+        type: string
+      pushDocker:
+        description: "Whether the built docker images are pushed to camunda registry"
+        type: boolean
+        default: true
+      previewEnv:
+        description: "Defines whether this is a preview environment build or not. If true, the image will be pushed to the Harbor Docker registry."
+        type: boolean
+        default: false
+
+defaults:
+  run:
+    # use bash shell by default to ensure pipefail behavior is the default
+    # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+    shell: bash
+
+# Define environment variables
+env:
+  BRANCH_NAME: ${{ inputs.branch }}
+  IS_DEFAULT_BRANCH: ${{ inputs.branch == 'main' }}
+  IS_MAIN_OR_STABLE_BRANCH: ${{ inputs.branch == 'main' || startsWith(inputs.branch, 'stable/') }}
+  DOCKER_PLATFORMS: "linux/amd64,linux/arm64"
+
+jobs:
+  # Dynamically generate the Docker tag (e.g., SNAPSHOT or X.Y-SNAPSHOT) based on branch name
+  utils-get-snapshot-docker-tag:
+    uses: ./.github/workflows/generate-snapshot-docker-tag.yml
+    secrets: inherit
+    permissions:
+      contents: read
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: [ utils-get-snapshot-docker-tag ]
+    steps:
+      # Setup: checkout branch
+      - name: Checkout '${{ inputs.branch }}' branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: refs/heads/${{ inputs.branch }}
+          fetch-depth: 0 # fetches all history for all branches and tags
+
+      #########################################################################
+      # Setup: define env variables
+      - name: Set GitHub environment variables
+        run: |
+          GIT_COMMIT_HASH=$(git rev-parse ${{ inputs.branch }})
+          BRANCH_SLUG=$(echo "${{ inputs.branch }}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g')
+          {
+            echo "IMAGE_TAG=$(if [ "${{ inputs.branch }}" = "main" ]; then echo "$GIT_COMMIT_HASH"; else echo "branch-$BRANCH_SLUG"; fi)"
+            echo "CI_IMAGE_TAG=ci-$GIT_COMMIT_HASH"
+            echo "PR_IMAGE_TAG=pr-$GIT_COMMIT_HASH"
+          } >> "$GITHUB_ENV"
+
+      #########################################################################
+      # Setup: import secrets from vault
+      - name: Import Secrets
+        id: secrets # important to refer to it in later steps
+        uses: hashicorp/vault-action@v3
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false # we rely on step outputs, no need for environment variables
+          secrets: |
+            secret/data/products/operate/ci/github-actions OPERATE_CI_ALERT_WEBHOOK_URL;
+
+      #########################################################################
+      # Setup and configure Maven, Docker, and settings
+      - uses: ./.github/actions/setup-build
+        name: Build setup
+        with:
+          dockerhub: ${{ env.IS_MAIN_OR_STABLE_BRANCH == 'true' }}
+          harbor: true
+          java-distribution: adopt
+          maven-cache-key-modifier: operate
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          minimus: true
+
+      #########################################################################
+      # Build Operate frontend
+      - name: Build frontend
+        uses: ./.github/actions/build-frontend
+        with:
+          directory: ./operate/client
+          package-manager: "npm"
+
+      #########################################################################
+      # Build: maven artifacts and Docker images
+      - name: Build Maven
+        run: |
+          ./mvnw clean deploy -B -T1C -P -docker,skipFrontendBuild -DskipTests -DskipChecks -DaltStagingDirectory=${{ github.workspace }}/staging-${{ env.BRANCH_NAME }} -DskipRemoteStaging=true -Dmaven.deploy.skip=true
+
+      #########################################################################
+      # Build Docker image
+      - name: Build Docker image
+        uses: ./.github/actions/build-platform-docker
+        with:
+          repository: ${{ inputs.previewEnv && 'registry.camunda.cloud/team-camunda/operate' || 'registry.camunda.cloud/team-operate/camunda-operate' }}
+          version: |
+            ${{ env.IMAGE_TAG }}
+            ${{ env.CI_IMAGE_TAG }}
+            ${{ env.PR_IMAGE_TAG }}
+          push: ${{ inputs.pushDocker }}
+          platforms: ${{ inputs.pushDocker && env.DOCKER_PLATFORMS || 'linux/amd64' }}
+          dockerfile: operate.Dockerfile
+
+      #########################################################################
+      # Build SNAPSHOT Docker image
+      - name: Build SNAPSHOT Docker image
+        if: ${{ env.IS_MAIN_OR_STABLE_BRANCH == 'true' }}
+        uses: ./.github/actions/build-platform-docker
+        with:
+          repository: camunda/operate
+          version: |
+            ${{ needs.utils-get-snapshot-docker-tag.outputs.version_tag }}
+            ${{ needs.utils-get-snapshot-docker-tag.outputs.snapshot_tag }}
+          push: true
+          platforms: ${{ env.DOCKER_PLATFORMS }}
+          dockerfile: operate.Dockerfile
+
+      #########################################################################
+      # Collect information about build status for central statistics with CI Analytics
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/operate-ci-test-reusable.yml
+++ b/.github/workflows/operate-ci-test-reusable.yml
@@ -1,0 +1,130 @@
+# This GitHub Actions workflow automates the CI test process for the 'operate' service.
+# It triggers on a `workflow_call` event and accepts inputs for branch name[required] and fork count[optional]
+#
+# It consists of a several steps:
+# 1. Setup: It checks out the specified branch, sets up Java and Maven with the provided inputs, and imports secrets from Vault.
+# 2. Tests: Runs unit and integration tests.
+# 3. Reports: Publishes the test results, even if some steps failed.
+#
+# Environment variables are used to control CPU limits.
+# This workflow is designed to provide a comprehensive, automated CI process that ensures code quality, handles secrets securely,
+# and enables detailed reporting of test results.
+
+# CI IT test reusable GitHub Actions Workflow
+# Triggers on a workflow_call event and accepts inputs for branch name and fork count
+# Performs integration tests for the operate service with parallel execution.
+# description: Automates the CI test process for operate
+# called by: operate-ci-data-layer.yml, operate-ci-core-features.yml
+# test location: operate
+# type: CI
+# owner: @camunda/data-layer, @camunda/core-features
+---
+name: Operate CI IT test reusable
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        description: "The branch name to be used for the workflow"
+        required: true
+        type: string
+      forkCount:
+        description: "The number of VMs to fork in parallel in order to execute the unit tests"
+        required: false
+        default: 4
+        type: number
+      command:
+        description: "Maven command to trigger the test"
+        required: true
+        type: string
+      test-type:
+        description: "Type of test, used in the job name, stage name, and report artifact name"
+        required: true
+        type: string
+      runner-type:
+        description: "CI runner type for the tests"
+        default: gcp-core-32-default
+        type: string
+
+permissions: {}
+
+defaults:
+  run:
+    shell: bash
+
+# Define environment variable for concurrency
+env:
+  BRANCH_NAME: ${{ inputs.branch }}
+  LIMITS_CPU: ${{ inputs.forkCount }}  # consumed by `maven-surefire-plugin` & `maven-failsafe-plugin` plugins defined in main `pom.xml` file
+  GHA_BEST_PRACTICES_LINTER: enabled
+
+jobs:
+  integration-tests:
+    name: ${{ inputs.test-type }}
+    timeout-minutes: 40
+    runs-on: ${{ inputs.runner-type }}
+    permissions: {}
+    if: ${{ !startsWith(inputs.branch, 'fe-') && !(startsWith(inputs.branch, 'renovate/') && contains(inputs.branch, '-fe-')) }}
+    services:
+      # local registry is used as this job needs to push its docker image to be used by IT
+      registry:
+        image: registry:3
+        ports:
+          - 5000:5000
+    steps:
+      # Setup: checkout branch
+      - name: Checkout '${{ inputs.branch }}' branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: refs/heads/${{ inputs.branch }}
+          fetch-depth: 0 # fetches all history for all branches and tags
+
+      # Setup: import secrets from vault
+      - name: Import Secrets
+        id: secrets  # important to refer to it in later steps
+        uses: hashicorp/vault-action@v3
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false  # we rely on step outputs, no need for environment variables
+          secrets: |
+            secret/data/products/operate/ci/github-actions OPERATE_CI_ALERT_WEBHOOK_URL;
+
+      # Setup: configure Java, Maven, settings.xml
+      - uses: ./.github/actions/setup-build
+        name: Build setup
+        with:
+          java-distribution: adopt
+          maven-cache-key-modifier: operate-tests
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          minimus: true
+      - uses: ./.github/actions/build-zeebe
+        id: build-camunda
+        with:
+          maven-extra-args: -PskipFrontendBuild
+
+      # Run integration tests in parallel
+      - name: Backend - ${{ inputs.test-type }}
+        run: |
+          ${{ inputs.command }}
+
+      # Reports: publish test metrics results
+      - name: Upload Test Report
+        if: ${{ (success() || failure()) }}
+        uses: ./.github/actions/collect-test-artifacts
+        with:
+          name: "Operate ${{ inputs.test-type }}"
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/operate-ci.yml
+++ b/.github/workflows/operate-ci.yml
@@ -1,0 +1,74 @@
+# description: Runs legacy integration CI tests
+# test location: operate/qa/integration-tests
+# type: CI
+# owner: @camunda/core-features, @camunda/data-layer
+name: "[Legacy] Operate"
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+      - 'stable/**'
+      - 'release**'
+    paths:
+      - '.ci/**'
+      - '.github/actions/**'
+      - '.github/workflows/operate-*'
+      - 'bom/*'
+      - 'operate.Dockerfile'
+      - 'operate/**'
+      - 'parent/*'
+      - 'pom.xml'
+      - 'webapps-common/**'
+      - 'zeebe/**'
+      - 'clients/**'
+  pull_request:
+    paths:
+      - '.ci/**'
+      - '.github/actions/**'
+      - '.github/workflows/operate-*'
+      - 'bom/*'
+      - 'operate/**'
+      - 'pom.xml'
+      - 'operate.Dockerfile'
+      - 'parent/*'
+      - 'webapps-common/**'
+      - 'zeebe/**'
+      - 'clients/**'
+permissions:
+  contents: read
+
+# Limit workflow to 1 concurrent run per ref (branch): new commit -> old runs are canceled to save costs
+# Exception for main branch: complete builds for every commit needed for confidenence
+concurrency:
+  cancel-in-progress: true
+  group: ${{ format('{0}-{1}', github.workflow, github.ref == 'refs/heads/main' && github.sha || github.ref) }}
+
+jobs:
+  # builds image and pushes to Dockerhub if branch is `main`
+  run-operate-build:
+    name: "Build / Operate and Image"
+    uses: ./.github/workflows/operate-ci-build-reusable.yml
+    secrets: inherit
+    with:
+      branch: ${{ github.head_ref || github.ref_name }} # head_ref = branch name on PR, ref_name = `main` or `stable/**`
+  # over 10min run time
+  run-core-features-integration-tests:
+    name: "Integration"
+    uses: ./.github/workflows/operate-ci-test-reusable.yml
+    secrets: inherit
+    with:
+      branch: ${{ github.head_ref || github.ref_name }}
+      command: ./mvnw -f operate/qa/integration-tests verify -P operateCoreFeaturesIT -B -DskipChecks -Dfailsafe.rerunFailingTestsCount=2
+      test-type: Core Features ITs
+      runner-type: gcp-core-32-default
+
+  run-data-layer-opensearch-tests:
+    name: "Integration"
+    uses: ./.github/workflows/operate-ci-test-reusable.yml
+    secrets: inherit
+    with:
+      branch: ${{ github.head_ref || github.ref_name }}
+      command: ./mvnw -f operate/qa/integration-tests verify -P operateItOpensearch,docker-opensearch -B -DskipChecks -Dfailsafe.rerunFailingTestsCount=2
+      test-type: Opensearch ITs
+      runner-type: gcp-core-32-default

--- a/.github/workflows/operate-docker-tests.yml
+++ b/.github/workflows/operate-docker-tests.yml
@@ -1,0 +1,128 @@
+# description:  Workflow for tests for running Integration tests on a docker image
+# test location: operate/qa/integration-tests
+# type: CI
+# owner: @camunda/core-features
+name: "[Legacy] Operate / Docker"
+on:
+  push:
+    branches:
+      - 'main'
+      - 'stable/**'
+      - 'release/**'
+    paths:
+      - '.ci/**'
+      - '.github/actions/**'
+      - '.github/workflows/operate-*'
+      - 'bom/*'
+      - 'operate.Dockerfile'
+      - 'operate/**'
+      - 'parent/*'
+      - 'pom.xml'
+      - 'webapps-common/**'
+  pull_request:
+    paths:
+      - '.ci/**'
+      - '.github/actions/**'
+      - '.github/workflows/operate-*'
+      - 'bom/*'
+      - 'operate.Dockerfile'
+      - 'operate/**'
+      - 'parent/*'
+      - 'pom.xml'
+      - 'webapps-common/**'
+
+# Limit workflow to 1 concurrent run per ref (branch): new commit -> old runs are canceled to save costs
+# Exception for main branch: complete builds for every commit needed for confidenence
+concurrency:
+  cancel-in-progress: true
+  group: ${{ format('{0}-{1}', github.workflow, github.ref == 'refs/heads/main' && github.sha || github.ref) }}
+
+jobs:
+  # does not meet the 10 minute runtime as required by the unified CI
+  integration-tests:
+    name: "Container Tests"
+    runs-on: gcp-core-4-default
+    timeout-minutes: 40
+    permissions: { }
+    env:
+      OPERATE_TEST_DOCKER_IMAGE: localhost:5000/camunda/operate:current-test
+    services:
+      registry:
+        image: registry:3
+        ports:
+          - 5000:5000
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: hadolint/hadolint-action@v3.3.0
+        with:
+          ignore: DL3018 # redundant when pinning the base image
+          dockerfile: operate.Dockerfile
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/github.com/organizations/camunda NEXUS_USR;
+            secret/data/github.com/organizations/camunda NEXUS_PSW;
+            secret/data/products/camunda/ci/github-actions REGISTRY_MINIMUS_PSW | minimus-token
+      - name: Login to Minimus
+        uses: docker/login-action@v4
+        with:
+          registry: reg.mini.dev
+          username: minimus
+          password: ${{ steps.secrets.outputs.minimus-token }}
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: "adopt"
+          java-version: "21"
+      # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
+      - name: 'Create settings.xml'
+        uses: s4u/maven-settings-action@v4.0.0
+        with:
+          githubServer: false
+          servers: |
+            [{
+               "id": "camunda-nexus",
+               "username": "${{ steps.secrets.outputs.NEXUS_USR }}",
+               "password": "${{ steps.secrets.outputs.NEXUS_PSW }}"
+             }]
+          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*", "name": "camunda Nexus"}]'
+      - name: Build backend
+        run: ./mvnw clean install -B -T1C -DskipChecks -P -docker,skipFrontendBuild -DskipTests=true -DskipRemoteStaging=true -Dmaven.deploy.skip=true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+        with:
+          driver-opts: network=host
+      - name: Build and push to local registry
+        uses: docker/build-push-action@v7
+        env:
+          DOCKER_BUILD_SUMMARY: false
+          DOCKER_BUILD_RECORD_UPLOAD: false
+        with:
+          context: .
+          push: true
+          tags: ${{ env.OPERATE_TEST_DOCKER_IMAGE }}
+          file: operate.Dockerfile
+      - name: Run Docker tests
+        run: ./mvnw -pl operate/qa/integration-tests -DskipChecks -Dtest=StartupIT -Dsurefire.failIfNoSpecifiedTests=false -Dspring.profiles.active=docker-test test
+      - name: Upload Test Report
+        if: failure()
+        uses: ./.github/actions/collect-test-artifacts
+        with:
+          name: "docker tests"
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/operate-e2e-tests.yml
+++ b/.github/workflows/operate-e2e-tests.yml
@@ -1,0 +1,185 @@
+# description: Workflow for Front-End end to end tests for Operate only. Tests will use a running instance of Operate for the API
+# test location: qa/c8-orchestration-cluster-e2e-test-suite
+# type: CI
+# owner: @camunda/core-features
+name: "[Legacy] Operate / E2E Tests"
+on:
+  push:
+    branches:
+      - "main"
+      - "stable/**"
+      - "release**"
+    paths:
+      - ".ci/**"
+      - ".github/actions/**"
+      - ".github/workflows/operate-*"
+      - "bom/*"
+      - "distro/**"
+      - "operate.Dockerfile"
+      - "operate/**"
+      - "zeebe/exporters/camunda-exporter/**"
+      - "parent/*"
+      - "pom.xml"
+
+  pull_request:
+    paths:
+      - ".ci/**"
+      - ".github/actions/**"
+      - ".github/workflows/operate-*"
+      - "bom/*"
+      - "distro/**"
+      - "operate.Dockerfile"
+      - "operate/**"
+      - "zeebe/exporters/camunda-exporter/**"
+      - "parent/*"
+      - "pom.xml"
+
+# Limit workflow to 1 concurrent run per ref (branch): new commit -> old runs are canceled to save costs
+# Exception for main branch: complete builds for every commit needed for confidenence
+concurrency:
+  cancel-in-progress: true
+  group: ${{ format('{0}-{1}', github.workflow, github.ref == 'refs/heads/main' && github.sha || github.ref) }}
+
+jobs:
+  test:
+    runs-on: gcp-core-4-default
+    services:
+      elasticsearch:
+        image: docker.elastic.co/elasticsearch/elasticsearch:8.19.13
+        env:
+          discovery.type: single-node
+          cluster.name: docker-cluster
+          bootstrap.memory_lock: true
+          xpack.security.enabled: false
+          ES_JAVA_OPTS: -Xms1024m -Xmx1024m
+        ports:
+          - 9200:9200
+          - 9300:9300
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/github.com/organizations/camunda NEXUS_USR;
+            secret/data/github.com/organizations/camunda NEXUS_PSW;
+
+      - name: Setup Node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 24
+
+      - name: Install node dependencies
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+        run: npm ci
+
+      - name: Install frontend dependencies
+        working-directory: ./operate/client
+        run: npm ci
+
+      - name: Install Playwright
+        run: npx playwright install --with-deps chromium
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+
+      - name: Build frontend
+        working-directory: ./operate/client
+        run: npm run build
+        env:
+          NODE_OPTIONS: --max_old_space_size=4096
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: "adopt"
+          java-version: "21"
+
+      # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
+      - name: "Create settings.xml"
+        uses: s4u/maven-settings-action@v4.0.0
+        with:
+          githubServer: false
+          servers: |
+            [{
+              "id": "camunda-nexus",
+              "username": "${{ steps.secrets.outputs.NEXUS_USR }}",
+              "password": "${{ steps.secrets.outputs.NEXUS_PSW }}"
+            }]
+          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*", "name": "camunda Nexus"}]'
+      - name: Build backend
+        # Currently, the e2e environment of operate conflicts with the optimize build. For the moment,
+        # we're excluding optimize from the build, not to impact this Operate workflow.
+        run: ./mvnw clean install -T1C -DskipChecks -P -docker,skipFrontendBuild -DskipTests=true -B -DskipRemoteStaging=true -Dmaven.deploy.skip=true
+      - name: Start Operate
+        run: >
+          ./mvnw -q -B spring-boot:start -pl dist -Dspring-boot.run.fork=true
+          -Dspring-boot.run.main-class=io.camunda.application.StandaloneCamunda
+        env:
+          SPRING_PROFILES_ACTIVE: operate,consolidated-auth,broker
+          ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_CLASSNAME: io.camunda.exporter.CamundaExporter
+          ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_URL: http://localhost:9200
+          ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_BULK_SIZE: 100
+          ZEEBE_BROKER_BACKPRESSURE_ENABLED: false
+          ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_INDEX_SHOULDWAITFORIMPORTERS: false
+          CAMUNDA_OPERATE_CSRF_PREVENTION_ENABLED: false
+          CAMUNDA_SECURITY_INITIALIZATION_USERS_0_USERNAME: demo
+          CAMUNDA_SECURITY_INITIALIZATION_USERS_0_PASSWORD: demo
+          CAMUNDA_SECURITY_INITIALIZATION_USERS_0_NAME: Demo
+          CAMUNDA_SECURITY_INITIALIZATION_USERS_0_EMAIL: demo@example.com
+          CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_USERS_0: demo
+          CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI: true
+          CAMUNDA_SECURITY_AUTHORIZATIONS_ENABLED: false
+
+      - name: Python setup
+        if: always()
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.x"
+
+      - name: Run tests
+        shell: bash
+        env:
+          LOCAL_TEST: "false"
+          CORE_APPLICATION_URL: http://localhost:8080
+          CAMUNDA_AUTH_STRATEGY: "BASIC"
+          CAMUNDA_BASIC_AUTH_USERNAME: "demo"
+          CAMUNDA_BASIC_AUTH_PASSWORD: "demo"
+          ZEEBE_REST_ADDRESS: "http://localhost:8080"
+        run: npm run test -- --project=operate-e2e
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        if: always()
+        with:
+          name: C8 Orchestration Cluster E2E Test Result (operate)
+          path: qa/c8-orchestration-cluster-e2e-test-suite/html-report
+          retention-days: 30
+
+      - name: Collect docker logs on failure
+        if: failure()
+        uses: jwalton/gh-docker-logs@v2
+        with:
+          dest: "./logs"
+      - name: Tar logs
+        if: failure()
+        run: tar cvzf ./logs.tgz ./logs
+      - name: Upload logs to GitHub
+        if: failure()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: logs.tgz
+          path: ./logs.tgz
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/tasklist-ci-build-reusable.yml
+++ b/.github/workflows/tasklist-ci-build-reusable.yml
@@ -1,0 +1,147 @@
+# This GitHub Actions workflow automates the CI build process for the 'tasklist' service.
+# It triggers on a `workflow_call` event and accepts inputs for branch name[required], Java version[optional]
+#
+# It consists of a several steps:
+# 1. Setup: It checks out the specified branch, sets up Java and Maven with the provided inputs, and imports secrets from Vault.
+# 2. Build: Then it builds the Maven artifacts and Docker images
+# 3. Upload: Deploys SNAPSHOT Docker image and mvn artifacts
+#
+# Environment variables are used to define the image tags used for Docker builds.
+# This workflow is designed to provide a comprehensive, automated CI process that ensures code quality, handles secrets securely,
+# and enables detailed reporting of test results.
+# description: Reuseable workflow for building Tasklist and a docker image
+# test location: /tasklist
+# called by: tasklist-ci.yml, preview-env-build-and-deploy.yml
+# type: CI
+# owner: @camunda/core-features
+
+name: Tasklist CI Reusable
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        description: "The branch name to be used for the workflow"
+        required: true
+        type: string
+      pushDocker:
+        description: "whether the built docker images are pushed to camunda registry"
+        type: boolean
+        default: true
+      previewEnv:
+        description: "Defines whether this is a preview environment build or not. If true, the image will be pushed to the Harbor Docker registry."
+        type: boolean
+        default: false
+
+defaults:
+  run:
+    # use bash shell by default to ensure pipefail behavior is the default
+    # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+    shell: bash
+
+# Define environment variables
+env:
+  BRANCH_NAME: ${{ inputs.branch }}
+  IS_DEFAULT_BRANCH: ${{ inputs.branch == 'main' }}
+  IS_MAIN_OR_STABLE_BRANCH: ${{ inputs.branch == 'main' || startsWith(inputs.branch, 'stable/') }}
+  DOCKER_PLATFORMS: "linux/amd64,linux/arm64"
+
+jobs:
+  # Dynamically generate the Docker tag (e.g., SNAPSHOT or X.Y-SNAPSHOT) based on branch name
+  utils-get-snapshot-docker-tag:
+    uses: ./.github/workflows/generate-snapshot-docker-tag.yml
+    secrets: inherit
+    permissions:
+      contents: read
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: [ utils-get-snapshot-docker-tag ]
+    steps:
+      # Setup: checkout branch
+      - name: Checkout '${{ inputs.branch }}' branch
+        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        with:
+          ref: refs/heads/${{ inputs.branch }}
+          fetch-depth: 0 # fetches all history for all branches and tags
+
+      #########################################################################
+      # Setup: define env variables
+      - name: Set GitHub environment variables
+        run: |
+          GIT_COMMIT_HASH=$(git rev-parse ${{ inputs.branch }})
+          BRANCH_SLUG=$(echo "${{ inputs.branch }}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g')
+          {
+            echo "IMAGE_TAG=$(if [ "${{ inputs.branch }}" = "main" ]; then echo "$GIT_COMMIT_HASH"; else echo "branch-$BRANCH_SLUG"; fi)"
+            echo "CI_IMAGE_TAG=ci-$GIT_COMMIT_HASH"
+            echo "PR_IMAGE_TAG=pr-$GIT_COMMIT_HASH"
+          } >> "$GITHUB_ENV"
+
+      #########################################################################
+      # Setup and configure Maven, Docker, and settings
+      - uses: ./.github/actions/setup-build
+        name: Build setup
+        with:
+          dockerhub: ${{ env.IS_MAIN_OR_STABLE_BRANCH == 'true' }}
+          harbor: true
+          java-distribution: adopt
+          maven-cache-key-modifier: tasklist
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          minimus: true
+
+      #########################################################################
+      # Build frontend
+      - name: Build frontend
+        uses: ./.github/actions/build-frontend
+        with:
+          directory: ./tasklist/client
+          package-manager: "npm"
+      #########################################################################
+      # Build backend
+      - name: Build backend
+        run: |
+          ./mvnw -T1C clean deploy -B -PskipFrontendBuild -DskipTests -DskipChecks -DaltStagingDirectory=${{ github.workspace }}/staging-${{ env.BRANCH_NAME }} -DskipRemoteStaging=true -Dmaven.deploy.skip=true
+
+      #########################################################################
+      # Build Docker image
+      - name: Build Docker image
+        uses: ./.github/actions/build-platform-docker
+        with:
+          repository: ${{ inputs.previewEnv && 'registry.camunda.cloud/team-camunda/tasklist' || 'registry.camunda.cloud/team-hto/tasklist' }}
+          version: |
+            ${{ env.IMAGE_TAG }}
+            ${{ env.CI_IMAGE_TAG }}
+            ${{ env.PR_IMAGE_TAG }}
+          push: ${{ inputs.pushDocker }}
+          platforms: ${{ inputs.pushDocker && env.DOCKER_PLATFORMS || 'linux/amd64' }}
+          dockerfile: tasklist.Dockerfile
+
+      #########################################################################
+      # Build SNAPSHOT Docker image
+      - name: Build SNAPSHOT Docker image
+        if: ${{ env.IS_MAIN_OR_STABLE_BRANCH == 'true' }}
+        uses: ./.github/actions/build-platform-docker
+        with:
+          repository: camunda/tasklist
+          version: |
+            ${{ needs.utils-get-snapshot-docker-tag.outputs.version_tag }}
+            ${{ needs.utils-get-snapshot-docker-tag.outputs.snapshot_tag }}
+          push: true
+          platforms: ${{ env.DOCKER_PLATFORMS }}
+          dockerfile: tasklist.Dockerfile
+
+      #########################################################################
+      # Collect information about build status for central statistics with CI Analytics
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/tasklist-ci-test-reusable.yml
+++ b/.github/workflows/tasklist-ci-test-reusable.yml
@@ -1,0 +1,141 @@
+# This GitHub Actions workflow automates the CI test process for the 'tasklist' service.
+# It triggers on a `workflow_call` event and accepts inputs for branch name[required] and fork count[optional]
+#
+# It consists of a several steps:
+# 1. Setup: It checks out the specified branch, sets up Java and Maven with the provided inputs, and imports secrets from Vault.
+# 2. Tests: Runs unit and integration tests.
+# 3. Reports: Publishes the test results, even if some steps failed.
+#
+# Environment variables are used to control CPU limits.
+# This workflow is designed to provide a comprehensive, automated CI process that ensures code quality, handles secrets securely,
+# and enables detailed reporting of test results.
+
+# CI IT test reusable GitHub Actions Workflow
+# Triggers on a workflow_call event and accepts inputs for branch name and fork count
+# Performs integration tests for the tasklist service with parallel execution.
+# description:
+# test location:
+# called by: tasklist-ci.yml
+# type: CI
+# owner: @camunda/core-features
+
+name: Tasklist CI IT test reusable
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        description: "The branch name to be used for the workflow"
+        required: true
+        type: string
+      forkCount:
+        description: "The number of VMs to fork in parallel in order to execute the tests"
+        required: false
+        default: 4
+        type: number
+
+defaults:
+  run:
+    shell: bash
+
+# Define environment variable for concurrency
+env:
+  LIMITS_CPU: ${{ inputs.forkCount }}  # consumed by `maven-surefire-plugin` & `maven-failsafe-plugin` plugins defined in main `pom.xml` file
+
+jobs:
+  integration-tests:
+    name: Tests
+    runs-on: gcp-perf-core-16-default
+    timeout-minutes: 40
+    permissions: { }
+    strategy:
+      fail-fast: false
+      matrix:
+        database: [ elasticsearch, opensearch ]
+        include:
+          - database: elasticsearch
+            testProfile: docker-es
+          - database: opensearch
+            testProfile: docker-os
+    env:
+      TASKLIST_TEST_DOCKER_IMAGE: localhost:5000/camunda/tasklist
+      TASKLIST_TEST_DOCKER_IMAGE_TAG: current-test
+    services:
+      # local registry is used as this job needs to push its docker image to be used by IT
+      registry:
+        image: registry:3
+        ports:
+          - 5000:5000
+    steps:
+      # Setup: checkout branch
+      - name: Checkout '${{ inputs.branch }}' branch
+        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        with:
+          ref: refs/heads/${{ inputs.branch }}
+          fetch-depth: 0 # fetches all history for all branches and tags
+
+      # Setup: configure Java, Maven, settings.xml
+      - uses: ./.github/actions/setup-build
+        name: Build setup
+        with:
+          java-distribution: adopt
+          maven-cache-key-modifier: tasklist-tests
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          minimus: true
+      - uses: ./.github/actions/build-zeebe
+        id: build-camunda
+        with:
+          maven-extra-args: -PskipFrontendBuild
+
+      # Run integration tests in parallel
+      - name: Run Integration Tests
+        run: |
+          ./mvnw verify \
+            -f tasklist \
+            -T${{ env.LIMITS_CPU }} \
+            -P ${{ matrix.testProfile }},skipFrontendBuild \
+            -B --fail-at-end \
+            -Dfailsafe.rerunFailingTestsCount=2 \
+            -Dcamunda.data.secondary-storage.type=${{ matrix.database }} \
+            -Dtasklist.currentVersion.docker.tag=${{ env.TASKLIST_TEST_DOCKER_IMAGE_TAG }} \
+            -Dtasklist.currentVersion.docker.repo=${{ env.TASKLIST_TEST_DOCKER_IMAGE }}
+
+      # Sanitize the branch name to replace non alphanumeric characters with `-`
+      - id: sanitize
+        uses: camunda/infra-global-github-actions/sanitize-branch-name@main
+        with:
+          branch: ${{ inputs.branch }}
+          max_length: '50'
+
+      - name: Upload failed test results
+        uses: ./.github/actions/collect-test-artifacts
+        if: failure() || cancelled()
+        with:
+          name: tasklist-test-results-${{ matrix.database }}
+          path: |
+            **/failsafe-reports/
+            **/surefire-reports/
+          retention-days: 1
+
+      # Upload JaCoCo report
+      - name: Upload JaCoCo report
+        uses: actions/upload-artifact@v7
+        if: ${{ (success() || failure()) }}
+        with:
+          name: jacoco-report-${{ steps.sanitize.outputs.branch_name }}-${{ matrix.database }}
+          path: ${{ github.workspace }}/test-coverage/target/site/jacoco-aggregate/
+          retention-days: 2
+
+      # Send metrics about CI health
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          job_name: "integration-tests/${{ matrix.database }}"
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/tasklist-ci.yml
+++ b/.github/workflows/tasklist-ci.yml
@@ -1,0 +1,56 @@
+# description: Workflow for running CI tests for Tasklist. Runs a build and Integration Tests
+# test location: /tasklist
+# type: CI
+# owner: @camunda/core-features
+---
+name: "[Legacy] Tasklist"
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "main"
+      - "stable/**"
+      - "release**"
+  pull_request:
+
+# Limit workflow to 1 concurrent run per ref (branch): new commit -> old runs are canceled to save costs
+# Exception for main branch: complete builds for every commit needed for confidenence
+concurrency:
+  cancel-in-progress: true
+  group: ${{ format('{0}-{1}', github.workflow, github.ref == 'refs/heads/main' && github.sha || github.ref) }}
+
+jobs:
+  detect-changes:
+    outputs:
+      tasklist-backend-changes: ${{ steps.filter.outputs.tasklist-backend-changes }}
+      tasklist-frontend-changes: ${{ steps.filter.outputs.tasklist-frontend-changes }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      # Detect changes against the base branch
+      - name: Detect changes
+        uses: ./.github/actions/paths-filter
+        id: filter
+
+  run-build:
+    name: run-build
+    needs: [detect-changes]
+    uses: ./.github/workflows/tasklist-ci-build-reusable.yml
+    secrets: inherit
+    with:
+      branch: ${{ github.head_ref || github.ref_name }} # head_ref = branch name on PR, ref_name = `main` or `stable/**`
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.tasklist-backend-changes == 'true' || needs.detect-changes.outputs.tasklist-frontend-changes == 'true' }}
+
+  # Does not meet run time requirements for Unified CI
+  run-integration-tests:
+    name: "Integration"
+    needs: [detect-changes]
+    uses: ./.github/workflows/tasklist-ci-test-reusable.yml
+    secrets: inherit
+    permissions: { }
+    with:
+      branch: ${{ github.head_ref || github.ref_name }}
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.tasklist-backend-changes == 'true' }}

--- a/.github/workflows/tasklist-e2e-tests.yml
+++ b/.github/workflows/tasklist-e2e-tests.yml
@@ -1,0 +1,176 @@
+# description: This is a Workflow for running end to end FE tests on Tasklist. Starts an instance of Tasklist and uses that instance to run tests on
+# test location: /tasklist/client/e2e
+# type: CI
+# owner: @camunda/core-features
+---
+name: "[Legacy] Tasklist / E2E Tests"
+on:
+  push:
+    branches:
+      - "main"
+      - "stable/**"
+      - "release**"
+  pull_request:
+
+permissions:
+  contents: read
+
+# Limit workflow to 1 concurrent run per ref (branch): new commit -> old runs are canceled to save costs
+# Exception for main branch: complete builds for every commit needed for confidenence
+concurrency:
+  cancel-in-progress: true
+  group: ${{ format('{0}-{1}', github.workflow, github.ref == 'refs/heads/main' && github.sha || github.ref) }}
+
+jobs:
+  detect-changes:
+    outputs:
+      tasklist-backend-changes: ${{ steps.filter.outputs.tasklist-backend-changes }}
+      tasklist-frontend-changes: ${{ steps.filter.outputs.tasklist-frontend-changes }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      # Detect changes against the base branch
+      - name: Detect changes
+        uses: ./.github/actions/paths-filter
+        id: filter
+
+  test:
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-latest
+    needs: [detect-changes]
+    if: ${{ needs.detect-changes.outputs.tasklist-backend-changes == 'true' || needs.detect-changes.outputs.tasklist-frontend-changes == 'true' }}
+    services:
+      elasticsearch:
+        image: docker.elastic.co/elasticsearch/elasticsearch:8.19.13
+        env:
+          discovery.type: single-node
+          cluster.name: docker-cluster
+          bootstrap.memory_lock: true
+          xpack.security.enabled: false
+          ES_JAVA_OPTS: -Xms1024m -Xmx1024m
+          action.destructive_requires_name: false
+        ports:
+          - 9200:9200
+          - 9300:9300
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@79632e33d6953d190b940ffa440bf97821cabd80
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/github.com/organizations/camunda NEXUS_USR;
+            secret/data/github.com/organizations/camunda NEXUS_PSW;
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Install node dependencies
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+        run: npm ci
+
+      - name: Install frontend dependencies
+        working-directory: ./tasklist/client
+        run: npm ci
+
+      - name: Install Playwright
+        run: npx playwright install --with-deps chromium
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+
+      - name: Build frontend
+        working-directory: ./tasklist/client
+        run: npm run build
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: "adopt"
+          java-version: "21"
+
+      # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
+      - name: "Create settings.xml"
+        uses: s4u/maven-settings-action@v4.0.0
+        with:
+          githubServer: false
+          servers: |
+            [{
+              "id": "camunda-nexus",
+              "username": "${{ steps.secrets.outputs.NEXUS_USR }}",
+              "password": "${{ steps.secrets.outputs.NEXUS_PSW }}"
+            }]
+          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*", "name": "camunda Nexus"}]'
+
+      - name: Build backend
+        # Currently, the e2e environment of tasklist conflicts with the optimize build. For the moment,
+        # we're excluding optimize from the build, not to impact this tasklist's workflow.
+        run: ./mvnw clean install -T1C -DskipChecks -PskipFrontendBuild -DskipTests=true -B -DskipRemoteStaging=true -Dmaven.deploy.skip=true
+
+      - name: Start Tasklist
+        env:
+          SPRING_PROFILES_ACTIVE: e2e-test,dev,tasklist,consolidated-auth,broker
+          ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_CLASSNAME: io.camunda.exporter.CamundaExporter
+          ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_URL: http://localhost:9200
+          ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_BULK_SIZE: 100
+          ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_INDEX_SHOULDWAITFORIMPORTERS: false
+          CAMUNDA_DATA_SECONDARYSTORAGE_ELASTICSEARCH_WAITFORIMPORTERS: false
+          ZEEBE_BROKER_BACKPRESSURE_ENABLED: false
+          CAMUNDA_SECURITY_INITIALIZATION_USERS_0_USERNAME: demo
+          CAMUNDA_SECURITY_INITIALIZATION_USERS_0_PASSWORD: demo
+          CAMUNDA_SECURITY_INITIALIZATION_USERS_0_NAME: Demo
+          CAMUNDA_SECURITY_INITIALIZATION_USERS_0_EMAIL: demo@example.com
+          CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_USERS_0: demo
+          CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI: true
+          CAMUNDA_SECURITY_AUTHORIZATIONS_ENABLED: false
+        run: >
+          ./mvnw -q -B spring-boot:start -pl dist
+          -Dspring-boot.run.main-class=io.camunda.application.StandaloneCamunda
+          -Dspring-boot.run.fork=true
+          -Dspring-boot.run.arguments="--camunda.tasklist.cloud.clusterId=449ac2ad-d3c6-4c73-9c68-7752e39ae616"
+
+      - name: Python setup
+        if: always()
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+
+      - name: Run tests
+        shell: bash
+        env:
+          LOCAL_TEST: "false"
+          CORE_APPLICATION_URL: http://localhost:8080
+          CAMUNDA_AUTH_STRATEGY: "BASIC"
+          CAMUNDA_BASIC_AUTH_USERNAME: "demo"
+          CAMUNDA_BASIC_AUTH_PASSWORD: "demo"
+          ZEEBE_REST_ADDRESS: "http://localhost:8080"
+        run: npm run test -- --project=tasklist-e2e
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: C8 Orchestration Cluster E2E Test Result
+          path: qa/c8-orchestration-cluster-e2e-test-suite/html-report
+          retention-days: 30
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          job_name: "test/tasklist-v2-api-e2e-tests"
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -54,9 +54,18 @@
 ###################
 
 # CI Files
+/.github/workflows/operate-ci-build-reusable.yml          @camunda/core-features
+/.github/workflows/operate-ci.yml                         @camunda/core-features
+/.github/workflows/operate-ci-test-reusable.yml           @camunda/core-features
+/.github/workflows/operate-docker-tests.yml           @camunda/core-features
+/.github/workflows/operate-e2e-tests.yml                  @camunda/core-features
 /.github/workflows/operate-playwright.yml                 @camunda/core-features
 /.github/workflows/ci-operate.yml                         @camunda/core-features
 /.github/workflows/ci-tasklist.yml                        @camunda/core-features
+/.github/workflows/tasklist-ci-build-reusable.yml          @camunda/core-features
+/.github/workflows/tasklist-ci-test-reusable.yml          @camunda/core-features
+/.github/workflows/tasklist-ci.yml                        @camunda/core-features
+/.github/workflows/tasklist-e2e-tests.yml                 @camunda/core-features
 /.github/workflows/ci-optimize.yml                        @camunda/core-features
 /.github/workflows/optimize-check-c4.yml                  @camunda/core-features
 /.github/workflows/optimize-e2e-test-cloud.yml            @camunda/core-features


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Restores the legacy Operate and Tasklist CI workflows that trigger existing integration tests for these Camunda webapps.

ℹ️ The Tasklist e2e workflow is modified to run only in `V2` mode.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #49674
