### PR TITLE
docs: add mockup SVG for MCP processes admin view

### DIFF
--- a/.github/mockups/mcp-processes-view.svg
+++ b/.github/mockups/mcp-processes-view.svg
@@ -46,10 +46,10 @@
 
   <!-- MCP Processes — ACTIVE ITEM -->
   <rect x="0" y="304" width="240" height="40" fill="#0F62FE"/>
-  <!-- MCP icon (simple flow icon) -->
+  <!-- MCP icon -->
   <circle cx="30" cy="324" r="6" fill="none" stroke="#ffffff" stroke-width="1.5"/>
   <line x1="36" y1="324" x2="44" y2="324" stroke="#ffffff" stroke-width="1.5"/>
-  <rect x="28" y="316" width="16" height="16" rx="2" fill="none" stroke="#ffffff" stroke-width="1.5" transform="translate(18,0)"/>
+  <rect x="46" y="316" width="16" height="16" rx="2" fill="none" stroke="#ffffff" stroke-width="1.5"/>
   <text x="56" y="329" fill="#ffffff" font-size="14" font-weight="600">MCP Processes</text>
 
   <!-- Operations Log -->
@@ -61,9 +61,7 @@
   <rect x="240" y="48" width="960" height="712" fill="#f4f4f4"/>
 
   <!-- Page Header -->
-  <rect x="240" y="48" width="960" height="64" fill="#f4f4f4"/>
   <text x="272" y="84" fill="#161616" font-size="20" font-weight="600">MCP Processes</text>
-  <!-- Docs link -->
   <text x="272" y="104" fill="#0F62FE" font-size="12">Learn about MCP processes ↗</text>
 
   <!-- DataTable Container -->
@@ -74,15 +72,12 @@
 
   <!-- Search box -->
   <rect x="272" y="140" width="280" height="28" fill="#ffffff" stroke="#8d8d8d" stroke-width="1"/>
-  <!-- Search icon -->
   <circle cx="288" cy="154" r="6" fill="none" stroke="#525252" stroke-width="1.5"/>
   <line x1="292" y1="158" x2="297" y2="163" stroke="#525252" stroke-width="1.5"/>
   <text x="306" y="159" fill="#8d8d8d" font-size="12">Search by tool name...</text>
 
   <!-- Table Header Row -->
   <rect x="256" y="176" width="928" height="40" fill="#e0e0e0"/>
-
-  <!-- Column headers -->
   <text x="280" y="201" fill="#525252" font-size="12" font-weight="600">Tool Name</text>
   <line x1="448" y1="176" x2="448" y2="216" stroke="#c6c6c6" stroke-width="1"/>
   <text x="464" y="201" fill="#525252" font-size="12" font-weight="600">Tool Description</text>
@@ -92,10 +87,9 @@
   <text x="880" y="201" fill="#525252" font-size="12" font-weight="600">Version</text>
   <line x1="952" y1="176" x2="952" y2="216" stroke="#c6c6c6" stroke-width="1"/>
   <text x="968" y="201" fill="#525252" font-size="12" font-weight="600">Tenant</text>
-  <!-- Sort indicator on Tool Name -->
   <polygon points="432,195 437,202 442,195" fill="#525252"/>
 
-  <!-- Row 1 (white) -->
+  <!-- Row 1 -->
   <rect x="256" y="216" width="928" height="48" fill="#ffffff"/>
   <text x="280" y="246" fill="#161616" font-size="13" font-weight="500">orderApproval</text>
   <line x1="448" y1="216" x2="448" y2="264" stroke="#e0e0e0" stroke-width="1"/>
@@ -108,7 +102,7 @@
   <text x="968" y="246" fill="#525252" font-size="13">&lt;default&gt;</text>
   <line x1="256" y1="264" x2="1184" y2="264" stroke="#e0e0e0" stroke-width="1"/>
 
