### PR TITLE
feat: update Docker images to use JDK 25 JRE

### DIFF
--- a/.ci/docker/test/camunda-docker-labels.golden.json
+++ b/.ci/docker/test/camunda-docker-labels.golden.json
@@ -12,12 +12,12 @@
   "org.opencontainers.image.description": "Camunda platform: the universal process orchestrator",
   "org.opencontainers.image.documentation": "https://docs.camunda.io/docs/self-managed/about-self-managed/",
   "org.opencontainers.image.licenses": "(Apache-2.0 AND LicenseRef-Camunda-License-1.0)",
-  "org.opencontainers.image.ref.name": "reg.mini.dev/1212/openjre-base:21-dev",
+  "org.opencontainers.image.ref.name": "reg.mini.dev/1212/openjre-base:25-dev",
   "org.opencontainers.image.revision": $REVISION,
   "org.opencontainers.image.source": "https://github.com/camunda/camunda",
   "org.opencontainers.image.title": "Camunda Platform",
   "org.opencontainers.image.url": "https://camunda.com/platform/",
   "org.opencontainers.image.vendor": "Camunda Services GmbH",
   "org.opencontainers.image.version": $VERSION,
-  "io.minimus.images.line": "21"
+  "io.minimus.images.line": "25"
 }

--- a/.ci/docker/test/operate-docker-labels.golden.json
+++ b/.ci/docker/test/operate-docker-labels.golden.json
@@ -18,5 +18,5 @@
   "org.opencontainers.image.url": "https://camunda.com/platform/operate/",
   "org.opencontainers.image.vendor": "Camunda Services GmbH",
   "org.opencontainers.image.version": $VERSION,
-  "io.minimus.images.line": "21"
+  "io.minimus.images.line": "25"
 }

--- a/.ci/docker/test/optimize-docker-labels.golden.json
+++ b/.ci/docker/test/optimize-docker-labels.golden.json
@@ -18,5 +18,5 @@
   "org.opencontainers.image.url": "https://docs.camunda.io/docs/components/optimize/what-is-optimize/",
   "org.opencontainers.image.vendor": "Camunda Services GmbH",
   "org.opencontainers.image.version": $VERSION,
-  "io.minimus.images.line": "21"
+  "io.minimus.images.line": "25"
 }

--- a/.ci/docker/test/tasklist-docker-labels.golden.json
+++ b/.ci/docker/test/tasklist-docker-labels.golden.json
@@ -18,5 +18,5 @@
   "org.opencontainers.image.url": "https://camunda.com/platform/tasklist/",
   "org.opencontainers.image.vendor": "Camunda Services GmbH",
   "org.opencontainers.image.version": $VERSION,
-  "io.minimus.images.line": "21"
+  "io.minimus.images.line": "25"
 }

--- a/.ci/docker/test/zeebe-docker-labels.golden.json
+++ b/.ci/docker/test/zeebe-docker-labels.golden.json
@@ -11,12 +11,12 @@
   "org.opencontainers.image.description": "Workflow engine for microservice orchestration",
   "org.opencontainers.image.documentation": "https://docs.camunda.io/docs/self-managed/zeebe-deployment/",
   "org.opencontainers.image.licenses": "(Apache-2.0 AND LicenseRef-Camunda-License-1.0)",
-  "org.opencontainers.image.ref.name": "reg.mini.dev/1212/openjre-base:21-dev",
+  "org.opencontainers.image.ref.name": "reg.mini.dev/1212/openjre-base:25-dev",
   "org.opencontainers.image.revision": $REVISION,
   "org.opencontainers.image.source": "https://github.com/camunda/camunda",
   "org.opencontainers.image.title": "Zeebe",
   "org.opencontainers.image.url": "https://zeebe.io",
   "org.opencontainers.image.vendor": "Camunda Services GmbH",
   "org.opencontainers.image.version": $VERSION,
-  "io.minimus.images.line": "21"
+  "io.minimus.images.line": "25"
 }

--- a/.codeowners
+++ b/.codeowners
@@ -40,7 +40,7 @@ camunda.Dockerfile          @camunda/orchestration-cluster
 
 # Zeebe shared ownership modules
 zeebe/README.md             @camunda/orchestration-cluster
-zeebe/docker/utils/startup.sh @camunda/orchestration-cluster
+zeebe/docker/utils/         @camunda/orchestration-cluster
 zeebe/docs/.htaccess        @camunda/orchestration-cluster
 zeebe/pom.xml               @camunda/orchestration-cluster
 zeebe/qa/pom.xml            @camunda/orchestration-cluster

--- a/.github/optimize/scripts/build-docker-image.sh
+++ b/.github/optimize/scripts/build-docker-image.sh
@@ -22,7 +22,6 @@ docker buildx create --use
 export VERSION="${VERSION}"
 export DATE="$(date +%FT%TZ)"
 export REVISION="${REVISION}"
-export BASE_IMAGE="reg.mini.dev/1212/openjre-base:21-dev"
 
 # if CI (GHA) export the variables for pushing in a later step
 if [ "${CI}" = "true" ]; then

--- a/.github/workflows/operate-release-reusable.yml
+++ b/.github/workflows/operate-release-reusable.yml
@@ -223,7 +223,7 @@ jobs:
           export VERSION="$VERSION"
           export DATE="$date_time_stamp"
           export REVISION="$commit_hash"
-          export BASE_IMAGE="reg.mini.dev/1212/openjre-base:21-dev"
+          export BASE_IMAGE="reg.mini.dev/1212/openjre-base:25-dev"
           sudo apt update
           sudo apt install -y jq
           sudo apt install -y bash

--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -338,7 +338,8 @@ jobs:
           DATE="$(date +%FT%TZ)"
           export DATE
           export REVISION="${REVISION}"
-          export BASE_IMAGE="reg.mini.dev/1212/openjre-base:21-dev"
+          export BASE_IMAGE="reg.mini.dev/1212/openjre-base:25-dev"
+          export BASE_DIGEST="sha256:e2772c8469b0b3cfc792708153d075fcf17778444d6d57792e4ba83d49bf82e6"
 
           # if CI (GHA) export the variables for pushing in a later step
           if [ "${CI}" = "true" ]; then
@@ -353,6 +354,7 @@ jobs:
               --build-arg DATE="${DATE}" \
               --build-arg REVISION="${REVISION}" \
               --build-arg BASE_IMAGE="${BASE_IMAGE}" \
+              --build-arg BASE_DIGEST="${BASE_DIGEST}" \
               --provenance false \
               --load \
               -f optimize.Dockerfile \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@
 # DOCKER_BUILDKIT=1
 # see https://docs.docker.com/build/buildkit/#getting-started
 
-ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base:21-dev"
-ARG BASE_DIGEST="sha256:c28de0ca6d34d1017166c2c16e2ed7757ee2f7ad20f7ac5bea8bbf9989cc9bc2"
+ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base:25-dev"
+ARG BASE_DIGEST="sha256:e2772c8469b0b3cfc792708153d075fcf17778444d6d57792e4ba83d49bf82e6"
 ARG JATTACH_VERSION="v2.2"
 ARG JATTACH_CHECKSUM_AMD64="acd9e17f15749306be843df392063893e97bfecc5260eef73ee98f06e5cfe02f"
 ARG JATTACH_CHECKSUM_ARM64="288ae5ed87ee7fe0e608c06db5a23a096a6217c9878ede53c4e33710bdcaab51"
@@ -12,8 +12,8 @@ ARG JATTACH_CHECKSUM_ARM64="288ae5ed87ee7fe0e608c06db5a23a096a6217c9878ede53c4e3
 # If you don't have access to Minimus hardened base images, you can use public
 # base images like this instead on your own risk.
 # Simply pass `--build-arg BASE=public` in order to build with the Temurin JDK.
-ARG BASE_IMAGE_PUBLIC="eclipse-temurin:21.0.10_7-jre-noble"
-ARG BASE_DIGEST_PUBLIC="sha256:be00aca3f4747fa3f4b936fc35dc64eb5862349e262b2ad8d3299cb96a305780"
+ARG BASE_IMAGE_PUBLIC="eclipse-temurin:25.0.2_10-jre-noble"
+ARG BASE_DIGEST_PUBLIC="sha256:cd44d91d4b2c7b2a171a96a88d77a5f4e94de4faaefea70eda4f0b8e3c3891e6"
 ARG BASE="hardened"
 
 # set to "build" to build zeebe from scratch instead of using a distball

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@
 # DOCKER_BUILDKIT=1
 # see https://docs.docker.com/build/buildkit/#getting-started
 
-ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base:21-dev"
-ARG BASE_DIGEST="sha256:f21d8148ffd3749c189231e78789ee5ef511f9c8d2c7f497537494d707f95074"
+ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base:25-dev"
+ARG BASE_DIGEST="sha256:e2772c8469b0b3cfc792708153d075fcf17778444d6d57792e4ba83d49bf82e6"
 ARG JATTACH_VERSION="v2.2"
 ARG JATTACH_CHECKSUM_AMD64="acd9e17f15749306be843df392063893e97bfecc5260eef73ee98f06e5cfe02f"
 ARG JATTACH_CHECKSUM_ARM64="288ae5ed87ee7fe0e608c06db5a23a096a6217c9878ede53c4e33710bdcaab51"
@@ -12,8 +12,8 @@ ARG JATTACH_CHECKSUM_ARM64="288ae5ed87ee7fe0e608c06db5a23a096a6217c9878ede53c4e3
 # If you don't have access to Minimus hardened base images, you can use public
 # base images like this instead on your own risk.
 # Simply pass `--build-arg BASE=public` in order to build with the Temurin JDK.
-ARG BASE_IMAGE_PUBLIC="eclipse-temurin:21.0.10_7-jre-noble"
-ARG BASE_DIGEST_PUBLIC="sha256:420374e45e8e9dce3057e768c87a3e8ba58e815049511d8df95ca88a041ec82b"
+ARG BASE_IMAGE_PUBLIC="eclipse-temurin:25.0.2_10-jre-noble"
+ARG BASE_DIGEST_PUBLIC="sha256:cd44d91d4b2c7b2a171a96a88d77a5f4e94de4faaefea70eda4f0b8e3c3891e6"
 ARG BASE="hardened"
 
 # set to "build" to build zeebe from scratch instead of using a distball

--- a/Dockerfile
+++ b/Dockerfile
@@ -183,6 +183,7 @@ VOLUME ${ZB_HOME}/documents
 VOLUME /driver-lib
 
 COPY --from=jattach --chown=1001:0 /jattach /usr/local/bin/jattach
+COPY --link --chown=1001:0 zeebe/docker/utils/jvm.options ${ZB_HOME}/config/jvm.options
 COPY --link --chown=1001:0 zeebe/docker/utils/startup.sh /usr/local/bin/startup.sh
 COPY --from=dist --chown=1001:0 /zeebe/camunda-zeebe ${ZB_HOME}
 

--- a/camunda.Dockerfile
+++ b/camunda.Dockerfile
@@ -3,8 +3,8 @@
 # DOCKER_BUILDKIT=1
 # see https://docs.docker.com/build/buildkit/#getting-started
 
-ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base:21-dev"
-ARG BASE_DIGEST="sha256:c28de0ca6d34d1017166c2c16e2ed7757ee2f7ad20f7ac5bea8bbf9989cc9bc2"
+ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base:25-dev"
+ARG BASE_DIGEST="sha256:e2772c8469b0b3cfc792708153d075fcf17778444d6d57792e4ba83d49bf82e6"
 ARG JATTACH_VERSION="v2.2"
 ARG JATTACH_CHECKSUM_AMD64="acd9e17f15749306be843df392063893e97bfecc5260eef73ee98f06e5cfe02f"
 ARG JATTACH_CHECKSUM_ARM64="288ae5ed87ee7fe0e608c06db5a23a096a6217c9878ede53c4e33710bdcaab51"
@@ -12,8 +12,8 @@ ARG JATTACH_CHECKSUM_ARM64="288ae5ed87ee7fe0e608c06db5a23a096a6217c9878ede53c4e3
 # If you don't have access to Minimus hardened base images, you can use public
 # base images like this instead on your own risk.
 # Simply pass `--build-arg BASE=public` in order to build with the Temurin JDK.
-ARG BASE_IMAGE_PUBLIC="eclipse-temurin:21.0.10_7-jre-noble"
-ARG BASE_DIGEST_PUBLIC="sha256:be00aca3f4747fa3f4b936fc35dc64eb5862349e262b2ad8d3299cb96a305780"
+ARG BASE_IMAGE_PUBLIC="eclipse-temurin:25.0.2_10-jre-noble"
+ARG BASE_DIGEST_PUBLIC="sha256:cd44d91d4b2c7b2a171a96a88d77a5f4e94de4faaefea70eda4f0b8e3c3891e6"
 ARG BASE="hardened"
 
 # set to "build" to build camunda from scratch instead of using a distball

--- a/camunda.Dockerfile
+++ b/camunda.Dockerfile
@@ -3,8 +3,8 @@
 # DOCKER_BUILDKIT=1
 # see https://docs.docker.com/build/buildkit/#getting-started
 
-ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base:21-dev"
-ARG BASE_DIGEST="sha256:f21d8148ffd3749c189231e78789ee5ef511f9c8d2c7f497537494d707f95074"
+ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base:25-dev"
+ARG BASE_DIGEST="sha256:e2772c8469b0b3cfc792708153d075fcf17778444d6d57792e4ba83d49bf82e6"
 ARG JATTACH_VERSION="v2.2"
 ARG JATTACH_CHECKSUM_AMD64="acd9e17f15749306be843df392063893e97bfecc5260eef73ee98f06e5cfe02f"
 ARG JATTACH_CHECKSUM_ARM64="288ae5ed87ee7fe0e608c06db5a23a096a6217c9878ede53c4e33710bdcaab51"
