### PR TITLE
ci: configure Elasticsearch scheduling for stables VMs deployments

### DIFF
--- a/load-tests/setup/default/values-stable.yaml
+++ b/load-tests/setup/default/values-stable.yaml
@@ -1,4 +1,15 @@
-# Additional values file to run Zeebe on stable VMs
+# Additional values file to run on stable VMs
+elasticsearch:
+  master:
+    nodeSelector:
+      component: benchmark-n2-standard-8-stable
+      topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+    tolerations:
+      - key: nodepool
+        operator: Equal
+        value: n2-standard-8-stable
+        effect: NoSchedule
+
 # https://github.com/camunda/camunda-platform-helm/blob/d3276435efc994e45b490f97d7875b4330ec0c42/charts/camunda-platform-8.8/values.yaml#L2945-L2948
 orchestration:
   # Require n2-standard-2 to ensure the broker is the only application running on its node


### PR DESCRIPTION
## Description

When requesting load tests to run on stable VMs, also deploy Elasticsearch alongside Camunda.

Fix https://github.com/camunda/camunda/issues/50877

It's already configured in 8.7 via https://github.com/camunda/camunda/pull/51051/ and https://github.com/camunda/camunda/pull/51155 (should have done this in main first then backport it to other branches :facepalm: )

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

* https://github.com/camunda/camunda/issues/50877
