### PR TITLE
fix: throttle recoverable exception log in RecoverableRetryStrategy

### DIFF
--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/RecoverableRetryStrategy.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/RecoverableRetryStrategy.java
@@ -12,6 +12,8 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.retry.ActorRetryMechanism.Control;
 import io.camunda.zeebe.util.exception.RecoverableException;
+import io.camunda.zeebe.util.logging.ThrottledLogger;
+import java.time.Duration;
 import java.util.function.BooleanSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,6 +21,8 @@ import org.slf4j.LoggerFactory;
 public final class RecoverableRetryStrategy implements RetryStrategy {
 
   private static final Logger LOG = LoggerFactory.getLogger(RecoverableRetryStrategy.class);
+  private static final ThrottledLogger THROTTLED_LOG =
+      new ThrottledLogger(LOG, Duration.ofSeconds(5));
 
   private final ActorControl actor;
   private final ActorRetryMechanism retryMechanism;
@@ -56,7 +60,7 @@ public final class RecoverableRetryStrategy implements RetryStrategy {
       }
     } catch (final RecoverableException ex) {
       if (!terminateCondition.getAsBoolean()) {
-        LOG.debug("Caught recoverable exception, will retry: {}", ex.getMessage(), ex);
+        THROTTLED_LOG.warn("Caught recoverable exception, will retry: {}", ex.getMessage(), ex);
         actor.run(this::run);
         actor.yieldThread();
       }

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/RecoverableRetryStrategy.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/RecoverableRetryStrategy.java
@@ -21,11 +21,10 @@ import org.slf4j.LoggerFactory;
 public final class RecoverableRetryStrategy implements RetryStrategy {
 
   private static final Logger LOG = LoggerFactory.getLogger(RecoverableRetryStrategy.class);
-  private static final ThrottledLogger THROTTLED_LOG =
-      new ThrottledLogger(LOG, Duration.ofSeconds(5));
 
   private final ActorControl actor;
   private final ActorRetryMechanism retryMechanism;
+  private final ThrottledLogger throttledLog = new ThrottledLogger(LOG, Duration.ofSeconds(5));
   private CompletableActorFuture<Boolean> currentFuture;
   private BooleanSupplier terminateCondition;
 
@@ -60,7 +59,7 @@ public final class RecoverableRetryStrategy implements RetryStrategy {
       }
     } catch (final RecoverableException ex) {
       if (!terminateCondition.getAsBoolean()) {
-        THROTTLED_LOG.warn("Caught recoverable exception, will retry: {}", ex.getMessage(), ex);
+        throttledLog.warn("Caught recoverable exception, will retry: {}", ex.getMessage(), ex);
         actor.run(this::run);
         actor.yieldThread();
       }


### PR DESCRIPTION
## Summary

- Replaces the per-tick `LOG.debug` in `RecoverableRetryStrategy` with a `ThrottledLogger` (5-second interval) at `warn` level
- Stops log flooding during the endless RocksDB retry loop described in #50958 while keeping the error visible

## Test plan

- [x] Existing `zeebe/scheduler` tests pass (`./mvnw verify -pl zeebe/scheduler -DskipTests=false -DskipITs -Dquickly`)
- [ ] No new warnings or errors introduced

Closes #50958

> 🤖 Generated with [Claude Code](https://claude.com/claude-code)