### PR TITLE
fix: resolve three flaky integration tests (JobStream, BackupRangeTracking, AuditLog)

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/JobStreamAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/JobStreamAuthorizationIT.java
@@ -29,10 +29,10 @@ import io.camunda.zeebe.qa.util.actuator.JobStreamActuator;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.jobstream.JobStreamActuatorAssert;
 import java.time.Duration;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -62,7 +62,7 @@ public class JobStreamAuthorizationIT {
   private static final String USER1_USERNAME = "user1";
   private static final String USER2_USERNAME = "user2";
 
-  private static final Set<Long> STARTED_PROCESS_INSTANCES = new HashSet<>();
+  private static final Set<Long> STARTED_PROCESS_INSTANCES = ConcurrentHashMap.<Long>newKeySet();
 
   @UserDefinition
   private static final TestUser USER1_USER =
@@ -113,7 +113,7 @@ public class JobStreamAuthorizationIT {
     // given
     final var jobType = uniqueJobType();
     // a job set for collecting jobs in the client
-    final var jobCollector = new HashSet<ActivatedJob>();
+    final var jobCollector = ConcurrentHashMap.<ActivatedJob>newKeySet();
     // and a job stream command created by the user1 client, with their authorizations
     final var command =
         camundaClient
@@ -139,7 +139,7 @@ public class JobStreamAuthorizationIT {
     deployProcess(PROCESS_ID_1, jobType, TENANT_A);
     deployProcess(PROCESS_ID_1, jobType, TENANT_B);
     // a job set for collecting jobs in the client
-    final var jobCollector = new HashSet<ActivatedJob>();
+    final var jobCollector = ConcurrentHashMap.<ActivatedJob>newKeySet();
     // and a job stream created by the user1 client, with their authorizations
     final var stream =
         user1Client
@@ -175,7 +175,7 @@ public class JobStreamAuthorizationIT {
     deployProcess(PROCESS_ID_1, jobType, TENANT_B);
     deployProcess(PROCESS_ID_2, jobType, TENANT_B);
     // a job set for collecting jobs in the client
-    final var jobCollector = new HashSet<ActivatedJob>();
+    final var jobCollector = ConcurrentHashMap.<ActivatedJob>newKeySet();
     // and a job stream created by the user2 client, with their authorizations
     final var stream =
         user2Client
@@ -217,7 +217,7 @@ public class JobStreamAuthorizationIT {
     final var jobType = uniqueJobType();
     deployProcess(PROCESS_ID_3, jobType, TENANT_A);
     deployProcess(PROCESS_ID_3, jobType, TENANT_B);
-    final var jobCollector = new HashSet<ActivatedJob>();
+    final var jobCollector = ConcurrentHashMap.<ActivatedJob>newKeySet();
     // a job stream created by user1 with ASSIGNED tenant filter (resolves to tenantA only)
     final var stream =
         user1Client
@@ -250,7 +250,7 @@ public class JobStreamAuthorizationIT {
     deployProcess(PROCESS_ID_3, jobType, TENANT_A);
     deployProcess(PROCESS_ID_3, jobType, TENANT_B);
     deployProcess(PROCESS_ID_4, jobType, TENANT_B);
-    final var jobCollector = new HashSet<ActivatedJob>();
+    final var jobCollector = ConcurrentHashMap.<ActivatedJob>newKeySet();
     // a job stream created by user2 with ASSIGNED tenant filter (resolves to tenantA and tenantB)
     final var stream =
         user2Client
@@ -288,7 +288,7 @@ public class JobStreamAuthorizationIT {
     // given
     final var jobType = uniqueJobType();
     deployProcess(PROCESS_ID_5, jobType, TENANT_B);
-    final var jobCollector = new HashSet<ActivatedJob>();
+    final var jobCollector = ConcurrentHashMap.<ActivatedJob>newKeySet();
     // a job stream with ASSIGNED filter AND an explicit tenantId(TENANT_A) —
     // the ASSIGNED filter should override the provided tenant IDs, so the broker
     // resolves from all assigned tenants (both A and B), not just tenantA

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/auditlog/AuditLogIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/auditlog/AuditLogIT.java
@@ -39,6 +39,7 @@ import io.camunda.security.reader.TenantCheck;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -431,8 +432,10 @@ public class AuditLogIT {
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final AuditLogDbReader auditLogReader = rdbmsService.getAuditLogReader();
 
-    final var processDefId1 = "process-def-1";
-    final var processDefId2 = "process-def-2";
+    // Use unique IDs to avoid interference from other tests sharing the same database instance
+    final var suffix = UUID.randomUUID().toString();
+    final var processDefId1 = "process-def-1-" + suffix;
+    final var processDefId2 = "process-def-2-" + suffix;
 
     // Create audit logs with different process definitions and categories
     final var log1 =
@@ -463,7 +466,10 @@ public class AuditLogIT {
                             .resourceIds(List.of("*")))),
             TenantCheck.disabled());
 
-    final var searchResult = auditLogReader.search(AuditLogQuery.of(b -> b), resourceAccessChecks);
+    // Explicit large page to avoid default-page truncation hiding results in a shared DB
+    final var searchResult =
+        auditLogReader.search(
+            AuditLogQuery.of(b -> b.page(p -> p.size(1000))), resourceAccessChecks);
 
     // Should return all USER_TASKS category logs
     assertThat(searchResult.items())

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupRangeTrackingIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupRangeTrackingIT.java
@@ -63,8 +63,13 @@ final class BackupRangeTrackingIT {
 
   @AfterEach
   void tearDown() throws InterruptedException {
-    executor.shutdownNow();
-    executor.awaitTermination(5, TimeUnit.SECONDS);
+    executor.shutdown();
+    if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+      executor.shutdownNow();
+      assertThat(executor.awaitTermination(5, TimeUnit.SECONDS))
+          .as("expected executor to terminate during test teardown")
+          .isTrue();
+    }
   }
 
   private void configureBroker(final TestStandaloneBroker broker) {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupRangeTrackingIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupRangeTrackingIT.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
@@ -61,8 +62,9 @@ final class BackupRangeTrackingIT {
   }
 
   @AfterEach
-  void tearDown() {
+  void tearDown() throws InterruptedException {
     executor.shutdownNow();
+    executor.awaitTermination(5, TimeUnit.SECONDS);
   }
 
   private void configureBroker(final TestStandaloneBroker broker) {
@@ -149,11 +151,22 @@ final class BackupRangeTrackingIT {
               }
             });
 
-    final var lastBackupBeforeLeaderChange =
-        actuator.state().getBackupStates().stream()
-            .filter((final PartitionBackupState state) -> state.getPartitionId() == 1)
-            .findFirst()
-            .orElseThrow();
+    // Partition 1's new leader may need time to report backup state; retry until available
+    final var lastBackupBeforeLeaderChangeRef = new AtomicReference<PartitionBackupState>();
+    Awaitility.await("Partition 1 backup state should be available on new leader")
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () -> {
+              final var state =
+                  actuator.state().getBackupStates().stream()
+                      .filter((final PartitionBackupState s) -> s.getPartitionId() == 1)
+                      .findFirst();
+              assertThat(state)
+                  .describedAs("Backup state for partition 1 should be present")
+                  .isPresent();
+              lastBackupBeforeLeaderChangeRef.set(state.get());
+            });
+    final var lastBackupBeforeLeaderChange = lastBackupBeforeLeaderChangeRef.get();
 
     // then
     Awaitility.await("New leader should continue to take backups and extend the existing range")


### PR DESCRIPTION
## Summary

Fixes three flaky tests that were slowing down builds and reducing reliability.

- **`JobStreamAuthorizationIT.shouldReceiveNoJobsWhenNotAuthorized`** — `jobCollector` and `STARTED_PROCESS_INSTANCES` used plain `HashSet`, written from gRPC stream callback threads and read from the test thread with no synchronization. Replace all usages with `ConcurrentHashMap.newKeySet()`.

- **`BackupRangeTrackingIT.shouldTrackBackupRangesDuringLeaderChanges`** — `lastBackupBeforeLeaderChange` was fetched via bare `orElseThrow()` outside any retry loop. During the leader-election window the new leader hasn't yet reported backup state, causing an immediate `NoSuchElementException`. Wrap the read in `Awaitility.await().untilAsserted()` with an `AtomicReference`. Also add `executor.awaitTermination(5s)` in `tearDown` so the load-generator thread can't interfere with assertions.

- **`AuditLogIT.shouldFilterByProcessDefinitionWithReadUserTaskWildcard` (MariaDB)** — All RDBMS tests share one database instance with no per-test cleanup. Accumulated `USER_TASKS` logs from earlier methods filled the default page before the test's own records, causing the `contains()` assertion to fail. Fix by adding `.page(p -> p.size(1000))` (consistent with the analogous `ReadProcessInstance` wildcard test) and using UUID-suffixed `processDefIds` to prevent cross-test key collisions.

## Test plan

- [ ] `JobStreamAuthorizationIT` — all stream authorization tests pass reliably; no `HashSet` concurrent-modification exceptions
- [ ] `BackupRangeTrackingIT.shouldTrackBackupRangesDuringLeaderChanges` — no `NoSuchElementException` during leader transition; executor drains cleanly in teardown
- [ ] `AuditLogIT.shouldFilterByProcessDefinitionWithReadUserTaskWildcard` — passes on MariaDB regardless of test execution order

🤖 Generated with [Claude Code](https://claude.com/claude-code)