### PR TITLE
feat: add workload scenario Make targets and simplify load test workflow

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -310,71 +310,6 @@ jobs:
             validate_image "camunda/connectors:${CONNECTORS_TAG}" || exit 1
           fi
 
-  calculate-scenario-config:
-    name: Calculate Scenario Configuration
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions: { }
-    outputs:
-      load-test-load: ${{ steps.config.outputs.load-test-load }}
-      platform-additional-config: ${{ steps.config.outputs.platform-additional-config }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ inputs.ref }}
-      - name: Calculate configuration based on scenario
-        id: config
-        run: |
-          scenario="${{ inputs.scenario }}"
-
-          # Default to max scenario if not provided
-          if [[ -z "$scenario" ]]; then
-            scenario="max"
-          fi
-
-          case "$scenario" in
-            latency)
-              echo "load-test-load=--set starter.rate=1 --set workers.worker.replicas=1" >> "$GITHUB_OUTPUT"
-              echo "platform-additional-config=" >> "$GITHUB_OUTPUT"
-              ;;
-            realistic)
-              echo "load-test-load=-f https://raw.githubusercontent.com/camunda/camunda-load-tests-helm/refs/heads/main/charts/camunda-load-tests/values-realistic-benchmark.yaml" >> "$GITHUB_OUTPUT"
-              echo "platform-additional-config=" >> "$GITHUB_OUTPUT"
-              ;;
-            archiver)
-              echo "load-test-load=--set starter.rate=1 --set starter.rateDuration=10m --set starter.processId=multiInstanceElements --set starter.bpmnXmlPath=bpmn/multiInstanceElements.bpmn --set starter.payloadPath=bpmn/multiInstanceElementsPayload.json --set workers.worker.replicas=0" >> "$GITHUB_OUTPUT"
-              echo "platform-additional-config=" >> "$GITHUB_OUTPUT"
-              ;;
-            typical)
-              # Output typical configuration directly to avoid quote escaping issues
-              echo "load-test-load=--set starter.rate=50 --set workers.worker.replicas=6 --set starter.bpmnXmlPath=bpmn/typical_process.bpmn" >> "$GITHUB_OUTPUT"
-              echo "platform-additional-config=" >> "$GITHUB_OUTPUT"
-              ;;
-            max)
-              echo "load-test-load=--set starter.rate=300" >> "$GITHUB_OUTPUT"
-              # For the max stress scenario, disable the experimental consistency checks to avoid overhead.
-              # We inject the overrides via --set-file into extraConfiguration[1] (application-override.yml),
-              # which is loaded after (and thus takes priority over) the base application.yml.
-              # All values files define extraConfiguration[1] as application-override.yml (empty by default),
-              # so this override works regardless of which secondary storage type is selected.
-              # The file is copied to the local namespace setup dir by newLoadTest.sh (copies all ../*.yaml).
-              echo "platform-additional-config=--set-file 'orchestration.extraConfiguration[1].content=./camunda-platform-override-values.yaml'" >> "$GITHUB_OUTPUT"
-              ;;
-            *)
-              echo "Error: Unknown scenario '$scenario'"
-              exit 1
-              ;;
-          esac
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-
   build-camunda-image:
     name: Build Camunda
     needs: calculate-image-tag
@@ -497,7 +432,6 @@ jobs:
     name: Deploy cluster under test
     needs:
       - calculate-image-tag
-      - calculate-scenario-config
       - build-camunda-image
       - build-load-test-images
     # To have the possibility to re-deploy the tests without rebuilding the images,
@@ -553,8 +487,7 @@ jobs:
                             --set global.extraEnvVars[0].name=CONFIG_FORCE_app_performReadBenchmarks \
                             --set global.extraEnvVars[0].value=${{inputs.perform-read-benchmarks}}"
 
-          # Append scenario load-test-load configuration and custom inputs
-          load_test_config="$load_test_config ${{ needs.calculate-scenario-config.outputs.load-test-load }}"
+          # Append custom load test inputs
           load_test_config="$load_test_config ${{ inputs.load-test-load }}"
 
           # Resolve image registry/repository: Docker Hub when orchestration-tag is set, internal registry otherwise
