### PR TITLE
feat: improve workflow_dispatch UX for camunda-load-test

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -57,9 +57,7 @@ on:
         default: ""
         required: false
       load-test-load:
-        description: |-
-          ── Configuration ──
-          Helm args for workload components (e.g. --set starter.rate=100). Ignored when scenario is not "custom".
+        description: '── Configuration ─────────────────── Helm args for workload components (e.g. --set starter.rate=100). Ignored when scenario is not "custom".'
         required: false
       platform-helm-values:
         description: 'Additional Helm values for the Camunda platform chart (e.g. --set orchestration.resources.limits.memory=2Gi)'
@@ -67,9 +65,7 @@ on:
         default: ""
         required: false
       stable-vms:
-        description: |-
-          ── Flags ──
-          Deploy to non-spot VMs (more stable, higher cost)
+        description: '── Flags ─────────────────────────── Deploy to non-spot VMs (more stable, higher cost)'
         type: boolean
         required: false
         default: false
@@ -89,9 +85,7 @@ on:
         required: false
         default: false
       ttl:
-        description: |-
-          ── Lifecycle & advanced ──
-          Days before the namespace is auto-deleted
+        description: '── Lifecycle & advanced ──────────── Days before the namespace is auto-deleted'
         type: number
         default: 1
         required: false

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -57,7 +57,9 @@ on:
         default: ""
         required: false
       load-test-load:
-        description: '── Configuration ── Helm args for workload components (e.g. --set starter.rate=100). Ignored when scenario is not "custom".'
+        description: |-
+          ── Configuration ──
+          Helm args for workload components (e.g. --set starter.rate=100). Ignored when scenario is not "custom".
         required: false
       platform-helm-values:
         description: 'Additional Helm values for the Camunda platform chart (e.g. --set orchestration.resources.limits.memory=2Gi)'
@@ -65,7 +67,9 @@ on:
         default: ""
         required: false
       stable-vms:
-        description: '── Flags ── Deploy to non-spot VMs (more stable, higher cost)'
+        description: |-
+          ── Flags ──
+          Deploy to non-spot VMs (more stable, higher cost)
         type: boolean
         required: false
         default: false
@@ -85,7 +89,9 @@ on:
         required: false
         default: false
       ttl:
-        description: '── Lifecycle & advanced ── Days before the namespace is auto-deleted'
+        description: |-
+          ── Lifecycle & advanced ──
+          Days before the namespace is auto-deleted
         type: number
         default: 1
         required: false

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -65,7 +65,7 @@ on:
         default: ""
         required: false
       stable-vms:
-        description: '── Flags ─────────────────────────── Deploy to non-spot VMs (more stable, higher cost)'
+        description: 'Deploy to non-spot VMs (more stable, higher cost)'
         type: boolean
         required: false
         default: false

--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -19,26 +19,16 @@ name: Camunda load test
 on:
   workflow_dispatch:
     inputs:
+      name:
+        description: 'Name of the load test (used as the Kubernetes namespace)'
+        required: true
       ref:
-        description: 'Specifies the ref (e.g. branch name, commit sha or tag) from which the docker image is built and used to run the load test against'
+        description: 'Git ref (branch, tag or commit SHA) to build and test against'
         default: 'main'
         type: string
         required: false
-      name:
-        description: 'Specifies the name of the load test'
-        required: true
-      ttl:
-        description: 'Specifies after how many days the load test namespace should be deleted'
-        type: number
-        default: 1
-        required: false
-      reuse-tag:
-        description: 'Reuse Tag: Pre-built image tag from the internal registry (registry.camunda.cloud). Skips the docker image build step. Cannot be used together with orchestration-tag.'
-        type: string
-        default: ""
-        required: false
       scenario:
-        description: 'Choose the variant of workload to use for the load test. When not set, it will default to max'
+        description: 'Workload scenario to run'
         required: false
         type: choice
         options:
@@ -48,36 +38,8 @@ on:
           - max
           - archiver
         default: max
