### PR TITLE
style: add named export and end of file eslint rules to shared linting package

### DIFF
--- a/identity/client/README.md
+++ b/identity/client/README.md
@@ -5,3 +5,4 @@ To start in development mode run
 ```shell
 npm run dev
 ```
+

--- a/identity/client/README.md
+++ b/identity/client/README.md
@@ -5,4 +5,3 @@ To start in development mode run
 ```shell
 npm run dev
 ```
-

--- a/operate/client/src/App/Dashboard/IncidentsByError/utils/getAccordionItemTitle.tsx
+++ b/operate/client/src/App/Dashboard/IncidentsByError/utils/getAccordionItemTitle.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import pluralSuffix from 'modules/utils/pluralSuffix';
+import {pluralSuffix} from 'modules/utils/pluralSuffix';
 
 function getAccordionItemTitle({
   processName,

--- a/operate/client/src/App/Dashboard/IncidentsByError/utils/getAccordionTitle.tsx
+++ b/operate/client/src/App/Dashboard/IncidentsByError/utils/getAccordionTitle.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import pluralSuffix from 'modules/utils/pluralSuffix';
+import {pluralSuffix} from 'modules/utils/pluralSuffix';
 
 function getAccordionTitle(
   instancesWithErrorCount: number,

--- a/operate/client/src/App/Dashboard/InstancesByProcessDefinition/utils/getAccordionItemLabel.tsx
+++ b/operate/client/src/App/Dashboard/InstancesByProcessDefinition/utils/getAccordionItemLabel.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import pluralSuffix from 'modules/utils/pluralSuffix';
+import {pluralSuffix} from 'modules/utils/pluralSuffix';
 
 function getAccordionItemLabel({
   name,

--- a/operate/client/src/App/Dashboard/InstancesByProcessDefinition/utils/getAccordionItemTitle.tsx
+++ b/operate/client/src/App/Dashboard/InstancesByProcessDefinition/utils/getAccordionItemTitle.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import pluralSuffix from 'modules/utils/pluralSuffix';
+import {pluralSuffix} from 'modules/utils/pluralSuffix';
 
 function getAccordionItemTitle({
   processName,

--- a/operate/client/src/App/Dashboard/InstancesByProcessDefinition/utils/getAccordionLabel.tsx
+++ b/operate/client/src/App/Dashboard/InstancesByProcessDefinition/utils/getAccordionLabel.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import pluralSuffix from 'modules/utils/pluralSuffix';
+import {pluralSuffix} from 'modules/utils/pluralSuffix';
 
 function getAccordionLabel({
   name,

--- a/operate/client/src/App/Dashboard/InstancesByProcessDefinition/utils/getAccordionTitle.tsx
+++ b/operate/client/src/App/Dashboard/InstancesByProcessDefinition/utils/getAccordionTitle.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import pluralSuffix from 'modules/utils/pluralSuffix';
+import {pluralSuffix} from 'modules/utils/pluralSuffix';
 
 function getAccordionTitle({
   processName,

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/ViewFullVariableButton/types.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/ViewFullVariableButton/types.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-export interface MaximizeButtonProps {
+interface MaximizeButtonProps {
   onClick: () => void;
 }
 
@@ -15,18 +15,18 @@ interface ViewFullVariableBaseProps {
   shouldSubmitOnApply?: boolean;
 }
 
-export interface ViewFullVariableButtonAddProps extends ViewFullVariableBaseProps {
+interface ViewFullVariableButtonAddProps extends ViewFullVariableBaseProps {
   mode: 'add';
   scopeId: string | null;
 }
 
-export interface ViewFullVariableButtonEditProps extends ViewFullVariableBaseProps {
+interface ViewFullVariableButtonEditProps extends ViewFullVariableBaseProps {
   mode: 'edit';
   variableValue: string;
   variableKey: string;
 }
 
-export interface ViewFullVariableButtonShowProps extends ViewFullVariableBaseProps {
+interface ViewFullVariableButtonShowProps extends ViewFullVariableBaseProps {
   mode: 'show';
   variableValue: string;
   variableKey: string;
@@ -34,7 +34,15 @@ export interface ViewFullVariableButtonShowProps extends ViewFullVariableBasePro
   canEdit?: boolean;
 }
 
-export type ViewFullVariableWrapperProps =
+type ViewFullVariableWrapperProps =
   | ViewFullVariableButtonAddProps
   | ViewFullVariableButtonEditProps
   | ViewFullVariableButtonShowProps;
+
+export type {
+  MaximizeButtonProps,
+  ViewFullVariableButtonAddProps,
+  ViewFullVariableButtonEditProps,
+  ViewFullVariableButtonShowProps,
+  ViewFullVariableWrapperProps,
+};

--- a/operate/client/src/App/ProcessInstance/tests/mocks.tsx
+++ b/operate/client/src/App/ProcessInstance/tests/mocks.tsx
@@ -171,6 +171,4 @@ function getWrapper(options?: {
   return Wrapper;
 }
 
-export {getWrapper, updateSearchParams};
-
-export {mockRequests};
+export {getWrapper, updateSearchParams, mockRequests};

--- a/operate/client/src/App/Processes/ListView/DiagramPanel/BatchModificationNotification/index.tsx
+++ b/operate/client/src/App/Processes/ListView/DiagramPanel/BatchModificationNotification/index.tsx
@@ -8,7 +8,7 @@
 
 import {observer} from 'mobx-react';
 import {useInstancesCount} from 'modules/queries/processInstancesStatistics/useInstancesCount';
-import pluralSuffix from 'modules/utils/pluralSuffix';
+import {pluralSuffix} from 'modules/utils/pluralSuffix';
 import {Container, InlineNotification, Button} from './styled';
 import {useProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 import {useListViewXml} from 'modules/queries/processDefinitions/useListViewXml';

--- a/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/index.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/index.tsx
@@ -12,7 +12,7 @@ import {
   TableBatchAction,
   TableBatchActions,
 } from '@carbon/react';
-import pluralSuffix from 'modules/utils/pluralSuffix';
+import {pluralSuffix} from 'modules/utils/pluralSuffix';
 import {useState} from 'react';
 import {RetryFailed, Error, TrashCan} from '@carbon/react/icons';
 import {MigrateAction} from './MigrateAction';

--- a/operate/client/src/App/Processes/MigrationView/MigrationDetails/index.tsx
+++ b/operate/client/src/App/Processes/MigrationView/MigrationDetails/index.tsx
@@ -8,7 +8,7 @@
 
 import {observer} from 'mobx-react';
 import {processInstanceMigrationStore} from 'modules/stores/processInstanceMigration';
-import pluralSuffix from 'modules/utils/pluralSuffix';
+import {pluralSuffix} from 'modules/utils/pluralSuffix';
 import {getProcessDefinitionName} from 'modules/hooks/processDefinitions';
 
 const MigrationDetails: React.FC = observer(() => {

--- a/operate/client/src/modules/components/InstanceHeader/index.tsx
+++ b/operate/client/src/modules/components/InstanceHeader/index.tsx
@@ -17,7 +17,7 @@ import {
   AdditionalContent,
 } from './styled';
 import {StateIcon} from 'modules/components/StateIcon';
-import pluralSuffix from 'modules/utils/pluralSuffix';
+import {pluralSuffix} from 'modules/utils/pluralSuffix';
 
 type Column = {
   title?: string;

--- a/operate/client/src/modules/components/PanelHeader/index.tsx
+++ b/operate/client/src/modules/components/PanelHeader/index.tsx
@@ -9,7 +9,7 @@
 import {Header} from './styled';
 import {Title} from '../PanelTitle';
 import {forwardRef} from 'react';
-import pluralSuffix from 'modules/utils/pluralSuffix';
+import {pluralSuffix} from 'modules/utils/pluralSuffix';
 
 type Props = {
   title?: string;

--- a/operate/client/src/modules/stores/modifications.ts
+++ b/operate/client/src/modules/stores/modifications.ts
@@ -754,6 +754,7 @@ class Modifications {
   };
 }
 
+const modificationsStore = new Modifications();
+
 export type {ElementModification, AncestorScopeType};
-export const modificationsStore = new Modifications();
-export {EMPTY_MODIFICATION};
+export {modificationsStore, EMPTY_MODIFICATION};

--- a/operate/client/src/modules/utils/elements/index.ts
+++ b/operate/client/src/modules/utils/elements/index.ts
@@ -14,11 +14,11 @@ import type {
 import type {DiagramModel} from 'bpmn-moddle';
 import {SUBPROCESS_WITH_INCIDENTS} from 'modules/bpmn-js/badgePositions';
 
-export function isFlowNode(businessObject: BusinessObject) {
+function isFlowNode(businessObject: BusinessObject) {
   return businessObject.$instanceOf?.('bpmn:FlowNode') ?? false;
 }
 
-export function getFlowNodes(elementsById?: DiagramModel['elementsById']) {
+function getFlowNodes(elementsById?: DiagramModel['elementsById']) {
   if (elementsById === undefined) {
     return [];
   }
@@ -28,7 +28,7 @@ export function getFlowNodes(elementsById?: DiagramModel['elementsById']) {
   );
 }
 
-export function getElement({
+function getElement({
   businessObjects,
   elementId,
 }: {
@@ -38,7 +38,7 @@ export function getElement({
   return elementId ? businessObjects?.[elementId] : undefined;
 }
 
-export function getElementName({
+function getElementName({
   businessObjects,
   elementId,
 }: {
@@ -48,7 +48,7 @@ export function getElementName({
   return getElement({businessObjects, elementId})?.name ?? elementId ?? '';
 }
 
-export function getSubprocessOverlayFromIncidentElements(
+function getSubprocessOverlayFromIncidentElements(
   flowNodes?: (BusinessObject | undefined)[],
   type: string = 'elementState',
 ) {
@@ -71,3 +71,11 @@ export function getSubprocessOverlayFromIncidentElements(
 
   return overlays;
 }
+
+export {
+  isFlowNode,
+  getFlowNodes,
+  getElement,
+  getElementName,
+  getSubprocessOverlayFromIncidentElements,
+};

--- a/operate/client/src/modules/utils/pluralSuffix/index.test.ts
+++ b/operate/client/src/modules/utils/pluralSuffix/index.test.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import pluralSuffix from './index';
+import {pluralSuffix} from './index';
 
 describe('pluralSuffix', () => {
   it('should append suffix when count === 0', () => {

--- a/operate/client/src/modules/utils/pluralSuffix/index.ts
+++ b/operate/client/src/modules/utils/pluralSuffix/index.ts
@@ -6,9 +6,8 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-/**
- * Adds an 's' at the end of a text, when count is not 1 or -1
- */
-export default function pluralSuffix(count: number, text: string) {
+function pluralSuffix(count: number, text: string) {
   return Math.abs(count) === 1 ? `${count} ${text}` : `${count} ${text}s`;
 }
+
+export {pluralSuffix};

--- a/tasklist/client/src/modules/i18n/index.tsx
+++ b/tasklist/client/src/modules/i18n/index.tsx
@@ -26,7 +26,7 @@ type LocaleConfig = {
   translationFile: Resource;
 };
 
-export type SelectionOption = {
+type SelectionOption = {
   id: string;
   label: string;
 };
@@ -78,4 +78,5 @@ const translationResources: Resource = Object.entries(
 const getCurrentDateLocale = () =>
   localeDefinitions[i18n.language]?.dateLocale ?? dateLocaleEnUS;
 
+export type {SelectionOption};
 export {languageItems, translationResources, getCurrentDateLocale};

--- a/webapp/client/packages/lint-config/eslint/typescript.js
+++ b/webapp/client/packages/lint-config/eslint/typescript.js
@@ -39,9 +39,7 @@ function typescriptConfig({browserFiles, testFiles, nodeFiles, tsconfigRootDir, 
 		},
 		{
 			files: [...browserFiles, ...testFiles],
-			plugins: {
-				import: importPlugin,
-			},
+			plugins: {import: importPlugin},
 			languageOptions: {
 				ecmaVersion: 2022,
 				sourceType: 'module',
@@ -58,6 +56,9 @@ function typescriptConfig({browserFiles, testFiles, nodeFiles, tsconfigRootDir, 
 				},
 			},
 			rules: {
+				'import/no-default-export': 'error',
+				'import/exports-last': 'error',
+				'import/group-exports': 'error',
 				'import/extensions': [
 					'error',
 					'ignorePackages',
@@ -75,6 +76,14 @@ function typescriptConfig({browserFiles, testFiles, nodeFiles, tsconfigRootDir, 
 						extensions: ['.js', '.jsx', '.ts', '.tsx'],
 					},
 				},
+			},
+		},
+		{
+			files: ['**/__mocks__/**', '**/*.d.ts'],
+			rules: {
+				'import/no-default-export': 'off',
+				'import/exports-last': 'off',
+				'import/group-exports': 'off',
 			},
 		},
 		{


### PR DESCRIPTION
## Description

Adds three new ESLint rules to the shared `@camunda/lint-config` package to enforce consistent export style across client packages:

- **`import/no-default-export`** – disallows default exports in favour of named exports
- **`import/exports-last`** – requires all exports to appear at the end of the file
- **`import/group-exports`** – requires exports to be grouped together

The rules are disabled for `__mocks__` and `.d.ts` files where defaults are necessary. Existing code in `operate/client` and `tasklist/client` has been updated to comply: default exports converted to named exports and export statements consolidated at the end of each file.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates to #51580
