### PR TITLE
feat: cache validated JWTs to avoid repeated signature verification

### DIFF
--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -183,6 +183,10 @@
       <artifactId>spring-security-oauth2-jose</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
       <scope>test</scope>

--- a/authentication/src/main/java/io/camunda/authentication/config/CachingJwtDecoder.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/CachingJwtDecoder.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Expiry;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.CompletionException;
+import org.springframework.security.oauth2.jwt.BadJwtException;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtException;
+
+/**
+ * A {@link JwtDecoder} that caches successfully validated JWTs by their raw token string.
+ *
+ * <p>JWT signature verification (RSA/ECDSA) is expensive. Under load, clients reuse the same token
+ * for its full lifetime. This decorator eliminates repeated cryptographic work by caching the
+ * parsed {@link Jwt} until the token's own {@code exp} claim expires.
+ *
+ * <p>Security properties:
+ *
+ * <ul>
+ *   <li>Entries are evicted at the token's {@code exp} time — expired tokens are never served from
+ *       cache.
+ *   <li>Tokens that fail validation are not cached; every invalid token is re-checked on the next
+ *       request.
+ *   <li>Mid-lifetime revocation (e.g. Keycloak logout, JWKS rotation) is not detected until the
+ *       cached entry expires. This is an accepted trade-off for stateless bearer tokens.
+ * </ul>
+ */
+public class CachingJwtDecoder implements JwtDecoder {
+
+  static final int DEFAULT_MAX_CACHE_SIZE = 10_000;
+  static final Duration DEFAULT_MAX_TOKEN_LIFETIME = Duration.ofHours(24);
+
+  private final JwtDecoder delegate;
+  private final Cache<String, Jwt> cache;
+
+  public CachingJwtDecoder(final JwtDecoder delegate) {
+    this(delegate, DEFAULT_MAX_CACHE_SIZE, DEFAULT_MAX_TOKEN_LIFETIME);
+  }
+
+  CachingJwtDecoder(
+      final JwtDecoder delegate, final int maxCacheSize, final Duration maxTokenLifetime) {
+    this.delegate = delegate;
+    this.cache =
+        Caffeine.newBuilder()
+            .maximumSize(maxCacheSize)
+            .expireAfter(expiryPolicy(maxTokenLifetime))
+            .build();
+  }
+
+  @Override
+  public Jwt decode(final String token) throws JwtException {
+    try {
+      return cache.get(token, delegate::decode);
+    } catch (final CompletionException e) {
+      final Throwable cause = e.getCause();
+      if (cause instanceof final JwtException jwtException) {
+        throw jwtException;
+      }
+      throw new BadJwtException("JWT decoding failed: " + cause.getMessage(), cause);
+    }
+  }
+
+  private static Expiry<String, Jwt> expiryPolicy(final Duration maxTokenLifetime) {
+    return new Expiry<>() {
+      @Override
+      public long expireAfterCreate(final String key, final Jwt value, final long currentTime) {
+        final Instant expiresAt = value.getExpiresAt();
+        if (expiresAt == null) {
+          return maxTokenLifetime.toNanos();
+        }
+        final long remainingNanos = ChronoUnit.NANOS.between(Instant.now(), expiresAt);
+        return Math.min(Math.max(0L, remainingNanos), maxTokenLifetime.toNanos());
+      }
+
+      @Override
+      public long expireAfterUpdate(
+          final String key, final Jwt value, final long currentTime, final long currentDuration) {
+        return currentDuration;
+      }
+
+      @Override
+      public long expireAfterRead(
+          final String key, final Jwt value, final long currentTime, final long currentDuration) {
+        return currentDuration;
+      }
+    };
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -751,6 +751,7 @@ public class WebSecurityConfig {
       final var additionalJwkSetUrisByIssuer =
           buildAdditionalJwkSetUrisByIssuer(oidcProviderRepository);
 
+      final JwtDecoder delegate;
       if (clientRegistrations.size() == 1) {
         final var clientRegistration = clientRegistrations.getFirst();
         final var additionalUris =
@@ -759,21 +760,25 @@ public class WebSecurityConfig {
         LOG.info(
             "Create Access Token JWT Decoder for OIDC Provider: {}",
             clientRegistration.getRegistrationId());
-        return new SupplierJwtDecoder(
-            () ->
-                oidcAccessTokenDecoderFactory.createAccessTokenDecoder(
-                    clientRegistration, additionalUris));
+        delegate =
+            new SupplierJwtDecoder(
+                () ->
+                    oidcAccessTokenDecoderFactory.createAccessTokenDecoder(
+                        clientRegistration, additionalUris));
       } else {
         LOG.info(
             "Create Issuer Aware JWT Decoder for multiple OIDC Providers: [{}]",
             clientRegistrations.stream()
                 .map(ClientRegistration::getRegistrationId)
                 .collect(Collectors.joining(", ")));
-        return new SupplierJwtDecoder(
-            () ->
-                oidcAccessTokenDecoderFactory.createIssuerAwareAccessTokenDecoder(
-                    clientRegistrations, additionalJwkSetUrisByIssuer));
+        delegate =
+            new SupplierJwtDecoder(
+                () ->
+                    oidcAccessTokenDecoderFactory.createIssuerAwareAccessTokenDecoder(
+                        clientRegistrations, additionalJwkSetUrisByIssuer));
       }
+      LOG.info("Wrapping JWT decoder with CachingJwtDecoder");
+      return new CachingJwtDecoder(delegate);
     }
 
     private Map<String, List<String>> buildAdditionalJwkSetUrisByIssuer(

--- a/authentication/src/test/java/io/camunda/authentication/config/CachingJwtDecoderTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/CachingJwtDecoderTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.jwt.BadJwtException;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtException;
+
+class CachingJwtDecoderTest {
+
+  private JwtDecoder delegate;
+  private CachingJwtDecoder cachingDecoder;
+
+  @BeforeEach
+  void setUp() {
+    delegate = mock(JwtDecoder.class);
+    cachingDecoder = new CachingJwtDecoder(delegate, 100, Duration.ofHours(1));
+  }
+
+  @Test
+  void delegatesOnFirstCall() {
+    final var jwt = buildJwt(Instant.now().plusSeconds(300));
+    when(delegate.decode("token")).thenReturn(jwt);
+
+    final var result = cachingDecoder.decode("token");
+
+    assertThat(result).isSameAs(jwt);
+    verify(delegate, times(1)).decode("token");
+  }
+
+  @Test
+  void returnsCachedJwtOnSubsequentCallsWithoutCallingDelegate() {
+    final var jwt = buildJwt(Instant.now().plusSeconds(300));
+    when(delegate.decode("token")).thenReturn(jwt);
+
+    cachingDecoder.decode("token");
+    cachingDecoder.decode("token");
+    cachingDecoder.decode("token");
+
+    verify(delegate, times(1)).decode("token");
+  }
+
+  @Test
+  void differentTokensAreEachDecodedOnce() {
+    final var jwt1 = buildJwt(Instant.now().plusSeconds(300));
+    final var jwt2 = buildJwt(Instant.now().plusSeconds(300));
+    when(delegate.decode("token1")).thenReturn(jwt1);
+    when(delegate.decode("token2")).thenReturn(jwt2);
+
+    cachingDecoder.decode("token1");
+    cachingDecoder.decode("token1");
+    cachingDecoder.decode("token2");
+    cachingDecoder.decode("token2");
+
+    verify(delegate, times(1)).decode("token1");
+    verify(delegate, times(1)).decode("token2");
+  }
+
+  @Test
+  void invalidTokenIsNotCached() {
+    when(delegate.decode("bad-token")).thenThrow(new BadJwtException("invalid"));
+
+    assertThatThrownBy(() -> cachingDecoder.decode("bad-token"))
+        .isInstanceOf(JwtException.class);
+    assertThatThrownBy(() -> cachingDecoder.decode("bad-token"))
+        .isInstanceOf(JwtException.class);
+
+    // delegate must be called each time since the error is not cached
+    verify(delegate, times(2)).decode("bad-token");
+  }
+
+  @Test
+  void jwtExceptionIsPropagatedUnwrapped() {
+    final var originalException = new BadJwtException("signature invalid");
+    when(delegate.decode("token")).thenThrow(originalException);
+
+    assertThatThrownBy(() -> cachingDecoder.decode("token"))
+        .isInstanceOf(JwtException.class)
+        .hasMessageContaining("signature invalid");
+  }
+
+  @Test
+  void tokenWithNullExpiryUsesMaxLifetimeAsTtl() {
+    // A token with no exp should still be cached (uses maxTokenLifetime cap)
+    final var jwt = buildJwt(null);
+    when(delegate.decode("token")).thenReturn(jwt);
+
+    cachingDecoder.decode("token");
+    cachingDecoder.decode("token");
+
+    verify(delegate, times(1)).decode("token");
+  }
+
+  private static Jwt buildJwt(final Instant expiresAt) {
+    return new Jwt(
+        "raw-token-value",
+        Instant.now(),
+        expiresAt,
+        Map.of("alg", "RS256"),
+        Map.of("sub", "test-user"));
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `CachingJwtDecoder`, a `JwtDecoder` decorator that caches successfully validated JWTs in a Caffeine cache keyed by the raw token string
- Cache entries expire at the token's own `exp` claim, so expired tokens are never served from cache; invalid tokens are not cached
- Wires the cache into the OIDC `jwtDecoder` bean in `WebSecurityConfig`

## Motivation

Under load, REST API clients reuse the same OIDC bearer token for its full lifetime (typically 5–60 minutes). JWT signature verification (RSA/ECDSA) ran on every single request, showing up as ~13% CPU in profiles even when resource-level authorization was disabled. The JWK key set was already cached (`JWSKeySelectorFactory.cache(true)`) but per-token crypto was not.

Reference: #35067

## Security trade-offs

- Mid-lifetime revocation (Keycloak logout, JWKS rotation) is not detected until the cached entry expires — accepted trade-off for stateless bearer tokens
- Tokens that fail validation are never cached, so bad tokens are always re-checked

## Test plan

- [ ] Unit tests in `CachingJwtDecoderTest` cover: cache hit on repeated calls, no caching of invalid tokens, null-expiry tokens, JwtException propagation
- [ ] Run load test with REST + OIDC auth and compare CPU flamegraphs before/after — `NimbusJwtDecoder`/`DefaultJWTProcessor` frames should collapse after first token use

🤖 Generated with [Claude Code](https://claude.com/claude-code)