### PR TITLE
fix: update paths for building starter and worker images in CI workflow

### DIFF
--- a/.github/workflows/ci-zeebe.yml
+++ b/.github/workflows/ci-zeebe.yml
@@ -501,9 +501,9 @@ jobs:
           minimus: true
       - run: ./mvnw -B -D skipTests -D skipChecks -pl zeebe/benchmarks/project -am install
       - name: Build Starter Image
-        run: ./mvnw -pl load-tests/load-tester jib:build -P starter -D image="${{ env.IMAGE_REPOSITORY }}/starter:${{ env.IMAGE_TAG }}"
+        run: ./mvnw -pl zeebe/benchmarks/project jib:build -P starter -D image="${{ env.IMAGE_REPOSITORY }}/starter:${{ env.IMAGE_TAG }}"
       - name: Build Worker Image
-        run: ./mvnw -pl load-tests/load-tester jib:build -P worker -D image="${{ env.IMAGE_REPOSITORY }}/worker:${{ env.IMAGE_TAG }}"
+        run: ./mvnw -pl zeebe/benchmarks/project jib:build -P worker -D image="${{ env.IMAGE_REPOSITORY }}/worker:${{ env.IMAGE_TAG }}"
       - name: Observe build status
         if: always()
         continue-on-error: true


### PR DESCRIPTION
This pull request updates the image build process in the CI workflow to use the correct project path for building Docker images. The change ensures that both the starter and worker images are built from the `zeebe/benchmarks/project` module instead of the previously used `load-tests/load-tester` module.

Build process fixes:

* Updated the `Build Starter Image` and `Build Worker Image` steps in `.github/workflows/ci-zeebe.yml` to build images from the `zeebe/benchmarks/project` module, correcting the project path used in the Maven commands.