### PR TITLE
ci: exclude version 8.6 from daily QA

### DIFF
--- a/.github/workflows/zeebe-daily-qa.yml
+++ b/.github/workflows/zeebe-daily-qa.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           # List all `stable/8.*` branches
           # Sort them in desc order
-          # Exclude versions that don't require daily QA - for example, 8.5 in extended support
+          # Exclude versions that don't require daily QA - for example, 8.6 in extended support
           # Remove the `origin/` prefix
           # Transform to json-formatted objects with branch and generation_template fields
           # Transform them to json-formatted array of those objects
@@ -47,6 +47,7 @@ jobs:
               | sort -Vr \
               | grep -v '^stable/8.4$' \
               | grep -v '^stable/8.5$' \
+              | grep -v '^stable/8.6$' \
               | while read -r branch; do
                   version="${branch#stable/}"
                   printf '{"branch":"%s","generation_template":"Camunda %s+gen1"}\n' "$branch" "$version"


### PR DESCRIPTION
## Description

There's no need to run the QA daily against versions that are in extended support. With 8.6 in extended support, we can exclude it.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

N/A
