### PR TITLE
feat: enhance stale backport tracker with Slack mentions and hourly updates

### DIFF
--- a/.ci/scripts/stale-backport-scripts/format-slack-report.sh
+++ b/.ci/scripts/stale-backport-scripts/format-slack-report.sh
@@ -182,37 +182,14 @@ while IFS= read -r repo_name; do
       ] | join("\n"))
     ')
 
-    # Resolve author avatar for section accessory
-    author_login=$(echo "$group" | jq -r '.original_pr_author // "unknown"')
-    author_name=$(echo "$group" | jq -r '.original_pr_author_name // ""')
-    map_entry=$(jq -c --arg login "$author_login" --arg name "$author_name" \
-      '(.[$login] // .[$name] // null) | if type == "string" then {slack_id: .} else . end' \
-      "$TMPDIR_WORK/slack_user_map.json" 2>/dev/null || echo 'null')
-    avatar_url=$(echo "$map_entry" | jq -r '.avatar_url // .image_48 // empty' 2>/dev/null || true)
-    if [[ -z "$avatar_url" && "$author_login" != app/* && "$author_login" != "unknown" ]]; then
-      avatar_url="https://github.com/${author_login}.png?size=24"
-    fi
-
     if [[ "$USE_GROUP_DIVIDERS" == "true" ]]; then
-      if [[ -n "$avatar_url" ]]; then
-        jq -c --arg text "$section_text" --arg avatar "$avatar_url" --arg alt "${author_name:-$author_login}" \
-          '. + [{type: "divider"}, {type: "section", text: {type: "mrkdwn", text: $text}, accessory: {type: "image", image_url: $avatar, alt_text: $alt}}]' \
-          "$TMPDIR_WORK/blocks.json" > "$TMPDIR_WORK/blocks_tmp.json" && mv "$TMPDIR_WORK/blocks_tmp.json" "$TMPDIR_WORK/blocks.json"
-      else
-        jq -c --arg text "$section_text" \
-          '. + [{type: "divider"}, {type: "section", text: {type: "mrkdwn", text: $text}}]' \
-          "$TMPDIR_WORK/blocks.json" > "$TMPDIR_WORK/blocks_tmp.json" && mv "$TMPDIR_WORK/blocks_tmp.json" "$TMPDIR_WORK/blocks.json"
-      fi
+      jq -c --arg text "$section_text" \
+        '. + [{type: "divider"}, {type: "section", text: {type: "mrkdwn", text: $text}}]' \
+        "$TMPDIR_WORK/blocks.json" > "$TMPDIR_WORK/blocks_tmp.json" && mv "$TMPDIR_WORK/blocks_tmp.json" "$TMPDIR_WORK/blocks.json"
     else
-      if [[ -n "$avatar_url" ]]; then
-        jq -c --arg text "$section_text" --arg avatar "$avatar_url" --arg alt "${author_name:-$author_login}" \
-          '. + [{type: "section", text: {type: "mrkdwn", text: ("── ── ── ── ──\n" + $text)}, accessory: {type: "image", image_url: $avatar, alt_text: $alt}}]' \
-          "$TMPDIR_WORK/blocks.json" > "$TMPDIR_WORK/blocks_tmp.json" && mv "$TMPDIR_WORK/blocks_tmp.json" "$TMPDIR_WORK/blocks.json"
-      else
-        jq -c --arg text "$section_text" \
-          '. + [{type: "section", text: {type: "mrkdwn", text: ("── ── ── ── ──\n" + $text)}}]' \
-          "$TMPDIR_WORK/blocks.json" > "$TMPDIR_WORK/blocks_tmp.json" && mv "$TMPDIR_WORK/blocks_tmp.json" "$TMPDIR_WORK/blocks.json"
-      fi
+      jq -c --arg text "$section_text" \
+        '. + [{type: "section", text: {type: "mrkdwn", text: ("── ── ── ── ──\n" + $text)}}]' \
+        "$TMPDIR_WORK/blocks.json" > "$TMPDIR_WORK/blocks_tmp.json" && mv "$TMPDIR_WORK/blocks_tmp.json" "$TMPDIR_WORK/blocks.json"
     fi
   done
   fi

--- a/.ci/scripts/stale-backport-scripts/format-slack-report.sh
+++ b/.ci/scripts/stale-backport-scripts/format-slack-report.sh
@@ -194,29 +194,25 @@ while IFS= read -r repo_name; do
       else empty end
     ' "$TMPDIR_WORK/slack_user_map.json" 2>/dev/null || true)
     if [[ -z "$avatar_url" && "$author_login" != app/* && "$author_login" != "unknown" ]]; then
-      avatar_url="https://github.com/${author_login}.png?size=48"
+      avatar_url="https://github.com/${author_login}.png?size=24"
     fi
 
     if [[ "$USE_GROUP_DIVIDERS" == "true" ]]; then
-      if [[ -n "$avatar_url" ]]; then
-        jq -c --arg text "$section_text" --arg avatar "$avatar_url" \
-          '. + [{type: "divider"}, {type: "section", text: {type: "mrkdwn", text: $text}, accessory: {type: "image", image_url: $avatar, alt_text: "author"}}]' \
-          "$TMPDIR_WORK/blocks.json" > "$TMPDIR_WORK/blocks_tmp.json" && mv "$TMPDIR_WORK/blocks_tmp.json" "$TMPDIR_WORK/blocks.json"
-      else
-        jq -c --arg text "$section_text" \
-          '. + [{type: "divider"}, {type: "section", text: {type: "mrkdwn", text: $text}}]' \
-          "$TMPDIR_WORK/blocks.json" > "$TMPDIR_WORK/blocks_tmp.json" && mv "$TMPDIR_WORK/blocks_tmp.json" "$TMPDIR_WORK/blocks.json"
-      fi
+      jq -c --arg text "$section_text" \
+        '. + [{type: "divider"}, {type: "section", text: {type: "mrkdwn", text: $text}}]' \
+        "$TMPDIR_WORK/blocks.json" > "$TMPDIR_WORK/blocks_tmp.json" && mv "$TMPDIR_WORK/blocks_tmp.json" "$TMPDIR_WORK/blocks.json"
     else
-      if [[ -n "$avatar_url" ]]; then
-        jq -c --arg text "$section_text" --arg avatar "$avatar_url" \
-          '. + [{type: "section", text: {type: "mrkdwn", text: ("── ── ── ── ──\n" + $text)}, accessory: {type: "image", image_url: $avatar, alt_text: "author"}}]' \
-          "$TMPDIR_WORK/blocks.json" > "$TMPDIR_WORK/blocks_tmp.json" && mv "$TMPDIR_WORK/blocks_tmp.json" "$TMPDIR_WORK/blocks.json"
-      else
-        jq -c --arg text "$section_text" \
-          '. + [{type: "section", text: {type: "mrkdwn", text: ("── ── ── ── ──\n" + $text)}}]' \
-          "$TMPDIR_WORK/blocks.json" > "$TMPDIR_WORK/blocks_tmp.json" && mv "$TMPDIR_WORK/blocks_tmp.json" "$TMPDIR_WORK/blocks.json"
-      fi
+      jq -c --arg text "$section_text" \
+        '. + [{type: "section", text: {type: "mrkdwn", text: ("── ── ── ── ──\n" + $text)}}]' \
+        "$TMPDIR_WORK/blocks.json" > "$TMPDIR_WORK/blocks_tmp.json" && mv "$TMPDIR_WORK/blocks_tmp.json" "$TMPDIR_WORK/blocks.json"
+    fi
+
+    # Add author avatar as a small context block below the section
+    if [[ -n "$avatar_url" ]]; then
+      display_label="${author_name:-$author_login}"
+      jq -c --arg avatar "$avatar_url" --arg label "$display_label" \
+        '. + [{type: "context", elements: [{type: "image", image_url: $avatar, alt_text: $label}, {type: "mrkdwn", text: $label}]}]' \
+        "$TMPDIR_WORK/blocks.json" > "$TMPDIR_WORK/blocks_tmp.json" && mv "$TMPDIR_WORK/blocks_tmp.json" "$TMPDIR_WORK/blocks.json"
     fi
   done
   fi
@@ -224,12 +220,13 @@ done < "$TMPDIR_WORK/repo_list.txt"
 
 # Legend + footer
 # Slack enforces a hard limit of 50 blocks per message. Trim excess content blocks first.
-# With group dividers: pre-verified to fit in 50, no truncation notice slot needed (limit=47).
-# Without group dividers: reserve 1 slot for the truncation notice section (limit=46).
+# Each PR group uses 1-2 blocks (section + optional context for avatar), plus dividers if enabled.
+# With group dividers: limit=45 (conservative for avatar context blocks).
+# Without group dividers: limit=44 (reserve slots for truncation notice + footer).
 if [[ "$USE_GROUP_DIVIDERS" == "true" ]]; then
-  CONTENT_LIMIT=47
+  CONTENT_LIMIT=45
 else
-  CONTENT_LIMIT=46
+  CONTENT_LIMIT=44
 fi
 content_count=$(jq 'length' "$TMPDIR_WORK/blocks.json")
 if [[ "$content_count" -gt "$CONTENT_LIMIT" ]]; then

--- a/.ci/scripts/stale-backport-scripts/format-slack-report.sh
+++ b/.ci/scripts/stale-backport-scripts/format-slack-report.sh
@@ -15,6 +15,7 @@
 #                        GitHub login keys are preferred (reliable); real-name keys also supported for backward compat.
 #   SLACK_USER_MAP_FILE - Alternative to SLACK_USER_MAP: path to a JSON file with the same format.
 #                        If both are set, SLACK_USER_MAP_FILE takes precedence.
+#   SLACK_USER_MAP_FALLBACK - If "true", shows a warning that the user map artifact was not accessible.
 
 set -euo pipefail
 
@@ -97,6 +98,12 @@ jq -c --arg header "⏰ *Stale Backport PRs*${branch_header}  ·  _Updated ${upd
 jq -c --argjson total "$total_prs" --argjson groups "$total_groups" --argjson repos "$repo_count" \
   '. + [{type: "section", text: {type: "mrkdwn", text: ("Found *\($total)* stale backport PR(s) across *\($groups)* original PR(s) in *\($repos)* repo(s)")}}]' \
   "$TMPDIR_WORK/blocks.json" > "$TMPDIR_WORK/blocks_tmp.json" && mv "$TMPDIR_WORK/blocks_tmp.json" "$TMPDIR_WORK/blocks.json"
+
+# Warning when user map artifact was not accessible
+if [[ "${SLACK_USER_MAP_FALLBACK:-}" == "true" ]]; then
+  jq -c '. + [{type: "context", elements: [{type: "mrkdwn", text: "⚠️ _GitHub-Slack user map not available — author names shown as GitHub usernames instead of Slack mentions. cc <!subteam^S09E9P9TPAA|@monorepo-devops-team>_"}]}]' \
+    "$TMPDIR_WORK/blocks.json" > "$TMPDIR_WORK/blocks_tmp.json" && mv "$TMPDIR_WORK/blocks_tmp.json" "$TMPDIR_WORK/blocks.json"
+fi
 
 # Build the list of repos to show: union of repos in data + REPOSITORIES env var
 jq -n --arg repos "$REPOSITORIES" --argjson data "$(jq -c '[.[].repository // "unknown"] | unique' "$TMPDIR_WORK/stale_data.json")" '

--- a/.ci/scripts/stale-backport-scripts/format-slack-report.sh
+++ b/.ci/scripts/stale-backport-scripts/format-slack-report.sh
@@ -101,7 +101,7 @@ jq -c --argjson total "$total_prs" --argjson groups "$total_groups" --argjson re
 
 # Warning when user map artifact was not accessible
 if [[ "${SLACK_USER_MAP_FALLBACK:-}" == "true" ]]; then
-  jq -c '. + [{type: "context", elements: [{type: "mrkdwn", text: "⚠️ _GitHub-Slack user map not available — author names shown as GitHub usernames instead of Slack mentions. cc <!subteam^S09E9P9TPAA|@monorepo-devops-team>_"}]}]' \
+  jq -c '. + [{type: "context", elements: [{type: "mrkdwn", text: "⚠️ _GitHub-Slack user map not available — author names shown as GitHub logins/real names instead of Slack mentions. cc <!subteam^S09E9P9TPAA|@monorepo-devops-team>_"}]}]' \
     "$TMPDIR_WORK/blocks.json" > "$TMPDIR_WORK/blocks_tmp.json" && mv "$TMPDIR_WORK/blocks_tmp.json" "$TMPDIR_WORK/blocks.json"
 fi
 

--- a/.ci/scripts/stale-backport-scripts/format-slack-report.sh
+++ b/.ci/scripts/stale-backport-scripts/format-slack-report.sh
@@ -202,6 +202,40 @@ while IFS= read -r repo_name; do
   fi
 done < "$TMPDIR_WORK/repo_list.txt"
 
+# Collect GitHub usernames that could not be resolved to Slack IDs.
+# Only meaningful when we actually have a user map (not in fallback mode).
+if [[ "${SLACK_USER_MAP_FALLBACK:-}" != "true" ]]; then
+  jq -r --slurpfile slack_map "$TMPDIR_WORK/slack_user_map.json" '
+    ($slack_map[0] | with_entries(
+      if (.value | type) == "string" then .value = {slack_id: .value}
+      else . end
+    )) as $smap |
+    def has_slack(login; name):
+      ($smap[login] // null) // (if name then $smap[name] // null else null end) | . != null;
+    [
+      .[] |
+      # Non-bot PR authors
+      (if ((.original_pr_author // "") | test("^app/") | not) and ((.original_pr_author // "") != "") then
+        {username: .original_pr_author, name: (.original_pr_author_name // null)}
+      else empty end),
+      # Bot PR approvers
+      (if (.original_pr_author // "") | test("^app/") then
+        (.original_pr_approver_names // [])[]
+      else empty end)
+    ] |
+    [.[] | select(.username != null and .username != "") | select(has_slack(.username; .name) | not) | .username] |
+    unique | .[]
+  ' "$TMPDIR_WORK/stale_data.json" > "$TMPDIR_WORK/unresolved_users.txt"
+
+  if [[ -s "$TMPDIR_WORK/unresolved_users.txt" ]]; then
+    # Format as comma-separated backtick-wrapped list
+    unresolved_list=$(sed 's/.*/ `&`/' "$TMPDIR_WORK/unresolved_users.txt" | paste -s -d',' -)
+    jq -c --arg users "$unresolved_list" \
+      '. + [{type: "context", elements: [{type: "mrkdwn", text: ("⚠️ _Could not resolve GitHub → Slack for: " + $users + ". These users either need to add or if its already present, remove and re-add their GitHub handle in Okta to sync it to Slack. See <https://camunda.slack.com/archives/C08F5RD5X8B/p1776240827921619|instructions>._")}]}]' \
+      "$TMPDIR_WORK/blocks.json" > "$TMPDIR_WORK/blocks_tmp.json" && mv "$TMPDIR_WORK/blocks_tmp.json" "$TMPDIR_WORK/blocks.json"
+  fi
+fi
+
 # Legend + footer
 # Slack enforces a hard limit of 50 blocks per message. Trim excess content blocks first.
 # Each PR group uses 1 block (section with optional image accessory), plus dividers if enabled.

--- a/.ci/scripts/stale-backport-scripts/format-slack-report.sh
+++ b/.ci/scripts/stale-backport-scripts/format-slack-report.sh
@@ -9,7 +9,12 @@
 #   GITHUB_REPOSITORY  - owner/repo (for workflow link, defaults to camunda/camunda)
 #   GITHUB_RUN_ID      - workflow run ID (for workflow link)
 #   TARGET_BRANCH      - if set, shows in the header
-#   SLACK_USER_MAP     - JSON mapping of real names to Slack user IDs (e.g. '{"Peter Szabo": "U09B7CWMX4P"}')
+#   SLACK_USER_MAP      - JSON mapping keyed by GitHub login or real name to Slack user info. Supports two formats:
+#                        Simple:  '{"szpraat": "U09B7CWMX4P"}'
+#                        Rich:    '{"szpraat": {"slack_id": "U09B7CWMX4P", "avatar_url": "https://..."}}'
+#                        GitHub login keys are preferred (reliable); real-name keys also supported for backward compat.
+#   SLACK_USER_MAP_FILE - Alternative to SLACK_USER_MAP: path to a JSON file with the same format.
+#                        If both are set, SLACK_USER_MAP_FILE takes precedence.
 
 set -euo pipefail
 
@@ -19,7 +24,9 @@ GITHUB_RUN_ID="${GITHUB_RUN_ID:-}"
 REPOSITORIES="${REPOSITORIES:-}"
 
 # Default to empty JSON object if no Slack user map provided
-if [[ -z "${SLACK_USER_MAP:-}" ]]; then
+if [[ -n "${SLACK_USER_MAP_FILE:-}" && -f "${SLACK_USER_MAP_FILE}" ]]; then
+  SLACK_USER_MAP=$(cat "$SLACK_USER_MAP_FILE")
+elif [[ -z "${SLACK_USER_MAP:-}" ]]; then
   SLACK_USER_MAP='{}'
 fi
 
@@ -130,7 +137,15 @@ while IFS= read -r repo_name; do
     jq -c --arg repo "$repo_name" '[.[] | select((.repository // "unknown") == $repo)] | .[]' "$TMPDIR_WORK/stale_data.json" | while IFS= read -r group; do
     # Build section text for this group in jq (safe from shell escaping)
     section_text=$(echo "$group" | jq -r --slurpfile slack_map "$TMPDIR_WORK/slack_user_map.json" '
-      $slack_map[0] as $smap |
+      # Normalize map: support both simple ("key": "UID") and rich ("key": {"slack_id": "UID", ...}) formats
+      ($slack_map[0] | with_entries(
+        if (.value | type) == "string" then .value = {slack_id: .value}
+        else . end
+      )) as $smap |
+      # Lookup by GitHub login first, then by real name (backward compat)
+      def slack_entry_for(login; name):
+        ($smap[login] // null) // (if name then $smap[name] // null else null end);
+      def slack_id_for(login; name): (slack_entry_for(login; name) | .slack_id // null);
       # Author display: for bot-authored PRs show bot name + approvers; otherwise <@USLACKID>, @RealName, or GitHub username
       (
         if (.original_pr_author // "") | test("^app/") then
@@ -138,15 +153,15 @@ while IFS= read -r repo_name; do
           ("🤖 \(.original_pr_author)" +
           (if (.original_pr_approver_names // []) | length > 0 then
             ", reviewed by " + ([.original_pr_approver_names[] |
-              if .name and ($smap[.name] // null) then "<@\($smap[.name])>"
+              if slack_id_for(.username; .name) then "<@\(slack_id_for(.username; .name))>"
               elif .name then "@\(.name)"
               else "@\(.username)" end
             ] | join(", "))
           else
             ""
           end))
-        elif .original_pr_author_name and $smap[.original_pr_author_name] then
-          "<@\($smap[.original_pr_author_name])>"
+        elif slack_id_for(.original_pr_author; .original_pr_author_name) then
+          "<@\(slack_id_for(.original_pr_author; .original_pr_author_name))>"
         elif .original_pr_author_name then
           "@\(.original_pr_author_name)"
         else
@@ -160,7 +175,7 @@ while IFS= read -r repo_name; do
         ":pull-request-merged: <\(.original_pr_url)|#\(.original_pr_number // "?")> \(.original_pr_title // "Unknown" | if length > 60 then .[:57] + "..." else . end)"
       else
         ":pull-request-merged: #\(.original_pr_number // "?") — \(.original_pr_title // "Unknown" | if length > 60 then .[:57] + "..." else . end)"
-      end) + "  · 👤 \($author_display)\n" +
+      end) + "  · \($author_display)\n" +
       "*Stale backports:*\n" +
       ([.backport_prs[] |
         (if .age_days > 0 then "\(.age_days)d \(.age_hours % 24)h" else "\(.age_hours)h \((.age_minutes // 0) % 60)m" end) as $age |
@@ -170,14 +185,38 @@ while IFS= read -r repo_name; do
       ] | join("\n"))
     ')
 
+    # Resolve author avatar: Slack avatar from map > GitHub avatar > none
+    author_login=$(echo "$group" | jq -r '.original_pr_author // "unknown"')
+    author_name=$(echo "$group" | jq -r '.original_pr_author_name // ""')
+    avatar_url=$(jq -r --arg login "$author_login" --arg name "$author_name" '
+      (.[$login] // .[$name] // null) |
+      if type == "object" then (.avatar_url // .image_48 // empty)
+      else empty end
+    ' "$TMPDIR_WORK/slack_user_map.json" 2>/dev/null || true)
+    if [[ -z "$avatar_url" && "$author_login" != app/* && "$author_login" != "unknown" ]]; then
+      avatar_url="https://github.com/${author_login}.png?size=48"
+    fi
+
     if [[ "$USE_GROUP_DIVIDERS" == "true" ]]; then
-      jq -c --arg text "$section_text" \
-        '. + [{type: "divider"}, {type: "section", text: {type: "mrkdwn", text: $text}}]' \
-        "$TMPDIR_WORK/blocks.json" > "$TMPDIR_WORK/blocks_tmp.json" && mv "$TMPDIR_WORK/blocks_tmp.json" "$TMPDIR_WORK/blocks.json"
+      if [[ -n "$avatar_url" ]]; then
+        jq -c --arg text "$section_text" --arg avatar "$avatar_url" \
+          '. + [{type: "divider"}, {type: "section", text: {type: "mrkdwn", text: $text}, accessory: {type: "image", image_url: $avatar, alt_text: "author"}}]' \
+          "$TMPDIR_WORK/blocks.json" > "$TMPDIR_WORK/blocks_tmp.json" && mv "$TMPDIR_WORK/blocks_tmp.json" "$TMPDIR_WORK/blocks.json"
+      else
+        jq -c --arg text "$section_text" \
+          '. + [{type: "divider"}, {type: "section", text: {type: "mrkdwn", text: $text}}]' \
+          "$TMPDIR_WORK/blocks.json" > "$TMPDIR_WORK/blocks_tmp.json" && mv "$TMPDIR_WORK/blocks_tmp.json" "$TMPDIR_WORK/blocks.json"
+      fi
     else
-      jq -c --arg text "$section_text" \
-        '. + [{type: "section", text: {type: "mrkdwn", text: ("── ── ── ── ──\n" + $text)}}]' \
-        "$TMPDIR_WORK/blocks.json" > "$TMPDIR_WORK/blocks_tmp.json" && mv "$TMPDIR_WORK/blocks_tmp.json" "$TMPDIR_WORK/blocks.json"
+      if [[ -n "$avatar_url" ]]; then
+        jq -c --arg text "$section_text" --arg avatar "$avatar_url" \
+          '. + [{type: "section", text: {type: "mrkdwn", text: ("── ── ── ── ──\n" + $text)}, accessory: {type: "image", image_url: $avatar, alt_text: "author"}}]' \
+          "$TMPDIR_WORK/blocks.json" > "$TMPDIR_WORK/blocks_tmp.json" && mv "$TMPDIR_WORK/blocks_tmp.json" "$TMPDIR_WORK/blocks.json"
+      else
+        jq -c --arg text "$section_text" \
+          '. + [{type: "section", text: {type: "mrkdwn", text: ("── ── ── ── ──\n" + $text)}}]' \
+          "$TMPDIR_WORK/blocks.json" > "$TMPDIR_WORK/blocks_tmp.json" && mv "$TMPDIR_WORK/blocks_tmp.json" "$TMPDIR_WORK/blocks.json"
+      fi
     fi
   done
   fi

--- a/.ci/scripts/stale-backport-scripts/format-slack-report.sh
+++ b/.ci/scripts/stale-backport-scripts/format-slack-report.sh
@@ -159,13 +159,20 @@ while IFS= read -r repo_name; do
         else "" end)
       else "" end) as $bot_info |
 
-      # Header with original PR
+      # Header with original PR — author mention inline for non-bot PRs
       "*Original PR:* " +
       (if .original_pr_url != "" then
         ":pull-request-merged: <\(.original_pr_url)|#\(.original_pr_number // "?")> \(.original_pr_title // "Unknown" | if length > 60 then .[:57] + "..." else . end)"
       else
         ":pull-request-merged: #\(.original_pr_number // "?") — \(.original_pr_title // "Unknown" | if length > 60 then .[:57] + "..." else . end)"
-      end) + (if $bot_info != "" then "  · \($bot_info)" else "" end) + "\n" +
+      end) + (if $bot_info != "" then "  · \($bot_info)"
+      else
+        (slack_id_for(.original_pr_author // ""; .original_pr_author_name // null)) as $sid |
+        if $sid then "  <@\($sid)>"
+        elif ((.original_pr_author_name // "") != "") then "  @\(.original_pr_author_name)"
+        elif ((.original_pr_author // "") != "") then "  \(.original_pr_author)"
+        else "" end
+      end) + "\n" +
       "*Stale backports:*\n" +
       ([.backport_prs[] |
         (if .age_days > 0 then "\(.age_days)d \(.age_hours % 24)h" else "\(.age_hours)h \((.age_minutes // 0) % 60)m" end) as $age |
@@ -175,46 +182,37 @@ while IFS= read -r repo_name; do
       ] | join("\n"))
     ')
 
-    # Resolve author info for context block: avatar + Slack mention
+    # Resolve author avatar for section accessory
     author_login=$(echo "$group" | jq -r '.original_pr_author // "unknown"')
     author_name=$(echo "$group" | jq -r '.original_pr_author_name // ""')
     map_entry=$(jq -c --arg login "$author_login" --arg name "$author_name" \
       '(.[$login] // .[$name] // null) | if type == "string" then {slack_id: .} else . end' \
       "$TMPDIR_WORK/slack_user_map.json" 2>/dev/null || echo 'null')
-    slack_id=$(echo "$map_entry" | jq -r '.slack_id // empty' 2>/dev/null || true)
     avatar_url=$(echo "$map_entry" | jq -r '.avatar_url // .image_48 // empty' 2>/dev/null || true)
     if [[ -z "$avatar_url" && "$author_login" != app/* && "$author_login" != "unknown" ]]; then
       avatar_url="https://github.com/${author_login}.png?size=24"
     fi
 
-    # Build author mention text for context block
-    if [[ -n "$slack_id" ]]; then
-      author_mention="<@${slack_id}>"
-    elif [[ -n "$author_name" ]]; then
-      author_mention="@${author_name}"
-    else
-      author_mention="${author_login}"
-    fi
-
     if [[ "$USE_GROUP_DIVIDERS" == "true" ]]; then
-      jq -c --arg text "$section_text" \
-        '. + [{type: "divider"}, {type: "section", text: {type: "mrkdwn", text: $text}}]' \
-        "$TMPDIR_WORK/blocks.json" > "$TMPDIR_WORK/blocks_tmp.json" && mv "$TMPDIR_WORK/blocks_tmp.json" "$TMPDIR_WORK/blocks.json"
+      if [[ -n "$avatar_url" ]]; then
+        jq -c --arg text "$section_text" --arg avatar "$avatar_url" --arg alt "${author_name:-$author_login}" \
+          '. + [{type: "divider"}, {type: "section", text: {type: "mrkdwn", text: $text}, accessory: {type: "image", image_url: $avatar, alt_text: $alt}}]' \
+          "$TMPDIR_WORK/blocks.json" > "$TMPDIR_WORK/blocks_tmp.json" && mv "$TMPDIR_WORK/blocks_tmp.json" "$TMPDIR_WORK/blocks.json"
+      else
+        jq -c --arg text "$section_text" \
+          '. + [{type: "divider"}, {type: "section", text: {type: "mrkdwn", text: $text}}]' \
+          "$TMPDIR_WORK/blocks.json" > "$TMPDIR_WORK/blocks_tmp.json" && mv "$TMPDIR_WORK/blocks_tmp.json" "$TMPDIR_WORK/blocks.json"
+      fi
     else
-      jq -c --arg text "$section_text" \
-        '. + [{type: "section", text: {type: "mrkdwn", text: ("── ── ── ── ──\n" + $text)}}]' \
-        "$TMPDIR_WORK/blocks.json" > "$TMPDIR_WORK/blocks_tmp.json" && mv "$TMPDIR_WORK/blocks_tmp.json" "$TMPDIR_WORK/blocks.json"
-    fi
-
-    # Add context block with avatar + author mention
-    if [[ -n "$avatar_url" ]]; then
-      jq -c --arg avatar "$avatar_url" --arg mention "$author_mention" --arg alt "${author_name:-$author_login}" \
-        '. + [{type: "context", elements: [{type: "image", image_url: $avatar, alt_text: $alt}, {type: "mrkdwn", text: $mention}]}]' \
-        "$TMPDIR_WORK/blocks.json" > "$TMPDIR_WORK/blocks_tmp.json" && mv "$TMPDIR_WORK/blocks_tmp.json" "$TMPDIR_WORK/blocks.json"
-    else
-      jq -c --arg mention "$author_mention" \
-        '. + [{type: "context", elements: [{type: "mrkdwn", text: $mention}]}]' \
-        "$TMPDIR_WORK/blocks.json" > "$TMPDIR_WORK/blocks_tmp.json" && mv "$TMPDIR_WORK/blocks_tmp.json" "$TMPDIR_WORK/blocks.json"
+      if [[ -n "$avatar_url" ]]; then
+        jq -c --arg text "$section_text" --arg avatar "$avatar_url" --arg alt "${author_name:-$author_login}" \
+          '. + [{type: "section", text: {type: "mrkdwn", text: ("── ── ── ── ──\n" + $text)}, accessory: {type: "image", image_url: $avatar, alt_text: $alt}}]' \
+          "$TMPDIR_WORK/blocks.json" > "$TMPDIR_WORK/blocks_tmp.json" && mv "$TMPDIR_WORK/blocks_tmp.json" "$TMPDIR_WORK/blocks.json"
+      else
+        jq -c --arg text "$section_text" \
+          '. + [{type: "section", text: {type: "mrkdwn", text: ("── ── ── ── ──\n" + $text)}}]' \
+          "$TMPDIR_WORK/blocks.json" > "$TMPDIR_WORK/blocks_tmp.json" && mv "$TMPDIR_WORK/blocks_tmp.json" "$TMPDIR_WORK/blocks.json"
+      fi
     fi
   done
   fi
@@ -222,13 +220,13 @@ done < "$TMPDIR_WORK/repo_list.txt"
 
 # Legend + footer
 # Slack enforces a hard limit of 50 blocks per message. Trim excess content blocks first.
-# Each PR group uses 1-2 blocks (section + optional context for avatar), plus dividers if enabled.
-# With group dividers: limit=45 (conservative for avatar context blocks).
-# Without group dividers: limit=44 (reserve slots for truncation notice + footer).
+# Each PR group uses 1 block (section with optional image accessory), plus dividers if enabled.
+# With group dividers: limit=47 (50 - 3 footer).
+# Without group dividers: limit=46 (reserve slots for truncation notice + footer).
 if [[ "$USE_GROUP_DIVIDERS" == "true" ]]; then
-  CONTENT_LIMIT=45
+  CONTENT_LIMIT=47
 else
-  CONTENT_LIMIT=44
+  CONTENT_LIMIT=46
 fi
 content_count=$(jq 'length' "$TMPDIR_WORK/blocks.json")
 if [[ "$content_count" -gt "$CONTENT_LIMIT" ]]; then

--- a/.ci/scripts/stale-backport-scripts/format-slack-report.sh
+++ b/.ci/scripts/stale-backport-scripts/format-slack-report.sh
@@ -146,28 +146,18 @@ while IFS= read -r repo_name; do
       def slack_entry_for(login; name):
         ($smap[login] // null) // (if name then $smap[name] // null else null end);
       def slack_id_for(login; name): (slack_entry_for(login; name) | .slack_id // null);
-      # Author display: for bot-authored PRs show bot name + approvers; otherwise <@USLACKID>, @RealName, or GitHub username
-      (
-        if (.original_pr_author // "") | test("^app/") then
-          # Bot-authored PR: show bot name and tag approvers
-          ("🤖 \(.original_pr_author)" +
-          (if (.original_pr_approver_names // []) | length > 0 then
-            ", reviewed by " + ([.original_pr_approver_names[] |
-              if slack_id_for(.username; .name) then "<@\(slack_id_for(.username; .name))>"
-              elif .name then "@\(.name)"
-              else "@\(.username)" end
-            ] | join(", "))
-          else
-            ""
-          end))
-        elif slack_id_for(.original_pr_author; .original_pr_author_name) then
-          "<@\(slack_id_for(.original_pr_author; .original_pr_author_name))>"
-        elif .original_pr_author_name then
-          "@\(.original_pr_author_name)"
-        else
-          .original_pr_author // "unknown"
-        end
-      ) as $author_display |
+
+      # For bot-authored PRs, show bot name + tagged approvers inline
+      (if (.original_pr_author // "") | test("^app/") then
+        "🤖 \(.original_pr_author)" +
+        (if (.original_pr_approver_names // []) | length > 0 then
+          ", reviewed by " + ([.original_pr_approver_names[] |
+            if slack_id_for(.username; .name) then "<@\(slack_id_for(.username; .name))>"
+            elif .name then "@\(.name)"
+            else "@\(.username)" end
+          ] | join(", "))
+        else "" end)
+      else "" end) as $bot_info |
 
       # Header with original PR
       "*Original PR:* " +
@@ -175,7 +165,7 @@ while IFS= read -r repo_name; do
         ":pull-request-merged: <\(.original_pr_url)|#\(.original_pr_number // "?")> \(.original_pr_title // "Unknown" | if length > 60 then .[:57] + "..." else . end)"
       else
         ":pull-request-merged: #\(.original_pr_number // "?") — \(.original_pr_title // "Unknown" | if length > 60 then .[:57] + "..." else . end)"
-      end) + "  · \($author_display)\n" +
+      end) + (if $bot_info != "" then "  · \($bot_info)" else "" end) + "\n" +
       "*Stale backports:*\n" +
       ([.backport_prs[] |
         (if .age_days > 0 then "\(.age_days)d \(.age_hours % 24)h" else "\(.age_hours)h \((.age_minutes // 0) % 60)m" end) as $age |
@@ -185,16 +175,25 @@ while IFS= read -r repo_name; do
       ] | join("\n"))
     ')
 
-    # Resolve author avatar: Slack avatar from map > GitHub avatar > none
+    # Resolve author info for context block: avatar + Slack mention
     author_login=$(echo "$group" | jq -r '.original_pr_author // "unknown"')
     author_name=$(echo "$group" | jq -r '.original_pr_author_name // ""')
-    avatar_url=$(jq -r --arg login "$author_login" --arg name "$author_name" '
-      (.[$login] // .[$name] // null) |
-      if type == "object" then (.avatar_url // .image_48 // empty)
-      else empty end
-    ' "$TMPDIR_WORK/slack_user_map.json" 2>/dev/null || true)
+    map_entry=$(jq -c --arg login "$author_login" --arg name "$author_name" \
+      '(.[$login] // .[$name] // null) | if type == "string" then {slack_id: .} else . end' \
+      "$TMPDIR_WORK/slack_user_map.json" 2>/dev/null || echo 'null')
+    slack_id=$(echo "$map_entry" | jq -r '.slack_id // empty' 2>/dev/null || true)
+    avatar_url=$(echo "$map_entry" | jq -r '.avatar_url // .image_48 // empty' 2>/dev/null || true)
     if [[ -z "$avatar_url" && "$author_login" != app/* && "$author_login" != "unknown" ]]; then
       avatar_url="https://github.com/${author_login}.png?size=24"
+    fi
+
+    # Build author mention text for context block
+    if [[ -n "$slack_id" ]]; then
+      author_mention="<@${slack_id}>"
+    elif [[ -n "$author_name" ]]; then
+      author_mention="@${author_name}"
+    else
+      author_mention="${author_login}"
     fi
 
     if [[ "$USE_GROUP_DIVIDERS" == "true" ]]; then
@@ -207,11 +206,14 @@ while IFS= read -r repo_name; do
         "$TMPDIR_WORK/blocks.json" > "$TMPDIR_WORK/blocks_tmp.json" && mv "$TMPDIR_WORK/blocks_tmp.json" "$TMPDIR_WORK/blocks.json"
     fi
 
-    # Add author avatar as a small context block below the section
+    # Add context block with avatar + author mention
     if [[ -n "$avatar_url" ]]; then
-      display_label="${author_name:-$author_login}"
-      jq -c --arg avatar "$avatar_url" --arg label "$display_label" \
-        '. + [{type: "context", elements: [{type: "image", image_url: $avatar, alt_text: $label}, {type: "mrkdwn", text: $label}]}]' \
+      jq -c --arg avatar "$avatar_url" --arg mention "$author_mention" --arg alt "${author_name:-$author_login}" \
+        '. + [{type: "context", elements: [{type: "image", image_url: $avatar, alt_text: $alt}, {type: "mrkdwn", text: $mention}]}]' \
+        "$TMPDIR_WORK/blocks.json" > "$TMPDIR_WORK/blocks_tmp.json" && mv "$TMPDIR_WORK/blocks_tmp.json" "$TMPDIR_WORK/blocks.json"
+    else
+      jq -c --arg mention "$author_mention" \
+        '. + [{type: "context", elements: [{type: "mrkdwn", text: $mention}]}]' \
         "$TMPDIR_WORK/blocks.json" > "$TMPDIR_WORK/blocks_tmp.json" && mv "$TMPDIR_WORK/blocks_tmp.json" "$TMPDIR_WORK/blocks.json"
     fi
   done

--- a/.github/workflows/stale-backport-tracker.yml
+++ b/.github/workflows/stale-backport-tracker.yml
@@ -95,7 +95,7 @@ jobs:
     steps:
       - name: Generate GitHub token
         id: github-token
-        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@fc4fa13813cbc1835129967f10a12f24aa7a393c # main
         with:
           github-app-id-vault-key: MONOREPO_RELEASE_APP_ID
           github-app-id-vault-path: secret/data/products/camunda/ci/camunda
@@ -154,7 +154,7 @@ jobs:
     steps:
       - name: Generate GitHub token
         id: github-token
-        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@fc4fa13813cbc1835129967f10a12f24aa7a393c # main
         with:
           github-app-id-vault-key: MONOREPO_RELEASE_APP_ID
           github-app-id-vault-path: secret/data/products/camunda/ci/camunda
@@ -201,7 +201,7 @@ jobs:
     steps:
       - name: Generate GitHub token
         id: github-token
-        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@fc4fa13813cbc1835129967f10a12f24aa7a393c # main
         with:
           github-app-id-vault-key: MONOREPO_DEVOPS_AUTOMATION_APP_ID
           github-app-id-vault-path: secret/data/products/camunda/ci/camunda

--- a/.github/workflows/stale-backport-tracker.yml
+++ b/.github/workflows/stale-backport-tracker.yml
@@ -7,9 +7,9 @@ name: Stale Backport Tracker
 
 on:
   schedule:
-    # Run every 4 hours during weekday business hours (UTC): 6, 10, 14, 18
+    # Run every hour during weekday business hours (UTC): 6–18
     # First run at 6 AM creates a new message; subsequent runs update it in-place.
-    - cron: '0 6-18/4 * * 1-5'
+    - cron: '0 6-18 * * 1-5'
   workflow_dispatch:
     inputs:
       target_branch:
@@ -233,13 +233,19 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.github-token.outputs.token }}
         run: |
-          # Download the pre-built GitHub-to-Slack user map artifact from monorepo-ci-data
+          # The GitHub-to-Slack user map is built weekly by a workflow in camunda/monorepo-ci-data.
+          # It resolves Slack custom profile fields (GitHub username) into a JSON mapping of
+          # GitHub login → {slack_id, display_name, real_name}.
+          # The map is stored as a GitHub Actions artifact named "github-slack-user-map".
+          # See: https://github.com/camunda/monorepo-ci-data/blob/main/.github/workflows/build-github-slack-user-map.yml
           if gh run download --repo camunda/monorepo-ci-data --name github-slack-user-map --dir /tmp/map 2>/dev/null; then
             cp /tmp/map/github-slack-user-map.json /tmp/slack-user-map.json
             echo "Downloaded map with $(jq 'length' /tmp/slack-user-map.json) entries"
+            echo "SLACK_USER_MAP_FALLBACK=false" >> "$GITHUB_ENV"
           else
             echo "⚠️ No GitHub-Slack user map artifact found — Slack mentions will use fallback" >&2
             echo '{}' > /tmp/slack-user-map.json
+            echo "SLACK_USER_MAP_FALLBACK=true" >> "$GITHUB_ENV"
           fi
 
       - name: Format Slack report
@@ -250,6 +256,7 @@ jobs:
           TARGET_BRANCH: ${{ inputs.target_branch || '' }}
           REPOSITORIES: "camunda/camunda,camunda/zeebe-process-test"
           SLACK_USER_MAP_FILE: /tmp/slack-user-map.json
+          SLACK_USER_MAP_FALLBACK: ${{ env.SLACK_USER_MAP_FALLBACK }}
         run: |
           chmod +x .ci/scripts/stale-backport-scripts/format-slack-report.sh
           payload=$(echo '${{ needs.collect-stale-backports.outputs.stale_data }}' | \

--- a/.github/workflows/stale-backport-tracker.yml
+++ b/.github/workflows/stale-backport-tracker.yml
@@ -203,9 +203,9 @@ jobs:
         id: github-token
         uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
         with:
-          github-app-id-vault-key: MONOREPO_RELEASE_APP_ID
+          github-app-id-vault-key: MONOREPO_DEVOPS_AUTOMATION_APP_ID
           github-app-id-vault-path: secret/data/products/camunda/ci/camunda
-          github-app-private-key-vault-key: MONOREPO_RELEASE_APP_PRIVATE_KEY
+          github-app-private-key-vault-key: MONOREPO_DEVOPS_AUTOMATION_APP_PRIVATE_KEY
           github-app-private-key-vault-path: secret/data/products/camunda/ci/camunda
           vault-auth-method: approle
           vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/stale-backport-tracker.yml
+++ b/.github/workflows/stale-backport-tracker.yml
@@ -199,6 +199,20 @@ jobs:
     timeout-minutes: 5
     permissions: {}
     steps:
+      - name: Generate GitHub token
+        id: github-token
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
+        with:
+          github-app-id-vault-key: MONOREPO_RELEASE_APP_ID
+          github-app-id-vault-path: secret/data/products/camunda/ci/camunda
+          github-app-private-key-vault-key: MONOREPO_RELEASE_APP_PRIVATE_KEY
+          github-app-private-key-vault-path: secret/data/products/camunda/ci/camunda
+          vault-auth-method: approle
+          vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          vault-url: ${{ secrets.VAULT_ADDR }}
+          repositories: "monorepo-ci-data"
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -215,25 +229,18 @@ jobs:
              secret/data/products/camunda/ci/github-actions SLACK_C8_MONOREPO_NOTIFICATIONS_BOT_TOKEN;
              secret/data/products/camunda/ci/github-actions SLACK_TOPMONOREPOCI_CHANNEL_ID;
 
-      - name: Resolve Slack user IDs
-        id: slack-users
+      - name: Download GitHub-Slack user map
         env:
-          SLACK_BOT_TOKEN: ${{ steps.secrets.outputs.SLACK_C8_MONOREPO_NOTIFICATIONS_BOT_TOKEN }}
+          GH_TOKEN: ${{ steps.github-token.outputs.token }}
         run: |
-          chmod +x .ci/scripts/stale-backport-scripts/resolve-slack-users.sh
-
-          # Extract unique author names from stale data
-          names=$(echo '${{ needs.collect-stale-backports.outputs.stale_data }}' | \
-            jq '[.[].original_pr_author_name // empty] | unique')
-
-          # Resolve names to Slack user IDs
-          slack_user_map=$(echo "$names" | .ci/scripts/stale-backport-scripts/resolve-slack-users.sh)
-
-          {
-            echo "slack_user_map<<SLACK_MAP_EOF"
-            echo "$slack_user_map"
-            echo "SLACK_MAP_EOF"
-          } >> "$GITHUB_OUTPUT"
+          # Download the pre-built GitHub-to-Slack user map artifact from monorepo-ci-data
+          if gh run download --repo camunda/monorepo-ci-data --name github-slack-user-map --dir /tmp/map 2>/dev/null; then
+            cp /tmp/map/github-slack-user-map.json /tmp/slack-user-map.json
+            echo "Downloaded map with $(jq 'length' /tmp/slack-user-map.json) entries"
+          else
+            echo "⚠️ No GitHub-Slack user map artifact found — Slack mentions will use fallback" >&2
+            echo '{}' > /tmp/slack-user-map.json
+          fi
 
       - name: Format Slack report
         id: format
@@ -242,7 +249,7 @@ jobs:
           GITHUB_RUN_ID: ${{ github.run_id }}
           TARGET_BRANCH: ${{ inputs.target_branch || '' }}
           REPOSITORIES: "camunda/camunda,camunda/zeebe-process-test"
-          SLACK_USER_MAP: ${{ steps.slack-users.outputs.slack_user_map }}
+          SLACK_USER_MAP_FILE: /tmp/slack-user-map.json
         run: |
           chmod +x .ci/scripts/stale-backport-scripts/format-slack-report.sh
           payload=$(echo '${{ needs.collect-stale-backports.outputs.stale_data }}' | \

--- a/.github/workflows/stale-backport-tracker.yml
+++ b/.github/workflows/stale-backport-tracker.yml
@@ -164,6 +164,7 @@ jobs:
           vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           vault-url: ${{ secrets.VAULT_ADDR }}
+          repositories: "camunda,zeebe-process-test"
   
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/stale-backport-tracker.yml
+++ b/.github/workflows/stale-backport-tracker.yml
@@ -1,5 +1,5 @@
 # description: Tracks stale backport PRs and notifies authors via GitHub comments and Slack.
-#   Runs every 4 hours on weekdays, on manual dispatch, and can be called by other workflows.
+# Runs every hours on weekdays, on manual dispatch, and can be called by other workflows.
 # type: CI Helper
 # owner: @camunda/monorepo-devops-team
 ---


### PR DESCRIPTION
## Description

Enhances the stale backport tracker Slack report with proper Slack user mentions and increases the update frequency.

### Changes

**Slack user mentions**
- Resolve PR authors to Slack `<@USLACKID>` mentions inline on the "Original PR" line, using a pre-built GitHub-to-Slack user map.
- The map is built weekly by [`build-github-slack-user-map.yml`](https://github.com/camunda/monorepo-ci-data/blob/main/.github/workflows/build-github-slack-user-map.yml) in `camunda/monorepo-ci-data` and stored as a GitHub Actions artifact.
- The map resolves Slack custom profile fields (GitHub username) into a JSON mapping of `github_login → {slack_id, display_name, real_name, avatar_url}`.
- When the map is unavailable, a warning is shown in the report mentioning `@monorepo-devops-team`, and authors fall back to `@RealName` or GitHub login.

**GitHub App token**
- Switch from `MONOREPO_RELEASE_APP` to `MONOREPO_DEVOPS_AUTOMATION_APP` in the `notify-slack` job for cross-repo artifact download (needs `actions:read` on `monorepo-ci-data`).

**Schedule**
- Increase cron frequency from every 4 hours to every hour during weekday business hours (6:00–18:00 UTC).

**Token scoping fix**
- Add `zeebe-process-test` to the `MONOREPO_RELEASE_APP` token scope in the `notify-github` job so it can comment on backport PRs in that repo.

### How it looks

When map is available:
```
Original PR: :pull-request-merged: #50654 fix(cpt): Fix conditional behavior...  <@U1234ABC>
Stale backports:
  ↳ :pr-draft: :warning: #50966 → stable/8.9 (created 2d 5h ago)
```

When map is unavailable (fallback):
```
⚠️ GitHub-Slack user map not available — author names shown as GitHub usernames instead of Slack mentions. cc @monorepo-devops-team

Original PR: :pull-request-merged: #50654 fix(cpt): Fix conditional behavior...  @Christopher Kujawa (Zell)
```

## 🧪  Test
[Successful workflow run](https://github.com/camunda/camunda/actions/runs/24552307575)
Result msg:
<img width="1171" height="712" alt="image" src="https://github.com/user-attachments/assets/075bff44-1aaa-4d4f-8cc5-424c96bc7f7b" />


Related https://github.com/camunda/camunda/issues/40006