### PR TITLE
feat: poc2 for multi instance execution listeners

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ZeebeExecutionListenersBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ZeebeExecutionListenersBuilder.java
@@ -28,6 +28,33 @@ public interface ZeebeExecutionListenersBuilder<B> {
 
   B zeebeEndExecutionListener(String type);
 
+  /**
+   * Adds a {@code beforeAll} execution listener to a multi-instance activity. The listener job is
+   * created and completed <em>before</em> the input collection or loop cardinality is evaluated and
+   * before any child element instances are created. Variables set by this listener are available to
+   * the {@code inputCollection} and {@code loopCardinality} expressions.
+   *
+   * <p>This listener type is only valid on multi-instance activities.
+   *
+   * @param type the job type of the listener worker
+   * @param retries the number of retries for the listener job
+   * @return this builder
+   */
+  default B zeebeBeforeAllExecutionListener(final String type, final String retries) {
+    return null;
+  }
+
+  /**
+   * Adds a {@code beforeAll} execution listener to a multi-instance activity using the default
+   * retry count. See {@link #zeebeBeforeAllExecutionListener(String, String)} for full semantics.
+   *
+   * @param type the job type of the listener worker
+   * @return this builder
+   */
+  default B zeebeBeforeAllExecutionListener(final String type) {
+    return null;
+  }
+
   B zeebeExecutionListener(
       final Consumer<ExecutionListenerBuilder> executionListenerBuilderConsumer);
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ZeebeExecutionListenersBuilderImpl.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ZeebeExecutionListenersBuilderImpl.java
@@ -30,6 +30,21 @@ public class ZeebeExecutionListenersBuilderImpl<B extends AbstractBaseElementBui
   }
 
   @Override
