### PR TITLE
optimize: fix 'occured' -> 'occurred' in ErrorBoundary UI text

### DIFF
--- a/optimize/client/src/modules/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/optimize/client/src/modules/components/ErrorBoundary/ErrorBoundary.tsx
@@ -37,7 +37,7 @@ export default class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBo
       return (
         <ErrorPage
           noLink
-          text={`An application error occured.
+          text={`An application error occurred.
 Refresh your browser or close it and sign in again.`}
         >
           <pre>{typeof error === 'object' ? error.message : error}</pre>


### PR DESCRIPTION
UI text in `optimize/client/src/modules/components/ErrorBoundary/ErrorBoundary.tsx` line 40 reads `An application error occured`. User-visible. Fixed to `occurred`. String-literal-only change.