### PR TITLE
51307 exporter configuration kebab case

### DIFF
--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageRdbmsTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageRdbmsTest.java
@@ -220,11 +220,15 @@ public class SecondaryStorageRdbmsTest {
       final ExporterCfg exporter = brokerBasedProperties.getRdbmsExporter();
       assertThat(exporter).isNotNull();
       final Map<String, Object> args = exporter.getArgs();
-      assertThat(args.get("queueSize")).isEqualTo(1000);
-      assertThat(args.get("queueMemoryLimit")).isEqualTo(20);
-      assertThat(args.get("flushInterval")).isEqualTo(Duration.ofMillis(500));
-      assertThat(args.get("exportBatchOperationItemsOnCreation")).isEqualTo(true);
-      assertThat(args.get("batchOperationItemInsertBlockSize")).isEqualTo(10000);
+      final ExporterConfiguration rdbmsExporterConfiguration =
+          io.camunda.zeebe.broker.exporter.context.ExporterConfiguration.fromArgs(
+              ExporterConfiguration.class, args);
+      assertThat(rdbmsExporterConfiguration.getQueueSize()).isEqualTo(1000);
+      assertThat(rdbmsExporterConfiguration.getQueueMemoryLimit()).isEqualTo(20);
+      assertThat(rdbmsExporterConfiguration.getFlushInterval()).isEqualTo(Duration.ofMillis(500));
+      assertThat(rdbmsExporterConfiguration.isExportBatchOperationItemsOnCreation()).isTrue();
+      assertThat(rdbmsExporterConfiguration.getBatchOperationItemInsertBlockSize())
+          .isEqualTo(10000);
     }
 
     @Test

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/context/ExporterConfiguration.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/context/ExporterConfiguration.java
@@ -11,14 +11,21 @@ import com.fasterxml.jackson.core.json.JsonReadFeature;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.camunda.zeebe.exporter.api.context.Configuration;
+import io.camunda.zeebe.exporter.api.context.StrictConfiguration;
 import io.camunda.zeebe.util.ReflectUtil;
 import java.nio.file.Path;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public record ExporterConfiguration(String id, Map<String, Object> arguments)
     implements Configuration {
@@ -30,6 +37,12 @@ public record ExporterConfiguration(String id, Map<String, Object> arguments)
    * <p>Features:
    *
    * <ul>
+   *   <li>Kebab-case property naming strategy: both {@code myField} and {@code my-field} are
+   *       accepted in YAML args. {@code asArgs}/{@code toArgs} serialise to kebab-case; {@code
+   *       fromArgs}/{@code instantiate} first convert camelCase keys to kebab-case via {@code
+   *       normalizeKeys}, then hand off to the MAPPER which matches via kebab-case canonical names
+   *       and {@code ACCEPT_CASE_INSENSITIVE_PROPERTIES} (e.g. {@code my-field} and {@code
+   *       MY-FIELD} are equivalent).
    *   <li>Case-insensitive enum, property, and value matching
    *   <li>Custom List deserializer for Spring Boot indexed properties (myList[0]=value)
    *   <li>Custom Path module to preserve relative/absolute paths (no resolution)
@@ -50,7 +63,18 @@ public record ExporterConfiguration(String id, Map<String, Object> arguments)
           .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_VALUES)
           .enable(JsonReadFeature.ALLOW_SINGLE_QUOTES)
           .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+          .propertyNamingStrategy(PropertyNamingStrategies.KEBAB_CASE)
           .build();
