### PR TITLE
feat: don't schedule ES load tests on stable VMs anymore

### DIFF
--- a/load-tests/setup/default/values-stable.yaml
+++ b/load-tests/setup/default/values-stable.yaml
@@ -1,15 +1,5 @@
 # Additional values file to run on stable VMs
-elasticsearch:
-  master:
-    nodeSelector:
-      component: benchmark-n2-standard-8-stable
-      topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
-    tolerations:
-      - key: nodepool
-        operator: Equal
-        value: n2-standard-8-stable
-        effect: NoSchedule
-
+# Scheduling on stable VMs is useful to observe long-term behavior, such as memory leaks, etc.
 # https://github.com/camunda/camunda-platform-helm/blob/d3276435efc994e45b490f97d7875b4330ec0c42/charts/camunda-platform-8.8/values.yaml#L2945-L2948
 orchestration:
   # Require n2-standard-2 to ensure the broker is the only application running on its node


### PR DESCRIPTION

## Description

1. This is too costly and requires more nodes than we currently have
2. Stable VMs are mostly useful to observe long-term behaviors, such as memory leaks for camunda itself.
3. For Elasticsearch: we keep scheduling on normal nodes to also have regular disruption and see how our application behaves.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

* https://github.com/camunda/camunda/issues/50877
