### PR TITLE
ci: fix Elasticsearch scheduling of load tests

### DIFF
--- a/zeebe/benchmarks/setup/default/values-stable.yaml
+++ b/zeebe/benchmarks/setup/default/values-stable.yaml
@@ -2,7 +2,7 @@
 elasticsearch:
   master:
     nodeSelector:
-      component: benchmark-n2-standard-8
+      component: benchmark-n2-standard-8-stable
       topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
     tolerations:
       - key: nodepool


### PR DESCRIPTION
## Description

Fix for https://github.com/camunda/camunda/pull/51051/changes: the toleration is configured for "stable" but the "component" selector was targetting a different node pool.

This prevented the release load tests for the stable/8.7 branch to be scheduled correctly.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

* https://github.com/camunda/camunda/actions/runs/24492967548
* https://camunda.slack.com/archives/C0ANMGS3D4Y/p1776316703219029
