### PR TITLE
poc reporting metrics importing pipeline

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/test/generator/VariableCatalogue.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/generator/VariableCatalogue.java
@@ -17,11 +17,14 @@ import java.util.stream.IntStream;
 /**
  * Generates variable name→value pairs for one synthetic process instance.
  *
- * <p>Three categories are emitted:
+ * <p>Four categories are emitted, covering every Optimize variable type both with and without the
+ * {@code REPORTING_PROCESS_} prefix:
  *
  * <ul>
- *   <li>Business variables — stable string sentinels keyed by instance key
- *   <li>Core {@code REPORTING_PROCESS_*} metrics — always present, randomly valued
+ *   <li>Business string variables — stable string sentinels keyed by instance key
+ *   <li>Business typed variables — one Integer, one Double, one Boolean (no prefix)
+ *   <li>Core {@code REPORTING_PROCESS_*} metrics — always present, randomly valued (numeric + one
+ *       String so that every type has a prefixed representative)
  *   <li>Optional {@code REPORTING_PROCESS_*} metrics — each included with 60 % probability
  * </ul>
  *
@@ -72,6 +75,7 @@ class VariableCatalogue {
   List<Map.Entry<String, String>> generate(final long instanceKey) {
     final List<Map.Entry<String, String>> vars = new ArrayList<>();
     vars.addAll(businessVars(instanceKey));
+    vars.addAll(businessTypedVars());
     vars.addAll(coreReportingVars());
     vars.addAll(optionalReportingVars());
     return vars;
@@ -83,6 +87,22 @@ class VariableCatalogue {
         .collect(Collectors.toList());
   }
 
+  /**
+   * Non-prefixed typed variables — one per non-String type so that the Optimize variable view
+   * (which requires at least one numeric variable) is usable on this process definition.
+   *
+   * <p>Values are bare JSON (no quotes) so Optimize infers the correct type from the raw value.
+   */
+  private List<Map.Entry<String, String>> businessTypedVars() {
+    return List.of(
+        Map.entry("score", String.valueOf(round2(rng.nextDouble() * 100))), // Double
+        Map.entry("itemCount", String.valueOf(rng.nextInt(500))), // Integer
+        Map.entry("approved", String.valueOf(rng.nextBoolean()))); // Boolean
+  }
+
+  private static final List<String> PROCESS_LABELS =
+      List.of("\"standard\"", "\"express\"", "\"bulk\"", "\"priority\"");
+
   private List<Map.Entry<String, String>> coreReportingVars() {
     final double baselineCost = round2(400 + rng.nextDouble() * 1_600);
     final double llmCost = round2(20 + rng.nextDouble() * 280);
@@ -91,6 +111,10 @@ class VariableCatalogue {
     final long tokenUsage = 1_000L + (long) (rng.nextDouble() * 49_000);
 
     return List.of(
+        // String — ensures every type has a REPORTING_PROCESS_ representative
+        Map.entry(
+            "REPORTING_PROCESS_processLabel",
+            PROCESS_LABELS.get(rng.nextInt(PROCESS_LABELS.size()))),
         Map.entry("REPORTING_PROCESS_baselineCost", String.valueOf(baselineCost)),
         Map.entry("REPORTING_PROCESS_llmCost", String.valueOf(llmCost)),
         Map.entry("REPORTING_PROCESS_automationCost", String.valueOf(automationCost)),

--- a/optimize/backend/src/it/resources/poc-scripts/ingestion.py
+++ b/optimize/backend/src/it/resources/poc-scripts/ingestion.py
@@ -15,6 +15,16 @@ PAGE_SIZE        = 1000
 STATE_FILE       = Path(__file__).parent / ".reporting_metrics_position.json"
 # ──────────────────────────────────────────────────────────────────────────────
 
+
+def parse_bool(value: str) -> bool:
+    normalized = value.strip().strip('"').lower()
+    if normalized == "true":
+        return True
+    if normalized == "false":
+        return False
+    raise ValueError(f"Invalid boolean value: {value}")
+
+
 FIELD_MAP = {
     "REPORTING_PROCESS_baselineCost":              ("baselineCost",              float),
     "REPORTING_PROCESS_llmCost":                   ("llmCost",                   float),
@@ -40,9 +50,9 @@ FIELD_MAP = {
     "REPORTING_PROCESS_customerSatisfactionScore": ("customerSatisfactionScore", float),
     "REPORTING_PROCESS_fraudRiskScore":            ("fraudRiskScore",            float),
     "REPORTING_PROCESS_externalServiceCostUsd":    ("externalServiceCostUsd",    float),
-    "REPORTING_PROCESS_slaBreached":               ("slaBreached",               bool),
-    "REPORTING_PROCESS_escalated":                 ("escalated",                 bool),
-    "REPORTING_PROCESS_manualOverride":            ("manualOverride",            bool),
+    "REPORTING_PROCESS_slaBreached":               ("slaBreached",               parse_bool),
+    "REPORTING_PROCESS_escalated":                 ("escalated",                 parse_bool),
+    "REPORTING_PROCESS_manualOverride":            ("manualOverride",            parse_bool),
 }
 
 
@@ -161,7 +171,7 @@ def count_pending(es: Elasticsearch, from_position: int) -> int:
     return count
 
 
-def run_import_round(es: Elasticsearch, from_position: int) -> tuple[int, int, int]:
+def run_import_round(es: Elasticsearch, from_position: int) -> tuple[int, int, int, int, int, int]:
     """
     Fetch REPORTING_PROCESS_* variable records with position > from_position,
     group by processInstanceKey, bulk-upsert into dest index.
@@ -216,7 +226,14 @@ def run_import_round(es: Elasticsearch, from_position: int) -> tuple[int, int, i
                     "processDefinitionKey": str(v.get("processDefinitionKey", "")),
                     "tenantId": v.get("tenantId", ""),
                 }
-            pi_docs[pi_key][field_name] = cast(v["value"].strip('"'))
+            try:
+                pi_docs[pi_key][field_name] = cast(v["value"].strip('"'))
+            except (TypeError, ValueError) as e:
+                print(
+                    f"  skipping value for {v['name']} on PI {pi_key}: "
+                    f"could not parse {v['value']!r} ({e})"
+                )
+                continue
             if ts is not None:
                 prev_first = pi_docs[pi_key].get("firstSeenAt")
                 prev_last  = pi_docs[pi_key].get("lastSeenAt")

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/importing/ReportingMetricsDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/importing/ReportingMetricsDto.java
@@ -1,0 +1,342 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.dto.optimize.importing;
+
+import io.camunda.optimize.dto.optimize.OptimizeDto;
+import java.util.Objects;
+
+/**
+ * Flat document written to {@code optimize-reporting-metrics}. One document per process instance.
+ * All fields are nullable so that partial updates (merge semantics) are supported across import
+ * batches.
+ */
+public class ReportingMetricsDto implements OptimizeDto {
+
+  private String processInstanceKey;
+  private String processDefinitionKey;
+  private String tenantId;
+
+  /** Epoch-ms of the earliest Zeebe variable record seen for this PI. */
+  private Long firstSeenAt;
+
+  /** Epoch-ms of the latest Zeebe variable record seen for this PI. */
+  private Long lastSeenAt;
+
+  private String processLabel;
+  private String startDate;
+  private String endDate;
+
+  private Double baselineCost;
+  private Double llmCost;
+  private Double automationCost;
+  private Double totalCost;
+  private Double valueCreated;
+
+  private Integer agentTaskCount;
+  private Integer humanTaskCount;
+  private Integer autoTaskCount;
+  private Long tokenUsage;
+
+  private Integer errorCount;
+  private Integer retryCount;
+  private Integer processingTimeMs;
+  private Integer queueWaitTimeMs;
+  private Integer apiCallCount;
+  private Integer complianceChecksPassed;
+
+  private Double dataVolumeMb;
+  private Double confidenceScore;
+  private Double co2EmissionsKg;
+  private Double customerSatisfactionScore;
+  private Double fraudRiskScore;
+  private Double externalServiceCostUsd;
+
+  private Boolean slaBreached;
+  private Boolean escalated;
+  private Boolean manualOverride;
+
+  public ReportingMetricsDto() {}
+
+  public String getProcessInstanceKey() {
+    return processInstanceKey;
+  }
+
+  public void setProcessInstanceKey(final String processInstanceKey) {
+    this.processInstanceKey = processInstanceKey;
+  }
+
+  public String getProcessDefinitionKey() {
+    return processDefinitionKey;
+  }
+
+  public void setProcessDefinitionKey(final String processDefinitionKey) {
+    this.processDefinitionKey = processDefinitionKey;
+  }
+
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  public void setTenantId(final String tenantId) {
+    this.tenantId = tenantId;
+  }
+
+  public Long getFirstSeenAt() {
+    return firstSeenAt;
+  }
+
+  public void setFirstSeenAt(final Long firstSeenAt) {
+    this.firstSeenAt = firstSeenAt;
+  }
+
+  public Long getLastSeenAt() {
+    return lastSeenAt;
+  }
+
+  public void setLastSeenAt(final Long lastSeenAt) {
+    this.lastSeenAt = lastSeenAt;
+  }
+
+  public String getProcessLabel() {
+    return processLabel;
+  }
+
+  public void setProcessLabel(final String processLabel) {
+    this.processLabel = processLabel;
+  }
+
+  public String getStartDate() {
+    return startDate;
+  }
+
+  public void setStartDate(final String startDate) {
+    this.startDate = startDate;
+  }
+
+  public String getEndDate() {
+    return endDate;
+  }
+
+  public void setEndDate(final String endDate) {
+    this.endDate = endDate;
+  }
+
+  public Double getBaselineCost() {
+    return baselineCost;
+  }
+
+  public void setBaselineCost(final Double baselineCost) {
+    this.baselineCost = baselineCost;
+  }
+
+  public Double getLlmCost() {
+    return llmCost;
+  }
+
+  public void setLlmCost(final Double llmCost) {
+    this.llmCost = llmCost;
+  }
+
+  public Double getAutomationCost() {
+    return automationCost;
+  }
+
+  public void setAutomationCost(final Double automationCost) {
+    this.automationCost = automationCost;
+  }
+
+  public Double getTotalCost() {
+    return totalCost;
+  }
+
+  public void setTotalCost(final Double totalCost) {
+    this.totalCost = totalCost;
+  }
+
+  public Double getValueCreated() {
+    return valueCreated;
+  }
+
+  public void setValueCreated(final Double valueCreated) {
+    this.valueCreated = valueCreated;
+  }
+
+  public Integer getAgentTaskCount() {
+    return agentTaskCount;
+  }
+
+  public void setAgentTaskCount(final Integer agentTaskCount) {
+    this.agentTaskCount = agentTaskCount;
+  }
+
+  public Integer getHumanTaskCount() {
+    return humanTaskCount;
+  }
+
+  public void setHumanTaskCount(final Integer humanTaskCount) {
+    this.humanTaskCount = humanTaskCount;
+  }
+
+  public Integer getAutoTaskCount() {
+    return autoTaskCount;
+  }
+
+  public void setAutoTaskCount(final Integer autoTaskCount) {
+    this.autoTaskCount = autoTaskCount;
+  }
+
+  public Long getTokenUsage() {
+    return tokenUsage;
+  }
+
+  public void setTokenUsage(final Long tokenUsage) {
+    this.tokenUsage = tokenUsage;
+  }
+
+  public Integer getErrorCount() {
+    return errorCount;
+  }
+
+  public void setErrorCount(final Integer errorCount) {
+    this.errorCount = errorCount;
+  }
+
+  public Integer getRetryCount() {
+    return retryCount;
+  }
+
+  public void setRetryCount(final Integer retryCount) {
+    this.retryCount = retryCount;
+  }
+
+  public Integer getProcessingTimeMs() {
+    return processingTimeMs;
+  }
+
+  public void setProcessingTimeMs(final Integer processingTimeMs) {
+    this.processingTimeMs = processingTimeMs;
+  }
+
+  public Integer getQueueWaitTimeMs() {
+    return queueWaitTimeMs;
+  }
+
+  public void setQueueWaitTimeMs(final Integer queueWaitTimeMs) {
+    this.queueWaitTimeMs = queueWaitTimeMs;
+  }
+
+  public Integer getApiCallCount() {
+    return apiCallCount;
+  }
+
+  public void setApiCallCount(final Integer apiCallCount) {
+    this.apiCallCount = apiCallCount;
+  }
+
+  public Integer getComplianceChecksPassed() {
+    return complianceChecksPassed;
+  }
+
+  public void setComplianceChecksPassed(final Integer complianceChecksPassed) {
+    this.complianceChecksPassed = complianceChecksPassed;
+  }
+
+  public Double getDataVolumeMb() {
+    return dataVolumeMb;
+  }
+
+  public void setDataVolumeMb(final Double dataVolumeMb) {
+    this.dataVolumeMb = dataVolumeMb;
+  }
+
+  public Double getConfidenceScore() {
+    return confidenceScore;
+  }
+
+  public void setConfidenceScore(final Double confidenceScore) {
+    this.confidenceScore = confidenceScore;
+  }
+
+  public Double getCo2EmissionsKg() {
+    return co2EmissionsKg;
+  }
+
+  public void setCo2EmissionsKg(final Double co2EmissionsKg) {
+    this.co2EmissionsKg = co2EmissionsKg;
+  }
+
+  public Double getCustomerSatisfactionScore() {
+    return customerSatisfactionScore;
+  }
+
+  public void setCustomerSatisfactionScore(final Double customerSatisfactionScore) {
+    this.customerSatisfactionScore = customerSatisfactionScore;
+  }
+
+  public Double getFraudRiskScore() {
+    return fraudRiskScore;
+  }
+
+  public void setFraudRiskScore(final Double fraudRiskScore) {
+    this.fraudRiskScore = fraudRiskScore;
+  }
+
+  public Double getExternalServiceCostUsd() {
+    return externalServiceCostUsd;
+  }
+
+  public void setExternalServiceCostUsd(final Double externalServiceCostUsd) {
+    this.externalServiceCostUsd = externalServiceCostUsd;
+  }
+
+  public Boolean getSlaBreached() {
+    return slaBreached;
+  }
+
+  public void setSlaBreached(final Boolean slaBreached) {
+    this.slaBreached = slaBreached;
+  }
+
+  public Boolean getEscalated() {
+    return escalated;
+  }
+
+  public void setEscalated(final Boolean escalated) {
+    this.escalated = escalated;
+  }
+
+  public Boolean getManualOverride() {
+    return manualOverride;
+  }
+
+  public void setManualOverride(final Boolean manualOverride) {
+    this.manualOverride = manualOverride;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(processInstanceKey);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ReportingMetricsDto that = (ReportingMetricsDto) o;
+    return Objects.equals(processInstanceKey, that.processInstanceKey);
+  }
+
+  @Override
+  public String toString() {
+    return "ReportingMetricsDto(processInstanceKey=" + processInstanceKey + ")";
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/importing/ReportingMetricsMappings.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/importing/ReportingMetricsMappings.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.dto.optimize.importing;
+
+import static java.util.Map.entry;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Shared mapping and script metadata for reporting-metrics import/upsert. */
+public final class ReportingMetricsMappings {
+
+  public static final String REPORTING_PREFIX = "REPORTING_PROCESS_";
+
+  private static final Logger LOG = LoggerFactory.getLogger(ReportingMetricsMappings.class);
+
+  private static final List<String> UPSERT_FIELDS =
+      List.of(
+          "agentTaskCount",
+          "apiCallCount",
+          "autoTaskCount",
+          "automationCost",
+          "baselineCost",
+          "co2EmissionsKg",
+          "complianceChecksPassed",
+          "confidenceScore",
+          "customerSatisfactionScore",
+          "dataVolumeMb",
+          "endDate",
+          "errorCount",
+          "escalated",
+          "externalServiceCostUsd",
+          "firstSeenAt",
+          "fraudRiskScore",
+          "humanTaskCount",
+          "lastSeenAt",
+          "llmCost",
+          "manualOverride",
+          "processDefinitionKey",
+          "processInstanceKey",
+          "processLabel",
+          "processingTimeMs",
+          "queueWaitTimeMs",
+          "retryCount",
+          "slaBreached",
+          "tenantId",
+          "tokenUsage",
+          "totalCost",
+          "valueCreated");
+
+  private static final String UPDATE_SCRIPT =
+      UPSERT_FIELDS.stream()
+          .sorted()
+          .map(
+              field ->
+                  "if (params.containsKey('"
+                      + field
+                      + "')) { ctx._source."
+                      + field
+                      + " = params."
+                      + field
+                      + "; }\n")
+          .collect(Collectors.joining());
+
+  private static final Map<String, BiConsumer<ReportingMetricsDto, String>> VARIABLE_APPLIERS =
+      Map.ofEntries(
+          entry(
+              "REPORTING_PROCESS_baselineCost",
+              (doc, raw) -> doc.setBaselineCost(parseDouble(raw))),
+          entry("REPORTING_PROCESS_llmCost", (doc, raw) -> doc.setLlmCost(parseDouble(raw))),
+          entry(
+              "REPORTING_PROCESS_automationCost",
+              (doc, raw) -> doc.setAutomationCost(parseDouble(raw))),
+          entry("REPORTING_PROCESS_totalCost", (doc, raw) -> doc.setTotalCost(parseDouble(raw))),
+          entry(
+              "REPORTING_PROCESS_valueCreated",
+              (doc, raw) -> doc.setValueCreated(parseDouble(raw))),
+          entry(
+              "REPORTING_PROCESS_agentTaskCount",
+              (doc, raw) -> doc.setAgentTaskCount(parseInt(raw))),
+          entry(
+              "REPORTING_PROCESS_humanTaskCount",
+              (doc, raw) -> doc.setHumanTaskCount(parseInt(raw))),
+          entry(
+              "REPORTING_PROCESS_autoTaskCount", (doc, raw) -> doc.setAutoTaskCount(parseInt(raw))),
+          entry("REPORTING_PROCESS_tokenUsage", (doc, raw) -> doc.setTokenUsage(parseLong(raw))),
+          entry("REPORTING_PROCESS_processLabel", (doc, raw) -> doc.setProcessLabel(unquote(raw))),
+          entry("REPORTING_PROCESS_startDate", (doc, raw) -> doc.setStartDate(unquote(raw))),
+          entry("REPORTING_PROCESS_endDate", (doc, raw) -> doc.setEndDate(unquote(raw))),
+          entry("REPORTING_PROCESS_errorCount", (doc, raw) -> doc.setErrorCount(parseInt(raw))),
+          entry("REPORTING_PROCESS_retryCount", (doc, raw) -> doc.setRetryCount(parseInt(raw))),
+          entry(
+              "REPORTING_PROCESS_processingTimeMs",
+              (doc, raw) -> doc.setProcessingTimeMs(parseInt(raw))),
+          entry(
+              "REPORTING_PROCESS_queueWaitTimeMs",
+              (doc, raw) -> doc.setQueueWaitTimeMs(parseInt(raw))),
+          entry("REPORTING_PROCESS_apiCallCount", (doc, raw) -> doc.setApiCallCount(parseInt(raw))),
+          entry(
+              "REPORTING_PROCESS_complianceChecksPassed",
+              (doc, raw) -> doc.setComplianceChecksPassed(parseInt(raw))),
+          entry(
+              "REPORTING_PROCESS_dataVolumeMb",
+              (doc, raw) -> doc.setDataVolumeMb(parseDouble(raw))),
+          entry(
+              "REPORTING_PROCESS_confidenceScore",
+              (doc, raw) -> doc.setConfidenceScore(parseDouble(raw))),
+          entry(
+              "REPORTING_PROCESS_co2EmissionsKg",
+              (doc, raw) -> doc.setCo2EmissionsKg(parseDouble(raw))),
+          entry(
+              "REPORTING_PROCESS_customerSatisfactionScore",
+              (doc, raw) -> doc.setCustomerSatisfactionScore(parseDouble(raw))),
+          entry(
+              "REPORTING_PROCESS_fraudRiskScore",
+              (doc, raw) -> doc.setFraudRiskScore(parseDouble(raw))),
+          entry(
+              "REPORTING_PROCESS_externalServiceCostUsd",
+              (doc, raw) -> doc.setExternalServiceCostUsd(parseDouble(raw))),
+          entry(
+              "REPORTING_PROCESS_slaBreached", (doc, raw) -> doc.setSlaBreached(parseBoolean(raw))),
+          entry("REPORTING_PROCESS_escalated", (doc, raw) -> doc.setEscalated(parseBoolean(raw))),
+          entry(
+              "REPORTING_PROCESS_manualOverride",
+              (doc, raw) -> doc.setManualOverride(parseBoolean(raw))));
+
+  private ReportingMetricsMappings() {}
+
+  public static String getUpdateScript() {
+    return UPDATE_SCRIPT;
+  }
+
+  public static boolean applyVariable(
+      final ReportingMetricsDto doc, final String variableName, final String rawValue) {
+    final BiConsumer<ReportingMetricsDto, String> applier = VARIABLE_APPLIERS.get(variableName);
+    if (applier == null) {
+      return false;
+    }
+    applier.accept(doc, rawValue);
+    return true;
+  }
+
+  private static Double parseDouble(final String raw) {
+    try {
+      return Double.parseDouble(raw.trim());
+    } catch (final RuntimeException e) {
+      LOG.debug("Could not parse double from value: {}", raw);
+      return null;
+    }
+  }
+
+  private static Integer parseInt(final String raw) {
+    try {
+      return Integer.parseInt(raw.trim());
+    } catch (final RuntimeException e) {
+      LOG.debug("Could not parse int from value: {}", raw);
+      return null;
+    }
+  }
+
+  private static Long parseLong(final String raw) {
+    try {
+      return Long.parseLong(raw.trim());
+    } catch (final RuntimeException e) {
+      LOG.debug("Could not parse long from value: {}", raw);
+      return null;
+    }
+  }
+
+  private static Boolean parseBoolean(final String raw) {
+    final String value = unquote(raw).trim();
+    if ("true".equalsIgnoreCase(value)) {
+      return true;
+    }
+    if ("false".equalsIgnoreCase(value)) {
+      return false;
+    }
+    LOG.debug("Could not parse boolean from value: {}", raw);
+    return null;
+  }
+
+  private static String unquote(final String raw) {
+    final String value = raw.trim();
+    if (value.length() >= 2 && value.charAt(0) == '"' && value.charAt(value.length() - 1) == '"') {
+      return value.substring(1, value.length() - 1);
+    }
+    return value;
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/writer/ReportingMetricsWriterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/writer/ReportingMetricsWriterES.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.es.writer;
+
+import static io.camunda.optimize.service.db.DatabaseConstants.NUMBER_OF_RETRIES_ON_CONFLICT;
+import static io.camunda.optimize.service.db.DatabaseConstants.REPORTING_METRICS_INDEX_NAME;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.optimize.dto.optimize.ImportRequestDto;
+import io.camunda.optimize.dto.optimize.RequestType;
+import io.camunda.optimize.dto.optimize.importing.ReportingMetricsDto;
+import io.camunda.optimize.service.db.writer.ReportingMetricsWriter;
+import io.camunda.optimize.service.db.writer.ReportingMetricsWriterSupport;
+import io.camunda.optimize.service.util.configuration.condition.ElasticSearchCondition;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+@Component
+@Conditional(ElasticSearchCondition.class)
+public class ReportingMetricsWriterES implements ReportingMetricsWriter {
+
+  private static final Logger LOG =
+      org.slf4j.LoggerFactory.getLogger(ReportingMetricsWriterES.class);
+
+  private final ObjectMapper objectMapper;
+
+  public ReportingMetricsWriterES(final ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public List<ImportRequestDto> generateImports(final List<ReportingMetricsDto> metricsDocuments) {
+    LOG.debug("Creating reporting-metrics imports for {} documents.", metricsDocuments.size());
+    return metricsDocuments.stream()
+        .map(
+            doc ->
+                ImportRequestDto.builder()
+                    .importName("reporting metrics")
+                    .type(RequestType.UPDATE)
+                    .id(doc.getProcessInstanceKey())
+                    .indexName(REPORTING_METRICS_INDEX_NAME)
+                    .source(doc)
+                    .scriptData(ReportingMetricsWriterSupport.buildScriptData(doc, objectMapper))
+                    .retryNumberOnConflict(NUMBER_OF_RETRIES_ON_CONFLICT)
+                    .build())
+        .collect(Collectors.toList());
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/writer/ReportingMetricsWriterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/writer/ReportingMetricsWriterOS.java
@@ -41,16 +41,19 @@ public class ReportingMetricsWriterOS implements ReportingMetricsWriter {
     LOG.debug("Creating reporting-metrics imports for {} documents.", metricsDocuments.size());
     return metricsDocuments.stream()
         .map(
-            doc ->
-                ImportRequestDto.builder()
-                    .importName("reporting metrics")
-                    .type(RequestType.UPDATE)
-                    .id(doc.getProcessInstanceKey())
-                    .indexName(REPORTING_METRICS_INDEX_NAME)
-                    .source(doc)
-                    .scriptData(ReportingMetricsWriterSupport.buildScriptData(doc, objectMapper))
-                    .retryNumberOnConflict(NUMBER_OF_RETRIES_ON_CONFLICT)
-                    .build())
+            doc -> {
+              final ImportRequestDto request =
+                  ImportRequestDto.builder()
+                      .importName("reporting metrics")
+                      .type(RequestType.UPDATE)
+                      .id(doc.getProcessInstanceKey())
+                      .indexName(REPORTING_METRICS_INDEX_NAME)
+                      .source(doc)
+                      .scriptData(ReportingMetricsWriterSupport.buildScriptData(doc, objectMapper))
+                      .retryNumberOnConflict(NUMBER_OF_RETRIES_ON_CONFLICT)
+                      .build();
+              return request;
+            })
         .collect(Collectors.toList());
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/writer/ReportingMetricsWriterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/writer/ReportingMetricsWriterOS.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.os.writer;
+
+import static io.camunda.optimize.service.db.DatabaseConstants.NUMBER_OF_RETRIES_ON_CONFLICT;
+import static io.camunda.optimize.service.db.DatabaseConstants.REPORTING_METRICS_INDEX_NAME;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.optimize.dto.optimize.ImportRequestDto;
+import io.camunda.optimize.dto.optimize.RequestType;
+import io.camunda.optimize.dto.optimize.importing.ReportingMetricsDto;
+import io.camunda.optimize.service.db.writer.ReportingMetricsWriter;
+import io.camunda.optimize.service.db.writer.ReportingMetricsWriterSupport;
+import io.camunda.optimize.service.util.configuration.condition.OpenSearchCondition;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+@Component
+@Conditional(OpenSearchCondition.class)
+public class ReportingMetricsWriterOS implements ReportingMetricsWriter {
+
+  private static final Logger LOG =
+      org.slf4j.LoggerFactory.getLogger(ReportingMetricsWriterOS.class);
+
+  private final ObjectMapper objectMapper;
+
+  public ReportingMetricsWriterOS(final ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public List<ImportRequestDto> generateImports(final List<ReportingMetricsDto> metricsDocuments) {
+    LOG.debug("Creating reporting-metrics imports for {} documents.", metricsDocuments.size());
+    return metricsDocuments.stream()
+        .map(
+            doc ->
+                ImportRequestDto.builder()
+                    .importName("reporting metrics")
+                    .type(RequestType.UPDATE)
+                    .id(doc.getProcessInstanceKey())
+                    .indexName(REPORTING_METRICS_INDEX_NAME)
+                    .source(doc)
+                    .scriptData(ReportingMetricsWriterSupport.buildScriptData(doc, objectMapper))
+                    .retryNumberOnConflict(NUMBER_OF_RETRIES_ON_CONFLICT)
+                    .build())
+        .collect(Collectors.toList());
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/ReportingMetricsWriter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/ReportingMetricsWriter.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.writer;
+
+import io.camunda.optimize.dto.optimize.ImportRequestDto;
+import io.camunda.optimize.dto.optimize.importing.ReportingMetricsDto;
+import java.util.List;
+
+/** Generates bulk-upsert requests for the {@code optimize-reporting-metrics} index. */
+public interface ReportingMetricsWriter {
+
+  List<ImportRequestDto> generateImports(List<ReportingMetricsDto> metricsDocuments);
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/ReportingMetricsWriterSupport.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/writer/ReportingMetricsWriterSupport.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.writer;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.optimize.dto.optimize.importing.ReportingMetricsDto;
+import io.camunda.optimize.dto.optimize.importing.ReportingMetricsMappings;
+import io.camunda.optimize.service.db.schema.ScriptData;
+import java.util.Map;
+import java.util.Objects;
+
+/** Shared script-data generation for reporting-metrics upserts. */
+public final class ReportingMetricsWriterSupport {
+
+  private ReportingMetricsWriterSupport() {}
+
+  public static ScriptData buildScriptData(
+      final ReportingMetricsDto doc, final ObjectMapper objectMapper) {
+    final Map<String, Object> params = objectMapper.convertValue(doc, new TypeReference<>() {});
+    params.values().removeIf(Objects::isNull);
+    return new ScriptData(params, ReportingMetricsMappings.getUpdateScript());
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/importing/DatabaseImportJob.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/importing/DatabaseImportJob.java
@@ -57,11 +57,15 @@ public abstract class DatabaseImportJob<OPT extends OptimizeDto> implements Runn
           success = true;
         } catch (final Exception e) {
           logger.error("Error while executing import to database", e);
+          if (Thread.currentThread().isInterrupted()) {
+            break;
+          }
           final long sleepTime = backoffCalculator.calculateSleepTime();
           try {
             Thread.sleep(sleepTime);
           } catch (final InterruptedException exception) {
             Thread.currentThread().interrupt();
+            break;
           }
         }
       } while (!success);

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/importing/ImportIndexHandlerRegistry.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/importing/ImportIndexHandlerRegistry.java
@@ -13,6 +13,7 @@ import io.camunda.optimize.service.importing.zeebe.handler.ZeebeImportIndexHandl
 import io.camunda.optimize.service.importing.zeebe.handler.ZeebeIncidentImportIndexHandler;
 import io.camunda.optimize.service.importing.zeebe.handler.ZeebeProcessDefinitionImportIndexHandler;
 import io.camunda.optimize.service.importing.zeebe.handler.ZeebeProcessInstanceImportIndexHandler;
+import io.camunda.optimize.service.importing.zeebe.handler.ZeebeReportingMetricsImportIndexHandler;
 import io.camunda.optimize.service.importing.zeebe.handler.ZeebeUserTaskImportIndexHandler;
 import io.camunda.optimize.service.importing.zeebe.handler.ZeebeVariableImportIndexHandler;
 import java.util.Collection;
@@ -76,6 +77,11 @@ public class ImportIndexHandlerRegistry {
   public ZeebeUserTaskImportIndexHandler getZeebeUserTaskImportIndexHandler(
       final Integer partitionId) {
     return getZeebeImportIndexHandler(partitionId, ZeebeUserTaskImportIndexHandler.class);
+  }
+
+  public ZeebeReportingMetricsImportIndexHandler getZeebeReportingMetricsImportIndexHandler(
+      final Integer partitionId) {
+    return getZeebeImportIndexHandler(partitionId, ZeebeReportingMetricsImportIndexHandler.class);
   }
 
   public ExternalVariableUpdateImportIndexHandler getExternalVariableUpdateImportIndexHandler() {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/importing/engine/service/zeebe/ZeebeReportingMetricsImportService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/importing/engine/service/zeebe/ZeebeReportingMetricsImportService.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.importing.engine.service.zeebe;
+
+import io.camunda.optimize.dto.optimize.importing.ReportingMetricsDto;
+import io.camunda.optimize.dto.optimize.importing.ReportingMetricsMappings;
+import io.camunda.optimize.dto.zeebe.variable.ZeebeVariableDataDto;
+import io.camunda.optimize.dto.zeebe.variable.ZeebeVariableRecordDto;
+import io.camunda.optimize.service.db.DatabaseClient;
+import io.camunda.optimize.service.db.writer.ReportingMetricsWriter;
+import io.camunda.optimize.service.importing.DatabaseImportJobExecutor;
+import io.camunda.optimize.service.importing.engine.service.ImportService;
+import io.camunda.optimize.service.importing.job.ReportingMetricsDatabaseImportJob;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import io.camunda.zeebe.protocol.record.intent.VariableIntent;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+
+/**
+ * Filters Zeebe variable records for the {@code REPORTING_PROCESS_*} prefix, groups them by process
+ * instance key, and upserts aggregated documents into {@code optimize-reporting-metrics}.
+ */
+public class ZeebeReportingMetricsImportService implements ImportService<ZeebeVariableRecordDto> {
+
+  private static final Logger LOG =
+      org.slf4j.LoggerFactory.getLogger(ZeebeReportingMetricsImportService.class);
+
+  private static final Set<VariableIntent> INTENTS_TO_IMPORT =
+      Set.of(VariableIntent.CREATED, VariableIntent.UPDATED);
+
+  private final DatabaseImportJobExecutor databaseImportJobExecutor;
+  private final ReportingMetricsWriter reportingMetricsWriter;
+  private final DatabaseClient databaseClient;
+  private final ConfigurationService configurationService;
+
+  public ZeebeReportingMetricsImportService(
+      final ConfigurationService configurationService,
+      final ReportingMetricsWriter reportingMetricsWriter,
+      final DatabaseClient databaseClient) {
+    this.configurationService = configurationService;
+    this.reportingMetricsWriter = reportingMetricsWriter;
+    this.databaseClient = databaseClient;
+    databaseImportJobExecutor =
+        new DatabaseImportJobExecutor(getClass().getSimpleName(), configurationService);
+  }
+
+  @Override
+  public void executeImport(
+      final List<ZeebeVariableRecordDto> zeebeRecords, final Runnable importCompleteCallback) {
+    if (zeebeRecords.isEmpty()) {
+      importCompleteCallback.run();
+      return;
+    }
+
+    final List<ReportingMetricsDto> metricsDocuments = filterAndMapToReportingMetrics(zeebeRecords);
+
+    if (!metricsDocuments.isEmpty()) {
+      final ReportingMetricsDatabaseImportJob importJob =
+          new ReportingMetricsDatabaseImportJob(
+              reportingMetricsWriter, configurationService, importCompleteCallback, databaseClient);
+      importJob.setEntitiesToImport(metricsDocuments);
+      databaseImportJobExecutor.executeImportJob(importJob);
+    } else {
+      importCompleteCallback.run();
+    }
+  }
+
+  @Override
+  public DatabaseImportJobExecutor getDatabaseImportJobExecutor() {
+    return databaseImportJobExecutor;
+  }
+
+  private List<ReportingMetricsDto> filterAndMapToReportingMetrics(
+      final List<ZeebeVariableRecordDto> zeebeRecords) {
+    final Map<Long, List<ZeebeVariableRecordDto>> byProcessInstance =
+        zeebeRecords.stream()
+            .filter(r -> INTENTS_TO_IMPORT.contains(r.getIntent()))
+            .filter(
+                r ->
+                    r.getValue().getName() != null
+                        && r.getValue()
+                            .getName()
+                            .startsWith(ReportingMetricsMappings.REPORTING_PREFIX))
+            .collect(Collectors.groupingBy(r -> r.getValue().getProcessInstanceKey()));
+
+    final List<ReportingMetricsDto> result =
+        byProcessInstance.values().stream().map(this::buildMetricsDoc).toList();
+
+    LOG.debug(
+        "Processing {} fetched Zeebe variable records: {} REPORTING_PROCESS_* records for {} process instances.",
+        zeebeRecords.size(),
+        byProcessInstance.values().stream().mapToLong(List::size).sum(),
+        result.size());
+
+    return result;
+  }
+
+  private ReportingMetricsDto buildMetricsDoc(final List<ZeebeVariableRecordDto> records) {
+    final ReportingMetricsDto doc = new ReportingMetricsDto();
+
+    // Identity fields from the first record
+    final ZeebeVariableDataDto first = records.getFirst().getValue();
+    doc.setProcessInstanceKey(String.valueOf(first.getProcessInstanceKey()));
+    doc.setProcessDefinitionKey(String.valueOf(first.getProcessDefinitionKey()));
+    doc.setTenantId(first.getTenantId());
+
+    // Timestamp bounds across all records in this batch
+    for (final ZeebeVariableRecordDto record : records) {
+      final long ts = record.getTimestamp();
+      if (doc.getFirstSeenAt() == null || ts < doc.getFirstSeenAt()) {
+        doc.setFirstSeenAt(ts);
+      }
+      if (doc.getLastSeenAt() == null || ts > doc.getLastSeenAt()) {
+        doc.setLastSeenAt(ts);
+      }
+
+      // Map variable name → DTO field
+      final String varName = record.getValue().getName();
+      final String rawValue = record.getValue().getValue();
+      if (varName != null && rawValue != null) {
+        if (!ReportingMetricsMappings.applyVariable(doc, varName, rawValue)) {
+          LOG.trace("Ignoring unknown REPORTING_PROCESS_ variable: {}", varName);
+        }
+      }
+    }
+
+    return doc;
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/importing/engine/service/zeebe/ZeebeVariableImportService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/importing/engine/service/zeebe/ZeebeVariableImportService.java
@@ -11,6 +11,7 @@ import static io.camunda.optimize.dto.optimize.ReportConstants.BOOLEAN_TYPE;
 import static io.camunda.optimize.dto.optimize.ReportConstants.DOUBLE_TYPE;
 import static io.camunda.optimize.dto.optimize.ReportConstants.OBJECT_TYPE;
 import static io.camunda.optimize.dto.optimize.ReportConstants.STRING_TYPE;
+import static io.camunda.optimize.dto.optimize.importing.ReportingMetricsMappings.REPORTING_PREFIX;
 import static io.camunda.optimize.service.db.DatabaseConstants.ZEEBE_VARIABLE_INDEX_NAME;
 import static io.camunda.optimize.service.db.schema.index.ExternalProcessVariableIndex.SERIALIZATION_DATA_FORMAT;
 
@@ -82,6 +83,7 @@ public class ZeebeVariableImportService
     final List<ProcessInstanceDto> optimizeDtos =
         zeebeRecords.stream()
             .filter(zeebeRecord -> INTENTS_TO_IMPORT.contains(zeebeRecord.getIntent()))
+            .filter(zeebeRecord -> !zeebeRecord.getValue().getName().startsWith(REPORTING_PREFIX))
             .collect(
                 Collectors.groupingBy(
                     zeebeRecord -> zeebeRecord.getValue().getProcessInstanceKey()))

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/importing/job/ReportingMetricsDatabaseImportJob.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/importing/job/ReportingMetricsDatabaseImportJob.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.importing.job;
+
+import io.camunda.optimize.dto.optimize.ImportRequestDto;
+import io.camunda.optimize.dto.optimize.importing.ReportingMetricsDto;
+import io.camunda.optimize.service.db.DatabaseClient;
+import io.camunda.optimize.service.db.writer.ReportingMetricsWriter;
+import io.camunda.optimize.service.importing.DatabaseImportJob;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import java.util.List;
+
+public class ReportingMetricsDatabaseImportJob extends DatabaseImportJob<ReportingMetricsDto> {
+
+  private final ReportingMetricsWriter reportingMetricsWriter;
+  private final ConfigurationService configurationService;
+
+  public ReportingMetricsDatabaseImportJob(
+      final ReportingMetricsWriter reportingMetricsWriter,
+      final ConfigurationService configurationService,
+      final Runnable importCompleteCallback,
+      final DatabaseClient databaseClient) {
+    super(importCompleteCallback, databaseClient);
+    this.reportingMetricsWriter = reportingMetricsWriter;
+    this.configurationService = configurationService;
+  }
+
+  @Override
+  protected void persistEntities(final List<ReportingMetricsDto> metricsDocuments) {
+    final List<ImportRequestDto> importRequests =
+        reportingMetricsWriter.generateImports(metricsDocuments);
+    databaseClient.executeImportRequestsAsBulk(
+        "Zeebe reporting metrics",
+        importRequests,
+        configurationService.getSkipDataAfterNestedDocLimitReached());
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/importing/zeebe/db/ZeebeReportingMetricsFetcher.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/importing/zeebe/db/ZeebeReportingMetricsFetcher.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.importing.zeebe.db;
+
+import io.camunda.optimize.dto.zeebe.variable.ZeebeVariableRecordDto;
+import io.camunda.optimize.service.importing.page.PositionBasedImportPage;
+import java.util.List;
+
+/**
+ * Fetcher for the reporting-metrics import pipeline. Reads Zeebe variable records from the same
+ * source index as {@link ZeebeVariableFetcher} but uses an independent position tracker so the two
+ * pipelines advance independently.
+ */
+public interface ZeebeReportingMetricsFetcher extends ZeebeFetcher {
+  List<ZeebeVariableRecordDto> getZeebeRecordsForPrefixAndPartitionFrom(
+      PositionBasedImportPage positionBasedImportPage);
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/importing/zeebe/fetcher/es/ZeebeReportingMetricsFetcherES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/importing/zeebe/fetcher/es/ZeebeReportingMetricsFetcherES.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.importing.zeebe.fetcher.es;
+
+import static io.camunda.optimize.service.db.DatabaseConstants.ZEEBE_VARIABLE_INDEX_NAME;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.optimize.dto.zeebe.variable.ZeebeVariableRecordDto;
+import io.camunda.optimize.service.db.es.OptimizeElasticsearchClient;
+import io.camunda.optimize.service.importing.zeebe.db.ZeebeReportingMetricsFetcher;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import io.camunda.optimize.service.util.configuration.condition.ElasticSearchCondition;
+import org.slf4j.Logger;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+@Component
+@Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+@Conditional(ElasticSearchCondition.class)
+public class ZeebeReportingMetricsFetcherES
+    extends AbstractZeebeRecordFetcherES<ZeebeVariableRecordDto>
+    implements ZeebeReportingMetricsFetcher {
+
+  private static final Logger LOG =
+      org.slf4j.LoggerFactory.getLogger(ZeebeReportingMetricsFetcherES.class);
+
+  public ZeebeReportingMetricsFetcherES(
+      final int partitionId,
+      final OptimizeElasticsearchClient esClient,
+      final ObjectMapper objectMapper,
+      final ConfigurationService configurationService) {
+    super(partitionId, esClient, objectMapper, configurationService);
+  }
+
+  @Override
+  protected String getBaseIndexName() {
+    return ZEEBE_VARIABLE_INDEX_NAME;
+  }
+
+  @Override
+  protected Class<ZeebeVariableRecordDto> getRecordDtoClass() {
+    return ZeebeVariableRecordDto.class;
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/importing/zeebe/fetcher/os/ZeebeReportingMetricsFetcherOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/importing/zeebe/fetcher/os/ZeebeReportingMetricsFetcherOS.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.importing.zeebe.fetcher.os;
+
+import static io.camunda.optimize.service.db.DatabaseConstants.ZEEBE_VARIABLE_INDEX_NAME;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.optimize.dto.zeebe.variable.ZeebeVariableRecordDto;
+import io.camunda.optimize.service.db.os.OptimizeOpenSearchClient;
+import io.camunda.optimize.service.importing.zeebe.db.ZeebeReportingMetricsFetcher;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import io.camunda.optimize.service.util.configuration.condition.OpenSearchCondition;
+import org.slf4j.Logger;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+@Component
+@Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+@Conditional(OpenSearchCondition.class)
+public class ZeebeReportingMetricsFetcherOS
+    extends AbstractZeebeRecordFetcherOS<ZeebeVariableRecordDto>
+    implements ZeebeReportingMetricsFetcher {
+
+  private static final Logger LOG =
+      org.slf4j.LoggerFactory.getLogger(ZeebeReportingMetricsFetcherOS.class);
+
+  public ZeebeReportingMetricsFetcherOS(
+      final int partitionId,
+      final OptimizeOpenSearchClient osClient,
+      final ObjectMapper objectMapper,
+      final ConfigurationService configurationService) {
+    super(partitionId, osClient, objectMapper, configurationService);
+  }
+
+  @Override
+  protected String getBaseIndexName() {
+    return ZEEBE_VARIABLE_INDEX_NAME;
+  }
+
+  @Override
+  protected Class<ZeebeVariableRecordDto> getRecordDtoClass() {
+    return ZeebeVariableRecordDto.class;
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/importing/zeebe/handler/ZeebeReportingMetricsImportIndexHandler.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/importing/zeebe/handler/ZeebeReportingMetricsImportIndexHandler.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.importing.zeebe.handler;
+
+import io.camunda.optimize.dto.optimize.datasource.ZeebeDataSourceDto;
+import io.camunda.optimize.service.importing.PositionBasedImportIndexHandler;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+@Component
+@Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+public class ZeebeReportingMetricsImportIndexHandler extends PositionBasedImportIndexHandler {
+
+  private static final String ZEEBE_REPORTING_METRICS_IMPORT_INDEX_DOC_ID =
+      "zeebeReportingMetricsImportIndex";
+
+  public ZeebeReportingMetricsImportIndexHandler(final ZeebeDataSourceDto dataSourceDto) {
+    this.dataSource = dataSourceDto;
+  }
+
+  @Override
+  protected String getDatabaseDocID() {
+    return ZEEBE_REPORTING_METRICS_IMPORT_INDEX_DOC_ID;
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/importing/zeebe/mediator/ZeebeReportingMetricsImportMediator.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/importing/zeebe/mediator/ZeebeReportingMetricsImportMediator.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.importing.zeebe.mediator;
+
+import static io.camunda.optimize.MetricEnum.NEW_PAGE_FETCH_TIME_METRIC;
+import static io.camunda.zeebe.protocol.record.ValueType.VARIABLE;
+
+import io.camunda.optimize.OptimizeMetrics;
+import io.camunda.optimize.dto.zeebe.variable.ZeebeVariableRecordDto;
+import io.camunda.optimize.service.importing.PositionBasedImportMediator;
+import io.camunda.optimize.service.importing.engine.mediator.MediatorRank;
+import io.camunda.optimize.service.importing.engine.service.zeebe.ZeebeReportingMetricsImportService;
+import io.camunda.optimize.service.importing.zeebe.db.ZeebeReportingMetricsFetcher;
+import io.camunda.optimize.service.importing.zeebe.handler.ZeebeReportingMetricsImportIndexHandler;
+import io.camunda.optimize.service.util.BackoffCalculator;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import java.util.List;
+
+public class ZeebeReportingMetricsImportMediator
+    extends PositionBasedImportMediator<
+        ZeebeReportingMetricsImportIndexHandler, ZeebeVariableRecordDto> {
+
+  private final ZeebeReportingMetricsFetcher fetcher;
+
+  public ZeebeReportingMetricsImportMediator(
+      final ZeebeReportingMetricsImportIndexHandler importIndexHandler,
+      final ZeebeReportingMetricsFetcher fetcher,
+      final ZeebeReportingMetricsImportService importService,
+      final ConfigurationService configurationService,
+      final BackoffCalculator idleBackoffCalculator) {
+    this.importIndexHandler = importIndexHandler;
+    this.fetcher = fetcher;
+    this.importService = importService;
+    this.configurationService = configurationService;
+    this.idleBackoffCalculator = idleBackoffCalculator;
+  }
+
+  @Override
+  public MediatorRank getRank() {
+    return MediatorRank.INSTANCE_SUB_ENTITIES;
+  }
+
+  @Override
+  protected boolean importNextPage(final Runnable importCompleteCallback) {
+    return importNextPagePositionBased(fetchRecords(), importCompleteCallback);
+  }
+
+  @Override
+  protected String getRecordType() {
+    return VARIABLE.name();
+  }
+
+  @Override
+  protected Integer getPartitionId() {
+    return fetcher.getPartitionId();
+  }
+
+  private List<ZeebeVariableRecordDto> fetchRecords() {
+    return OptimizeMetrics.getTimer(NEW_PAGE_FETCH_TIME_METRIC, getRecordType(), getPartitionId())
+        .record(
+            () ->
+                fetcher.getZeebeRecordsForPrefixAndPartitionFrom(importIndexHandler.getNextPage()));
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/importing/zeebe/mediator/factory/ZeebeReportingMetricsMediatorFactory.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/importing/zeebe/mediator/factory/ZeebeReportingMetricsMediatorFactory.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.importing.zeebe.mediator.factory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.optimize.dto.optimize.datasource.ZeebeDataSourceDto;
+import io.camunda.optimize.service.db.DatabaseClient;
+import io.camunda.optimize.service.db.writer.ReportingMetricsWriter;
+import io.camunda.optimize.service.importing.ImportIndexHandlerRegistry;
+import io.camunda.optimize.service.importing.ImportMediator;
+import io.camunda.optimize.service.importing.engine.service.zeebe.ZeebeReportingMetricsImportService;
+import io.camunda.optimize.service.importing.zeebe.db.ZeebeReportingMetricsFetcher;
+import io.camunda.optimize.service.importing.zeebe.mediator.ZeebeReportingMetricsImportMediator;
+import io.camunda.optimize.service.util.BackoffCalculator;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import java.util.Collections;
+import java.util.List;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ZeebeReportingMetricsMediatorFactory extends AbstractZeebeImportMediatorFactory {
+
+  private final ReportingMetricsWriter reportingMetricsWriter;
+
+  public ZeebeReportingMetricsMediatorFactory(
+      final BeanFactory beanFactory,
+      final ImportIndexHandlerRegistry importIndexHandlerRegistry,
+      final ConfigurationService configurationService,
+      final ObjectMapper objectMapper,
+      final DatabaseClient databaseClient,
+      final ReportingMetricsWriter reportingMetricsWriter) {
+    super(
+        beanFactory,
+        importIndexHandlerRegistry,
+        configurationService,
+        objectMapper,
+        databaseClient);
+    this.reportingMetricsWriter = reportingMetricsWriter;
+  }
+
+  @Override
+  public List<ImportMediator> createMediators(final ZeebeDataSourceDto zeebeDataSourceDto) {
+    return Collections.singletonList(
+        new ZeebeReportingMetricsImportMediator(
+            importIndexHandlerRegistry.getZeebeReportingMetricsImportIndexHandler(
+                zeebeDataSourceDto.getPartitionId()),
+            beanFactory.getBean(
+                ZeebeReportingMetricsFetcher.class,
+                zeebeDataSourceDto.getPartitionId(),
+                databaseClient,
+                objectMapper,
+                configurationService),
+            new ZeebeReportingMetricsImportService(
+                configurationService, reportingMetricsWriter, databaseClient),
+            configurationService,
+            new BackoffCalculator(configurationService)));
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/importing/ZeebeReportingMetricsImportServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/importing/ZeebeReportingMetricsImportServiceTest.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.importing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.camunda.optimize.dto.optimize.importing.ReportingMetricsDto;
+import io.camunda.optimize.dto.zeebe.variable.ZeebeVariableDataDto;
+import io.camunda.optimize.dto.zeebe.variable.ZeebeVariableRecordDto;
+import io.camunda.optimize.service.db.DatabaseClient;
+import io.camunda.optimize.service.db.writer.ReportingMetricsWriter;
+import io.camunda.optimize.service.importing.engine.service.zeebe.ZeebeReportingMetricsImportService;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import io.camunda.zeebe.protocol.record.intent.VariableIntent;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ZeebeReportingMetricsImportServiceTest {
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private ConfigurationService configurationService;
+
+  @Mock private DatabaseClient databaseClient;
+
+  private final AtomicReference<List<ReportingMetricsDto>> capturedDocs = new AtomicReference<>();
+
+  private ZeebeReportingMetricsImportService underTest;
+
+  @BeforeEach
+  void setUp() {
+    when(configurationService.getJobExecutorThreadCount()).thenReturn(1);
+    when(configurationService.getJobExecutorQueueSize()).thenReturn(10);
+    final ReportingMetricsWriter captureWriter =
+        docs -> {
+          capturedDocs.set(docs);
+          return List.of();
+        };
+    underTest =
+        new ZeebeReportingMetricsImportService(configurationService, captureWriter, databaseClient);
+  }
+
+  // ── helpers ───────────────────────────────────────────────────────────────
+
+  private ZeebeVariableRecordDto record(
+      final long piKey,
+      final VariableIntent intent,
+      final long timestamp,
+      final String varName,
+      final String varValue) {
+    final ZeebeVariableDataDto data = new ZeebeVariableDataDto();
+    data.setProcessInstanceKey(piKey);
+    data.setProcessDefinitionKey(100L);
+    data.setTenantId("t1");
+    data.setName(varName);
+    data.setValue(varValue);
+
+    final ZeebeVariableRecordDto dto = new ZeebeVariableRecordDto();
+    dto.setValue(data);
+    dto.setIntent(intent);
+    dto.setTimestamp(timestamp);
+    return dto;
+  }
+
+  // ── tests ─────────────────────────────────────────────────────────────────
+
+  @Test
+  void shouldFilterOutNonReportingVariables() {
+    // given: one REPORTING_PROCESS_ variable and one unrelated variable
+    final List<ZeebeVariableRecordDto> input =
+        List.of(
+            record(1L, VariableIntent.CREATED, 1000L, "REPORTING_PROCESS_totalCost", "42.5"),
+            record(1L, VariableIntent.CREATED, 2000L, "someOtherVariable", "hello"));
+
+    // when
+    executeImport(input);
+
+    // then: only the reporting doc is written
+    assertThat(capturedDocs.get()).hasSize(1);
+    assertThat(capturedDocs.get().getFirst().getTotalCost()).isEqualTo(42.5);
+  }
+
+  @Test
+  void shouldGroupByProcessInstanceKey() {
+    // given: two variables for two different PIs
+    final List<ZeebeVariableRecordDto> input =
+        List.of(
+            record(1L, VariableIntent.CREATED, 1000L, "REPORTING_PROCESS_totalCost", "10.0"),
+            record(2L, VariableIntent.CREATED, 2000L, "REPORTING_PROCESS_totalCost", "20.0"));
+
+    // when
+    executeImport(input);
+
+    // then
+    assertThat(capturedDocs.get()).hasSize(2);
+  }
+
+  @Test
+  void shouldMergeMultipleVariablesForSameProcessInstance() {
+    // given: several REPORTING_PROCESS_ vars for the same PI
+    final List<ZeebeVariableRecordDto> input =
+        List.of(
+            record(1L, VariableIntent.CREATED, 1000L, "REPORTING_PROCESS_totalCost", "99.9"),
+            record(1L, VariableIntent.CREATED, 1500L, "REPORTING_PROCESS_agentTaskCount", "3"),
+            record(1L, VariableIntent.CREATED, 500L, "REPORTING_PROCESS_slaBreached", "true"),
+            record(
+                1L,
+                VariableIntent.CREATED,
+                2000L,
+                "REPORTING_PROCESS_processLabel",
+                "\"My Process\""));
+
+    // when
+    executeImport(input);
+
+    // then
+    assertThat(capturedDocs.get()).hasSize(1);
+    final ReportingMetricsDto doc = capturedDocs.get().getFirst();
+    assertThat(doc.getProcessInstanceKey()).isEqualTo("1");
+    assertThat(doc.getProcessDefinitionKey()).isEqualTo("100");
+    assertThat(doc.getTenantId()).isEqualTo("t1");
+    assertThat(doc.getTotalCost()).isEqualTo(99.9);
+    assertThat(doc.getAgentTaskCount()).isEqualTo(3);
+    assertThat(doc.getSlaBreached()).isTrue();
+    assertThat(doc.getProcessLabel()).isEqualTo("My Process");
+  }
+
+  @Test
+  void shouldTrackFirstAndLastSeenAtFromTimestamps() {
+    // given
+    final List<ZeebeVariableRecordDto> input =
+        List.of(
+            record(1L, VariableIntent.CREATED, 3000L, "REPORTING_PROCESS_totalCost", "1.0"),
+            record(1L, VariableIntent.UPDATED, 1000L, "REPORTING_PROCESS_valueCreated", "2.0"),
+            record(1L, VariableIntent.CREATED, 2000L, "REPORTING_PROCESS_tokenUsage", "500"));
+
+    // when
+    executeImport(input);
+
+    // then
+    final ReportingMetricsDto doc = capturedDocs.get().getFirst();
+    assertThat(doc.getFirstSeenAt()).isEqualTo(1000L);
+    assertThat(doc.getLastSeenAt()).isEqualTo(3000L);
+  }
+
+  @Test
+  void shouldIgnoreRecordsWithNonImportableIntents() {
+    // given: only a MIGRATED intent record (not CREATED or UPDATED)
+    final List<ZeebeVariableRecordDto> input =
+        List.of(record(1L, VariableIntent.MIGRATED, 1000L, "REPORTING_PROCESS_totalCost", "42.0"));
+
+    // when
+    executeImport(input);
+
+    // then: the async executor should never be called (no records match)
+    // The callback is invoked directly since the filtered list is empty
+    assertThat(capturedDocs.get()).isNull();
+  }
+
+  @Test
+  void shouldDoNothingOnEmptyInput() {
+    // given / when
+    executeImport(List.of());
+
+    // then: no docs captured
+    assertThat(capturedDocs.get()).isNull();
+  }
+
+  @Test
+  void shouldUnquoteStringVariableValues() {
+    // given: processLabel stored as JSON-quoted string
+    final List<ZeebeVariableRecordDto> input =
+        List.of(
+            record(
+                1L,
+                VariableIntent.CREATED,
+                1000L,
+                "REPORTING_PROCESS_processLabel",
+                "\"Invoice Approval\""));
+
+    // when
+    executeImport(input);
+
+    // then: surrounding quotes stripped
+    assertThat(capturedDocs.get().getFirst().getProcessLabel()).isEqualTo("Invoice Approval");
+  }
+
+  @Test
+  void shouldParseBooleanFlags() {
+    // given
+    final List<ZeebeVariableRecordDto> input =
+        List.of(
+            record(1L, VariableIntent.CREATED, 1000L, "REPORTING_PROCESS_escalated", "true"),
+            record(1L, VariableIntent.CREATED, 1001L, "REPORTING_PROCESS_manualOverride", "false"));
+
+    // when
+    executeImport(input);
+
+    // then
+    final ReportingMetricsDto doc = capturedDocs.get().getFirst();
+    assertThat(doc.getEscalated()).isTrue();
+    assertThat(doc.getManualOverride()).isFalse();
+  }
+
+  private void executeImport(final List<ZeebeVariableRecordDto> input) {
+    final CountDownLatch importDone = new CountDownLatch(1);
+    underTest.executeImport(input, importDone::countDown);
+    awaitImportCompletion(importDone);
+  }
+
+  private void awaitImportCompletion(final CountDownLatch importDone) {
+    try {
+      assertThat(importDone.await(2, TimeUnit.SECONDS)).isTrue();
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new AssertionError("Interrupted while waiting for import completion", e);
+    }
+  }
+}

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/DatabaseConstants.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/DatabaseConstants.java
@@ -59,6 +59,7 @@ public final class DatabaseConstants {
   public static final String BUSINESS_KEY_INDEX_NAME = "business-key";
   public static final String SETTINGS_INDEX_NAME = "settings";
   public static final String EXTERNAL_PROCESS_VARIABLE_INDEX_NAME = "external-process-variable";
+  public static final String REPORTING_METRICS_INDEX_NAME = "reporting-metrics";
   // Before 8.8, Optimize indices could be templated and rolled over, and would have a numbered
   // suffix. External variable indices were created with such a suffix, but otherwise they are not
   // present

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/es/OptimizeElasticsearchClient.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/es/OptimizeElasticsearchClient.java
@@ -115,6 +115,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
@@ -877,8 +878,25 @@ public class OptimizeElasticsearchClient extends DatabaseClient {
                   bulkResponse.items().stream()
                       .filter(i -> Objects.nonNull(i.error()))
                       .map(
-                          i ->
-                              i.operationType() + " " + i.error().type() + " " + i.error().reason())
+                          i -> {
+                            final String cause =
+                                Optional.ofNullable(i.error().causedBy())
+                                    .map(
+                                        c ->
+                                            c.type()
+                                                + ": "
+                                                + c.reason()
+                                                + (c.causedBy() != null
+                                                    ? " -> " + c.causedBy().reason()
+                                                    : ""))
+                                    .orElse(null);
+                            return i.operationType()
+                                + " "
+                                + i.error().type()
+                                + " "
+                                + i.error().reason()
+                                + (cause != null ? " (caused by: " + cause + ")" : "");
+                          })
                       .collect(Collectors.joining(" , "))));
         }
       } catch (final IOException e) {

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/es/schema/ElasticSearchSchemaManager.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/es/schema/ElasticSearchSchemaManager.java
@@ -34,6 +34,7 @@ import io.camunda.optimize.service.db.es.schema.index.MetadataIndexES;
 import io.camunda.optimize.service.db.es.schema.index.ProcessDefinitionIndexES;
 import io.camunda.optimize.service.db.es.schema.index.ProcessOverviewIndexES;
 import io.camunda.optimize.service.db.es.schema.index.ReportShareIndexES;
+import io.camunda.optimize.service.db.es.schema.index.ReportingMetricsIndexES;
 import io.camunda.optimize.service.db.es.schema.index.SettingsIndexES;
 import io.camunda.optimize.service.db.es.schema.index.TenantIndexES;
 import io.camunda.optimize.service.db.es.schema.index.TerminatedUserSessionIndexES;
@@ -396,6 +397,7 @@ public class ElasticSearchSchemaManager
         new ExternalProcessVariableIndexES(),
         new VariableLabelIndexES(),
         new ProcessOverviewIndexES(),
-        new InstantPreviewDashboardMetadataIndexES());
+        new InstantPreviewDashboardMetadataIndexES(),
+        new ReportingMetricsIndexES());
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/es/schema/index/ReportingMetricsIndexES.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/es/schema/index/ReportingMetricsIndexES.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.es.schema.index;
+
+import co.elastic.clients.elasticsearch.indices.IndexSettings;
+import io.camunda.optimize.service.db.schema.index.ReportingMetricsIndex;
+import java.io.IOException;
+
+public class ReportingMetricsIndexES extends ReportingMetricsIndex<IndexSettings.Builder> {
+
+  @Override
+  public IndexSettings.Builder addStaticSetting(
+      final String key, final int value, final IndexSettings.Builder builder) throws IOException {
+    return builder.numberOfShards(Integer.toString(value));
+  }
+}

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/schema/OpenSearchSchemaManager.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/schema/OpenSearchSchemaManager.java
@@ -32,6 +32,7 @@ import io.camunda.optimize.service.db.os.schema.index.MetadataIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.ProcessDefinitionIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.ProcessOverviewIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.ReportShareIndexOS;
+import io.camunda.optimize.service.db.os.schema.index.ReportingMetricsIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.SettingsIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.TenantIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.TerminatedUserSessionIndexOS;
@@ -567,6 +568,7 @@ public class OpenSearchSchemaManager
         new ExternalProcessVariableIndexOS(),
         new VariableLabelIndexOS(),
         new ProcessOverviewIndexOS(),
-        new InstantPreviewDashboardMetadataIndexOS());
+        new InstantPreviewDashboardMetadataIndexOS(),
+        new ReportingMetricsIndexOS());
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/schema/index/ReportingMetricsIndexOS.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/schema/index/ReportingMetricsIndexOS.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.os.schema.index;
+
+import io.camunda.optimize.service.db.os.OptimizeOpenSearchUtil;
+import io.camunda.optimize.service.db.schema.index.ReportingMetricsIndex;
+import org.opensearch.client.opensearch.indices.IndexSettings;
+
+public class ReportingMetricsIndexOS extends ReportingMetricsIndex<IndexSettings.Builder> {
+
+  @Override
+  public IndexSettings.Builder addStaticSetting(
+      final String key, final int value, final IndexSettings.Builder contentBuilder) {
+    return OptimizeOpenSearchUtil.addStaticSetting(key, value, contentBuilder);
+  }
+}

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/IndexLookupUtil.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/IndexLookupUtil.java
@@ -21,6 +21,7 @@ import io.camunda.optimize.service.db.es.schema.index.ProcessDefinitionIndexES;
 import io.camunda.optimize.service.db.es.schema.index.ProcessInstanceIndexES;
 import io.camunda.optimize.service.db.es.schema.index.ProcessOverviewIndexES;
 import io.camunda.optimize.service.db.es.schema.index.ReportShareIndexES;
+import io.camunda.optimize.service.db.es.schema.index.ReportingMetricsIndexES;
 import io.camunda.optimize.service.db.es.schema.index.SettingsIndexES;
 import io.camunda.optimize.service.db.es.schema.index.TenantIndexES;
 import io.camunda.optimize.service.db.es.schema.index.TerminatedUserSessionIndexES;
@@ -44,6 +45,7 @@ import io.camunda.optimize.service.db.os.schema.index.ProcessDefinitionIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.ProcessInstanceIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.ProcessOverviewIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.ReportShareIndexOS;
+import io.camunda.optimize.service.db.os.schema.index.ReportingMetricsIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.SettingsIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.TenantIndexOS;
 import io.camunda.optimize.service.db.os.schema.index.TerminatedUserSessionIndexOS;
@@ -148,6 +150,8 @@ public class IndexLookupUtil {
         index -> new InstantPreviewDashboardMetadataIndexOS());
     lookupMap.put(DecisionInstanceIndexES.class.getSimpleName(), DecisionInstanceIndexOS::new);
     lookupMap.put(ProcessInstanceIndexES.class.getSimpleName(), ProcessInstanceIndexOS::new);
+    lookupMap.put(
+        ReportingMetricsIndexES.class.getSimpleName(), index -> new ReportingMetricsIndexOS());
     return lookupMap;
   }
 
@@ -197,6 +201,8 @@ public class IndexLookupUtil {
         index -> new InstantPreviewDashboardMetadataIndexES());
     lookupMap.put(DecisionInstanceIndexOS.class.getSimpleName(), DecisionInstanceIndexES::new);
     lookupMap.put(ProcessInstanceIndexOS.class.getSimpleName(), ProcessInstanceIndexES::new);
+    lookupMap.put(
+        ReportingMetricsIndexOS.class.getSimpleName(), index -> new ReportingMetricsIndexES());
     return lookupMap;
   }
 

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/ReportingMetricsIndex.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/ReportingMetricsIndex.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.schema.index;
+
+import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
+import io.camunda.optimize.service.db.DatabaseConstants;
+import io.camunda.optimize.service.db.schema.DefaultIndexMappingCreator;
+
+/**
+ * Index mapping for {@code optimize-reporting-metrics}. One document per process instance,
+ * aggregated from {@code REPORTING_PROCESS_*} Zeebe variable records.
+ *
+ * <p>Field types mirror the Python ingestion script in {@code poc-scripts/ingestion.py}, which is
+ * the authoritative schema definition for this index.
+ */
+public abstract class ReportingMetricsIndex<TBuilder> extends DefaultIndexMappingCreator<TBuilder> {
+
+  public static final int VERSION = 1;
+
+  // Identity / routing fields
+  public static final String PROCESS_INSTANCE_KEY = "processInstanceKey";
+  public static final String PROCESS_DEFINITION_KEY = "processDefinitionKey";
+  public static final String TENANT_ID = "tenantId";
+  public static final String PROCESS_LABEL = "processLabel";
+  public static final String STATE = "state";
+
+  // Timestamp fields — stored as epoch-millisecond longs, formatted with "epoch_millis"
+  public static final String FIRST_SEEN_AT = "firstSeenAt";
+  public static final String LAST_SEEN_AT = "lastSeenAt";
+
+  // Date string fields written by BPMN processes
+  public static final String START_DATE = "startDate";
+  public static final String END_DATE = "endDate";
+
+  // Cost / value metrics
+  public static final String BASELINE_COST = "baselineCost";
+  public static final String LLM_COST = "llmCost";
+  public static final String AUTOMATION_COST = "automationCost";
+  public static final String TOTAL_COST = "totalCost";
+  public static final String VALUE_CREATED = "valueCreated";
+  public static final String EXTERNAL_SERVICE_COST_USD = "externalServiceCostUsd";
+
+  // Task-count metrics
+  public static final String AGENT_TASK_COUNT = "agentTaskCount";
+  public static final String HUMAN_TASK_COUNT = "humanTaskCount";
+  public static final String AUTO_TASK_COUNT = "autoTaskCount";
+  public static final String TOKEN_USAGE = "tokenUsage";
+  public static final String ERROR_COUNT = "errorCount";
+  public static final String RETRY_COUNT = "retryCount";
+  public static final String API_CALL_COUNT = "apiCallCount";
+  public static final String COMPLIANCE_CHECKS_PASSED = "complianceChecksPassed";
+
+  // Timing metrics
+  public static final String PROCESSING_TIME_MS = "processingTimeMs";
+  public static final String QUEUE_WAIT_TIME_MS = "queueWaitTimeMs";
+
+  // Environmental / quality metrics
+  public static final String DATA_VOLUME_MB = "dataVolumeMb";
+  public static final String CONFIDENCE_SCORE = "confidenceScore";
+  public static final String CO2_EMISSIONS_KG = "co2EmissionsKg";
+  public static final String CUSTOMER_SATISFACTION_SCORE = "customerSatisfactionScore";
+  public static final String FRAUD_RISK_SCORE = "fraudRiskScore";
+
+  // Boolean flags
+  public static final String SLA_BREACHED = "slaBreached";
+  public static final String ESCALATED = "escalated";
+  public static final String MANUAL_OVERRIDE = "manualOverride";
+
+  @Override
+  public String getIndexName() {
+    return DatabaseConstants.REPORTING_METRICS_INDEX_NAME;
+  }
+
+  @Override
+  public int getVersion() {
+    return VERSION;
+  }
+
+  @Override
+  public TypeMapping.Builder addProperties(final TypeMapping.Builder builder) {
+    return builder
+        // Identity / routing
+        .properties(PROCESS_INSTANCE_KEY, p -> p.keyword(k -> k))
+        .properties(PROCESS_DEFINITION_KEY, p -> p.keyword(k -> k))
+        .properties(TENANT_ID, p -> p.keyword(k -> k))
+        .properties(PROCESS_LABEL, p -> p.keyword(k -> k))
+        .properties(STATE, p -> p.keyword(k -> k))
+        // Timestamps: epoch-ms longs from Zeebe
+        .properties(FIRST_SEEN_AT, p -> p.date(d -> d.format("epoch_millis")))
+        .properties(LAST_SEEN_AT, p -> p.date(d -> d.format("epoch_millis")))
+        // Date strings set by BPMN processes
+        .properties(START_DATE, p -> p.date(d -> d))
+        .properties(END_DATE, p -> p.date(d -> d))
+        // Cost / value metrics
+        .properties(BASELINE_COST, p -> p.double_(d -> d))
+        .properties(LLM_COST, p -> p.double_(d -> d))
+        .properties(AUTOMATION_COST, p -> p.double_(d -> d))
+        .properties(TOTAL_COST, p -> p.double_(d -> d))
+        .properties(VALUE_CREATED, p -> p.double_(d -> d))
+        .properties(EXTERNAL_SERVICE_COST_USD, p -> p.double_(d -> d))
+        // Task-count / quality metrics
+        .properties(AGENT_TASK_COUNT, p -> p.integer(i -> i))
+        .properties(HUMAN_TASK_COUNT, p -> p.integer(i -> i))
+        .properties(AUTO_TASK_COUNT, p -> p.integer(i -> i))
+        .properties(TOKEN_USAGE, p -> p.long_(l -> l))
+        .properties(ERROR_COUNT, p -> p.integer(i -> i))
+        .properties(RETRY_COUNT, p -> p.integer(i -> i))
+        .properties(API_CALL_COUNT, p -> p.integer(i -> i))
+        .properties(COMPLIANCE_CHECKS_PASSED, p -> p.integer(i -> i))
+        // Timing
+        .properties(PROCESSING_TIME_MS, p -> p.integer(i -> i))
+        .properties(QUEUE_WAIT_TIME_MS, p -> p.integer(i -> i))
+        // Environmental / quality
+        .properties(DATA_VOLUME_MB, p -> p.double_(d -> d))
+        .properties(CONFIDENCE_SCORE, p -> p.double_(d -> d))
+        .properties(CO2_EMISSIONS_KG, p -> p.double_(d -> d))
+        .properties(CUSTOMER_SATISFACTION_SCORE, p -> p.double_(d -> d))
+        .properties(FRAUD_RISK_SCORE, p -> p.double_(d -> d))
+        // Boolean flags
+        .properties(SLA_BREACHED, p -> p.boolean_(b -> b))
+        .properties(ESCALATED, p -> p.boolean_(b -> b))
+        .properties(MANUAL_OVERRIDE, p -> p.boolean_(b -> b));
+  }
+}


### PR DESCRIPTION
## Description

Adds a position-based Optimize import pipeline that reads Zeebe variable records prefixed with REPORTING_PROCESS_* and upserts them as flat, per-process-instance documents into a new optimize-reporting-metrics index. Variables with this prefix are now filtered out of the standard ZeebeVariableImportService to avoid storing them in the process-instance index (write amplification).                                                     
                                                                                                                                                          
  Changes

  New import pipeline (end-to-end)                                                                                                                          
  - ReportingMetricsDto + REPORTING_METRICS_INDEX_NAME constant — flat nullable document model, one per process instance
  - ReportingMetricsIndex (ES + OS) — index schema, registered in both schema managers                                                                      
  - ZeebeReportingMetricsFetcher (ES + OS) — reads from the same Zeebe variable source index with its own independent position                            
  - ZeebeReportingMetricsImportIndexHandler — persists position under zeebeReportingMetricsImportIndex, decoupled from the variable importer                
  - ZeebeReportingMetricsImportService — groups by process instance key, applies typed field mappings via ReportingMetricsMappings                          
  - ReportingMetricsWriter (ES + OS) — bulk upsert with a generated Painless script that only overwrites non-null fields                                    
  - Mediator, factory, and registry wiring into the standard Optimize import loop                                                                           
                                                                                                                                                            
  Write-amplification fix                                                                                                                                   
  - ZeebeVariableImportService now drops records whose name starts with REPORTING_PROCESS_ before grouping, so each record is processed by exactly one pipeline                                                                                                                                                  
                                                                                                                                                          
  Fixes                                                                                                                                                     
  - Import shutdown no longer retries persistence when the worker thread is interrupted                                                                   
  - ES bulk error messages now include nested cause details              

## Related issues

closes https://github.com/camunda/camunda/issues/50635