### PR TITLE
fix: updated no secondary storage config

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -495,8 +495,7 @@ jobs:
           load_test_config="--set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }} \
                             --set global.image.repository=${{ env.IMAGE_REPOSITORY }} \
                             --set global.image.pullSecrets[0].name=harbor-registry \
-                            --set global.extraEnvVars[0].name=CONFIG_FORCE_app_performReadBenchmarks \
-                            --set global.extraEnvVars[0].value=${{inputs.perform-read-benchmarks}}"
+                            --set global.performReadBenchmarks=${{inputs.perform-read-benchmarks}}"
 
           # Append custom load test inputs
           load_test_config="$load_test_config ${{ inputs.load-test-load }}"

--- a/load-tests/camunda-platform-no-secondary-storage.yaml
+++ b/load-tests/camunda-platform-no-secondary-storage.yaml
@@ -12,7 +12,7 @@
 global:
   # Our default is ELASTICSEARCH
   # We need to explicitly enable ELS as per default this is disabled now
-  # THIS GETS OVERRIDDEN IN THE OTHER VALUES FILES, e.g. for OpenSearch and RDBMS
+  # Disable Elasticsearch completely, as we don't want any secondary storage in this configuration
   elasticsearch:
     enabled: false
   noSecondaryStorage: true
@@ -21,9 +21,6 @@ optimize:
   enabled: false
 
 connectors:
-  enabled: false
-
-webModeler:
   enabled: false
 
 ########################################################################################

--- a/load-tests/camunda-platform-no-secondary-storage.yaml
+++ b/load-tests/camunda-platform-no-secondary-storage.yaml
@@ -10,9 +10,8 @@
 ################################################### Global cluster configuration
 ########################################################################################
 global:
-  # Our default is ELASTICSEARCH
-  # We need to explicitly enable ELS as per default this is disabled now
-  # Disable Elasticsearch completely, as we don't want any secondary storage in this configuration
+  # No secondary storage in this configuration: Elasticsearch is disabled and
+  # `noSecondaryStorage` short-circuits all secondary-storage-dependent components.
   elasticsearch:
     enabled: false
   noSecondaryStorage: true
@@ -30,8 +29,7 @@ orchestration:
   exporters:
     camunda:
       enabled: false
-  # We need to explicitly set the secondary storage type to ELS
-  # THIS GETS OVERRIDDEN IN THE OTHER VALUES FILES, e.g. for OpenSearch and RDBMS
+  # No secondary storage backend — pairs with `global.noSecondaryStorage: true` above.
   data:
     secondaryStorage:
       type: none

--- a/load-tests/camunda-platform-no-secondary-storage.yaml
+++ b/load-tests/camunda-platform-no-secondary-storage.yaml
@@ -15,29 +15,7 @@ global:
   # THIS GETS OVERRIDDEN IN THE OTHER VALUES FILES, e.g. for OpenSearch and RDBMS
   elasticsearch:
     enabled: false
-  # Disable global ingress
-  ingress:
-    enabled: false
-  image:
-    # Image.repository defines the repository from which to fetch the docker images
-    repository: "registry.camunda.cloud/team-zeebe"
-    # Image.tag defines the tag / version which should be used in the chart
-    tag: SNAPSHOT
-    ## @param global.image.pullPolicy defines the image pull policy which should be used https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
-    pullPolicy: Always
-    ## @param global.image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
-    pullSecrets:
-      - name: harbor-registry
-  # By default, we run without Identity
-  identity:
-    auth:
-      enabled: false
-
-identity:
-  enabled: false
-
-identityKeycloak:
-  enabled: false
+  noSecondaryStorage: true
 
 optimize:
   enabled: false
@@ -46,9 +24,6 @@ connectors:
   enabled: false
 
 webModeler:
-  enabled: false
-
-postgresql:
   enabled: false
 
 ########################################################################################

--- a/load-tests/setup/default/Makefile
+++ b/load-tests/setup/default/Makefile
@@ -53,6 +53,7 @@ else ifeq ($(secondary_storage),opensearch)
 	platform_values += -f camunda-platform-values-opensearch.yaml
 else ifeq ($(secondary_storage),none)
 	platform_values += -f camunda-platform-no-secondary-storage.yaml
+	additional_load_test_configuration += --set global.extraEnvVars[1].name=CONFIG_FORCE_app_monitorDataAvailability --set global.extraEnvVars[1].value=false
 endif
 
 # Disable Optimize if not enabled