-  <!-- Row 2 (light grey) -->
+  <!-- Row 2 -->
   <rect x="256" y="264" width="928" height="48" fill="#f4f4f4"/>
   <text x="280" y="294" fill="#161616" font-size="13" font-weight="500">sendCustomerNotification</text>
   <line x1="448" y1="264" x2="448" y2="312" stroke="#e0e0e0" stroke-width="1"/>
@@ -121,7 +115,7 @@
   <text x="968" y="294" fill="#525252" font-size="13">&lt;default&gt;</text>
   <line x1="256" y1="312" x2="1184" y2="312" stroke="#e0e0e0" stroke-width="1"/>
 
-  <!-- Row 3 (white) -->
+  <!-- Row 3 -->
   <rect x="256" y="312" width="928" height="48" fill="#ffffff"/>
   <text x="280" y="342" fill="#161616" font-size="13" font-weight="500">generateInvoice</text>
   <line x1="448" y1="312" x2="448" y2="360" stroke="#e0e0e0" stroke-width="1"/>
@@ -134,7 +128,7 @@
   <text x="968" y="342" fill="#525252" font-size="13">acme-corp</text>
   <line x1="256" y1="360" x2="1184" y2="360" stroke="#e0e0e0" stroke-width="1"/>
 
-  <!-- Row 4 (light grey) -->
+  <!-- Row 4 -->
   <rect x="256" y="360" width="928" height="48" fill="#f4f4f4"/>
   <text x="280" y="390" fill="#161616" font-size="13" font-weight="500">scheduleDelivery</text>
   <line x1="448" y1="360" x2="448" y2="408" stroke="#e0e0e0" stroke-width="1"/>
@@ -147,7 +141,7 @@
   <text x="968" y="390" fill="#525252" font-size="13">acme-corp</text>
   <line x1="256" y1="408" x2="1184" y2="408" stroke="#e0e0e0" stroke-width="1"/>
 
-  <!-- Row 5 (white) -->
+  <!-- Row 5 -->
   <rect x="256" y="408" width="928" height="48" fill="#ffffff"/>
   <text x="280" y="438" fill="#161616" font-size="13" font-weight="500">escalateIncident</text>
   <line x1="448" y1="408" x2="448" y2="456" stroke="#e0e0e0" stroke-width="1"/>
@@ -160,26 +154,20 @@
   <text x="968" y="438" fill="#525252" font-size="13">&lt;default&gt;</text>
   <line x1="256" y1="456" x2="1184" y2="456" stroke="#e0e0e0" stroke-width="1"/>
 
-  <!-- Pagination area -->
+  <!-- Pagination -->
   <rect x="256" y="648" width="928" height="32" fill="#f4f4f4" stroke="#e0e0e0" stroke-width="1"/>
   <text x="272" y="668" fill="#525252" font-size="12">Items per page:</text>
   <text x="384" y="668" fill="#161616" font-size="12" font-weight="500">10 ▾</text>
   <text x="432" y="668" fill="#525252" font-size="12">|</text>
   <text x="448" y="668" fill="#525252" font-size="12">1–10 of 5 items</text>
-  <!-- Pagination buttons (right-aligned) -->
   <text x="1080" y="668" fill="#8d8d8d" font-size="12">◀</text>
   <text x="1100" y="668" fill="#8d8d8d" font-size="12">▶</text>
 
-  <!-- Empty rows hint -->
-  <text x="280" y="516" fill="#8d8d8d" font-size="12" font-style="italic">Showing processes with MCP start events, filtered from /v2/message-subscriptions/search</text>
+  <!-- Annotation: Search API -->
+  <rect x="680" y="136" width="490" height="24" fill="#e5f6ff" stroke="#0F62FE" stroke-width="1" rx="2"/>
+  <text x="692" y="152" fill="#0043ce" font-size="11" font-weight="500">API: GET /v2/message-subscriptions/search  filter: messageSubscriptionType=START_EVENT_SUBSCRIPTION</text>
 
