### PR TITLE
feat: update CI to build and run on JDK 25

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -44,7 +44,7 @@ inputs:
   java-version:
     description: JDK version to install
     required: false
-    default: "21"
+    default: "25"
   maven-cache-key-modifier:
     description: A modifier to use for maven cache key
     required: false

--- a/.github/actions/setup-c8run/action.yml
+++ b/.github/actions/setup-c8run/action.yml
@@ -186,7 +186,7 @@ runs:
     - if: ${{ inputs.os == 'macos-15-intel' }}
       name: Set env
       shell: bash
-      run: echo "JAVA_HOME=$(echo $JAVA_HOME_21_X64)" >> $GITHUB_ENV
+      run: echo "JAVA_HOME=$(echo $JAVA_HOME_25_X64)" >> $GITHUB_ENV
 
     - if: ${{ inputs.os == 'ubuntu-latest' }}
       name: Linux - Run c8run
@@ -194,8 +194,8 @@ runs:
       shell: bash
       working-directory: ./c8run
       env:
-        JAVA_HOME: /usr/lib/jvm/temurin-21-jdk-amd64
-        JAVA_VERSION: 21.0.3
+        JAVA_HOME: /usr/lib/jvm/temurin-25-jdk-amd64
+        JAVA_VERSION: 25.0.2
 
     - if: ${{ startsWith(inputs.os, 'macos') }}
       name: Mac - Run c8run
@@ -203,7 +203,7 @@ runs:
       run: ./c8run start --config e2e_tests/prefix-config.yaml
       working-directory: ./c8run
       env:
-        JAVA_VERSION: 21.0.3
+        JAVA_VERSION: 25.0.2
 
     - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
@@ -480,7 +480,7 @@ jobs:
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
-          java-version: '21'
+          java-version: '25'
 
       - name: Python setup
         if: always()

--- a/.github/workflows/c8-orchestration-cluster-reusable-rdbms-api-tests.yml
+++ b/.github/workflows/c8-orchestration-cluster-reusable-rdbms-api-tests.yml
@@ -195,7 +195,7 @@ jobs:
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
-          java-version: '21'
+          java-version: '25'
 
       - name: Python setup
         if: always()

--- a/.github/workflows/camunda8-getting-started-bundle.yaml
+++ b/.github/workflows/camunda8-getting-started-bundle.yaml
@@ -479,7 +479,7 @@ jobs:
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: "temurin"
-          java-version: "21"
+          java-version: "25"
 
       - name: Run starter script integration test (Unix)
         if: matrix.platform.script_extension == 'sh'

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -26,4 +26,4 @@ jobs:
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '25'

--- a/.github/workflows/identity-regression-test.yml
+++ b/.github/workflows/identity-regression-test.yml
@@ -127,11 +127,11 @@ jobs:
           ref: ${{ inputs.branch }}
           fetch-depth: 0
 
-      - name: Set up Java 21
+      - name: Set up Java 25
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 25
 
       - name: Download Camunda Distribution Artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/operate-docker-tests.yml
+++ b/.github/workflows/operate-docker-tests.yml
@@ -80,7 +80,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: "adopt"
-          java-version: "21"
+          java-version: "25"
       # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
       - name: 'Create settings.xml'
         uses: s4u/maven-settings-action@v4.0.0

--- a/.github/workflows/operate-e2e-tests.yml
+++ b/.github/workflows/operate-e2e-tests.yml
@@ -97,7 +97,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: "adopt"
-          java-version: "21"
+          java-version: "25"
 
       # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
       - name: "Create settings.xml"

--- a/.github/workflows/operate-release-reusable.yml
+++ b/.github/workflows/operate-release-reusable.yml
@@ -65,7 +65,7 @@ defaults:
     shell: bash
 
 env:
-  JAVA_VERSION: 21
+  JAVA_VERSION: 25
   LIMITS_CPU: 4
   RELEASE_VERSION: ${{ inputs.releaseVersion }}
   TAG_VERSION: operate-${{ inputs.releaseVersion }}
@@ -223,7 +223,7 @@ jobs:
           export VERSION="$VERSION"
           export DATE="$date_time_stamp"
           export REVISION="$commit_hash"
-          export BASE_IMAGE="reg.mini.dev/1212/openjre-base:21-dev"
+          export BASE_IMAGE="reg.mini.dev/1212/openjre-base:25-dev"
           sudo apt update
           sudo apt install -y jq
           sudo apt install -y bash

--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -334,7 +334,7 @@ jobs:
           DATE="$(date +%FT%TZ)"
           export DATE
           export REVISION="${REVISION}"
-          export BASE_IMAGE="reg.mini.dev/1212/openjre-base:21-dev"
+          export BASE_IMAGE="reg.mini.dev/1212/openjre-base:25-dev"
 
           # if CI (GHA) export the variables for pushing in a later step
           if [ "${CI}" = "true" ]; then

--- a/.github/workflows/tasklist-e2e-tests.yml
+++ b/.github/workflows/tasklist-e2e-tests.yml
@@ -98,7 +98,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: "adopt"
-          java-version: "21"
+          java-version: "25"
 
       # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
       - name: "Create settings.xml"


### PR DESCRIPTION
## Summary

- Update `setup-build` default `java-version` from `21` to `25` so all workflows using the action automatically build on JDK 25
- Update `setup-c8run` to reference Temurin 25 paths/versions (`JAVA_HOME`, `JAVA_HOME_25_X64`, `JAVA_VERSION`)
- Update all workflows that hardcode `java-version: 21` via `actions/setup-java` directly (E2E tests, docker tests, regression tests, orchestration cluster tests, Copilot environment)
- Update `BASE_IMAGE` in the operate and optimize release workflows to `openjre-base:25-dev`, consistent with the Dockerfiles

## Test plan

- [ ] CI passes on this branch with JDK 25
- [ ] `setup-build` callers pick up JDK 25 by default
- [ ] `setup-c8run` starts c8run with JDK 25 on Linux and macOS
- [ ] Release workflows build Docker images using the correct `25-dev` base image

Part of #51201