### PR TITLE
ci: explicitly include makeLatest and prerelease when updating GH release

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -1081,10 +1081,12 @@ jobs:
         with:
           allowUpdates: true
           bodyFile: changelog.md
+          makeLatest: ${{ inputs.isLatest }}
           omitBodyDuringUpdate: false
           omitNameDuringUpdate: true
           omitDraftDuringUpdate: true
-          omitPrereleaseDuringUpdate: true
+          omitPrereleaseDuringUpdate: false
+          prerelease: ${{ steps.pre-release.outputs.result }}
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ env.RELEASE_TAG }}
       - name: Warn if Github release body update failed


### PR DESCRIPTION
## Description

**Workflow improvements:**

* The `makeLatest` parameter is now set based on the workflow input `${{ inputs.isLatest }}`, allowing more flexible control over which release is marked as the latest.
* The `prerelease` parameter is now explicitly set using the output from the `pre-release` step, ensuring prerelease status is determined dynamically.

For more details see: https://camunda.slack.com/archives/C06UWQNCU7M/p1776437548194389?thread_ts=1776429388.975929&cid=C06UWQNCU7M

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
