### PR TITLE
test: error tests on unhandled requests in Operate

### DIFF
--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/elementInstancesTreeStore.test.ts
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/elementInstancesTreeStore.test.ts
@@ -108,6 +108,7 @@ const mockChildResponse = createMockResponse(mockChildInstances, 2);
 const mockEmptyResponse = createMockResponse([], 0);
 
 describe('elementInstancesTreeStore', () => {
+  beforeEach(() => (elementInstancesTreeStore.forceDisablePolling = false));
   afterEach(() => {
     elementInstancesTreeStore.reset();
     vi.clearAllTimers();
@@ -987,6 +988,40 @@ describe('elementInstancesTreeStore', () => {
     });
 
     vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('should skip polling when it is force disabled', async () => {
+    vi.useFakeTimers({shouldAdvanceTime: true});
+
+    mockSearchElementInstances().withSuccess(mockFirstPageResponse);
+
+    elementInstancesTreeStore.forceDisablePolling = true;
+    elementInstancesTreeStore.setRootNode(mockProcessInstanceKey, {
+      enablePolling: true,
+    });
+
+    await waitFor(() => {
+      expect(
+        elementInstancesTreeStore.state.nodes.get(mockProcessInstanceKey)
+          ?.pageMetadata.totalItems,
+      ).toBe(150);
+    });
+
+    mockSearchElementInstances().withSuccess(
+      createMockResponse(mockFirstPageItems, 160),
+    );
+
+    vi.advanceTimersByTime(5000);
+
+    await waitFor(() => {
+      expect(
+        elementInstancesTreeStore.state.nodes.get(mockProcessInstanceKey)
+          ?.pageMetadata.totalItems,
+      ).toBe(150);
+    });
+
+    elementInstancesTreeStore.forceDisablePolling = false;
     vi.useRealTimers();
   });
 

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/elementInstancesTreeStore.ts
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/elementInstancesTreeStore.ts
@@ -44,6 +44,8 @@ class ElementInstancesTreeStore extends NetworkReconnectionHandler {
     abortControllers: new Map(),
   };
 
+  /** **Warning:** Only use in tests to stabilize them in slow environments. */
+  forceDisablePolling: boolean = false;
   isPollRequestRunning: boolean = false;
   intervalId: ReturnType<typeof setInterval> | null = null;
   pollAbortController: AbortController | null = null;
@@ -406,7 +408,7 @@ class ElementInstancesTreeStore extends NetworkReconnectionHandler {
   };
 
   pollExpandedNodes = async () => {
-    if (document.visibilityState === 'hidden') {
+    if (this.forceDisablePolling || document.visibilityState === 'hidden') {
       return;
     }
 

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/multiInstanceSubprocess.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/multiInstanceSubprocess.test.tsx
@@ -19,6 +19,7 @@ import {mockQueryBatchOperationItems} from 'modules/mocks/api/v2/batchOperations
 import {parseDiagramXML} from 'modules/utils/bpmn';
 import {businessObjectsParser} from 'modules/queries/processDefinitions/useBusinessObjects';
 import type {ElementInstance} from '@camunda/camunda-api-zod-schemas/8.10';
+import {elementInstancesTreeStore} from './elementInstancesTreeStore';
 
 const diagramModel = await parseDiagramXML(multiInstanceProcess);
 const businessObjects = businessObjectsParser({diagramModel});
@@ -210,6 +211,7 @@ describe('ElementInstancesTree - Multi Instance Subprocess', () => {
   });
 
   it('should poll for instances on root level', async () => {
+    elementInstancesTreeStore.forceDisablePolling = false;
     mockFetchProcessInstance().withSuccess(mockMultiInstanceProcessInstance);
     mockFetchElementInstancesStatistics().withSuccess({
       items: [],

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/index.test.tsx
@@ -24,6 +24,7 @@ import {Paths} from 'modules/Routes';
 import {mockFetchElementInstancesStatistics} from 'modules/mocks/api/v2/elementInstances/elementInstancesStatistics/fetchElementInstancesStatistics';
 import {mockSearchElementInstances} from 'modules/mocks/api/v2/elementInstances/searchElementInstances';
 import {mockQueryBatchOperationItems} from 'modules/mocks/api/v2/batchOperations/queryBatchOperationItems';
+import {elementInstancesTreeStore} from './ElementInstancesTree/elementInstancesTreeStore';
 
 vi.mock('modules/utils/bpmn');
 
@@ -244,6 +245,7 @@ describe('ElementInstanceLog', () => {
   });
 
   it('should continue polling after poll failure', async () => {
+    elementInstancesTreeStore.forceDisablePolling = false;
     mockFetchProcessDefinitionXml().withSuccess('');
     mockFetchProcessInstance().withSuccess(mockProcessInstance);
     mockFetchElementInstancesStatistics().withSuccess({items: []});

--- a/operate/client/src/modules/react-query/mockQueryClient.test.ts
+++ b/operate/client/src/modules/react-query/mockQueryClient.test.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {QueryObserver} from '@tanstack/react-query';
+import {getMockQueryClient} from './mockQueryClient';
+
+describe('getMockQueryClient', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should disable query refetch intervals', async () => {
+    vi.useFakeTimers();
+
+    const queryFn = vi.fn().mockResolvedValue('result');
+    const queryObserver = new QueryObserver(getMockQueryClient(), {
+      queryKey: ['polling-query'],
+      queryFn,
+      refetchInterval: () => 10,
+      refetchIntervalInBackground: true,
+    });
+
+    const unsubscribe = queryObserver.subscribe(() => {});
+    expect(queryFn).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(50);
+    expect(queryFn).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    vi.useRealTimers();
+  });
+
+  it('should allow explicitly enabling query refetch intervals', async () => {
+    vi.useFakeTimers();
+
+    const queryFn = vi.fn().mockResolvedValue('result');
+    const queryObserver = new QueryObserver(
+      getMockQueryClient({forceNoRetchInterval: false}),
+      {
+        queryKey: ['polling-query'],
+        queryFn,
+        refetchInterval: () => 10,
+        refetchIntervalInBackground: true,
+      },
+    );
+
+    const unsubscribe = queryObserver.subscribe(() => {});
+    expect(queryFn).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(50);
+    expect(queryFn).toHaveBeenCalledTimes(6);
+
+    unsubscribe();
+    vi.useRealTimers();
+  });
+});

--- a/operate/client/src/modules/react-query/mockQueryClient.ts
+++ b/operate/client/src/modules/react-query/mockQueryClient.ts
@@ -8,7 +8,12 @@
 
 import {QueryClient} from '@tanstack/react-query';
 
-function getMockQueryClient() {
+interface MockQueryClientOptions {
+  /** Forcefully disables queries refetch intervals in tests. @default true */
+  forceNoRetchInterval?: boolean;
+}
+
+function getMockQueryClient(options?: MockQueryClientOptions) {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
@@ -22,6 +27,18 @@ function getMockQueryClient() {
       },
     },
   });
+
+  if (options?.forceNoRetchInterval !== false) {
+    // TanStack Query v5 applies query specific options after the initial default options.
+    // In tests, we want to ensure that refetch intervals are always disabled,
+    // unless explicitly enabled by a test case.
+    const resolvesOptions = queryClient.defaultQueryOptions.bind(queryClient);
+    queryClient.defaultQueryOptions = (options) => {
+      const defaultedOptions = resolvesOptions(options);
+      defaultedOptions.refetchInterval = false;
+      return defaultedOptions;
+    };
+  }
 
   queryClient.clear();
   return queryClient;

--- a/operate/client/src/setupTests.tsx
+++ b/operate/client/src/setupTests.tsx
@@ -21,6 +21,7 @@ import MockBpmnJs from '__mocks__/bpmn-js';
 import MockBpmnIoElementTemplateIconRenderer from '__mocks__/@bpmn-io/element-template-icon-renderer';
 import MockReactMarkdown from '__mocks__/react-markdown';
 import ResizeObserverPolyfill from 'resize-observer-polyfill';
+import {elementInstancesTreeStore} from 'App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/elementInstancesTreeStore';
 
 vi.mock('dmn-js-shared/lib/base/Manager', () => ({
   default: MockDmnJsSharedManager,
@@ -197,6 +198,9 @@ const localStorageMock = (function () {
     removeItem: vi.fn(),
   };
 })();
+
+beforeEach(() => (elementInstancesTreeStore.forceDisablePolling = true));
+afterEach(() => (elementInstancesTreeStore.forceDisablePolling = false));
 
 let unhandledRequestsCount = 0;
 beforeAll(() => {

--- a/operate/client/src/setupTests.tsx
+++ b/operate/client/src/setupTests.tsx
@@ -198,15 +198,28 @@ const localStorageMock = (function () {
   };
 })();
 
+let unhandledRequestsCount = 0;
 beforeAll(() => {
   mockServer.listen({
-    onUnhandledRequest: 'error',
+    onUnhandledRequest: (_, print) => {
+      unhandledRequestsCount++;
+      return print.error();
+    },
   });
 
   // temporary fix while jsdom doesn't implement this: https://github.com/jsdom/jsdom/issues/1695
   window.HTMLElement.prototype.scrollIntoView = function () {};
 });
-afterEach(() => mockServer.resetHandlers());
+afterEach(() => {
+  mockServer.resetHandlers();
+  if (unhandledRequestsCount !== 0) {
+    const reportCount = unhandledRequestsCount;
+    unhandledRequestsCount = 0;
+    throw new Error(
+      `[Unhandled Requests] The test produced ${reportCount} unhandled request(s).`,
+    );
+  }
+});
 afterAll(() => mockServer.close());
 beforeEach(async () => {
   vi.stubEnv('TZ', 'UTC');


### PR DESCRIPTION
## Description

Adds a small mechanism to `setupTests`, which will throw an error when a test produces unhandled requests. This should avoid the problem in the future.

Because tests run a lot slower in CI, they often trigger query refetches. This PR forces `QueryClient` used in tests to disable the `refetchInterval`. Furthermore, `ElementInstancesTreeStore` is the last MobX store that fetches data with polling. Is also contains a flag to forcefully disable polling, which is activated for tests.

> [!NOTE]
> One test still keeps failing (only in CI) with a unhandled request and failing DOM assertion. I haven't figured out the root cause yet, and will stop looking into it for now. `ElementInstancesTreeStore` polling should be disabled for that test...

_Note: The change in `setupTests` IMHO a bit ugly. It could likely be more robust and readable with [Tests Contexts](https://vitest.dev/guide/test-context.html) ([Playwright Fixtures](https://playwright.dev/docs/test-fixtures) but for Vitest). However, introducing test contexts is currently unfeasible, as it needs to change **every** test file from using global Vitest functions to our custom `test` function (just like to Playwright fixtures)._

## Related issues

relates #51060
