### PR TITLE
feat: Archive Documents by ID And Parallelise Process Instance Archiving

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/DocumentBasedHistory.java
+++ b/configuration/src/main/java/io/camunda/configuration/DocumentBasedHistory.java
@@ -20,6 +20,7 @@ public class DocumentBasedHistory {
   private static final boolean DEFAULT_HISTORY_PROCESS_INSTANCE_ENABLED = true;
   private static final ProcessInstanceRetentionMode
       DEFAULT_HISTORY_PROCESS_INSTANCE_RETENTION_MODE = ProcessInstanceRetentionMode.PI_HIERARCHY;
+  private static final boolean DEFAULT_HISTORY_ARCHIVE_BY_ID_ENABLED = false;
   private static final String DEFAULT_HISTORY_POLICY_NAME = "camunda-retention-policy";
   private static final String DEFAULT_HISTORY_ELS_ROLLOVER_DATE_FORMAT = "date";
   private static final String DEFAULT_HISTORY_ROLLOVER_INTERVAL = "1d";
@@ -49,6 +50,8 @@ public class DocumentBasedHistory {
 
   private ProcessInstanceRetentionMode processInstanceRetentionMode =
       DEFAULT_HISTORY_PROCESS_INSTANCE_RETENTION_MODE;
+
+  private boolean archiveByIdEnabled = DEFAULT_HISTORY_ARCHIVE_BY_ID_ENABLED;
 
   /** Date format for historical indices in Java DateTimeFormatter syntax */
   private String elsRolloverDateFormat = DEFAULT_HISTORY_ELS_ROLLOVER_DATE_FORMAT;
@@ -103,6 +106,14 @@ public class DocumentBasedHistory {
   public void setProcessInstanceRetentionMode(
       final ProcessInstanceRetentionMode processInstanceRetentionMode) {
     this.processInstanceRetentionMode = processInstanceRetentionMode;
+  }
+
+  public boolean isArchiveByIdEnabled() {
+    return archiveByIdEnabled;
+  }
+
+  public void setArchiveByIdEnabled(final boolean archiveByIdEnabled) {
+    this.archiveByIdEnabled = archiveByIdEnabled;
   }
 
   public String getPrefix() {

--- a/configuration/src/main/java/io/camunda/configuration/DocumentBasedHistory.java
+++ b/configuration/src/main/java/io/camunda/configuration/DocumentBasedHistory.java
@@ -25,6 +25,7 @@ public class DocumentBasedHistory {
   private static final String DEFAULT_HISTORY_ELS_ROLLOVER_DATE_FORMAT = "date";
   private static final String DEFAULT_HISTORY_ROLLOVER_INTERVAL = "1d";
   private static final int DEFAULT_HISTORY_ROLLOVER_BATCH_SIZE = 100;
+  private static final int DEFAULT_HISTORY_REINDEX_BATCH_SIZE = 1000;
   private static final String DEFAULT_HISTORY_WAIT_PERIOD_BEFORE_ARCHIVING = "1h";
   private static final Map<String, String> LEGACY_BROKER_PROPERTIES =
       Map.of(
@@ -61,6 +62,9 @@ public class DocumentBasedHistory {
 
   /** Maximum number of process instances per archiving batch */
   private int rolloverBatchSize = DEFAULT_HISTORY_ROLLOVER_BATCH_SIZE;
+
+  /** Maximum number of docs reindexed/deleted in a batch */
+  private int reindexBatchSize = DEFAULT_HISTORY_REINDEX_BATCH_SIZE;
 
   /**
    * Grace period before archiving completed processes. Processes finished within this window are
@@ -157,6 +161,14 @@ public class DocumentBasedHistory {
 
   public void setRolloverBatchSize(final int rolloverBatchSize) {
     this.rolloverBatchSize = rolloverBatchSize;
+  }
+
+  public int getReindexBatchSize() {
+    return reindexBatchSize;
+  }
+
+  public void setReindexBatchSize(final int reindexBatchSize) {
+    this.reindexBatchSize = reindexBatchSize;
   }
 
   public String getWaitPeriodBeforeArchiving() {

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/CamundaExporterConfigurationApplier.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/CamundaExporterConfigurationApplier.java
@@ -156,6 +156,7 @@ public final class CamundaExporterConfigurationApplier {
     target.setElsRolloverDateFormat(source.getHistory().getElsRolloverDateFormat());
     target.setRolloverInterval(source.getHistory().getRolloverInterval());
     target.setRolloverBatchSize(source.getHistory().getRolloverBatchSize());
+    target.setReindexBatchSize(source.getHistory().getReindexBatchSize());
     target.setWaitPeriodBeforeArchiving(source.getHistory().getWaitPeriodBeforeArchiving());
     target.setDelayBetweenRuns(
         Math.toIntExact(source.getHistory().getDelayBetweenRuns().toMillis()));

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/CamundaExporterConfigurationApplier.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/CamundaExporterConfigurationApplier.java
@@ -151,6 +151,7 @@ public final class CamundaExporterConfigurationApplier {
     final HistoryConfiguration target = exporterConfiguration.getHistory();
     target.setProcessInstanceEnabled(source.getHistory().isProcessInstanceEnabled());
     target.setProcessInstanceRetentionMode(source.getHistory().getProcessInstanceRetentionMode());
+    target.setArchiveByIdEnabled(source.getHistory().isArchiveByIdEnabled());
     target.getRetention().setPolicyName(source.getHistory().getPolicyName());
     target.setElsRolloverDateFormat(source.getHistory().getElsRolloverDateFormat());
     target.setRolloverInterval(source.getHistory().getRolloverInterval());

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -240,6 +240,7 @@ public class ExporterConfiguration {
     private String rolloverInterval = "1d";
     private String usageMetricsRolloverInterval = "1M";
     private int rolloverBatchSize = 100;
+    private int reindexBatchSize = 1000;
     private String waitPeriodBeforeArchiving = "1h";
     private int delayBetweenRuns = 2000;
     private int maxDelayBetweenRuns = 60000;
@@ -296,6 +297,14 @@ public class ExporterConfiguration {
 
     public void setRolloverBatchSize(final int rolloverBatchSize) {
       this.rolloverBatchSize = rolloverBatchSize;
+    }
+
+    public int getReindexBatchSize() {
+      return reindexBatchSize;
+    }
+
+    public void setReindexBatchSize(final int reindexBatchSize) {
+      this.reindexBatchSize = reindexBatchSize;
     }
 
     public RetentionConfiguration getRetention() {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -235,6 +235,7 @@ public class ExporterConfiguration {
     private boolean processInstanceEnabled = true;
     private ProcessInstanceRetentionMode processInstanceRetentionMode =
         ProcessInstanceRetentionMode.PI_HIERARCHY;
+    private boolean archiveByIdEnabled = false;
     private String elsRolloverDateFormat = "date";
     private String rolloverInterval = "1d";
     private String usageMetricsRolloverInterval = "1M";
@@ -251,6 +252,14 @@ public class ExporterConfiguration {
 
     public void setProcessInstanceEnabled(final boolean processInstanceEnabled) {
       this.processInstanceEnabled = processInstanceEnabled;
+    }
+
+    public boolean isArchiveByIdEnabled() {
+      return archiveByIdEnabled;
+    }
+
+    public void setArchiveByIdEnabled(final boolean archiveByIdEnabled) {
+      this.archiveByIdEnabled = archiveByIdEnabled;
     }
 
     public String getElsRolloverDateFormat() {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
@@ -21,6 +21,8 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.InstantSource;
 import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -96,6 +98,7 @@ public class CamundaExporterMetrics implements AutoCloseable {
   private final Counter auditLogsArchived;
 
   private final Timer archiverSearchTimer;
+  private final Timer archiverDocIdsBatchSearchTimer;
   private final Timer archiverDeleteTimer;
   private final Counter archiverDeletedDocs;
   private final Counter archiverReindexedDocs;
@@ -111,6 +114,9 @@ public class CamundaExporterMetrics implements AutoCloseable {
   private final Timer flushDuration;
   private final Counter failedFlush;
   private final Timer recordExportDuration;
+
+  private final Map<String, Timer> timersBySource = new ConcurrentHashMap<>();
+  private final Map<String, Counter> docCountersBySource = new ConcurrentHashMap<>();
 
   private final AtomicReference<Instant> lastFlushTime = new AtomicReference<>(Instant.now());
   private final AtomicInteger processInstancesAwaitingArchival = new AtomicInteger(0);
@@ -208,6 +214,13 @@ public class CamundaExporterMetrics implements AutoCloseable {
             .description(
                 "Duration of how long it takes to run the search request to resolve completed entities, that need to be archived.")
             .tags("type", "search")
+            .publishPercentileHistogram()
+            .register(meterRegistry);
+    archiverDocIdsBatchSearchTimer =
+        Timer.builder(meterName("archiver.request.duration"))
+            .description(
+                "Duration of how long it takes to run the search request to resolve the IDs of documents, that need to be archived.")
+            .tags("type", "search-docid-batch")
             .publishPercentileHistogram()
             .register(meterRegistry);
     archiverDeleteTimer =
@@ -349,6 +362,10 @@ public class CamundaExporterMetrics implements AutoCloseable {
 
   public void measureArchiverSearch(final Timer.Sample sample) {
     sample.stop(archiverSearchTimer);
+  }
+
+  public void measureArchiveDocIdsSearchDuration(final Timer.Sample sample) {
+    sample.stop(archiverDocIdsBatchSearchTimer);
   }
 
   public void recordBulkSize(final int bulkSize) {
@@ -501,6 +518,42 @@ public class CamundaExporterMetrics implements AutoCloseable {
     timer.stop(archivingDuration);
   }
 
+  public void measureArchiveIndexDuration(
+      final String sourceIndex, final Sample sample, final Long count) {
+    // NOTE: We intentionally use get() + putIfAbsent() instead of compute() here.
+    // Using compute() could cause a deadlock because ConcurrentHashMap holds a bucket lock
+    // while executing the remapping function, and register() acquires internal locks in the
+    // CompositeMeterRegistry. See https://github.com/camunda/camunda/issues/33941
+    Timer timer = timersBySource.get(sourceIndex);
+    if (timer == null) {
+      timer =
+          Timer.builder(meterName("archiver.index.duration"))
+              .description("Duration of how long it takes to archive docs from " + sourceIndex)
+              .tag("source", sourceIndex)
+              .publishPercentileHistogram()
+              .register(meterRegistry);
+      final Timer existing = timersBySource.putIfAbsent(sourceIndex, timer);
+      if (existing != null) {
+        timer = existing;
+      }
+    }
+    sample.stop(timer);
+
+    Counter counter = docCountersBySource.get(sourceIndex);
+    if (counter == null) {
+      counter =
+          Counter.builder(meterName("archiver.index.docs"))
+              .tag("source", sourceIndex)
+              .description("Count of how many " + sourceIndex + " documents archived.")
+              .register(meterRegistry);
+      final Counter existing = docCountersBySource.putIfAbsent(sourceIndex, counter);
+      if (existing != null) {
+        counter = existing;
+      }
+    }
+    counter.increment(count == null ? 0 : count);
+  }
+
   @Override
   public void close() {
     // clean up all registered meters
@@ -511,6 +564,7 @@ public class CamundaExporterMetrics implements AutoCloseable {
     meterRegistry.remove(batchOperationsArchived);
     meterRegistry.remove(batchOperationsArchiving);
     meterRegistry.remove(archiverSearchTimer);
+    meterRegistry.remove(archiverDocIdsBatchSearchTimer);
     meterRegistry.remove(archiverDeleteTimer);
     meterRegistry.remove(archiverDeletedDocs);
     meterRegistry.remove(archiverReindexTimer);
@@ -540,6 +594,9 @@ public class CamundaExporterMetrics implements AutoCloseable {
     meterRegistry.remove(auditLogsArchived);
 
     meterRegistry.find(FLUSH_FAILURE_TYPE_METER_NAME).meters().forEach(meterRegistry::remove);
+
+    timersBySource.values().forEach(meterRegistry::remove);
+    docCountersBySource.values().forEach(meterRegistry::remove);
 
     // Remove custom gauges by their names if needed
     removeGaugeIfExists(SINCE_LAST_FLUSH_SECONDS_METER_NAME);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/CamundaBackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/CamundaBackgroundTaskManagerFactory.java
@@ -28,6 +28,7 @@ import io.camunda.exporter.tasks.archiver.JobBatchMetricsArchiverJob;
 import io.camunda.exporter.tasks.archiver.OpenSearchArchiverRepository;
 import io.camunda.exporter.tasks.archiver.OpensearchAuditLogArchiverRepository;
 import io.camunda.exporter.tasks.archiver.ProcessInstanceArchiverJob;
+import io.camunda.exporter.tasks.archiver.ProcessInstanceByIdArchiverJob;
 import io.camunda.exporter.tasks.archiver.ProcessInstanceToBeArchivedCountJob;
 import io.camunda.exporter.tasks.archiver.StandaloneDecisionArchiverJob;
 import io.camunda.exporter.tasks.archiver.UsageMetricArchiverJob;
@@ -403,15 +404,30 @@ public final class CamundaBackgroundTaskManagerFactory {
         .map(ProcessInstanceDependant.class::cast)
         .forEach(dependantTemplates::add);
 
-    return buildReschedulingArchiverTask(
-        new ProcessInstanceArchiverJob(
-            config.getHistory(),
-            archiverRepository,
-            resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class),
-            dependantTemplates,
-            metrics,
-            logger,
-            executor));
+    final ProcessInstanceArchiverJob piArchiverJob;
+
+    if (config.getHistory().isArchiveByIdEnabled()) {
+      piArchiverJob =
+          new ProcessInstanceByIdArchiverJob(
+              config.getHistory(),
+              archiverRepository,
+              resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class),
+              dependantTemplates,
+              metrics,
+              logger,
+              executor);
+    } else {
+      piArchiverJob =
+          new ProcessInstanceArchiverJob(
+              config.getHistory(),
+              archiverRepository,
+              resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class),
+              dependantTemplates,
+              metrics,
+              logger,
+              executor);
+    }
+    return buildReschedulingArchiverTask(piArchiverJob);
   }
 
   private ReschedulingTask buildBatchOperationArchiverJob() {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveByIDTaskSupplier.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveByIDTaskSupplier.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.archiver;
+
+import com.google.common.base.Stopwatch;
+import io.camunda.zeebe.util.function.TriFunction;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import org.slf4j.Logger;
+
+public class ArchiveByIdTaskSupplier<SortFieldType> {
+  private final String sourceIdx;
+  private final String destinationIdx;
+  private final Function<List<SortFieldType>, CompletableFuture<ArchiveDocIdsBatch<SortFieldType>>>
+      idsSupplier;
+  private final TriFunction<String, String, List<String>, CompletableFuture<Long>> reindexer;
+  private final BiFunction<String, List<String>, CompletableFuture<Long>> deleter;
+  private final Executor executor;
+  private final Logger logger;
+
+  private final AtomicReference<ArchiveDocIdsBatch<SortFieldType>> lastSearchResponse =
+      new AtomicReference<>(null);
+  private final AtomicBoolean finished = new AtomicBoolean(false);
+
+  private final AtomicLong totalArchived = new AtomicLong(0);
+  private final AtomicLong totalTimeTakenMs = new AtomicLong(0);
+
+  public ArchiveByIdTaskSupplier(
+      final String sourceIdx,
+      final String destinationIdx,
+      final Function<List<SortFieldType>, CompletableFuture<ArchiveDocIdsBatch<SortFieldType>>>
+          idsSupplier,
+      final TriFunction<String, String, List<String>, CompletableFuture<Long>> reindexer,
+      final BiFunction<String, List<String>, CompletableFuture<Long>> deleter,
+      final Executor executor,
+      final Logger logger) {
+    this.sourceIdx = sourceIdx;
+    this.destinationIdx = destinationIdx;
+    this.idsSupplier = idsSupplier;
+    this.reindexer = reindexer;
+    this.deleter = deleter;
+    this.executor = executor;
+    this.logger = logger;
+  }
+
+  public boolean isComplete() {
+    return finished.get();
+  }
+
+  public long getTotalArchived() {
+    return totalArchived.get();
+  }
+
+  public long getTotalTimeTakenMs() {
+    return totalTimeTakenMs.get();
+  }
+
+  public CompletableFuture<Long> moveNextBatch() {
+    final Stopwatch stopwatch = Stopwatch.createStarted();
+    return idsSupplier
+        .apply(getLastSearchPosition())
+        .thenComposeAsync(
+            response -> {
+              // we can set this in another stage (like after reindex/delete if we want retries)
+              lastSearchResponse.set(response);
+
+              if (response.isEmpty()) {
+                finished.set(true);
+                return CompletableFuture.completedFuture(0L);
+              }
+
+              return reindex(response)
+                  .thenCompose(reindexedCount -> delete(response))
+                  .thenApply(
+                      deletedCount -> {
+                        // advance search position only after both archive steps completed
+                        // successfully
+                        lastSearchResponse.set(response);
+                        totalArchived.accumulateAndGet(deletedCount, Long::sum);
+                        return deletedCount;
+                      })
+                  .exceptionally(
+                      ex -> {
+                        final var cause = ex instanceof CompletionException ? ex.getCause() : ex;
+                        if (cause instanceof final BatchCountMismatchException countMismatchEx) {
+                          logger.debug(
+                              "Processed batch count during '{}' stage doesn't match expected doc "
+                                  + "count when archiving docs from '{}' to '{}'.",
+                              countMismatchEx.operation,
+                              sourceIdx,
+                              destinationIdx);
+                          return 0L;
+                        }
+                        // re-throw unexpected exceptions
+                        throw ex instanceof final RuntimeException re
+                            ? re
+                            : new RuntimeException(ex);
+                      });
+            },
+            executor)
+        .whenCompleteAsync(
+            (val, err) ->
+                totalTimeTakenMs.accumulateAndGet(
+                    stopwatch.stop().elapsed(TimeUnit.MILLISECONDS), Long::sum),
+            executor);
+  }
+
+  private List<SortFieldType> getLastSearchPosition() {
+    final ArchiveDocIdsBatch<SortFieldType> lstResponse = lastSearchResponse.get();
+    return lstResponse == null ? List.of() : lstResponse.searchAfter();
+  }
+
+  private CompletableFuture<Long> reindex(final ArchiveDocIdsBatch<SortFieldType> response) {
+    return reindexer
+        .apply(sourceIdx, destinationIdx, response.ids())
+        .thenApply(
+            reindexCount -> validateProcessedCount("reindex", reindexCount, response.ids().size()));
+  }
+
+  private CompletableFuture<Long> delete(final ArchiveDocIdsBatch<SortFieldType> response) {
+    return deleter
+        .apply(sourceIdx, response.ids())
+        .thenApply(
+            deleteCount -> validateProcessedCount("delete", deleteCount, response.ids().size()));
+  }
+
+  private long validateProcessedCount(
+      final String operation, final long processedCount, final int expectedCount) {
+    if (processedCount != expectedCount) {
+      throw new BatchCountMismatchException(
+          operation,
+          String.format(
+              "The '%s' operation for a batch when archiving %s processed %d docs, however was "
+                  + "expecting %d docs",
+              operation, sourceIdx, processedCount, expectedCount));
+    }
+    return processedCount;
+  }
+
+  public record ArchiveDocIdsBatch<T>(List<String> ids, List<T> searchAfter) {
+    static <T> ArchiveDocIdsBatch<T> empty() {
+      return new ArchiveDocIdsBatch<>(List.of(), List.of());
+    }
+
+    static <T> ArchiveDocIdsBatch<T> from(final List<String> ids, final List<T> searchAfter) {
+      return new ArchiveDocIdsBatch<>(ids, searchAfter);
+    }
+
+    public boolean isEmpty() {
+      return ids.isEmpty();
+    }
+  }
+
+  /**
+   * Used when the number of documents processed by a reindex or delete operation does not match the
+   * expected count. This is caught in the future chain to end the current execution gracefully so
+   * the same batch can be retried on the next invocation.
+   */
+  static class BatchCountMismatchException extends RuntimeException {
+    final String operation;
+
+    BatchCountMismatchException(final String operation, final String message) {
+      super(message);
+      this.operation = operation;
+    }
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplier.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplier.java
@@ -7,21 +7,26 @@
  */
 package io.camunda.exporter.tasks.archiver;
 
+import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import com.google.common.base.Stopwatch;
 import io.camunda.zeebe.util.function.TriFunction;
+import java.net.SocketTimeoutException;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.slf4j.Logger;
 
 public class ArchiveByIdTaskSupplier<SortFieldType> {
+  private static final int MAX_RETRY_COUNT = 3;
+
   private final String sourceIdx;
   private final String destinationIdx;
   private final Function<List<SortFieldType>, CompletableFuture<ArchiveDocIdsBatch<SortFieldType>>>
@@ -34,6 +39,7 @@ public class ArchiveByIdTaskSupplier<SortFieldType> {
   private final AtomicReference<ArchiveDocIdsBatch<SortFieldType>> lastSearchResponse =
       new AtomicReference<>(null);
   private final AtomicBoolean finished = new AtomicBoolean(false);
+  private final AtomicInteger retryCount = new AtomicInteger(0);
 
   private final AtomicLong totalArchived = new AtomicLong(0);
   private final AtomicLong totalTimeTakenMs = new AtomicLong(0);
@@ -90,18 +96,19 @@ public class ArchiveByIdTaskSupplier<SortFieldType> {
                         // successfully
                         lastSearchResponse.set(response);
                         totalArchived.accumulateAndGet(deletedCount, Long::sum);
+                        retryCount.set(0);
                         return deletedCount;
                       })
                   .exceptionally(
                       ex -> {
-                        final var cause = ex instanceof CompletionException ? ex.getCause() : ex;
-                        if (cause instanceof final BatchCountMismatchException countMismatchEx) {
+                        if (isRetryableError(ex)
+                            && retryCount.incrementAndGet() < MAX_RETRY_COUNT) {
                           logger.debug(
-                              "Processed batch count during '{}' stage doesn't match expected doc "
-                                  + "count when archiving docs from '{}' to '{}'.",
-                              countMismatchEx.operation,
+                              "Encountered retryable error when archiving docs from '{}' to '{}', "
+                                  + "retrying the batch. Error: {}",
                               sourceIdx,
-                              destinationIdx);
+                              destinationIdx,
+                              ex.getMessage());
                           return 0L;
                         }
                         // re-throw unexpected exceptions
@@ -148,6 +155,15 @@ public class ArchiveByIdTaskSupplier<SortFieldType> {
               operation, sourceIdx, processedCount, expectedCount));
     }
     return processedCount;
+  }
+
+  private boolean isRetryableError(final Throwable thr) {
+    if (thr != null && thr.getCause() != null) {
+      return thr.getCause() instanceof SocketTimeoutException
+          || thr.getCause() instanceof ElasticsearchException
+          || thr.getCause() instanceof OpenSearchException;
+    }
+    return false;
   }
 
   public record ArchiveDocIdsBatch<T>(List<String> ids, List<T> searchAfter) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverRepository.java
@@ -83,16 +83,12 @@ public interface ArchiverRepository extends AutoCloseable {
         .thenComposeAsync(ok -> deleteDocuments(sourceIndexName, keysByField, filters), executor);
   }
 
-  default CompletableFuture<Void> moveDocumentsById(
+  CompletableFuture<Void> moveDocumentsById(
       final String sourceIndexName,
       final String destinationIndexName,
       final Map<String, List<String>> keysByField,
       final Map<String, String> filters,
-      final Executor executor) {
-    return reindexDocuments(sourceIndexName, destinationIndexName, keysByField, filters)
-        .thenComposeAsync(ok -> setIndexLifeCycle(destinationIndexName), executor)
-        .thenComposeAsync(ok -> deleteDocuments(sourceIndexName, keysByField, filters), executor);
-  }
+      final Executor executor);
 
   CompletableFuture<Integer> getCountOfProcessInstancesAwaitingArchival();
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverRepository.java
@@ -87,7 +87,8 @@ public interface ArchiverRepository extends AutoCloseable {
       final String sourceIndexName,
       final String destinationIndexName,
       final Map<String, List<String>> keysByField,
-      final Map<String, String> filters,
+      final Map<String, String> inclusionFilters,
+      final Map<String, String> exclusionFilters,
       final Executor executor);
 
   CompletableFuture<Integer> getCountOfProcessInstancesAwaitingArchival();

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverRepository.java
@@ -83,6 +83,17 @@ public interface ArchiverRepository extends AutoCloseable {
         .thenComposeAsync(ok -> deleteDocuments(sourceIndexName, keysByField, filters), executor);
   }
 
+  default CompletableFuture<Void> moveDocumentsById(
+      final String sourceIndexName,
+      final String destinationIndexName,
+      final Map<String, List<String>> keysByField,
+      final Map<String, String> filters,
+      final Executor executor) {
+    return reindexDocuments(sourceIndexName, destinationIndexName, keysByField, filters)
+        .thenComposeAsync(ok -> setIndexLifeCycle(destinationIndexName), executor)
+        .thenComposeAsync(ok -> deleteDocuments(sourceIndexName, keysByField, filters), executor);
+  }
+
   CompletableFuture<Integer> getCountOfProcessInstancesAwaitingArchival();
 
   default String getRetentionPolicyName(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/AsyncRepeatUntil.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/AsyncRepeatUntil.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.archiver;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+// Use to repeatedly call an async task until a condition is met.
+// NB avoiding using closures for this as with all the callbacks it can
+// easily lead to memory leaks if not used carefully. By using an explicit class
+// we can ensure that the state is properly cleaned up after completion.
+final class AsyncRepeatUntil<T> {
+  private final CompletableFuture<Void> finalFuture = new CompletableFuture<>();
+  private final Supplier<CompletableFuture<T>> asyncTask;
+  private final Predicate<T> until;
+
+  private AsyncRepeatUntil(
+      final Supplier<CompletableFuture<T>> asyncTask, final Predicate<T> until) {
+    this.asyncTask = asyncTask;
+    this.until = until;
+  }
+
+  private void next() {
+    try {
+      asyncTask
+          .get()
+          .thenAcceptAsync(this::completeOrNext)
+          .exceptionally(this::completeExceptionally);
+    } catch (final Throwable err) {
+      completeExceptionally(err);
+    }
+  }
+
+  private void completeOrNext(final T result) {
+    try {
+      if (until.test(result)) {
+        finalFuture.complete(null);
+      } else {
+        next();
+      }
+    } catch (final Throwable err) {
+      completeExceptionally(err);
+    }
+  }
+
+  private Void completeExceptionally(final Throwable err) {
+    finalFuture.completeExceptionally(err);
+    return null;
+  }
+
+  static <T> CompletableFuture<Void> repeatUntil(
+      final Supplier<CompletableFuture<T>> asyncTask, final Predicate<T> until) {
+    final var repeat = new AsyncRepeatUntil<>(asyncTask, until);
+
+    repeat.next();
+
+    return repeat.finalFuture;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -14,17 +14,23 @@ import co.elastic.clients.elasticsearch._types.Conflicts;
 import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.Slices;
 import co.elastic.clients.elasticsearch._types.SlicesCalculation;
+import co.elastic.clients.elasticsearch._types.SortOptions;
 import co.elastic.clients.elasticsearch._types.SortOrder;
 import co.elastic.clients.elasticsearch._types.Time;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders;
 import co.elastic.clients.elasticsearch._types.query_dsl.TermsQuery;
+import co.elastic.clients.elasticsearch.core.BulkRequest;
+import co.elastic.clients.elasticsearch.core.BulkResponse;
 import co.elastic.clients.elasticsearch.core.CountRequest;
 import co.elastic.clients.elasticsearch.core.DeleteByQueryRequest;
 import co.elastic.clients.elasticsearch.core.DeleteByQueryResponse;
 import co.elastic.clients.elasticsearch.core.ReindexRequest;
+import co.elastic.clients.elasticsearch.core.ReindexResponse;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchRequest.Builder;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import co.elastic.clients.elasticsearch.indices.PutIndicesSettingsRequest;
 import co.elastic.clients.elasticsearch.indices.PutIndicesSettingsResponse;
@@ -37,6 +43,7 @@ import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration.Pro
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.ProcessInstanceArchiveBatch;
+import io.camunda.exporter.tasks.archiver.ArchiveByIdTaskSupplier.ArchiveDocIdsBatch;
 import io.camunda.exporter.tasks.util.DateOfArchivedDocumentsUtil;
 import io.camunda.exporter.tasks.util.ElasticsearchRepository;
 import io.camunda.search.schema.config.RetentionConfiguration;
@@ -48,6 +55,7 @@ import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTUTemplate;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTemplate;
 import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
+import io.camunda.zeebe.util.VisibleForTesting;
 import io.micrometer.core.instrument.Timer;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -340,6 +348,57 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
   }
 
   @Override
+  public CompletableFuture<Void> moveDocumentsById(
+      final String sourceIndexName,
+      final String destinationIndexName,
+      final Map<String, List<String>> keysByField,
+      final Map<String, String> filters,
+      final Executor executor) {
+
+    final ArchiveByIdTaskSupplier<FieldValue> taskSupplier =
+        new ArchiveByIdTaskSupplier<>(
+            sourceIndexName,
+            destinationIndexName,
+            searchAfter ->
+                getArchiveDocIdsBatch(sourceIndexName, keysByField, filters, searchAfter),
+            this::reindexDocumentsById,
+            this::deleteDocumentsById,
+            executor,
+            logger);
+
+    final var timer = Timer.start();
+    return AsyncRepeatUntil.repeatUntil(
+            taskSupplier::moveNextBatch, count -> taskSupplier.isComplete())
+        .thenComposeAsync(docIds -> setIndexLifeCycle(destinationIndexName), executor)
+        .thenApply(
+            ignored -> {
+              logger.debug(
+                  "Successfully completed archiving {} to the {} index, moved {} docs in {}s",
+                  sourceIndexName,
+                  destinationIndexName,
+                  taskSupplier.getTotalArchived(),
+                  taskSupplier.getTotalTimeTakenMs() / 1000);
+
+              metrics.measureArchiveIndexDuration(
+                  sourceIndexName, timer, taskSupplier.getTotalArchived());
+              return ignored;
+            })
+        .whenComplete(
+            (val, err) -> {
+              if (err != null) {
+                logger.error(
+                    "Failed archiving {} to the {} index, moved {} docs so far in {}s, error={}",
+                    sourceIndexName,
+                    destinationIndexName,
+                    taskSupplier.getTotalArchived(),
+                    taskSupplier.getTotalTimeTakenMs() / 1000,
+                    err.getMessage(),
+                    err);
+              }
+            });
+  }
+
+  @Override
   public CompletableFuture<Integer> getCountOfProcessInstancesAwaitingArchival() {
     final var countRequest =
         CountRequest.of(
@@ -350,6 +409,121 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
                             config.getArchivingTimePoint(), partitionId)));
 
     return client.count(countRequest).thenApplyAsync(res -> Math.toIntExact(res.count()));
+  }
+
+  @VisibleForTesting
+  CompletableFuture<ArchiveDocIdsBatch<FieldValue>> getArchiveDocIdsBatch(
+      final String sourceIndexName,
+      final Map<String, List<String>> keysByField,
+      final Map<String, String> filters,
+      final List<FieldValue> searchAfter) {
+    final Query query = buildFilterQuery(keysByField, filters);
+    final Builder requestBuilder =
+        new SearchRequest.Builder()
+            .index(sourceIndexName)
+            .requestCache(false)
+            .allowNoIndices(true)
+            .ignoreUnavailable(true)
+            .query(query)
+            .size(config.getReindexBatchSize())
+            .source(s -> s.fetch(false))
+            .sort(SortOptions.of(s -> s.field(f -> f.field("id").order(SortOrder.Asc))));
+
+    if (searchAfter != null && !searchAfter.isEmpty()) {
+      requestBuilder.searchAfter(searchAfter);
+    }
+
+    final var timer = Timer.start();
+    return client
+        .search(requestBuilder.build())
+        .whenCompleteAsync(
+            (response, error) -> metrics.measureArchiveDocIdsSearchDuration(timer), executor)
+        .thenApply(
+            response -> {
+              final List<Hit<Void>> hits = response.hits().hits();
+              if (hits.isEmpty()) {
+                return ArchiveDocIdsBatch.empty();
+              }
+              return ArchiveDocIdsBatch.from(
+                  hits.stream().map(Hit::id).toList(), hits.getLast().sort());
+            });
+  }
+
+  @VisibleForTesting
+  CompletableFuture<Long> reindexDocumentsById(
+      final String sourceIndexName, final String destinationIndexName, final List<String> docIds) {
+    if (docIds.isEmpty()) {
+      return CompletableFuture.completedFuture(0L);
+    }
+
+    final var query = QueryBuilders.bool(q -> q.filter(b -> b.ids(id -> id.values(docIds))));
+    final var request =
+        new ReindexRequest.Builder()
+            .source(src -> src.index(sourceIndexName).query(query))
+            .dest(dest -> dest.index(destinationIndexName))
+            .conflicts(Conflicts.Proceed)
+            .scroll(REINDEX_SCROLL_TIMEOUT)
+            .slices(AUTO_SLICES)
+            .build();
+
+    final var timer = Timer.start();
+    return client
+        .reindex(request)
+        .thenApplyAsync(
+            response -> {
+              validateReindexResponse(sourceIndexName, response);
+              return response.total();
+            },
+            executor)
+        .whenCompleteAsync(
+            (total, error) -> metrics.measureArchiverReindex(total, timer), executor);
+  }
+
+  private static void validateReindexResponse(
+      final String sourceIndex, final ReindexResponse response) {
+    if (Boolean.TRUE.equals(response.timedOut())) {
+      throw new IllegalStateException("Reindex request from %s timed out".formatted(sourceIndex));
+    }
+    final var failures = response.failures();
+    if (failures != null && !failures.isEmpty()) {
+      throw new IllegalStateException(
+          "Reindex request from %s index completed with %d failures"
+              .formatted(sourceIndex, failures.size()));
+    }
+  }
+
+  @VisibleForTesting
+  CompletableFuture<Long> deleteDocumentsById(
+      final String sourceIndexName, final List<String> docIds) {
+    if (docIds.isEmpty()) {
+      return CompletableFuture.completedFuture(0L);
+    }
+
+    final var operations =
+        docIds.stream()
+            .map(docId -> new BulkOperation.Builder().delete(d -> d.id(docId)).build())
+            .toList();
+
+    final var request =
+        new BulkRequest.Builder().index(sourceIndexName).operations(operations).build();
+
+    final var timer = Timer.start();
+    return client
+        .bulk(request)
+        .thenApplyAsync(response -> getDeletedDocCount(sourceIndexName, response), executor)
+        .whenCompleteAsync(
+            (idsSize, error) -> metrics.measureArchiverDelete(idsSize, timer), executor);
+  }
+
+  private long getDeletedDocCount(final String sourceIndex, final BulkResponse response) {
+    if (response.errors()) {
+      final long errorCount =
+          response.items().stream().filter(item -> item.error() != null).count();
+      throw new IllegalStateException(
+          "Deleting reindexed documents from %s index completed with %d failures"
+              .formatted(sourceIndex, errorCount));
+    }
+    return response.items().size();
   }
 
   private Query finishedProcessInstancesQuery(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -352,7 +352,8 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
       final String sourceIndexName,
       final String destinationIndexName,
       final Map<String, List<String>> keysByField,
-      final Map<String, String> filters,
+      final Map<String, String> inclusionFilters,
+      final Map<String, String> exclusionFilters,
       final Executor executor) {
 
     final ArchiveByIdTaskSupplier<FieldValue> taskSupplier =
@@ -360,7 +361,8 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
             sourceIndexName,
             destinationIndexName,
             searchAfter ->
-                getArchiveDocIdsBatch(sourceIndexName, keysByField, filters, searchAfter),
+                getArchiveDocIdsBatch(
+                    sourceIndexName, keysByField, inclusionFilters, exclusionFilters, searchAfter),
             this::reindexDocumentsById,
             this::deleteDocumentsById,
             executor,
@@ -415,9 +417,10 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
   CompletableFuture<ArchiveDocIdsBatch<FieldValue>> getArchiveDocIdsBatch(
       final String sourceIndexName,
       final Map<String, List<String>> keysByField,
-      final Map<String, String> filters,
+      final Map<String, String> inclusionFilters,
+      final Map<String, String> exclusionFilters,
       final List<FieldValue> searchAfter) {
-    final Query query = buildFilterQuery(keysByField, filters);
+    final Query query = buildFilterQuery(keysByField, inclusionFilters, exclusionFilters);
     final Builder requestBuilder =
         new SearchRequest.Builder()
             .index(sourceIndexName)
@@ -675,7 +678,14 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
   }
 
   private Query buildFilterQuery(
-      final Map<String, List<String>> keysByField, final Map<String, String> filters) {
+      final Map<String, List<String>> keysByField, final Map<String, String> inclusionFilters) {
+    return buildFilterQuery(keysByField, inclusionFilters, Map.of());
+  }
+
+  private Query buildFilterQuery(
+      final Map<String, List<String>> keysByField,
+      final Map<String, String> inclusionFilters,
+      final Map<String, String> exclusionFilters) {
     final var boolBuilder = QueryBuilders.bool();
 
     // Match any keys
@@ -688,9 +698,15 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
       boolBuilder.filter(keysBoolBuilder.build()._toQuery());
     }
 
-    // Match all the extra filters
-    for (final var filter : filters.entrySet()) {
+    // Match all additional inclusion filters
+    for (final var filter : inclusionFilters.entrySet()) {
       boolBuilder.filter(
+          f -> f.term(t -> t.field(filter.getKey()).value(FieldValue.of(filter.getValue()))));
+    }
+
+    // Exclude all docs matching exclusion filters
+    for (final var filter : exclusionFilters.entrySet()) {
+      boolBuilder.mustNot(
           f -> f.term(t -> t.field(filter.getKey()).value(FieldValue.of(filter.getValue()))));
     }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -19,6 +19,7 @@ import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration.Pro
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.BasicArchiveBatch;
 import io.camunda.exporter.tasks.archiver.ArchiveBatch.ProcessInstanceArchiveBatch;
+import io.camunda.exporter.tasks.archiver.ArchiveByIdTaskSupplier.ArchiveDocIdsBatch;
 import io.camunda.exporter.tasks.util.DateOfArchivedDocumentsUtil;
 import io.camunda.exporter.tasks.util.OpensearchRepository;
 import io.camunda.search.schema.config.RetentionConfiguration;
@@ -31,6 +32,7 @@ import io.camunda.webapps.schema.descriptors.template.UsageMetricTUTemplate;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTemplate;
 import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
 import io.camunda.zeebe.exporter.api.ExporterException;
+import io.camunda.zeebe.util.VisibleForTesting;
 import io.micrometer.core.instrument.Timer;
 import java.io.IOException;
 import java.time.Duration;
@@ -52,12 +54,17 @@ import org.opensearch.client.opensearch._types.Time;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch._types.query_dsl.QueryBuilders;
 import org.opensearch.client.opensearch._types.query_dsl.TermsQuery;
+import org.opensearch.client.opensearch.core.BulkRequest;
+import org.opensearch.client.opensearch.core.BulkResponse;
 import org.opensearch.client.opensearch.core.CountRequest;
 import org.opensearch.client.opensearch.core.DeleteByQueryRequest;
 import org.opensearch.client.opensearch.core.DeleteByQueryResponse;
 import org.opensearch.client.opensearch.core.ReindexRequest;
+import org.opensearch.client.opensearch.core.ReindexResponse;
 import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.SearchRequest.Builder;
 import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.bulk.BulkOperation;
 import org.opensearch.client.opensearch.core.search.Hit;
 import org.opensearch.client.opensearch.generic.OpenSearchGenericClient;
 import org.opensearch.client.opensearch.generic.Requests;
@@ -352,6 +359,57 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
   }
 
   @Override
+  public CompletableFuture<Void> moveDocumentsById(
+      final String sourceIndexName,
+      final String destinationIndexName,
+      final Map<String, List<String>> keysByField,
+      final Map<String, String> filters,
+      final Executor executor) {
+
+    final ArchiveByIdTaskSupplier<FieldValue> taskSupplier =
+        new ArchiveByIdTaskSupplier<>(
+            sourceIndexName,
+            destinationIndexName,
+            searchAfter ->
+                getArchiveDocIdsBatch(sourceIndexName, keysByField, filters, searchAfter),
+            this::reindexDocumentsById,
+            this::deleteDocumentsById,
+            executor,
+            logger);
+
+    final var timer = Timer.start();
+    return AsyncRepeatUntil.repeatUntil(
+            taskSupplier::moveNextBatch, count -> taskSupplier.isComplete())
+        .thenComposeAsync(docIds -> setIndexLifeCycle(destinationIndexName), executor)
+        .thenApply(
+            ignored -> {
+              logger.debug(
+                  "Successfully completed archiving {} to the {} index, moved {} docs in {}s",
+                  sourceIndexName,
+                  destinationIndexName,
+                  taskSupplier.getTotalArchived(),
+                  taskSupplier.getTotalTimeTakenMs() / 1000);
+
+              metrics.measureArchiveIndexDuration(
+                  sourceIndexName, timer, taskSupplier.getTotalArchived());
+              return ignored;
+            })
+        .whenComplete(
+            (val, err) -> {
+              if (err != null) {
+                logger.error(
+                    "Failed archiving {} to the {} index, moved {} docs so far in {}s, error={}",
+                    sourceIndexName,
+                    destinationIndexName,
+                    taskSupplier.getTotalArchived(),
+                    taskSupplier.getTotalTimeTakenMs() / 1000,
+                    err.getMessage(),
+                    err);
+              }
+            });
+  }
+
+  @Override
   public CompletableFuture<Integer> getCountOfProcessInstancesAwaitingArchival() {
     final var countRequest =
         CountRequest.of(
@@ -366,6 +424,116 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
     } catch (final IOException e) {
       return CompletableFuture.failedFuture(e);
     }
+  }
+
+  @VisibleForTesting
+  CompletableFuture<ArchiveDocIdsBatch<FieldValue>> getArchiveDocIdsBatch(
+      final String sourceIndexName,
+      final Map<String, List<String>> keysByField,
+      final Map<String, String> filters,
+      final List<FieldValue> searchAfter) {
+    final Query query = buildFilterQuery(keysByField, filters);
+    final Builder requestBuilder =
+        new Builder()
+            .index(sourceIndexName)
+            .requestCache(false)
+            .allowNoIndices(true)
+            .ignoreUnavailable(true)
+            .query(query)
+            .size(config.getReindexBatchSize())
+            .source(s -> s.fetch(false))
+            .sort(sort -> sort.field(field -> field.field("id").order(SortOrder.Asc)));
+
+    if (searchAfter != null && !searchAfter.isEmpty()) {
+      requestBuilder.searchAfter(searchAfter);
+    }
+
+    final var timer = Timer.start();
+    return sendRequestAsync(() -> client.search(requestBuilder.build(), Object.class))
+        .whenCompleteAsync(
+            (response, error) -> metrics.measureArchiveDocIdsSearchDuration(timer), executor)
+        .thenApply(
+            response -> {
+              final List<Hit<Object>> hits = response.hits().hits();
+              if (hits.isEmpty()) {
+                return ArchiveDocIdsBatch.empty();
+              }
+              return ArchiveDocIdsBatch.from(
+                  hits.stream().map(Hit::id).toList(), hits.getLast().sort());
+            });
+  }
+
+  @VisibleForTesting
+  CompletableFuture<Long> reindexDocumentsById(
+      final String sourceIndexName, final String destinationIndexName, final List<String> docIds) {
+    if (docIds.isEmpty()) {
+      return CompletableFuture.completedFuture(0L);
+    }
+
+    final var query = QueryBuilders.bool().filter(b -> b.ids(id -> id.values(docIds))).build();
+    final var request =
+        new ReindexRequest.Builder()
+            .source(src -> src.index(sourceIndexName).query(query.toQuery()))
+            .dest(dest -> dest.index(destinationIndexName))
+            .conflicts(Conflicts.Proceed)
+            .scroll(REINDEX_SCROLL_TIMEOUT)
+            .slices(AUTO_SLICES)
+            .build();
+
+    final var timer = Timer.start();
+    return sendRequestAsync(() -> client.reindex(request))
+        .thenApplyAsync(
+            response -> {
+              validateReindexResponse(sourceIndexName, response);
+              return response.total();
+            },
+            executor)
+        .whenCompleteAsync(
+            (total, error) -> metrics.measureArchiverReindex(total, timer), executor);
+  }
+
+  private static void validateReindexResponse(
+      final String sourceIndex, final ReindexResponse response) {
+    if (Boolean.TRUE.equals(response.timedOut())) {
+      throw new IllegalStateException("Reindex request from %s timed out".formatted(sourceIndex));
+    }
+    final var failures = response.failures();
+    if (!failures.isEmpty()) {
+      throw new IllegalStateException(
+          "Reindex request from %s index completed with %d failures"
+              .formatted(sourceIndex, failures.size()));
+    }
+  }
+
+  @VisibleForTesting
+  CompletableFuture<Long> deleteDocumentsById(
+      final String sourceIndexName, final List<String> docIds) {
+    if (docIds.isEmpty()) {
+      return CompletableFuture.completedFuture(0L);
+    }
+
+    final var operations =
+        docIds.stream().map(docId -> BulkOperation.of(b -> b.delete(d -> d.id(docId)))).toList();
+
+    final BulkRequest request =
+        BulkRequest.of(b -> b.index(sourceIndexName).operations(operations));
+
+    final var timer = Timer.start();
+    return sendRequestAsync(() -> client.bulk(request))
+        .thenApplyAsync(response -> getDeletedDocCount(sourceIndexName, response), executor)
+        .whenCompleteAsync(
+            (idsSize, error) -> metrics.measureArchiverDelete(idsSize, timer), executor);
+  }
+
+  private long getDeletedDocCount(final String sourceIndex, final BulkResponse response) {
+    if (response.errors()) {
+      final long errorCount =
+          response.items().stream().filter(item -> item.error() != null).count();
+      throw new IllegalStateException(
+          "Deleting reindexed documents from %s index completed with %d failures"
+              .formatted(sourceIndex, errorCount));
+    }
+    return response.items().size();
   }
 
   private SearchRequest createUsageMetricSearchRequest(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -363,7 +363,8 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
       final String sourceIndexName,
       final String destinationIndexName,
       final Map<String, List<String>> keysByField,
-      final Map<String, String> filters,
+      final Map<String, String> inclusionFilters,
+      final Map<String, String> exclusionFilters,
       final Executor executor) {
 
     final ArchiveByIdTaskSupplier<FieldValue> taskSupplier =
@@ -371,7 +372,8 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
             sourceIndexName,
             destinationIndexName,
             searchAfter ->
-                getArchiveDocIdsBatch(sourceIndexName, keysByField, filters, searchAfter),
+                getArchiveDocIdsBatch(
+                    sourceIndexName, keysByField, inclusionFilters, exclusionFilters, searchAfter),
             this::reindexDocumentsById,
             this::deleteDocumentsById,
             executor,
@@ -430,9 +432,10 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
   CompletableFuture<ArchiveDocIdsBatch<FieldValue>> getArchiveDocIdsBatch(
       final String sourceIndexName,
       final Map<String, List<String>> keysByField,
-      final Map<String, String> filters,
+      final Map<String, String> inclusionFilters,
+      final Map<String, String> exclusionFilters,
       final List<FieldValue> searchAfter) {
-    final Query query = buildFilterQuery(keysByField, filters);
+    final Query query = buildFilterQuery(keysByField, inclusionFilters, exclusionFilters);
     final Builder requestBuilder =
         new Builder()
             .index(sourceIndexName)
@@ -890,7 +893,14 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
   }
 
   private Query buildFilterQuery(
-      final Map<String, List<String>> keysByField, final Map<String, String> filters) {
+      final Map<String, List<String>> keysByField, final Map<String, String> inclusionFilters) {
+    return buildFilterQuery(keysByField, inclusionFilters, Map.of());
+  }
+
+  private Query buildFilterQuery(
+      final Map<String, List<String>> keysByField,
+      final Map<String, String> inclusionFilters,
+      final Map<String, String> exclusionFilters) {
     final var boolBuilder = QueryBuilders.bool();
 
     // Match any keys
@@ -903,9 +913,15 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
       boolBuilder.filter(keysBoolBuilder.build().toQuery());
     }
 
-    // Match all the extra filters
-    for (final var filter : filters.entrySet()) {
+    // Match all additional inclusion filters
+    for (final var filter : inclusionFilters.entrySet()) {
       boolBuilder.filter(
+          f -> f.term(t -> t.field(filter.getKey()).value(FieldValue.of(filter.getValue()))));
+    }
+
+    // Exclude all docs matching exclusion filters
+    for (final var filter : exclusionFilters.entrySet()) {
+      boolBuilder.mustNot(
           f -> f.term(t -> t.field(filter.getKey()).value(FieldValue.of(filter.getValue()))));
     }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJob.java
@@ -13,6 +13,7 @@ import io.camunda.exporter.tasks.archiver.ArchiveBatch.ProcessInstanceArchiveBat
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
+import io.camunda.zeebe.util.FunctionUtil;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -100,11 +101,7 @@ public class ProcessInstanceArchiverJob extends ArchiverJob<ProcessInstanceArchi
       final IndexTemplateDescriptor templateDescriptor, final ProcessInstanceArchiveBatch batch) {
     return archiveProcessDependants(batch)
         .thenComposeAsync(v -> archive(templateDescriptor, batch, Map.of()), getExecutor())
-        .thenApply(
-            archived -> {
-              recentlyArchivedProcessInstances.markRecentlyArchived(batch);
-              return archived;
-            });
+        .thenApply(FunctionUtil.peek(archived -> markBatchRecentlyArchived(batch)));
   }
 
   @Override
@@ -143,6 +140,10 @@ public class ProcessInstanceArchiverJob extends ArchiverJob<ProcessInstanceArchi
       final ProcessInstanceArchiveBatch batch) {
     final List<CompletableFuture<?>> dependentFutures = getProcessDependentArchiveFutures(batch);
     return CompletableFuture.allOf(dependentFutures.toArray(CompletableFuture[]::new));
+  }
+
+  protected void markBatchRecentlyArchived(final ProcessInstanceArchiveBatch batch) {
+    recentlyArchivedProcessInstances.markRecentlyArchived(batch);
   }
 
   protected List<CompletableFuture<?>> getProcessDependentArchiveFutures(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJob.java
@@ -139,15 +139,13 @@ public class ProcessInstanceArchiverJob extends ArchiverJob<ProcessInstanceArchi
     return idsMap;
   }
 
-  private int largeBatchSize() {
-    final int rolloverBatchSize = config.getRolloverBatchSize();
-    final int largeBatchSize =
-        Math.min(MAX_LARGE_BATCH_SIZE, SUB_BATCHES_PER_LARGE_BATCH * rolloverBatchSize);
-    // just in case rollover batch size is configured very high
-    return Math.max(largeBatchSize, rolloverBatchSize);
+  protected CompletableFuture<Void> archiveProcessDependants(
+      final ProcessInstanceArchiveBatch batch) {
+    final List<CompletableFuture<?>> dependentFutures = getProcessDependentArchiveFutures(batch);
+    return CompletableFuture.allOf(dependentFutures.toArray(CompletableFuture[]::new));
   }
 
-  private CompletableFuture<Void> archiveProcessDependants(
+  protected List<CompletableFuture<?>> getProcessDependentArchiveFutures(
       final ProcessInstanceArchiveBatch batch) {
     final var futures = new ArrayList<CompletableFuture<?>>();
 
@@ -155,6 +153,14 @@ public class ProcessInstanceArchiverJob extends ArchiverJob<ProcessInstanceArchi
       futures.add(archive(dependant, batch, Map.of()));
     }
 
-    return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new));
+    return futures;
+  }
+
+  private int largeBatchSize() {
+    final int rolloverBatchSize = config.getRolloverBatchSize();
+    final int largeBatchSize =
+        Math.min(MAX_LARGE_BATCH_SIZE, SUB_BATCHES_PER_LARGE_BATCH * rolloverBatchSize);
+    // just in case rollover batch size is configured very high
+    return Math.max(largeBatchSize, rolloverBatchSize);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJob.java
@@ -99,7 +99,7 @@ public class ProcessInstanceArchiverJob extends ArchiverJob<ProcessInstanceArchi
   protected CompletableFuture<Integer> archive(
       final IndexTemplateDescriptor templateDescriptor, final ProcessInstanceArchiveBatch batch) {
     return archiveProcessDependants(batch)
-        .thenComposeAsync(v -> super.archive(templateDescriptor, batch), getExecutor())
+        .thenComposeAsync(v -> archive(templateDescriptor, batch, Map.of()), getExecutor())
         .thenApply(
             archived -> {
               recentlyArchivedProcessInstances.markRecentlyArchived(batch);
@@ -152,7 +152,7 @@ public class ProcessInstanceArchiverJob extends ArchiverJob<ProcessInstanceArchi
     final var futures = new ArrayList<CompletableFuture<?>>();
 
     for (final var dependant : processInstanceDependants) {
-      futures.add(super.archive(dependant, batch));
+      futures.add(archive(dependant, batch, Map.of()));
     }
 
     return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new));

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceByIdArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceByIdArchiverJob.java
@@ -51,6 +51,37 @@ public class ProcessInstanceByIdArchiverJob extends ProcessInstanceArchiverJob {
   }
 
   @Override
+  protected CompletableFuture<Void> archiveProcessDependants(
+      final ProcessInstanceArchiveBatch batch) {
+    // get the usual process instance dependent archive tasks
+    final List<CompletableFuture<?>> dependentFutures = getProcessDependentArchiveFutures(batch);
+
+    // add archiving tasks to archive data from list-view in parallel with the dependent indexes.
+
+    // Note: We can archive all data except documents with `joinRelation: processInstance`.
+    // These must be moved last to avoid dangling data (i.e., child/dependent records that cannot
+    // be moved independently of their parent instance). We use fields from the parent
+    // document (e.g., `endDate`, `status`) to decide whether to archive documents from the
+    // main index.
+
+    // add archiving variables from the list view index as a parallel task
+    dependentFutures.add(
+        archive(
+            getTemplateDescriptor(),
+            batch,
+            Map.of(ListViewTemplate.JOIN_RELATION, ListViewTemplate.VARIABLES_JOIN_RELATION)));
+
+    // add archiving flownodes/activities from the list view index as a parallel task
+    dependentFutures.add(
+        archive(
+            getTemplateDescriptor(),
+            batch,
+            Map.of(ListViewTemplate.JOIN_RELATION, ListViewTemplate.ACTIVITIES_JOIN_RELATION)));
+
+    return CompletableFuture.allOf(dependentFutures.toArray(CompletableFuture[]::new));
+  }
+
+  @Override
   protected CompletableFuture<Integer> archive(
       final IndexTemplateDescriptor templateDescriptor,
       final ProcessInstanceArchiveBatch batch,

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceByIdArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceByIdArchiverJob.java
@@ -13,6 +13,7 @@ import io.camunda.exporter.tasks.archiver.ArchiveBatch.ProcessInstanceArchiveBat
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
+import io.camunda.zeebe.util.FunctionUtil;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -51,6 +52,28 @@ public class ProcessInstanceByIdArchiverJob extends ProcessInstanceArchiverJob {
   }
 
   @Override
+  protected CompletableFuture<Integer> archive(
+      final IndexTemplateDescriptor templateDescriptor, final ProcessInstanceArchiveBatch batch) {
+    // 1. First archive docs from dependent indices and `joinRelation={variable OR activity}`
+    // from operate-list-view index
+    // 2. Then archive all docs except `joinRelation=processInstance` from operate-list-view index
+    // 3. Then archive remaining docs from operate-list-view index (catch-all without filters)
+    return archiveProcessDependants(batch)
+        .thenComposeAsync(
+            v ->
+                archive(
+                    templateDescriptor,
+                    batch,
+                    Map.of(),
+                    Map.of(
+                        ListViewTemplate.JOIN_RELATION,
+                        ListViewTemplate.PROCESS_INSTANCE_JOIN_RELATION)),
+            getExecutor())
+        .thenComposeAsync(ignored -> archive(templateDescriptor, batch, Map.of()), getExecutor())
+        .thenApply(FunctionUtil.peek(archived -> markBatchRecentlyArchived(batch)));
+  }
+
+  @Override
   protected CompletableFuture<Void> archiveProcessDependants(
       final ProcessInstanceArchiveBatch batch) {
     // get the usual process instance dependent archive tasks
@@ -85,13 +108,26 @@ public class ProcessInstanceByIdArchiverJob extends ProcessInstanceArchiverJob {
   protected CompletableFuture<Integer> archive(
       final IndexTemplateDescriptor templateDescriptor,
       final ProcessInstanceArchiveBatch batch,
-      final Map<String, String> filters) {
+      final Map<String, String> inclusionFilters) {
+    return archive(templateDescriptor, batch, inclusionFilters, Map.of());
+  }
+
+  protected CompletableFuture<Integer> archive(
+      final IndexTemplateDescriptor templateDescriptor,
+      final ProcessInstanceArchiveBatch batch,
+      final Map<String, String> inclusionFilters,
+      final Map<String, String> exclusionFilters) {
     final var sourceIdxName = templateDescriptor.getFullQualifiedName();
     final var idsMap = createIdsByFieldMap(templateDescriptor, batch);
     final var finishDate = batch.finishDate();
     return getArchiverRepository()
         .moveDocumentsById(
-            sourceIdxName, sourceIdxName + finishDate, idsMap, filters, getExecutor())
+            sourceIdxName,
+            sourceIdxName + finishDate,
+            idsMap,
+            inclusionFilters,
+            exclusionFilters,
+            getExecutor())
         .thenApplyAsync(ok -> batch.size(), getExecutor());
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceByIdArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceByIdArchiverJob.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.archiver;
+
+import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
+import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.tasks.archiver.ArchiveBatch.ProcessInstanceArchiveBatch;
+import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
+import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
+import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import org.slf4j.Logger;
+
+/**
+ * This is an experimental archiver job for handling process instance data where we reindex
+ * documents by id. Similar to the {@link ProcessInstanceArchiverJob} this job handles the archiving
+ * of the process instance records itself and also delegates to the repository to move dependent
+ * records (decisions, flow node instances, variable updates, etc).
+ */
+public class ProcessInstanceByIdArchiverJob extends ProcessInstanceArchiverJob {
+
+  public ProcessInstanceByIdArchiverJob(
+      final HistoryConfiguration config,
+      final ArchiverRepository repository,
+      final ListViewTemplate processInstanceTemplate,
+      final List<ProcessInstanceDependant> processInstanceDependants,
+      final CamundaExporterMetrics metrics,
+      final Logger logger,
+      final Executor executor) {
+    super(
+        config,
+        repository,
+        processInstanceTemplate,
+        processInstanceDependants,
+        metrics,
+        logger,
+        executor);
+  }
+
+  @Override
+  String getJobName() {
+    return "process-instance-by-id";
+  }
+
+  @Override
+  protected CompletableFuture<Integer> archive(
+      final IndexTemplateDescriptor templateDescriptor,
+      final ProcessInstanceArchiveBatch batch,
+      final Map<String, String> filters) {
+    final var sourceIdxName = templateDescriptor.getFullQualifiedName();
+    final var idsMap = createIdsByFieldMap(templateDescriptor, batch);
+    final var finishDate = batch.finishDate();
+    return getArchiverRepository()
+        .moveDocumentsById(
+            sourceIdxName, sourceIdxName + finishDate, idsMap, filters, getExecutor())
+        .thenApplyAsync(ok -> batch.size(), getExecutor());
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AsyncRepeatUntilTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AsyncRepeatUntilTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.archiver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+class AsyncRepeatUntilTest {
+
+  @Test
+  void shouldCompleteWhenTaskCompletes() {
+    // given
+    // when
+    final var future =
+        AsyncRepeatUntil.repeatUntil(() -> CompletableFuture.completedFuture(1), result -> true);
+
+    // then
+    assertThat(future).succeedsWithin(Duration.ofSeconds(2));
+    // ensure no exceptions are thrown
+    future.join();
+  }
+
+  @Test
+  void shouldNotCompleteWhenTaskDoesNotComplete() {
+    // given
+    // when
+    final var future = AsyncRepeatUntil.repeatUntil(CompletableFuture::new, result -> true);
+
+    // then
+    assertThat(future.isDone()).isFalse();
+  }
+
+  @Test
+  void shouldCompleteExceptionallyWhenTasksFailsAsync() {
+    // given
+    // when
+    final var future =
+        AsyncRepeatUntil.repeatUntil(
+            // task fails in an async manner
+            () -> CompletableFuture.failedFuture(new RuntimeException("future failed")),
+            result -> true);
+
+    // then
+    assertThat(future.isDone()).isTrue();
+    assertThat(future.isCompletedExceptionally()).isTrue();
+    assertThatThrownBy(future::join)
+        .isInstanceOf(CompletionException.class)
+        .cause()
+        .hasMessageContaining("future failed");
+  }
+
+  @Test
+  void shouldCompleteExceptionallyWhenTasksFailsSync() {
+    // given
+    // when
+    final var future =
+        AsyncRepeatUntil.repeatUntil(
+            () -> {
+              // task fails, but in a non-async way
+              throw new RuntimeException("task failed");
+            },
+            result -> true);
+
+    // then
+    assertThat(future.isDone()).isTrue();
+    assertThat(future.isCompletedExceptionally()).isTrue();
+    assertThatThrownBy(future::join)
+        .isInstanceOf(CompletionException.class)
+        .cause()
+        .hasMessageContaining("task failed");
+  }
+
+  @Test
+  void shouldCompleteExceptionallyWhenUntilFails() {
+    // given
+    // when
+    final var future =
+        AsyncRepeatUntil.repeatUntil(
+            () -> CompletableFuture.completedFuture(1),
+            result -> {
+              throw new RuntimeException("until failed");
+            });
+
+    // then
+    //    assertThat(future.isDone()).isTrue();
+    assertThat(future).failsWithin(Duration.ofSeconds(2));
+    assertThatThrownBy(future::join)
+        .isInstanceOf(CompletionException.class)
+        .cause()
+        .hasMessageContaining("until failed");
+  }
+
+  @Test
+  void shouldCompleteWhenConditionMet() {
+    // given
+    final var counter = new AtomicInteger();
+
+    // when
+    final var future =
+        AsyncRepeatUntil.repeatUntil(
+            () -> CompletableFuture.completedFuture(counter.getAndIncrement()),
+            result -> result >= 5);
+
+    future.join();
+
+    // then
+    assertThat(counter.get()).isEqualTo(6);
+  }
+
+  @Test
+  void shouldRunTasksSerially() {
+    // given
+    final CompletableFuture<Integer> future1 = new CompletableFuture<>();
+    final CompletableFuture<Integer> future2 = new CompletableFuture<>();
+
+    final Supplier<CompletableFuture<Integer>> taskSupplier = mock(Supplier.class);
+
+    when(taskSupplier.get()).thenReturn(future1).thenReturn(future2);
+
+    // when
+    final var future = AsyncRepeatUntil.repeatUntil(taskSupplier, result -> result >= 2);
+
+    // then
+    assertThat(future.isDone()).isFalse();
+    verify(taskSupplier).get();
+
+    // when
+    // complete the first task, which should trigger the second task to be called
+    future1.complete(1);
+
+    // then
+    assertThat(future.isDone()).isFalse();
+    Awaitility.await().untilAsserted(() -> verify(taskSupplier, times(2)).get());
+
+    // when
+    // complete the second task, which should complete the future
+    future2.complete(2);
+
+    // then
+    assertThat(future).succeedsWithin(Duration.ofSeconds(2));
+    verify(taskSupplier, times(2)).get();
+
+    future.join();
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
@@ -1154,11 +1154,11 @@ final class ElasticsearchArchiverRepositoryIT {
     final var repository = createRepository();
     final var documents =
         List.of(
-            new TestProcessDocument("1", 111L),
-            new TestProcessDocument("2", 111L),
-            new TestProcessDocument("3", 222L),
-            new TestProcessDocument("4", 111L),
-            new TestProcessDocument("5", 222L));
+            new TestProcessDocument("1", 111L, "variable"),
+            new TestProcessDocument("2", 111L, "activity"),
+            new TestProcessDocument("3", 222L, "variable"),
+            new TestProcessDocument("4", 111L, "variable"),
+            new TestProcessDocument("5", 222L, "activity"));
 
     // create the index template first to ensure ID is a keyword, otherwise the surrounding
     // aggregation will fail
@@ -1171,7 +1171,11 @@ final class ElasticsearchArchiverRepositoryIT {
     final var batch =
         repository
             .getArchiveDocIdsBatch(
-                processInstanceIndex, Map.of("processInstanceKey", List.of("111")), Map.of(), null)
+                processInstanceIndex,
+                Map.of("processInstanceKey", List.of("111")),
+                Map.of(),
+                Map.of(),
+                null)
             .join();
 
     assertThat(batch.ids()).containsExactlyInAnyOrder("1", "2", "4");
@@ -1183,7 +1187,11 @@ final class ElasticsearchArchiverRepositoryIT {
     final var emptyBatch =
         repository
             .getArchiveDocIdsBatch(
-                processInstanceIndex, Map.of("processInstanceKey", List.of("999")), Map.of(), null)
+                processInstanceIndex,
+                Map.of("processInstanceKey", List.of("999")),
+                Map.of(),
+                Map.of(),
+                null)
             .join();
 
     assertThat(emptyBatch.isEmpty()).isTrue();
@@ -1196,7 +1204,11 @@ final class ElasticsearchArchiverRepositoryIT {
     final var batchPg1 =
         repository
             .getArchiveDocIdsBatch(
-                processInstanceIndex, Map.of("processInstanceKey", List.of("111")), Map.of(), null)
+                processInstanceIndex,
+                Map.of("processInstanceKey", List.of("111")),
+                Map.of(),
+                Map.of(),
+                null)
             .join();
 
     assertThat(batchPg1.ids()).containsExactlyInAnyOrder("1", "2");
@@ -1210,6 +1222,7 @@ final class ElasticsearchArchiverRepositoryIT {
             .getArchiveDocIdsBatch(
                 processInstanceIndex,
                 Map.of("processInstanceKey", List.of("111")),
+                Map.of(),
                 Map.of(),
                 batchPg1.searchAfter())
             .join();
@@ -1226,12 +1239,43 @@ final class ElasticsearchArchiverRepositoryIT {
                 processInstanceIndex,
                 Map.of("processInstanceKey", List.of("111")),
                 Map.of(),
+                Map.of(),
                 batchPg2.searchAfter())
             .join();
 
     assertThat(batchPg3.isEmpty()).isTrue();
     assertThat(batchPg3.ids()).isEmpty();
     assertThat(batchPg3.searchAfter()).isEmpty();
+
+    // when searching for process instance key 111 with exclusion filter for joinRelation=activity
+    // then - we expect only documents with joinRelation != activity (IDs 1 and 4)
+    config.setReindexBatchSize(100);
+    final var batchExcluded =
+        repository
+            .getArchiveDocIdsBatch(
+                processInstanceIndex,
+                Map.of("processInstanceKey", List.of("111")),
+                Map.of(),
+                Map.of("joinRelation", "activity"),
+                null)
+            .join();
+
+    assertThat(batchExcluded.ids()).containsExactlyInAnyOrder("1", "4");
+
+    // when searching for process instance key 111 with inclusion filter for joinRelation=variable
+    // and exclusion filter for joinRelation=activity
+    // then - we expect only documents matching joinRelation=variable (IDs 1 and 4)
+    final var batchBothFilters =
+        repository
+            .getArchiveDocIdsBatch(
+                processInstanceIndex,
+                Map.of("processInstanceKey", List.of("111")),
+                Map.of("joinRelation", "variable"),
+                Map.of("joinRelation", "activity"),
+                null)
+            .join();
+
+    assertThat(batchBothFilters.ids()).containsExactlyInAnyOrder("1", "4");
   }
 
   @Test
@@ -1323,6 +1367,7 @@ final class ElasticsearchArchiverRepositoryIT {
             processInstanceIndex,
             processInstanceIndex + "_dest",
             Map.of("processInstanceKey", List.of("111", "333")),
+            Map.of(),
             Map.of(),
             executor)
         .join(); // wait for completion
@@ -1657,7 +1702,12 @@ final class ElasticsearchArchiverRepositoryIT {
 
   private record TestDocument(String id) implements TDocument {}
 
-  private record TestProcessDocument(String id, Long processInstanceKey) implements TDocument {}
+  private record TestProcessDocument(String id, Long processInstanceKey, String joinRelation)
+      implements TDocument {
+    TestProcessDocument(final String id, final Long processInstanceKey) {
+      this(id, processInstanceKey, null);
+    }
+  }
 
   private record TestBatchOperation(String id, String endDate) implements TDocument {}
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
@@ -57,6 +57,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.http.HttpHost;
@@ -99,6 +102,7 @@ final class ElasticsearchArchiverRepositoryIT {
   private final String zeebeIndex = zeebeIndexPrefix + "-" + UUID.randomUUID();
   private final ElasticsearchClient testClient = new ElasticsearchClient(transport);
   private final ObjectMapper objectMapper = TestObjectMapper.objectMapper();
+  @AutoClose private final ExecutorService executor = Executors.newSingleThreadExecutor();
 
   @AfterEach
   void afterEach() throws IOException {
@@ -1145,6 +1149,241 @@ final class ElasticsearchArchiverRepositoryIT {
     }
   }
 
+  @Test
+  void shouldGetArchiveDocIdsBatch() throws IOException {
+    final var repository = createRepository();
+    final var documents =
+        List.of(
+            new TestProcessDocument("1", 111L),
+            new TestProcessDocument("2", 111L),
+            new TestProcessDocument("3", 222L),
+            new TestProcessDocument("4", 111L),
+            new TestProcessDocument("5", 222L));
+
+    // create the index template first to ensure ID is a keyword, otherwise the surrounding
+    // aggregation will fail
+    createProcessInstanceIndex();
+    documents.forEach(doc -> index(processInstanceIndex, doc));
+    testClient.indices().refresh(r -> r.index(processInstanceIndex));
+
+    // when searching for process instance key 111
+    // then - we expect documents with IDs 1,2 and 4 to be returned
+    final var batch =
+        repository
+            .getArchiveDocIdsBatch(
+                processInstanceIndex, Map.of("processInstanceKey", List.of("111")), Map.of(), null)
+            .join();
+
+    assertThat(batch.ids()).containsExactlyInAnyOrder("1", "2", "4");
+    assertThat(batch.searchAfter()).hasSize(1);
+    assertThat(batch.searchAfter().getFirst().stringValue()).isEqualTo("4");
+
+    // when searching for process instance key 999
+    // then - we expect no documents to be returned
+    final var emptyBatch =
+        repository
+            .getArchiveDocIdsBatch(
+                processInstanceIndex, Map.of("processInstanceKey", List.of("999")), Map.of(), null)
+            .join();
+
+    assertThat(emptyBatch.isEmpty()).isTrue();
+    assertThat(emptyBatch.ids()).isEmpty();
+    assertThat(emptyBatch.searchAfter()).isEmpty();
+
+    // when searching for process instance key 111 with reindex batch size of 2
+    // then - we expect documents with IDs 1 and 2 to be returned
+    config.setReindexBatchSize(2);
+    final var batchPg1 =
+        repository
+            .getArchiveDocIdsBatch(
+                processInstanceIndex, Map.of("processInstanceKey", List.of("111")), Map.of(), null)
+            .join();
+
+    assertThat(batchPg1.ids()).containsExactlyInAnyOrder("1", "2");
+    assertThat(batchPg1.searchAfter().getFirst().stringValue()).isEqualTo("2");
+
+    // when searching for process instance key 111 with searchAfter from page 1
+    // then - we expect document with ID 4 to be returned
+    config.setReindexBatchSize(2);
+    final var batchPg2 =
+        repository
+            .getArchiveDocIdsBatch(
+                processInstanceIndex,
+                Map.of("processInstanceKey", List.of("111")),
+                Map.of(),
+                batchPg1.searchAfter())
+            .join();
+
+    assertThat(batchPg2.ids()).containsExactlyInAnyOrder("4");
+    assertThat(batchPg2.searchAfter().getFirst().stringValue()).isEqualTo("4");
+
+    // when searching for process instance key 111 with searchAfter from page 2
+    // then - we expect no documents to be returned
+    config.setReindexBatchSize(2);
+    final var batchPg3 =
+        repository
+            .getArchiveDocIdsBatch(
+                processInstanceIndex,
+                Map.of("processInstanceKey", List.of("111")),
+                Map.of(),
+                batchPg2.searchAfter())
+            .join();
+
+    assertThat(batchPg3.isEmpty()).isTrue();
+    assertThat(batchPg3.ids()).isEmpty();
+    assertThat(batchPg3.searchAfter()).isEmpty();
+  }
+
+  @Test
+  void shouldReindexDocumentsById() throws IOException {
+    // given
+    final var sourceIndexName = UUID.randomUUID().toString();
+    final var destIndexName = UUID.randomUUID().toString();
+    final var repository = createRepository();
+    final var documents =
+        List.of(new TestDocument("1"), new TestDocument("2"), new TestDocument("3"));
+    documents.forEach(doc -> index(sourceIndexName, doc));
+    testClient.indices().refresh(r -> r.index(sourceIndexName));
+    testClient.indices().create(r -> r.index(destIndexName));
+
+    // when - reindex the first two documents
+    final var result =
+        repository.reindexDocumentsById(sourceIndexName, destIndexName, List.of("1", "2"));
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ofSeconds(30));
+    testClient.indices().refresh(r -> r.index(destIndexName));
+    final var remaining =
+        testClient.search(r -> r.index(sourceIndexName).requestCache(false), TestDocument.class);
+    final var reindexed =
+        testClient.search(r -> r.index(destIndexName).requestCache(false), TestDocument.class);
+    assertThat(reindexed.hits().hits())
+        .as("only first two documents were reindexed")
+        .hasSize(2)
+        .map(Hit::id)
+        .containsExactlyInAnyOrder("1", "2");
+    assertThat(remaining.hits().hits())
+        .as("all documents are remaining")
+        .hasSize(3)
+        .extracting(Hit::id)
+        .containsExactlyInAnyOrder("1", "2", "3");
+  }
+
+  @Test
+  void shouldDeleteDocumentsById() throws IOException {
+    // given
+    final var indexName = UUID.randomUUID().toString();
+    final var repository = createRepository();
+    final var documents =
+        List.of(new TestDocument("1"), new TestDocument("2"), new TestDocument("3"));
+    documents.forEach(doc -> index(indexName, doc));
+    testClient.indices().refresh(r -> r.index(indexName));
+
+    // when - delete the first two documents
+    final var result = repository.deleteDocumentsById(indexName, List.of("1", "2"));
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ofSeconds(30));
+    testClient.indices().refresh(r -> r.index(indexName));
+    final var remaining =
+        testClient.search(r -> r.index(indexName).requestCache(false), TestDocument.class);
+    assertThat(remaining.hits().hits())
+        .as("only the third document is remaining")
+        .hasSize(1)
+        .first()
+        .extracting(Hit::id)
+        .isEqualTo("3");
+  }
+
+  @Test
+  void shouldMoveDocumentsById() throws IOException {
+    final var repository = createRepository();
+    final List<TestProcessDocument> documents = new ArrayList<>();
+
+    IntStream.rangeClosed(100, 199)
+        .mapToObj(i -> new TestProcessDocument(String.valueOf(i), 111L))
+        .forEach(documents::add);
+    IntStream.rangeClosed(200, 299)
+        .mapToObj(i -> new TestProcessDocument(String.valueOf(i), 222L))
+        .forEach(documents::add);
+    IntStream.rangeClosed(300, 399)
+        .mapToObj(i -> new TestProcessDocument(String.valueOf(i), 333L))
+        .forEach(documents::add);
+
+    // create the index template first to ensure ID is a keyword, otherwise the surrounding
+    // aggregation will fail
+    createProcessInstanceIndex();
+    documents.forEach(doc -> index(processInstanceIndex, doc));
+    testClient.indices().refresh(r -> r.index(processInstanceIndex));
+
+    // when moving documents by id
+    config.setReindexBatchSize(10); // force multiple batches
+    repository
+        .moveDocumentsById(
+            processInstanceIndex,
+            processInstanceIndex + "_dest",
+            Map.of("processInstanceKey", List.of("111", "333")),
+            Map.of(),
+            executor)
+        .join(); // wait for completion
+
+    // then refresh indices
+    testClient.indices().refresh(r -> r.index(processInstanceIndex));
+    testClient.indices().refresh(r -> r.index(processInstanceIndex + "_dest"));
+
+    // then confirm docs were moved
+
+    final var totalSource =
+        testClient.count(r -> r.index(processInstanceIndex).query(q -> q.matchAll(a -> a))).count();
+    // only docs with `processInstanceKey=222` should be present
+    assertThat(totalSource).isEqualTo(100);
+
+    final List<Integer> sourceIds =
+        testClient
+            .search(
+                r ->
+                    r.index(processInstanceIndex)
+                        .query(q -> q.matchAll(a -> a))
+                        .size(1000)
+                        .source(s -> s.fetch(false)),
+                Object.class)
+            .hits()
+            .hits()
+            .stream()
+            .map(Hit::id)
+            .map(Integer::valueOf)
+            .sorted()
+            .toList();
+    assertThat(sourceIds.getFirst()).isEqualTo(200);
+    assertThat(sourceIds.getLast()).isEqualTo(299);
+
+    final var totalDestination =
+        testClient
+            .count(r -> r.index(processInstanceIndex + "_dest").query(q -> q.matchAll(a -> a)))
+            .count();
+    // only docs with `processInstanceKey=[111,333]` should be present
+    assertThat(totalDestination).isEqualTo(200);
+
+    final List<Integer> destinationIds =
+        testClient
+            .search(
+                r ->
+                    r.index(processInstanceIndex + "_dest")
+                        .query(q -> q.matchAll(a -> a))
+                        .size(1000)
+                        .source(s -> s.fetch(false)),
+                Object.class)
+            .hits()
+            .hits()
+            .stream()
+            .map(Hit::id)
+            .map(Integer::valueOf)
+            .sorted()
+            .toList();
+    assertThat(destinationIds.getFirst()).isEqualTo(100);
+    assertThat(destinationIds.getLast()).isEqualTo(399);
+  }
+
   private void startupSchema() {
     final var searchEngineClient = new ElasticsearchEngineClient(testClient, objectMapper);
     final var connectConfig = new ConnectConfiguration();
@@ -1417,6 +1656,8 @@ final class ElasticsearchArchiverRepositoryIT {
   private record TestAuditLogDocument(String id, String entityType) implements TDocument {}
 
   private record TestDocument(String id) implements TDocument {}
+
+  private record TestProcessDocument(String id, Long processInstanceKey) implements TDocument {}
 
   private record TestBatchOperation(String id, String endDate) implements TDocument {}
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/NoopArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/NoopArchiverRepository.java
@@ -11,6 +11,7 @@ import io.camunda.exporter.tasks.archiver.ArchiveBatch.ProcessInstanceArchiveBat
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 
 public class NoopArchiverRepository implements ArchiverRepository {
 
@@ -89,6 +90,16 @@ public class NoopArchiverRepository implements ArchiverRepository {
       final String destinationIndexName,
       final Map<String, List<String>> keysByField,
       final Map<String, String> filters) {
+    return CompletableFuture.completedFuture(null);
+  }
+
+  @Override
+  public CompletableFuture<Void> moveDocumentsById(
+      final String sourceIndexName,
+      final String destinationIndexName,
+      final Map<String, List<String>> keysByField,
+      final Map<String, String> filters,
+      final Executor executor) {
     return CompletableFuture.completedFuture(null);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/NoopArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/NoopArchiverRepository.java
@@ -98,7 +98,8 @@ public class NoopArchiverRepository implements ArchiverRepository {
       final String sourceIndexName,
       final String destinationIndexName,
       final Map<String, List<String>> keysByField,
-      final Map<String, String> filters,
+      final Map<String, String> inclusionFilters,
+      final Map<String, String> exclusionFilters,
       final Executor executor) {
     return CompletableFuture.completedFuture(null);
   }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -1254,11 +1254,11 @@ final class OpenSearchArchiverRepositoryIT {
     final var repository = createRepository();
     final var documents =
         List.of(
-            new TestProcessDocument("1", 111L),
-            new TestProcessDocument("2", 111L),
-            new TestProcessDocument("3", 222L),
-            new TestProcessDocument("4", 111L),
-            new TestProcessDocument("5", 222L));
+            new TestProcessDocument("1", 111L, "variable"),
+            new TestProcessDocument("2", 111L, "activity"),
+            new TestProcessDocument("3", 222L, "variable"),
+            new TestProcessDocument("4", 111L, "variable"),
+            new TestProcessDocument("5", 222L, "activity"));
 
     // create the index template first to ensure ID is a keyword, otherwise the surrounding
     // aggregation will fail
@@ -1271,7 +1271,11 @@ final class OpenSearchArchiverRepositoryIT {
     final var batch =
         repository
             .getArchiveDocIdsBatch(
-                processInstanceIndex, Map.of("processInstanceKey", List.of("111")), Map.of(), null)
+                processInstanceIndex,
+                Map.of("processInstanceKey", List.of("111")),
+                Map.of(),
+                Map.of(),
+                null)
             .join();
 
     assertThat(batch.ids()).containsExactlyInAnyOrder("1", "2", "4");
@@ -1283,7 +1287,11 @@ final class OpenSearchArchiverRepositoryIT {
     final var emptyBatch =
         repository
             .getArchiveDocIdsBatch(
-                processInstanceIndex, Map.of("processInstanceKey", List.of("999")), Map.of(), null)
+                processInstanceIndex,
+                Map.of("processInstanceKey", List.of("999")),
+                Map.of(),
+                Map.of(),
+                null)
             .join();
 
     assertThat(emptyBatch.isEmpty()).isTrue();
@@ -1296,7 +1304,11 @@ final class OpenSearchArchiverRepositoryIT {
     final var batchPg1 =
         repository
             .getArchiveDocIdsBatch(
-                processInstanceIndex, Map.of("processInstanceKey", List.of("111")), Map.of(), null)
+                processInstanceIndex,
+                Map.of("processInstanceKey", List.of("111")),
+                Map.of(),
+                Map.of(),
+                null)
             .join();
 
     assertThat(batchPg1.ids()).containsExactlyInAnyOrder("1", "2");
@@ -1310,6 +1322,7 @@ final class OpenSearchArchiverRepositoryIT {
             .getArchiveDocIdsBatch(
                 processInstanceIndex,
                 Map.of("processInstanceKey", List.of("111")),
+                Map.of(),
                 Map.of(),
                 batchPg1.searchAfter())
             .join();
@@ -1326,12 +1339,43 @@ final class OpenSearchArchiverRepositoryIT {
                 processInstanceIndex,
                 Map.of("processInstanceKey", List.of("111")),
                 Map.of(),
+                Map.of(),
                 batchPg2.searchAfter())
             .join();
 
     assertThat(batchPg3.isEmpty()).isTrue();
     assertThat(batchPg3.ids()).isEmpty();
     assertThat(batchPg3.searchAfter()).isEmpty();
+
+    // when searching for process instance key 111 with exclusion filter for joinRelation=activity
+    // then - we expect only documents with joinRelation != activity (IDs 1 and 4)
+    config.setReindexBatchSize(100);
+    final var batchExcluded =
+        repository
+            .getArchiveDocIdsBatch(
+                processInstanceIndex,
+                Map.of("processInstanceKey", List.of("111")),
+                Map.of(),
+                Map.of("joinRelation", "activity"),
+                null)
+            .join();
+
+    assertThat(batchExcluded.ids()).containsExactlyInAnyOrder("1", "4");
+
+    // when searching for process instance key 111 with inclusion filter for joinRelation=variable
+    // and exclusion filter for joinRelation=activity
+    // then - we expect only documents matching joinRelation=variable (IDs 1 and 4)
+    final var batchBothFilters =
+        repository
+            .getArchiveDocIdsBatch(
+                processInstanceIndex,
+                Map.of("processInstanceKey", List.of("111")),
+                Map.of("joinRelation", "variable"),
+                Map.of("joinRelation", "activity"),
+                null)
+            .join();
+
+    assertThat(batchBothFilters.ids()).containsExactlyInAnyOrder("1", "4");
   }
 
   @Test
@@ -1423,6 +1467,7 @@ final class OpenSearchArchiverRepositoryIT {
             processInstanceIndex,
             processInstanceIndex + "_dest",
             Map.of("processInstanceKey", List.of("111", "333")),
+            Map.of(),
             Map.of(),
             executor)
         .join(); // wait for completion
@@ -1953,7 +1998,12 @@ final class OpenSearchArchiverRepositoryIT {
 
   private record TestDocument(String id) implements TDocument {}
 
-  private record TestProcessDocument(String id, Long processInstanceKey) implements TDocument {}
+  private record TestProcessDocument(String id, Long processInstanceKey, String joinRelation)
+      implements TDocument {
+    TestProcessDocument(final String id, final Long processInstanceKey) {
+      this(id, processInstanceKey, null);
+    }
+  }
 
   private record TestProcessInstance(
       String id,

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -54,6 +54,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hc.core5.http.HttpHost;
@@ -107,6 +110,7 @@ final class OpenSearchArchiverRepositoryIT {
   private TestExporterResourceProvider resourceProvider;
   private String indexPrefix;
   private final ObjectMapper objectMapper = TestObjectMapper.objectMapper();
+  @AutoClose private final ExecutorService executor = Executors.newSingleThreadExecutor();
 
   @AfterEach
   void afterEach() {
@@ -1246,6 +1250,241 @@ final class OpenSearchArchiverRepositoryIT {
   }
 
   @Test
+  void shouldGetArchiveDocIdsBatch() throws IOException {
+    final var repository = createRepository();
+    final var documents =
+        List.of(
+            new TestProcessDocument("1", 111L),
+            new TestProcessDocument("2", 111L),
+            new TestProcessDocument("3", 222L),
+            new TestProcessDocument("4", 111L),
+            new TestProcessDocument("5", 222L));
+
+    // create the index template first to ensure ID is a keyword, otherwise the surrounding
+    // aggregation will fail
+    createProcessInstanceIndex();
+    documents.forEach(doc -> index(processInstanceIndex, doc));
+    testClient.indices().refresh(r -> r.index(processInstanceIndex));
+
+    // when searching for process instance key 111
+    // then - we expect documents with IDs 1,2 and 4 to be returned
+    final var batch =
+        repository
+            .getArchiveDocIdsBatch(
+                processInstanceIndex, Map.of("processInstanceKey", List.of("111")), Map.of(), null)
+            .join();
+
+    assertThat(batch.ids()).containsExactlyInAnyOrder("1", "2", "4");
+    assertThat(batch.searchAfter()).hasSize(1);
+    assertThat(batch.searchAfter().getFirst().stringValue()).isEqualTo("4");
+
+    // when searching for process instance key 999
+    // then - we expect no documents to be returned
+    final var emptyBatch =
+        repository
+            .getArchiveDocIdsBatch(
+                processInstanceIndex, Map.of("processInstanceKey", List.of("999")), Map.of(), null)
+            .join();
+
+    assertThat(emptyBatch.isEmpty()).isTrue();
+    assertThat(emptyBatch.ids()).isEmpty();
+    assertThat(emptyBatch.searchAfter()).isEmpty();
+
+    // when searching for process instance key 111 with reindex batch size of 2
+    // then - we expect documents with IDs 1 and 2 to be returned
+    config.setReindexBatchSize(2);
+    final var batchPg1 =
+        repository
+            .getArchiveDocIdsBatch(
+                processInstanceIndex, Map.of("processInstanceKey", List.of("111")), Map.of(), null)
+            .join();
+
+    assertThat(batchPg1.ids()).containsExactlyInAnyOrder("1", "2");
+    assertThat(batchPg1.searchAfter().getFirst().stringValue()).isEqualTo("2");
+
+    // when searching for process instance key 111 with searchAfter from page 1
+    // then - we expect document with ID 4 to be returned
+    config.setReindexBatchSize(2);
+    final var batchPg2 =
+        repository
+            .getArchiveDocIdsBatch(
+                processInstanceIndex,
+                Map.of("processInstanceKey", List.of("111")),
+                Map.of(),
+                batchPg1.searchAfter())
+            .join();
+
+    assertThat(batchPg2.ids()).containsExactlyInAnyOrder("4");
+    assertThat(batchPg2.searchAfter().getFirst().stringValue()).isEqualTo("4");
+
+    // when searching for process instance key 111 with searchAfter from page 2
+    // then - we expect no documents to be returned
+    config.setReindexBatchSize(2);
+    final var batchPg3 =
+        repository
+            .getArchiveDocIdsBatch(
+                processInstanceIndex,
+                Map.of("processInstanceKey", List.of("111")),
+                Map.of(),
+                batchPg2.searchAfter())
+            .join();
+
+    assertThat(batchPg3.isEmpty()).isTrue();
+    assertThat(batchPg3.ids()).isEmpty();
+    assertThat(batchPg3.searchAfter()).isEmpty();
+  }
+
+  @Test
+  void shouldReindexDocumentsById() throws IOException {
+    // given
+    final var sourceIndexName = ARCHIVER_IDX_PREFIX + UUID.randomUUID().toString();
+    final var destIndexName = ARCHIVER_IDX_PREFIX + UUID.randomUUID().toString();
+    final var repository = createRepository();
+    final var documents =
+        List.of(new TestDocument("1"), new TestDocument("2"), new TestDocument("3"));
+    documents.forEach(doc -> index(sourceIndexName, doc));
+    testClient.indices().refresh(r -> r.index(sourceIndexName));
+    testClient.indices().create(r -> r.index(destIndexName));
+
+    // when - reindex the first two documents
+    final var result =
+        repository.reindexDocumentsById(sourceIndexName, destIndexName, List.of("1", "2"));
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ofSeconds(30));
+    testClient.indices().refresh(r -> r.index(destIndexName));
+    final var remaining =
+        testClient.search(r -> r.index(sourceIndexName).requestCache(false), TestDocument.class);
+    final var reindexed =
+        testClient.search(r -> r.index(destIndexName).requestCache(false), TestDocument.class);
+    assertThat(reindexed.hits().hits())
+        .as("only first two documents were reindexed")
+        .hasSize(2)
+        .map(Hit::id)
+        .containsExactlyInAnyOrder("1", "2");
+    assertThat(remaining.hits().hits())
+        .as("all documents are remaining")
+        .hasSize(3)
+        .extracting(Hit::id)
+        .containsExactlyInAnyOrder("1", "2", "3");
+  }
+
+  @Test
+  void shouldDeleteDocumentsById() throws IOException {
+    // given
+    final var indexName = ARCHIVER_IDX_PREFIX + UUID.randomUUID().toString();
+    final var repository = createRepository();
+    final var documents =
+        List.of(new TestDocument("1"), new TestDocument("2"), new TestDocument("3"));
+    documents.forEach(doc -> index(indexName, doc));
+    testClient.indices().refresh(r -> r.index(indexName));
+
+    // when - delete the first two documents
+    final var result = repository.deleteDocumentsById(indexName, List.of("1", "2"));
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ofSeconds(30));
+    testClient.indices().refresh(r -> r.index(indexName));
+    final var remaining =
+        testClient.search(r -> r.index(indexName).requestCache(false), TestDocument.class);
+    assertThat(remaining.hits().hits())
+        .as("only the third document is remaining")
+        .hasSize(1)
+        .first()
+        .extracting(Hit::id)
+        .isEqualTo("3");
+  }
+
+  @Test
+  void shouldMoveDocumentsById() throws IOException {
+    final var repository = createRepository();
+    final List<TestProcessDocument> documents = new ArrayList<>();
+
+    IntStream.rangeClosed(100, 199)
+        .mapToObj(i -> new TestProcessDocument(String.valueOf(i), 111L))
+        .forEach(documents::add);
+    IntStream.rangeClosed(200, 299)
+        .mapToObj(i -> new TestProcessDocument(String.valueOf(i), 222L))
+        .forEach(documents::add);
+    IntStream.rangeClosed(300, 399)
+        .mapToObj(i -> new TestProcessDocument(String.valueOf(i), 333L))
+        .forEach(documents::add);
+
+    // create the index template first to ensure ID is a keyword, otherwise the surrounding
+    // aggregation will fail
+    createProcessInstanceIndex();
+    documents.forEach(doc -> index(processInstanceIndex, doc));
+    testClient.indices().refresh(r -> r.index(processInstanceIndex));
+
+    // when moving documents by id
+    config.setReindexBatchSize(10); // force multiple batches
+    repository
+        .moveDocumentsById(
+            processInstanceIndex,
+            processInstanceIndex + "_dest",
+            Map.of("processInstanceKey", List.of("111", "333")),
+            Map.of(),
+            executor)
+        .join(); // wait for completion
+
+    // then refresh indices
+    testClient.indices().refresh(r -> r.index(processInstanceIndex));
+    testClient.indices().refresh(r -> r.index(processInstanceIndex + "_dest"));
+
+    // then confirm docs were moved
+
+    final var totalSource =
+        testClient.count(r -> r.index(processInstanceIndex).query(q -> q.matchAll(a -> a))).count();
+    // only docs with `processInstanceKey=222` should be present
+    assertThat(totalSource).isEqualTo(100);
+
+    final List<Integer> sourceIds =
+        testClient
+            .search(
+                r ->
+                    r.index(processInstanceIndex)
+                        .query(q -> q.matchAll(a -> a))
+                        .size(1000)
+                        .source(s -> s.fetch(false)),
+                Object.class)
+            .hits()
+            .hits()
+            .stream()
+            .map(Hit::id)
+            .map(Integer::valueOf)
+            .sorted()
+            .toList();
+    assertThat(sourceIds.getFirst()).isEqualTo(200);
+    assertThat(sourceIds.getLast()).isEqualTo(299);
+
+    final var totalDestination =
+        testClient
+            .count(r -> r.index(processInstanceIndex + "_dest").query(q -> q.matchAll(a -> a)))
+            .count();
+    // only docs with `processInstanceKey=[111,333]` should be present
+    assertThat(totalDestination).isEqualTo(200);
+
+    final List<Integer> destinationIds =
+        testClient
+            .search(
+                r ->
+                    r.index(processInstanceIndex + "_dest")
+                        .query(q -> q.matchAll(a -> a))
+                        .size(1000)
+                        .source(s -> s.fetch(false)),
+                Object.class)
+            .hits()
+            .hits()
+            .stream()
+            .map(Hit::id)
+            .map(Integer::valueOf)
+            .sorted()
+            .toList();
+    assertThat(destinationIds.getFirst()).isEqualTo(100);
+    assertThat(destinationIds.getLast()).isEqualTo(399);
+  }
+
+  @Test
   void shouldMaintainSeparateArchiverDatesForDifferentTemplates() throws IOException {
     // given
     final var repository = createRepository();
@@ -1713,6 +1952,8 @@ final class OpenSearchArchiverRepositoryIT {
   private record TestBatchOperation(String id, String endDate) implements TDocument {}
 
   private record TestDocument(String id) implements TDocument {}
+
+  private record TestProcessDocument(String id, Long processInstanceKey) implements TDocument {}
 
   private record TestProcessInstance(
       String id,

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ProcessInstanceByIdArchiverJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ProcessInstanceByIdArchiverJobIT.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.archiver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.exporter.ExporterResourceProvider;
+import io.camunda.exporter.config.ExporterConfiguration;
+import io.camunda.search.test.utils.SearchClientAdapter;
+import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
+import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
+import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.TestTemplate;
+
+@TestInstance(Lifecycle.PER_CLASS)
+public class ProcessInstanceByIdArchiverJobIT
+    extends ArchiverJobIT<ProcessInstanceByIdArchiverJob> {
+
+  @TestTemplate
+  void shouldArchiveLoneProcessInstance(
+      final ExporterConfiguration config, final SearchClientAdapter client) throws Exception {
+    withArchiverJob(
+        config,
+        (job, resourceProvider) -> {
+          // given
+          final ProcessInstanceForListViewEntity processInstance =
+              new ProcessInstanceForListViewEntity();
+          processInstance.setId("1234");
+          processInstance.setKey(1234L);
+          processInstance.setPartitionId(PARTITION_ID);
+          processInstance.setEndDate(OffsetDateTime.parse("2020-01-01T00:00:00+00:00"));
+
+          client.index(
+              processInstance.getId(),
+              resourceProvider
+                  .getIndexTemplateDescriptor(ListViewTemplate.class)
+                  .getFullQualifiedName(),
+              processInstance);
+
+          client.refresh();
+
+          // when
+          final var archived = job.execute();
+
+          // then
+          assertThat(archived).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(1);
+
+          // check that the process is no longer in the main index
+          final var listViewTemplate =
+              resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class);
+          final var oldIndexPI =
+              client.get(
+                  processInstance.getId(),
+                  listViewTemplate.getFullQualifiedName(),
+                  ProcessInstanceForListViewEntity.class);
+          assertThat(oldIndexPI).isNull();
+
+          // process should now be in the dated index
+          final var dateIndex = listViewTemplate.getFullQualifiedName() + "2020-01-01";
+          final var newIndexPI =
+              client.get(
+                  processInstance.getId(), dateIndex, ProcessInstanceForListViewEntity.class);
+          assertThat(newIndexPI).isEqualTo(processInstance);
+        });
+  }
+
+  @Override
+  ProcessInstanceByIdArchiverJob createArchiveJob(
+      final ExporterConfiguration config,
+      final ExporterResourceProvider resourceProvider,
+      final ArchiverRepository repository) {
+
+    final var dependantTemplates =
+        resourceProvider.getIndexTemplateDescriptors().stream()
+            .filter(ProcessInstanceDependant.class::isInstance)
+            .map(ProcessInstanceDependant.class::cast)
+            .toList();
+
+    return new ProcessInstanceByIdArchiverJob(
+        config.getHistory(),
+        repository,
+        resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class),
+        dependantTemplates,
+        exporterMetrics,
+        LOGGER,
+        executor);
+  }
+}


### PR DESCRIPTION
## Description

Archiving currently moves data from main/hot indexes to dated indexes by selecting parent IDs, triggering reindex jobs for those IDs, and deleting source documents after completion. This works for most archiving jobs but performs poorly for others due to the additional load it places on Elasticsearch/OpenSearch clusters.

This new functionality will archive documents by the ID of the actual document being moved. It first reads a batch of IDs related to the ProcessInstanceKey or the parent ID. It then copies them from the main index to the dated destination index and deletes those copied documents from the main index. Afterwards, using the last position read in the current batch (i.e. searchAfter), it reads the next batch and continues until all documents are moved.

Technically, we are making more calls for reindexing; however, given their targeted nature, they are less strenuous on ES/OS. Overall, this may increase latency for smaller reindex operations but will significantly improve performance when there are many documents to move or when the documents being moved are larger. This may reduce performance in some cases, but it significantly improves stability and creates an opportunity for archiving to work without continually failing.

In addition, this will create dependent tasks for archiving list-view dependents/child documents as a parallel task that gets executed at the same time as the other dependent indexes. This adds many more read and write tasks than we currently have, but because they all target different indexes, the load is distributed. Also, the impact of reindexing by ID is much lower on ES/OS than the previous approach of reindexing with a parent-ID match query. This also significantly reduces the time needed for the final archiving step, which is archiving data from the list-view index. By the time that step starts, the bulk of the data has already been moved to the dated indexes.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #50621 