+  public B zeebeBeforeAllExecutionListener(final String type, final String retries) {
+    final ZeebeExecutionListener listener = createZeebeExecutionListener();
+    listener.setEventType(ZeebeExecutionListenerEventType.beforeAll);
+    listener.setType(type);
+    listener.setRetries(retries);
+
+    return elementBuilder;
+  }
+
+  @Override
+  public B zeebeBeforeAllExecutionListener(final String type) {
+    return zeebeBeforeAllExecutionListener(type, ZeebeExecutionListener.DEFAULT_RETRIES);
+  }
+
+  @Override
   public B zeebeStartExecutionListener(final String type, final String retries) {
     final ZeebeExecutionListener listener = createZeebeExecutionListener();
     listener.setEventType(ZeebeExecutionListenerEventType.start);

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeExecutionListenerEventType.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeExecutionListenerEventType.java
@@ -20,6 +20,7 @@ package io.camunda.zeebe.model.bpmn.instance.zeebe;
  * (beginning) or at the end (completion) of an element's processing.
  */
 public enum ZeebeExecutionListenerEventType {
+  beforeAll,
   start,
   end
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ExecutionListenersValidator.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ExecutionListenersValidator.java
@@ -16,7 +16,10 @@
 package io.camunda.zeebe.model.bpmn.validation.zeebe;
 
 import io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants;
+import io.camunda.zeebe.model.bpmn.instance.Activity;
+import io.camunda.zeebe.model.bpmn.instance.MultiInstanceLoopCharacteristics;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListener;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListenerEventType;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListeners;
 import java.util.Arrays;
 import java.util.Collection;
@@ -26,6 +29,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import org.camunda.bpm.model.xml.instance.ModelElementInstance;
 import org.camunda.bpm.model.xml.validation.ModelElementValidator;
 import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
 
@@ -74,8 +78,9 @@ public class ExecutionListenersValidator implements ModelElementValidator<ZeebeE
       return;
     }
 
-    final String parentElementTypeName =
-        element.getParentElement().getParentElement().getElementType().getTypeName();
+    final ModelElementInstance bpmnElement =
+        element.getParentElement().getParentElement();
+    final String parentElementTypeName = bpmnElement.getElementType().getTypeName();
     if (!ELEMENTS_THAT_SUPPORT_EXECUTION_LISTENERS.contains(parentElementTypeName)) {
       final String errorMessage =
           String.format(
@@ -84,6 +89,8 @@ public class ExecutionListenersValidator implements ModelElementValidator<ZeebeE
       validationResultCollector.addError(0, errorMessage);
       return;
     }
+
+    validateBeforeAllListeners(executionListeners, bpmnElement, validationResultCollector);
 
     final Function<ZeebeExecutionListener, String> eventTypeAndTypeClassifier =
         listener -> listener.getEventType() + "|" + listener.getType();
@@ -96,6 +103,45 @@ public class ExecutionListenersValidator implements ModelElementValidator<ZeebeE
     listenersGroupedByType.values().stream()
         .filter(duplicates -> duplicates.size() > 1)
         .forEach(duplicates -> reportDuplicateListeners(duplicates, validationResultCollector));
+  }
+
+  /**
+   * Validates that {@code beforeAll} execution listeners are only used on multi-instance activities
+   * (i.e., activities with a {@link MultiInstanceLoopCharacteristics}). Using {@code beforeAll} on
+   * any other element type is an error because the semantics — running before the input collection
+   * is evaluated — only apply to the enclosing multi-instance body.
+   */
+  private void validateBeforeAllListeners(
+      final Collection<ZeebeExecutionListener> executionListeners,
+      final ModelElementInstance bpmnElement,
+      final ValidationResultCollector validationResultCollector) {
+
+    final boolean hasBeforeAllListener =
+        executionListeners.stream()
+            .anyMatch(
+                l ->
+                    l.getEventType() != null
+                        && l.getEventType() == ZeebeExecutionListenerEventType.beforeAll);
+
+    if (!hasBeforeAllListener) {
+      return;
+    }
+
+    final boolean isMultiInstanceActivity =
+        (bpmnElement instanceof Activity)
+            && (((Activity) bpmnElement).getLoopCharacteristics()
+                instanceof MultiInstanceLoopCharacteristics);
+
+    if (!isMultiInstanceActivity) {
+      validationResultCollector.addError(
+          0,
+          "Execution listeners with event type 'beforeAll' are only supported on multi-instance "
+              + "activities (activities that have a multiInstanceLoopCharacteristics). "
+              + "They run before the input collection or loop cardinality is evaluated "
+              + "and are not valid on '"
+              + bpmnElement.getElementType().getTypeName()
+              + "' without multi-instance loop characteristics.");
+    }
   }
 
   private void reportDuplicateListeners(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowNode;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableMultiInstanceBody;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutionListener;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -169,8 +170,7 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
         final var activatingContext = stateTransitionBehavior.transitionToActivating(context);
         stateTransitionBehavior
             .onElementActivating(element, activatingContext)
-            .flatMap(ok -> processor.onActivate(element, activatingContext))
-            .flatMap(ok -> afterActivating(element, processor, activatingContext))
+            .flatMap(ok -> beforeActivating(element, processor, activatingContext))
             .ifLeft(failure -> incidentBehavior.createIncident(failure, activatingContext));
         break;
       case COMPLETE_ELEMENT:
@@ -191,9 +191,16 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
         final ProcessInstanceIntent elementState =
             stateBehavior.getElementInstance(context).getState();
         switch (elementState) {
-          case ELEMENT_ACTIVATING ->
+          case ELEMENT_ACTIVATING -> {
+            if (element instanceof final ExecutableMultiInstanceBody multiInstanceBody
+                && !multiInstanceBody.getBeforeAllExecutionListeners().isEmpty()) {
+              onBeforeAllExecutionListenerComplete(multiInstanceBody, processor, context)
+                  .ifLeft(failure -> incidentBehavior.createIncident(failure, context));
+            } else {
               onStartExecutionListenerComplete((ExecutableFlowNode) element, processor, context)
                   .ifLeft(failure -> incidentBehavior.createIncident(failure, context));
+            }
+          }
           case ELEMENT_COMPLETING ->
               onEndExecutionListenerComplete((ExecutableFlowNode) element, processor, context)
                   .ifLeft(failure -> incidentBehavior.createIncident(failure, context));
@@ -212,6 +219,34 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
                 "Expected the processor '%s' to handle the event but the intent '%s' is not supported",
                 processor.getClass(), intent));
     }
