### PR TITLE
[Backport stable/8.8] ci: configure load tests to log as JSON

### DIFF
--- a/zeebe/benchmarks/camunda-platform-values.yaml
+++ b/zeebe/benchmarks/camunda-platform-values.yaml
@@ -59,6 +59,10 @@ identity:
     secret:
       existingSecret: camunda-credentials
       existingSecretKey: identity-firstuser-password
+  env:
+    # https://docs.camunda.io/docs/self-managed/components/management-identity/miscellaneous/configuration-variables/#google-stackdriver-json-logging
+    - name: IDENTITY_LOG_APPENDER
+      value: Stackdriver
   tolerations:
     - key: nodepool
       operator: Equal
@@ -75,6 +79,10 @@ optimize:
         ttl: 'P1D'
         processDataCleanup:
           enabled: true
+  env:
+    # https://docs.camunda.io/docs/self-managed/components/optimize/configuration/logging/#google-stackdriver-json-logging
+    - name: OPTIMIZE_LOG_APPENDER
+      value: Stackdriver
   nodeSelector:
     component: benchmark-n2-standard-4
     topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
@@ -95,6 +103,10 @@ identityKeycloak:
       operator: Equal
       value: n2-standard-4
       effect: NoSchedule
+  extraEnvVars:
+    # https://www.keycloak.org/server/logging#_console
+    - name: KC_LOG_CONSOLE_OUTPUT
+      value: json
 
 connectors:
   enabled: true
@@ -106,6 +118,10 @@ connectors:
         secret:
           existingSecret: camunda-credentials
           existingSecretKey: connectors-security-authentication-oidc-secret
+  env:
+    # https://docs.camunda.io/docs/self-managed/components/connectors/connectors-configuration/#google-stackdriver-json-logging
+    - name: CONNECTORS_LOG_APPENDER
+      value: stackdriver
   tolerations:
     - key: nodepool
       operator: Equal

--- a/zeebe/benchmarks/prometheus-elasticsearch-exporter-values.yaml
+++ b/zeebe/benchmarks/prometheus-elasticsearch-exporter-values.yaml
@@ -7,6 +7,9 @@ image:
   # Set your specific exporter version here
   tag: "v1.10.0"
 
+log:
+  format: json
+
 serviceMonitor:
   ## If true, a ServiceMonitor CRD is created for a prometheus operator
   ## https://github.com/coreos/prometheus-operator


### PR DESCRIPTION
⤵️ Backport of #51220 → `stable/8.8`

relates to camunda/camunda#51170

Recreated from https://github.com/camunda/camunda/pull/51238, which I can't reopen

---
<sub><img src="https://avatars.githubusercontent.com/u/97796249?s=16" width="16" height="16" align="absmiddle"> Created by <a href="https://github.com/korthout/backport-action">backport-action</a></sub>