### PR TITLE
fix: Fix PI migration of MI subprocesses

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
@@ -794,10 +794,13 @@ public final class ProcessInstanceMigrationPreconditions {
       }
 
       final var targetCatchEventId = sourceElementIdToTargetElementId.get(sourceCatchEventId);
+      // a generic lookup traverses to the inner activity, which has no boundary events
+      final Class<? extends ExecutableCatchEventSupplier> expectedType =
+          sourceCatchEventSupplier instanceof ExecutableMultiInstanceBody
+              ? ExecutableMultiInstanceBody.class
+              : ExecutableCatchEventSupplier.class;
       final var targetElement =
-          targetProcessDefinition
-              .getProcess()
-              .getElementById(targetElementId, ExecutableCatchEventSupplier.class);
+          targetProcessDefinition.getProcess().getElementById(targetElementId, expectedType);
       if (targetElement.getEvents().stream()
           .map(catchEvent -> BufferUtil.bufferAsString(catchEvent.getId()))
           .noneMatch(targetCatchEventId::equals)) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateParallelMultiInstanceBodyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateParallelMultiInstanceBodyTest.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.TimerIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
@@ -1292,5 +1293,103 @@ public class MigrateParallelMultiInstanceBodyTest {
                 .findAny())
         .describedAs("Expect that the process instance is continued in the target process")
         .isPresent();