+  }
+
+  /**
+   * Called from {@link io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent#ACTIVATE_ELEMENT}
+   * processing after {@code onElementActivating}. For multi-instance bodies that have {@code
+   * beforeAll} execution listeners, this method creates the first listener job and defers {@code
+   * onActivate} (collection evaluation + child creation) until all {@code beforeAll} listeners
+   * complete. For all other elements — or multi-instance bodies without {@code beforeAll} listeners
+   * — it delegates directly to {@code onActivate} and then {@code afterActivating}.
+   */
+  private Either<Failure, ?> beforeActivating(
+      final ExecutableFlowElement element,
+      final BpmnElementProcessor<ExecutableFlowElement> processor,
+      final BpmnElementContext context) {
+
+    if (element instanceof final ExecutableMultiInstanceBody multiInstanceBody) {
+      final List<ExecutionListener> beforeAllListeners =
+          multiInstanceBody.getBeforeAllExecutionListeners();
+      if (!beforeAllListeners.isEmpty()) {
+        // Fire first beforeAll listener; onActivate is deferred until all complete.
+        return createExecutionListenerJob(context, beforeAllListeners.getFirst());
+      }
+    }
+
+    // No beforeAll listeners — proceed with normal activation.
+    return processor
+        .onActivate(element, context)
+        .flatMap(ok -> afterActivating(element, processor, context));
   }
 
   private Either<Failure, ?> afterActivating(
@@ -287,6 +322,41 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
         context,
         ExecutableFlowNode::getEndExecutionListeners,
         processor::finalizeCompletion);