+
+  private static final Logger LOG = LoggerFactory.getLogger(ExporterConfiguration.class);
+
+  /**
+   * Strict variant of {@link #MAPPER} that rejects unknown properties. Used in {@link
+   * #fromArgs(Class, Map)} to fail fast at startup when the exporter args contain a typo or an
+   * unsupported property name.
+   */
+  private static final ObjectMapper STRICT_MAPPER =
+      MAPPER.copy().enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 
   @Override
   public String getId() {
@@ -69,12 +93,87 @@ public record ExporterConfiguration(String id, Map<String, Object> arguments)
 
   public static <T> T fromArgs(final Class<T> configClass, final Map<String, Object> values) {
     if (values != null) {
-      // Use MAPPER (with custom list deserializer) to properly handle Spring Boot indexed
-      // properties like myList[0]=value which are stored as Maps with numeric string keys
-      return MAPPER.convertValue(values, configClass);
+      // Normalize camelCase keys to kebab-case so that both forms are accepted in YAML args.
+      // Spring Boot relaxed binding (camelCase ↔ kebab-case) only applies to
+      // @ConfigurationProperties
+      // beans and does NOT apply here — the args arrive as a raw Map<String, Object> that Jackson
+      // binds directly. With KEBAB_CASE naming strategy the mapper expects kebab-case keys, so we
+      // pre-process the map to convert any camelCase keys before handing off to convertValue().
+      final var normalized = normalizeKeys(values);
+      final var mapper =
+          configClass.isAnnotationPresent(StrictConfiguration.class) ? STRICT_MAPPER : MAPPER;
+      try {
+        return mapper.convertValue(normalized, configClass);
+      } catch (final IllegalArgumentException e) {
+        if (e.getCause() instanceof final UnrecognizedPropertyException upe) {
+          LOG.error(
+              "Unknown exporter configuration property '{}' in config class {}; known properties: {}",
+              upe.getPropertyName(),
+              configClass.getSimpleName(),
+              upe.getKnownPropertyIds());
+          throw new IllegalArgumentException(
+              "Unknown exporter configuration property '"
+                  + upe.getPropertyName()
+                  + "' in config class "
+                  + configClass.getSimpleName()
+                  + "; known properties: "
+                  + upe.getKnownPropertyIds(),
+              upe);
+        }
+        throw e;
+      }
     } else {
       return ReflectUtil.newInstance(configClass);
     }
+  }
+
+  /**
+   * Recursively converts all camelCase map keys to kebab-case. Leaves already kebab-case and
+   * numeric keys unchanged. Nested {@link Map} values, as well as {@link Iterable} and array
+   * elements containing maps, are normalized in the same pass.
+   *
+   * @param map the raw exporter args map
+   * @return the same structure with normalized kebab-case keys
+   */
+  private static Map<String, Object> normalizeKeys(final Map<String, Object> map) {
+    final var result = new LinkedHashMap<String, Object>(map.size());
+    for (final var entry : map.entrySet()) {
+      final var key = camelToKebab(entry.getKey());
+      final var value = normalizeValue(entry.getValue());
+      result.put(key, value);
+    }
+    return result;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Object normalizeValue(final Object value) {
+    if (value instanceof final Map<?, ?> nested) {
+      return normalizeKeys((Map<String, Object>) nested);
+    }
+
+    if (value instanceof final Iterable<?> iterable) {
+      final var normalized = new java.util.ArrayList<>();
+      for (final var element : iterable) {
+        normalized.add(normalizeValue(element));
+      }
+      return normalized;
+    }
+
+    if (value != null && value.getClass().isArray()) {
+      final var length = java.lang.reflect.Array.getLength(value);
+      final var normalized = new java.util.ArrayList<>(length);
+      for (int i = 0; i < length; i++) {
+        normalized.add(normalizeValue(java.lang.reflect.Array.get(value, i)));
+      }
+      return normalized;
+    }
+
+    return value;
+  }
+
+  /** Converts a camelCase or PascalCase string to kebab-case. Kebab-case input is unchanged. */
+  private static String camelToKebab(final String name) {
+    return name.replaceAll("([a-z\\d])([A-Z])", "$1-$2").toLowerCase(Locale.ROOT);
   }
 
   /**
@@ -113,12 +212,9 @@ public record ExporterConfiguration(String id, Map<String, Object> arguments)
                   final com.fasterxml.jackson.core.JsonGenerator gen,
                   final com.fasterxml.jackson.databind.SerializerProvider serializers)
                   throws java.io.IOException {
-                // Write as embedded POJO to preserve Duration object when using convertValue()
-                // For TokenBuffer (used by convertValue), this keeps the Duration object as-is
                 if (gen instanceof com.fasterxml.jackson.databind.util.TokenBuffer) {
                   gen.writeEmbeddedObject(value);
                 } else {
-                  // For actual JSON output, write as ISO-8601 string
                   gen.writeString(value.toString());
                 }
               }
@@ -131,7 +227,6 @@ public record ExporterConfiguration(String id, Map<String, Object> arguments)
                   final com.fasterxml.jackson.core.JsonParser p,
                   final com.fasterxml.jackson.databind.DeserializationContext ctxt)
                   throws java.io.IOException {
-                // Handle embedded Duration objects (from TokenBuffer used by convertValue)
                 if (p.currentToken()
                     == com.fasterxml.jackson.core.JsonToken.VALUE_EMBEDDED_OBJECT) {
                   final Object embedded = p.getEmbeddedObject();
@@ -139,7 +234,6 @@ public record ExporterConfiguration(String id, Map<String, Object> arguments)
                     return (java.time.Duration) embedded;
                   }
                 }
-                // Parse from string format like "PT0.5S" (from Spring Boot properties)
                 final String text = p.getText();
                 if (text != null && !text.isEmpty()) {
                   return java.time.Duration.parse(text);
@@ -168,7 +262,6 @@ public record ExporterConfiguration(String id, Map<String, Object> arguments)
                   final com.fasterxml.jackson.core.JsonGenerator gen,
                   final com.fasterxml.jackson.databind.SerializerProvider serializers)
                   throws java.io.IOException {
-                // Serialize Path as its string representation, preserving relative/absolute form
                 gen.writeString(value.toString());
               }
             })
@@ -180,7 +273,6 @@ public record ExporterConfiguration(String id, Map<String, Object> arguments)
                   final com.fasterxml.jackson.core.JsonParser p,
                   final com.fasterxml.jackson.databind.DeserializationContext ctxt)
                   throws java.io.IOException {
-                // Deserialize string to Path using Path.of(), preserving relative/absolute form
                 return Path.of(p.getText());
               }
             });

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/context/ExporterConfigurationListDeserializer.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/context/ExporterConfigurationListDeserializer.java
@@ -67,9 +67,12 @@ final class ExporterConfigurationListDeserializer<E> extends JsonDeserializer<Li
     return switch (p.currentToken()) {
       case START_ARRAY -> deserializeArray(p, ctxt);
       case START_OBJECT -> deserializeMapWithNumericKeys(p, ctxt);
+      // Spring Boot flattens an empty YAML list (`[]`) to an empty string in the args map.
+      // Treat any empty string value as an empty list rather than failing.
+      case VALUE_STRING -> p.getText().isEmpty() ? List.of() : deserializeSingletonList(p, ctxt);
       default ->
           throw new IllegalArgumentException(
-              "Expected START_ARRAY or START_OBJECT, got: " + p.currentToken());
+              "Expected START_ARRAY, START_OBJECT, or VALUE_STRING, got: " + p.currentToken());
     };
   }
 
@@ -85,6 +88,19 @@ final class ExporterConfigurationListDeserializer<E> extends JsonDeserializer<Li
       final E value = (E) ctxt.readValue(p, contentType);
       result.add(value);
     }
+    return result;
+  }
+
+  /**
+   * Wraps a single non-empty string value into a one-element list. Spring Boot may pass a plain
+   * string when only one value is configured without explicit YAML array syntax.
+   */
+  @SuppressWarnings("unchecked")
+  private List<E> deserializeSingletonList(final JsonParser p, final DeserializationContext ctxt)
+      throws IOException {
+    final E value = (E) ctxt.readValue(p, contentType);
+    final List<E> result = new ArrayList<>(1);
+    result.add(value);
     return result;
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/context/ExporterConfigurationTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/context/ExporterConfigurationTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker.exporter.context;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
+import io.camunda.zeebe.exporter.api.context.StrictConfiguration;
 import io.camunda.zeebe.test.util.junit.RegressionTest;
 import java.util.List;
 import java.util.Map;
@@ -22,7 +23,15 @@ import org.junit.jupiter.params.provider.ValueSource;
 @Execution(ExecutionMode.CONCURRENT)
 final class ExporterConfigurationTest {
   @ParameterizedTest
-  @ValueSource(strings = {"numberofshards", "numberOfShards", "NUMBEROFSHARDS"})
+  @ValueSource(
+      strings = {
+        // kebab-case (canonical form with KEBAB_CASE naming strategy)
+        "number-of-shards",
+        // camelCase (normalized to kebab-case by fromArgs pre-processing)
+        "numberOfShards",
+        // uppercase kebab-case (matched via ACCEPT_CASE_INSENSITIVE_PROPERTIES)
+        "NUMBER-OF-SHARDS"
+      })
   void shouldInstantiateConfigWithCaseInsensitiveProperties(final String property) {
     // given
     final var args = Map.<String, Object>of(property, 1);
@@ -37,7 +46,7 @@ final class ExporterConfigurationTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"numberofshards", "numberOfShards", "NUMBEROFSHARDS"})
+  @ValueSource(strings = {"number-of-shards", "numberOfShards", "NUMBER-OF-SHARDS"})
   void shouldInstantiateNestedConfigWithCaseInsensitiveProperties(final String property) {
     // given
     final var args = Map.<String, Object>of("nested", Map.of(property, 1));
@@ -53,8 +62,8 @@ final class ExporterConfigurationTest {
 
   @Test
   void shouldInstantiateConfigWithUnknownProperty() {
-    // given
-    final var args = Map.<String, Object>of("numberofshards", 1, "unknownProp", false);
+    // given — unannotated config class: unknown properties are silently ignored
+    final var args = Map.<String, Object>of("number-of-shards", 1, "unknownProp", false);
     final var expected = new Config(1);
     final var config = new ExporterConfiguration("id", args);
 
@@ -65,12 +74,26 @@ final class ExporterConfigurationTest {
     assertThat(instance).isEqualTo(expected);
   }
 
+  @Test
+  void shouldRejectStrictConfigWithUnknownProperty() {
+    // given — @StrictConfiguration: unknown properties must be rejected
+    final var args = Map.<String, Object>of("number-of-shards", 1, "unknownProp", false);
+    final var config = new ExporterConfiguration("id", args);
+
+    // when - then
+    assertThatCode(() -> config.instantiate(StrictConfig.class))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("unknown-prop")
+        .hasMessageContaining("StrictConfig");
+  }
+
   @RegressionTest("https://github.com/camunda/camunda/issues/4552")
   void shouldInstantiateMapOfIntegersAsList() {
     // given
     final var args =
         Map.<String, Object>of(
-            "configs", Map.of("0", Map.of("numberofshards", 0), "1", Map.of("numberofshards", 1)));
+            "configs",
+            Map.of("0", Map.of("number-of-shards", 0), "1", Map.of("number-of-shards", 1)));
     final var expected = new ListConfig(List.of(new Config(0), new Config(1)));
     final var config = new ExporterConfiguration("id", args);
 
@@ -85,7 +108,8 @@ final class ExporterConfigurationTest {
   void shouldInstantiateMapOfIntegersAsListNested() {
     // given
     final var serializedConfigs =
-        Map.<String, Object>of("0", Map.of("numberofshards", 0), "1", Map.of("numberofshards", 1));
+        Map.<String, Object>of(
+            "0", Map.of("number-of-shards", 0), "1", Map.of("number-of-shards", 1));
     final var args =
         Map.<String, Object>of("list", Map.of("0", Map.of("configs", serializedConfigs)));
     final var expected =
@@ -101,10 +125,11 @@ final class ExporterConfigurationTest {
 
   @RegressionTest("https://github.com/camunda/camunda/issues/4552")
   void shouldNotInstantiateSparseList() {
-    // given
+    // given — list indices start at 1 instead of 0, so insertion at index 1 fails
     final var args =
         Map.<String, Object>of(
-            "configs", Map.of("1", Map.of("numberofshards", 0), "2", Map.of("numberofshards", 1)));
+            "configs",
+            Map.of("1", Map.of("number-of-shards", 0), "2", Map.of("number-of-shards", 1)));
     final var config = new ExporterConfiguration("id", args);
 
     // when - then
@@ -115,11 +140,11 @@ final class ExporterConfigurationTest {
 
   @RegressionTest("https://github.com/camunda/camunda/issues/4552")
   void shouldNotInstantiateNonIntegerList() {
-    // given
+    // given — list indices are non-integer strings, so parsing to int fails
     final var args =
         Map.<String, Object>of(
             "configs",
-            Map.of("foo", Map.of("numberofshards", 0), "bar", Map.of("numberofshards", 1)));
+            Map.of("foo", Map.of("number-of-shards", 0), "bar", Map.of("number-of-shards", 1)));
     final var config = new ExporterConfiguration("id", args);
 
     // when - then
@@ -129,6 +154,9 @@ final class ExporterConfigurationTest {
   }
 
   private record Config(int numberOfShards) {}
+
+  @StrictConfiguration
+  private record StrictConfig(int numberOfShards) {}
 
   private record ContainerConfig(Config nested) {}
 

--- a/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/StrictConfiguration.java
+++ b/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/StrictConfiguration.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.exporter.api.context;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks an exporter configuration class as strict: when {@link Configuration#instantiate(Class)}
+ * maps the raw YAML args onto this class, any argument key that does not correspond to a known
+ * property (after camelCase → kebab-case normalisation) is treated as an error. The application
+ * logs a human-readable message and refuses to start.
+ *
+ * <p>Exporter authors who want early feedback on typos or unsupported property names should
+ * annotate their configuration class with this annotation.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface StrictConfiguration {}

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -8,12 +8,14 @@
 package io.camunda.zeebe.exporter;
 
 import io.camunda.search.connect.plugin.PluginConfiguration;
+import io.camunda.zeebe.exporter.api.context.StrictConfiguration;
 import io.camunda.zeebe.exporter.filter.FilterConfiguration;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import java.util.ArrayList;
 import java.util.List;
 
+@StrictConfiguration
 public class ElasticsearchExporterConfiguration implements FilterConfiguration {
 
   private static final String DEFAULT_URL = "http://localhost:9200";

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchIndexConfigurationTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchIndexConfigurationTest.java
@@ -8,9 +8,11 @@
 package io.camunda.zeebe.exporter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 import io.camunda.zeebe.broker.exporter.context.ExporterConfiguration;
 import io.camunda.zeebe.exporter.ElasticsearchExporterConfiguration.IndexConfiguration;
+import io.camunda.zeebe.exporter.api.context.StrictConfiguration;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -22,6 +24,27 @@ import org.junit.jupiter.api.Test;
  * exact mapper the Zeebe broker uses to instantiate exporter configuration at runtime.
  */
 final class ElasticsearchIndexConfigurationTest {
+
+  // ---------------------------------------------------------------------------
+  // @StrictConfiguration — unknown properties must be rejected at startup
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldBeAnnotatedWithStrictConfiguration() {
+    assertThat(ElasticsearchExporterConfiguration.class).hasAnnotation(StrictConfiguration.class);
+  }
+
+  @Test
+  void shouldRejectUnknownPropertyOnInstantiate() {
+    // given
+    final var args = Map.<String, Object>of("unknownProp", "value");
+    final var config = new ExporterConfiguration("id", args);
+
+    // when - then
+    assertThatCode(() -> config.instantiate(ElasticsearchExporterConfiguration.class))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("unknown-prop");
+  }
 
   // ---------------------------------------------------------------------------
   // exportLocalVariablesEnabled
@@ -38,7 +61,7 @@ final class ElasticsearchIndexConfigurationTest {
     final var args = Map.<String, Object>of("exportLocalVariablesEnabled", false);
 
     // when
-    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+    final var config = ExporterConfiguration.fromArgs(IndexConfiguration.class, args);
 
     // then
     assertThat(config.isExportLocalVariablesEnabled()).isFalse();
@@ -55,7 +78,7 @@ final class ElasticsearchIndexConfigurationTest {
         Map.<String, Object>of("localVariableNameInclusionExact", List.of("localVar", "other"));
 
     // when
-    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+    final var config = ExporterConfiguration.fromArgs(IndexConfiguration.class, args);
 
     // then
     assertThat(config.getLocalVariableNameInclusionExact()).containsExactly("localVar", "other");
@@ -68,7 +91,7 @@ final class ElasticsearchIndexConfigurationTest {
         Map.<String, Object>of("localVariableNameExclusionStartWith", List.of("debug_", "tmp_"));
 
     // when
-    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+    final var config = ExporterConfiguration.fromArgs(IndexConfiguration.class, args);
 
     // then
     assertThat(config.getLocalVariableNameExclusionStartWith()).containsExactly("debug_", "tmp_");
@@ -84,7 +107,7 @@ final class ElasticsearchIndexConfigurationTest {
     final var args = Map.<String, Object>of("rootVariableNameInclusionExact", List.of("rootVar"));
 
     // when
-    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+    final var config = ExporterConfiguration.fromArgs(IndexConfiguration.class, args);
 
     // then
     assertThat(config.getRootVariableNameInclusionExact()).containsExactly("rootVar");
@@ -96,7 +119,7 @@ final class ElasticsearchIndexConfigurationTest {
     final var args = Map.<String, Object>of("rootVariableNameExclusionEndWith", List.of("_secret"));
 
     // when
-    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+    final var config = ExporterConfiguration.fromArgs(IndexConfiguration.class, args);
 
     // then
     assertThat(config.getRootVariableNameExclusionEndWith()).containsExactly("_secret");
@@ -115,7 +138,7 @@ final class ElasticsearchIndexConfigurationTest {
             "rootVariableValueTypeExclusion", List.of("BOOLEAN"));
 
     // when
-    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+    final var config = ExporterConfiguration.fromArgs(IndexConfiguration.class, args);
 
     // then
     assertThat(config.getLocalVariableValueTypeInclusion()).containsExactly("NUMBER", "STRING");
@@ -162,7 +185,7 @@ final class ElasticsearchIndexConfigurationTest {
             "localVariableNameInclusionExact", Map.of("0", "localVar", "1", "other"));
 
     // when
-    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+    final var config = ExporterConfiguration.fromArgs(IndexConfiguration.class, args);
 
     // then
     assertThat(config.getLocalVariableNameInclusionExact()).containsExactly("localVar", "other");
@@ -176,7 +199,7 @@ final class ElasticsearchIndexConfigurationTest {
             "rootVariableNameExclusionExact", Map.of("0", "_secret", "1", "_internal"));
 
     // when
-    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+    final var config = ExporterConfiguration.fromArgs(IndexConfiguration.class, args);
 
     // then
     assertThat(config.getRootVariableNameExclusionExact()).containsExactly("_secret", "_internal");
@@ -190,9 +213,59 @@ final class ElasticsearchIndexConfigurationTest {
             "localVariableValueTypeInclusion", Map.of("0", "NUMBER", "1", "STRING"));
 
     // when
-    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+    final var config = ExporterConfiguration.fromArgs(IndexConfiguration.class, args);
 
     // then
     assertThat(config.getLocalVariableValueTypeInclusion()).containsExactly("NUMBER", "STRING");
+  }
+
+  @Test
+  void shouldDeserializeApplicationDevVariableFilterCases() {
+    // given
+    final var indexArgs =
+        Map.<String, Object>ofEntries(
+            Map.entry("export-local-variables-enabled", true),
+            Map.entry("root-variable-name-inclusion-exact", List.of("customerId", "orderId")),
+            Map.entry("rootVariableNameInclusionStartWith", List.of("REPORTING_", "order_")),
+            Map.entry("root-variable-name-inclusion-end-with", Map.of("0", "_Id", "1", "_Key")),
+            Map.entry("root-variable-name-exclusion-exact", ""),
+            Map.entry("rootVariableNameExclusionStartWith", ""),
+            Map.entry("root-variable-name-exclusion-end-with", "_tmp"),
+            Map.entry("localVariableNameInclusionExact", List.of("loopCounter", "taskResult")),
+            Map.entry("local-variable-name-inclusion-start-with", List.of("tmp_", "debug_")),
+            Map.entry("localVariableNameInclusionEndWith", Map.of("0", "_local")),
+            Map.entry("local-variable-name-exclusion-exact", ""),
+            Map.entry("localVariableNameExclusionStartWith", ""),
+            Map.entry("local-variable-name-exclusion-end-with", ""),
+            Map.entry("root-variable-value-type-inclusion", ""),
+            Map.entry("root-variable-value-type-exclusion", ""),
+            Map.entry("local-variable-value-type-inclusion", List.of("String", "Number")),
+            Map.entry("localVariableValueTypeExclusion", ""));
+    final var args = Map.<String, Object>of("url", "http://localhost:9200", "index", indexArgs);
+    final var exporterConfig = new ExporterConfiguration("id", args);
+
+    // when
+    final var config = exporterConfig.instantiate(ElasticsearchExporterConfiguration.class).index;
+
+    // then
+    assertThat(config.isExportLocalVariablesEnabled()).isTrue();
+    assertThat(config.getRootVariableNameInclusionExact()).containsExactly("customerId", "orderId");
+    assertThat(config.getRootVariableNameInclusionStartWith())
+        .containsExactly("REPORTING_", "order_");
+    assertThat(config.getRootVariableNameInclusionEndWith()).containsExactly("_Id", "_Key");
+    assertThat(config.getRootVariableNameExclusionExact()).isEmpty();
+    assertThat(config.getRootVariableNameExclusionStartWith()).isEmpty();
+    assertThat(config.getRootVariableNameExclusionEndWith()).containsExactly("_tmp");
+    assertThat(config.getLocalVariableNameInclusionExact())
+        .containsExactly("loopCounter", "taskResult");
+    assertThat(config.getLocalVariableNameInclusionStartWith()).containsExactly("tmp_", "debug_");
+    assertThat(config.getLocalVariableNameInclusionEndWith()).containsExactly("_local");
+    assertThat(config.getLocalVariableNameExclusionExact()).isEmpty();
+    assertThat(config.getLocalVariableNameExclusionStartWith()).isEmpty();
+    assertThat(config.getLocalVariableNameExclusionEndWith()).isEmpty();
+    assertThat(config.getRootVariableValueTypeInclusion()).isEmpty();
+    assertThat(config.getRootVariableValueTypeExclusion()).isEmpty();
+    assertThat(config.getLocalVariableValueTypeInclusion()).containsExactly("String", "Number");
+    assertThat(config.getLocalVariableValueTypeExclusion()).isEmpty();
   }
 }

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.exporter.opensearch;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.search.connect.plugin.PluginConfiguration;
+import io.camunda.zeebe.exporter.api.context.StrictConfiguration;
 import io.camunda.zeebe.exporter.filter.FilterConfiguration;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -18,6 +19,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+@StrictConfiguration
 public class OpensearchExporterConfiguration implements FilterConfiguration {
 
   private static final String DEFAULT_URL = "http://localhost:9200";

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchIndexConfigurationTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchIndexConfigurationTest.java
@@ -8,8 +8,10 @@
 package io.camunda.zeebe.exporter.opensearch;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 import io.camunda.zeebe.broker.exporter.context.ExporterConfiguration;
+import io.camunda.zeebe.exporter.api.context.StrictConfiguration;
 import io.camunda.zeebe.exporter.opensearch.OpensearchExporterConfiguration.IndexConfiguration;
 import java.util.List;
 import java.util.Map;
@@ -22,6 +24,27 @@ import org.junit.jupiter.api.Test;
  * exact mapper the Zeebe broker uses to instantiate exporter configuration at runtime.
  */
 final class OpensearchIndexConfigurationTest {
+
+  // ---------------------------------------------------------------------------
+  // @StrictConfiguration — unknown properties must be rejected at startup
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldBeAnnotatedWithStrictConfiguration() {
+    assertThat(OpensearchExporterConfiguration.class).hasAnnotation(StrictConfiguration.class);
+  }
+
+  @Test
+  void shouldRejectUnknownPropertyOnInstantiate() {
+    // given
+    final var args = Map.<String, Object>of("unknownProp", "value");
+    final var config = new ExporterConfiguration("id", args);
+
+    // when - then
+    assertThatCode(() -> config.instantiate(OpensearchExporterConfiguration.class))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("unknown-prop");
+  }
 
   // ---------------------------------------------------------------------------
   // exportLocalVariablesEnabled
@@ -38,7 +61,7 @@ final class OpensearchIndexConfigurationTest {
     final var args = Map.<String, Object>of("exportLocalVariablesEnabled", false);
 
     // when
-    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+    final var config = ExporterConfiguration.fromArgs(IndexConfiguration.class, args);
 
     // then
     assertThat(config.isExportLocalVariablesEnabled()).isFalse();
@@ -55,7 +78,7 @@ final class OpensearchIndexConfigurationTest {
         Map.<String, Object>of("localVariableNameInclusionExact", List.of("localVar", "other"));
 
     // when
-    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+    final var config = ExporterConfiguration.fromArgs(IndexConfiguration.class, args);
 
     // then
     assertThat(config.getLocalVariableNameInclusionExact()).containsExactly("localVar", "other");
@@ -68,7 +91,7 @@ final class OpensearchIndexConfigurationTest {
         Map.<String, Object>of("localVariableNameExclusionStartWith", List.of("debug_", "tmp_"));
 
     // when
-    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+    final var config = ExporterConfiguration.fromArgs(IndexConfiguration.class, args);
 
     // then
     assertThat(config.getLocalVariableNameExclusionStartWith()).containsExactly("debug_", "tmp_");
@@ -84,7 +107,7 @@ final class OpensearchIndexConfigurationTest {
     final var args = Map.<String, Object>of("rootVariableNameInclusionExact", List.of("rootVar"));
 
     // when
-    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+    final var config = ExporterConfiguration.fromArgs(IndexConfiguration.class, args);
 
     // then
     assertThat(config.getRootVariableNameInclusionExact()).containsExactly("rootVar");
@@ -96,7 +119,7 @@ final class OpensearchIndexConfigurationTest {
     final var args = Map.<String, Object>of("rootVariableNameExclusionEndWith", List.of("_secret"));
 
     // when
-    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+    final var config = ExporterConfiguration.fromArgs(IndexConfiguration.class, args);
 
     // then
     assertThat(config.getRootVariableNameExclusionEndWith()).containsExactly("_secret");
@@ -115,7 +138,7 @@ final class OpensearchIndexConfigurationTest {
             "rootVariableValueTypeExclusion", List.of("BOOLEAN"));
 
     // when
-    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+    final var config = ExporterConfiguration.fromArgs(IndexConfiguration.class, args);
 
     // then
     assertThat(config.getLocalVariableValueTypeInclusion()).containsExactly("NUMBER", "STRING");
@@ -162,7 +185,7 @@ final class OpensearchIndexConfigurationTest {
             "localVariableNameInclusionExact", Map.of("0", "localVar", "1", "other"));
 
     // when
-    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+    final var config = ExporterConfiguration.fromArgs(IndexConfiguration.class, args);
 
     // then
     assertThat(config.getLocalVariableNameInclusionExact()).containsExactly("localVar", "other");
@@ -176,7 +199,7 @@ final class OpensearchIndexConfigurationTest {
             "rootVariableNameExclusionExact", Map.of("0", "_secret", "1", "_internal"));
 
     // when
-    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+    final var config = ExporterConfiguration.fromArgs(IndexConfiguration.class, args);
 
     // then
     assertThat(config.getRootVariableNameExclusionExact()).containsExactly("_secret", "_internal");
@@ -190,9 +213,59 @@ final class OpensearchIndexConfigurationTest {
             "localVariableValueTypeInclusion", Map.of("0", "NUMBER", "1", "STRING"));
 
     // when
-    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+    final var config = ExporterConfiguration.fromArgs(IndexConfiguration.class, args);
 
     // then
     assertThat(config.getLocalVariableValueTypeInclusion()).containsExactly("NUMBER", "STRING");
+  }
+
+  @Test
+  void shouldDeserializeApplicationDevVariableFilterCases() {
+    // given
+    final var indexArgs =
+        Map.<String, Object>ofEntries(
+            Map.entry("export-local-variables-enabled", true),
+            Map.entry("root-variable-name-inclusion-exact", List.of("customerId", "orderId")),
+            Map.entry("rootVariableNameInclusionStartWith", List.of("REPORTING_", "order_")),
+            Map.entry("root-variable-name-inclusion-end-with", Map.of("0", "_Id", "1", "_Key")),
+            Map.entry("root-variable-name-exclusion-exact", ""),
+            Map.entry("rootVariableNameExclusionStartWith", ""),
+            Map.entry("root-variable-name-exclusion-end-with", "_tmp"),
+            Map.entry("localVariableNameInclusionExact", List.of("loopCounter", "taskResult")),
+            Map.entry("local-variable-name-inclusion-start-with", List.of("tmp_", "debug_")),
+            Map.entry("localVariableNameInclusionEndWith", Map.of("0", "_local")),
+            Map.entry("local-variable-name-exclusion-exact", ""),
+            Map.entry("localVariableNameExclusionStartWith", ""),
+            Map.entry("local-variable-name-exclusion-end-with", ""),
+            Map.entry("root-variable-value-type-inclusion", ""),
+            Map.entry("root-variable-value-type-exclusion", ""),
+            Map.entry("local-variable-value-type-inclusion", List.of("String", "Number")),
+            Map.entry("localVariableValueTypeExclusion", ""));
+    final var args = Map.<String, Object>of("url", "http://localhost:9200", "index", indexArgs);
+    final var exporterConfig = new ExporterConfiguration("id", args);
+
+    // when
+    final var config = exporterConfig.instantiate(OpensearchExporterConfiguration.class).index;
+
+    // then
+    assertThat(config.isExportLocalVariablesEnabled()).isTrue();
+    assertThat(config.getRootVariableNameInclusionExact()).containsExactly("customerId", "orderId");
+    assertThat(config.getRootVariableNameInclusionStartWith())
+        .containsExactly("REPORTING_", "order_");
+    assertThat(config.getRootVariableNameInclusionEndWith()).containsExactly("_Id", "_Key");
+    assertThat(config.getRootVariableNameExclusionExact()).isEmpty();
+    assertThat(config.getRootVariableNameExclusionStartWith()).isEmpty();
+    assertThat(config.getRootVariableNameExclusionEndWith()).containsExactly("_tmp");
+    assertThat(config.getLocalVariableNameInclusionExact())
+        .containsExactly("loopCounter", "taskResult");
+    assertThat(config.getLocalVariableNameInclusionStartWith()).containsExactly("tmp_", "debug_");
+    assertThat(config.getLocalVariableNameInclusionEndWith()).containsExactly("_local");
+    assertThat(config.getLocalVariableNameExclusionExact()).isEmpty();
+    assertThat(config.getLocalVariableNameExclusionStartWith()).isEmpty();
+    assertThat(config.getLocalVariableNameExclusionEndWith()).isEmpty();
+    assertThat(config.getRootVariableValueTypeInclusion()).isEmpty();
+    assertThat(config.getRootVariableValueTypeExclusion()).isEmpty();
+    assertThat(config.getLocalVariableValueTypeInclusion()).containsExactly("String", "Number");
+    assertThat(config.getLocalVariableValueTypeExclusion()).isEmpty();
   }
 }


### PR DESCRIPTION
## Description

 This PR hardens exporter configuration binding and expands test coverage for configuration parsing in broker, Elasticsearch exporter, and Opensearch exporter modules.

  Motivation

  Exporter args are provided as raw maps and can come in multiple key/value shapes.
  Previously, binding was not reliably kebab-case compatible for these raw exporter args, so config keys could behave inconsistently depending on how they were written. This PR makes parsing robust for both kebab-case and camelCase keys, and improves fail-fast behaviour for invalid properties.

  Changes

  Feature changes

   - Added a new @StrictConfiguration annotation for exporter configuration classes.
   - Updated broker-side exporter configuration mapping to:
   - normalize camelCase keys to kebab-case before binding,
   - handle both kebab-case and camelCase inputs consistently,
   - support strict unknown-property rejection for classes annotated with @StrictConfiguration,
   - improve unknown-property error reporting.
   - Enhanced list deserialization behavior to support:
   - empty string values as empty lists,
   - single non-empty string values as singleton lists.
   - Applied @StrictConfiguration to:
   - ElasticsearchExporterConfiguration
   - OpensearchExporterConfiguration

  Test changes

   - Added/updated broker tests to cover:
   - key normalization behavior (kebab-case and camelCase),
   - strict unknown-property rejection,
   - indexed-list and list edge cases.
   - Expanded Elasticsearch exporter index configuration tests to validate mixed key styles and list encodings via ExporterConfiguration.fromArgs.
   - Expanded Opensearch exporter index configuration tests with the same mapping scenarios for parity.

  Result

   - Exporter configuration parsing is now consistent for both kebab-case and camelCase keys.
   - Invalid exporter properties fail fast for strict configs.
   - Test coverage now explicitly guards key parsing and list-shape compatibility across broker, Elasticsearch, and Opensearch exporter paths.


## Related issues

closes # https://github.com/camunda/camunda/issues/51307
