### PR TITLE
refactor: move load test client-specific configuration to the same location

### DIFF
--- a/load-tests/load-test-values.yaml
+++ b/load-tests/load-test-values.yaml
@@ -1,4 +1,9 @@
 global:
+  image:
+    repository: registry.camunda.cloud/team-zeebe
+    pullSecrets:
+      - name: harbor-registry
+
   preferRest:
     enabled: true
 

--- a/load-tests/setup/default/Makefile
+++ b/load-tests/setup/default/Makefile
@@ -13,7 +13,7 @@ additional_platform_configuration ?=
 # Optional: additional Helm configuration for the load test release.
 # Use this to pass extra `--set`/`-f` flags when installing/upgrading the load tests.
 # See the load test README for example values and guidance.
-additional_load_test_configuration ?= --set global.image.repository=registry.camunda.cloud/team-zeebe --set global.image.pullSecrets[0].name=harbor-registry
+additional_load_test_configuration ?=
 
 helm_chart_platform := camunda-platform-helm/charts/$(helm_chart)
 helm_chart_load_tests := camunda-load-tests/camunda-load-tests


### PR DESCRIPTION
## Description

Keep the configuration experience consitent by having all the configuration in the YAML file

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