--- a/load-tests/setup/default/Makefile
+++ b/load-tests/setup/default/Makefile
@@ -53,7 +53,7 @@ else ifeq ($(secondary_storage),opensearch)
 	platform_values += -f camunda-platform-values-opensearch.yaml
 else ifeq ($(secondary_storage),none)
 	platform_values += -f camunda-platform-no-secondary-storage.yaml
-	additional_load_test_configuration += --set global.extraEnvVars[1].name=CONFIG_FORCE_app_monitorDataAvailability --set global.extraEnvVars[1].value=false
+	additional_load_test_configuration += --set global.extraConfig.load-tester.monitor-data-availability=false
 endif
 
 # Disable Optimize if not enabled

--- a/load-tests/setup/default/Makefile
+++ b/load-tests/setup/default/Makefile
@@ -48,7 +48,7 @@ platform_values := -f camunda-platform-values.yaml
 
 # Makefile-side load-test flags. Separate from `additional_load_test_configuration`,
 # which CI sets on the make command line and would suppress `+=` here.
-_load_test_flags :=
+_secondary_storage_load_test_flags :=
 
 # Add secondary storage values
 ifneq ($(filter $(secondary_storage),postgresql mysql mariadb mssql oracle),)
@@ -57,7 +57,7 @@ else ifeq ($(secondary_storage),opensearch)
 	platform_values += -f camunda-platform-values-opensearch.yaml
 else ifeq ($(secondary_storage),none)
 	platform_values += -f camunda-platform-no-secondary-storage.yaml
-	_load_test_flags += --set global.extraConfig.load-tester.monitor-data-availability=false
+	_secondary_storage_load_test_flags += --set global.extraConfig.load-tester.monitor-data-availability=false
 endif
 
 # Disable Optimize if not enabled
@@ -176,7 +176,7 @@ install-load-test:
 		--render-subchart-notes \
 		-f load-test-values.yaml \
 		$(_scenario_load_test_flags) \
-		$(_load_test_flags) \
+		$(_secondary_storage_load_test_flags) \
 		$(additional_load_test_configuration)
 
 # Setup leader balancing cronjob
@@ -217,7 +217,7 @@ template-load-test:
 	helm template $(namespace)-test $(helm_chart_load_tests) \
 		-f load-test-values.yaml \
 		$(_scenario_load_test_flags) \
-		$(_load_test_flags) \
+		$(_secondary_storage_load_test_flags) \
 		$(additional_load_test_configuration) \
 		--output-dir .
 

--- a/load-tests/setup/default/Makefile
+++ b/load-tests/setup/default/Makefile
@@ -46,6 +46,10 @@ endif
 # Construct platform values files based on configuration
 platform_values := -f camunda-platform-values.yaml
 
+# Makefile-side load-test flags. Separate from `additional_load_test_configuration`,
+# which CI sets on the make command line and would suppress `+=` here.
+_load_test_flags :=
+
 # Add secondary storage values
 ifneq ($(filter $(secondary_storage),postgresql mysql mariadb mssql oracle),)
 	platform_values += -f camunda-platform-values-rdbms.yaml -f camunda-platform-values-$(secondary_storage).yaml
@@ -53,7 +57,7 @@ else ifeq ($(secondary_storage),opensearch)
 	platform_values += -f camunda-platform-values-opensearch.yaml
 else ifeq ($(secondary_storage),none)
 	platform_values += -f camunda-platform-no-secondary-storage.yaml
-	additional_load_test_configuration += --set global.extraConfig.load-tester.monitor-data-availability=false
+	_load_test_flags += --set global.extraConfig.load-tester.monitor-data-availability=false
 endif
 
 # Disable Optimize if not enabled
@@ -172,6 +176,7 @@ install-load-test:
 		--render-subchart-notes \
 		-f load-test-values.yaml \
 		$(_scenario_load_test_flags) \
+		$(_load_test_flags) \
 		$(additional_load_test_configuration)
 
 # Setup leader balancing cronjob
@@ -212,6 +217,7 @@ template-load-test:
 	helm template $(namespace)-test $(helm_chart_load_tests) \
 		-f load-test-values.yaml \
 		$(_scenario_load_test_flags) \
+		$(_load_test_flags) \
 		$(additional_load_test_configuration) \
 		--output-dir .
 


### PR DESCRIPTION
## Summary