-      load-test-load:
-        description: 'Specifies which load test components to deploy. For example, `starter` can be assigned with the rate at which they start instances. Allows arbitrary helm arguments, like --set starter.rate=100. This is ignored when scenario is not "custom".'
-        required: false
-      platform-helm-values:
-        description: 'Allows to specify additional values/configurations for the Camunda platform Helm chart, which will be deployed. For example, the Orchestration cluster `resources` can be modified. Allows arbitrary helm arguments, like --set orchestration.resources.limits.memory=2Gi'
-        type: string
-        default: ""
-        required: false
-      perform-read-benchmarks:
-        description: 'Perform continuous read benchmarks on secondary storage. This may influence the exporter performance as it puts more load on the secondary database. The metrics are available in the Data-Layer dashboard.'
-        type: boolean
-        required: false
-        default: false
-      stable-vms:
-        description: 'Deploy to non-spot VMs'
-        type: boolean
-        required: false
-        default: false
-      enable-optimize:
-        description: 'Enable Optimize for load testing'
-        type: boolean
-        required: false
-        default: true
-      build-frontend:
-        description: 'Build the frontend as part of the load test image build'
-        type: boolean
-        required: false
-        default: false
       secondary-storage-type:
-        description: 'Specifies the type of the secondary database used by Camunda Platform, can be "elasticsearch", "opensearch", "postgresql", "mysql", "mariadb", "mssql", "oracle" or "none"'
+        description: 'Secondary database backend for Camunda Platform'
         type: choice
         options:
         - elasticsearch
@@ -89,23 +51,61 @@ on:
         - oracle
         - none
         default: elasticsearch
+      reuse-tag:
+        description: 'Pre-built image tag from the internal registry (registry.camunda.cloud). Skips the build step. ⚠ Cannot be used with orchestration-tag.'
+        type: string
+        default: ""
+        required: false
+      load-test-load:
+        description: '── Configuration ── Helm args for workload components (e.g. --set starter.rate=100). Ignored when scenario is not "custom".'
+        required: false
+      platform-helm-values:
+        description: 'Additional Helm values for the Camunda platform chart (e.g. --set orchestration.resources.limits.memory=2Gi)'
+        type: string
+        default: ""
+        required: false
+      stable-vms:
+        description: '── Flags ── Deploy to non-spot VMs (more stable, higher cost)'
+        type: boolean
+        required: false
+        default: false
+      enable-optimize:
+        description: 'Enable Optimize for load testing'
+        type: boolean
+        required: false
+        default: true
+      build-frontend:
+        description: 'Build frontend assets as part of the load test image build'
+        type: boolean
+        required: false
+        default: false
+      perform-read-benchmarks:
+        description: 'Run continuous read benchmarks on secondary storage (may affect exporter performance)'
+        type: boolean
+        required: false
+        default: false
+      ttl:
+        description: '── Lifecycle & advanced ── Days before the namespace is auto-deleted'
+        type: number
+        default: 1
+        required: false
       orchestration-tag:
-        description: 'Orchestration Tag: Docker image tag for official Camunda images from Docker Hub (docker.io/camunda/camunda). When set, official Docker Hub images are used instead of building from source. Cannot be used together with reuse-tag.'
+        description: 'Official Docker Hub image tag (docker.io/camunda/camunda). Uses Docker Hub instead of building. ⚠ Cannot be used with reuse-tag.'
         type: string
         default: ""
         required: false
       optimize-tag:
-        description: 'Optimize Tag: Docker image tag for Optimize from Docker Hub (docker.io/camunda/optimize). When set, overrides the optimize image regardless of build mode. If not set, custom builds use the built image from the internal registry; official images use Helm chart defaults.'
+        description: 'Override Optimize image tag (docker.io/camunda/optimize). Overrides build mode defaults.'
         type: string
         default: ""
         required: false
       identity-tag:
-        description: 'Identity Tag: Docker image tag for Identity from Docker Hub (docker.io/camunda/identity). If not set, defaults to the Helm chart default image.'
+        description: 'Override Identity image tag (docker.io/camunda/identity). Defaults to Helm chart default.'
         type: string
         default: ""
         required: false
       connectors-tag:
