### PR TITLE
Make dry run obvious, when creating getting started bundles

### DIFF
--- a/.github/workflows/camunda8-getting-started-bundle.yaml
+++ b/.github/workflows/camunda8-getting-started-bundle.yaml
@@ -17,7 +17,7 @@ on:
         required: true
         default: "latest"
       dry_run:
-        description: "If true, artifacts are only uploaded to the workflow run, not to the GitHub release."
+        description: "Dry run only: artifacts are only uploaded to the workflow run, not to the GitHub release."
         type: boolean
         required: true
         default: true


### PR DESCRIPTION
## Description

It's not clear from the checkbox, if it's a dryrun. Name the option accordingly.

## Checklist
No backport needed

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