-  <!-- Annotation callout 1: Search API note -->
-  <rect x="680" y="136" width="340" height="32" fill="#e5f6ff" stroke="#0F62FE" stroke-width="1" rx="2"/>
-  <text x="692" y="152" fill="#0043ce" font-size="11" font-weight="500">Queries /v2/message-subscriptions/search (messageSubscriptionType=START_EVENT_SUBSCRIPTION)</text>
-
-  <!-- Annotation callout 2: Extension properties note -->
-  <rect x="440" y="220" width="8" height="8" fill="#0F62FE" rx="1"/>
-  <line x1="444" y1="228" x2="444" y2="252" stroke="#0F62FE" stroke-width="1" stroke-dasharray="3,2"/>
-  <rect x="256" y="692" width="500" height="28" fill="#fff8e1" stroke="#f1c21b" stroke-width="1" rx="2"/>
-  <text x="268" y="710" fill="#8a6000" font-size="11">Tool Name and Description are read from extensionProperties (set by the MCP start event element template)</text>
+  <!-- Annotation: Extension properties -->
+  <rect x="256" y="692" width="570" height="24" fill="#fff8e1" stroke="#f1c21b" stroke-width="1" rx="2"/>
+  <text x="268" y="708" fill="#8a6000" font-size="11">Tool Name + Description sourced from extensionProperties set by the MCP start event element template (#48496)</text>
 </svg>

--- a/.github/mockups/mcp-processes-view.svg
+++ b/.github/mockups/mcp-processes-view.svg
@@ -1,0 +1,185 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="760" viewBox="0 0 1200 760" font-family="'IBM Plex Sans', Arial, sans-serif">
+  <!-- Background -->
+  <rect width="1200" height="760" fill="#f4f4f4"/>
+
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="48" fill="#161616"/>
+  <!-- Camunda Logo area -->
+  <rect x="16" y="14" width="20" height="20" rx="4" fill="#0F62FE"/>
+  <text x="44" y="28" fill="#ffffff" font-size="14" font-weight="600">Camunda</text>
+  <text x="120" y="28" fill="#8d8d8d" font-size="14">Orchestration Cluster Admin</text>
+  <!-- User avatar -->
+  <circle cx="1172" cy="24" r="14" fill="#393939"/>
+  <text x="1172" y="29" fill="#c6c6c6" font-size="11" text-anchor="middle">JD</text>
+
+  <!-- Left Sidebar -->
+  <rect x="0" y="48" width="240" height="712" fill="#262626"/>
+
+  <!-- Sidebar nav items -->
+  <!-- Users -->
+  <rect x="0" y="80" width="240" height="40" fill="transparent"/>
+  <text x="56" y="105" fill="#c6c6c6" font-size="14">Users</text>
+  <rect x="20" y="90" width="20" height="20" fill="#6f6f6f" rx="2"/>
+
+  <!-- Roles -->
+  <rect x="0" y="120" width="240" height="40" fill="transparent"/>
+  <text x="56" y="145" fill="#c6c6c6" font-size="14">Roles</text>
+  <rect x="20" y="130" width="20" height="20" fill="#6f6f6f" rx="2"/>
+
+  <!-- Groups -->
+  <rect x="0" y="160" width="240" height="40" fill="transparent"/>
+  <text x="56" y="185" fill="#c6c6c6" font-size="14">Groups</text>
+  <rect x="20" y="170" width="20" height="20" fill="#6f6f6f" rx="2"/>
+
+  <!-- Tenants -->
+  <rect x="0" y="200" width="240" height="40" fill="transparent"/>
+  <text x="56" y="225" fill="#c6c6c6" font-size="14">Tenants</text>
+  <rect x="20" y="210" width="20" height="20" fill="#6f6f6f" rx="2"/>
+
+  <!-- Authorizations -->
+  <rect x="0" y="240" width="240" height="40" fill="transparent"/>
+  <text x="56" y="265" fill="#c6c6c6" font-size="14">Authorizations</text>
+  <rect x="20" y="250" width="20" height="20" fill="#6f6f6f" rx="2"/>
+
+  <!-- Divider -->
+  <line x1="16" y1="296" x2="224" y2="296" stroke="#393939" stroke-width="1"/>
+
+  <!-- MCP Processes — ACTIVE ITEM -->
+  <rect x="0" y="304" width="240" height="40" fill="#0F62FE"/>
+  <!-- MCP icon (simple flow icon) -->
+  <circle cx="30" cy="324" r="6" fill="none" stroke="#ffffff" stroke-width="1.5"/>
+  <line x1="36" y1="324" x2="44" y2="324" stroke="#ffffff" stroke-width="1.5"/>
+  <rect x="28" y="316" width="16" height="16" rx="2" fill="none" stroke="#ffffff" stroke-width="1.5" transform="translate(18,0)"/>
+  <text x="56" y="329" fill="#ffffff" font-size="14" font-weight="600">MCP Processes</text>
+
+  <!-- Operations Log -->
+  <rect x="0" y="344" width="240" height="40" fill="transparent"/>
+  <text x="56" y="369" fill="#c6c6c6" font-size="14">Operations Log</text>
+  <rect x="20" y="354" width="20" height="20" fill="#6f6f6f" rx="2"/>
+
+  <!-- Main Content Area -->
+  <rect x="240" y="48" width="960" height="712" fill="#f4f4f4"/>
+
+  <!-- Page Header -->
+  <rect x="240" y="48" width="960" height="64" fill="#f4f4f4"/>
+  <text x="272" y="84" fill="#161616" font-size="20" font-weight="600">MCP Processes</text>
+  <!-- Docs link -->
+  <text x="272" y="104" fill="#0F62FE" font-size="12">Learn about MCP processes ↗</text>
+
+  <!-- DataTable Container -->
+  <rect x="256" y="128" width="928" height="552" fill="#ffffff" stroke="#e0e0e0" stroke-width="1"/>
+
+  <!-- Toolbar -->
+  <rect x="256" y="128" width="928" height="48" fill="#f4f4f4"/>
+
+  <!-- Search box -->
+  <rect x="272" y="140" width="280" height="28" fill="#ffffff" stroke="#8d8d8d" stroke-width="1"/>
+  <!-- Search icon -->
+  <circle cx="288" cy="154" r="6" fill="none" stroke="#525252" stroke-width="1.5"/>
+  <line x1="292" y1="158" x2="297" y2="163" stroke="#525252" stroke-width="1.5"/>
+  <text x="306" y="159" fill="#8d8d8d" font-size="12">Search by tool name...</text>
+
+  <!-- Table Header Row -->
+  <rect x="256" y="176" width="928" height="40" fill="#e0e0e0"/>
+
+  <!-- Column headers -->
+  <text x="280" y="201" fill="#525252" font-size="12" font-weight="600">Tool Name</text>
+  <line x1="448" y1="176" x2="448" y2="216" stroke="#c6c6c6" stroke-width="1"/>
+  <text x="464" y="201" fill="#525252" font-size="12" font-weight="600">Tool Description</text>
+  <line x1="672" y1="176" x2="672" y2="216" stroke="#c6c6c6" stroke-width="1"/>
+  <text x="688" y="201" fill="#525252" font-size="12" font-weight="600">Process Name</text>
+  <line x1="864" y1="176" x2="864" y2="216" stroke="#c6c6c6" stroke-width="1"/>
+  <text x="880" y="201" fill="#525252" font-size="12" font-weight="600">Version</text>
+  <line x1="952" y1="176" x2="952" y2="216" stroke="#c6c6c6" stroke-width="1"/>
+  <text x="968" y="201" fill="#525252" font-size="12" font-weight="600">Tenant</text>
+  <!-- Sort indicator on Tool Name -->
+  <polygon points="432,195 437,202 442,195" fill="#525252"/>
+
+  <!-- Row 1 (white) -->
+  <rect x="256" y="216" width="928" height="48" fill="#ffffff"/>
+  <text x="280" y="246" fill="#161616" font-size="13" font-weight="500">orderApproval</text>
+  <line x1="448" y1="216" x2="448" y2="264" stroke="#e0e0e0" stroke-width="1"/>
+  <text x="464" y="246" fill="#525252" font-size="13">Approves a purchase order up to the defined limit</text>
+  <line x1="672" y1="216" x2="672" y2="264" stroke="#e0e0e0" stroke-width="1"/>
+  <text x="688" y="246" fill="#525252" font-size="13">Order Approval Process</text>
+  <line x1="864" y1="216" x2="864" y2="264" stroke="#e0e0e0" stroke-width="1"/>
+  <text x="880" y="246" fill="#525252" font-size="13">3</text>
+  <line x1="952" y1="216" x2="952" y2="264" stroke="#e0e0e0" stroke-width="1"/>
+  <text x="968" y="246" fill="#525252" font-size="13">&lt;default&gt;</text>
+  <line x1="256" y1="264" x2="1184" y2="264" stroke="#e0e0e0" stroke-width="1"/>
+
+  <!-- Row 2 (light grey) -->
+  <rect x="256" y="264" width="928" height="48" fill="#f4f4f4"/>
+  <text x="280" y="294" fill="#161616" font-size="13" font-weight="500">sendCustomerNotification</text>
+  <line x1="448" y1="264" x2="448" y2="312" stroke="#e0e0e0" stroke-width="1"/>
+  <text x="464" y="294" fill="#525252" font-size="13">Sends a notification email to the specified customer</text>
+  <line x1="672" y1="264" x2="672" y2="312" stroke="#e0e0e0" stroke-width="1"/>
+  <text x="688" y="294" fill="#525252" font-size="13">Customer Notification</text>
+  <line x1="864" y1="264" x2="864" y2="312" stroke="#e0e0e0" stroke-width="1"/>
+  <text x="880" y="294" fill="#525252" font-size="13">1</text>
+  <line x1="952" y1="264" x2="952" y2="312" stroke="#e0e0e0" stroke-width="1"/>
+  <text x="968" y="294" fill="#525252" font-size="13">&lt;default&gt;</text>
+  <line x1="256" y1="312" x2="1184" y2="312" stroke="#e0e0e0" stroke-width="1"/>
+
+  <!-- Row 3 (white) -->
+  <rect x="256" y="312" width="928" height="48" fill="#ffffff"/>
+  <text x="280" y="342" fill="#161616" font-size="13" font-weight="500">generateInvoice</text>
+  <line x1="448" y1="312" x2="448" y2="360" stroke="#e0e0e0" stroke-width="1"/>
+  <text x="464" y="342" fill="#525252" font-size="13">Creates and sends an invoice for a completed order</text>
+  <line x1="672" y1="312" x2="672" y2="360" stroke="#e0e0e0" stroke-width="1"/>
+  <text x="688" y="342" fill="#525252" font-size="13">Invoice Generation</text>
+  <line x1="864" y1="312" x2="864" y2="360" stroke="#e0e0e0" stroke-width="1"/>
+  <text x="880" y="342" fill="#525252" font-size="13">2</text>
+  <line x1="952" y1="312" x2="952" y2="360" stroke="#e0e0e0" stroke-width="1"/>
+  <text x="968" y="342" fill="#525252" font-size="13">acme-corp</text>
+  <line x1="256" y1="360" x2="1184" y2="360" stroke="#e0e0e0" stroke-width="1"/>
+
+  <!-- Row 4 (light grey) -->
+  <rect x="256" y="360" width="928" height="48" fill="#f4f4f4"/>
+  <text x="280" y="390" fill="#161616" font-size="13" font-weight="500">scheduleDelivery</text>
+  <line x1="448" y1="360" x2="448" y2="408" stroke="#e0e0e0" stroke-width="1"/>
+  <text x="464" y="390" fill="#525252" font-size="13">Schedules a delivery for an order at the given address</text>
+  <line x1="672" y1="360" x2="672" y2="408" stroke="#e0e0e0" stroke-width="1"/>
+  <text x="688" y="390" fill="#525252" font-size="13">Delivery Scheduling</text>
+  <line x1="864" y1="360" x2="864" y2="408" stroke="#e0e0e0" stroke-width="1"/>
+  <text x="880" y="390" fill="#525252" font-size="13">1</text>
+  <line x1="952" y1="360" x2="952" y2="408" stroke="#e0e0e0" stroke-width="1"/>
+  <text x="968" y="390" fill="#525252" font-size="13">acme-corp</text>
+  <line x1="256" y1="408" x2="1184" y2="408" stroke="#e0e0e0" stroke-width="1"/>
+
+  <!-- Row 5 (white) -->
+  <rect x="256" y="408" width="928" height="48" fill="#ffffff"/>
+  <text x="280" y="438" fill="#161616" font-size="13" font-weight="500">escalateIncident</text>
+  <line x1="448" y1="408" x2="448" y2="456" stroke="#e0e0e0" stroke-width="1"/>
+  <text x="464" y="438" fill="#525252" font-size="13">Escalates a support incident to the operations team</text>
+  <line x1="672" y1="408" x2="672" y2="456" stroke="#e0e0e0" stroke-width="1"/>
+  <text x="688" y="438" fill="#525252" font-size="13">Incident Escalation</text>
+  <line x1="864" y1="408" x2="864" y2="456" stroke="#e0e0e0" stroke-width="1"/>
+  <text x="880" y="438" fill="#525252" font-size="13">4</text>
+  <line x1="952" y1="408" x2="952" y2="456" stroke="#e0e0e0" stroke-width="1"/>
+  <text x="968" y="438" fill="#525252" font-size="13">&lt;default&gt;</text>
+  <line x1="256" y1="456" x2="1184" y2="456" stroke="#e0e0e0" stroke-width="1"/>
+
+  <!-- Pagination area -->
+  <rect x="256" y="648" width="928" height="32" fill="#f4f4f4" stroke="#e0e0e0" stroke-width="1"/>
+  <text x="272" y="668" fill="#525252" font-size="12">Items per page:</text>
+  <text x="384" y="668" fill="#161616" font-size="12" font-weight="500">10 ▾</text>
+  <text x="432" y="668" fill="#525252" font-size="12">|</text>
+  <text x="448" y="668" fill="#525252" font-size="12">1–10 of 5 items</text>
+  <!-- Pagination buttons (right-aligned) -->
+  <text x="1080" y="668" fill="#8d8d8d" font-size="12">◀</text>
+  <text x="1100" y="668" fill="#8d8d8d" font-size="12">▶</text>
+
+  <!-- Empty rows hint -->
+  <text x="280" y="516" fill="#8d8d8d" font-size="12" font-style="italic">Showing processes with MCP start events, filtered from /v2/message-subscriptions/search</text>
+
+  <!-- Annotation callout 1: Search API note -->
+  <rect x="680" y="136" width="340" height="32" fill="#e5f6ff" stroke="#0F62FE" stroke-width="1" rx="2"/>
+  <text x="692" y="152" fill="#0043ce" font-size="11" font-weight="500">Queries /v2/message-subscriptions/search (messageSubscriptionType=START_EVENT_SUBSCRIPTION)</text>
+
+  <!-- Annotation callout 2: Extension properties note -->
+  <rect x="440" y="220" width="8" height="8" fill="#0F62FE" rx="1"/>
+  <line x1="444" y1="228" x2="444" y2="252" stroke="#0F62FE" stroke-width="1" stroke-dasharray="3,2"/>
+  <rect x="256" y="692" width="500" height="28" fill="#fff8e1" stroke="#f1c21b" stroke-width="1" rx="2"/>
+  <text x="268" y="710" fill="#8a6000" font-size="11">Tool Name and Description are read from extensionProperties (set by the MCP start event element template)</text>
+</svg>


### PR DESCRIPTION
## Summary

- Adds a Carbon Design System style SVG mockup for the new MCP Processes view in the Orchestration Cluster Admin webapp
- The mockup is referenced in the feature issue https://github.com/camunda/camunda/issues/51241

## Test plan

- [ ] Mockup image renders correctly when viewed via the raw GitHub URL referenced in the issue



https://claude.ai/code/session_016ZqGm2XzPjpsQKW3ShE9ZK