### PR TITLE
Make default roles read-only on the Roles page

### DIFF
--- a/identity/client/src/components/entityList/EntityList.tsx
+++ b/identity/client/src/components/entityList/EntityList.tsx
@@ -76,7 +76,7 @@ type TextMenuItem<D> = {
   label: string;
   onClick: (entity: D) => void;
   isDangerous?: boolean;
-  disabled?: boolean;
+  disabled?: boolean | ((entity: D) => boolean);
   hidden?: boolean;
 };
 
@@ -390,8 +390,12 @@ const EntityList = <D extends EntityData>({
                                       onClick,
                                       icon,
                                       isDangerous,
-                                      disabled,
+                                      disabled: disabledProp,
                                     } = menuItem as MenuItem<D>;
+                                    const disabled =
+                                      typeof disabledProp === "function"
+                                        ? disabledProp(index[rowId])
+                                        : disabledProp;
 
                                     const kind: ButtonKind = isDangerous
                                       ? "danger--ghost"

--- a/identity/client/src/components/entityList/EntityList.tsx
+++ b/identity/client/src/components/entityList/EntityList.tsx
@@ -392,9 +392,12 @@ const EntityList = <D extends EntityData>({
                                       isDangerous,
                                       disabled: disabledProp,
                                     } = menuItem as MenuItem<D>;
+                                    const entity = index[rowId];
                                     const disabled =
                                       typeof disabledProp === "function"
-                                        ? disabledProp(index[rowId])
+                                        ? entity !== undefined
+                                          ? disabledProp(entity)
+                                          : false
                                         : disabledProp;
 
                                     const kind: ButtonKind = isDangerous

--- a/identity/client/src/pages/roles/List.tsx
+++ b/identity/client/src/pages/roles/List.tsx
@@ -17,6 +17,7 @@ import { searchRoles } from "src/utility/api/roles";
 import { TranslatedErrorInlineNotification } from "src/components/notifications/InlineNotification";
 import useModal, { useEntityModal } from "src/components/modal/useModal";
 import AddModal from "src/pages/roles/modals/AddModal";
+import { isProtectedRole } from "src/pages/roles/protected-roles";
 import DeleteModal from "src/pages/roles/modals/DeleteModal";
 import EditModal from "src/pages/roles/modals/EditModal";
 import PageEmptyState from "src/components/layout/PageEmptyState";
@@ -83,12 +84,14 @@ const List: FC = () => {
             label: t("editRole"),
             icon: Edit,
             onClick: editRole,
+            disabled: ({ roleId }: Role) => isProtectedRole(roleId),
           },
           {
             label: t("delete"),
             icon: TrashCan,
             isDangerous: true,
             onClick: deleteRole,
+            disabled: ({ roleId }: Role) => isProtectedRole(roleId),
           },
         ]}
         searchPlaceholder={t("searchByRoleId")}

--- a/identity/client/src/pages/roles/detail/index.tsx
+++ b/identity/client/src/pages/roles/detail/index.tsx
@@ -28,6 +28,7 @@ import Groups from "src/pages/roles/detail/groups";
 import MappingRules from "src/pages/roles/detail/mapping-rules";
 import Clients from "src/pages/roles/detail/clients";
 import { isOIDC } from "src/configuration";
+import { isProtectedRole } from "src/pages/roles/protected-roles";
 
 const Details: FC = () => {
   const navigate = useNavigate();
@@ -65,19 +66,21 @@ const Details: FC = () => {
                 <Stack gap={spacing03}>
                   <Stack orientation="horizontal" gap={spacing01}>
                     <PageHeadline>{role.name}</PageHeadline>
-                    <OverflowMenu ariaLabel={t("openRoleContextMenu")}>
-                      <OverflowMenuItem
-                        itemText={t("editRole")}
-                        onClick={() => editRole(role)}
-                      />
-                      <OverflowMenuItem
-                        itemText={t("delete")}
-                        isDelete
-                        onClick={() => {
-                          deleteRole(role);
-                        }}
-                      />
-                    </OverflowMenu>
+                    {!isProtectedRole(role.roleId) && (
+                      <OverflowMenu ariaLabel={t("openRoleContextMenu")}>
+                        <OverflowMenuItem
+                          itemText={t("editRole")}
+                          onClick={() => editRole(role)}
+                        />
+                        <OverflowMenuItem
+                          itemText={t("delete")}
+                          isDelete
+                          onClick={() => {
+                            deleteRole(role);
+                          }}
+                        />
+                      </OverflowMenu>
+                    )}
                   </Stack>
                   <p>
                     {t("roleId")}: {role.roleId}

--- a/identity/client/src/pages/roles/protected-roles.ts
+++ b/identity/client/src/pages/roles/protected-roles.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+const PROTECTED_ROLE_IDS = new Set(["admin", "readonly-admin", "rpa", "connectors"]);
+
+export const isProtectedRole = (roleId: string): boolean =>
+  PROTECTED_ROLE_IDS.has(roleId);


### PR DESCRIPTION
## Description

This updates the OC Identity Roles page to make default roles read-only. This addresses issue https://github.com/camunda/camunda/issues/35545

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/35545
