### PR TITLE
refactor: remove unused `DatabaseType` annotation in `ProcessDefinitionSearchIT`

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionSearchIT.java
@@ -21,7 +21,6 @@ import io.camunda.client.api.search.response.ProcessDefinition;
 import io.camunda.client.api.search.sort.ProcessDefinitionSort;
 import io.camunda.it.util.TestHelper;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
-import io.camunda.qa.util.multidb.CamundaMultiDBExtension.DatabaseType;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -38,7 +37,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-@MultiDbTest(DatabaseType.RDBMS_MSSQL)
+@MultiDbTest
 @CompatibilityTest
 public class ProcessDefinitionSearchIT {
   private static final String PROCESS_ID_WITH_START_FORM = "processStartForm";


### PR DESCRIPTION
## Description

Remove unused `DatabaseType` annotation in `ProcessDefinitionSearchIT`
