### PR TITLE
fix: use stricter iframe rules

### DIFF
--- a/optimize/client/src/modules/components/DashboardRenderer/DashboardTile/ExternalUrlTile/ExternalUrlTile.test.tsx
+++ b/optimize/client/src/modules/components/DashboardRenderer/DashboardTile/ExternalUrlTile/ExternalUrlTile.test.tsx
@@ -38,6 +38,15 @@ it('should include an iframe with the provided external url', () => {
   expect(iframe).toHaveProp('src', 'externalURL');
 });
 
+it('should sandbox the iframe to prevent form submission and restrict capabilities', () => {
+  const node = shallow(<ExternalUrlTile {...props} />);
+
+  const iframe = node.find('iframe');
+
+  expect(iframe).toHaveProp('sandbox', 'allow-scripts allow-same-origin');
+  expect(iframe).toHaveProp('referrerPolicy', 'no-referrer');
+});
+
 it('should update the iframe key to reload it when loadTileData function is called ', async () => {
   const node = shallow(
     <ExternalUrlTile {...props} children={(props) => <p {...props}>child</p>} />

--- a/optimize/client/src/modules/components/DashboardRenderer/DashboardTile/ExternalUrlTile/ExternalUrlTile.test.tsx
+++ b/optimize/client/src/modules/components/DashboardRenderer/DashboardTile/ExternalUrlTile/ExternalUrlTile.test.tsx
@@ -43,7 +43,7 @@ it('should sandbox the iframe to prevent form submission and restrict capabiliti
 
   const iframe = node.find('iframe');
 
-  expect(iframe).toHaveProp('sandbox', 'allow-scripts allow-same-origin');
+  expect(iframe).toHaveProp('sandbox', 'allow-scripts');
   expect(iframe).toHaveProp('referrerPolicy', 'no-referrer');
 });
 

--- a/optimize/client/src/modules/components/DashboardRenderer/DashboardTile/ExternalUrlTile/ExternalUrlTile.tsx
+++ b/optimize/client/src/modules/components/DashboardRenderer/DashboardTile/ExternalUrlTile/ExternalUrlTile.tsx
@@ -31,6 +31,8 @@ export default function ExternalUrlTile({tile, children}: DashboardTileProps) {
         key={reloadState}
         title="External URL"
         src={tile.configuration.external}
+        sandbox="allow-scripts allow-same-origin"
+        referrerPolicy="no-referrer"
         frameBorder="0"
         style={{width: '100%', height: '100%'}}
       />

--- a/optimize/client/src/modules/components/DashboardRenderer/DashboardTile/ExternalUrlTile/ExternalUrlTile.tsx
+++ b/optimize/client/src/modules/components/DashboardRenderer/DashboardTile/ExternalUrlTile/ExternalUrlTile.tsx
@@ -31,7 +31,7 @@ export default function ExternalUrlTile({tile, children}: DashboardTileProps) {
         key={reloadState}
         title="External URL"
         src={tile.configuration.external}
-        sandbox="allow-scripts allow-same-origin"
+        sandbox="allow-scripts"
         referrerPolicy="no-referrer"
         frameBorder="0"
         style={{width: '100%', height: '100%'}}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This one is a bit tricky. I can't make the iframe 100% strict because then it would be unusable on Optimize so I just added some extra security flags.

I've added the [`sandbox`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/iframe#sandbox) config with [`allow-scripts`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/iframe#allow-scripts) so the user can still render some basic pages

This won't allow users to use forms between other things but since the main goal of Optimize is have business intelligence I believe that's ok.

If any customer complains about this we can research this more and consider other alternatives

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #49491
