### PR TITLE
fix: remove flakiness from ProcessInstanceIT

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceIT.java
@@ -528,7 +528,7 @@ public class ProcessInstanceIT {
   public void shouldSelectRootExpiredRootProcessInstances(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
-    final int partitionId = nextKey().intValue();
+    final var partitionId = nextKey().intValue();
 
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(partitionId);
 
@@ -571,7 +571,7 @@ public class ProcessInstanceIT {
   public void shouldSelectExpiredRootProcessInstancesWithLimit(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
-    final int partitionId = nextKey().intValue();
+    final var partitionId = nextKey().intValue();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(partitionId);
 
     final var cleanupDate = NOW;
@@ -626,7 +626,7 @@ public class ProcessInstanceIT {
   public void shouldNotSelectExpiredRootProcessInstancesFromDifferentPartition(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
-    final int partitionId = nextKey().intValue();
+    final var partitionId = nextKey().intValue();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(partitionId);
 
     final var cleanupDate = NOW;
@@ -660,7 +660,7 @@ public class ProcessInstanceIT {
   public void shouldNotSelectRootProcessInstancesWithoutCleanupDate(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
-    final int partitionId = nextKey().intValue();
+    final var partitionId = nextKey().intValue();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(partitionId);
 
     final var cleanupDate = NOW;
@@ -692,7 +692,7 @@ public class ProcessInstanceIT {
   public void shouldNotScheduleNonRootProcessInstancesForCleanupByThemselves(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
-    final int partitionId = nextKey().intValue();
+    final var partitionId = nextKey().intValue();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(partitionId);
 
     final var cleanupDate = NOW;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceIT.java
@@ -143,13 +143,15 @@ public class ProcessInstanceIT {
     final ProcessInstanceDbReader processInstanceReader = rdbmsService.getProcessInstanceReader();
 
     final Long processInstanceKey = nextKey();
+    final Long processDefinitionKey = nextKey();
+    final String processDefinitionId = ProcessInstanceFixtures.nextStringId();
     createAndSaveProcessInstance(
         rdbmsWriters,
         ProcessInstanceFixtures.createRandomized(
             b ->
                 b.processInstanceKey(processInstanceKey)
-                    .processDefinitionId("test-process-unique")
-                    .processDefinitionKey(1338L)
+                    .processDefinitionId(processDefinitionId)
+                    .processDefinitionKey(processDefinitionKey)
                     .state(ProcessInstanceState.ACTIVE)
                     .startDate(NOW)
                     .parentProcessInstanceKey(-1L)
@@ -160,7 +162,7 @@ public class ProcessInstanceIT {
         processInstanceReader.search(
             ProcessInstanceQuery.of(
                 b ->
-                    b.filter(f -> f.processDefinitionIds("test-process-unique"))
+                    b.filter(f -> f.processDefinitionIds(processDefinitionId))
                         .sort(s -> s)
                         .page(p -> p.from(0).size(10))));
 
@@ -171,8 +173,8 @@ public class ProcessInstanceIT {
     final var instance = searchResult.items().getFirst();
 
     assertThat(instance.processInstanceKey()).isEqualTo(processInstanceKey);
-    assertThat(instance.processDefinitionId()).isEqualTo("test-process-unique");
-    assertThat(instance.processDefinitionKey()).isEqualTo(1338L);
+    assertThat(instance.processDefinitionId()).isEqualTo(processDefinitionId);
+    assertThat(instance.processDefinitionKey()).isEqualTo(processDefinitionKey);
     assertThat(instance.state()).isEqualTo(ProcessInstanceState.ACTIVE);
     assertThat(instance.startDate())
         .isCloseTo(NOW, new TemporalUnitWithinOffset(1, ChronoUnit.MILLIS));
@@ -188,7 +190,10 @@ public class ProcessInstanceIT {
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final ProcessInstanceDbReader processInstanceReader = rdbmsService.getProcessInstanceReader();
 
-    final var processInstance = createAndSaveRandomProcessInstance(rdbmsWriters, b -> b);
+    final String uniqueProcessDefinitionId = ProcessInstanceFixtures.nextStringId();
+    final var processInstance =
+        createAndSaveRandomProcessInstance(
+            rdbmsWriters, b -> b.processDefinitionId(uniqueProcessDefinitionId));
     createAndSaveRandomProcessInstances(rdbmsWriters);
 
     final var searchResult =
@@ -523,7 +528,7 @@ public class ProcessInstanceIT {
   public void shouldSelectRootExpiredRootProcessInstances(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
-    final var partitionId = (int) (Math.random() * 1000);
+    final int partitionId = nextKey().intValue();
 
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(partitionId);
 
@@ -566,7 +571,7 @@ public class ProcessInstanceIT {
   public void shouldSelectExpiredRootProcessInstancesWithLimit(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
-    final var partitionId = (int) (Math.random() * 1000);
+    final int partitionId = nextKey().intValue();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(partitionId);
 
     final var cleanupDate = NOW;
@@ -621,7 +626,7 @@ public class ProcessInstanceIT {
   public void shouldNotSelectExpiredRootProcessInstancesFromDifferentPartition(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
-    final var partitionId = (int) (Math.random() * 1000);
+    final int partitionId = nextKey().intValue();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(partitionId);
 
     final var cleanupDate = NOW;
@@ -655,7 +660,7 @@ public class ProcessInstanceIT {
   public void shouldNotSelectRootProcessInstancesWithoutCleanupDate(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
-    final var partitionId = (int) (Math.random() * 1000);
+    final int partitionId = nextKey().intValue();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(partitionId);
 
     final var cleanupDate = NOW;
@@ -687,7 +692,7 @@ public class ProcessInstanceIT {
   public void shouldNotScheduleNonRootProcessInstancesForCleanupByThemselves(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
-    final var partitionId = (int) (Math.random() * 1000);
+    final int partitionId = nextKey().intValue();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(partitionId);
 
     final var cleanupDate = NOW;


### PR DESCRIPTION
## Summary

Fixes test flakiness in `ProcessInstanceIT` by replacing low-cardinality random values with guaranteed-unique identifiers. All tests in this class share the same long-lived database instance (via the static `SUPPORTED_TEST_APPLICATIONS`), so data from one test accumulates and can corrupt another test's count assertions.

**Root causes fixed:**

- **`shouldFindProcessInstanceByBpmnProcessId`**: hardcoded `processDefinitionId("test-process-unique")` and `processDefinitionKey(1338L)` — any test that writes a process instance with the same string inflates the count. Replaced with `nextStringId()` (UUID) and `nextKey()`.
- **`shouldFindProcessInstanceByAuthorizationResourceId`**: the specific PI received a `processDefinitionId` from `"process-" + RANDOM.nextInt(10000)` (10 000 possible values), giving the 20 noise instances and accumulated DB data a non-trivial collision probability. Replaced with `nextStringId()`.
- **Five partition-scoped cleanup tests** (`shouldSelectRootExpiredRootProcessInstances`, `shouldSelectExpiredRootProcessInstancesWithLimit`, `shouldNotSelectExpiredRootProcessInstancesFromDifferentPartition`, `shouldNotSelectRootProcessInstancesWithoutCleanupDate`, `shouldNotScheduleNonRootProcessInstancesForCleanupByThemselves`): used `(int)(Math.random() * 1000)` (values 0–999), so two tests sharing the same partition ID would find each other's expired instances. Replaced with `nextKey().intValue()` which uses the shared `AtomicLong` counter and never repeats within a test run.

Closes #50860