@@ -602,12 +535,8 @@ jobs:
             additional_platform_config+=" ${{ inputs.platform-helm-values }}"
           fi
 
-          # Append scenario-specific platform configuration if present (e.g. max scenario disables consistency checks)
-          if [[ -n "${{ needs.calculate-scenario-config.outputs.platform-additional-config }}" ]]; then
-            additional_platform_config+=" ${{ needs.calculate-scenario-config.outputs.platform-additional-config }}"
-          fi
-
           make ${{ inputs.stable-vms && 'install-stable' || 'install' }} \
+            scenario=${{ inputs.scenario }} \
             secondary_storage=${{ inputs.secondary-storage-type }} \
             enable_optimize=${{ inputs.enable-optimize }} \
             additional_platform_configuration="$additional_platform_config" \

--- a/load-tests/setup/README.md
+++ b/load-tests/setup/README.md
@@ -199,6 +199,44 @@ The Camunda Platform deployment automatically sets up a leader balancing cronjob
 
 This will deploy the full Camunda Platform (including `orchestration cluster`, `elasticsearch`, `optimize`, `connectors`, `identity` and `keycloak`) and load test applications (e.g. `starter` and `worker`).
 
+### Running specific scenarios
+
+By default, `make install` uses the load test chart's own defaults (no workload profile applied).
+To run a specific workload profile, use one of the named targets:
+
+```sh
+make latency   # 1 instance/s, 1 worker — low-throughput, useful for latency measurements
+make typical   # 50 instances/s, 6 workers, typical_process BPMN
+make realistic # Realistic multi-instance benchmark (values from camunda-load-tests-helm)
+make max       # 300 instances/s — maximum stress, also disables consistency check overhead
+make archiver  # Multi-instance archiver scenario (no workers)
+```
+
+You can also pass `scenario=` directly to combine with additional overrides:
+
+```sh
+make install scenario=max additional_platform_configuration="--set orchestration.resources.limits.memory=4Gi"
+```
+
+For stable (non-spot) VMs, use `install-stable` with the `scenario=` variable:
+
+```sh
+make install-stable scenario=max
+```
+
+To inspect the resolved flags without running any Helm commands:
+
+```sh
+make print-scenario scenario=max
+```
+
+To render Helm templates for inspection:
+
+```sh
+make template scenario=max          # renders platform manifests
+make template-load-test scenario=max  # renders load test manifests
+```
+
 ### How to clean up a load test
 
 After you're done with your load test, you should remove the remaining namespace.

--- a/load-tests/setup/default/Makefile
+++ b/load-tests/setup/default/Makefile
@@ -15,6 +15,31 @@ additional_platform_configuration ?=
 # See the load test README for example values and guidance.
 additional_load_test_configuration ?= --set global.image.repository=registry.camunda.cloud/team-zeebe --set global.image.pullSecrets[0].name=harbor-registry
 
+# Scenario: controls the workload profile for the load test.
+# Options: latency, realistic, typical, max, archiver
+# Use named targets (make max) or pass directly: make install scenario=max
+scenario ?=
+
+ifeq ($(scenario),latency)
+_scenario_load_test_flags := --set starter.rate=1 --set workers.worker.replicas=1
+_scenario_platform_flags  :=
+else ifeq ($(scenario),realistic)
+_scenario_load_test_flags := -f https://raw.githubusercontent.com/camunda/camunda-load-tests-helm/refs/heads/main/charts/camunda-load-tests/values-realistic-benchmark.yaml
+_scenario_platform_flags  :=
+else ifeq ($(scenario),typical)
+_scenario_load_test_flags := --set starter.rate=50 --set workers.worker.replicas=6 --set starter.bpmnXmlPath=bpmn/typical_process.bpmn
+_scenario_platform_flags  :=
+else ifeq ($(scenario),max)
+_scenario_load_test_flags := --set starter.rate=300
+_scenario_platform_flags  := --set-file 'orchestration.extraConfiguration[1].content=./camunda-platform-override-values.yaml'
+else ifeq ($(scenario),archiver)
+_scenario_load_test_flags := --set starter.rate=1 --set starter.rateDuration=10m --set starter.processId=multiInstanceElements --set starter.bpmnXmlPath=bpmn/multiInstanceElements.bpmn --set starter.payloadPath=bpmn/multiInstanceElementsPayload.json --set workers.worker.replicas=0
+_scenario_platform_flags  :=
+else
+_scenario_load_test_flags :=
+_scenario_platform_flags  :=
+endif
+
 # Construct platform values files based on configuration
 platform_values := -f camunda-platform-values.yaml
 