-        description: 'Connectors Tag: Docker image tag for Connectors from Docker Hub (docker.io/camunda/connectors). If not set, defaults to the Helm chart default image.'
+        description: 'Override Connectors image tag (docker.io/camunda/connectors). Defaults to Helm chart default.'
         type: string
         default: ""
         required: false
@@ -218,18 +218,29 @@ jobs:
     steps:
       - name: Show summary
         run: |-
-          INPUTS=$(cat <<EOF | jq . --sort-keys
-          ${{ toJSON(inputs) }}
-          EOF
-          )
-          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
-          # Load test configuration
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ## Load test: `${{ env.NAMESPACE }}`
 
-          A load test was created with the following inputs:
+          > 📊 **[Open Grafana Dashboard](https://dashboard.benchmark.camunda.cloud/d/zeebe-dashboard/zeebe?var-namespace=${{ env.NAMESPACE }})**
 
-          \`\`\`json
-          $INPUTS
-          \`\`\`
+          | Input | Value |
+          |-------|-------|
+          | Name | `${{ inputs.name }}` |
+          | Ref | `${{ inputs.ref }}` |
+          | Scenario | `${{ inputs.scenario }}` |
+          | Secondary storage | `${{ inputs.secondary-storage-type }}` |
+          | Reuse tag | ${{ inputs.reuse-tag || '—' }} |
+          | Orchestration tag | ${{ inputs.orchestration-tag || '—' }} |
+          | Load test load | ${{ inputs.load-test-load || '—' }} |
+          | Platform helm values | ${{ inputs.platform-helm-values || '—' }} |
+          | TTL (days) | `${{ inputs.ttl }}` |
+          | Stable VMs | `${{ inputs.stable-vms }}` |
+          | Enable Optimize | `${{ inputs.enable-optimize }}` |
+          | Build frontend | `${{ inputs.build-frontend }}` |
+          | Perform read benchmarks | `${{ inputs.perform-read-benchmarks }}` |
+          | Optimize tag | ${{ inputs.optimize-tag || '—' }} |
+          | Identity tag | ${{ inputs.identity-tag || '—' }} |
+          | Connectors tag | ${{ inputs.connectors-tag || '—' }} |
           EOF
 
   calculate-image-tag:


### PR DESCRIPTION
## Summary

- Reorder `workflow_dispatch` inputs by priority/usage: `name`, `ref`, `scenario`, `secondary-storage-type`, `reuse-tag` first; config values (`load-test-load`, `platform-helm-values`) next; flags last; lifecycle/advanced at the bottom
- Add Unicode section markers (`── Configuration ──`, `── Flags ──`, `── Lifecycle & advanced ──`) to input descriptions to visually group fields in the GitHub dispatch form
- Replace the raw JSON input dump in the step summary with a Markdown table and a prominent Grafana dashboard link at the top

## Before

<img width="579" height="970" alt="main-input" src="https://github.com/user-attachments/assets/fcbe4185-d1db-4c17-afb0-94f410344eaa" />

Output before

<img width="1055" height="897" alt="main-output" src="https://github.com/user-attachments/assets/0e1326db-baf8-4175-9b11-bc906456df5b" />



## After

 * Reorder - important inputs first
 * Clear separation via sections

<img width="408" height="885" alt="new-input" src="https://github.com/user-attachments/assets/fcfd1485-4113-4778-9612-418ecf064701" />
<img width="716" height="806" alt="main-input2" src="https://github.com/user-attachments/assets/45c21881-8a17-477c-89c1-b61251d08dc8" />


Output shows now as table and at the top the grafana link:

<img width="1424" height="1254" alt="output" src="https://github.com/user-attachments/assets/c6931ac3-1aad-4ac6-8e0f-01ea9a3a600d" />




## Test plan

- [x] Trigger the workflow manually via `workflow_dispatch` and verify the input order and section markers appear correctly in the GitHub UI
- [x] Verify the step summary renders the Markdown table with the Grafana link correctly
- [ ] Verify `workflow_call` callers (daily/weekly/release load tests) are unaffected (no input renames)


closes https://github.com/camunda/camunda/issues/50384

🤖 Generated with [Claude Code](https://claude.com/claude-code)