+  }
+
+  @Test
+  public void shouldMigrateMappedTimerBoundaryEventAttachedToMultiInstanceSubprocess() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .subProcess(
+                        "sub",
+                        sub ->
+                            sub.multiInstance(
+                                b ->
+                                    b.zeebeInputCollectionExpression("[1,2,3]")
+                                        .zeebeInputElement("index")))
+                    .embeddedSubProcess()
+                    .startEvent()
+                    .serviceTask("task", t -> t.zeebeJobType("task"))
+                    .endEvent()
+                    .subProcessDone()
+                    .boundaryEvent("timerBoundary", b -> b.timerWithDuration("PT1H"))
+                    .cancelActivity(false)
+                    .endEvent("boundaryEnd")
+                    .moveToActivity("sub")
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .subProcess(
+                        "sub",
+                        sub ->
+                            sub.multiInstance(
+                                b ->
+                                    b.zeebeInputCollectionExpression("[1,2,3]")
+                                        .zeebeInputElement("index")))
+                    .embeddedSubProcess()
+                    .startEvent()
+                    .serviceTask("task", t -> t.zeebeJobType("task"))
+                    .endEvent()
+                    .subProcessDone()
+                    .boundaryEvent("timerBoundary", b -> b.timerWithDuration("PT1H"))
+                    .cancelActivity(false)
+                    .endEvent("boundaryEnd")
+                    .moveToActivity("sub")
+                    .endEvent()
+                    .done())
+            .deploy();
+
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementId("task")
+                .limit(3))
+        .describedAs("Wait until all three subprocess service tasks have activated")
+        .hasSize(3);
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("sub", "sub")
+        .addMappingInstruction("task", "task")
+        .addMappingInstruction("timerBoundary", "timerBoundary")
+        .migrate();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.MULTI_INSTANCE_BODY)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that the multi-instance body is migrated to the target process")
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .hasBpmnProcessId(targetProcessId)
+        .hasElementId("sub");
+
+    assertThat(
+            RecordingExporter.timerRecords(TimerIntent.MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .exists())
+        .describedAs(
+            "Expect that the timer boundary event subscription is migrated to the target process")
+        .isTrue();
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateParallelMultiInstanceBodyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateParallelMultiInstanceBodyTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.groups.Tuple.tuple;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
@@ -1304,48 +1305,8 @@ public class MigrateParallelMultiInstanceBodyTest {
     final var deployment =
         ENGINE
             .deployment()
-            .withXmlResource(
-                Bpmn.createExecutableProcess(processId)
-                    .startEvent()
-                    .subProcess(
-                        "sub",
-                        sub ->
-                            sub.multiInstance(
-                                b ->
-                                    b.zeebeInputCollectionExpression("[1,2,3]")
-                                        .zeebeInputElement("index")))
-                    .embeddedSubProcess()
-                    .startEvent()
-                    .serviceTask("task", t -> t.zeebeJobType("task"))
-                    .endEvent()
-                    .subProcessDone()
-                    .boundaryEvent("timerBoundary", b -> b.timerWithDuration("PT1H"))
-                    .cancelActivity(false)
-                    .endEvent("boundaryEnd")
-                    .moveToActivity("sub")
-                    .endEvent()
-                    .done())
-            .withXmlResource(
-                Bpmn.createExecutableProcess(targetProcessId)
-                    .startEvent()
-                    .subProcess(
-                        "sub",
-                        sub ->
-                            sub.multiInstance(
-                                b ->
-                                    b.zeebeInputCollectionExpression("[1,2,3]")
-                                        .zeebeInputElement("index")))
-                    .embeddedSubProcess()
-                    .startEvent()
-                    .serviceTask("task", t -> t.zeebeJobType("task"))
-                    .endEvent()
-                    .subProcessDone()
-                    .boundaryEvent("timerBoundary", b -> b.timerWithDuration("PT1H"))
-                    .cancelActivity(false)
-                    .endEvent("boundaryEnd")
-                    .moveToActivity("sub")
-                    .endEvent()
-                    .done())
+            .withXmlResource(parallelSubProcessWithTimerBoundary(processId))
+            .withXmlResource(parallelSubProcessWithTimerBoundary(targetProcessId))
             .deploy();
 
     final long targetProcessDefinitionKey =
@@ -1391,5 +1352,26 @@ public class MigrateParallelMultiInstanceBodyTest {
         .describedAs(
             "Expect that the timer boundary event subscription is migrated to the target process")
         .isTrue();
+  }
+
+  private static BpmnModelInstance parallelSubProcessWithTimerBoundary(final String processId) {
+    return Bpmn.createExecutableProcess(processId)
+        .startEvent()
+        .subProcess(
+            "sub",
+            sub ->
+                sub.multiInstance(
+                    b -> b.zeebeInputCollectionExpression("[1,2,3]").zeebeInputElement("index")))
+        .embeddedSubProcess()
+        .startEvent()
+        .serviceTask("task", t -> t.zeebeJobType("task"))
+        .endEvent()
+        .subProcessDone()
+        .boundaryEvent("timerBoundary", b -> b.timerWithDuration("PT1H"))
+        .cancelActivity(false)
+        .endEvent("boundaryEnd")
+        .moveToActivity("sub")
+        .endEvent()
+        .done();
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateSequentialMultiInstanceBodyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateSequentialMultiInstanceBodyTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
@@ -929,50 +930,8 @@ public class MigrateSequentialMultiInstanceBodyTest {
     final var deployment =
         ENGINE
             .deployment()
-            .withXmlResource(
-                Bpmn.createExecutableProcess(processId)
-                    .startEvent()
-                    .subProcess(
-                        "sub",
-                        sub ->
-                            sub.multiInstance(
-                                b ->
-                                    b.sequential()
-                                        .zeebeInputCollectionExpression("[1,2,3]")
-                                        .zeebeInputElement("index")))
-                    .embeddedSubProcess()
-                    .startEvent()
-                    .serviceTask("task", t -> t.zeebeJobType("task"))
-                    .endEvent()
-                    .subProcessDone()
-                    .boundaryEvent("timerBoundary", b -> b.timerWithDuration("PT1H"))
-                    .cancelActivity(false)
-                    .endEvent("boundaryEnd")
-                    .moveToActivity("sub")
-                    .endEvent()
-                    .done())
-            .withXmlResource(
-                Bpmn.createExecutableProcess(targetProcessId)
-                    .startEvent()
-                    .subProcess(
-                        "sub",
-                        sub ->
-                            sub.multiInstance(
-                                b ->
-                                    b.sequential()
-                                        .zeebeInputCollectionExpression("[1,2,3]")
-                                        .zeebeInputElement("index")))
-                    .embeddedSubProcess()
-                    .startEvent()
-                    .serviceTask("task", t -> t.zeebeJobType("task"))
-                    .endEvent()
-                    .subProcessDone()
-                    .boundaryEvent("timerBoundary", b -> b.timerWithDuration("PT1H"))
-                    .cancelActivity(false)
-                    .endEvent("boundaryEnd")
-                    .moveToActivity("sub")
-                    .endEvent()
-                    .done())
+            .withXmlResource(sequentialSubProcessWithTimerBoundary(processId))
+            .withXmlResource(sequentialSubProcessWithTimerBoundary(targetProcessId))
             .deploy();
 
     final long targetProcessDefinitionKey =
@@ -1014,6 +973,30 @@ public class MigrateSequentialMultiInstanceBodyTest {
                 .exists())
         .describedAs("Expect that the timer boundary event subscription is migrated")
         .isTrue();
+  }
+
+  private static BpmnModelInstance sequentialSubProcessWithTimerBoundary(final String processId) {
+    return Bpmn.createExecutableProcess(processId)
+        .startEvent()
+        .subProcess(
+            "sub",
+            sub ->
+                sub.multiInstance(
+                    b ->
+                        b.sequential()
+                            .zeebeInputCollectionExpression("[1,2,3]")
+                            .zeebeInputElement("index")))
+        .embeddedSubProcess()
+        .startEvent()
+        .serviceTask("task", t -> t.zeebeJobType("task"))
+        .endEvent()
+        .subProcessDone()
+        .boundaryEvent("timerBoundary", b -> b.timerWithDuration("PT1H"))
+        .cancelActivity(false)
+        .endEvent("boundaryEnd")
+        .moveToActivity("sub")
+        .endEvent()
+        .done();
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateSequentialMultiInstanceBodyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateSequentialMultiInstanceBodyTest.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.TimerIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
@@ -917,6 +918,102 @@ public class MigrateSequentialMultiInstanceBodyTest {
                 .findAny())
         .describedAs("Expect that the process instance is continued in the target process")
         .isPresent();
+  }
+
+  @Test
+  public void shouldMigrateMappedTimerBoundaryEventAttachedToSequentialMultiInstanceSubprocess() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .subProcess(
+                        "sub",
+                        sub ->
+                            sub.multiInstance(
+                                b ->
+                                    b.sequential()
+                                        .zeebeInputCollectionExpression("[1,2,3]")
+                                        .zeebeInputElement("index")))
+                    .embeddedSubProcess()
+                    .startEvent()
+                    .serviceTask("task", t -> t.zeebeJobType("task"))
+                    .endEvent()
+                    .subProcessDone()
+                    .boundaryEvent("timerBoundary", b -> b.timerWithDuration("PT1H"))
+                    .cancelActivity(false)
+                    .endEvent("boundaryEnd")
+                    .moveToActivity("sub")
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .subProcess(
+                        "sub",
+                        sub ->
+                            sub.multiInstance(
+                                b ->
+                                    b.sequential()
+                                        .zeebeInputCollectionExpression("[1,2,3]")
+                                        .zeebeInputElement("index")))
+                    .embeddedSubProcess()
+                    .startEvent()
+                    .serviceTask("task", t -> t.zeebeJobType("task"))
+                    .endEvent()
+                    .subProcessDone()
+                    .boundaryEvent("timerBoundary", b -> b.timerWithDuration("PT1H"))
+                    .cancelActivity(false)
+                    .endEvent("boundaryEnd")
+                    .moveToActivity("sub")
+                    .endEvent()
+                    .done())
+            .deploy();
+
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("task")
+        .await();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("sub", "sub")
+        .addMappingInstruction("task", "task")
+        .addMappingInstruction("timerBoundary", "timerBoundary")
+        .migrate();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.MULTI_INSTANCE_BODY)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that the multi-instance body is migrated to the target process")
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .hasBpmnProcessId(targetProcessId)
+        .hasElementId("sub");
+
+    assertThat(
+            RecordingExporter.timerRecords(TimerIntent.MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .exists())
+        .describedAs("Expect that the timer boundary event subscription is migrated")
+        .isTrue();
   }
 
   @Test


### PR DESCRIPTION
## Description

See relevant [issue](https://github.com/camunda/camunda/issues/51295).

Migrating a running process instance with a mapped boundary catch event on a multi-instance subprocess was incorrectly rejected with INVALID_STATE, even when the migration was structurally valid. 

The [execution path](https://github.com/camunda/camunda/blob/883778e920bdf9302fe7ce852427e50600faf500/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationCatchEventBehaviour.java#L121) is already handling this situation correctly.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/51295