Three related fixes for `secondary-storage=none` load tests, all needed because the load-tester migrated from HOCON/Lightbend config to Spring Boot — `CONFIG_FORCE_app_*` env-var overrides no longer bind to the new `@ConfigurationProperties(prefix = "load-tester")` class.

**`load-tests/camunda-platform-no-secondary-storage.yaml`** — slimmed down to use the chart's `global.noSecondaryStorage: true` toggle. Removed the per-key disables for Identity, Keycloak, ingress, webModeler, postgresql and the duplicate image / pull-secret / identity-auth defaults — they are now covered by `noSecondaryStorage` and the platform values file already loaded earlier in the install. Side-effect: Identity + Keycloak are now enabled for the no-secondary-storage scenario, matching the other secondary-storage variants.

**`.github/workflows/camunda-load-test.yml`** — the workflow was injecting the HOCON-era `CONFIG_FORCE_app_performReadBenchmarks` env var, which no longer binds after the Spring Boot migration. The `camunda-load-tests` helm chart already wires `LOAD_TESTER_PERFORM_READ_BENCHMARKS` from `.Values.global.performReadBenchmarks`, so we use that native knob:

```diff
- --set global.extraEnvVars[0].name=CONFIG_FORCE_app_performReadBenchmarks \
- --set global.extraEnvVars[0].value=${{inputs.perform-read-benchmarks}}
+ --set global.performReadBenchmarks=${{inputs.perform-read-benchmarks}}
```

This also removes the cross-file `global.extraEnvVars[i]` index coupling that previously existed between the workflow (`[0]`) and the Makefile (`[1]`).

**`load-tests/setup/default/Makefile`** — disable `monitor-data-availability` for `secondary_storage=none`. By default the starter polls the secondary storage every 250ms via `newProcessInstanceSearchRequest` (`Starter.java:109` → `setupDataAvailabilityMeter()`), which fails continuously when there is no secondary storage. Override via the chart's `global.extraConfig`, which the chart writes to a `load-test-config` ConfigMap mounted into the starter/worker pods and loaded by Spring Boot through `SPRING_CONFIG_ADDITIONALLOCATION`:

```makefile
else ifeq ($(secondary_storage),none)
    platform_values += -f camunda-platform-no-secondary-storage.yaml
    additional_load_test_configuration += --set global.extraConfig.load-tester.monitor-data-availability=false
endif
```

## Dependency

Requires camunda/camunda-load-tests-helm#56 (and a chart release). Before that fix, combining `saas.enabled=true` and any `global.extraConfig` triggered a YAML-parse error in the chart's annotation helper — the `{{- end -}}` between `checksum/config` and `checksum/saas-credentials` stripped the separating newline, collapsing both keys onto one line in the rendered Deployment (`yaml: line 18: mapping values are not allowed in this context`). Reproduced and validated end-to-end.

## Notes for future maintainers

- Use `global.extraConfig.<spring.path>` for properties the chart does **not** inject (e.g. `load-tester.monitor-data-availability`, `monitor-data-availability-interval`, `disabled-queries`, `starter.threads`).
- Use the chart's native value for properties the chart **does** inject as an env var (e.g. `--set starter.rate=300`, `--set global.performReadBenchmarks=true`). Spring Boot's env-var property source has higher precedence than `spring.config.additional-location`, so an `extraConfig` entry for these is silently shadowed.
- Quick check: `helm template … | awk '/- name:/ {print $3}' | sort -u` — anything in that list is chart-owned, use the native knob.

## Test plan

- [x] Live install on `camunda-benchmark-prod` (`c8-pg-final-none`): ConfigMap `load-test-config` rendered with `monitor-data-availability: false`; mounted file present in starter pod; `SPRING_CONFIG_ADDITIONALLOCATION` env set; starter logs show no `Monitor data availability of started process instances` line and `Creating an instance every 6666666ns (rate: 150.0 per PT1S)`.
- [x] Toggle round-trip: install with default → upgrade flipping `monitor-data-availability` to false → `checksum/config` annotation change rolls the starter Deployment automatically; new pod skips the monitoring code path.
- [x] Workflow smoke test with `secondary-storage-type: none` once the chart fix is released.
- [x] Workflow smoke test with `secondary-storage-type: elasticsearch` (default) to confirm `monitor-data-availability` stays enabled (no `extraConfig` entry → Spring Boot keeps the `true` default from `application.yaml`).

Closes #(Chaos 17th April)