### PR TITLE
ci: configure load tests to log as JSON

### DIFF
--- a/load-tests/camunda-platform-values.yaml
+++ b/load-tests/camunda-platform-values.yaml
@@ -65,6 +65,10 @@ identity:
     secret:
       existingSecret: camunda-credentials
       existingSecretKey: identity-firstuser-password
+  env:
+    # https://docs.camunda.io/docs/self-managed/components/management-identity/miscellaneous/configuration-variables/#google-stackdriver-json-logging
+    - name: IDENTITY_LOG_APPENDER
+      value: Stackdriver
   tolerations:
     - key: nodepool
       operator: Equal
@@ -82,6 +86,10 @@ optimize:
           ttl: 'P1D'
           processDataCleanup:
             enabled: true
+  env:
+    # https://docs.camunda.io/docs/self-managed/components/optimize/configuration/logging/#google-stackdriver-json-logging
+    - name: OPTIMIZE_LOG_APPENDER
+      value: Stackdriver
   tolerations:
     - key: nodepool
       operator: Equal
@@ -99,6 +107,10 @@ identityKeycloak:
       operator: Equal
       value: n2-standard-4
       effect: NoSchedule
+  extraEnvVars:
+    # https://www.keycloak.org/server/logging#_console
+    - name: KC_LOG_CONSOLE_OUTPUT
+      value: json
   postgresql:
     fullnameOverride: keycloak-postgresql # we override the names for simplicity of the deployment
 
@@ -112,6 +124,10 @@ connectors:
         secret:
           existingSecret: camunda-credentials
           existingSecretKey: connectors-security-authentication-oidc-secret
+  env:
+    # https://docs.camunda.io/docs/self-managed/components/connectors/connectors-configuration/#google-stackdriver-json-logging
+    - name: CONNECTORS_LOG_APPENDER
+      value: stackdriver
   tolerations:
     - key: nodepool
       operator: Equal

--- a/load-tests/prometheus-elasticsearch-exporter-values.yaml
+++ b/load-tests/prometheus-elasticsearch-exporter-values.yaml
@@ -7,6 +7,9 @@ image:
   # Set your specific exporter version here
   tag: "v1.10.0"
 
+log:
+  format: json
+
 serviceMonitor:
   ## If true, a ServiceMonitor CRD is created for a prometheus operator
   ## https://github.com/coreos/prometheus-operator


### PR DESCRIPTION
## Description

This configures each application to with the Stackdriver logger, which outputs logs as JSON-formatted logs (compatible with Google Stackdriver)

* For PostgreSQL, it's a bit more tricky and we have to dig into the Bitnami image, that we will stop using soon. It's not configured to log as JSON
* For Elasticsearch, I had a look a few weeks ago and couldn't find an easy way to pass the option ; I should be easier once we use the stock Elasticsearch image + the ECK operator
* For the load testing applications themselves, I'll take a look after https://github.com/camunda/camunda/pull/51020 is merged

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

* https://github.com/camunda/camunda/issues/51170
