### PR TITLE
fix: load test option for max scenario on stable/8.8

### DIFF
--- a/zeebe/benchmarks/setup/default/Makefile
+++ b/zeebe/benchmarks/setup/default/Makefile
@@ -34,7 +34,7 @@ _scenario_load_test_flags := --set starter.rate=50 --set workers.worker.replicas
 _scenario_platform_flags  :=
 else ifeq ($(scenario),max)
 _scenario_load_test_flags := --set starter.rate=300
-_scenario_platform_flags  := --set-file 'orchestration.extraConfiguration[1].content=./camunda-platform-override-values.yaml'
+_scenario_platform_flags  := --set-file 'orchestration.extraConfiguration.application-override\.yml=./camunda-platform-override-values.yaml'
 else ifeq ($(scenario),archiver)
 _scenario_load_test_flags := --set starter.rate=1 --set starter.rateDuration=10m --set starter.processId=multiInstanceElements --set starter.bpmnXmlPath=bpmn/multiInstanceElements.bpmn --set starter.payloadPath=bpmn/multiInstanceElementsPayload.json --set workers.worker.replicas=0
 _scenario_platform_flags  :=


### PR DESCRIPTION
## Description

In 8.8, the `extraConfiguration` is a map of `filename` → `content`, whereas in 8.9, it's a list of `name`/`content` fields.

Deploying the current code with Helm returns an error:
```
Error: failed parsing --set-file data: unable to parse key: interface conversion: interface {} is map[string]interface {}, not []interface {}
```

References:

* https://github.com/camunda/camunda-platform-helm/blob/91918a75eca5051b294be4746de1a57546881845/charts/camunda-platform-8.8/values.yaml#L3080
* https://github.com/camunda/camunda/blob/4ca241ea36230aa69c033d1a5eb7657d99e72a2e/zeebe/benchmarks/camunda-platform-values.yaml#L250-L251

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

* https://camunda.slack.com/archives/C0807665N8G/p1776438758521409
* https://github.com/camunda/camunda/pull/51176
* https://github.com/camunda/camunda/pull/51354
