### PR TITLE
docs: replace release manager with medic, when apropriate

### DIFF
--- a/docs/monorepo-docs/release.md
+++ b/docs/monorepo-docs/release.md
@@ -279,7 +279,9 @@ QA Release Manager: can help with questions around steps the QA team performs.
 
 _Caveat: Not all steps with "QA" in the name mean that the QA team is actually involved, so check twice_
 
-Zeebe Release Manager: can help with Zeebe-specific questions and tasks.
+Zeebe Medic: can help with Zeebe-specific questions and tasks.
+
+Core Features Medic: can help with questions and tasks related to Operate, Tasklist, and other core features.
 
 ## Backporting Guidelines
 


### PR DESCRIPTION
## Description

Based on [this discussion](https://camunda.slack.com/archives/C08F5RD5X8B/p1776255056040489?thread_ts=1776153237.997339&cid=C08F5RD5X8B):
* Renamed "Zeebe Release Manager" to "Zeebe Medic" to better reflect the responsibilities for Zeebe-specific questions and tasks.
* Added a new "Core Features Medic" role to assist with questions and tasks related to Operate, Tasklist, and other core features.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
