### PR TITLE
feat: enable noPropertyAccessFromIndexSignature TS config in Operate

### DIFF
--- a/operate/client/playwright.config.ts
+++ b/operate/client/playwright.config.ts
@@ -14,9 +14,9 @@ import {
 import playwrightPkg from '@playwright/test/package.json' with {type: 'json'};
 
 const BASE_URL = 'http://localhost:3003/operate/';
-const IS_CI = Boolean(process.env.CI);
+const IS_CI = Boolean(process.env['CI']);
 const USE_CONTAINERIZED_BROWSER =
-  !IS_CI && Boolean(process.env.CONTAINERIZED_BROWSER);
+  !IS_CI && Boolean(process.env['CONTAINERIZED_BROWSER']);
 
 const webServer: PlaywrightTestConfig['webServer'] = [
   {
@@ -107,7 +107,7 @@ const config = defineConfig({
     video: 'retain-on-failure',
     ...(USE_CONTAINERIZED_BROWSER && {
       connectOptions: {
-        wsEndpoint: `ws://127.0.0.1:${process.env.PLAYWRIGHT_SERVER_PORT}/`,
+        wsEndpoint: `ws://127.0.0.1:${process.env['PLAYWRIGHT_SERVER_PORT']}/`,
       },
     }),
   },

--- a/operate/client/src/App/Dashboard/NoInstancesEmptyState.tsx
+++ b/operate/client/src/App/Dashboard/NoInstancesEmptyState.tsx
@@ -13,7 +13,7 @@ import {useCurrentUser} from 'modules/queries/useCurrentUser';
 
 const NoInstancesEmptyState: React.FC = () => {
   const {data: currentUser} = useCurrentUser();
-  const modelerLink = currentUser?.c8Links?.modeler;
+  const modelerLink = currentUser?.c8Links?.['modeler'];
 
   return (
     <EmptyState

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/EditButtons.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/EditButtons.tsx
@@ -12,11 +12,12 @@ import {useFieldError} from 'modules/hooks/useFieldError';
 import {Button} from '@carbon/react';
 import {Checkmark, Close} from '@carbon/react/icons';
 import {Loading} from './EditButtons.styled';
+import type {VariableFormValues} from 'modules/types/variables';
 
 const EditButtons: React.FC = () => {
   const form = useForm();
   const {values, initialValues, validating, hasValidationErrors} =
-    useFormState();
+    useFormState<VariableFormValues>();
 
   const nameError = useFieldError('name');
   const valueError = useFieldError('value');

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/Footer/NewVariable.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/Footer/NewVariable.tsx
@@ -8,6 +8,7 @@
 
 import {useState} from 'react';
 import {Field, useForm, useFormState} from 'react-final-form';
+import type {VariableFormValues} from 'modules/types/variables';
 import {useFieldError} from 'modules/hooks/useFieldError';
 import {Layer} from './styled';
 import {
@@ -28,7 +29,7 @@ import {MaximizeButton} from '../ViewFullVariableButton/MaximizeButton';
 import {InlineJsonEditor} from 'modules/components/InlineJsonEditor';
 
 const NewVariable: React.FC = () => {
-  const formState = useFormState();
+  const formState = useFormState<VariableFormValues>();
   const form = useForm();
   const [isModalVisible, setIsModalVisible] = useState(false);
   const {data: variablesData} = useVariables();
@@ -98,7 +99,7 @@ const NewVariable: React.FC = () => {
               ? `Edit Variable "${formState.values?.name}"`
               : 'Edit a new Variable'
           }
-          value={formState.values?.value}
+          value={formState.values?.value ?? ''}
           onClose={() => {
             setIsModalVisible(false);
             tracking.track({

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/NewVariableModification/Name.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/NewVariableModification/Name.tsx
@@ -67,7 +67,7 @@ const Name: React.FC<Props> = ({variableName, scopeId}) => {
             hideLabel
             labelText="Name"
             onBlur={() => {
-              form.mutators?.triggerValidation?.(
+              form.mutators?.['triggerValidation']?.(
                 createNewVariableFieldName(variableName, 'name'),
               );
 

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/NewVariableModification/Value.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/NewVariableModification/Value.tsx
@@ -52,7 +52,7 @@ const Value: React.FC<Props> = ({variableName, scopeId}) => {
             id={valueFieldName}
             fieldError={fieldError}
             onBlur={() => {
-              form.mutators?.triggerValidation?.(valueFieldName);
+              form.mutators?.['triggerValidation']?.(valueFieldName);
               input.onBlur();
 
               createModification({

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/VariablesTable.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/VariablesTable.tsx
@@ -38,7 +38,7 @@ const VariablesTable: React.FC<Props> = ({
   isVariableModificationAllowed,
 }) => {
   const {data: isProcessInstanceRunning} = useIsProcessInstanceRunning();
-  const {initialValues} = useFormState();
+  const {initialValues} = useFormState<VariableFormValues>();
   const form = useForm<VariableFormValues>();
   const variableNameRef = useRef<HTMLDivElement>(null);
 

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/index.tsx
@@ -59,7 +59,7 @@ const Variables: React.FC<Props> = observer(
       return disposer;
     }, [isModificationModeEnabled, form]);
 
-    const {initialValues} = useFormState();
+    const {initialValues} = useFormState<VariableFormValues>();
 
     const fieldArray = useFieldArray('newVariables');
 

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/VariablesForm.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/VariablesForm.tsx
@@ -46,7 +46,7 @@ const VariablesForm: React.FC<FormRenderProps<VariableFormValues>> = observer(
         {isModificationAllowed && (
           <AddVariableButton
             onClick={() => {
-              form.mutators.push?.('newVariables', {
+              form.mutators['push']?.('newVariables', {
                 id: generateUniqueID(),
               });
             }}

--- a/operate/client/src/App/ProcessInstance/index.tsx
+++ b/operate/client/src/App/ProcessInstance/index.tsx
@@ -75,8 +75,8 @@ const onProcessInstanceTabTransition = ({
   return (
     currentProcessInstance !== null &&
     nextProcessInstance !== null &&
-    currentProcessInstance.params.processInstanceId ===
-      nextProcessInstance.params.processInstanceId
+    currentProcessInstance.params['processInstanceId'] ===
+      nextProcessInstance.params['processInstanceId']
   );
 };
 

--- a/operate/client/src/App/Processes/ListView/Filters/VariableField/index.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariableField/index.tsx
@@ -139,7 +139,7 @@ const Variable: React.FC = observer(() => {
         ? createPortal(
             <MultipleValuesModal
               isVisible={isModalVisible}
-              initialValue={formState.values?.variableValues}
+              initialValue={formState.values?.['variableValues']}
               onClose={() => {
                 setIsModalVisible(false);
                 tracking.track({
@@ -162,7 +162,7 @@ const Variable: React.FC = observer(() => {
             <JSONEditorModal
               isVisible={isModalVisible}
               title="Edit Variable Value"
-              value={formState.values?.variableValues}
+              value={formState.values?.['variableValues']}
               onClose={() => {
                 setIsModalVisible(false);
                 tracking.track({

--- a/operate/client/src/vite-env.d.ts
+++ b/operate/client/src/vite-env.d.ts
@@ -10,3 +10,19 @@
 
 /// <reference types="vite/client" />
 /// <reference types="vite-plugin-svgr/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_VERSION: string;
+  readonly VITE_DEV_ENV_URL: string;
+  readonly VITE_INT_ENV_URL: string;
+  readonly VITE_PROD_ENV_URL: string;
+  readonly VITE_MIXPANEL_TOKEN: string;
+  readonly VITE_MIXPANEL_HOST: string;
+  readonly VITE_OSANO_INT_ENV_URL: string;
+  readonly VITE_OSANO_PROD_ENV_URL: string;
+  readonly VITE_CUES_HOST: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/operate/client/tsconfig.base.json
+++ b/operate/client/tsconfig.base.json
@@ -23,7 +23,7 @@
     "noImplicitReturns": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noPropertyAccessFromIndexSignature": false,
+    "noPropertyAccessFromIndexSignature": true,
     "noUncheckedIndexedAccess": true,
     "allowUnreachableCode": false
   }

--- a/operate/client/vite.config.ts
+++ b/operate/client/vite.config.ts
@@ -23,7 +23,7 @@ function getReporters(): Pick<
   NonNullable<UserConfig['test']>,
   'reporters' | 'outputFile'
 > {
-  if (process.env.CI) {
+  if (process.env['CI']) {
     return {
       reporters: ['default', 'junit', 'github-actions'],
       outputFile: {
@@ -89,7 +89,7 @@ export default defineConfig(({mode}) => ({
     clearMocks: true,
     resetMocks: true,
     unstubEnvs: true,
-    retry: process.env.CI ? 3 : 0,
+    retry: process.env['CI'] ? 3 : 0,
     ...getReporters(),
     server: {
       deps: {


### PR DESCRIPTION
## Description

As discussed in https://github.com/camunda/camunda/pull/50888#discussion_r3077787000, this PR enables the `noPropertyAccessFromIndexSignature` TS config option.

## Related issues

relates #50173
