### PR TITLE
feat: Archive Documents by ID

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/DocumentBasedHistory.java
+++ b/configuration/src/main/java/io/camunda/configuration/DocumentBasedHistory.java
@@ -20,6 +20,7 @@ public class DocumentBasedHistory {
   private static final boolean DEFAULT_HISTORY_PROCESS_INSTANCE_ENABLED = true;
   private static final ProcessInstanceRetentionMode
       DEFAULT_HISTORY_PROCESS_INSTANCE_RETENTION_MODE = ProcessInstanceRetentionMode.PI_HIERARCHY;
+  private static final boolean DEFAULT_HISTORY_ARCHIVE_BY_ID_ENABLED = false;
   private static final String DEFAULT_HISTORY_POLICY_NAME = "camunda-retention-policy";
   private static final String DEFAULT_HISTORY_ELS_ROLLOVER_DATE_FORMAT = "date";
   private static final String DEFAULT_HISTORY_ROLLOVER_INTERVAL = "1d";
@@ -49,6 +50,8 @@ public class DocumentBasedHistory {
 
   private ProcessInstanceRetentionMode processInstanceRetentionMode =
       DEFAULT_HISTORY_PROCESS_INSTANCE_RETENTION_MODE;
+
+  private boolean archiveByIdEnabled = DEFAULT_HISTORY_ARCHIVE_BY_ID_ENABLED;
 
   /** Date format for historical indices in Java DateTimeFormatter syntax */
   private String elsRolloverDateFormat = DEFAULT_HISTORY_ELS_ROLLOVER_DATE_FORMAT;
@@ -103,6 +106,14 @@ public class DocumentBasedHistory {
   public void setProcessInstanceRetentionMode(
       final ProcessInstanceRetentionMode processInstanceRetentionMode) {
     this.processInstanceRetentionMode = processInstanceRetentionMode;
+  }
+
+  public boolean isArchiveByIdEnabled() {
+    return archiveByIdEnabled;
+  }
+
+  public void setArchiveByIdEnabled(final boolean archiveByIdEnabled) {
+    this.archiveByIdEnabled = archiveByIdEnabled;
   }
 
   public String getPrefix() {

--- a/configuration/src/main/java/io/camunda/configuration/DocumentBasedHistory.java
+++ b/configuration/src/main/java/io/camunda/configuration/DocumentBasedHistory.java
@@ -25,6 +25,7 @@ public class DocumentBasedHistory {
   private static final String DEFAULT_HISTORY_ELS_ROLLOVER_DATE_FORMAT = "date";
   private static final String DEFAULT_HISTORY_ROLLOVER_INTERVAL = "1d";
   private static final int DEFAULT_HISTORY_ROLLOVER_BATCH_SIZE = 100;
+  private static final int DEFAULT_HISTORY_REINDEX_BATCH_SIZE = 1000;
   private static final String DEFAULT_HISTORY_WAIT_PERIOD_BEFORE_ARCHIVING = "1h";
   private static final Map<String, String> LEGACY_BROKER_PROPERTIES =
       Map.of(
@@ -61,6 +62,9 @@ public class DocumentBasedHistory {
 
   /** Maximum number of process instances per archiving batch */
   private int rolloverBatchSize = DEFAULT_HISTORY_ROLLOVER_BATCH_SIZE;
+
+  /** Maximum number of docs reindexed/deleted in a batch */
+  private int reindexBatchSize = DEFAULT_HISTORY_REINDEX_BATCH_SIZE;
 
   /**
    * Grace period before archiving completed processes. Processes finished within this window are
@@ -157,6 +161,14 @@ public class DocumentBasedHistory {
 
   public void setRolloverBatchSize(final int rolloverBatchSize) {
     this.rolloverBatchSize = rolloverBatchSize;
+  }
+
+  public int getReindexBatchSize() {
+    return reindexBatchSize;
+  }
+
+  public void setReindexBatchSize(final int reindexBatchSize) {
+    this.reindexBatchSize = reindexBatchSize;
   }
 
   public String getWaitPeriodBeforeArchiving() {

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/CamundaExporterConfigurationApplier.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/CamundaExporterConfigurationApplier.java
@@ -156,6 +156,7 @@ public final class CamundaExporterConfigurationApplier {
     target.setElsRolloverDateFormat(source.getHistory().getElsRolloverDateFormat());
     target.setRolloverInterval(source.getHistory().getRolloverInterval());
     target.setRolloverBatchSize(source.getHistory().getRolloverBatchSize());
+    target.setReindexBatchSize(source.getHistory().getReindexBatchSize());
     target.setWaitPeriodBeforeArchiving(source.getHistory().getWaitPeriodBeforeArchiving());
     target.setDelayBetweenRuns(
         Math.toIntExact(source.getHistory().getDelayBetweenRuns().toMillis()));

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/CamundaExporterConfigurationApplier.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/CamundaExporterConfigurationApplier.java
@@ -151,6 +151,7 @@ public final class CamundaExporterConfigurationApplier {
     final HistoryConfiguration target = exporterConfiguration.getHistory();
     target.setProcessInstanceEnabled(source.getHistory().isProcessInstanceEnabled());
     target.setProcessInstanceRetentionMode(source.getHistory().getProcessInstanceRetentionMode());
+    target.setArchiveByIdEnabled(source.getHistory().isArchiveByIdEnabled());
     target.getRetention().setPolicyName(source.getHistory().getPolicyName());
     target.setElsRolloverDateFormat(source.getHistory().getElsRolloverDateFormat());
     target.setRolloverInterval(source.getHistory().getRolloverInterval());

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -240,6 +240,7 @@ public class ExporterConfiguration {
     private String rolloverInterval = "1d";
     private String usageMetricsRolloverInterval = "1M";
     private int rolloverBatchSize = 100;
+    private int reindexBatchSize = 1000;
     private String waitPeriodBeforeArchiving = "1h";
     private int delayBetweenRuns = 2000;
     private int maxDelayBetweenRuns = 60000;
@@ -296,6 +297,14 @@ public class ExporterConfiguration {
 
     public void setRolloverBatchSize(final int rolloverBatchSize) {
       this.rolloverBatchSize = rolloverBatchSize;
+    }
+
+    public int getReindexBatchSize() {
+      return reindexBatchSize;
+    }
+
+    public void setReindexBatchSize(final int reindexBatchSize) {
+      this.reindexBatchSize = reindexBatchSize;
     }
 
     public RetentionConfiguration getRetention() {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -235,6 +235,7 @@ public class ExporterConfiguration {
     private boolean processInstanceEnabled = true;
     private ProcessInstanceRetentionMode processInstanceRetentionMode =
         ProcessInstanceRetentionMode.PI_HIERARCHY;
+    private boolean archiveByIdEnabled = false;
     private String elsRolloverDateFormat = "date";
     private String rolloverInterval = "1d";
     private String usageMetricsRolloverInterval = "1M";
@@ -251,6 +252,14 @@ public class ExporterConfiguration {
 
     public void setProcessInstanceEnabled(final boolean processInstanceEnabled) {
       this.processInstanceEnabled = processInstanceEnabled;
+    }
+
+    public boolean isArchiveByIdEnabled() {
+      return archiveByIdEnabled;
+    }
+
+    public void setArchiveByIdEnabled(final boolean archiveByIdEnabled) {
+      this.archiveByIdEnabled = archiveByIdEnabled;
     }
 
     public String getElsRolloverDateFormat() {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
@@ -21,6 +21,8 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.InstantSource;
 import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -96,6 +98,7 @@ public class CamundaExporterMetrics implements AutoCloseable {
   private final Counter auditLogsArchived;
 
   private final Timer archiverSearchTimer;
+  private final Timer archiverDocIdsBatchSearchTimer;
   private final Timer archiverDeleteTimer;
   private final Counter archiverDeletedDocs;
   private final Counter archiverReindexedDocs;
@@ -108,6 +111,9 @@ public class CamundaExporterMetrics implements AutoCloseable {
   private final Timer flushDuration;
   private final Counter failedFlush;
   private final Timer recordExportDuration;
+
+  private final Map<String, Timer> timersBySource = new ConcurrentHashMap<>();
+  private final Map<String, Counter> docCountersBySource = new ConcurrentHashMap<>();
 
   private final AtomicReference<Instant> lastFlushTime = new AtomicReference<>(Instant.now());
   private final AtomicInteger processInstancesAwaitingArchival = new AtomicInteger(0);
@@ -205,6 +211,13 @@ public class CamundaExporterMetrics implements AutoCloseable {
             .description(
                 "Duration of how long it takes to run the search request to resolve completed entities, that need to be archived.")
             .tags("type", "search")
+            .publishPercentileHistogram()
+            .register(meterRegistry);
+    archiverDocIdsBatchSearchTimer =
+        Timer.builder(meterName("archiver.request.duration"))
+            .description(
+                "Duration of how long it takes to run the search request to resolve the IDs of documents, that need to be archived.")
+            .tags("type", "search-docid-batch")
             .publishPercentileHistogram()
             .register(meterRegistry);
     archiverDeleteTimer =
@@ -318,6 +331,10 @@ public class CamundaExporterMetrics implements AutoCloseable {
 
   public void measureArchiverSearch(final Timer.Sample sample) {
     sample.stop(archiverSearchTimer);
+  }
+
+  public void measureArchiveDocIdsSearchDuration(final Timer.Sample sample) {
+    sample.stop(archiverDocIdsBatchSearchTimer);
   }
 
   public void recordBulkSize(final int bulkSize) {
@@ -470,6 +487,42 @@ public class CamundaExporterMetrics implements AutoCloseable {
     timer.stop(archivingDuration);
   }
 
+  public void measureArchiveIndexDuration(
+      final String sourceIndex, final Sample sample, final Long count) {
+    // NOTE: We intentionally use get() + putIfAbsent() instead of compute() here.
+    // Using compute() could cause a deadlock because ConcurrentHashMap holds a bucket lock
+    // while executing the remapping function, and register() acquires internal locks in the
+    // CompositeMeterRegistry. See https://github.com/camunda/camunda/issues/33941
+    Timer timer = timersBySource.get(sourceIndex);
+    if (timer == null) {
+      timer =
+          Timer.builder(meterName("archiver.index.duration"))
+              .description("Duration of how long it takes to archive docs from " + sourceIndex)
+              .tag("source", sourceIndex)
+              .publishPercentileHistogram()
+              .register(meterRegistry);
+      final Timer existing = timersBySource.putIfAbsent(sourceIndex, timer);
+      if (existing != null) {
+        timer = existing;
+      }
+    }
+    sample.stop(timer);
+
+    Counter counter = docCountersBySource.get(sourceIndex);
+    if (counter == null) {
+      counter =
+          Counter.builder(meterName("archiver.index.docs"))
+              .tag("source", sourceIndex)
+              .description("Count of how many " + sourceIndex + " documents archived.")
+              .register(meterRegistry);
+      final Counter existing = docCountersBySource.putIfAbsent(sourceIndex, counter);
+      if (existing != null) {
+        counter = existing;
+      }
+    }
+    counter.increment(count == null ? 0 : count);
+  }
+
   @Override
   public void close() {
     // clean up all registered meters
@@ -480,6 +533,7 @@ public class CamundaExporterMetrics implements AutoCloseable {
     meterRegistry.remove(batchOperationsArchived);
     meterRegistry.remove(batchOperationsArchiving);
     meterRegistry.remove(archiverSearchTimer);
+    meterRegistry.remove(archiverDocIdsBatchSearchTimer);
     meterRegistry.remove(archiverDeleteTimer);
     meterRegistry.remove(archiverDeletedDocs);
     meterRegistry.remove(archiverReindexTimer);
@@ -506,6 +560,9 @@ public class CamundaExporterMetrics implements AutoCloseable {
     meterRegistry.remove(auditLogsArchived);
 
     meterRegistry.find(FLUSH_FAILURE_TYPE_METER_NAME).meters().forEach(meterRegistry::remove);
+
+    timersBySource.values().forEach(meterRegistry::remove);
+    docCountersBySource.values().forEach(meterRegistry::remove);
 
     // Remove custom gauges by their names if needed
     removeGaugeIfExists(SINCE_LAST_FLUSH_SECONDS_METER_NAME);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/CamundaBackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/CamundaBackgroundTaskManagerFactory.java
@@ -28,6 +28,7 @@ import io.camunda.exporter.tasks.archiver.JobBatchMetricsArchiverJob;
 import io.camunda.exporter.tasks.archiver.OpenSearchArchiverRepository;
 import io.camunda.exporter.tasks.archiver.OpensearchAuditLogArchiverRepository;
 import io.camunda.exporter.tasks.archiver.ProcessInstanceArchiverJob;
+import io.camunda.exporter.tasks.archiver.ProcessInstanceByIdArchiverJob;
 import io.camunda.exporter.tasks.archiver.ProcessInstanceToBeArchivedCountJob;
 import io.camunda.exporter.tasks.archiver.StandaloneDecisionArchiverJob;
 import io.camunda.exporter.tasks.archiver.UsageMetricArchiverJob;
@@ -403,15 +404,30 @@ public final class CamundaBackgroundTaskManagerFactory {
         .map(ProcessInstanceDependant.class::cast)
         .forEach(dependantTemplates::add);
 
-    return buildReschedulingArchiverTask(
-        new ProcessInstanceArchiverJob(
-            config.getHistory(),
-            archiverRepository,
-            resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class),
-            dependantTemplates,
-            metrics,
-            logger,
-            executor));
+    final ProcessInstanceArchiverJob piArchiverJob;
+
+    if (config.getHistory().isArchiveByIdEnabled()) {
+      piArchiverJob =
+          new ProcessInstanceByIdArchiverJob(
+              config.getHistory(),
+              archiverRepository,
+              resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class),
+              dependantTemplates,
+              metrics,
+              logger,
+              executor);
+    } else {
+      piArchiverJob =
+          new ProcessInstanceArchiverJob(
+              config.getHistory(),
+              archiverRepository,
+              resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class),
+              dependantTemplates,
+              metrics,
+              logger,
+              executor);
+    }
+    return buildReschedulingArchiverTask(piArchiverJob);
   }
 
   private ReschedulingTask buildBatchOperationArchiverJob() {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveByIDTaskSupplier.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveByIDTaskSupplier.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.archiver;
+
+import com.google.common.base.Stopwatch;
+import io.camunda.zeebe.util.function.TriFunction;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+public class ArchiveByIDTaskSupplier<SortFieldType> {
+  private final String sourceIdx;
+  private final String destinationIdx;
+  private final Function<List<SortFieldType>, CompletableFuture<ArchiveDocIdsBatch<SortFieldType>>>
+      idsSupplier;
+  private final TriFunction<String, String, List<String>, CompletableFuture<Long>> reindexer;
+  private final BiFunction<String, List<String>, CompletableFuture<Long>> deleter;
+  private final Executor executor;
+
+  private final AtomicReference<ArchiveDocIdsBatch<SortFieldType>> lastSearchResponse =
+      new AtomicReference<>(null);
+  private final AtomicBoolean finished = new AtomicBoolean(false);
+
+  private final AtomicLong totalArchived = new AtomicLong(0);
+  private final AtomicLong totalTimeTakenMs = new AtomicLong(0);
+
+  public ArchiveByIDTaskSupplier(
+      final String sourceIdx,
+      final String destinationIdx,
+      final Function<List<SortFieldType>, CompletableFuture<ArchiveDocIdsBatch<SortFieldType>>>
+          idsSupplier,
+      final TriFunction<String, String, List<String>, CompletableFuture<Long>> reindexer,
+      final BiFunction<String, List<String>, CompletableFuture<Long>> deleter,
+      final Executor executor) {
+    this.sourceIdx = sourceIdx;
+    this.destinationIdx = destinationIdx;
+    this.idsSupplier = idsSupplier;
+    this.reindexer = reindexer;
+    this.deleter = deleter;
+    this.executor = executor;
+  }
+
+  public boolean isComplete() {
+    return finished.get();
+  }
+
+  public long getTotalArchived() {
+    return totalArchived.get();
+  }
+
+  public long getTotalTimeTakenMs() {
+    return totalTimeTakenMs.get();
+  }
+
+  public CompletableFuture<Long> getNextBatch() {
+    final Stopwatch stopwatch = Stopwatch.createStarted();
+    return idsSupplier
+        .apply(getLastSearchPosition())
+        .thenComposeAsync(
+            response -> {
+              // we can set this in another stage (like after reindex/delete if we want retries)
+              lastSearchResponse.set(response);
+
+              if (response.isEmpty()) {
+                finished.set(true);
+                return CompletableFuture.completedFuture(0L);
+              }
+
+              return reindexer
+                  .apply(sourceIdx, destinationIdx, response.ids())
+                  .thenCompose(count -> deleter.apply(sourceIdx, response.ids()))
+                  .thenApply(
+                      count -> {
+                        totalArchived.accumulateAndGet(count, Long::sum);
+                        return count;
+                      });
+            },
+            executor)
+        .whenCompleteAsync(
+            (val, err) ->
+                totalTimeTakenMs.accumulateAndGet(
+                    stopwatch.stop().elapsed(TimeUnit.MILLISECONDS), Long::sum),
+            executor);
+  }
+
+  private List<SortFieldType> getLastSearchPosition() {
+    final ArchiveDocIdsBatch<SortFieldType> lstResponse = lastSearchResponse.get();
+    return lstResponse == null ? List.of() : lstResponse.searchAfter();
+  }
+
+  public record ArchiveDocIdsBatch<T>(List<String> ids, List<T> searchAfter) {
+    static <T> ArchiveDocIdsBatch<T> empty() {
+      return new ArchiveDocIdsBatch<>(List.of(), List.of());
+    }
+
+    static <T> ArchiveDocIdsBatch<T> from(final List<String> ids, final List<T> searchAfter) {
+      return new ArchiveDocIdsBatch<>(ids, searchAfter);
+    }
+
+    public boolean isEmpty() {
+      return ids.isEmpty();
+    }
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverRepository.java
@@ -83,6 +83,17 @@ public interface ArchiverRepository extends AutoCloseable {
         .thenComposeAsync(ok -> deleteDocuments(sourceIndexName, keysByField, filters), executor);
   }
 
+  default CompletableFuture<Void> moveDocumentsById(
+      final String sourceIndexName,
+      final String destinationIndexName,
+      final Map<String, List<String>> keysByField,
+      final Map<String, String> filters,
+      final Executor executor) {
+    return reindexDocuments(sourceIndexName, destinationIndexName, keysByField, filters)
+        .thenComposeAsync(ok -> setIndexLifeCycle(destinationIndexName), executor)
+        .thenComposeAsync(ok -> deleteDocuments(sourceIndexName, keysByField, filters), executor);
+  }
+
   CompletableFuture<Integer> getCountOfProcessInstancesAwaitingArchival();
 
   default String getRetentionPolicyName(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/AsyncRepeatUntil.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/AsyncRepeatUntil.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.archiver;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+// Use to repeatedly call an async task until a condition is met.
+// NB avoiding using closures for this as with all the callbacks it can
+// easily lead to memory leaks if not used carefully. By using an explicit class
+// we can ensure that the state is properly cleaned up after completion.
+final class AsyncRepeatUntil<T> {
+  private final CompletableFuture<Void> finalFuture = new CompletableFuture<>();
+  private final Supplier<CompletableFuture<T>> asyncTask;
+  private final Predicate<T> until;
+
+  private AsyncRepeatUntil(
+      final Supplier<CompletableFuture<T>> asyncTask, final Predicate<T> until) {
+    this.asyncTask = asyncTask;
+    this.until = until;
+  }
+
+  private void next() {
+    try {
+      asyncTask.get().thenAccept(this::completeOrNext).exceptionally(this::completeExceptionally);
+    } catch (final Throwable err) {
+      completeExceptionally(err);
+    }
+  }
+
+  private void completeOrNext(final T result) {
+    try {
+      if (until.test(result)) {
+        finalFuture.complete(null);
+      } else {
+        next();
+      }
+    } catch (final Throwable err) {
+      completeExceptionally(err);
+    }
+  }
+
+  private Void completeExceptionally(final Throwable err) {
+    finalFuture.completeExceptionally(err);
+    return null;
+  }
+
+  static <T> CompletableFuture<Void> repeatUntil(
+      final Supplier<CompletableFuture<T>> asyncTask, final Predicate<T> until) {
+    final var repeat = new AsyncRepeatUntil<>(asyncTask, until);
+
+    repeat.next();
+
+    return repeat.finalFuture;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -14,17 +14,22 @@ import co.elastic.clients.elasticsearch._types.Conflicts;
 import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.Slices;
 import co.elastic.clients.elasticsearch._types.SlicesCalculation;
+import co.elastic.clients.elasticsearch._types.SortOptions;
 import co.elastic.clients.elasticsearch._types.SortOrder;
 import co.elastic.clients.elasticsearch._types.Time;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders;
 import co.elastic.clients.elasticsearch._types.query_dsl.TermsQuery;
+import co.elastic.clients.elasticsearch.core.BulkRequest;
 import co.elastic.clients.elasticsearch.core.CountRequest;
 import co.elastic.clients.elasticsearch.core.DeleteByQueryRequest;
 import co.elastic.clients.elasticsearch.core.DeleteByQueryResponse;
 import co.elastic.clients.elasticsearch.core.ReindexRequest;
+import co.elastic.clients.elasticsearch.core.ReindexResponse;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchRequest.Builder;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import co.elastic.clients.elasticsearch.indices.PutIndicesSettingsRequest;
 import co.elastic.clients.elasticsearch.indices.PutIndicesSettingsResponse;
@@ -37,6 +42,7 @@ import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration.Pro
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.ProcessInstanceArchiveBatch;
+import io.camunda.exporter.tasks.archiver.ArchiveByIDTaskSupplier.ArchiveDocIdsBatch;
 import io.camunda.exporter.tasks.util.DateOfArchivedDocumentsUtil;
 import io.camunda.exporter.tasks.util.ElasticsearchRepository;
 import io.camunda.search.schema.config.RetentionConfiguration;
@@ -340,6 +346,56 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
   }
 
   @Override
+  public CompletableFuture<Void> moveDocumentsById(
+      final String sourceIndexName,
+      final String destinationIndexName,
+      final Map<String, List<String>> keysByField,
+      final Map<String, String> filters,
+      final Executor executor) {
+
+    final ArchiveByIDTaskSupplier<FieldValue> taskSupplier =
+        new ArchiveByIDTaskSupplier<>(
+            sourceIndexName,
+            destinationIndexName,
+            searchAfter ->
+                getArchiveDocIdsBatch(sourceIndexName, keysByField, filters, searchAfter),
+            this::reindexDocumentsById,
+            this::deleteDocumentsById,
+            executor);
+
+    final var timer = Timer.start();
+    return AsyncRepeatUntil.repeatUntil(
+            taskSupplier::getNextBatch, count -> taskSupplier.isComplete())
+        .thenComposeAsync(docIds -> setIndexLifeCycle(destinationIndexName), executor)
+        .thenApply(
+            ignored -> {
+              logger.debug(
+                  "Successfully completed archiving {} to the {} index, moved {} docs in {}s",
+                  sourceIndexName,
+                  destinationIndexName,
+                  taskSupplier.getTotalArchived(),
+                  taskSupplier.getTotalTimeTakenMs() / 1000);
+
+              metrics.measureArchiveIndexDuration(
+                  sourceIndexName, timer, taskSupplier.getTotalArchived());
+              return ignored;
+            })
+        .whenComplete(
+            (val, err) -> {
+              if (err != null) {
+                logger.error(
+                    "Failed archiving {} to the {} index, moved {} docs so far in {}s, error={}",
+                    sourceIndexName,
+                    destinationIndexName,
+                    taskSupplier.getTotalArchived(),
+                    taskSupplier.getTotalTimeTakenMs() / 1000,
+                    err.getMessage(),
+                    err);
+              }
+            });
+  }
+
+  @Override
   public CompletableFuture<Integer> getCountOfProcessInstancesAwaitingArchival() {
     final var countRequest =
         CountRequest.of(
@@ -350,6 +406,86 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
                             config.getArchivingTimePoint(), partitionId)));
 
     return client.count(countRequest).thenApplyAsync(res -> Math.toIntExact(res.count()));
+  }
+
+  private CompletableFuture<ArchiveDocIdsBatch<FieldValue>> getArchiveDocIdsBatch(
+      final String sourceIndexName,
+      final Map<String, List<String>> keysByField,
+      final Map<String, String> filters,
+      final List<FieldValue> searchAfter) {
+    final Query query = buildFilterQuery(keysByField, filters);
+    final Builder requestBuilder =
+        new SearchRequest.Builder()
+            .index(sourceIndexName)
+            .query(query)
+            .size(config.getReindexBatchSize())
+            .source(s -> s.fetch(false))
+            .sort(SortOptions.of(s -> s.field(f -> f.field("id").order(SortOrder.Asc))));
+
+    if (searchAfter != null && !searchAfter.isEmpty()) {
+      requestBuilder.searchAfter(searchAfter);
+    }
+
+    final var timer = Timer.start();
+    return client
+        .search(requestBuilder.build())
+        .whenCompleteAsync(
+            (response, error) -> metrics.measureArchiveDocIdsSearchDuration(timer), executor)
+        .thenApply(
+            response -> {
+              final List<Hit<Void>> hits = response.hits().hits();
+              if (hits.isEmpty()) {
+                return ArchiveDocIdsBatch.empty();
+              }
+              return ArchiveDocIdsBatch.from(
+                  hits.stream().map(Hit::id).toList(), hits.getLast().sort());
+            });
+  }
+
+  private CompletableFuture<Long> reindexDocumentsById(
+      final String sourceIndexName, final String destinationIndexName, final List<String> docIds) {
+    if (docIds.isEmpty()) {
+      return CompletableFuture.completedFuture(0L);
+    }
+
+    final var query = QueryBuilders.bool(q -> q.filter(b -> b.ids(id -> id.values(docIds))));
+    final var request =
+        new ReindexRequest.Builder()
+            .source(src -> src.index(sourceIndexName).query(query))
+            .dest(dest -> dest.index(destinationIndexName))
+            .conflicts(Conflicts.Proceed)
+            .scroll(REINDEX_SCROLL_TIMEOUT)
+            .slices(AUTO_SLICES)
+            .build();
+
+    final var timer = Timer.start();
+    return client
+        .reindex(request)
+        .thenApplyAsync(ReindexResponse::total)
+        .whenCompleteAsync(
+            (total, error) -> metrics.measureArchiverReindex(total, timer), executor);
+  }
+
+  private CompletableFuture<Long> deleteDocumentsById(
+      final String sourceIndexName, final List<String> docIds) {
+    if (docIds.isEmpty()) {
+      return CompletableFuture.completedFuture(0L);
+    }
+
+    final var operations =
+        docIds.stream()
+            .map(docId -> new BulkOperation.Builder().delete(d -> d.id(docId)).build())
+            .toList();
+
+    final var request =
+        new BulkRequest.Builder().index(sourceIndexName).operations(operations).build();
+
+    final var timer = Timer.start();
+    return client
+        .bulk(request)
+        .thenApplyAsync(response -> (long) response.items().size())
+        .whenCompleteAsync(
+            (idsSize, error) -> metrics.measureArchiverDelete(idsSize, timer), executor);
   }
 
   private Query finishedProcessInstancesQuery(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -19,6 +19,7 @@ import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration.Pro
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.ProcessInstanceArchiveBatch;
+import io.camunda.exporter.tasks.archiver.ArchiveByIDTaskSupplier.ArchiveDocIdsBatch;
 import io.camunda.exporter.tasks.util.DateOfArchivedDocumentsUtil;
 import io.camunda.exporter.tasks.util.OpensearchRepository;
 import io.camunda.search.schema.config.RetentionConfiguration;
@@ -52,12 +53,16 @@ import org.opensearch.client.opensearch._types.Time;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch._types.query_dsl.QueryBuilders;
 import org.opensearch.client.opensearch._types.query_dsl.TermsQuery;
+import org.opensearch.client.opensearch.core.BulkRequest;
 import org.opensearch.client.opensearch.core.CountRequest;
 import org.opensearch.client.opensearch.core.DeleteByQueryRequest;
 import org.opensearch.client.opensearch.core.DeleteByQueryResponse;
 import org.opensearch.client.opensearch.core.ReindexRequest;
+import org.opensearch.client.opensearch.core.ReindexResponse;
 import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.SearchRequest.Builder;
 import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.bulk.BulkOperation;
 import org.opensearch.client.opensearch.core.search.Hit;
 import org.opensearch.client.opensearch.generic.OpenSearchGenericClient;
 import org.opensearch.client.opensearch.generic.Requests;
@@ -352,6 +357,56 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
   }
 
   @Override
+  public CompletableFuture<Void> moveDocumentsById(
+      final String sourceIndexName,
+      final String destinationIndexName,
+      final Map<String, List<String>> keysByField,
+      final Map<String, String> filters,
+      final Executor executor) {
+
+    final ArchiveByIDTaskSupplier<FieldValue> taskSupplier =
+        new ArchiveByIDTaskSupplier<>(
+            sourceIndexName,
+            destinationIndexName,
+            searchAfter ->
+                getArchiveDocIdsBatch(sourceIndexName, keysByField, filters, searchAfter),
+            this::reindexDocumentsById,
+            this::deleteDocumentsById,
+            executor);
+
+    final var timer = Timer.start();
+    return AsyncRepeatUntil.repeatUntil(
+            taskSupplier::getNextBatch, count -> taskSupplier.isComplete())
+        .thenComposeAsync(docIds -> setIndexLifeCycle(destinationIndexName), executor)
+        .thenApply(
+            ignored -> {
+              logger.debug(
+                  "Successfully completed archiving {} to the {} index, moved {} docs in {}s",
+                  sourceIndexName,
+                  destinationIndexName,
+                  taskSupplier.getTotalArchived(),
+                  taskSupplier.getTotalTimeTakenMs() / 1000);
+
+              metrics.measureArchiveIndexDuration(
+                  sourceIndexName, timer, taskSupplier.getTotalArchived());
+              return ignored;
+            })
+        .whenComplete(
+            (val, err) -> {
+              if (err != null) {
+                logger.error(
+                    "Failed archiving {} to the {} index, moved {} docs so far in {}s, error={}",
+                    sourceIndexName,
+                    destinationIndexName,
+                    taskSupplier.getTotalArchived(),
+                    taskSupplier.getTotalTimeTakenMs() / 1000,
+                    err.getMessage(),
+                    err);
+              }
+            });
+  }
+
+  @Override
   public CompletableFuture<Integer> getCountOfProcessInstancesAwaitingArchival() {
     final var countRequest =
         CountRequest.of(
@@ -366,6 +421,81 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
     } catch (final IOException e) {
       return CompletableFuture.failedFuture(e);
     }
+  }
+
+  public CompletableFuture<ArchiveDocIdsBatch<FieldValue>> getArchiveDocIdsBatch(
+      final String sourceIndexName,
+      final Map<String, List<String>> keysByField,
+      final Map<String, String> filters,
+      final List<FieldValue> searchAfter) {
+    final Query query = buildFilterQuery(keysByField, filters);
+    final Builder requestBuilder =
+        new Builder()
+            .index(sourceIndexName)
+            .query(query)
+            .size(config.getReindexBatchSize())
+            .source(s -> s.fetch(false))
+            .sort(sort -> sort.field(field -> field.field("id").order(SortOrder.Asc)));
+
+    if (searchAfter != null && !searchAfter.isEmpty()) {
+      requestBuilder.searchAfter(searchAfter);
+    }
+
+    final var timer = Timer.start();
+    return sendRequestAsync(() -> client.search(requestBuilder.build(), Object.class))
+        .whenCompleteAsync(
+            (response, error) -> metrics.measureArchiveDocIdsSearchDuration(timer), executor)
+        .thenApply(
+            response -> {
+              final List<Hit<Object>> hits = response.hits().hits();
+              if (hits.isEmpty()) {
+                return ArchiveDocIdsBatch.empty();
+              }
+              return ArchiveDocIdsBatch.from(
+                  hits.stream().map(Hit::id).toList(), hits.getLast().sort());
+            });
+  }
+
+  private CompletableFuture<Long> reindexDocumentsById(
+      final String sourceIndexName, final String destinationIndexName, final List<String> docIds) {
+    if (docIds.isEmpty()) {
+      return CompletableFuture.completedFuture(0L);
+    }
+
+    final var query = QueryBuilders.bool().filter(b -> b.ids(id -> id.values(docIds))).build();
+    final var request =
+        new ReindexRequest.Builder()
+            .source(src -> src.index(sourceIndexName).query(query.toQuery()))
+            .dest(dest -> dest.index(destinationIndexName))
+            .conflicts(Conflicts.Proceed)
+            .scroll(REINDEX_SCROLL_TIMEOUT)
+            .slices(AUTO_SLICES)
+            .build();
+
+    final var timer = Timer.start();
+    return sendRequestAsync(() -> client.reindex(request))
+        .thenApplyAsync(ReindexResponse::total)
+        .whenCompleteAsync(
+            (total, error) -> metrics.measureArchiverReindex(total, timer), executor);
+  }
+
+  private CompletableFuture<Long> deleteDocumentsById(
+      final String sourceIndexName, final List<String> docIds) {
+    if (docIds.isEmpty()) {
+      return CompletableFuture.completedFuture(0L);
+    }
+
+    final var operations =
+        docIds.stream().map(docId -> BulkOperation.of(b -> b.delete(d -> d.id(docId)))).toList();
+
+    final BulkRequest request =
+        BulkRequest.of(b -> b.index(sourceIndexName).operations(operations));
+
+    final var timer = Timer.start();
+    return sendRequestAsync(() -> client.bulk(request))
+        .thenApplyAsync(response -> (long) response.items().size())
+        .whenCompleteAsync(
+            (idsSize, error) -> metrics.measureArchiverDelete(idsSize, timer), executor);
   }
 
   private SearchRequest createUsageMetricSearchRequest(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJob.java
@@ -99,7 +99,7 @@ public class ProcessInstanceArchiverJob extends ArchiverJob<ProcessInstanceArchi
   protected CompletableFuture<Integer> archive(
       final IndexTemplateDescriptor templateDescriptor, final ProcessInstanceArchiveBatch batch) {
     return archiveProcessDependants(batch)
-        .thenComposeAsync(v -> super.archive(templateDescriptor, batch), getExecutor())
+        .thenComposeAsync(v -> archive(templateDescriptor, batch, Map.of()), getExecutor())
         .thenApply(
             archived -> {
               recentlyArchivedProcessInstances.markRecentlyArchived(batch);
@@ -152,7 +152,7 @@ public class ProcessInstanceArchiverJob extends ArchiverJob<ProcessInstanceArchi
     final var futures = new ArrayList<CompletableFuture<?>>();
 
     for (final var dependant : processInstanceDependants) {
-      futures.add(super.archive(dependant, batch));
+      futures.add(archive(dependant, batch, Map.of()));
     }
 
     return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new));

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceByIdArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceByIdArchiverJob.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.archiver;
+
+import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
+import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.tasks.archiver.ArchiveBatch.ProcessInstanceArchiveBatch;
+import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
+import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
+import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import org.slf4j.Logger;
+
+/**
+ * This is an experimental archiver job for handling process instance data where we reindex
+ * documents by id. Similar to the {@link ProcessInstanceArchiverJob} this job handles the archiving
+ * of the process instance records itself and also delegates to the repository to move dependent
+ * records (decisions, flow node instances, variable updates, etc).
+ */
+public class ProcessInstanceByIdArchiverJob extends ProcessInstanceArchiverJob {
+
+  public ProcessInstanceByIdArchiverJob(
+      final HistoryConfiguration config,
+      final ArchiverRepository repository,
+      final ListViewTemplate processInstanceTemplate,
+      final List<ProcessInstanceDependant> processInstanceDependants,
+      final CamundaExporterMetrics metrics,
+      final Logger logger,
+      final Executor executor) {
+    super(
+        config,
+        repository,
+        processInstanceTemplate,
+        processInstanceDependants,
+        metrics,
+        logger,
+        executor);
+  }
+
+  @Override
+  String getJobName() {
+    return "process-instance-by-id";
+  }
+
+  @Override
+  protected CompletableFuture<Integer> archive(
+      final IndexTemplateDescriptor templateDescriptor,
+      final ProcessInstanceArchiveBatch batch,
+      final Map<String, String> filters) {
+    final var sourceIdxName = templateDescriptor.getFullQualifiedName();
+    final var idsMap = createIdsByFieldMap(templateDescriptor, batch);
+    final var finishDate = batch.finishDate();
+    return getArchiverRepository()
+        .moveDocumentsById(
+            sourceIdxName, sourceIdxName + finishDate, idsMap, filters, getExecutor())
+        .thenApplyAsync(ok -> batch.size(), getExecutor());
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AsyncRepeatUntilTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AsyncRepeatUntilTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.archiver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+
+class AsyncRepeatUntilTest {
+
+  @Test
+  void shouldCompleteWhenTaskCompletes() {
+    // given
+    // when
+    final var future =
+        AsyncRepeatUntil.repeatUntil(() -> CompletableFuture.completedFuture(1), result -> true);
+
+    // then
+    assertThat(future.isDone()).isTrue();
+    // ensure no exceptions are thrown
+    future.join();
+  }
+
+  @Test
+  void shouldNotCompleteWhenTaskDoesNotComplete() {
+    // given
+    // when
+    final var future = AsyncRepeatUntil.repeatUntil(CompletableFuture::new, result -> true);
+
+    // then
+    assertThat(future.isDone()).isFalse();
+  }
+
+  @Test
+  void shouldCompleteExceptionallyWhenTasksFailsAsync() {
+    // given
+    // when
+    final var future =
+        AsyncRepeatUntil.repeatUntil(
+            // task fails in an async manner
+            () -> CompletableFuture.failedFuture(new RuntimeException("future failed")),
+            result -> true);
+
+    // then
+    assertThat(future.isDone()).isTrue();
+    assertThat(future.isCompletedExceptionally()).isTrue();
+    assertThatThrownBy(future::join)
+        .isInstanceOf(CompletionException.class)
+        .cause()
+        .hasMessageContaining("future failed");
+  }
+
+  @Test
+  void shouldCompleteExceptionallyWhenTasksFailsSync() {
+    // given
+    // when
+    final var future =
+        AsyncRepeatUntil.repeatUntil(
+            () -> {
+              // task fails, but in a non-async way
+              throw new RuntimeException("task failed");
+            },
+            result -> true);
+
+    // then
+    assertThat(future.isDone()).isTrue();
+    assertThat(future.isCompletedExceptionally()).isTrue();
+    assertThatThrownBy(future::join)
+        .isInstanceOf(CompletionException.class)
+        .cause()
+        .hasMessageContaining("task failed");
+  }
+
+  @Test
+  void shouldCompleteExceptionallyWhenUntilFails() {
+    // given
+    // when
+    final var future =
+        AsyncRepeatUntil.repeatUntil(
+            () -> CompletableFuture.completedFuture(1),
+            result -> {
+              throw new RuntimeException("until failed");
+            });
+
+    // then
+    assertThat(future.isDone()).isTrue();
+    assertThat(future.isCompletedExceptionally()).isTrue();
+    assertThatThrownBy(future::join)
+        .isInstanceOf(CompletionException.class)
+        .cause()
+        .hasMessageContaining("until failed");
+  }
+
+  @Test
+  void shouldCompleteWhenConditionMet() {
+    // given
+    final var counter = new AtomicInteger();
+
+    // when
+    final var future =
+        AsyncRepeatUntil.repeatUntil(
+            () -> CompletableFuture.completedFuture(counter.getAndIncrement()),
+            result -> result >= 5);
+
+    future.join();
+
+    // then
+    assertThat(counter.get()).isEqualTo(6);
+  }
+
+  @Test
+  void shouldRunTasksSerially() {
+    // given
+    final CompletableFuture<Integer> future1 = new CompletableFuture<>();
+    final CompletableFuture<Integer> future2 = new CompletableFuture<>();
+
+    final Supplier<CompletableFuture<Integer>> taskSupplier = mock(Supplier.class);
+
+    when(taskSupplier.get()).thenReturn(future1).thenReturn(future2);
+
+    // when
+    final var future = AsyncRepeatUntil.repeatUntil(taskSupplier, result -> result >= 2);
+
+    // then
+    assertThat(future.isDone()).isFalse();
+    verify(taskSupplier).get();
+
+    // when
+    // complete the first task, which should trigger the second task to be called
+    future1.complete(1);
+
+    // then
+    assertThat(future.isDone()).isFalse();
+    verify(taskSupplier, times(2)).get();
+
+    // when
+    // complete the second task, which should complete the future
+    future2.complete(2);
+
+    // then
+    assertThat(future.isDone()).isTrue();
+    verify(taskSupplier, times(2)).get();
+
+    future.join();
+  }
+}


### PR DESCRIPTION
## Description

Archiving currently moves data from main/hot indexes to dated indexes by selecting parent IDs, triggering reindex jobs for those IDs, and deleting source documents after completion. This works for most archiving jobs but performs poorly for others due to the additional load it places on Elasticsearch/OpenSearch clusters.

This new functionality will archive documents by the ID of the actual document being moved. It first reads a batch of IDs related to the ProcessInstanceKey or the parent ID. It then copies them from the main index to the dated destination index and deletes those copied documents from the main index. Afterwards, using the last position read in the current batch (i.e. `searchAfter`), it reads the next batch and continues until all documents are moved.

Technically, we are making more calls for reindexing; however, given their targeted nature, they are less strenuous on ES/OS. Overall, this may increase latency for smaller reindex operations but will significantly improve performance when there are many documents to move or when the documents being moved are larger. This may reduce performance in some cases, but it significantly improves stability and creates an opportunity for archiving to work without continually failing.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates to #50588