@@ -12,8 +12,8 @@ ARG JATTACH_CHECKSUM_ARM64="288ae5ed87ee7fe0e608c06db5a23a096a6217c9878ede53c4e3
 # If you don't have access to Minimus hardened base images, you can use public
 # base images like this instead on your own risk.
 # Simply pass `--build-arg BASE=public` in order to build with the Temurin JDK.
-ARG BASE_IMAGE_PUBLIC="eclipse-temurin:21.0.10_7-jre-noble"
-ARG BASE_DIGEST_PUBLIC="sha256:420374e45e8e9dce3057e768c87a3e8ba58e815049511d8df95ca88a041ec82b"
+ARG BASE_IMAGE_PUBLIC="eclipse-temurin:25.0.2_10-jre-noble"
+ARG BASE_DIGEST_PUBLIC="sha256:cd44d91d4b2c7b2a171a96a88d77a5f4e94de4faaefea70eda4f0b8e3c3891e6"
 ARG BASE="hardened"
 
 # set to "build" to build camunda from scratch instead of using a distball

--- a/camunda.Dockerfile
+++ b/camunda.Dockerfile
@@ -182,6 +182,7 @@ VOLUME ${CAMUNDA_HOME}/documents
 VOLUME /driver-lib
 
 COPY --from=jattach --chown=1001:0 /jattach /usr/local/bin/jattach
+COPY --link --chown=1001:0 zeebe/docker/utils/jvm.options ${CAMUNDA_HOME}/config/jvm.options
 COPY --from=dist --chown=1001:0 /camunda/camunda-zeebe ${CAMUNDA_HOME}
 
 RUN ln -s /driver-lib ${CAMUNDA_HOME}/driver-lib

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -926,8 +926,8 @@
             -Dfile.encoding=UTF-8 -Xshare:auto
             ${jvm.module.opens}</extraJvmArguments>
           <!-- Custom templates add optional @argfile support via config/jvm.options -->