+  }
+
+  /**
+   * Handles the completion of a {@code beforeAll} execution listener on a multi-instance body.
+   *
+   * <p>Variables produced by the completed listener are merged into the multi-instance body's local
+   * scope so they are available to the {@code inputCollection} / {@code loopCardinality}
+   * expressions. If more {@code beforeAll} listeners remain, the next one is created. When all
+   * {@code beforeAll} listeners have completed, the element proceeds with {@code onActivate}
+   * (collection evaluation + child instance creation) followed by {@code afterActivating} (any
+   * {@code start} listeners on the body, then finalize activation).
+   */
+  public Either<Failure, ?> onBeforeAllExecutionListenerComplete(
+      final ExecutableMultiInstanceBody element,
+      final BpmnElementProcessor<ExecutableFlowElement> processor,
+      final BpmnElementContext context) {
+    // Merge listener output variables into the body's local scope (local = true) so that
+    // inputCollection / loopCardinality expressions can see them.
+    mergeVariablesOfExecutionListener(context, true);
+
+    final List<ExecutionListener> beforeAllListeners = element.getBeforeAllExecutionListeners();
+    final int currentListenerIndex =
+        stateBehavior.getElementInstance(context).getExecutionListenerIndex();
+    final Optional<ExecutionListener> nextListener =
+        findNextExecutionListener(beforeAllListeners, currentListenerIndex);
+
+    if (nextListener.isPresent()) {
+      return createExecutionListenerJob(context, nextListener.get());
+    }
+
+    // All beforeAll listeners completed — proceed to onActivate (collection evaluation) then
+    // afterActivating (start listeners on body, if any, then finalizeActivation).
+    return processor
+        .onActivate(element, context)
+        .flatMap(ok -> afterActivating(element, processor, context));
   }
 
   private Either<Failure, ?> onExecutionListenerComplete(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -390,6 +390,7 @@ public final class BpmnJobBehavior {
     return switch (eventType) {
       case start -> JobListenerEventType.START;
       case end -> JobListenerEventType.END;
+      case beforeAll -> JobListenerEventType.BEFORE_ALL;
     };
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableFlowNode.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableFlowNode.java
@@ -88,6 +88,40 @@ public class ExecutableFlowNode extends AbstractFlowElement {
         .toList();
   }
 
+  /**
+   * Returns the {@code beforeAll} execution listeners defined on this element.
+   *
+   * <p>{@code beforeAll} listeners are only meaningful on the enclosing body of a multi-instance
+   * element ({@link ExecutableMultiInstanceBody}). They fire before the input collection or loop
+   * cardinality is evaluated and before child element instances are created.
+   */
+  public List<ExecutionListener> getBeforeAllExecutionListeners() {
+    return executionListeners.stream()
+        .filter(el -> el.getEventType() == ZeebeExecutionListenerEventType.beforeAll)
+        .toList();
+  }
+
+  /**
+   * Removes and returns all {@code beforeAll} execution listeners from this element. Used by
+   * {@link
+   * io.camunda.zeebe.engine.processing.deployment.model.transformer.MultiInstanceActivityTransformer}
+   * to transfer {@code beforeAll} listeners from the inner activity to the enclosing multi-instance
+   * body.
+   */
+  public List<ExecutionListener> removeBeforeAllExecutionListeners() {
+    final List<ExecutionListener> beforeAll = getBeforeAllExecutionListeners();
+    executionListeners.removeAll(beforeAll);
+    return beforeAll;
+  }
+
+  /**
+   * Adds an already-constructed {@link ExecutionListener} directly to this element. Used when
+   * transferring listeners between elements (e.g., from inner activity to multi-instance body).
+   */
+  public void addExecutionListener(final ExecutionListener listener) {
+    executionListeners.add(listener);
+  }
+
   public boolean hasExecutionListeners() {
     return !executionListeners.isEmpty();
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/MultiInstanceActivityTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/MultiInstanceActivityTransformer.java
@@ -111,6 +111,7 @@ public final class MultiInstanceActivityTransformer implements ModelElementTrans
     connectSequenceFlowsToMultiInstanceBody(innerActivity, multiInstanceBody);
     replaceCompensationHandlerWithMultiInstanceBody(process, innerActivity, multiInstanceBody);
     replaceAdHocActivityWithMultiInstanceBody(process, innerActivity, multiInstanceBody);
+    transferBeforeAllListenersToMultiInstanceBody(innerActivity, multiInstanceBody);
 
     // replace the inner element with the body
     process.addFlowElement(multiInstanceBody);
@@ -171,5 +172,19 @@ public final class MultiInstanceActivityTransformer implements ModelElementTrans
                 adHocSubProcess.getAdHocActivitiesById().values().stream()
                     .filter(innerActivity::equals)
                     .forEach(adHocActivity -> adHocSubProcess.addAdHocActivity(multiInstanceBody)));
+  }
+
+  /**
+   * Moves {@code beforeAll} execution listeners from the inner activity to the enclosing
+   * multi-instance body. {@code beforeAll} listeners must fire before the input collection or loop
+   * cardinality is evaluated — which happens on the body, not on individual instances — so they
+   * belong to the body element.
+   */
+  private static void transferBeforeAllListenersToMultiInstanceBody(
+      final ExecutableActivity innerActivity,
+      final ExecutableMultiInstanceBody multiInstanceBody) {
+    innerActivity
+        .removeBeforeAllExecutionListeners()
+        .forEach(multiInstanceBody::addExecutionListener);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/multiinstance/MultiInstanceBeforeAllExecutionListenerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/multiinstance/MultiInstanceBeforeAllExecutionListenerTest.java
@@ -1,0 +1,352 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.bpmn.multiinstance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.JobKind;
+import io.camunda.zeebe.protocol.record.value.JobListenerEventType;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
+import java.util.Map;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Tests for the {@code beforeAll} execution listener event type on multi-instance activities.
+ *
+ * <p>{@code beforeAll} listeners run on the enclosing multi-instance body <em>before</em> the
+ * input collection or loop cardinality is evaluated and before any child instances are created.
+ * Variables produced by these listeners are therefore available to the {@code inputCollection}
+ * expression.
+ */
+public class MultiInstanceBeforeAllExecutionListenerTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final String PROCESS_ID = "process";
+  private static final String ELEMENT_ID = "task";
+  private static final String BEFORE_ALL_EL_TYPE = "before-all-listener";
+  private static final String SECOND_BEFORE_ALL_EL_TYPE = "before-all-listener-2";
+  private static final String SERVICE_TASK_TYPE = "service-task";
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  // ---------------------------------------------------------------------------
+  // Basic lifecycle
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void shouldCreateBeforeAllListenerJobBeforeChildInstancesAreCreated() {
+    // given — inputCollection variable is not set; the beforeAll listener will set it
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .serviceTask(
+                ELEMENT_ID,
+                t ->
+                    t.zeebeJobType(SERVICE_TASK_TYPE)
+                        .zeebeBeforeAllExecutionListener(BEFORE_ALL_EL_TYPE)
+                        .multiInstance(
+                            m -> m.zeebeInputCollectionExpression("items").zeebeInputElement("item")))
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when — beforeAll listener job is created
+    final Record<JobRecordValue> listenerJob =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(BEFORE_ALL_EL_TYPE)
+            .getFirst();
+
+    // then — job kind and event type are correct
+    assertThat(listenerJob.getValue().getJobKind()).isEqualTo(JobKind.EXECUTION_LISTENER);
+    assertThat(listenerJob.getValue().getJobListenerEventType())
+        .isEqualTo(JobListenerEventType.BEFORE_ALL);
+
+    // and no child instances exist yet (the multi-instance body is still ELEMENT_ACTIVATING)
+    final long miBodyKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.MULTI_INSTANCE_BODY)
+            .getFirst()
+            .getKey();
+
+    final boolean anyChildActivating =
+        RecordingExporter.processInstanceRecords()
+            .withProcessInstanceKey(processInstanceKey)
+            .withFlowScopeKey(miBodyKey)
+            .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .exists();
+
+    assertThat(anyChildActivating)
+        .as("No child instances should be created before beforeAll listener completes")
+        .isFalse();
+  }
+
+  @Test
+  public void shouldSetInputCollectionVariableViaBeforeAllListener() {
+    // given — a process where inputCollection depends on a variable produced by the beforeAll EL
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .serviceTask(
+                ELEMENT_ID,
+                t ->
+                    t.zeebeJobType(SERVICE_TASK_TYPE)
+                        .zeebeBeforeAllExecutionListener(BEFORE_ALL_EL_TYPE)
+                        .multiInstance(
+                            m ->
+                                m.zeebeInputCollectionExpression("items")
+                                    .zeebeInputElement("item")))
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when — the beforeAll listener completes with the inputCollection variable
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(BEFORE_ALL_EL_TYPE)
+        .withVariables(Map.of("items", List.of("a", "b", "c")))
+        .complete();
+
+    // then — the multi-instance body activates and creates 3 child instances
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementId(ELEMENT_ID)
+                .withElementType(BpmnElementType.SERVICE_TASK)
+                .limit(3)
+                .count())
+        .isEqualTo(3);
+  }
+
+  @Test
+  public void shouldProcessMultipleBeforeAllListenersInOrder() {
+    // given — two beforeAll listeners chained before child creation
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .serviceTask(
+                ELEMENT_ID,
+                t ->
+                    t.zeebeJobType(SERVICE_TASK_TYPE)
+                        .zeebeBeforeAllExecutionListener(BEFORE_ALL_EL_TYPE)
+                        .zeebeBeforeAllExecutionListener(SECOND_BEFORE_ALL_EL_TYPE)
+                        .multiInstance(
+                            m ->
+                                m.zeebeInputCollectionExpression("items")
+                                    .zeebeInputElement("item")))
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when — first beforeAll listener runs
+    final Record<JobRecordValue> firstJob =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(BEFORE_ALL_EL_TYPE)
+            .getFirst();
+
+    assertThat(firstJob.getValue().getJobListenerEventType())
+        .isEqualTo(JobListenerEventType.BEFORE_ALL);
+
+    // first listener sets the collection
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(BEFORE_ALL_EL_TYPE)
+        .withVariables(Map.of("items", List.of("x")))
+        .complete();
+
+    // then — second beforeAll listener is created next (no child instances yet)
+    final Record<JobRecordValue> secondJob =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(SECOND_BEFORE_ALL_EL_TYPE)
+            .getFirst();
+
+    assertThat(secondJob.getValue().getJobListenerEventType())
+        .isEqualTo(JobListenerEventType.BEFORE_ALL);
+
+    // no child instances until both listeners complete
+    final long miBodyKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.MULTI_INSTANCE_BODY)
+            .getFirst()
+            .getKey();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .withFlowScopeKey(miBodyKey)
+                .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+                .exists())
+        .as("No child instances before all beforeAll listeners complete")
+        .isFalse();
+
+    // when — second beforeAll listener completes
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(SECOND_BEFORE_ALL_EL_TYPE)
+        .complete();
+
+    // then — 1 child instance is created (items = ["x"] from first listener)
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementId(ELEMENT_ID)
+                .withElementType(BpmnElementType.SERVICE_TASK)
+                .limit(1)
+                .count())
+        .isEqualTo(1);
+  }
+
+  @Test
+  public void shouldCompleteProcessWithBeforeAllListener() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .serviceTask(
+                ELEMENT_ID,
+                t ->
+                    t.zeebeJobType(SERVICE_TASK_TYPE)
+                        .zeebeBeforeAllExecutionListener(BEFORE_ALL_EL_TYPE)
+                        .multiInstance(
+                            m ->
+                                m.zeebeInputCollectionExpression("items")
+                                    .zeebeInputElement("item")))
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when — beforeAll listener sets the collection with a single item
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(BEFORE_ALL_EL_TYPE)
+        .withVariables(Map.of("items", List.of("only-item")))
+        .complete();
+
+    // and the service task job completes
+    ENGINE.job().ofInstance(processInstanceKey).withType(SERVICE_TASK_TYPE).complete();
+
+    // then — process instance completes
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+                .withProcessInstanceKey(processInstanceKey)
+                .filter(r -> r.getValue().getBpmnElementType() == BpmnElementType.PROCESS)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldCreateIncidentWhenInputCollectionMissingAfterBeforeAllListener() {
+    // given — beforeAll listener does NOT set `items`; expect an incident on MI body
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .serviceTask(
+                ELEMENT_ID,
+                t ->
+                    t.zeebeJobType(SERVICE_TASK_TYPE)
+                        .zeebeBeforeAllExecutionListener(BEFORE_ALL_EL_TYPE)
+                        .multiInstance(
+                            m ->
+                                m.zeebeInputCollectionExpression("items")
+                                    .zeebeInputElement("item")))
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when — beforeAll listener completes without providing `items`
+    ENGINE.job().ofInstance(processInstanceKey).withType(BEFORE_ALL_EL_TYPE).complete();
+
+    // then — an incident is raised on the multi-instance body
+    assertThat(
+            RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldExposeMiBodyJobWithCorrectEventTypeInRecords() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .serviceTask(
+                ELEMENT_ID,
+                t ->
+                    t.zeebeJobType(SERVICE_TASK_TYPE)
+                        .zeebeBeforeAllExecutionListener(BEFORE_ALL_EL_TYPE)
+                        .multiInstance(
+                            m ->
+                                m.zeebeInputCollectionExpression("items")
+                                    .zeebeInputElement("item")))
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when — complete the listener with 2 items
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(BEFORE_ALL_EL_TYPE)
+        .withVariables(Map.of("items", List.of(1, 2)))
+        .complete();
+
+    // then — verify job record fields for the beforeAll EL job
+    assertThat(
+            RecordingExporter.jobRecords(JobIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withType(BEFORE_ALL_EL_TYPE)
+                .map(Record::getValue))
+        .extracting(JobRecordValue::getJobKind, JobRecordValue::getJobListenerEventType)
+        .containsExactly(tuple(JobKind.EXECUTION_LISTENER, JobListenerEventType.BEFORE_ALL));
+  }
+}
+

--- a/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
@@ -1035,6 +1035,7 @@ components:
       type: string
       enum:
         - ASSIGNING
+        - BEFORE_ALL
         - CANCELING
         - COMPLETING
         - CREATING

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobListenerEventType.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobListenerEventType.java
@@ -26,6 +26,13 @@ public enum JobListenerEventType {
   // ---------------------------------------------------------------------------
 
   /**
+   * Represents the `beforeAll` event for an execution listener. This event type is used to indicate
+   * that the listener should be triggered before starting the execution, such as the composition
+   * of inputCollection for multi-instance cases
+   */
+  BEFORE_ALL,
+
+  /**
    * Represents the `start` event for an execution listener. This event type is used to indicate
    * that the listener should be triggered at the start of an execution, such as the beginning of a
    * process instance, sub-process or element (task, event, gateway).


### PR DESCRIPTION
## Description

poc that introduces eventType `beforeAll`
<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates #50446
