### PR TITLE
test: increased batch size

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-e2e-api-test-branch-on-demand.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-api-test-branch-on-demand.yml
@@ -269,10 +269,10 @@ jobs:
             --project 'C8' \
             --username "$TESTRAIL_USERNAME" \
             --key "$TESTRAIL_KEY" \
+            --batch-size 500 \
             parse_junit --suite-id 17050 \
             --title "On Demand C8 Orchestration Cluster API Test Run Results - ${{ github.event.inputs.branch }} - $(date '+%Y-%m-%d %H:%M:%S')" \
             --close-run \
-            --batch-size 500 \
             -f "$JUNIT_RESULTS_FILE"
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/c8-orchestration-cluster-e2e-api-test-branch-on-demand.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-api-test-branch-on-demand.yml
@@ -272,6 +272,7 @@ jobs:
             parse_junit --suite-id 17050 \
             --title "On Demand C8 Orchestration Cluster API Test Run Results - ${{ github.event.inputs.branch }} - $(date '+%Y-%m-%d %H:%M:%S')" \
             --close-run \
+            --batch-size 500 \
             -f "$JUNIT_RESULTS_FILE"
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/c8-orchestration-cluster-e2e-api-test-branch-on-demand.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-api-test-branch-on-demand.yml
@@ -264,7 +264,7 @@ jobs:
           TESTRAIL_KEY: ${{ steps.secrets.outputs.TESTRAIL_QA_PSW }}
           JUNIT_RESULTS_FILE: "qa/c8-orchestration-cluster-e2e-test-suite/test-results/junit-report.xml"
         run: |
-          pip install trcli
+          pip install trcli==1.14.1
           trcli -y -h "$TESTRAIL_HOST" \
             --project 'C8' \
             --username "$TESTRAIL_USERNAME" \

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
@@ -215,7 +215,7 @@ jobs:
           TESTRAIL_KEY: ${{ steps.secrets.outputs.TESTRAIL_QA_PSW }}
           JUNIT_RESULTS_FILE: "qa/c8-orchestration-cluster-e2e-test-suite/test-results/junit-report.xml"
         run: |
-          pip install trcli
+          pip install trcli==1.14.1
           trcli -y -h "$TESTRAIL_HOST" \
             --project 'C8' \
             --username "$TESTRAIL_USERNAME" \
@@ -610,7 +610,7 @@ jobs:
           TESTRAIL_KEY: ${{ steps.secrets.outputs.TESTRAIL_QA_PSW }}
           JUNIT_RESULTS_FILE: "qa/c8-orchestration-cluster-e2e-test-suite/test-results/junit-report.xml"
         run: |
-          pip install trcli
+          pip install trcli==1.14.1
           trcli -y -h "$TESTRAIL_HOST" \
             --project 'C8' \
             --username "$TESTRAIL_USERNAME" \

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
@@ -223,6 +223,7 @@ jobs:
             parse_junit --suite-id 17050 \
             --title "On Demand C8 Orchestration Cluster API Test Run Results - ${{ github.event.inputs.branch }} - $(date '+%Y-%m-%d %H:%M:%S')" \
             --close-run \
+            --batch-size 500 \
             -f "$JUNIT_RESULTS_FILE"
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
@@ -617,6 +618,7 @@ jobs:
             parse_junit --suite-id 17050 \
             --title "On Demand C8 Orchestration Cluster Test Run Results - ${{ github.event.inputs.branch }} (Tasklist ${{ matrix.tasklist_mode }} mode) - $(date '+%Y-%m-%d %H:%M:%S')" \
             --close-run \
+            --batch-size 500 \
             -f "$JUNIT_RESULTS_FILE"
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
@@ -220,10 +220,10 @@ jobs:
             --project 'C8' \
             --username "$TESTRAIL_USERNAME" \
             --key "$TESTRAIL_KEY" \
+            --batch-size 500 \
             parse_junit --suite-id 17050 \
             --title "On Demand C8 Orchestration Cluster API Test Run Results - ${{ github.event.inputs.branch }} - $(date '+%Y-%m-%d %H:%M:%S')" \
             --close-run \
-            --batch-size 500 \
             -f "$JUNIT_RESULTS_FILE"
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
@@ -615,10 +615,10 @@ jobs:
             --project 'C8' \
             --username "$TESTRAIL_USERNAME" \
             --key "$TESTRAIL_KEY" \
+            --batch-size 500 \
             parse_junit --suite-id 17050 \
             --title "On Demand C8 Orchestration Cluster Test Run Results - ${{ github.event.inputs.branch }} (Tasklist ${{ matrix.tasklist_mode }} mode) - $(date '+%Y-%m-%d %H:%M:%S')" \
             --close-run \
-            --batch-size 500 \
             -f "$JUNIT_RESULTS_FILE"
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
@@ -279,6 +279,7 @@ jobs:
             parse_junit --suite-id 17050 \
             --title "Release C8 Orchestration Cluster API Test Run Results - v${{ needs.validate-release.outputs.release_version }} - $(date '+%Y-%m-%d %H:%M:%S')" \
             --close-run \
+            --batch-size 500 \
             -f "$JUNIT_RESULTS_FILE"
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
@@ -900,6 +901,7 @@ jobs:
             parse_junit --suite-id 17050 \
             --title "Release C8 Orchestration Cluster Test Run Results - v${{ needs.validate-release.outputs.release_version }} (Tasklist ${{ matrix.tasklist_mode }} mode) - $(date '+%Y-%m-%d %H:%M:%S')" \
             --close-run \
+            --batch-size 500 \
             -f "$JUNIT_RESULTS_FILE"
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
@@ -276,10 +276,10 @@ jobs:
             --project 'C8' \
             --username "$TESTRAIL_USERNAME" \
             --key "$TESTRAIL_KEY" \
+            --batch-size 500 \
             parse_junit --suite-id 17050 \
             --title "Release C8 Orchestration Cluster API Test Run Results - v${{ needs.validate-release.outputs.release_version }} - $(date '+%Y-%m-%d %H:%M:%S')" \
             --close-run \
-            --batch-size 500 \
             -f "$JUNIT_RESULTS_FILE"
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
@@ -898,10 +898,10 @@ jobs:
             --project 'C8' \
             --username "$TESTRAIL_USERNAME" \
             --key "$TESTRAIL_KEY" \
+            --batch-size 500 \
             parse_junit --suite-id 17050 \
             --title "Release C8 Orchestration Cluster Test Run Results - v${{ needs.validate-release.outputs.release_version }} (Tasklist ${{ matrix.tasklist_mode }} mode) - $(date '+%Y-%m-%d %H:%M:%S')" \
             --close-run \
-            --batch-size 500 \
             -f "$JUNIT_RESULTS_FILE"
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
@@ -271,7 +271,7 @@ jobs:
           TESTRAIL_KEY: ${{ steps.secrets.outputs.TESTRAIL_QA_PSW }} # Use the imported secret
           JUNIT_RESULTS_FILE: "qa/c8-orchestration-cluster-e2e-test-suite/test-results/junit-report.xml"
         run: |
-          pip install trcli
+          pip install trcli==1.14.1
           trcli -y -h "$TESTRAIL_HOST" \
             --project 'C8' \
             --username "$TESTRAIL_USERNAME" \
@@ -893,7 +893,7 @@ jobs:
           TESTRAIL_KEY: ${{ steps.secrets.outputs.TESTRAIL_QA_PSW }} # Use the imported secret
           JUNIT_RESULTS_FILE: "qa/c8-orchestration-cluster-e2e-test-suite/test-results/junit-report.xml"
         run: |
-          pip install trcli
+          pip install trcli==1.14.1
           trcli -y -h "$TESTRAIL_HOST" \
             --project 'C8' \
             --username "$TESTRAIL_USERNAME" \

--- a/.github/workflows/c8-orchestration-cluster-reusable-api-tests.yml
+++ b/.github/workflows/c8-orchestration-cluster-reusable-api-tests.yml
@@ -187,7 +187,7 @@ jobs:
           JUNIT_RESULTS_FILE: "qa/c8-orchestration-cluster-e2e-test-suite/test-results/junit-report.xml"
           BRANCH_NAME: ${{ inputs.branch }}
         run: |
-          pip install trcli
+          pip install trcli==1.14.1
           trcli -y -h "$TESTRAIL_HOST" \
             --project 'C8' \
             --username "$TESTRAIL_USERNAME" \

--- a/.github/workflows/c8-orchestration-cluster-reusable-api-tests.yml
+++ b/.github/workflows/c8-orchestration-cluster-reusable-api-tests.yml
@@ -192,10 +192,10 @@ jobs:
             --project 'C8' \
             --username "$TESTRAIL_USERNAME" \
             --key "$TESTRAIL_KEY" \
+            --batch-size 500 \
             parse_junit --suite-id 17050 \
             --title "Nightly C8 Orchestration Cluster Test Results - $BRANCH_NAME - API tests - $(date '+%Y-%m-%d %H:%M:%S')" \
             --close-run \
-            --batch-size 500 \
             -f "$JUNIT_RESULTS_FILE"
 
       - name: Sanitize branch name for artifact names

--- a/.github/workflows/c8-orchestration-cluster-reusable-api-tests.yml
+++ b/.github/workflows/c8-orchestration-cluster-reusable-api-tests.yml
@@ -195,6 +195,7 @@ jobs:
             parse_junit --suite-id 17050 \
             --title "Nightly C8 Orchestration Cluster Test Results - $BRANCH_NAME - API tests - $(date '+%Y-%m-%d %H:%M:%S')" \
             --close-run \
+            --batch-size 500 \
             -f "$JUNIT_RESULTS_FILE"
 
       - name: Sanitize branch name for artifact names

--- a/.github/workflows/c8-orchestration-cluster-reusable-e2e-tests.yml
+++ b/.github/workflows/c8-orchestration-cluster-reusable-e2e-tests.yml
@@ -217,10 +217,10 @@ jobs:
             --project 'C8' \
             --username "$TESTRAIL_USERNAME" \
             --key "$TESTRAIL_KEY" \
+            --batch-size 500 \
             parse_junit --suite-id 17050 \
             --title "Nightly C8 Orchestration Cluster Test Results - $BRANCH_NAME (Tasklist ${{ inputs.tasklist_mode }} mode) - $(date '+%Y-%m-%d %H:%M:%S')" \
             --close-run \
-            --batch-size 500 \
             -f "$JUNIT_RESULTS_FILE"
 
       - name: Sanitize branch name for artifact names

--- a/.github/workflows/c8-orchestration-cluster-reusable-e2e-tests.yml
+++ b/.github/workflows/c8-orchestration-cluster-reusable-e2e-tests.yml
@@ -220,6 +220,7 @@ jobs:
             parse_junit --suite-id 17050 \
             --title "Nightly C8 Orchestration Cluster Test Results - $BRANCH_NAME (Tasklist ${{ inputs.tasklist_mode }} mode) - $(date '+%Y-%m-%d %H:%M:%S')" \
             --close-run \
+            --batch-size 500 \
             -f "$JUNIT_RESULTS_FILE"
 
       - name: Sanitize branch name for artifact names

--- a/.github/workflows/c8-orchestration-cluster-reusable-e2e-tests.yml
+++ b/.github/workflows/c8-orchestration-cluster-reusable-e2e-tests.yml
@@ -212,7 +212,7 @@ jobs:
           JUNIT_RESULTS_FILE: "qa/c8-orchestration-cluster-e2e-test-suite/test-results/junit-report.xml"
           BRANCH_NAME: ${{ inputs.branch }}
         run: |
-          pip install trcli
+          pip install trcli==1.14.1
           trcli -y -h "$TESTRAIL_HOST" \
             --project 'C8' \
             --username "$TESTRAIL_USERNAME" \

--- a/.github/workflows/c8-orchestration-cluster-reusable-rdbms-api-tests.yml
+++ b/.github/workflows/c8-orchestration-cluster-reusable-rdbms-api-tests.yml
@@ -398,6 +398,7 @@ jobs:
             parse_junit --suite-id 17050 \
             --title "Nightly C8 Orchestration Cluster Test Results - $BRANCH_NAME - $DATABASE_NAME - API tests - $(date '+%Y-%m-%d %H:%M:%S')" \
             --close-run \
+            --batch-size 500 \
             -f "$JUNIT_RESULTS_FILE"
 
       - name: Upload json report to GitHub Actions Artifacts

--- a/.github/workflows/c8-orchestration-cluster-reusable-rdbms-api-tests.yml
+++ b/.github/workflows/c8-orchestration-cluster-reusable-rdbms-api-tests.yml
@@ -395,10 +395,10 @@ jobs:
             --project 'C8' \
             --username "$TESTRAIL_USERNAME" \
             --key "$TESTRAIL_KEY" \
+            --batch-size 500 \
             parse_junit --suite-id 17050 \
             --title "Nightly C8 Orchestration Cluster Test Results - $BRANCH_NAME - $DATABASE_NAME - API tests - $(date '+%Y-%m-%d %H:%M:%S')" \
             --close-run \
-            --batch-size 500 \
             -f "$JUNIT_RESULTS_FILE"
 
       - name: Upload json report to GitHub Actions Artifacts

--- a/.github/workflows/c8-orchestration-cluster-reusable-rdbms-api-tests.yml
+++ b/.github/workflows/c8-orchestration-cluster-reusable-rdbms-api-tests.yml
@@ -390,7 +390,7 @@ jobs:
           BRANCH_NAME: ${{ inputs.branch }}
           DATABASE_NAME: ${{ matrix.database.database-name }}
         run: |
-          pip install trcli
+          pip install trcli==1.14.1
           trcli -y -h "$TESTRAIL_HOST" \
             --project 'C8' \
             --username "$TESTRAIL_USERNAME" \


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Applies the same fix as camunda/c8-cross-component-e2e-tests#2003 to the orchestration cluster e2e test workflows in this monorepo.

trcli defaults to batch size 50, sends chunks in parallel via ThreadPoolExecutor, then collects responses with as_completed() (completion order ≠ submission order). The subsequent zip(request_chunks, responses) silently mismatches entire chunks, causing TestRail screenshots to be associated with wrong tests.

Adding --batch-size 500 forces all results into a single API call, sidestepping the ordering bug.

Updated all 8 trcli invocations across 6 workflow files:

c8-orchestration-cluster-e2e-tests-on-demand.yml (×2)
c8-orchestration-cluster-reusable-e2e-tests.yml
c8-orchestration-cluster-e2e-tests-release.yml (×2)
c8-orchestration-cluster-e2e-api-test-branch-on-demand.yml
c8-orchestration-cluster-reusable-api-tests.yml
c8-orchestration-cluster-reusable-rdbms-api-tests.yml


Run: https://github.com/camunda/camunda/actions/runs/24566804716
I quickly checked 10 images for random tests, they had the correct images.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
