### PR TITLE
fix: include worker name as override key in Javadoc

### DIFF
--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/CamundaClientWorkerProperties.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/CamundaClientWorkerProperties.java
@@ -25,7 +25,7 @@ public class CamundaClientWorkerProperties {
 
   /**
    * Properties for overriding settings of individual job workers registered to the Camunda client.
-   * The key of the override is the job type.
+   * The key of the override is the job type or worker name.
    */
   private Map<String, CamundaClientJobWorkerProperties> override = new HashMap<>();
 


### PR DESCRIPTION
## Summary
- The Javadoc on `CamundaClientWorkerProperties.override` only mentioned "job type" as the override key, but worker name is also supported.
- Updated the description to say "the job type or worker name".

## Test plan
- [ ] Verify the generated Spring Boot configuration metadata includes the updated description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)