### PR TITLE
fix: use per-instance ThrottledLogger in SegmentsManager

### DIFF
--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
@@ -43,9 +43,9 @@ final class SegmentsManager implements AutoCloseable {
   private static final long INITIAL_ASQN = SegmentedJournal.ASQN_IGNORE;
 
   private static final Logger LOG = LoggerFactory.getLogger(SegmentsManager.class);
-  private static final Logger THROTTLED_LOG = new ThrottledLogger(LOG, Duration.ofSeconds(5));
 
   private final NavigableMap<Long, Segment> segments = new ConcurrentSkipListMap<>();
+  private final ThrottledLogger throttledLog = new ThrottledLogger(LOG, Duration.ofSeconds(5));
   private CompletableFuture<UninitializedSegment> nextSegment = null;
 
   private final JournalMetrics journalMetrics;
@@ -182,7 +182,7 @@ final class SegmentsManager implements AutoCloseable {
     final SortedMap<Long, Segment> compactSegments =
         segments.headMap(segmentEntry.getValue().index());
     if (compactSegments.isEmpty()) {
-      THROTTLED_LOG.debug(
+      throttledLog.debug(
           "No segments can be deleted with index < {} (first log index: {})",
           index,
           getFirstIndex());


### PR DESCRIPTION
## Summary

`SegmentsManager` is created once per partition journal. The previous `static` `ThrottledLogger` was shared across all instances, meaning a log from one partition would suppress the same log from another partition for 5 seconds.

This converts it to a per-instance field so each journal's throttle window is independent, consistent with how `ThrottledLogger` is intended to be used.

Discovered while auditing static `ThrottledLogger` usages across the codebase following #50958.

## Test plan

- [ ] `zeebe/journal` tests pass (`./mvnw verify -pl zeebe/journal -DskipTests=false -DskipITs -Dquickly`)

> 🤖 Generated with [Claude Code](https://claude.com/claude-code)