-          <unixScriptTemplate>src/main/scripts/unixBinTemplate</unixScriptTemplate>
-          <windowsScriptTemplate>src/main/scripts/windowsBinTemplate</windowsScriptTemplate>
+          <unixScriptTemplate>${project.basedir}/src/main/scripts/unixBinTemplate</unixScriptTemplate>
+	  <windowsScriptTemplate>${project.basedir}/src/main/scripts/windowsBinTemplate</windowsScriptTemplate>
           <!-- This will be added to the classpath as /urs/local/camunda/driver-lib/* -->
           <endorsedDir>driver-lib</endorsedDir>
           <includeConfigurationDirectoryInClasspath>true</includeConfigurationDirectoryInClasspath>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -927,7 +927,7 @@
             ${jvm.module.opens}</extraJvmArguments>
           <!-- Custom templates add optional @argfile support via config/jvm.options -->
           <unixScriptTemplate>${project.basedir}/src/main/scripts/unixBinTemplate</unixScriptTemplate>
-	  <windowsScriptTemplate>${project.basedir}/src/main/scripts/windowsBinTemplate</windowsScriptTemplate>
+          <windowsScriptTemplate>${project.basedir}/src/main/scripts/windowsBinTemplate</windowsScriptTemplate>
           <!-- This will be added to the classpath as /urs/local/camunda/driver-lib/* -->
           <endorsedDir>driver-lib</endorsedDir>
           <includeConfigurationDirectoryInClasspath>true</includeConfigurationDirectoryInClasspath>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -925,6 +925,9 @@
           <extraJvmArguments>-XX:+ExitOnOutOfMemoryError
             -Dfile.encoding=UTF-8 -Xshare:auto
             ${jvm.module.opens}</extraJvmArguments>
+          <!-- Custom templates add optional @argfile support via config/jvm.options -->
+          <unixScriptTemplate>src/main/scripts/unixBinTemplate</unixScriptTemplate>
+          <windowsScriptTemplate>src/main/scripts/windowsBinTemplate</windowsScriptTemplate>
           <!-- This will be added to the classpath as /urs/local/camunda/driver-lib/* -->
           <endorsedDir>driver-lib</endorsedDir>
           <includeConfigurationDirectoryInClasspath>true</includeConfigurationDirectoryInClasspath>

--- a/dist/src/main/scripts/unixBinTemplate
+++ b/dist/src/main/scripts/unixBinTemplate
@@ -1,6 +1,18 @@
 #!/usr/bin/env sh
 @LICENSE_HEADER@
 
+# -----------------------------------------------------------------------------
+# This is a verbatim copy of the unixBinTemplate from appassembler-maven-plugin
+# 2.1.0 (org/codehaus/mojo/appassembler/daemon/script/unixBinTemplate inside the
+# plugin jar). The plugin has not been updated since 2015 and is effectively
+# frozen, so this copy should not require maintenance.
+#
+# The only change we made is the "CAMUNDA ADDITION" block below, which loads an
+# optional config/jvm.options @argfile before the exec call so that
+# runtime-specific JVM flags (e.g. flags only available on JDK 23+) can be
+# applied in Docker images without breaking the general distribution.
+# -----------------------------------------------------------------------------
+
 # resolve links - $0 may be a softlink
 PRG="$0"
 
@@ -99,11 +111,16 @@ if $cygwin; then
   [ -n "$REPO" ] && REPO=`cygpath --path --windows "$REPO"`
 fi
 
-# Load optional JVM options file (e.g. for runtime-specific flags not suited for the general distribution)
+# --- CAMUNDA ADDITION ---------------------------------------------------------
+# Load an optional JVM options file as a @argfile. This allows runtime-specific
+# flags (e.g. --sun-misc-unsafe-memory-access=allow, only available on JDK 23+)
+# to be supplied by Docker images without baking them into the general
+# distribution tarball, where they would break older JDK versions.
 EXTRA_JVM_OPTS=
 if [ -r "${BASEDIR}/config/jvm.options" ]; then
   EXTRA_JVM_OPTS="@${BASEDIR}/config/jvm.options"
 fi
+# --- END CAMUNDA ADDITION -----------------------------------------------------
 
 exec "$JAVACMD" $JAVA_OPTS @EXTRA_JVM_ARGUMENTS@ $EXTRA_JVM_OPTS \
   -classpath "$CLASSPATH" \

--- a/dist/src/main/scripts/unixBinTemplate
+++ b/dist/src/main/scripts/unixBinTemplate
@@ -1,0 +1,116 @@
+#!/usr/bin/env sh
+@LICENSE_HEADER@
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+PRGDIR=`dirname "$PRG"`
+BASEDIR=`cd "$PRGDIR/.." >/dev/null; pwd`
+
+# Reset the REPO variable. If you need to influence this use the environment setup file.
+REPO=
+@ENV_SETUP@
+
+# OS specific support.  $var _must_ be set to either true or false.
+cygwin=false;
+darwin=false;
+case "`uname`" in
+  CYGWIN*) cygwin=true ;;
+  Darwin*) darwin=true
+           if [ -z "$JAVA_VERSION" ] ; then
+             JAVA_VERSION="CurrentJDK"
+           else
+             echo "Using Java version: $JAVA_VERSION"
+           fi
+		   if [ -z "$JAVA_HOME" ]; then
+		      if [ -x "/usr/libexec/java_home" ]; then
+			      JAVA_HOME=`/usr/libexec/java_home`
+			  else
+			      JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+			  fi
+           fi
+           ;;
+esac
+
+if [ -z "$JAVA_HOME" ] ; then
+  if [ -r /etc/gentoo-release ] ; then
+    JAVA_HOME=`java-config --jre-home`
+  fi
+fi
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin ; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$CLASSPATH" ] && CLASSPATH=`cygpath --path --unix "$CLASSPATH"`
+fi
+
+# If a specific java binary isn't specified search for the standard 'java' binary
+if [ -z "$JAVACMD" ] ; then
+  if [ -n "$JAVA_HOME"  ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+    fi
+  else
+    JAVACMD=`which java`
+  fi
+fi
+
+if [ ! -x "$JAVACMD" ] ; then
+  echo "Error: JAVA_HOME is not defined correctly." 1>&2
+  echo "  We cannot execute $JAVACMD" 1>&2
+  exit 1
+fi
+
+if [ -z "$REPO" ]
+then
+  REPO="$BASEDIR"/@REPO@
+fi
+
+CLASSPATH=@CLASSPATH@
+
+ENDORSED_DIR=@ENDORSED_DIR@
+if [ -n "$ENDORSED_DIR" ] ; then
+  CLASSPATH=$BASEDIR/$ENDORSED_DIR/*:$CLASSPATH
+fi
+
+if [ -n "$CLASSPATH_PREFIX" ] ; then
+  CLASSPATH=$CLASSPATH_PREFIX:$CLASSPATH
+fi
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+  [ -n "$CLASSPATH" ] && CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --path --windows "$JAVA_HOME"`
+  [ -n "$HOME" ] && HOME=`cygpath --path --windows "$HOME"`
+  [ -n "$BASEDIR" ] && BASEDIR=`cygpath --path --windows "$BASEDIR"`
+  [ -n "$REPO" ] && REPO=`cygpath --path --windows "$REPO"`
+fi
+
+# Load optional JVM options file (e.g. for runtime-specific flags not suited for the general distribution)
+EXTRA_JVM_OPTS=
+if [ -r "${BASEDIR}/config/jvm.options" ]; then
+  EXTRA_JVM_OPTS="@${BASEDIR}/config/jvm.options"
+fi
+
+exec "$JAVACMD" $JAVA_OPTS @EXTRA_JVM_ARGUMENTS@ $EXTRA_JVM_OPTS \
+  -classpath "$CLASSPATH" \
+  -Dapp.name="@APP_NAME@" \
+  -Dapp.pid="$$" \
+  -Dapp.repo="$REPO" \
+  -Dapp.home="$BASEDIR" \
+  -Dbasedir="$BASEDIR" \
+  @MAINCLASS@ \
+  @APP_ARGUMENTS@"$@"@UNIX_BACKGROUND@

--- a/dist/src/main/scripts/windowsBinTemplate
+++ b/dist/src/main/scripts/windowsBinTemplate
@@ -1,4 +1,16 @@
 #LICENSE_HEADER#
+@REM -----------------------------------------------------------------------------
+@REM This is a verbatim copy of the windowsBinTemplate from
+@REM appassembler-maven-plugin 2.1.0 (org/codehaus/mojo/appassembler/daemon/
+@REM script/windowsBinTemplate inside the plugin jar). The plugin has not been
+@REM updated since 2015 and is effectively frozen, so this copy should not
+@REM require maintenance.
+@REM
+@REM The only change we made is the "CAMUNDA ADDITION" block below, which loads
+@REM an optional config\jvm.options @argfile before the exec call so that
+@REM runtime-specific JVM flags (e.g. flags only available on JDK 23+) can be
+@REM applied in Docker images without breaking the general distribution.
+@REM -----------------------------------------------------------------------------
 @echo off
 
 set ERROR_CODE=0
@@ -61,9 +73,14 @@ if NOT "%ENDORSED_DIR%" == "" set CLASSPATH="%BASEDIR%"\%ENDORSED_DIR%\*;%CLASSP
 
 if NOT "%CLASSPATH_PREFIX%" == "" set CLASSPATH=%CLASSPATH_PREFIX%;%CLASSPATH%
 
-@REM Load optional JVM options file (e.g. for runtime-specific flags not suited for the general distribution)
+@REM --- CAMUNDA ADDITION --------------------------------------------------------
+@REM Load an optional JVM options file as a @argfile. This allows runtime-specific
+@REM flags (e.g. --sun-misc-unsafe-memory-access=allow, only available on JDK 23+)
+@REM to be supplied by Docker images without baking them into the general
+@REM distribution tarball, where they would break older JDK versions.
 set EXTRA_JVM_OPTS=
 if exist "%BASEDIR%\config\jvm.options" set EXTRA_JVM_OPTS=@%BASEDIR%\config\jvm.options
+@REM --- END CAMUNDA ADDITION ---------------------------------------------------
 
 @REM Reaching here means variables are defined and arguments have been captured
 :endInit

--- a/dist/src/main/scripts/windowsBinTemplate
+++ b/dist/src/main/scripts/windowsBinTemplate
@@ -1,0 +1,99 @@
+#LICENSE_HEADER#
+@echo off
+
+set ERROR_CODE=0
+
+:init
+@REM Decide how to startup depending on the version of windows
+
+@REM -- Win98ME
+if NOT "%OS%"=="Windows_NT" goto Win9xArg
+
+@REM set local scope for the variables with windows NT shell
+if "%OS%"=="Windows_NT" @setlocal
+
+@REM -- 4NT shell
+if "%eval[2+2]" == "4" goto 4NTArgs
+
+@REM -- Regular WinNT shell
+set CMD_LINE_ARGS=%*
+goto WinNTGetScriptDir
+
+@REM The 4NT Shell from jp software
+:4NTArgs
+set CMD_LINE_ARGS=%$
+goto WinNTGetScriptDir
+
+:Win9xArg
+@REM Slurp the command line arguments.  This loop allows for an unlimited number
+@REM of arguments (up to the command line limit, anyway).
+set CMD_LINE_ARGS=
+:Win9xApp
+if %1a==a goto Win9xGetScriptDir
+set CMD_LINE_ARGS=%CMD_LINE_ARGS% %1
+shift
+goto Win9xApp
+
+:Win9xGetScriptDir
+set SAVEDIR=%CD%
+%0\
+cd %0\..\..
+set BASEDIR=%CD%
+cd %SAVEDIR%
+set SAVE_DIR=
+goto repoSetup
+
+:WinNTGetScriptDir
+for %%i in ("%~dp0..") do set "BASEDIR=%%~fi"
+
+:repoSetup
+set REPO=
+#ENV_SETUP#
+
+if "%JAVACMD%"=="" set JAVACMD=#JAVA_BINARY#
+
+if "%REPO%"=="" set REPO=%BASEDIR%\#REPO#
+
+set CLASSPATH=#CLASSPATH#
+
+set ENDORSED_DIR=#ENDORSED_DIR#
+if NOT "%ENDORSED_DIR%" == "" set CLASSPATH="%BASEDIR%"\%ENDORSED_DIR%\*;%CLASSPATH%
+
+if NOT "%CLASSPATH_PREFIX%" == "" set CLASSPATH=%CLASSPATH_PREFIX%;%CLASSPATH%
+
+@REM Load optional JVM options file (e.g. for runtime-specific flags not suited for the general distribution)
+set EXTRA_JVM_OPTS=
+if exist "%BASEDIR%\config\jvm.options" set EXTRA_JVM_OPTS=@%BASEDIR%\config\jvm.options
+
+@REM Reaching here means variables are defined and arguments have been captured
+:endInit
+
+%JAVACMD% %JAVA_OPTS% #EXTRA_JVM_ARGUMENTS# %EXTRA_JVM_OPTS% -classpath %CLASSPATH% -Dapp.name="#APP_NAME#" -Dapp.repo="%REPO%" -Dapp.home="%BASEDIR%" -Dbasedir="%BASEDIR%" #MAINCLASS# #APP_ARGUMENTS#%CMD_LINE_ARGS%
+if %ERRORLEVEL% NEQ 0 goto error
+goto end
+
+:error
+if "%OS%"=="Windows_NT" @endlocal
+set ERROR_CODE=%ERRORLEVEL%
+
+:end
+@REM set local scope for the variables with windows NT shell
+if "%OS%"=="Windows_NT" goto endNT
+
+@REM For old DOS remove the set variables from ENV - we assume they were not set
+@REM before we started - at least we don't leave any baggage around
+set CMD_LINE_ARGS=
+goto postExec
+
+:endNT
+@REM If error code is set to 1 then the endlocal was done already in :error.
+if %ERROR_CODE% EQU 0 @endlocal
+
+
+:postExec
+
+if "%FORCE_EXIT_ON_ERROR%" == "on" (
+  if %ERROR_CODE% NEQ 0 exit %ERROR_CODE%
+)
+
+exit /B %ERROR_CODE%

--- a/docs/monorepo-docs/architecture/components/orchestration-cluster/adr/0001-jvm-options-argfile-for-runtime-specific-flags.md
+++ b/docs/monorepo-docs/architecture/components/orchestration-cluster/adr/0001-jvm-options-argfile-for-runtime-specific-flags.md
@@ -1,0 +1,51 @@
+# ADR-0001: Optional jvm.options @argfile for Runtime-Specific JVM Flags
+
+## Status
+
+Accepted
+
+## Deciders
+
+- Nicolas Pepin-Perreault ([@npepinpe](https://github.com/npepinpe))
+- Lena Schoenburg ([@lenaschoenburg](https://github.com/lenaschoenburg))
+- Carlo Sana ([@entangled90](https://github.com/entangled90))
+
+## Context
+
+Moving to JRE 25 base images surfaces JVM warnings requiring flags unavailable on older JREs:
+
+- `--enable-native-access=ALL-UNNAMED` (jffi): safe on JRE 17+, added unconditionally to `jvm.module.opens`.
+- `--sun-misc-unsafe-memory-access=allow` (Kryo): JRE 23+ only — passing it on JRE 21 causes a hard startup failure.
+
+For the JRE 23+ flag, alternatives considered:
+
+1. **`ENV JAVA_TOOL_OPTIONS` in Dockerfiles** — doesn't cover the distribution tarball; overridable.
+2. **Version check in launcher** — calls `java -version` on every startup; fragile.
+3. **Bake into `extraJvmArguments`** — breaks JRE 21 tarball users.
+4. **Optional `@argfile`** — launcher loads `config/jvm.options` if present; absent from tarball, shipped only in Docker images.
+
+Option 4 requires custom appassembler script templates. The maintenance concern was weighed against
+the fact that the plugin has not been updated since 2015 and is effectively frozen; the templates
+are a one-time copy unlikely to diverge.
+
+## Decision
+
+Load an optional `config/jvm.options` as a JVM `@argfile` in all launcher scripts (option 4).
+Custom appassembler templates in `dist/src/main/scripts/` — verbatim copies of the plugin's 2.1.0
+defaults — add this check. Docker images `COPY` `zeebe/docker/utils/jvm.options` into `config/`;
+the distribution tarball ships no such file.
+
+## Consequences
+
+### Positive
+
+- Runtime-specific flags stay at the deployment boundary, not the distribution.
+- `config/jvm.options` is a general extension point for operators.
+- No startup overhead.
+
+### Negative
+
+- Custom appassembler templates must be diffed on any future plugin upgrade, though such upgrades
+  are unlikely given the plugin has been frozen since 2015.
+- `optimize-startup.sh` uses its own startup script and requires the same pattern maintained
+  separately.

--- a/docs/monorepo-docs/architecture/components/orchestration-cluster/adr/0002-jdk-25-base-images-with-jdk-21-runtime-support.md
+++ b/docs/monorepo-docs/architecture/components/orchestration-cluster/adr/0002-jdk-25-base-images-with-jdk-21-runtime-support.md
@@ -1,0 +1,58 @@
+# ADR-0002: JRE 25 Docker Base Images While Retaining JRE 21 Runtime Support
+
+## Status
+
+Accepted
+
+## Deciders
+
+- Nicolas Pepin-Perreault ([@npepinpe](https://github.com/npepinpe))
+- Lena Schoenburg ([@lenaschoenburg](https://github.com/lenaschoenburg))
+
+## Context
+
+Docker images previously used JRE 21. JRE 21 remains a supported runtime for self-managed
+bare-metal deployments; upgrading the minimum runtime across the board would be a breaking change
+requiring careful communication.
+
+JRE 25 (latest LTS) brings two relevant improvements:
+
+- **Virtual Thread improvements**: reduces carrier thread pinning, which caused throughput
+  degradation under load.
+- **General performance improvements**.
+
+One concern raised was test coverage regression: E2E and reliability tests run against Docker
+images, so upgrading to JRE 25 means they no longer exercise JRE 21 Virtual Thread behavior.
+However, coverage of pinning was already incomplete on JRE 21 — production systems may use custom
+exporters or agents that introduce pinning, and deployment topologies affect the common fork join
+pool in ways CI cannot reproduce. Pinning leads to deadlocks at worst, not data loss. Since most
+users run Docker images, resolving Virtual Thread issues for that majority was judged to outweigh
+the risk of missing pinning regressions for the small subset of JRE 21 bare-metal users.
+
+## Decision
+
+Upgrade Docker base images to JRE 25 (`openjre-base:25-dev` hardened and
+`eclipse-temurin:25.0.2_10-jre-noble` public fallback). This change is scoped to Docker images
+only — bare-metal deployments continue to target JRE 21 and are unaffected. The Maven build target
+remains 21. CI continues to validate against JRE 21. No dedicated JRE 21 Docker test job is
+introduced at this time.
+
+Because bare-metal support is unchanged and the build target remains 21, this change is relatively
+transparent to users: containerized deployments benefit from the JRE 25 improvements, while
+bare-metal users observe no difference.
+
+We accept that a small minority of users may still encounter Virtual Thread pinning issues that CI
+could have — but would not necessarily have — detected had we kept JRE 21 Docker images.
+
+## Consequences
+
+### Positive
+
+- Virtual Thread pinning issues resolved for the majority of users.
+- General JVM performance improvements for all containerized deployments.
+
+### Negative
+
+- E2E and reliability tests no longer exercise JRE 21 JVM behavior; Virtual Thread pinning
+  regressions on JRE 21 will not be caught by CI unless a dedicated job is added.
+- Bare-metal JRE 21 users receive no direct benefit from this change.

--- a/monorepo-docs-site/sidebars.js
+++ b/monorepo-docs-site/sidebars.js
@@ -84,6 +84,20 @@ const sidebars = {
               ],
             },
             {
+              type: 'category',
+              label: 'Orchestration Cluster',
+              items: [
+                {
+                  type: 'category',
+                  label: 'ADRs',
+                  items: [
+                    'architecture/components/orchestration-cluster/adr/jvm-options-argfile-for-runtime-specific-flags',
+                    'architecture/components/orchestration-cluster/adr/jdk-25-base-images-with-jdk-21-runtime-support',
+                  ],
+                },
+              ],
+            },
+            {
               type: 'doc',
               id: 'architecture/components/identity/management_identity_architecture_docs',
               label: 'Management Identity',

--- a/operate.Dockerfile
+++ b/operate.Dockerfile
@@ -1,12 +1,12 @@
 # hadolint global ignore=DL3006
-ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base:21-dev"
-ARG BASE_DIGEST="sha256:c28de0ca6d34d1017166c2c16e2ed7757ee2f7ad20f7ac5bea8bbf9989cc9bc2"
+ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base:25-dev"
+ARG BASE_DIGEST="sha256:e2772c8469b0b3cfc792708153d075fcf17778444d6d57792e4ba83d49bf82e6"
 
 # If you don't have access to Minimus hardened base images, you can use public
 # base images like this instead on your own risk.
 # Simply pass `--build-arg BASE=public` in order to build with the Temurin JDK.
-ARG BASE_IMAGE_PUBLIC="eclipse-temurin:21.0.10_7-jre-noble"
-ARG BASE_DIGEST_PUBLIC="sha256:be00aca3f4747fa3f4b936fc35dc64eb5862349e262b2ad8d3299cb96a305780"
+ARG BASE_IMAGE_PUBLIC="eclipse-temurin:25.0.2_10-jre-noble"
+ARG BASE_DIGEST_PUBLIC="sha256:cd44d91d4b2c7b2a171a96a88d77a5f4e94de4faaefea70eda4f0b8e3c3891e6"
 ARG BASE="hardened"
 
 ### Base Application Image ###

--- a/operate.Dockerfile
+++ b/operate.Dockerfile
@@ -83,6 +83,7 @@ RUN addgroup --gid 1001 camunda && \
     chown -R 1001:0 ${OPE_HOME} && \
     chmod -R 0775 ${OPE_HOME}
 
+COPY --link --chown=1001:0 zeebe/docker/utils/jvm.options ${OPE_HOME}/config/jvm.options
 COPY --from=prepare --chown=1001:0 --chmod=0775 /tmp/operate ${OPE_HOME}
 
 USER 1001:1001

--- a/operate.Dockerfile
+++ b/operate.Dockerfile
@@ -1,12 +1,12 @@
 # hadolint global ignore=DL3006
-ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base:21-dev"
-ARG BASE_DIGEST="sha256:f21d8148ffd3749c189231e78789ee5ef511f9c8d2c7f497537494d707f95074"
+ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base:25-dev"
+ARG BASE_DIGEST="sha256:e2772c8469b0b3cfc792708153d075fcf17778444d6d57792e4ba83d49bf82e6"
 
 # If you don't have access to Minimus hardened base images, you can use public
 # base images like this instead on your own risk.
 # Simply pass `--build-arg BASE=public` in order to build with the Temurin JDK.
-ARG BASE_IMAGE_PUBLIC="eclipse-temurin:21.0.10_7-jre-noble"
-ARG BASE_DIGEST_PUBLIC="sha256:420374e45e8e9dce3057e768c87a3e8ba58e815049511d8df95ca88a041ec82b"
+ARG BASE_IMAGE_PUBLIC="eclipse-temurin:25.0.2_10-jre-noble"
+ARG BASE_DIGEST_PUBLIC="sha256:cd44d91d4b2c7b2a171a96a88d77a5f4e94de4faaefea70eda4f0b8e3c3891e6"
 ARG BASE="hardened"
 
 ### Base Application Image ###

--- a/optimize-distro/src/optimize-startup.sh
+++ b/optimize-distro/src/optimize-startup.sh
@@ -30,6 +30,12 @@ if [ -z "$OPTIMIZE_JAVA_OPTS" ]; then
   OPTIMIZE_JAVA_OPTS="-Xms1024m -Xmx1024m -XX:MetaspaceSize=256m -XX:MaxMetaspaceSize=256m"
 fi
 
+# Load optional JVM options file (e.g. for runtime-specific flags not suited for the general distribution)
+OPTIMIZE_EXTRA_JVM_OPTS=
+if [ -r "${BASEDIR}/config/jvm.options" ]; then
+  OPTIMIZE_EXTRA_JVM_OPTS="@${BASEDIR}/config/jvm.options"
+fi
+
 # check if debug mode should be enabled
 if [ "$1" == "--debug" ]; then
   DEBUG_PORT=9999
@@ -60,4 +66,4 @@ echo
 echo "Starting Camunda Optimize ${project.version}..."
 echo
 
-exec $JAVA ${OPTIMIZE_JAVA_OPTS} -cp "${OPTIMIZE_CLASSPATH}" ${DEBUG_JAVA_OPTS} ${JAVA_SYSTEM_PROPERTIES} -Dfile.encoding=UTF-8 io.camunda.optimize.Main
+exec $JAVA ${OPTIMIZE_JAVA_OPTS} ${OPTIMIZE_EXTRA_JVM_OPTS} -cp "${OPTIMIZE_CLASSPATH}" ${DEBUG_JAVA_OPTS} ${JAVA_SYSTEM_PROPERTIES} -Dfile.encoding=UTF-8 io.camunda.optimize.Main

--- a/optimize.Dockerfile
+++ b/optimize.Dockerfile
@@ -1,12 +1,12 @@
 # hadolint global ignore=DL3006
-ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base:21-dev"
-ARG BASE_DIGEST="sha256:c28de0ca6d34d1017166c2c16e2ed7757ee2f7ad20f7ac5bea8bbf9989cc9bc2"
+ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base:25-dev"
+ARG BASE_DIGEST="sha256:e2772c8469b0b3cfc792708153d075fcf17778444d6d57792e4ba83d49bf82e6"
 
 # If you don't have access to Minimus hardened base images, you can use public
 # base images like this instead on your own risk.
 # Simply pass `--build-arg BASE=public` in order to build with the Temurin JDK.
-ARG BASE_IMAGE_PUBLIC="eclipse-temurin:21.0.10_7-jre-noble"
-ARG BASE_DIGEST_PUBLIC="sha256:be00aca3f4747fa3f4b936fc35dc64eb5862349e262b2ad8d3299cb96a305780"
+ARG BASE_IMAGE_PUBLIC="eclipse-temurin:25.0.2_10-jre-noble"
+ARG BASE_DIGEST_PUBLIC="sha256:cd44d91d4b2c7b2a171a96a88d77a5f4e94de4faaefea70eda4f0b8e3c3891e6"
 ARG BASE="hardened"
 
 ### Base Application Image ###

--- a/optimize.Dockerfile
+++ b/optimize.Dockerfile
@@ -1,12 +1,12 @@
 # hadolint global ignore=DL3006
-ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base:21-dev"
-ARG BASE_DIGEST="sha256:f21d8148ffd3749c189231e78789ee5ef511f9c8d2c7f497537494d707f95074"
+ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base:25-dev"
+ARG BASE_DIGEST="sha256:e2772c8469b0b3cfc792708153d075fcf17778444d6d57792e4ba83d49bf82e6"
 
 # If you don't have access to Minimus hardened base images, you can use public
 # base images like this instead on your own risk.
 # Simply pass `--build-arg BASE=public` in order to build with the Temurin JDK.
-ARG BASE_IMAGE_PUBLIC="eclipse-temurin:21.0.10_7-jre-noble"
-ARG BASE_DIGEST_PUBLIC="sha256:420374e45e8e9dce3057e768c87a3e8ba58e815049511d8df95ca88a041ec82b"
+ARG BASE_IMAGE_PUBLIC="eclipse-temurin:25.0.2_10-jre-noble"
+ARG BASE_DIGEST_PUBLIC="sha256:cd44d91d4b2c7b2a171a96a88d77a5f4e94de4faaefea70eda4f0b8e3c3891e6"
 ARG BASE="hardened"
 
 ### Base Application Image ###
@@ -98,4 +98,5 @@ USER 1001:1001
 
 CMD ["./optimize.sh"]
 
+COPY --link --chown=1001:1001 zeebe/docker/utils/jvm.options config/jvm.options
 COPY --chown=1001:1001 --from=base /tmp/build .

--- a/optimize/docker/test/docker-labels.golden.json
+++ b/optimize/docker/test/docker-labels.golden.json
@@ -18,5 +18,5 @@
   "org.opencontainers.image.url": "https://docs.camunda.io/docs/components/optimize/what-is-optimize/",
   "org.opencontainers.image.vendor": "Camunda Services GmbH",
   "org.opencontainers.image.version": $VERSION,
-  "io.minimus.images.line": "21"
+  "io.minimus.images.line": "25"
 }

--- a/optimize/docker/test/verify.sh
+++ b/optimize/docker/test/verify.sh
@@ -9,7 +9,6 @@
 #   VERSION - required; the semantic version, e.g. 8.6.0 or 8.6.0-alpha1
 #   REVISION - required; the sha1 of the commit used to build the artifact
 #   DATE - required; the ISO 8601 date at which the image was built
-#   BASE_IMAGE - required; Docker base image name (e.g. docker.io/library/alpine:3.23.0)
 # Arguments:
 #   1 - Docker image names to be checked (no limit on number of images, each is checked separately)
 # Outputs:
@@ -43,29 +42,37 @@ if [ -z "${DATE}" ]; then
 fi
 echo "[INFO] DATE=${DATE}"
 
-if [ -z "${BASE_IMAGE}" ]; then
-  echo >&2 "No BASE_IMAGE was given; make sure to pass a valid base image name, e.g. docker.io/library/alpine:3.23.0"
-  exit 1
-fi
-echo "[INFO] BASE_IMAGE=${BASE_IMAGE}"
-
-# Check that the base image exists
-if ! baseImageInfo="$(docker manifest inspect "${BASE_IMAGE}")"; then
-  echo >&2 "No known Docker base image ${BASE_IMAGE} exists; did you pass the right name?"
-  exit 1
-fi
-echo "[INFO] Base image ${BASE_IMAGE} exists and is accessible"
-
 SCRIPT_DIR=$(dirname -- "$(readlink -f -- "${BASH_SOURCE[0]}")")
 DOCKERFILE_PATH="${SCRIPT_DIR}/../../../optimize.Dockerfile"
+DOCKERFILE=$(<"${DOCKERFILE_PATH}")
 
 echo "[INFO] Looking for digest in Dockerfile: ${DOCKERFILE_PATH}"
-DIGEST=$(cat "$DOCKERFILE_PATH" | grep -o 'sha256:[a-f0-9]\{64\}' | head -n 1)
+DIGEST=$(echo "${DOCKERFILE}" | grep -o 'sha256:[a-f0-9]\{64\}' | head -n 1)
 if [[ -z "$DIGEST" ]]; then
     echo >&2 "Docker image digest can not be found in the Dockerfile (with name $DOCKERFILE_PATH)"
     exit 1
 fi
 echo "Digest found: $DIGEST"
+
+BASE_IMAGE_REGEX='ARG BASE_IMAGE="([^"]+)"'
+if [[ $DOCKERFILE =~ $BASE_IMAGE_REGEX ]]; then
+    BASE_IMAGE="${BASH_REMATCH[1]}"
+else
+    echo >&2 "Base image cannot be found in the Dockerfile (with name $DOCKERFILE_PATH)"
+    exit 1
+fi
+# If the base image is not fully qualified, add the default registry prefix
+if [[ ! $BASE_IMAGE =~ ^(.+[\.|:].+)?/.*$ ]]; then
+  BASE_IMAGE="docker.io/library/${BASE_IMAGE}"
+fi
+echo "[INFO] BASE_IMAGE=${BASE_IMAGE}"
+
+# Check that the base image exists
+if ! docker manifest inspect "${BASE_IMAGE}" > /dev/null; then
+  echo >&2 "No known Docker base image ${BASE_IMAGE} exists; did you pass the right name?"
+  exit 1
+fi
+echo "[INFO] Base image ${BASE_IMAGE} exists and is accessible"
 
 imageName="${1}"
 # Iterate through all the images passed as parameter

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -269,8 +269,9 @@
       JVM module opens required across the project:
       - java.base/java.io: required for NativeFS raw file descriptor access
       - java.base/jdk.internal.misc: required for agrona's UnsafeApi
+      - enable-native-access=ALL-UNNAMED: suppresses restricted method warnings from jffi (JDK 17+)
     -->
-    <jvm.module.opens>--add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED</jvm.module.opens>
+    <jvm.module.opens>--add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED --enable-native-access=ALL-UNNAMED</jvm.module.opens>
 
     <!--
       you can use the following to disable specific check plugins. this can also be used to skip the

--- a/tasklist.Dockerfile
+++ b/tasklist.Dockerfile
@@ -1,12 +1,12 @@
 # hadolint global ignore=DL3006
-ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base:21-dev"
-ARG BASE_DIGEST="sha256:c28de0ca6d34d1017166c2c16e2ed7757ee2f7ad20f7ac5bea8bbf9989cc9bc2"
+ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base:25-dev"
+ARG BASE_DIGEST="sha256:e2772c8469b0b3cfc792708153d075fcf17778444d6d57792e4ba83d49bf82e6"
 
 # If you don't have access to Minimus hardened base images, you can use public
 # base images like this instead on your own risk.
 # Simply pass `--build-arg BASE=public` in order to build with the Temurin JDK.
-ARG BASE_IMAGE_PUBLIC="eclipse-temurin:21.0.10_7-jre-noble"
-ARG BASE_DIGEST_PUBLIC="sha256:be00aca3f4747fa3f4b936fc35dc64eb5862349e262b2ad8d3299cb96a305780"
+ARG BASE_IMAGE_PUBLIC="eclipse-temurin:25.0.2_10-jre-noble"
+ARG BASE_DIGEST_PUBLIC="sha256:cd44d91d4b2c7b2a171a96a88d77a5f4e94de4faaefea70eda4f0b8e3c3891e6"
 ARG BASE="hardened"
 
 ### Base Application Image ###

--- a/tasklist.Dockerfile
+++ b/tasklist.Dockerfile
@@ -81,6 +81,7 @@ RUN addgroup --gid 1001 camunda && \
     chown -R 1001:0 ${TASKLIST_HOME} && \
     chmod -R 0775 ${TASKLIST_HOME}
 
+COPY --link --chown=1001:0 zeebe/docker/utils/jvm.options ${TASKLIST_HOME}/config/jvm.options
 COPY --from=prepare --chown=1001:0 --chmod=0775 /tmp/tasklist ${TASKLIST_HOME}
 
 # rename tasklist-migrate script to migrate (as expected by SaaS)

--- a/tasklist.Dockerfile
+++ b/tasklist.Dockerfile
@@ -1,12 +1,12 @@
 # hadolint global ignore=DL3006
-ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base:21-dev"
-ARG BASE_DIGEST="sha256:f21d8148ffd3749c189231e78789ee5ef511f9c8d2c7f497537494d707f95074"
+ARG BASE_IMAGE="reg.mini.dev/1212/openjre-base:25-dev"
+ARG BASE_DIGEST="sha256:e2772c8469b0b3cfc792708153d075fcf17778444d6d57792e4ba83d49bf82e6"
 
 # If you don't have access to Minimus hardened base images, you can use public
 # base images like this instead on your own risk.
 # Simply pass `--build-arg BASE=public` in order to build with the Temurin JDK.
-ARG BASE_IMAGE_PUBLIC="eclipse-temurin:21.0.10_7-jre-noble"
-ARG BASE_DIGEST_PUBLIC="sha256:420374e45e8e9dce3057e768c87a3e8ba58e815049511d8df95ca88a041ec82b"
+ARG BASE_IMAGE_PUBLIC="eclipse-temurin:25.0.2_10-jre-noble"
+ARG BASE_DIGEST_PUBLIC="sha256:cd44d91d4b2c7b2a171a96a88d77a5f4e94de4faaefea70eda4f0b8e3c3891e6"
 ARG BASE="hardened"
 
 ### Base Application Image ###

--- a/zeebe/docker/utils/jvm.options
+++ b/zeebe/docker/utils/jvm.options
@@ -1,0 +1,1 @@
+--sun-misc-unsafe-memory-access=allow


### PR DESCRIPTION
## Summary

Updates all 5 Dockerfiles to use JDK 25 JRE base images (`openjre-base:25-dev` / `eclipse-temurin:25.0.2_10-jre-noble`). The Maven build target release remains 21 for backwards compatibility.

Part of #51201.

### Changes

**Base image updates**
- `Dockerfile`, `camunda.Dockerfile`, `operate.Dockerfile`, `tasklist.Dockerfile`: switched to JDK 25 hardened and public base images
- `optimize.Dockerfile` and its associated tooling (golden files, `verify.sh`, `build-docker-image.sh`, release workflow): same update, isolated in a separate commit (`7718dd4`) that can be dropped independently if Optimize does not need this

**Release workflow fixes**
- `optimize-release-optimize-c8-only.yml`: was hardcoding `openjre-base:21-dev` as `BASE_IMAGE` build-arg, overriding the Dockerfile default; updated to JDK 25 and added `BASE_DIGEST` so the tag@digest pair is consistent
- `operate-release-reusable.yml`: updated `BASE_IMAGE` export to reflect JDK 25 (cosmetic; build already uses Dockerfile defaults)

**JVM flag fixes for JDK 25**

Two warnings appear at runtime with JDK 25 that are suppressed with these changes:

1. *Restricted native access* (`jffi` / `System::load`): `--enable-native-access=ALL-UNNAMED` added to `jvm.module.opens` in `parent/pom.xml`. Flag exists since JDK 17 — JDK 21 unaffected.

2. *Terminally deprecated `sun.misc.Unsafe`* (`kryo`): `--sun-misc-unsafe-memory-access=allow` is JDK 23+ only; baking it into the launcher scripts would break JDK 21 users. Instead:
   - Custom appassembler script templates added in `dist/src/main/scripts/` (verbatim copies of the plugin's built-in 2.1.0 templates, which have not been updated since 2015) with an optional `@argfile` load: if `config/jvm.options` exists at startup it is passed to the JVM
   - appassembler plugin has not been updated since 2015, so the likelihood of these templates changing is low, and maintenance for them is also low (especially with LLMs)
   - All 4 non-optimize Docker images `COPY` `zeebe/docker/utils/jvm.options` (containing `--sun-misc-unsafe-memory-access=allow`) into their `config/` directory; the distribution tarball ships no such file, so JDK 21 users are unaffected
   - `optimize-startup.sh` receives the same `@argfile` mechanism (part of the droppable optimize commit)

## Test plan

- [x] CI Docker build jobs pass with the new base images
- [x] Container smoke tests pass