@@ -118,6 +143,7 @@ install-platform: setup-leader-balancer
 		--render-subchart-notes \
 		$(platform_values) \
 		-f values-preemptible.yaml \
+		$(_scenario_platform_flags) \
 		$(additional_platform_configuration)
 
 # Install/upgrade Camunda Platform on stable VMs
@@ -129,6 +155,7 @@ install-platform-stable: setup-leader-balancer
 		--reset-then-reuse-values \
 		--render-subchart-notes \
 		$(platform_values_stable) \
+		$(_scenario_platform_flags) \
 		$(additional_platform_configuration)
 
 # Install/upgrade load test helm chart
@@ -140,6 +167,7 @@ install-load-test:
 		--reset-then-reuse-values \
 		--render-subchart-notes \
 		-f load-test-values.yaml \
+		$(_scenario_load_test_flags) \
 		$(additional_load_test_configuration)
 
 # Setup leader balancing cronjob
@@ -162,13 +190,47 @@ template:
 	helm template $(namespace) camunda-platform-helm/charts/$(helm_chart) \
 		$(platform_values) \
 		-f values-preemptible.yaml \
+		$(_scenario_platform_flags) \
+		$(additional_platform_configuration) \
 		--output-dir .
 
 .PHONY: template-stable
 template-stable:
 	helm template $(namespace) camunda-platform-helm/charts/$(helm_chart) \
 		$(platform_values_stable) \
+		$(_scenario_platform_flags) \
+		$(additional_platform_configuration) \
 		--output-dir .
+
+# Generates templates from the load test helm chart
+.PHONY: template-load-test
+template-load-test:
+	helm template $(namespace)-test camunda-load-tests/camunda-load-tests \
+		-f load-test-values.yaml \
+		$(_scenario_load_test_flags) \
+		$(additional_load_test_configuration) \
+		--output-dir .
+
+# Print the resolved scenario flags without running any Helm commands
+.PHONY: print-scenario
+print-scenario:
+	@echo "Scenario:         $(if $(scenario),$(scenario),(none — chart defaults apply))"
+	@echo "Load test flags:  $(if $(_scenario_load_test_flags),$(_scenario_load_test_flags),(none))"
+	@echo "Platform flags:   $(if $(_scenario_platform_flags),$(_scenario_platform_flags),(none))"
+
+# Workload scenario shortcuts — each runs 'make install' with the corresponding scenario profile.
+# For stable VMs, use: make install-stable scenario=<name>
+.PHONY: latency realistic typical max archiver
+latency:
+	$(MAKE) install scenario=latency
+realistic:
+	$(MAKE) install scenario=realistic
+typical:
+	$(MAKE) install scenario=typical
+max:
+	$(MAKE) install scenario=max
+archiver:
+	$(MAKE) install scenario=archiver
 
 .PHONY: clean
 clean:

--- a/load-tests/setup/default/Makefile
+++ b/load-tests/setup/default/Makefile
@@ -15,6 +15,9 @@ additional_platform_configuration ?=
 # See the load test README for example values and guidance.
 additional_load_test_configuration ?= --set global.image.repository=registry.camunda.cloud/team-zeebe --set global.image.pullSecrets[0].name=harbor-registry
 
+helm_chart_platform := camunda-platform-helm/charts/$(helm_chart)
+helm_chart_load_tests := camunda-load-tests/camunda-load-tests
+
 # Scenario: controls the workload profile for the load test.
 # Options: latency, realistic, typical, max, archiver
 # Use named targets (make max) or pass directly: make install scenario=max
@@ -136,7 +139,7 @@ endif
 # Install/upgrade Camunda Platform helm chart
 .PHONY: install-platform
 install-platform: setup-leader-balancer
