### PR TITLE
ci: run scheduled release load tests on weekdays only at 2am

### DIFF
--- a/.github/workflows/camunda-release-load-test.yaml
+++ b/.github/workflows/camunda-release-load-test.yaml
@@ -3,7 +3,7 @@
 #              accepting required name and tag inputs plus optional per-component
 #              tag overrides: optimize-tag, identity-tag, and connectors-tag.
 #              Uses official Docker images with scenario: realistic.
-# called-by: camunda-scheduled-release-load-tests.yml (daily schedule),
+# called-by: camunda-scheduled-release-load-tests.yml (weekdays Mon-Fri at 02:00 UTC),
 #            release BPMN process (workflow_dispatch via GitHub API)
 # calls: camunda-load-test.yml (orchestration-tag: <tag>, scenario: realistic)
 # note: Verification and namespace cleanup are handled externally by the scheduled workflow

--- a/.github/workflows/camunda-scheduled-release-load-tests.yml
+++ b/.github/workflows/camunda-scheduled-release-load-tests.yml
@@ -1,4 +1,4 @@
-# description: Orchestrates daily release load tests across all active stable branches and main.
+# description: Orchestrates weekday release load tests across all active stable branches and main.
 #              Each branch has a hardcoded release tag. Patch releases do NOT require updates —
 #              only new minor versions or deprecated branches need changes.
 # calls: camunda-release-load-test.yaml (one call per branch),

--- a/.github/workflows/camunda-scheduled-release-load-tests.yml
+++ b/.github/workflows/camunda-scheduled-release-load-tests.yml
@@ -9,7 +9,7 @@
 name: Scheduled Camunda Release Load Tests
 on:
   schedule:
-    - cron: '0 4 * * *' # every day at 04:00 UTC
+    - cron: '0 2 * * 1-5' # every weekday (Mon-Fri) at 02:00 UTC
   workflow_dispatch: {}
 
 defaults:

--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -90,7 +90,7 @@ graph TD
 | 00:00 UTC Monday | `zeebe-update-long-running-migrating-benchmark.yaml` | Weekly    |
 | 01:00 UTC Monday | `camunda-weekly-load-tests.yml`                      | Weekly    |
 | 02:00 UTC Mon-Fri| `camunda-scheduled-release-load-tests.yml`           | Weekdays  |
-| 04:00 UTC        | `camunda-daily-load-tests.yml`                       | Daily     |
+| 02:00 UTC Mon-Fri| `camunda-daily-load-tests.yml`                       | Weekdays  |
 | 04:00 UTC        | `camunda-load-test-clean-up.yml`                     | Daily     |
 
 For detailed inputs, triggers, and job definitions, see each workflow's header comments in [`.github/workflows/`](../.github/workflows/). For branch-specific path differences, see [directory structure history](docs/directory-structure.md).

--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -89,7 +89,7 @@ graph TD
 |------------------|------------------------------------------------------|-----------|
 | 00:00 UTC Monday | `zeebe-update-long-running-migrating-benchmark.yaml` | Weekly    |
 | 01:00 UTC Monday | `camunda-weekly-load-tests.yml`                      | Weekly    |
-| 04:00 UTC        | `camunda-scheduled-release-load-tests.yml`           | Daily     |
+| 02:00 UTC Mon-Fri| `camunda-scheduled-release-load-tests.yml`           | Weekdays  |
 | 04:00 UTC        | `camunda-daily-load-tests.yml`                       | Daily     |
 | 04:00 UTC        | `camunda-load-test-clean-up.yml`                     | Daily     |
 

--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -38,7 +38,7 @@ All automated load tests flow through `camunda-load-test.yml`, which builds imag
 ```mermaid
 graph TD
     subgraph "Scheduled Triggers"
-        SCHEDULED["camunda-scheduled-release-<br/>load-tests.yml<br/><i>Daily 04:00 UTC</i>"]
+        SCHEDULED["camunda-scheduled-release-<br/>load-tests.yml<br/><i>Weekdays 02:00 UTC</i>"]
         DAILY["camunda-daily-load-tests.yml<br/><i>Weekdays 02:00 UTC</i>"]
         WEEKLY["camunda-weekly-load-tests.yml<br/><i>Monday 01:00 UTC</i>"]
         ROLLING["zeebe-update-long-running-<br/>migrating-benchmark.yaml<br/><i>Monday 00:00 UTC</i>"]

--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -85,12 +85,12 @@ graph TD
 
 ### Schedule
 
-|       Time       |                       Workflow                       | Frequency |
-|------------------|------------------------------------------------------|-----------|
-| 00:00 UTC Monday | `zeebe-update-long-running-migrating-benchmark.yaml` | Weekly    |
-| 01:00 UTC Monday | `camunda-weekly-load-tests.yml`                      | Weekly    |
-| 02:00 UTC Mon-Fri| `camunda-scheduled-release-load-tests.yml`           | Weekdays  |
-| 02:00 UTC Mon-Fri| `camunda-daily-load-tests.yml`                       | Weekdays  |
-| 04:00 UTC        | `camunda-load-test-clean-up.yml`                     | Daily     |
+|       Time        |                       Workflow                       | Frequency |
+|-------------------|------------------------------------------------------|-----------|
+| 00:00 UTC Monday  | `zeebe-update-long-running-migrating-benchmark.yaml` | Weekly    |
+| 01:00 UTC Monday  | `camunda-weekly-load-tests.yml`                      | Weekly    |
+| 02:00 UTC Mon-Fri | `camunda-scheduled-release-load-tests.yml`           | Weekdays  |
+| 02:00 UTC Mon-Fri | `camunda-daily-load-tests.yml`                       | Weekdays  |
+| 04:00 UTC         | `camunda-load-test-clean-up.yml`                     | Daily     |
 
 For detailed inputs, triggers, and job definitions, see each workflow's header comments in [`.github/workflows/`](../.github/workflows/). For branch-specific path differences, see [directory structure history](docs/directory-structure.md).


### PR DESCRIPTION
## Summary

- Changed cron schedule from daily at 4am (`0 4 * * *`) to weekdays at 2am (`0 2 * * 1-5`) in `camunda-scheduled-release-load-tests.yml`
- Reduces weekend cloud spend without impacting weekday regression detection
- Updated `load-tests/README.md` diagram to reflect new schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)