### PR TITLE
Process definition statistics api test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/message-subscription-statistics-process.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/message-subscription-statistics-process.bpmn
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_15h9kcx" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.40.1" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <bpmn:process id="message-statistics-test" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0a7rg98</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0a7rg98" sourceRef="StartEvent_1" targetRef="Event_12y7kfq" />
+    <bpmn:endEvent id="Event_1l0m921">
+      <bpmn:incoming>Flow_0uid9uh</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0uid9uh" sourceRef="Event_12y7kfq" targetRef="Event_1l0m921" />
+    <bpmn:intermediateCatchEvent id="Event_12y7kfq">
+      <bpmn:incoming>Flow_0a7rg98</bpmn:incoming>
+      <bpmn:outgoing>Flow_0uid9uh</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1i5kfgu" messageRef="Message_2l3lsuj" />
+    </bpmn:intermediateCatchEvent>
+  </bpmn:process>
+  <bpmn:message id="Message_2l3lsuj" name="Message_2l3lsuj">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=213213" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="message-statistics-test">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1l0m921_di" bpmnElement="Event_1l0m921">
+        <dc:Bounds x="362" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1lsqvmq_di" bpmnElement="Event_12y7kfq">
+        <dc:Bounds x="272" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0a7rg98_di" bpmnElement="Flow_0a7rg98">
+        <di:waypoint x="218" y="100" />
+        <di:waypoint x="272" y="100" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0uid9uh_di" bpmnElement="Flow_0uid9uh">
+        <di:waypoint x="308" y="100" />
+        <di:waypoint x="362" y="100" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/audit-log/audit-log-search-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/audit-log/audit-log-search-api-tests.spec.ts
@@ -378,7 +378,6 @@ test.describe.parallel('Search Audit Logs API Tests', () => {
       const values = body.items.map(
         (item: Record<string, unknown>) => item.actorId,
       ) as string[];
-      console.log('Extracted actorIds:', values);
       const sorted = [...values].sort();
       expect(values).toEqual(sorted);
     }).toPass(defaultAssertionOptions);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-message-statistics-subscription-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-message-statistics-subscription-api.spec.ts
@@ -1,0 +1,316 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect, test} from '@playwright/test';
+import {cancelProcessInstance, createInstances, createSingleInstance, deploy} from '../../../../utils/zeebeClient';
+import {
+  assertBadRequest,
+  assertInvalidArgument,
+  assertStatusCode,
+  assertUnauthorizedRequest,
+  buildUrl,
+  jsonHeaders,
+  encode,
+} from '../../../../utils/http';
+import {validateResponse} from '../../../../json-body-assertions';
+import {defaultAssertionOptions} from '../../../../utils/constants';
+import { cleanupUsers } from 'utils/usersCleanup';
+import {
+  CORRELATE_MESSAGE,
+  CORRELATE_MESSAGE1,
+  CORRELATE_MESSAGE2,
+  CORRELATE_MESSAGE_DOUBLE_1,
+  CORRELATE_MESSAGE_DOUBLE_2,
+} from '../../../../utils/beans/requestBeans';
+import {
+  expectProcessInstanceCanBeFound,
+  searchCorrelatedMessageSubscriptions,
+  grantUserResourceAuthorization,
+  createUser,
+} from '@requestHelpers';
+
+type MessageSubscriptionStatisticsResponse = {
+    processDefinitionId: string;
+    processDefinitionKey: string;
+    tenantId: string;
+    processInstancesWithActiveSubscriptions: number;
+    activeSubscriptions: number;
+};
+
+test.describe.parallel('Get message subscription statistics API Tests', () => {
+  let userWithResourcesAuthorizationToSendRequest: {
+    username: string;
+    name: string;
+    email: string;
+    password: string;
+  } = {} as {
+    username: string;
+    name: string;
+    email: string;
+    password: string;
+  };
+  let processInstanceKeys: string[] = [];
+  let messageKeys: string[] = [];
+  const processDefinitionId = 'messageCatchEvent1';
+
+  test.beforeAll(async ({request}) => {
+    await test.step('Setup - Create test user with Resource Authorization and user for granting Authorization', async () => {
+      userWithResourcesAuthorizationToSendRequest = await createUser(request);
+      await grantUserResourceAuthorization(
+        request,
+        userWithResourcesAuthorizationToSendRequest,
+      );
+    });
+
+    await test.step('Deploy processes', async () => {
+      await deploy([
+        './resources/messageCatchEvent3.bpmn',
+        './resources/messageCatchEvent1.bpmn',
+        './resources/messageCatchEvent2.bpmn',
+        './resources/doubleMessageCatchEvent.bpmn',
+      ]);
+    });
+
+    await test.step('Create process instances', async () => {
+      const [procA] = await createInstances('messageCatchEvent3', 1, 1);
+      const [procB] = await createInstances('messageCatchEvent1', 1, 1);
+      const [procC] = await createInstances('messageCatchEvent2', 1, 1);
+      const [procD] = await createInstances(
+        'Process_double_message_catch',
+        1,
+        1,
+      );
+      processInstanceKeys.push(procA.processInstanceKey);
+      processInstanceKeys.push(procB.processInstanceKey);
+      processInstanceKeys.push(procC.processInstanceKey);
+      processInstanceKeys.push(procD.processInstanceKey);
+    });
+
+    await test.step('Poll process instances', async () => {
+        for (const key of processInstanceKeys) {
+          expectProcessInstanceCanBeFound(request, key);
+        }
+    });
+
+    await test.step('Correlate messages', async () => {
+      const correlationPayloads = [
+        {body: CORRELATE_MESSAGE, stateKey: 'messageKeyPrimary'},
+        {body: CORRELATE_MESSAGE2, stateKey: 'messageKeySecondary'},
+        {body: CORRELATE_MESSAGE1, stateKey: 'messageKeyTertiary'},
+        {body: CORRELATE_MESSAGE_DOUBLE_1, stateKey: 'messageKeyDouble1'},
+        {body: CORRELATE_MESSAGE_DOUBLE_2, stateKey: 'messageKeyDouble2'},
+      ];
+
+      for (const payload of correlationPayloads) {
+        const res = await request.post(buildUrl('/messages/correlation'), {
+          headers: jsonHeaders(),
+          data: payload.body,
+        });
+        await assertStatusCode(res, 200);
+        await validateResponse(
+          {
+            path: '/messages/correlation',
+            method: 'POST',
+            status: '200',
+          },
+          res,
+        );
+        const json = await res.json();
+        messageKeys.push(json.messageKey);
+      }
+    });
+
+    await test.step('Wait for message subscriptions to be created', async () => {
+      for (const key of messageKeys) {
+        await searchCorrelatedMessageSubscriptions(request, key);
+      }
+    });
+  });
+
+  test.afterAll(async ({request}) => {
+    await test.step('Cleanup - Delete test users', async () => {
+      await cleanupUsers(request, [
+        userWithResourcesAuthorizationToSendRequest.username,
+      ]);
+    });
+
+    await test.step('Cancel process instances', async () => {
+        for (const key of processInstanceKeys) {
+            await cancelProcessInstance(key);
+        }
+    });
+
+    await test.step('Clean arrays', async () => {
+        processInstanceKeys = [];
+        messageKeys = [];
+    });
+  });
+
+  test('Get message subscription statistics - Success', async ({request}) => {
+    const res = await request.post(
+        buildUrl('/process-definitions/statistics/message-subscriptions'),
+        {
+            headers: jsonHeaders(),
+            data: {
+                filter: {},
+            },
+          }
+    );
+    assertStatusCode(res, 200);
+    const body = await res.json();
+    validateResponse(
+        {
+            path: '/process-definitions/statistics/message-subscriptions',
+            method: 'POST',
+            status: '200',
+        }, 
+        res
+    );
+    expect(body.page.totalItems).toBeGreaterThanOrEqual(1);
+    expect(body.items.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test('Get message subscription statistics filter by processDefinitionId - Success', async ({request}) => {
+    const res = await request.post(
+        buildUrl('/process-definitions/statistics/message-subscriptions'),
+        {
+            headers: jsonHeaders(),
+            data: {
+                filter: {
+                    processDefinitionId
+                },
+            },
+          }
+    );
+    assertStatusCode(res, 200);
+    const body = await res.json();
+    validateResponse(
+        {
+            path: '/process-definitions/statistics/message-subscriptions',
+            method: 'POST',
+            status: '200',
+        }, 
+        res
+    );
+    expect(body.page.totalItems).toBe(1);
+    expect(body.items.length).toBe(1);
+    expect(body.items[0].processDefinitionId).toBe(processDefinitionId);
+  });
+  
+  test('Get message subscription statistics by process instance key - Success', async ({request}) => {
+    const processInstanceKey = processInstanceKeys[1];
+    let processDefinitionKey: string = '';
+    await test.step('Get definitionKEy of process instance', async () => {
+        const res = await request.get(buildUrl(`/process-instances/${processInstanceKey}`),
+        {
+            headers: jsonHeaders()
+        });
+        assertStatusCode(res, 200);
+        await validateResponse({
+            path: '/process-instances/{processInstanceKey}',
+            method: 'GET',
+            status: '200',
+        }, res);
+        const body = await res.json();
+        processDefinitionKey = body.processDefinitionKey;
+    });
+
+    await test.step('Get message subscription statistics by process instance key', async () => {
+        const res = await request.post(
+            buildUrl('/process-definitions/statistics/message-subscriptions'),
+            {
+                headers: jsonHeaders(),
+                data: {
+                    filter: {
+                        processInstanceKey
+                    },
+                },
+            }
+        );
+        assertStatusCode(res, 200);
+        const body = await res.json();
+        validateResponse(
+            {
+                path: '/process-definitions/statistics/message-subscriptions',
+                method: 'POST',
+                status: '200',
+            }, 
+            res
+        );
+        expect(body.page.totalItems).toBe(1);
+        expect(body.items.length).toBe(1);
+        const item = body.items[0];
+        expect(item.processDefinitionKey).toBe(processDefinitionKey);
+        expect(item.processDefinitionId).toBe(processDefinitionId);
+        expect(item.processInstancesWithActiveSubscriptions).toBe(1);
+        expect(item.activeSubscriptions).toBe(1);
+    });
+  });
+
+  test('Get message subscription statistics with not existing filter - Bad Request', async ({request}) => {
+    const res = await request.post(
+        buildUrl('/process-definitions/statistics/message-subscriptions'),
+        {
+            headers: jsonHeaders(),
+            data: {
+                filter: {
+                    nonExistingFilter: 'test'
+                },
+            },
+          }
+    );
+    await assertBadRequest(res, 'Request property [filter.nonExistingFilter] cannot be parsed');
+  });
+
+  test('Get message subscription statistics with not valid process instance key - Invalid Argument', async ({request}) => {
+    const wrongProcessInstanceKey = 'abc';
+    const res = await request.post(
+        buildUrl('/process-definitions/statistics/message-subscriptions'),
+        {
+            headers: jsonHeaders(),
+            data: {
+                filter: {
+                    processInstanceKey: wrongProcessInstanceKey
+                },
+            },
+          }
+    );
+    await assertInvalidArgument(res, 400,  `The provided processInstanceKey '${wrongProcessInstanceKey}' is not a valid key.`);
+  });
+
+  test('Get message subscription statistics without authorization - Unauthorized', async ({request}) => {
+    const res = await request.post(
+        buildUrl('/process-definitions/statistics/message-subscriptions'),
+        {
+            headers: {},
+          }
+    );
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Get message subscription statistics - Forbidden, 200, empty response', async ({request}) => {
+    const token = encode(`${userWithResourcesAuthorizationToSendRequest.username}:${userWithResourcesAuthorizationToSendRequest.password}`);
+    const res = await request.post(
+        buildUrl('/process-definitions/statistics/message-subscriptions'),
+        {
+            headers: jsonHeaders(token),
+        });
+    assertStatusCode(res, 200);
+    const body = await res.json();
+    validateResponse(
+        {
+            path: '/process-definitions/statistics/message-subscriptions',
+            method: 'POST',
+            status: '200',
+        }, 
+        res
+    );
+    expect(body.page.totalItems).toBe(0);
+    expect(body.items.length).toBe(0);
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-message-statistics-subscription-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-message-statistics-subscription-api.spec.ts
@@ -9,7 +9,7 @@
 import {expect, test} from '@playwright/test';
 import {
   cancelProcessInstance,
-  createInstances,
+  createSingleInstance,
   deploy,
 } from '../../../../utils/zeebeClient';
 import {
@@ -24,18 +24,19 @@ import {
 import {validateResponse} from '../../../../json-body-assertions';
 import {cleanupUsers} from 'utils/usersCleanup';
 import {
-  CORRELATE_MESSAGE,
-  CORRELATE_MESSAGE1,
-  CORRELATE_MESSAGE2,
-  CORRELATE_MESSAGE_DOUBLE_1,
-  CORRELATE_MESSAGE_DOUBLE_2,
-} from '../../../../utils/beans/requestBeans';
-import {
   expectProcessInstanceCanBeFound,
   searchCorrelatedMessageSubscriptions,
   grantUserResourceAuthorization,
   createUser,
 } from '@requestHelpers';
+
+const expectedMessageSubscription = {
+  messageName: 'Message_2l3lsuj',
+  correlationKey: '213213',
+  tenantId: '<default>',
+  elementId: 'Event_12y7kfq',
+  processDefinitionId: 'message-statistics-test',
+}
 
 test.describe.parallel('Get message subscription statistics API Tests', () => {
   let userWithResourcesAuthorizationToSendRequest: {
@@ -51,7 +52,7 @@ test.describe.parallel('Get message subscription statistics API Tests', () => {
   };
   let processInstanceKeys: string[] = [];
   let messageKeys: string[] = [];
-  const processDefinitionId = 'messageCatchEvent1';
+  const processDefinitionId = 'message-statistics-test';
 
   test.beforeAll(async ({request}) => {
     await test.step('Setup - Create test user with Resource Authorization and user for granting Authorization', async () => {
@@ -64,26 +65,13 @@ test.describe.parallel('Get message subscription statistics API Tests', () => {
 
     await test.step('Deploy processes', async () => {
       await deploy([
-        './resources/messageCatchEvent3.bpmn',
-        './resources/messageCatchEvent1.bpmn',
-        './resources/messageCatchEvent2.bpmn',
-        './resources/doubleMessageCatchEvent.bpmn',
+        './resources/message-subscription-statistics-process.bpmn',
       ]);
     });
 
     await test.step('Create process instances', async () => {
-      const [procA] = await createInstances('messageCatchEvent3', 1, 1);
-      const [procB] = await createInstances('messageCatchEvent1', 1, 1);
-      const [procC] = await createInstances('messageCatchEvent2', 1, 1);
-      const [procD] = await createInstances(
-        'Process_double_message_catch',
-        1,
-        1,
-      );
-      processInstanceKeys.push(procA.processInstanceKey);
-      processInstanceKeys.push(procB.processInstanceKey);
-      processInstanceKeys.push(procC.processInstanceKey);
-      processInstanceKeys.push(procD.processInstanceKey);
+      const meow = await createSingleInstance('message-statistics-test', 1);
+      processInstanceKeys.push(meow.processInstanceKey);
     });
 
     await test.step('Poll process instances', async () => {
@@ -93,31 +81,28 @@ test.describe.parallel('Get message subscription statistics API Tests', () => {
     });
 
     await test.step('Correlate messages', async () => {
-      const correlationPayloads = [
-        {body: CORRELATE_MESSAGE, stateKey: 'messageKeyPrimary'},
-        {body: CORRELATE_MESSAGE2, stateKey: 'messageKeySecondary'},
-        {body: CORRELATE_MESSAGE1, stateKey: 'messageKeyTertiary'},
-        {body: CORRELATE_MESSAGE_DOUBLE_1, stateKey: 'messageKeyDouble1'},
-        {body: CORRELATE_MESSAGE_DOUBLE_2, stateKey: 'messageKeyDouble2'},
-      ];
+      const bodyToCorrelateMessage = {
+        name: expectedMessageSubscription.messageName,
+        correlationKey: expectedMessageSubscription.correlationKey,
+        variables: {fooboo: 'bar'},
+        tenantId: '<default>',
+      };
 
-      for (const payload of correlationPayloads) {
-        const res = await request.post(buildUrl('/messages/correlation'), {
-          headers: jsonHeaders(),
-          data: payload.body,
-        });
-        await assertStatusCode(res, 200);
-        await validateResponse(
-          {
-            path: '/messages/correlation',
-            method: 'POST',
-            status: '200',
-          },
-          res,
-        );
-        const json = await res.json();
-        messageKeys.push(json.messageKey);
-      }
+      const res = await request.post(buildUrl('/messages/correlation'), {
+        headers: jsonHeaders(),
+        data: bodyToCorrelateMessage,
+      });
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: '/messages/correlation',
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+      const json = await res.json();
+      messageKeys.push(json.messageKey);
     });
 
     await test.step('Wait for message subscriptions to be created', async () => {
@@ -202,7 +187,7 @@ test.describe.parallel('Get message subscription statistics API Tests', () => {
   test('Get message subscription statistics by process instance key - Success', async ({
     request,
   }) => {
-    const processInstanceKey = processInstanceKeys[1];
+    const processInstanceKey = processInstanceKeys[0];
     let processDefinitionKey: string = '';
 
     await test.step('Get definitionKEy of process instance', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-message-statistics-subscription-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-message-statistics-subscription-api.spec.ts
@@ -7,7 +7,12 @@
  */
 
 import {expect, test} from '@playwright/test';
-import {cancelProcessInstance, createInstances, createSingleInstance, deploy} from '../../../../utils/zeebeClient';
+import {
+  cancelProcessInstance,
+  createInstances,
+  createSingleInstance,
+  deploy,
+} from '../../../../utils/zeebeClient';
 import {
   assertBadRequest,
   assertInvalidArgument,
@@ -19,7 +24,7 @@ import {
 } from '../../../../utils/http';
 import {validateResponse} from '../../../../json-body-assertions';
 import {defaultAssertionOptions} from '../../../../utils/constants';
-import { cleanupUsers } from 'utils/usersCleanup';
+import {cleanupUsers} from 'utils/usersCleanup';
 import {
   CORRELATE_MESSAGE,
   CORRELATE_MESSAGE1,
@@ -35,11 +40,11 @@ import {
 } from '@requestHelpers';
 
 type MessageSubscriptionStatisticsResponse = {
-    processDefinitionId: string;
-    processDefinitionKey: string;
-    tenantId: string;
-    processInstancesWithActiveSubscriptions: number;
-    activeSubscriptions: number;
+  processDefinitionId: string;
+  processDefinitionKey: string;
+  tenantId: string;
+  processInstancesWithActiveSubscriptions: number;
+  activeSubscriptions: number;
 };
 
 test.describe.parallel('Get message subscription statistics API Tests', () => {
@@ -92,9 +97,9 @@ test.describe.parallel('Get message subscription statistics API Tests', () => {
     });
 
     await test.step('Poll process instances', async () => {
-        for (const key of processInstanceKeys) {
-          expectProcessInstanceCanBeFound(request, key);
-        }
+      for (const key of processInstanceKeys) {
+        expectProcessInstanceCanBeFound(request, key);
+      }
     });
 
     await test.step('Correlate messages', async () => {
@@ -140,175 +145,203 @@ test.describe.parallel('Get message subscription statistics API Tests', () => {
     });
 
     await test.step('Cancel process instances', async () => {
-        for (const key of processInstanceKeys) {
-            await cancelProcessInstance(key);
-        }
+      for (const key of processInstanceKeys) {
+        await cancelProcessInstance(key);
+      }
     });
 
     await test.step('Clean arrays', async () => {
-        processInstanceKeys = [];
-        messageKeys = [];
+      processInstanceKeys = [];
+      messageKeys = [];
     });
   });
 
   test('Get message subscription statistics - Success', async ({request}) => {
     const res = await request.post(
-        buildUrl('/process-definitions/statistics/message-subscriptions'),
-        {
-            headers: jsonHeaders(),
-            data: {
-                filter: {},
-            },
-          }
+      buildUrl('/process-definitions/statistics/message-subscriptions'),
+      {
+        headers: jsonHeaders(),
+        data: {
+          filter: {},
+        },
+      },
     );
     assertStatusCode(res, 200);
     const body = await res.json();
     validateResponse(
-        {
-            path: '/process-definitions/statistics/message-subscriptions',
-            method: 'POST',
-            status: '200',
-        }, 
-        res
+      {
+        path: '/process-definitions/statistics/message-subscriptions',
+        method: 'POST',
+        status: '200',
+      },
+      res,
     );
     expect(body.page.totalItems).toBeGreaterThanOrEqual(1);
     expect(body.items.length).toBeGreaterThanOrEqual(1);
   });
 
-  test('Get message subscription statistics filter by processDefinitionId - Success', async ({request}) => {
+  test('Get message subscription statistics filter by processDefinitionId - Success', async ({
+    request,
+  }) => {
     const res = await request.post(
-        buildUrl('/process-definitions/statistics/message-subscriptions'),
-        {
-            headers: jsonHeaders(),
-            data: {
-                filter: {
-                    processDefinitionId
-                },
-            },
-          }
+      buildUrl('/process-definitions/statistics/message-subscriptions'),
+      {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            processDefinitionId,
+          },
+        },
+      },
     );
     assertStatusCode(res, 200);
     const body = await res.json();
     validateResponse(
-        {
-            path: '/process-definitions/statistics/message-subscriptions',
-            method: 'POST',
-            status: '200',
-        }, 
-        res
+      {
+        path: '/process-definitions/statistics/message-subscriptions',
+        method: 'POST',
+        status: '200',
+      },
+      res,
     );
     expect(body.page.totalItems).toBe(1);
     expect(body.items.length).toBe(1);
     expect(body.items[0].processDefinitionId).toBe(processDefinitionId);
   });
-  
-  test('Get message subscription statistics by process instance key - Success', async ({request}) => {
+
+  test('Get message subscription statistics by process instance key - Success', async ({
+    request,
+  }) => {
     const processInstanceKey = processInstanceKeys[1];
     let processDefinitionKey: string = '';
+
     await test.step('Get definitionKEy of process instance', async () => {
-        const res = await request.get(buildUrl(`/process-instances/${processInstanceKey}`),
+      const res = await request.get(
+        buildUrl(`/process-instances/${processInstanceKey}`),
         {
-            headers: jsonHeaders()
-        });
-        assertStatusCode(res, 200);
-        await validateResponse({
-            path: '/process-instances/{processInstanceKey}',
-            method: 'GET',
-            status: '200',
-        }, res);
-        const body = await res.json();
-        processDefinitionKey = body.processDefinitionKey;
+          headers: jsonHeaders(),
+        },
+      );
+      assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: '/process-instances/{processInstanceKey}',
+          method: 'GET',
+          status: '200',
+        },
+        res,
+      );
+      const body = await res.json();
+      processDefinitionKey = body.processDefinitionKey;
     });
 
     await test.step('Get message subscription statistics by process instance key', async () => {
-        const res = await request.post(
-            buildUrl('/process-definitions/statistics/message-subscriptions'),
-            {
-                headers: jsonHeaders(),
-                data: {
-                    filter: {
-                        processInstanceKey
-                    },
-                },
-            }
-        );
-        assertStatusCode(res, 200);
-        const body = await res.json();
-        validateResponse(
-            {
-                path: '/process-definitions/statistics/message-subscriptions',
-                method: 'POST',
-                status: '200',
-            }, 
-            res
-        );
-        expect(body.page.totalItems).toBe(1);
-        expect(body.items.length).toBe(1);
-        const item = body.items[0];
-        expect(item.processDefinitionKey).toBe(processDefinitionKey);
-        expect(item.processDefinitionId).toBe(processDefinitionId);
-        expect(item.processInstancesWithActiveSubscriptions).toBe(1);
-        expect(item.activeSubscriptions).toBe(1);
+      const res = await request.post(
+        buildUrl('/process-definitions/statistics/message-subscriptions'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              processInstanceKey,
+            },
+          },
+        },
+      );
+      assertStatusCode(res, 200);
+      const body = await res.json();
+      validateResponse(
+        {
+          path: '/process-definitions/statistics/message-subscriptions',
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+      expect(body.page.totalItems).toBe(1);
+      expect(body.items.length).toBe(1);
+      const item = body.items[0];
+      expect(item.processDefinitionKey).toBe(processDefinitionKey);
+      expect(item.processDefinitionId).toBe(processDefinitionId);
+      expect(item.processInstancesWithActiveSubscriptions).toBe(1);
+      expect(item.activeSubscriptions).toBe(1);
     });
   });
 
-  test('Get message subscription statistics with not existing filter - Bad Request', async ({request}) => {
+  test('Get message subscription statistics with not existing filter - Bad Request', async ({
+    request,
+  }) => {
     const res = await request.post(
-        buildUrl('/process-definitions/statistics/message-subscriptions'),
-        {
-            headers: jsonHeaders(),
-            data: {
-                filter: {
-                    nonExistingFilter: 'test'
-                },
-            },
-          }
+      buildUrl('/process-definitions/statistics/message-subscriptions'),
+      {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            nonExistingFilter: 'test',
+          },
+        },
+      },
     );
-    await assertBadRequest(res, 'Request property [filter.nonExistingFilter] cannot be parsed');
+    await assertBadRequest(
+      res,
+      'Request property [filter.nonExistingFilter] cannot be parsed',
+    );
   });
 
-  test('Get message subscription statistics with not valid process instance key - Invalid Argument', async ({request}) => {
+  test('Get message subscription statistics with not valid process instance key - Invalid Argument', async ({
+    request,
+  }) => {
     const wrongProcessInstanceKey = 'abc';
     const res = await request.post(
-        buildUrl('/process-definitions/statistics/message-subscriptions'),
-        {
-            headers: jsonHeaders(),
-            data: {
-                filter: {
-                    processInstanceKey: wrongProcessInstanceKey
-                },
-            },
-          }
+      buildUrl('/process-definitions/statistics/message-subscriptions'),
+      {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            processInstanceKey: wrongProcessInstanceKey,
+          },
+        },
+      },
     );
-    await assertInvalidArgument(res, 400,  `The provided processInstanceKey '${wrongProcessInstanceKey}' is not a valid key.`);
+    await assertInvalidArgument(
+      res,
+      400,
+      `The provided processInstanceKey '${wrongProcessInstanceKey}' is not a valid key.`,
+    );
   });
 
-  test('Get message subscription statistics without authorization - Unauthorized', async ({request}) => {
+  test('Get message subscription statistics without authorization - Unauthorized', async ({
+    request,
+  }) => {
     const res = await request.post(
-        buildUrl('/process-definitions/statistics/message-subscriptions'),
-        {
-            headers: {},
-          }
+      buildUrl('/process-definitions/statistics/message-subscriptions'),
+      {
+        headers: {},
+      },
     );
     await assertUnauthorizedRequest(res);
   });
 
-  test('Get message subscription statistics - Forbidden, 200, empty response', async ({request}) => {
-    const token = encode(`${userWithResourcesAuthorizationToSendRequest.username}:${userWithResourcesAuthorizationToSendRequest.password}`);
+  test('Get message subscription statistics - Forbidden, 200, empty response', async ({
+    request,
+  }) => {
+    const token = encode(
+      `${userWithResourcesAuthorizationToSendRequest.username}:${userWithResourcesAuthorizationToSendRequest.password}`,
+    );
     const res = await request.post(
-        buildUrl('/process-definitions/statistics/message-subscriptions'),
-        {
-            headers: jsonHeaders(token),
-        });
+      buildUrl('/process-definitions/statistics/message-subscriptions'),
+      {
+        headers: jsonHeaders(token),
+      },
+    );
     assertStatusCode(res, 200);
     const body = await res.json();
     validateResponse(
-        {
-            path: '/process-definitions/statistics/message-subscriptions',
-            method: 'POST',
-            status: '200',
-        }, 
-        res
+      {
+        path: '/process-definitions/statistics/message-subscriptions',
+        method: 'POST',
+        status: '200',
+      },
+      res,
     );
     expect(body.page.totalItems).toBe(0);
     expect(body.items.length).toBe(0);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-message-statistics-subscription-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-message-statistics-subscription-api.spec.ts
@@ -10,7 +10,6 @@ import {expect, test} from '@playwright/test';
 import {
   cancelProcessInstance,
   createInstances,
-  createSingleInstance,
   deploy,
 } from '../../../../utils/zeebeClient';
 import {
@@ -23,7 +22,6 @@ import {
   encode,
 } from '../../../../utils/http';
 import {validateResponse} from '../../../../json-body-assertions';
-import {defaultAssertionOptions} from '../../../../utils/constants';
 import {cleanupUsers} from 'utils/usersCleanup';
 import {
   CORRELATE_MESSAGE,
@@ -38,14 +36,6 @@ import {
   grantUserResourceAuthorization,
   createUser,
 } from '@requestHelpers';
-
-type MessageSubscriptionStatisticsResponse = {
-  processDefinitionId: string;
-  processDefinitionKey: string;
-  tenantId: string;
-  processInstancesWithActiveSubscriptions: number;
-  activeSubscriptions: number;
-};
 
 test.describe.parallel('Get message subscription statistics API Tests', () => {
   let userWithResourcesAuthorizationToSendRequest: {
@@ -98,7 +88,7 @@ test.describe.parallel('Get message subscription statistics API Tests', () => {
 
     await test.step('Poll process instances', async () => {
       for (const key of processInstanceKeys) {
-        expectProcessInstanceCanBeFound(request, key);
+        await expectProcessInstanceCanBeFound(request, key);
       }
     });
 
@@ -166,9 +156,9 @@ test.describe.parallel('Get message subscription statistics API Tests', () => {
         },
       },
     );
-    assertStatusCode(res, 200);
+    await assertStatusCode(res, 200);
     const body = await res.json();
-    validateResponse(
+    await validateResponse(
       {
         path: '/process-definitions/statistics/message-subscriptions',
         method: 'POST',
@@ -194,9 +184,9 @@ test.describe.parallel('Get message subscription statistics API Tests', () => {
         },
       },
     );
-    assertStatusCode(res, 200);
+    await assertStatusCode(res, 200);
     const body = await res.json();
-    validateResponse(
+    await validateResponse(
       {
         path: '/process-definitions/statistics/message-subscriptions',
         method: 'POST',
@@ -222,7 +212,7 @@ test.describe.parallel('Get message subscription statistics API Tests', () => {
           headers: jsonHeaders(),
         },
       );
-      assertStatusCode(res, 200);
+      await assertStatusCode(res, 200);
       await validateResponse(
         {
           path: '/process-instances/{processInstanceKey}',
@@ -247,9 +237,9 @@ test.describe.parallel('Get message subscription statistics API Tests', () => {
           },
         },
       );
-      assertStatusCode(res, 200);
+      await assertStatusCode(res, 200);
       const body = await res.json();
-      validateResponse(
+      await validateResponse(
         {
           path: '/process-definitions/statistics/message-subscriptions',
           method: 'POST',
@@ -333,9 +323,9 @@ test.describe.parallel('Get message subscription statistics API Tests', () => {
         headers: jsonHeaders(token),
       },
     );
-    assertStatusCode(res, 200);
+    await assertStatusCode(res, 200);
     const body = await res.json();
-    validateResponse(
+    await validateResponse(
       {
         path: '/process-definitions/statistics/message-subscriptions',
         method: 'POST',

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-message-statistics-subscription-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-message-statistics-subscription-api.spec.ts
@@ -36,7 +36,7 @@ const expectedMessageSubscription = {
   tenantId: '<default>',
   elementId: 'Event_12y7kfq',
   processDefinitionId: 'message-statistics-test',
-}
+};
 
 test.describe.parallel('Get message subscription statistics API Tests', () => {
   let userWithResourcesAuthorizationToSendRequest: {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-process-instance-statistics-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-process-instance-statistics-api.spec.ts
@@ -91,7 +91,7 @@ test.describe.parallel('Get process instance statistics API Tests', () => {
     );
     await assertStatusCode(res, 200);
     const body = await res.json();
-    validateResponse(
+    await validateResponse(
       {
         path: '/process-definitions/statistics/process-instances',
         method: 'POST',
@@ -121,7 +121,7 @@ test.describe.parallel('Get process instance statistics API Tests', () => {
     );
     await assertStatusCode(res, 200);
     const body = await res.json();
-    validateResponse(
+    await validateResponse(
       {
         path: '/process-definitions/statistics/process-instances',
         method: 'POST',
@@ -131,12 +131,12 @@ test.describe.parallel('Get process instance statistics API Tests', () => {
     );
     expect(body.page.totalItems).toBeGreaterThanOrEqual(1);
     const actualActiveInstancesWithIncidentCountList = body.items.map(
-      (item: {ActiveInstancesWithIncidentCount: string}) =>
-        item.ActiveInstancesWithIncidentCount,
+      (item: {activeInstancesWithIncidentCount: string}) =>
+        item.activeInstancesWithIncidentCount,
     );
     const expectedActiveInstancesWithIncidentCountList = [
       ...actualActiveInstancesWithIncidentCountList,
-    ].sort();
+    ].sort().reverse();
     expect(actualActiveInstancesWithIncidentCountList).toEqual(
       expectedActiveInstancesWithIncidentCountList,
     );
@@ -161,7 +161,7 @@ test.describe.parallel('Get process instance statistics API Tests', () => {
     );
     await assertStatusCode(res, 200);
     const body = await res.json();
-    validateResponse(
+    await validateResponse(
       {
         path: '/process-definitions/statistics/process-instances',
         method: 'POST',
@@ -171,12 +171,12 @@ test.describe.parallel('Get process instance statistics API Tests', () => {
     );
     expect(body.page.totalItems).toBeGreaterThanOrEqual(1);
     const actualActiveInstancesWithoutIncidentCountList = body.items.map(
-      (item: {ActiveInstancesWithoutIncidentCount: string}) =>
-        item.ActiveInstancesWithoutIncidentCount,
+      (item: {activeInstancesWithoutIncidentCount: number}) =>
+        item.activeInstancesWithoutIncidentCount,
     );
     const expectedActiveInstancesWithoutIncidentCountList = [
       ...actualActiveInstancesWithoutIncidentCountList,
-    ].sort();
+    ].sort((a, b) => a - b);
     expect(actualActiveInstancesWithoutIncidentCountList).toEqual(
       expectedActiveInstancesWithoutIncidentCountList,
     );
@@ -202,7 +202,7 @@ test.describe.parallel('Get process instance statistics API Tests', () => {
     );
     await assertStatusCode(res, 200);
     const body = await res.json();
-    validateResponse(
+    await validateResponse(
       {
         path: '/process-definitions/statistics/process-instances',
         method: 'POST',
@@ -264,7 +264,7 @@ test.describe.parallel('Get process instance statistics API Tests', () => {
       );
       await assertStatusCode(res, 200);
       const body = await res.json();
-      validateResponse(
+      await validateResponse(
         {
           path: '/process-definitions/statistics/process-instances',
           method: 'POST',
@@ -323,7 +323,7 @@ test.describe.parallel('Get process instance statistics API Tests', () => {
     );
     await assertStatusCode(res, 200);
     const body = await res.json();
-    validateResponse(
+    await validateResponse(
       {
         path: '/process-definitions/statistics/process-instances',
         method: 'POST',

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-process-instance-statistics-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-process-instance-statistics-api.spec.ts
@@ -7,7 +7,11 @@
  */
 
 import {expect, test} from '@playwright/test';
-import {cancelProcessInstance, createSingleInstance, deploy} from '../../../../utils/zeebeClient';
+import {
+  cancelProcessInstance,
+  createSingleInstance,
+  deploy,
+} from '../../../../utils/zeebeClient';
 import {
   assertBadRequest,
   assertInvalidArgument,
@@ -19,9 +23,9 @@ import {
 } from '../../../../utils/http';
 import {validateResponse} from '../../../../json-body-assertions';
 import {defaultAssertionOptions} from '../../../../utils/constants';
-import { cleanupUsers } from 'utils/usersCleanup';
-import { grantUserResourceAuthorization } from 'utils/requestHelpers/authorization-requestHelpers';
-import { createUser } from 'utils/requestHelpers/user-requestHelpers';
+import {cleanupUsers} from 'utils/usersCleanup';
+import {grantUserResourceAuthorization} from 'utils/requestHelpers/authorization-requestHelpers';
+import {createUser} from 'utils/requestHelpers/user-requestHelpers';
 
 test.describe.parallel('Get process instance statistics API Tests', () => {
   let userWithResourcesAuthorizationToSendRequest: {
@@ -79,219 +83,256 @@ test.describe.parallel('Get process instance statistics API Tests', () => {
   });
 
   test('Get process instance statistics - Success', async ({request}) => {
-        const res = await request.post(
-          buildUrl(`/process-definitions/statistics/process-instances`),
-          {
-            headers: jsonHeaders(),
-          }
-        );
-        await assertStatusCode(res, 200);
-        const body = await res.json();
-        validateResponse(
-          {
-            path: '/process-definitions/statistics/process-instances',
-            method: 'POST',
-            status: '200',
-            },
-            res,
-        );
-        expect(body.page.totalItems).toBeGreaterThanOrEqual(1);
+    const res = await request.post(
+      buildUrl(`/process-definitions/statistics/process-instances`),
+      {
+        headers: jsonHeaders(),
+      },
+    );
+    await assertStatusCode(res, 200);
+    const body = await res.json();
+    validateResponse(
+      {
+        path: '/process-definitions/statistics/process-instances',
+        method: 'POST',
+        status: '200',
+      },
+      res,
+    );
+    expect(body.page.totalItems).toBeGreaterThanOrEqual(1);
   });
 
-  test('Get process instance statistics sort by activeInstancesWithIncidentCount - Success', async ({request}) => {
-        const res = await request.post(
-          buildUrl(`/process-definitions/statistics/process-instances`),
-          {
-            headers: jsonHeaders(),
-            data: {
-              sort: [
-                {
-                    field: "activeInstancesWithIncidentCount",
-                    order: "DESC"
-                }
-            ]
+  test('Get process instance statistics sort by activeInstancesWithIncidentCount - Success', async ({
+    request,
+  }) => {
+    const res = await request.post(
+      buildUrl(`/process-definitions/statistics/process-instances`),
+      {
+        headers: jsonHeaders(),
+        data: {
+          sort: [
+            {
+              field: 'activeInstancesWithIncidentCount',
+              order: 'DESC',
             },
-          }
-        );
-        await assertStatusCode(res, 200);
-        const body = await res.json();
-        validateResponse(
-          {
-            path: '/process-definitions/statistics/process-instances',
-            method: 'POST',
-            status: '200',
-            },
-            res,
-        );
-        expect(body.page.totalItems).toBeGreaterThanOrEqual(1);
-        const actualActiveInstancesWithIncidentCountList = body.items.map(
-          (item: {ActiveInstancesWithIncidentCount: string}) => item.ActiveInstancesWithIncidentCount,
-        );
-        const expectedActiveInstancesWithIncidentCountList = [...actualActiveInstancesWithIncidentCountList].sort();
-        expect(actualActiveInstancesWithIncidentCountList).toEqual(expectedActiveInstancesWithIncidentCountList);
+          ],
+        },
+      },
+    );
+    await assertStatusCode(res, 200);
+    const body = await res.json();
+    validateResponse(
+      {
+        path: '/process-definitions/statistics/process-instances',
+        method: 'POST',
+        status: '200',
+      },
+      res,
+    );
+    expect(body.page.totalItems).toBeGreaterThanOrEqual(1);
+    const actualActiveInstancesWithIncidentCountList = body.items.map(
+      (item: {ActiveInstancesWithIncidentCount: string}) =>
+        item.ActiveInstancesWithIncidentCount,
+    );
+    const expectedActiveInstancesWithIncidentCountList = [
+      ...actualActiveInstancesWithIncidentCountList,
+    ].sort();
+    expect(actualActiveInstancesWithIncidentCountList).toEqual(
+      expectedActiveInstancesWithIncidentCountList,
+    );
   });
 
-  test('Get process instance statistics sort by activeInstancesWithoutIncidentCount - Success', async ({request}) => {
-        const res = await request.post(
-          buildUrl(`/process-definitions/statistics/process-instances`),
-          {
-            headers: jsonHeaders(),
-            data: {
-              sort: [
-                {
-                    field: "activeInstancesWithoutIncidentCount",
-                    order: "ASC"
-                }
-            ]
+  test('Get process instance statistics sort by activeInstancesWithoutIncidentCount - Success', async ({
+    request,
+  }) => {
+    const res = await request.post(
+      buildUrl(`/process-definitions/statistics/process-instances`),
+      {
+        headers: jsonHeaders(),
+        data: {
+          sort: [
+            {
+              field: 'activeInstancesWithoutIncidentCount',
+              order: 'ASC',
             },
-          }
-        );
-        await assertStatusCode(res, 200);
-        const body = await res.json();
-        validateResponse(
-          {
-            path: '/process-definitions/statistics/process-instances',
-            method: 'POST',
-            status: '200',
-            },
-            res,
-        );
-        expect(body.page.totalItems).toBeGreaterThanOrEqual(1);
-        const actualActiveInstancesWithoutIncidentCountList = body.items.map(
-          (item: {ActiveInstancesWithoutIncidentCount: string}) => item.ActiveInstancesWithoutIncidentCount,
-        );
-        const expectedActiveInstancesWithoutIncidentCountList = [...actualActiveInstancesWithoutIncidentCountList].sort();
-        expect(actualActiveInstancesWithoutIncidentCountList).toEqual(expectedActiveInstancesWithoutIncidentCountList);
+          ],
+        },
+      },
+    );
+    await assertStatusCode(res, 200);
+    const body = await res.json();
+    validateResponse(
+      {
+        path: '/process-definitions/statistics/process-instances',
+        method: 'POST',
+        status: '200',
+      },
+      res,
+    );
+    expect(body.page.totalItems).toBeGreaterThanOrEqual(1);
+    const actualActiveInstancesWithoutIncidentCountList = body.items.map(
+      (item: {ActiveInstancesWithoutIncidentCount: string}) =>
+        item.ActiveInstancesWithoutIncidentCount,
+    );
+    const expectedActiveInstancesWithoutIncidentCountList = [
+      ...actualActiveInstancesWithoutIncidentCountList,
+    ].sort();
+    expect(actualActiveInstancesWithoutIncidentCountList).toEqual(
+      expectedActiveInstancesWithoutIncidentCountList,
+    );
   });
 
   //Skipped due to bug 50945: https://github.com/camunda/camunda/issues/50945
-  test.skip('Get process instance statistics sort by processDefinitionId - Success', async ({request}) => {
-        const res = await request.post(
-          buildUrl(`/process-definitions/statistics/process-instances`),
-          {
-            headers: jsonHeaders(),
-            data: {
-              sort: [
-                {
-                    field: "processDefinitionId",
-                    order: "ASC"
-                }
-            ]
+  test.skip('Get process instance statistics sort by processDefinitionId - Success', async ({
+    request,
+  }) => {
+    const res = await request.post(
+      buildUrl(`/process-definitions/statistics/process-instances`),
+      {
+        headers: jsonHeaders(),
+        data: {
+          sort: [
+            {
+              field: 'processDefinitionId',
+              order: 'ASC',
             },
-          }
-        );
-        await assertStatusCode(res, 200);
-        const body = await res.json();
-        validateResponse(
-          {
-            path: '/process-definitions/statistics/process-instances',
-            method: 'POST',
-            status: '200',
-            },
-            res,
-        );
-        expect(body.page.totalItems).toBeGreaterThanOrEqual(1);
-        const actualProcessDefinitionIdList = body.items.map(
-          (item: {ProcessDefinitionId: string}) => item.ProcessDefinitionId,
-        );
-        const expectedProcessDefinitionIdList = [...actualProcessDefinitionIdList].sort();
-        expect(actualProcessDefinitionIdList).toEqual(expectedProcessDefinitionIdList);
+          ],
+        },
+      },
+    );
+    await assertStatusCode(res, 200);
+    const body = await res.json();
+    validateResponse(
+      {
+        path: '/process-definitions/statistics/process-instances',
+        method: 'POST',
+        status: '200',
+      },
+      res,
+    );
+    expect(body.page.totalItems).toBeGreaterThanOrEqual(1);
+    const actualProcessDefinitionIdList = body.items.map(
+      (item: {ProcessDefinitionId: string}) => item.ProcessDefinitionId,
+    );
+    const expectedProcessDefinitionIdList = [
+      ...actualProcessDefinitionIdList,
+    ].sort();
+    expect(actualProcessDefinitionIdList).toEqual(
+      expectedProcessDefinitionIdList,
+    );
   });
 
-  test('Get process instance statistics sort by not existing field - Bad Request', async ({request}) => {
-    const notExistingField = "meow";
-        const res = await request.post(
-          buildUrl(`/process-definitions/statistics/process-instances`),
-          {
-            headers: jsonHeaders(),
-            data: {
-              sort: [
-                {
-                    field: notExistingField,
-                    order: "DESC"
-                }
-            ]
+  test('Get process instance statistics sort by not existing field - Bad Request', async ({
+    request,
+  }) => {
+    const notExistingField = 'meow';
+    const res = await request.post(
+      buildUrl(`/process-definitions/statistics/process-instances`),
+      {
+        headers: jsonHeaders(),
+        data: {
+          sort: [
+            {
+              field: notExistingField,
+              order: 'DESC',
             },
-          }
-        );
-        await assertBadRequest(res, `Unexpected value '${notExistingField}' for enum field 'field'.`);
+          ],
+        },
+      },
+    );
+    await assertBadRequest(
+      res,
+      `Unexpected value '${notExistingField}' for enum field 'field'.`,
+    );
   });
 
-  test('Get process instance statistics with page limit 1 - Success', async ({request}) => {
+  test('Get process instance statistics with page limit 1 - Success', async ({
+    request,
+  }) => {
     await expect(async () => {
-        const res = await request.post(
-          buildUrl(`/process-definitions/statistics/process-instances`),
-          {
-            headers: jsonHeaders(),
-            data: {
-              page: {
-                from: 0,
-                limit: 1
-              }
+      const res = await request.post(
+        buildUrl(`/process-definitions/statistics/process-instances`),
+        {
+          headers: jsonHeaders(),
+          data: {
+            page: {
+              from: 0,
+              limit: 1,
             },
-          }
-        );
-        await assertStatusCode(res, 200);
-        const body = await res.json();
-        validateResponse(
-          {
-            path: '/process-definitions/statistics/process-instances',
-            method: 'POST',
-            status: '200',
-            },
-            res,
-        );
-        expect(body.page.totalItems).toBeGreaterThanOrEqual(1);
-        expect(body.items.length).toEqual(1);
+          },
+        },
+      );
+      await assertStatusCode(res, 200);
+      const body = await res.json();
+      validateResponse(
+        {
+          path: '/process-definitions/statistics/process-instances',
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+      expect(body.page.totalItems).toBeGreaterThanOrEqual(1);
+      expect(body.items.length).toEqual(1);
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Get process instance statistics with page limit -1 - Bad Request', async ({request}) => {
-        const res = await request.post(
-          buildUrl(`/process-definitions/statistics/process-instances`),
-          {
-            headers: jsonHeaders(),
-            data: {
-              page: {
-                from: 0,
-                limit: -1
-              }
-            },
-          }
-        );
-        await assertInvalidArgument(res, 400, 'The value for page.limit is \'-1\' but must be a non-negative number.');
+  test('Get process instance statistics with page limit -1 - Bad Request', async ({
+    request,
+  }) => {
+    const res = await request.post(
+      buildUrl(`/process-definitions/statistics/process-instances`),
+      {
+        headers: jsonHeaders(),
+        data: {
+          page: {
+            from: 0,
+            limit: -1,
+          },
+        },
+      },
+    );
+    await assertInvalidArgument(
+      res,
+      400,
+      "The value for page.limit is '-1' but must be a non-negative number.",
+    );
   });
 
   test('Get process instance statistics - Unauthorized', async ({request}) => {
-        const res = await request.post(
-          buildUrl(`/process-definitions/statistics/process-instances`),
-          {
-            headers: {},
-          }
-        );
-        await assertUnauthorizedRequest(res);
+    const res = await request.post(
+      buildUrl(`/process-definitions/statistics/process-instances`),
+      {
+        headers: {},
+      },
+    );
+    await assertUnauthorizedRequest(res);
   });
 
-  test('Get process instance statistics with user without proper authorization - Forbidden, 200, empty result', async ({request}) => {
-    const token = encode(`${userWithResourcesAuthorizationToSendRequest.username}:${userWithResourcesAuthorizationToSendRequest.password}`);
-        const res = await request.post(
-          buildUrl(`/process-definitions/statistics/process-instances`),
-          {
-            headers: jsonHeaders(token), // overrides default demo:demo
-          }
-        );
-        await assertStatusCode(res, 200);
-        const body = await res.json();
-        validateResponse(
-          {
-            path: '/process-definitions/statistics/process-instances',
-            method: 'POST',
-            status: '200',
-            },
-            res,
-        );
-        expect(body.page.totalItems).toEqual(0);
-        expect(body.items.length).toEqual(0);
-        expect(body.page.hasMoreTotalItems).toBe(false);
+  test('Get process instance statistics with user without proper authorization - Forbidden, 200, empty result', async ({
+    request,
+  }) => {
+    const token = encode(
+      `${userWithResourcesAuthorizationToSendRequest.username}:${userWithResourcesAuthorizationToSendRequest.password}`,
+    );
+    const res = await request.post(
+      buildUrl(`/process-definitions/statistics/process-instances`),
+      {
+        headers: jsonHeaders(token), // overrides default demo:demo
+      },
+    );
+    await assertStatusCode(res, 200);
+    const body = await res.json();
+    validateResponse(
+      {
+        path: '/process-definitions/statistics/process-instances',
+        method: 'POST',
+        status: '200',
+      },
+      res,
+    );
+    expect(body.page.totalItems).toEqual(0);
+    expect(body.items.length).toEqual(0);
+    expect(body.page.hasMoreTotalItems).toBe(false);
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-process-instance-statistics-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-process-instance-statistics-api.spec.ts
@@ -1,0 +1,313 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect, test} from '@playwright/test';
+import {cancelProcessInstance, createSingleInstance, deploy} from '../../../../utils/zeebeClient';
+import {
+  assertBadRequest,
+  assertInvalidArgument,
+  assertStatusCode,
+  assertUnauthorizedRequest,
+  buildUrl,
+  jsonHeaders,
+  encode,
+} from '../../../../utils/http';
+import {validateResponse} from '../../../../json-body-assertions';
+import {defaultAssertionOptions} from '../../../../utils/constants';
+import { cleanupUsers } from 'utils/usersCleanup';
+import { grantUserResourceAuthorization } from 'utils/requestHelpers/authorization-requestHelpers';
+import { createUser } from 'utils/requestHelpers/user-requestHelpers';
+
+test.describe.parallel('Get process instance statistics API Tests', () => {
+  let userWithResourcesAuthorizationToSendRequest: {
+    username: string;
+    name: string;
+    email: string;
+    password: string;
+  } = {} as {
+    username: string;
+    name: string;
+    email: string;
+    password: string;
+  };
+  let processInstanceKeys: string[] = [];
+
+  test.beforeAll(async ({request}) => {
+    await test.step('Setup - Deploy process and create instances', async () => {
+      await deploy([
+        './resources/calledProcess.bpmn',
+        './resources/IncidentProcess.bpmn',
+      ]);
+
+      const incidentInstance = await createSingleInstance('IncidentProcess', 1);
+      const calledInstance = await createSingleInstance('CalledProcess', 1);
+
+      processInstanceKeys.push(incidentInstance.processInstanceKey);
+      processInstanceKeys.push(calledInstance.processInstanceKey);
+    });
+
+    await test.step('Setup - Create test user with Resource Authorization and user for granting Authorization', async () => {
+      userWithResourcesAuthorizationToSendRequest = await createUser(request);
+      await grantUserResourceAuthorization(
+        request,
+        userWithResourcesAuthorizationToSendRequest,
+      );
+    });
+  });
+
+  test.afterAll(async ({request}) => {
+    await test.step('Cleanup - Delete test users', async () => {
+      await cleanupUsers(request, [
+        userWithResourcesAuthorizationToSendRequest.username,
+      ]);
+    });
+
+    await test.step('Cleanup - Cancel process instances', async () => {
+      for (const processInstanceKey of processInstanceKeys) {
+        await cancelProcessInstance(processInstanceKey);
+      }
+    });
+
+    await test.step('Cleanup - Clean array', async () => {
+      processInstanceKeys = [];
+    });
+  });
+
+  test('Get process instance statistics - Success', async ({request}) => {
+    await expect(async () => {
+        const res = await request.post(
+          buildUrl(`/process-definitions/statistics/process-instances`),
+          {
+            headers: jsonHeaders(),
+          }
+        );
+        await assertStatusCode(res, 200);
+        const body = await res.json();
+        validateResponse(
+          {
+            path: '/process-definitions/statistics/process-instances',
+            method: 'POST',
+            status: '200',
+            },
+            res,
+        );
+        expect(body.page.totalItems).toBeGreaterThanOrEqual(1);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Get process instance statistics sort by activeInstancesWithIncidentCount - Success', async ({request}) => {
+    await expect(async () => {
+        const res = await request.post(
+          buildUrl(`/process-definitions/statistics/process-instances`),
+          {
+            headers: jsonHeaders(),
+            data: {
+              sort: [
+                {
+                    field: "activeInstancesWithIncidentCount",
+                    order: "DESC"
+                }
+            ]
+            },
+          }
+        );
+        await assertStatusCode(res, 200);
+        const body = await res.json();
+        validateResponse(
+          {
+            path: '/process-definitions/statistics/process-instances',
+            method: 'POST',
+            status: '200',
+            },
+            res,
+        );
+        expect(body.page.totalItems).toBeGreaterThanOrEqual(1);
+        const actualActiveInstancesWithIncidentCountList = body.items.map(
+          (item: {ActiveInstancesWithIncidentCount: string}) => item.ActiveInstancesWithIncidentCount,
+        );
+        const expectedActiveInstancesWithIncidentCountList = [...actualActiveInstancesWithIncidentCountList].sort();
+        expect(actualActiveInstancesWithIncidentCountList).toEqual(expectedActiveInstancesWithIncidentCountList);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Get process instance statistics sort by activeInstancesWithoutIncidentCount - Success', async ({request}) => {
+    await expect(async () => {
+        const res = await request.post(
+          buildUrl(`/process-definitions/statistics/process-instances`),
+          {
+            headers: jsonHeaders(),
+            data: {
+              sort: [
+                {
+                    field: "activeInstancesWithoutIncidentCount",
+                    order: "ASC"
+                }
+            ]
+            },
+          }
+        );
+        await assertStatusCode(res, 200);
+        const body = await res.json();
+        validateResponse(
+          {
+            path: '/process-definitions/statistics/process-instances',
+            method: 'POST',
+            status: '200',
+            },
+            res,
+        );
+        expect(body.page.totalItems).toBeGreaterThanOrEqual(1);
+        const actualActiveInstancesWithoutIncidentCountList = body.items.map(
+          (item: {ActiveInstancesWithoutIncidentCount: string}) => item.ActiveInstancesWithoutIncidentCount,
+        );
+        const expectedActiveInstancesWithoutIncidentCountList = [...actualActiveInstancesWithoutIncidentCountList].sort();
+        expect(actualActiveInstancesWithoutIncidentCountList).toEqual(expectedActiveInstancesWithoutIncidentCountList);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  //Skipped due to bug 50945: https://github.com/camunda/camunda/issues/50945
+  test.skip('Get process instance statistics sort by processDefinitionId - Success', async ({request}) => {
+    await expect(async () => {
+        const res = await request.post(
+          buildUrl(`/process-definitions/statistics/process-instances`),
+          {
+            headers: jsonHeaders(),
+            data: {
+              sort: [
+                {
+                    field: "processDefinitionId",
+                    order: "ASC"
+                }
+            ]
+            },
+          }
+        );
+        await assertStatusCode(res, 200);
+        const body = await res.json();
+        validateResponse(
+          {
+            path: '/process-definitions/statistics/process-instances',
+            method: 'POST',
+            status: '200',
+            },
+            res,
+        );
+        expect(body.page.totalItems).toBeGreaterThanOrEqual(1);
+        const actualProcessDefinitionIdList = body.items.map(
+          (item: {ProcessDefinitionId: string}) => item.ProcessDefinitionId,
+        );
+        const expectedProcessDefinitionIdList = [...actualProcessDefinitionIdList].sort();
+        expect(actualProcessDefinitionIdList).toEqual(expectedProcessDefinitionIdList);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Get process instance statistics sort by not existing field - Bad Request', async ({request}) => {
+    const notExistingField = "meow";
+    await expect(async () => {
+        const res = await request.post(
+          buildUrl(`/process-definitions/statistics/process-instances`),
+          {
+            headers: jsonHeaders(),
+            data: {
+              sort: [
+                {
+                    field: notExistingField,
+                    order: "DESC"
+                }
+            ]
+            },
+          }
+        );
+        await assertBadRequest(res, `Unexpected value '${notExistingField}' for enum field 'field'.`);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Get process instance statistics with page limit 1 - Success', async ({request}) => {
+    await expect(async () => {
+        const res = await request.post(
+          buildUrl(`/process-definitions/statistics/process-instances`),
+          {
+            headers: jsonHeaders(),
+            data: {
+              page: {
+                from: 0,
+                limit: 1
+              }
+            },
+          }
+        );
+        await assertStatusCode(res, 200);
+        const body = await res.json();
+        validateResponse(
+          {
+            path: '/process-definitions/statistics/process-instances',
+            method: 'POST',
+            status: '200',
+            },
+            res,
+        );
+        expect(body.page.totalItems).toBeGreaterThanOrEqual(1);
+        expect(body.items.length).toEqual(1);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Get process instance statistics with page limit -1 - Bad Request', async ({request}) => {
+    await expect(async () => {
+        const res = await request.post(
+          buildUrl(`/process-definitions/statistics/process-instances`),
+          {
+            headers: jsonHeaders(),
+            data: {
+              page: {
+                from: 0,
+                limit: -1
+              }
+            },
+          }
+        );
+        await assertInvalidArgument(res, 400, 'The value for page.limit is \'-1\' but must be a non-negative number.');
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Get process instance statistics - Unauthorized', async ({request}) => {
+    await expect(async () => {
+        const res = await request.post(
+          buildUrl(`/process-definitions/statistics/process-instances`),
+          {
+            headers: {},
+          }
+        );
+        await assertUnauthorizedRequest(res);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Get process instance statistics with user without proper authorization - Forbidden, 200, empty result', async ({request}) => {
+    const token = encode(`${userWithResourcesAuthorizationToSendRequest.username}:${userWithResourcesAuthorizationToSendRequest.password}`);
+    await expect(async () => {
+        const res = await request.post(
+          buildUrl(`/process-definitions/statistics/process-instances`),
+          {
+            headers: jsonHeaders(token), // overrides default demo:demo
+          }
+        );
+        await assertStatusCode(res, 200);
+        const body = await res.json();
+        validateResponse(
+          {
+            path: '/process-definitions/statistics/process-instances',
+            method: 'POST',
+            status: '200',
+            },
+            res,
+        );
+        expect(body.page.totalItems).toEqual(0);
+        expect(body.items.length).toEqual(0);
+        expect(body.page.hasMoreTotalItems).toBe(false);
+    }).toPass(defaultAssertionOptions);
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-process-instance-statistics-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-process-instance-statistics-api.spec.ts
@@ -79,7 +79,6 @@ test.describe.parallel('Get process instance statistics API Tests', () => {
   });
 
   test('Get process instance statistics - Success', async ({request}) => {
-    await expect(async () => {
         const res = await request.post(
           buildUrl(`/process-definitions/statistics/process-instances`),
           {
@@ -97,11 +96,9 @@ test.describe.parallel('Get process instance statistics API Tests', () => {
             res,
         );
         expect(body.page.totalItems).toBeGreaterThanOrEqual(1);
-    }).toPass(defaultAssertionOptions);
   });
 
   test('Get process instance statistics sort by activeInstancesWithIncidentCount - Success', async ({request}) => {
-    await expect(async () => {
         const res = await request.post(
           buildUrl(`/process-definitions/statistics/process-instances`),
           {
@@ -132,11 +129,9 @@ test.describe.parallel('Get process instance statistics API Tests', () => {
         );
         const expectedActiveInstancesWithIncidentCountList = [...actualActiveInstancesWithIncidentCountList].sort();
         expect(actualActiveInstancesWithIncidentCountList).toEqual(expectedActiveInstancesWithIncidentCountList);
-    }).toPass(defaultAssertionOptions);
   });
 
   test('Get process instance statistics sort by activeInstancesWithoutIncidentCount - Success', async ({request}) => {
-    await expect(async () => {
         const res = await request.post(
           buildUrl(`/process-definitions/statistics/process-instances`),
           {
@@ -167,12 +162,10 @@ test.describe.parallel('Get process instance statistics API Tests', () => {
         );
         const expectedActiveInstancesWithoutIncidentCountList = [...actualActiveInstancesWithoutIncidentCountList].sort();
         expect(actualActiveInstancesWithoutIncidentCountList).toEqual(expectedActiveInstancesWithoutIncidentCountList);
-    }).toPass(defaultAssertionOptions);
   });
 
   //Skipped due to bug 50945: https://github.com/camunda/camunda/issues/50945
   test.skip('Get process instance statistics sort by processDefinitionId - Success', async ({request}) => {
-    await expect(async () => {
         const res = await request.post(
           buildUrl(`/process-definitions/statistics/process-instances`),
           {
@@ -203,12 +196,10 @@ test.describe.parallel('Get process instance statistics API Tests', () => {
         );
         const expectedProcessDefinitionIdList = [...actualProcessDefinitionIdList].sort();
         expect(actualProcessDefinitionIdList).toEqual(expectedProcessDefinitionIdList);
-    }).toPass(defaultAssertionOptions);
   });
 
   test('Get process instance statistics sort by not existing field - Bad Request', async ({request}) => {
     const notExistingField = "meow";
-    await expect(async () => {
         const res = await request.post(
           buildUrl(`/process-definitions/statistics/process-instances`),
           {
@@ -224,7 +215,6 @@ test.describe.parallel('Get process instance statistics API Tests', () => {
           }
         );
         await assertBadRequest(res, `Unexpected value '${notExistingField}' for enum field 'field'.`);
-    }).toPass(defaultAssertionOptions);
   });
 
   test('Get process instance statistics with page limit 1 - Success', async ({request}) => {
@@ -257,7 +247,6 @@ test.describe.parallel('Get process instance statistics API Tests', () => {
   });
 
   test('Get process instance statistics with page limit -1 - Bad Request', async ({request}) => {
-    await expect(async () => {
         const res = await request.post(
           buildUrl(`/process-definitions/statistics/process-instances`),
           {
@@ -271,11 +260,9 @@ test.describe.parallel('Get process instance statistics API Tests', () => {
           }
         );
         await assertInvalidArgument(res, 400, 'The value for page.limit is \'-1\' but must be a non-negative number.');
-    }).toPass(defaultAssertionOptions);
   });
 
   test('Get process instance statistics - Unauthorized', async ({request}) => {
-    await expect(async () => {
         const res = await request.post(
           buildUrl(`/process-definitions/statistics/process-instances`),
           {
@@ -283,12 +270,10 @@ test.describe.parallel('Get process instance statistics API Tests', () => {
           }
         );
         await assertUnauthorizedRequest(res);
-    }).toPass(defaultAssertionOptions);
   });
 
   test('Get process instance statistics with user without proper authorization - Forbidden, 200, empty result', async ({request}) => {
     const token = encode(`${userWithResourcesAuthorizationToSendRequest.username}:${userWithResourcesAuthorizationToSendRequest.password}`);
-    await expect(async () => {
         const res = await request.post(
           buildUrl(`/process-definitions/statistics/process-instances`),
           {
@@ -308,6 +293,5 @@ test.describe.parallel('Get process instance statistics API Tests', () => {
         expect(body.page.totalItems).toEqual(0);
         expect(body.items.length).toEqual(0);
         expect(body.page.hasMoreTotalItems).toBe(false);
-    }).toPass(defaultAssertionOptions);
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-process-instance-statistics-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-process-instance-statistics-api.spec.ts
@@ -136,7 +136,9 @@ test.describe.parallel('Get process instance statistics API Tests', () => {
     );
     const expectedActiveInstancesWithIncidentCountList = [
       ...actualActiveInstancesWithIncidentCountList,
-    ].sort().reverse();
+    ]
+      .sort()
+      .reverse();
     expect(actualActiveInstancesWithIncidentCountList).toEqual(
       expectedActiveInstancesWithIncidentCountList,
     );

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-process-instance-statistics-by-version-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-process-instance-statistics-by-version-api.spec.ts
@@ -30,7 +30,7 @@ import {createUser} from 'utils/requestHelpers/user-requestHelpers';
 type ProcessInstanceStatisticsByVersionResponse = {
   processDefinitionId: string;
   processDefinitionKey: string;
-  processDefinitionName: string;
+  processDefinitionName: string | null;
   tenantId: string;
   processDefinitionVersion: number;
   activeInstancesWithIncidentCount: number;
@@ -119,7 +119,7 @@ test.describe
       );
       await assertStatusCode(res, 200);
       const body = await res.json();
-      validateResponse(
+      await validateResponse(
         {
           path: '/process-definitions/statistics/process-instances-by-version',
           method: 'POST',
@@ -169,7 +169,7 @@ test.describe
         );
         await assertStatusCode(res, 200);
         const body = await res.json();
-        validateResponse(
+        await validateResponse(
           {
             path: '/process-definitions/statistics/process-instances-by-version',
             method: 'POST',
@@ -250,7 +250,7 @@ test.describe
     );
     await assertStatusCode(res, 200);
     const body = await res.json();
-    validateResponse(
+    await validateResponse(
       {
         path: '/process-definitions/statistics/process-instances-by-version',
         method: 'POST',
@@ -298,7 +298,7 @@ test.describe
     );
     await assertStatusCode(res, 200);
     const body = await res.json();
-    validateResponse(
+    await validateResponse(
       {
         path: '/process-definitions/statistics/process-instances-by-version',
         method: 'POST',

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-process-instance-statistics-by-version-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-process-instance-statistics-by-version-api.spec.ts
@@ -180,6 +180,23 @@ test.describe.parallel('Get process instance statistics by version API Tests', (
         await assertInvalidArgument(res, 400, 'No filter provided.');
   });
 
+  test('Get process instance statistics by version with non-existing field - Bad Request', async ({request}) => {
+    const notExistingField = {meow: 'meow'};
+    const res = await request.post(
+      buildUrl(`/process-definitions/statistics/process-instances-by-version`),
+      {
+        headers: jsonHeaders(),
+        data: {
+            filter: {
+                processDefinitionId,
+                ...notExistingField,
+            },
+        },
+      }
+    );
+    await assertBadRequest(res, 'Request property [filter.meow] cannot be parsed');
+  });
+
   test('Get process instance statistics by version with non-existing processDefinitionId - Success, empty result', async ({request}) => {
     const nonExistingProcessDefinitionId = 'nonExistingProcessDefinitionId';
         const res = await request.post(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-process-instance-statistics-by-version-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-process-instance-statistics-by-version-api.spec.ts
@@ -7,7 +7,11 @@
  */
 
 import {expect, test} from '@playwright/test';
-import {cancelProcessInstance, createSingleInstance, deploy} from '../../../../utils/zeebeClient';
+import {
+  cancelProcessInstance,
+  createSingleInstance,
+  deploy,
+} from '../../../../utils/zeebeClient';
 import {
   assertBadRequest,
   assertInvalidArgument,
@@ -19,21 +23,22 @@ import {
 } from '../../../../utils/http';
 import {validateResponse} from '../../../../json-body-assertions';
 import {defaultAssertionOptions} from '../../../../utils/constants';
-import { cleanupUsers } from 'utils/usersCleanup';
-import { grantUserResourceAuthorization } from 'utils/requestHelpers/authorization-requestHelpers';
-import { createUser } from 'utils/requestHelpers/user-requestHelpers';
+import {cleanupUsers} from 'utils/usersCleanup';
+import {grantUserResourceAuthorization} from 'utils/requestHelpers/authorization-requestHelpers';
+import {createUser} from 'utils/requestHelpers/user-requestHelpers';
 
 type ProcessInstanceStatisticsByVersionResponse = {
-    processDefinitionId: string;
-    processDefinitionKey: string;
-    processDefinitionName: string;
-    tenantId: string;
-    processDefinitionVersion: number;
-    activeInstancesWithIncidentCount: number;
-    activeInstancesWithoutIncidentCount: number;
+  processDefinitionId: string;
+  processDefinitionKey: string;
+  processDefinitionName: string;
+  tenantId: string;
+  processDefinitionVersion: number;
+  activeInstancesWithIncidentCount: number;
+  activeInstancesWithoutIncidentCount: number;
 };
 
-test.describe.parallel('Get process instance statistics by version API Tests', () => {
+test.describe
+  .parallel('Get process instance statistics by version API Tests', () => {
   let userWithResourcesAuthorizationToSendRequest: {
     username: string;
     name: string;
@@ -51,11 +56,17 @@ test.describe.parallel('Get process instance statistics by version API Tests', (
   test.beforeAll(async ({request}) => {
     await test.step('Setup - Deploy process and create instances', async () => {
       await deploy(['./resources/processWithMultipleVersions_v_1.bpmn']);
-      const processInstanceV1 = await createSingleInstance(processDefinitionId, 1);
+      const processInstanceV1 = await createSingleInstance(
+        processDefinitionId,
+        1,
+      );
       const processInstanceKeyV1 = processInstanceV1.processInstanceKey;
-      
+
       await deploy(['./resources/processWithMultipleVersions_v_2.bpmn']);
-      const processInstanceV2 = await createSingleInstance(processDefinitionId, 2);
+      const processInstanceV2 = await createSingleInstance(
+        processDefinitionId,
+        2,
+      );
       const processInstanceKeyV2 = processInstanceV2.processInstanceKey;
 
       processInstanceKeys.push(processInstanceKeyV1);
@@ -89,18 +100,72 @@ test.describe.parallel('Get process instance statistics by version API Tests', (
     });
   });
 
-  test('Get process instance statistics by version - Success', async ({request}) => {
-      await expect(async () => {
+  test('Get process instance statistics by version - Success', async ({
+    request,
+  }) => {
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl(
+          `/process-definitions/statistics/process-instances-by-version`,
+        ),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              processDefinitionId,
+            },
+          },
+        },
+      );
+      await assertStatusCode(res, 200);
+      const body = await res.json();
+      validateResponse(
+        {
+          path: '/process-definitions/statistics/process-instances-by-version',
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+      expect(body.page.totalItems).toBeGreaterThanOrEqual(2);
+      body.items.forEach(
+        (element: ProcessInstanceStatisticsByVersionResponse) => {
+          expect(element.processDefinitionId).toBe(processDefinitionId);
+          expect(
+            element.activeInstancesWithoutIncidentCount,
+          ).toBeGreaterThanOrEqual(1);
+        },
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Get process instance statistics by version, sorting - Success', async ({
+    request,
+  }) => {
+    const sort = [
+      //Skipped due to bug 50976: https://github.com/camunda/camunda/issues/50976
+      // {field: "processDefinitionId", order: "ASC"},
+      // {field: "processDefinitionKey", order: "ASC"},
+      // {field: "processDefinitionName", order: "ASC"},
+      // {field: "processDefinitionVersion", order: "ASC"},
+      {field: 'activeInstancesWithIncidentCount', order: 'ASC'},
+      {field: 'activeInstancesWithoutIncidentCount', order: 'ASC'},
+    ];
+    await expect(async () => {
+      for (const sortOption of sort) {
         const res = await request.post(
-          buildUrl(`/process-definitions/statistics/process-instances-by-version`),
+          buildUrl(
+            `/process-definitions/statistics/process-instances-by-version`,
+          ),
           {
             headers: jsonHeaders(),
             data: {
-                filter: {
-                    processDefinitionId
-                },
+              filter: {
+                processDefinitionId,
+              },
+              sort: [sortOption],
             },
-          }
+          },
         );
         await assertStatusCode(res, 200);
         const body = await res.json();
@@ -109,160 +174,139 @@ test.describe.parallel('Get process instance statistics by version API Tests', (
             path: '/process-definitions/statistics/process-instances-by-version',
             method: 'POST',
             status: '200',
-            },
-            res,
+          },
+          res,
         );
+        const field =
+          sortOption.field as keyof ProcessInstanceStatisticsByVersionResponse;
+        const fieldValues: string[] = body.items.map(
+          (item: ProcessInstanceStatisticsByVersionResponse) =>
+            item[field] as string,
+        );
+        const sortedfieldValues = [...fieldValues].sort();
+        expect(fieldValues).toEqual(sortedfieldValues);
         expect(body.page.totalItems).toBeGreaterThanOrEqual(2);
-        body.items.forEach((element: ProcessInstanceStatisticsByVersionResponse) => {
+        body.items.forEach(
+          (element: ProcessInstanceStatisticsByVersionResponse) => {
             expect(element.processDefinitionId).toBe(processDefinitionId);
-            expect(element.activeInstancesWithoutIncidentCount).toBeGreaterThanOrEqual(1);
-        });
-      }).toPass(defaultAssertionOptions);
-  });
-
-  test('Get process instance statistics by version, sorting - Success', async ({request}) => {
-        const sort = [
-            //Skipped due to bug 50976: https://github.com/camunda/camunda/issues/50976
-            // {field: "processDefinitionId", order: "ASC"},
-            // {field: "processDefinitionKey", order: "ASC"},
-            // {field: "processDefinitionName", order: "ASC"},
-            // {field: "processDefinitionVersion", order: "ASC"},
-            {field: "activeInstancesWithIncidentCount", order: "ASC"},
-            {field: "activeInstancesWithoutIncidentCount", order: "ASC"},
-        ];
-        await expect(async () => {
-            for (const sortOption of sort) {
-                const res = await request.post(
-                    buildUrl(`/process-definitions/statistics/process-instances-by-version`),
-                    {
-                        headers: jsonHeaders(),
-                        data: {
-                            filter: {
-                                processDefinitionId
-                            },
-                            sort: [sortOption],
-                        },
-                    }
-                );
-                await assertStatusCode(res, 200);
-                const body = await res.json();
-                validateResponse(
-                {
-                    path: '/process-definitions/statistics/process-instances-by-version',
-                    method: 'POST',
-                    status: '200',
-                    },
-                    res,
-                );
-                const field = sortOption.field as keyof ProcessInstanceStatisticsByVersionResponse;
-                const fieldValues: string[] = body.items.map(
-                  (item: ProcessInstanceStatisticsByVersionResponse) => item[field] as string,
-                );
-                const sortedfieldValues = [...fieldValues].sort();
-                expect(fieldValues).toEqual(sortedfieldValues);
-                expect(body.page.totalItems).toBeGreaterThanOrEqual(2);
-                body.items.forEach((element: ProcessInstanceStatisticsByVersionResponse) => {
-                    expect(element.processDefinitionId).toBe(processDefinitionId);
-                    expect(element.activeInstancesWithoutIncidentCount).toBeGreaterThanOrEqual(1);
-                });
-            }
-        }).toPass(defaultAssertionOptions);
-  });
-
-  test('Get process instance statistics by version without processDefinitionId - Invalid Argument', async ({request}) => {
-        const res = await request.post(
-          buildUrl(`/process-definitions/statistics/process-instances-by-version`),
-          {
-            headers: jsonHeaders(),
-            data: {},
-          }
+            expect(
+              element.activeInstancesWithoutIncidentCount,
+            ).toBeGreaterThanOrEqual(1);
+          },
         );
-        await assertInvalidArgument(res, 400, 'No filter provided.');
+      }
+    }).toPass(defaultAssertionOptions);
   });
 
-  test('Get process instance statistics by version with non-existing field - Bad Request', async ({request}) => {
+  test('Get process instance statistics by version without processDefinitionId - Invalid Argument', async ({
+    request,
+  }) => {
+    const res = await request.post(
+      buildUrl(`/process-definitions/statistics/process-instances-by-version`),
+      {
+        headers: jsonHeaders(),
+        data: {},
+      },
+    );
+    await assertInvalidArgument(res, 400, 'No filter provided.');
+  });
+
+  test('Get process instance statistics by version with non-existing field - Bad Request', async ({
+    request,
+  }) => {
     const notExistingField = {meow: 'meow'};
     const res = await request.post(
       buildUrl(`/process-definitions/statistics/process-instances-by-version`),
       {
         headers: jsonHeaders(),
         data: {
-            filter: {
-                processDefinitionId,
-                ...notExistingField,
-            },
+          filter: {
+            processDefinitionId,
+            ...notExistingField,
+          },
         },
-      }
+      },
     );
-    await assertBadRequest(res, 'Request property [filter.meow] cannot be parsed');
+    await assertBadRequest(
+      res,
+      'Request property [filter.meow] cannot be parsed',
+    );
   });
 
-  test('Get process instance statistics by version with non-existing processDefinitionId - Success, empty result', async ({request}) => {
+  test('Get process instance statistics by version with non-existing processDefinitionId - Success, empty result', async ({
+    request,
+  }) => {
     const nonExistingProcessDefinitionId = 'nonExistingProcessDefinitionId';
-        const res = await request.post(
-          buildUrl(`/process-definitions/statistics/process-instances-by-version`),
-          {
-            headers: jsonHeaders(),
-            data: {
-                filter: {
-                    processDefinitionId: nonExistingProcessDefinitionId,
-                },
-            },
-          }
-        );
-        await assertStatusCode(res, 200);
-        const body = await res.json();
-        validateResponse(
-          {
-            path: '/process-definitions/statistics/process-instances-by-version',
-            method: 'POST',
-            status: '200',
-            },
-            res,
-        );
-        expect(body.page.totalItems).toBe(0);
-        expect(body.items.length).toEqual(0);
+    const res = await request.post(
+      buildUrl(`/process-definitions/statistics/process-instances-by-version`),
+      {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            processDefinitionId: nonExistingProcessDefinitionId,
+          },
+        },
+      },
+    );
+    await assertStatusCode(res, 200);
+    const body = await res.json();
+    validateResponse(
+      {
+        path: '/process-definitions/statistics/process-instances-by-version',
+        method: 'POST',
+        status: '200',
+      },
+      res,
+    );
+    expect(body.page.totalItems).toBe(0);
+    expect(body.items.length).toEqual(0);
   });
 
-  test('Get process instance statistics by version without authorization - Unauthorized', async ({request}) => {
-        const res = await request.post(
-          buildUrl(`/process-definitions/statistics/process-instances-by-version`),
-          {
-            headers: {},
-            data: {
-                filter: {
-                    processDefinitionId,
-                },
-            },
-          }
-        );
-        await assertUnauthorizedRequest(res);
+  test('Get process instance statistics by version without authorization - Unauthorized', async ({
+    request,
+  }) => {
+    const res = await request.post(
+      buildUrl(`/process-definitions/statistics/process-instances-by-version`),
+      {
+        headers: {},
+        data: {
+          filter: {
+            processDefinitionId,
+          },
+        },
+      },
+    );
+    await assertUnauthorizedRequest(res);
   });
 
-  test('Get process instance statistics by version with user without proper authorization - Forbidden, 200, empty result', async ({request}) => {
-    const token = encode(`${userWithResourcesAuthorizationToSendRequest.username}:${userWithResourcesAuthorizationToSendRequest.password}`);
-        const res = await request.post(
-          buildUrl(`/process-definitions/statistics/process-instances-by-version`),
-          {
-            headers: jsonHeaders(token), // overrides default demo:demo
-            data: {
-                filter: {
-                    processDefinitionId,
-                },
-            },
-          }
-        );
-        await assertStatusCode(res, 200);
-        const body = await res.json();
-        validateResponse(
-          {
-            path: '/process-definitions/statistics/process-instances-by-version',
-            method: 'POST',
-            status: '200',
-            },
-            res,
-        );
-        expect(body.page.totalItems).toBe(0);
-        expect(body.items.length).toEqual(0);
+  test('Get process instance statistics by version with user without proper authorization - Forbidden, 200, empty result', async ({
+    request,
+  }) => {
+    const token = encode(
+      `${userWithResourcesAuthorizationToSendRequest.username}:${userWithResourcesAuthorizationToSendRequest.password}`,
+    );
+    const res = await request.post(
+      buildUrl(`/process-definitions/statistics/process-instances-by-version`),
+      {
+        headers: jsonHeaders(token), // overrides default demo:demo
+        data: {
+          filter: {
+            processDefinitionId,
+          },
+        },
+      },
+    );
+    await assertStatusCode(res, 200);
+    const body = await res.json();
+    validateResponse(
+      {
+        path: '/process-definitions/statistics/process-instances-by-version',
+        method: 'POST',
+        status: '200',
+      },
+      res,
+    );
+    expect(body.page.totalItems).toBe(0);
+    expect(body.items.length).toEqual(0);
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-process-instance-statistics-by-version-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-process-instance-statistics-by-version-api.spec.ts
@@ -1,0 +1,251 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect, test} from '@playwright/test';
+import {cancelProcessInstance, createSingleInstance, deploy} from '../../../../utils/zeebeClient';
+import {
+  assertBadRequest,
+  assertInvalidArgument,
+  assertStatusCode,
+  assertUnauthorizedRequest,
+  buildUrl,
+  jsonHeaders,
+  encode,
+} from '../../../../utils/http';
+import {validateResponse} from '../../../../json-body-assertions';
+import {defaultAssertionOptions} from '../../../../utils/constants';
+import { cleanupUsers } from 'utils/usersCleanup';
+import { grantUserResourceAuthorization } from 'utils/requestHelpers/authorization-requestHelpers';
+import { createUser } from 'utils/requestHelpers/user-requestHelpers';
+
+type ProcessInstanceStatisticsByVersionResponse = {
+    processDefinitionId: string;
+    processDefinitionKey: string;
+    processDefinitionName: string;
+    tenantId: string;
+    processDefinitionVersion: number;
+    activeInstancesWithIncidentCount: number;
+    activeInstancesWithoutIncidentCount: number;
+};
+
+test.describe.parallel('Get process instance statistics by version API Tests', () => {
+  let userWithResourcesAuthorizationToSendRequest: {
+    username: string;
+    name: string;
+    email: string;
+    password: string;
+  } = {} as {
+    username: string;
+    name: string;
+    email: string;
+    password: string;
+  };
+  let processInstanceKeys: string[] = [];
+  const processDefinitionId: string = 'processWithMultipleVersions';
+
+  test.beforeAll(async ({request}) => {
+    await test.step('Setup - Deploy process and create instances', async () => {
+      await deploy(['./resources/processWithMultipleVersions_v_1.bpmn']);
+      const processInstanceV1 = await createSingleInstance(processDefinitionId, 1);
+      const processInstanceKeyV1 = processInstanceV1.processInstanceKey;
+      
+      await deploy(['./resources/processWithMultipleVersions_v_2.bpmn']);
+      const processInstanceV2 = await createSingleInstance(processDefinitionId, 2);
+      const processInstanceKeyV2 = processInstanceV2.processInstanceKey;
+
+      processInstanceKeys.push(processInstanceKeyV1);
+      processInstanceKeys.push(processInstanceKeyV2);
+    });
+
+    await test.step('Setup - Create test user with Resource Authorization and user for granting Authorization', async () => {
+      userWithResourcesAuthorizationToSendRequest = await createUser(request);
+      await grantUserResourceAuthorization(
+        request,
+        userWithResourcesAuthorizationToSendRequest,
+      );
+    });
+  });
+
+  test.afterAll(async ({request}) => {
+    await test.step('Cleanup - Delete test users', async () => {
+      await cleanupUsers(request, [
+        userWithResourcesAuthorizationToSendRequest.username,
+      ]);
+    });
+
+    await test.step('Cleanup - Cancel process instances', async () => {
+      for (const processInstanceKey of processInstanceKeys) {
+        await cancelProcessInstance(processInstanceKey);
+      }
+    });
+
+    await test.step('Cleanup - Clean array', async () => {
+      processInstanceKeys = [];
+    });
+  });
+
+  test('Get process instance statistics by version - Success', async ({request}) => {
+      await expect(async () => {
+        const res = await request.post(
+          buildUrl(`/process-definitions/statistics/process-instances-by-version`),
+          {
+            headers: jsonHeaders(),
+            data: {
+                filter: {
+                    processDefinitionId
+                },
+            },
+          }
+        );
+        await assertStatusCode(res, 200);
+        const body = await res.json();
+        validateResponse(
+          {
+            path: '/process-definitions/statistics/process-instances-by-version',
+            method: 'POST',
+            status: '200',
+            },
+            res,
+        );
+        expect(body.page.totalItems).toBeGreaterThanOrEqual(2);
+        body.items.forEach((element: ProcessInstanceStatisticsByVersionResponse) => {
+            expect(element.processDefinitionId).toBe(processDefinitionId);
+            expect(element.activeInstancesWithoutIncidentCount).toBeGreaterThanOrEqual(1);
+        });
+      }).toPass(defaultAssertionOptions);
+  });
+
+  test('Get process instance statistics by version, sorting - Success', async ({request}) => {
+        const sort = [
+            //Skipped due to bug 50976: https://github.com/camunda/camunda/issues/50976
+            // {field: "processDefinitionId", order: "ASC"},
+            // {field: "processDefinitionKey", order: "ASC"},
+            // {field: "processDefinitionName", order: "ASC"},
+            // {field: "processDefinitionVersion", order: "ASC"},
+            {field: "activeInstancesWithIncidentCount", order: "ASC"},
+            {field: "activeInstancesWithoutIncidentCount", order: "ASC"},
+        ];
+        await expect(async () => {
+            for (const sortOption of sort) {
+                const res = await request.post(
+                    buildUrl(`/process-definitions/statistics/process-instances-by-version`),
+                    {
+                        headers: jsonHeaders(),
+                        data: {
+                            filter: {
+                                processDefinitionId
+                            },
+                            sort: [sortOption],
+                        },
+                    }
+                );
+                await assertStatusCode(res, 200);
+                const body = await res.json();
+                validateResponse(
+                {
+                    path: '/process-definitions/statistics/process-instances-by-version',
+                    method: 'POST',
+                    status: '200',
+                    },
+                    res,
+                );
+                const field = sortOption.field as keyof ProcessInstanceStatisticsByVersionResponse;
+                const fieldValues: string[] = body.items.map(
+                  (item: ProcessInstanceStatisticsByVersionResponse) => item[field] as string,
+                );
+                const sortedfieldValues = [...fieldValues].sort();
+                expect(fieldValues).toEqual(sortedfieldValues);
+                expect(body.page.totalItems).toBeGreaterThanOrEqual(2);
+                body.items.forEach((element: ProcessInstanceStatisticsByVersionResponse) => {
+                    expect(element.processDefinitionId).toBe(processDefinitionId);
+                    expect(element.activeInstancesWithoutIncidentCount).toBeGreaterThanOrEqual(1);
+                });
+            }
+        }).toPass(defaultAssertionOptions);
+  });
+
+  test('Get process instance statistics by version without processDefinitionId - Invalid Argument', async ({request}) => {
+        const res = await request.post(
+          buildUrl(`/process-definitions/statistics/process-instances-by-version`),
+          {
+            headers: jsonHeaders(),
+            data: {},
+          }
+        );
+        await assertInvalidArgument(res, 400, 'No filter provided.');
+  });
+
+  test('Get process instance statistics by version with non-existing processDefinitionId - Success, empty result', async ({request}) => {
+    const nonExistingProcessDefinitionId = 'nonExistingProcessDefinitionId';
+        const res = await request.post(
+          buildUrl(`/process-definitions/statistics/process-instances-by-version`),
+          {
+            headers: jsonHeaders(),
+            data: {
+                filter: {
+                    processDefinitionId: nonExistingProcessDefinitionId,
+                },
+            },
+          }
+        );
+        await assertStatusCode(res, 200);
+        const body = await res.json();
+        validateResponse(
+          {
+            path: '/process-definitions/statistics/process-instances-by-version',
+            method: 'POST',
+            status: '200',
+            },
+            res,
+        );
+        expect(body.page.totalItems).toBe(0);
+        expect(body.items.length).toEqual(0);
+  });
+
+  test('Get process instance statistics by version without authorization - Unauthorized', async ({request}) => {
+        const res = await request.post(
+          buildUrl(`/process-definitions/statistics/process-instances-by-version`),
+          {
+            headers: {},
+            data: {
+                filter: {
+                    processDefinitionId,
+                },
+            },
+          }
+        );
+        await assertUnauthorizedRequest(res);
+  });
+
+  test('Get process instance statistics by version with user without proper authorization - Forbidden, 200, empty result', async ({request}) => {
+    const token = encode(`${userWithResourcesAuthorizationToSendRequest.username}:${userWithResourcesAuthorizationToSendRequest.password}`);
+        const res = await request.post(
+          buildUrl(`/process-definitions/statistics/process-instances-by-version`),
+          {
+            headers: jsonHeaders(token), // overrides default demo:demo
+            data: {
+                filter: {
+                    processDefinitionId,
+                },
+            },
+          }
+        );
+        await assertStatusCode(res, 200);
+        const body = await res.json();
+        validateResponse(
+          {
+            path: '/process-definitions/statistics/process-instances-by-version',
+            method: 'POST',
+            status: '200',
+            },
+            res,
+        );
+        expect(body.page.totalItems).toBe(0);
+        expect(body.items.length).toEqual(0);
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-process-instance-statistics-by-version-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-definition/get-process-instance-statistics-by-version-api.spec.ts
@@ -37,8 +37,7 @@ type ProcessInstanceStatisticsByVersionResponse = {
   activeInstancesWithoutIncidentCount: number;
 };
 
-test.describe
-  .parallel('Get process instance statistics by version API Tests', () => {
+test.describe.parallel('Process instance statistics by version', () => {
   let userWithResourcesAuthorizationToSendRequest: {
     username: string;
     name: string;

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tsconfig.json
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tsconfig.json
@@ -6,7 +6,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
-    "ignoreDeprecations": "5.0",
+    "ignoreDeprecations": "6.0",
     "baseUrl": "./",
     "noEmit": true,
     "paths": {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tsconfig.json
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tsconfig.json
@@ -6,7 +6,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
-    "ignoreDeprecations": "6.0",
+    "ignoreDeprecations": "5.0",
     "baseUrl": "./",
     "noEmit": true,
     "paths": {


### PR DESCRIPTION
## Description

This PR introduces tests for process definition statistics APIs

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

related to [this issue](https://github.com/camunda/team-test-automation/issues/62)

## On demand workflow
[was all green](https://github.com/camunda/camunda/actions/runs/25918024166)
