### PR TITLE
fix: add MESSAGE CREATE permission for orchestration client in load tests

### DIFF
--- a/load-tests/camunda-platform-values.yaml
+++ b/load-tests/camunda-platform-values.yaml
@@ -158,7 +158,15 @@ orchestration:
             - UPDATE_PROCESS_INSTANCE
             - READ_PROCESS_INSTANCE
             - READ_PROCESS_DEFINITION
-
+        # Grant the orchestration client permission to publish messages
+        # (required by realistic benchmark workers: customer_notification,
+        # dispute_process_request_proof_from_vendor)
+        - ownerType: CLIENT
+          ownerId: orchestration
+          resourceType: MESSAGE
+          resourceId: "*"
+          permissions:
+            - CREATE
   # For simplicity of the deployment, we override the names to camunda
   # This means we will have pods like: camunda-0, camunda-1, camunda-2
   fullnameOverride: camunda


### PR DESCRIPTION
## Description

Adds a missing authorization entry in the load test Camunda platform values to grant the
`orchestration` client `CREATE` permission on the `MESSAGE` resource type.

Without this, realistic benchmark workers (`customer_notification`,
`dispute_process_request_proof_from_vendor`) that publish messages via the orchestration client
fail with authorization errors.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #