### PR TITLE
fix: resolve latest c8run release by semver, not publish order

### DIFF
--- a/.github/workflows/camunda8-getting-started-bundle.yaml
+++ b/.github/workflows/camunda8-getting-started-bundle.yaml
@@ -50,10 +50,19 @@ jobs:
         run: |
           # Resolve c8run version
           if [[ "${INPUT_C8RUN_VERSION}" == "latest" ]]; then
-            # Get latest stable release (exclude pre-releases) that has c8run artifacts
-            c8run_version=$(gh api repos/camunda/camunda/releases --jq '
-              [.[] | select(.prerelease == false) | select(.assets[].name | test("camunda8-run-"))] | first | .tag_name
-            ')
+            # Pick the semantically highest stable release that ships c8run artifacts.
+            # GitHub returns releases ordered by publication date, so picking `first`
+            # is wrong when patches on older minor lines (e.g. 8.7.27) ship after a
+            # newer minor (e.g. 8.9.0). We paginate to cover all historical releases,
+            # restrict to strict X.Y.Z tags (drops `c8run-*` legacy tags and any
+            # mislabeled pre-release like `8.8.0-alpha7`), then sort by semver.
+            c8run_version=$(gh api --paginate repos/camunda/camunda/releases --jq '
+              .[]
+              | select(.prerelease == false)
+              | select(any(.assets[]; .name | test("camunda8-run-")))
+              | .tag_name
+              | select(test("^[0-9]+\\.[0-9]+\\.[0-9]+$"))
+            ' | sort -V | tail -n 1)
             echo "Resolved c8run version: ${c8run_version}"
           else
             c8run_version="${INPUT_C8RUN_VERSION}"


### PR DESCRIPTION
## Summary
- The `resolve-versions` job in `camunda8-getting-started-bundle.yaml` picked the most recently **published** non-prerelease, which returned `8.7.27` even though `8.9.0` is the semver max — patch releases on older minor lines (8.7.x) are published after newer minors and shuffled to the top of GitHub's release list.
- Fix paginates the releases listing, filters to strict `X.Y.Z` tags that ship c8run artifacts, and picks the semver max via `sort -V`. This drops legacy `c8run-*` tags and mislabeled prereleases like `8.8.0-alpha7` (flagged `prerelease: false` on GitHub).
- Also replaces `select(.assets[].name | test(...))` with `any(.assets[]; .name | test(...))` to avoid emitting the same release once per matching asset.

Validated against the live API: old code → `8.7.27`, new code → `8.9.0`.

Reference: a recent run resolved `latest` to `8.7.27` — https://github.com/camunda/camunda/actions/runs/24564208917/workflow#L52-L61

## Test plan
- [x] Trigger `Camunda 8: Getting Started Bundle` with `c8run_version=latest`, `dry_run=true`, and confirm the `Resolve versions` step prints `Resolved c8run version: 8.9.0`.
- [x] Verify the resolved version still drives the correct asset download (`camunda8-run-8.9.0-<platform>.<ext>`) in the `build-bundle` matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)