### PR TITLE
fix: upgrade bouncycastle to 1.84

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -39,7 +39,7 @@
     <version.animal-sniffer>1.27</version.animal-sniffer>
     <version.assertj>3.27.7</version.assertj>
     <version.awaitility>4.3.0</version.awaitility>
-    <version.bouncycastle>1.83</version.bouncycastle>
+    <version.bouncycastle>1.84</version.bouncycastle>
     <version.camunda>7.24.0</version.camunda>
     <version.camunda-license-check>2.11.2</version.camunda-license-check>
     <version.checkstyle>13.4.0</version.checkstyle>


### PR DESCRIPTION
## Description

- CVE-2026-5588
- [CVE-2026-14813](https://github.com/advisories/GHSA-574f-3g2m-x479)
- CVE-2026-0636

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates #51284