-	helm upgrade $(namespace) camunda-platform-helm/charts/$(helm_chart) \
+	helm upgrade $(namespace) $(helm_chart_platform) \
 		--install \
 		--namespace $(namespace) \
 		--reset-then-reuse-values \
@@ -149,7 +152,7 @@ install-platform: setup-leader-balancer
 # Install/upgrade Camunda Platform on stable VMs
 .PHONY: install-platform-stable
 install-platform-stable: setup-leader-balancer
-	helm upgrade $(namespace) camunda-platform-helm/charts/$(helm_chart) \
+	helm upgrade $(namespace) $(helm_chart_platform) \
 		--install \
 		--namespace $(namespace) \
 		--reset-then-reuse-values \
@@ -161,7 +164,7 @@ install-platform-stable: setup-leader-balancer
 # Install/upgrade load test helm chart
 .PHONY: install-load-test
 install-load-test:
-	helm upgrade $(namespace)-test camunda-load-tests/camunda-load-tests \
+	helm upgrade $(namespace)-test $(helm_chart_load_tests) \
 		--install \
 		--namespace $(namespace) \
 		--reset-then-reuse-values \
@@ -187,7 +190,7 @@ setup-leader-balancer:
 # Generates templates from the Camunda Platform helm chart
 .PHONY: template
 template:
-	helm template $(namespace) camunda-platform-helm/charts/$(helm_chart) \
+	helm template $(namespace) $(helm_chart_platform) \
 		$(platform_values) \
 		-f values-preemptible.yaml \
 		$(_scenario_platform_flags) \
@@ -196,7 +199,7 @@ template:
 
 .PHONY: template-stable
 template-stable:
-	helm template $(namespace) camunda-platform-helm/charts/$(helm_chart) \
+	helm template $(namespace) $(helm_chart_platform) \
 		$(platform_values_stable) \
 		$(_scenario_platform_flags) \
 		$(additional_platform_configuration) \
@@ -205,7 +208,7 @@ template-stable:
 # Generates templates from the load test helm chart
 .PHONY: template-load-test
 template-load-test:
-	helm template $(namespace)-test camunda-load-tests/camunda-load-tests \
+	helm template $(namespace)-test $(helm_chart_load_tests) \
 		-f load-test-values.yaml \
 		$(_scenario_load_test_flags) \
 		$(additional_load_test_configuration) \


### PR DESCRIPTION
## Summary

- Adds named Make targets (`make max`, `make latency`, `make typical`, `make realistic`, `make archiver`) to the self-managed load test Makefile so users can pick a workload profile without memorising Helm flags
- Makes the Makefile the single source of truth for scenario configs by introducing a `scenario` variable with `ifeq` logic — removes the duplicate `calculate-scenario-config` job from the GitHub workflow
- Adds `template-load-test` and `print-scenario` targets for dry-run inspection without running Helm

## Changes

- `load-tests/setup/default/Makefile` — scenario variable block, updated `install-platform`/`install-platform-stable`/`install-load-test`/`template`/`template-stable`, new `template-load-test`, `print-scenario`, and named scenario targets
- `.github/workflows/camunda-load-test.yml` — removes `calculate-scenario-config` job; deploy step now passes `scenario=${{ inputs.scenario }}` to make
- `load-tests/setup/README.md` — documents the new scenario targets

## Usage

```sh
# Named targets (local manual testing)
make max
make latency
make install-stable scenario=realistic

# Dry-run inspection
make print-scenario scenario=max
make template-load-test scenario=max
```

## Test plan

- [x] Verify `make print-scenario scenario=max` outputs `--set starter.rate=300` and the `--set-file` platform override
- [x] Verify `make print-scenario scenario=latency` outputs `--set starter.rate=1 --set workers.worker.replicas=1` with no platform flags
- [x] Verify `make print-scenario` (no scenario) outputs `(none — chart defaults apply)` — no regression
- [ ] Trigger `camunda-load-test.yml` via `workflow_dispatch` with `scenario: latency` and confirm the workflow no longer has a `calculate-scenario-config` job in the run
- [ ] Confirm `camunda-release-load-test.yaml` still works end-to-end (`scenario: realistic` + `stable-vms: true` → `make install-stable scenario=realistic`)

> 🤖 This PR was created with [Claude Code](https://claude.ai/claude-code)