### PR TITLE
ci: improve flaky test report

### DIFF
--- a/.github/workflows/statistics-daily.yml
+++ b/.github/workflows/statistics-daily.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   flaky-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 5
     permissions: {}  # GITHUB_TOKEN unused in this job
     steps:
@@ -72,10 +72,13 @@ jobs:
           NUMBER_OF_FLAKYTESTS_JOBS=$(bq query --format=json --use_legacy_sql=false --quiet=true 'SELECT COUNT(*) as number_of_all_jobs FROM `ci-30-162810.prod_ci_analytics.build_status_v2` WHERE TIMESTAMP_SUB(TIMESTAMP_TRUNC(CURRENT_TIMESTAMP, DAY), INTERVAL 1 DAY)<=report_time AND report_time<=TIMESTAMP_TRUNC(CURRENT_TIMESTAMP, DAY) AND ci_url="https://github.com/camunda/camunda" AND user_reason="flaky-tests"' | jq -r '.[0].number_of_all_jobs')
           # shellcheck disable=SC2016
           TOP5_FLAKYTESTS=$(bq query --format=json --use_legacy_sql=false --quiet=true 'SELECT test_class_name, test_name, COUNT(*) as number_of_flakes FROM `ci-30-162810.prod_ci_analytics.test_status_v1` ts LEFT OUTER JOIN `ci-30-162810.prod_ci_analytics.build_status_v2` bs ON ts.ci_url=bs.ci_url AND ts.build_id=bs.build_id AND ts.job_name=bs.job_name WHERE TIMESTAMP_SUB(TIMESTAMP_TRUNC(CURRENT_TIMESTAMP, DAY), INTERVAL 1 DAY)<=ts.report_time AND ts.report_time<=TIMESTAMP_TRUNC(CURRENT_TIMESTAMP, DAY) AND ts.ci_url="https://github.com/camunda/camunda" AND test_status = "flaky" GROUP BY test_class_name, test_name ORDER BY number_of_flakes DESC LIMIT 5')
+          # calculate percentage
+          FLAKY_PCT=$(echo "scale=1; 100 * $NUMBER_OF_FLAKYTESTS_JOBS / $NUMBER_OF_ALL_JOBS" | bc)
+          [[ "$FLAKY_PCT" == .* ]] && FLAKY_PCT="0${FLAKY_PCT}"
 
           {
             echo "MESSAGE<<EOF"
-            echo "📈 ~$(echo "scale=1; 100 * $NUMBER_OF_FLAKYTESTS_JOBS / $NUMBER_OF_ALL_JOBS" | bc)% of jobs had flaky tests yesterday ($NUMBER_OF_FLAKYTESTS_JOBS from total of $NUMBER_OF_ALL_JOBS jobs)."
+            echo "📈 ~${FLAKY_PCT}% of jobs had flaky tests yesterday ($NUMBER_OF_FLAKYTESTS_JOBS from total of $NUMBER_OF_ALL_JOBS jobs)."
             echo ""
             echo ""
             echo "🥇 *Top 5 flakiest tests yesterday:*"
@@ -120,7 +123,7 @@ jobs:
 
             done
             echo ""
-            echo "📊 Check out <https://dashboard.int.camunda.com/d/ae2j69npxh3b4f/flaky-tests-camunda-camunda-monorepo?orgId=1&from=now-1d%2Fd&to=now-1d%2Fd&timezone=browser&var-branch=main|Grafana for links and more details>."
+            echo "📊 Check out <https://dashboard.int.camunda.com/d/ae2j69npxh3b4f/flaky-tests-camunda-camunda-monorepo?orgId=1&from=now-1d%2Fd&to=now-1d%2Fd&timezone=browser&var-branch=main|Grafana (\`main\`) for links and more details>. Above tests are from all branches, so change the branch in Grafana accordingly."
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Description

This pull request makes several improvements to the daily statistics GitHub Actions workflow: switching to a lighter runner image, correcting the calculation and formatting of the flaky test percentage, and clarifying the Grafana dashboard link.

**CI Workflow Improvements:**

* Changed the runner image for the `flaky-tests` job from `ubuntu-latest` to `ubuntu-slim` to use a lighter environment.

**Reporting and Output Enhancements:**

* Refactored the calculation of the flaky test percentage to ensure correct formatting (e.g., handling numbers that start with a decimal point) and reuse of the computed value in the output message.
* Updated the summary message to clarify that the Grafana dashboard link is for the `main` branch and that the listed tests are from all branches, advising users to change the branch filter in Grafana as needed.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)) - only run on `main`

## Related issues

[Slack](https://camunda.slack.com/archives/C071KP5BTHB/p1776322978291359?thread_ts=1776322097.400549&cid=C071KP5BTHB)
