### PR TITLE
fix: spring boot properties alignment

### DIFF
--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/CamundaClientClusterVariablesProperties.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/CamundaClientClusterVariablesProperties.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.client.spring.properties;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class CamundaClientClusterVariablesProperties {
@@ -26,7 +27,7 @@ public class CamundaClientClusterVariablesProperties {
   private boolean enabled = true;
 
   /** Cluster variables to set at startup as key-value pairs. */
-  private Map<String, Object> variables;
+  private Map<String, Object> variables = new LinkedHashMap<>();
 
   public boolean isEnabled() {
     return enabled;

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/CamundaClientClusterVariablesProperties.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/CamundaClientClusterVariablesProperties.java
@@ -15,7 +15,6 @@
  */
 package io.camunda.client.spring.properties;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class CamundaClientClusterVariablesProperties {
@@ -27,7 +26,7 @@ public class CamundaClientClusterVariablesProperties {
   private boolean enabled = true;
 
   /** Cluster variables to set at startup as key-value pairs. */
-  private Map<String, Object> variables = new LinkedHashMap<>();
+  private Map<String, Object> variables;
 
   public boolean isEnabled() {
     return enabled;

--- a/clients/camunda-spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/clients/camunda-spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -231,6 +231,38 @@
       "defaultValue": false
     },
     {
+      "name": "camunda.client.keep-alive",
+      "defaultValue": "PT45S"
+    },
+    {
+      "name": "camunda.client.worker.override",
+      "defaultValue": {}
+    },
+    {
+      "name": "camunda.client.auth.proactive-token-refresh-threshold",
+      "defaultValue": "PT30S"
+    },
+    {
+      "name": "camunda.client.auth.token-fetch-max-retries",
+      "defaultValue": 5
+    },
+    {
+      "name": "camunda.client.auth.token-fetch-initial-backoff",
+      "defaultValue": "PT1S"
+    },
+    {
+      "name": "camunda.client.auth.token-fetch-backoff-multiplier",
+      "defaultValue": 2.0
+    },
+    {
+      "name": "camunda.client.auth.token-fetch-retryable-status-codes",
+      "defaultValue": [404, 429, 500, 502, 503, 504]
+    },
+    {
+      "name": "camunda.client.auth.token-fetch-non-retryable-cooldown",
+      "defaultValue": "PT5M"
+    },
+    {
       "name": "common.auth-url",
       "type": "java.lang.String",
       "sourceType": "io.camunda.spring.client.properties.CommonConfigurationProperties",

--- a/clients/camunda-spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/clients/camunda-spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -238,6 +238,38 @@
       "defaultValue": false
     },
     {
+      "name": "camunda.client.keep-alive",
+      "defaultValue": "PT45S"
+    },
+    {
+      "name": "camunda.client.worker.override",
+      "defaultValue": {}
+    },
+    {
+      "name": "camunda.client.auth.proactive-token-refresh-threshold",
+      "defaultValue": "PT30S"
+    },
+    {
+      "name": "camunda.client.auth.token-fetch-max-retries",
+      "defaultValue": 5
+    },
+    {
+      "name": "camunda.client.auth.token-fetch-initial-backoff",
+      "defaultValue": "PT1S"
+    },
+    {
+      "name": "camunda.client.auth.token-fetch-backoff-multiplier",
+      "defaultValue": 2.0
+    },
+    {
+      "name": "camunda.client.auth.token-fetch-retryable-status-codes",
+      "defaultValue": [404, 429, 500, 502, 503, 504]
+    },
+    {
+      "name": "camunda.client.auth.token-fetch-non-retryable-cooldown",
+      "defaultValue": "PT5M"
+    },
+    {
       "name": "common.auth-url",
       "type": "java.lang.String",
       "sourceType": "io.camunda.spring.client.properties.CommonConfigurationProperties",

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configurationMetadata/AlignmentTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configurationMetadata/AlignmentTest.java
@@ -146,15 +146,24 @@ public class AlignmentTest {
   Stream<DynamicTest> alignmentWithDefaultPropertiesTest() throws IOException {
     final JsonNode jsonNode =
         MAPPER.readTree(
-            ResourceUtils.getFile(
-                "classpath:META-INF/additional-spring-configuration-metadata.json"));
+            ResourceUtils.getFile("classpath:META-INF/spring-configuration-metadata.json"));
     final ArrayNode properties = (ArrayNode) jsonNode.get("properties");
     return properties
         .valueStream()
-        .filter(p -> p.has("defaultValue"))
+        .filter(p -> !p.has("deprecation"))
         .map(
             p -> {
               final String name = p.get("name").asText();
+              if (!p.has("defaultValue")) {
+                return DynamicTest.dynamicTest(
+                    "Property " + name + " without default value",
+                    () -> {
+                      assertThat(NEW_GETTERS).containsKey(name);
+                      final Getter getter = NEW_GETTERS.get(name);
+                      final Object value = getter.getter().apply(camundaClientProperties);
+                      assertThat(value).isNull();
+                    });
+              }
               final JsonNode defaultValue = p.get("defaultValue");
               return DynamicTest.dynamicTest(
                   "Property " + name + " with default value " + defaultValue,

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configurationMetadata/AlignmentTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configurationMetadata/AlignmentTest.java
@@ -32,7 +32,9 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,13 +44,19 @@ import org.springframework.util.unit.DataSize;
 
 @SpringBootTest(classes = CamundaClientPropertiesTestConfig.class)
 public class AlignmentTest {
+  private static final Function<JsonNode, Object> INT_SET_MAPPER =
+      p ->
+          StreamSupport.stream(p.spliterator(), false)
+              .map(JsonNode::asInt)
+              .collect(Collectors.toSet());
   private static final ObjectMapper MAPPER = new ObjectMapper();
   private static final Function<JsonNode, Object> DURATION_MAPPER = p -> Duration.parse(p.asText());
   private static final Function<JsonNode, Object> DATA_SIZE_MAPPER =
       p -> DataSize.parse(p.asText());
   private static final Function<JsonNode, Object> URI_MAPPER = p -> URI.create(p.asText());
+  private static final Function<JsonNode, Object> DOUBLE_MAPPER = JsonNode::doubleValue;
   private static final Map<String, Getter> NEW_GETTERS =
-      Map.ofEntries(
+      Map.<String, Getter>ofEntries(
           entry(
               "camunda.client.use-client-side-load-balancing",
               new Getter(CamundaClientProperties::isUseClientSideLoadBalancing)),
@@ -134,7 +142,94 @@ public class AlignmentTest {
               new Getter(CamundaClientProperties::getMaxHttpConnections)),
           entry(
               "camunda.client.worker.defaults.retry-backoff",
-              new Getter(p -> p.getWorker().getDefaults().getRetryBackoff(), DURATION_MAPPER)));
+              new Getter(p -> p.getWorker().getDefaults().getRetryBackoff(), DURATION_MAPPER)),
+          entry(
+              "camunda.client.keep-alive",
+              new Getter(CamundaClientProperties::getKeepAlive, DURATION_MAPPER)),
+          entry("camunda.client.mode", new Getter(CamundaClientProperties::getMode)),
+          entry(
+              "camunda.client.override-authority",
+              new Getter(CamundaClientProperties::getOverrideAuthority)),
+          entry(
+              "camunda.client.auth.client-assertion.keystore-password",
+              new Getter(p -> p.getAuth().getClientAssertion().getKeystorePassword())),
+          entry(
+              "camunda.client.auth.client-assertion.keystore-path",
+              new Getter(p -> p.getAuth().getClientAssertion().getKeystorePath())),
+          entry("camunda.client.auth.client-id", new Getter(p -> p.getAuth().getClientId())),
+          entry(
+              "camunda.client.auth.client-secret", new Getter(p -> p.getAuth().getClientSecret())),
+          entry(
+              "camunda.client.worker.defaults.fetch-variables",
+              new Getter(p -> p.getWorker().getDefaults().getFetchVariables())),
+          entry(
+              "camunda.client.worker.defaults.type",
+              new Getter(p -> p.getWorker().getDefaults().getType())),
+          entry("camunda.client.worker.override", new Getter(p -> p.getWorker().getOverride())),
+          entry("camunda.client.enabled", new Getter(CamundaClientProperties::getEnabled)),
+          entry(
+              "camunda.client.ca-certificate-path",
+              new Getter(CamundaClientProperties::getCaCertificatePath)),
+          entry("camunda.client.cloud.cluster-id", new Getter(p -> p.getCloud().getClusterId())),
+          entry("camunda.client.cloud.domain", new Getter(p -> p.getCloud().getDomain())),
+          entry("camunda.client.cloud.port", new Getter(p -> p.getCloud().getPort())),
+          entry("camunda.client.cloud.region", new Getter(p -> p.getCloud().getRegion())),
+          entry(
+              "camunda.client.deployment.enabled", new Getter(p -> p.getDeployment().isEnabled())),
+          entry(
+              "camunda.client.deployment.own-jar-only",
+              new Getter(p -> p.getDeployment().isOwnJarOnly())),
+          // as the auth method is set by the properties post processor, we have to hardcode it to
+          // null for this test
+          entry("camunda.client.auth.method", new Getter(p -> null)),
+          entry("camunda.client.auth.username", new Getter(p -> p.getAuth().getUsername())),
+          entry("camunda.client.auth.password", new Getter(p -> p.getAuth().getPassword())),
+          entry("camunda.client.auth.token-url", new Getter(p -> p.getAuth().getTokenUrl())),
+          entry("camunda.client.auth.issuer-url", new Getter(p -> p.getAuth().getIssuerUrl())),
+          entry(
+              "camunda.client.auth.well-known-configuration-url",
+              new Getter(p -> p.getAuth().getWellKnownConfigurationUrl())),
+          entry("camunda.client.auth.audience", new Getter(p -> p.getAuth().getAudience())),
+          entry("camunda.client.auth.scope", new Getter(p -> p.getAuth().getScope())),
+          entry("camunda.client.auth.resource", new Getter(p -> p.getAuth().getResource())),
+          entry(
+              "camunda.client.auth.keystore-path", new Getter(p -> p.getAuth().getKeystorePath())),
+          entry(
+              "camunda.client.auth.keystore-password",
+              new Getter(p -> p.getAuth().getKeystorePassword())),
+          entry(
+              "camunda.client.auth.keystore-key-password",
+              new Getter(p -> p.getAuth().getKeystoreKeyPassword())),
+          entry(
+              "camunda.client.auth.truststore-path",
+              new Getter(p -> p.getAuth().getTruststorePath())),
+          entry(
+              "camunda.client.auth.truststore-password",
+              new Getter(p -> p.getAuth().getTruststorePassword())),
+          entry(
+              "camunda.client.auth.proactive-token-refresh-threshold",
+              new Getter(p -> p.getAuth().getProactiveTokenRefreshThreshold(), DURATION_MAPPER)),
+          entry(
+              "camunda.client.auth.token-fetch-max-retries",
+              new Getter(p -> p.getAuth().getTokenFetchMaxRetries())),
+          entry(
+              "camunda.client.auth.token-fetch-initial-backoff",
+              new Getter(p -> p.getAuth().getTokenFetchInitialBackoff(), DURATION_MAPPER)),
+          entry(
+              "camunda.client.auth.token-fetch-backoff-multiplier",
+              new Getter(p -> p.getAuth().getTokenFetchBackoffMultiplier(), DOUBLE_MAPPER)),
+          entry(
+              "camunda.client.auth.token-fetch-retryable-status-codes",
+              new Getter(p -> p.getAuth().getTokenFetchRetryableStatusCodes(), INT_SET_MAPPER)),
+          entry(
+              "camunda.client.auth.token-fetch-non-retryable-cooldown",
+              new Getter(p -> p.getAuth().getTokenFetchNonRetryableCooldown(), DURATION_MAPPER)),
+          entry(
+              "camunda.client.auth.client-assertion.keystore-key-alias",
+              new Getter(p -> p.getAuth().getClientAssertion().getKeystoreKeyAlias())),
+          entry(
+              "camunda.client.auth.client-assertion.keystore-key-password",
+              new Getter(p -> p.getAuth().getClientAssertion().getKeystoreKeyPassword())));
 
   @Autowired CamundaClientProperties camundaClientProperties;
 
@@ -151,6 +246,7 @@ public class AlignmentTest {
     return properties
         .valueStream()
         .filter(p -> !p.has("deprecation"))
+        .filter(p -> p.get("name").asText().startsWith("camunda.client."))
         .map(
             p -> {
               final String name = p.get("name").asText();

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configurationMetadata/AlignmentTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configurationMetadata/AlignmentTest.java
@@ -237,7 +237,11 @@ public class AlignmentTest {
               new Getter(p -> p.getClusterVariables().isEnabled())),
           entry(
               "camunda.client.cluster-variables.variables",
-              new Getter(p -> p.getClusterVariables().getVariables())));
+              new Getter(
+                  p -> {
+                    final Map<String, Object> vars = p.getClusterVariables().getVariables();
+                    return vars == null || vars.isEmpty() ? null : vars;
+                  })));
 
   @Autowired CamundaClientProperties camundaClientProperties;
 

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configurationMetadata/AlignmentTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configurationMetadata/AlignmentTest.java
@@ -237,11 +237,7 @@ public class AlignmentTest {
               new Getter(p -> p.getClusterVariables().isEnabled())),
           entry(
               "camunda.client.cluster-variables.variables",
-              new Getter(
-                  p -> {
-                    final Map<String, Object> vars = p.getClusterVariables().getVariables();
-                    return vars == null || vars.isEmpty() ? null : vars;
-                  })));
+              new Getter(p -> p.getClusterVariables().getVariables())));
 
   @Autowired CamundaClientProperties camundaClientProperties;
 

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configurationMetadata/AlignmentTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configurationMetadata/AlignmentTest.java
@@ -228,13 +228,23 @@ public class AlignmentTest {
               new Getter(p -> p.getAuth().getClientAssertion().getKeystoreKeyAlias())),
           entry(
               "camunda.client.auth.client-assertion.keystore-key-password",
-              new Getter(p -> p.getAuth().getClientAssertion().getKeystoreKeyPassword())));
+              new Getter(p -> p.getAuth().getClientAssertion().getKeystoreKeyPassword())),
+          entry(
+              "camunda.client.auth.credentials-cache-path",
+              new Getter(p -> p.getAuth().getCredentialsCachePath())),
+          entry(
+              "camunda.client.cluster-variables.enabled",
+              new Getter(p -> p.getClusterVariables().isEnabled())),
+          entry(
+              "camunda.client.cluster-variables.variables",
+              new Getter(p -> p.getClusterVariables().getVariables())));
 
   @Autowired CamundaClientProperties camundaClientProperties;
 
   /**
-   * This test enforces the alignment between the additional properties defined in the metadata json
-   * and the code
+   * This test enforces the alignment between the generated Spring configuration metadata
+   * (META-INF/spring-configuration-metadata.json) and the code, covering all camunda.client.*
+   * properties and skipping deprecated ones.
    */
   @TestFactory
   Stream<DynamicTest> alignmentWithDefaultPropertiesTest() throws IOException {

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configurationMetadata/AlignmentTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configurationMetadata/AlignmentTest.java
@@ -145,15 +145,24 @@ public class AlignmentTest {
   Stream<DynamicTest> alignmentWithDefaultPropertiesTest() throws IOException {
     final JsonNode jsonNode =
         MAPPER.readTree(
-            ResourceUtils.getFile(
-                "classpath:META-INF/additional-spring-configuration-metadata.json"));
+            ResourceUtils.getFile("classpath:META-INF/spring-configuration-metadata.json"));
     final ArrayNode properties = (ArrayNode) jsonNode.get("properties");
     return properties
         .valueStream()
-        .filter(p -> p.has("defaultValue"))
+        .filter(p -> !p.has("deprecation"))
         .map(
             p -> {
               final String name = p.get("name").asText();
+              if (!p.has("defaultValue")) {
+                return DynamicTest.dynamicTest(
+                    "Property " + name + " without default value",
+                    () -> {
+                      assertThat(NEW_GETTERS).containsKey(name);
+                      final Getter getter = NEW_GETTERS.get(name);
+                      final Object value = getter.getter().apply(camundaClientProperties);
+                      assertThat(value).isNull();
+                    });
+              }
               final JsonNode defaultValue = p.get("defaultValue");
               return DynamicTest.dynamicTest(
                   "Property " + name + " with default value " + defaultValue,

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configurationMetadata/AlignmentTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configurationMetadata/AlignmentTest.java
@@ -31,7 +31,9 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,13 +43,19 @@ import org.springframework.util.unit.DataSize;
 
 @SpringBootTest(classes = CamundaClientPropertiesTestConfig.class)
 public class AlignmentTest {
+  private static final Function<JsonNode, Object> INT_SET_MAPPER =
+      p ->
+          StreamSupport.stream(p.spliterator(), false)
+              .map(JsonNode::asInt)
+              .collect(Collectors.toSet());
   private static final ObjectMapper MAPPER = new ObjectMapper();
   private static final Function<JsonNode, Object> DURATION_MAPPER = p -> Duration.parse(p.asText());
   private static final Function<JsonNode, Object> DATA_SIZE_MAPPER =
       p -> DataSize.parse(p.asText());
   private static final Function<JsonNode, Object> URI_MAPPER = p -> URI.create(p.asText());
+  private static final Function<JsonNode, Object> DOUBLE_MAPPER = JsonNode::doubleValue;
   private static final Map<String, Getter> NEW_GETTERS =
-      Map.ofEntries(
+      Map.<String, Getter>ofEntries(
           entry(
               "camunda.client.use-client-side-load-balancing",
               new Getter(CamundaClientProperties::isUseClientSideLoadBalancing)),
@@ -133,7 +141,94 @@ public class AlignmentTest {
               new Getter(CamundaClientProperties::getMaxHttpConnections)),
           entry(
               "camunda.client.worker.defaults.retry-backoff",
-              new Getter(p -> p.getWorker().getDefaults().getRetryBackoff(), DURATION_MAPPER)));
+              new Getter(p -> p.getWorker().getDefaults().getRetryBackoff(), DURATION_MAPPER)),
+          entry(
+              "camunda.client.keep-alive",
+              new Getter(CamundaClientProperties::getKeepAlive, DURATION_MAPPER)),
+          entry("camunda.client.mode", new Getter(CamundaClientProperties::getMode)),
+          entry(
+              "camunda.client.override-authority",
+              new Getter(CamundaClientProperties::getOverrideAuthority)),
+          entry(
+              "camunda.client.auth.client-assertion.keystore-password",
+              new Getter(p -> p.getAuth().getClientAssertion().getKeystorePassword())),
+          entry(
+              "camunda.client.auth.client-assertion.keystore-path",
+              new Getter(p -> p.getAuth().getClientAssertion().getKeystorePath())),
+          entry("camunda.client.auth.client-id", new Getter(p -> p.getAuth().getClientId())),
+          entry(
+              "camunda.client.auth.client-secret", new Getter(p -> p.getAuth().getClientSecret())),
+          entry(
+              "camunda.client.worker.defaults.fetch-variables",
+              new Getter(p -> p.getWorker().getDefaults().getFetchVariables())),
+          entry(
+              "camunda.client.worker.defaults.type",
+              new Getter(p -> p.getWorker().getDefaults().getType())),
+          entry("camunda.client.worker.override", new Getter(p -> p.getWorker().getOverride())),
+          entry("camunda.client.enabled", new Getter(CamundaClientProperties::getEnabled)),
+          entry(
+              "camunda.client.ca-certificate-path",
+              new Getter(CamundaClientProperties::getCaCertificatePath)),
+          entry("camunda.client.cloud.cluster-id", new Getter(p -> p.getCloud().getClusterId())),
+          entry("camunda.client.cloud.domain", new Getter(p -> p.getCloud().getDomain())),
+          entry("camunda.client.cloud.port", new Getter(p -> p.getCloud().getPort())),
+          entry("camunda.client.cloud.region", new Getter(p -> p.getCloud().getRegion())),
+          entry(
+              "camunda.client.deployment.enabled", new Getter(p -> p.getDeployment().isEnabled())),
+          entry(
+              "camunda.client.deployment.own-jar-only",
+              new Getter(p -> p.getDeployment().isOwnJarOnly())),
+          // as the auth method is set by the properties post processor, we have to hardcode it to
+          // null for this test
+          entry("camunda.client.auth.method", new Getter(p -> null)),
+          entry("camunda.client.auth.username", new Getter(p -> p.getAuth().getUsername())),
+          entry("camunda.client.auth.password", new Getter(p -> p.getAuth().getPassword())),
+          entry("camunda.client.auth.token-url", new Getter(p -> p.getAuth().getTokenUrl())),
+          entry("camunda.client.auth.issuer-url", new Getter(p -> p.getAuth().getIssuerUrl())),
+          entry(
+              "camunda.client.auth.well-known-configuration-url",
+              new Getter(p -> p.getAuth().getWellKnownConfigurationUrl())),
+          entry("camunda.client.auth.audience", new Getter(p -> p.getAuth().getAudience())),
+          entry("camunda.client.auth.scope", new Getter(p -> p.getAuth().getScope())),
+          entry("camunda.client.auth.resource", new Getter(p -> p.getAuth().getResource())),
+          entry(
+              "camunda.client.auth.keystore-path", new Getter(p -> p.getAuth().getKeystorePath())),
+          entry(
+              "camunda.client.auth.keystore-password",
+              new Getter(p -> p.getAuth().getKeystorePassword())),
+          entry(
+              "camunda.client.auth.keystore-key-password",
+              new Getter(p -> p.getAuth().getKeystoreKeyPassword())),
+          entry(
+              "camunda.client.auth.truststore-path",
+              new Getter(p -> p.getAuth().getTruststorePath())),
+          entry(
+              "camunda.client.auth.truststore-password",
+              new Getter(p -> p.getAuth().getTruststorePassword())),
+          entry(
+              "camunda.client.auth.proactive-token-refresh-threshold",
+              new Getter(p -> p.getAuth().getProactiveTokenRefreshThreshold(), DURATION_MAPPER)),
+          entry(
+              "camunda.client.auth.token-fetch-max-retries",
+              new Getter(p -> p.getAuth().getTokenFetchMaxRetries())),
+          entry(
+              "camunda.client.auth.token-fetch-initial-backoff",
+              new Getter(p -> p.getAuth().getTokenFetchInitialBackoff(), DURATION_MAPPER)),
+          entry(
+              "camunda.client.auth.token-fetch-backoff-multiplier",
+              new Getter(p -> p.getAuth().getTokenFetchBackoffMultiplier(), DOUBLE_MAPPER)),
+          entry(
+              "camunda.client.auth.token-fetch-retryable-status-codes",
+              new Getter(p -> p.getAuth().getTokenFetchRetryableStatusCodes(), INT_SET_MAPPER)),
+          entry(
+              "camunda.client.auth.token-fetch-non-retryable-cooldown",
+              new Getter(p -> p.getAuth().getTokenFetchNonRetryableCooldown(), DURATION_MAPPER)),
+          entry(
+              "camunda.client.auth.client-assertion.keystore-key-alias",
+              new Getter(p -> p.getAuth().getClientAssertion().getKeystoreKeyAlias())),
+          entry(
+              "camunda.client.auth.client-assertion.keystore-key-password",
+              new Getter(p -> p.getAuth().getClientAssertion().getKeystoreKeyPassword())));
 
   @Autowired CamundaClientProperties camundaClientProperties;
 
@@ -150,6 +245,7 @@ public class AlignmentTest {
     return properties
         .valueStream()
         .filter(p -> !p.has("deprecation"))
+        .filter(p -> p.get("name").asText().startsWith("camunda.client."))
         .map(
             p -> {
               final String name = p.get("name").asText();


### PR DESCRIPTION
## Description

This pull request adds support for several new configuration properties to the Camunda Spring Boot starter and updates the alignment test to ensure these properties are correctly mapped and tested. The changes mainly focus on introducing new client and authentication-related settings and ensuring the test suite recognizes and validates them.

**Configuration property additions:**

* Added new properties to `additional-spring-configuration-metadata.json` for client keep-alive, worker overrides, and advanced authentication settings such as proactive token refresh, token fetch retries, backoff strategies, and retryable status codes.

**Test enhancements and alignment:**

* Updated `AlignmentTest` to include new property getters for the recently added configuration options, ensuring they are covered by the test suite. [[1]](diffhunk://#diff-658c31270765045ced8e345710a8e043edba2d2c44c2950b456656e10a39be0cR47-R59) [[2]](diffhunk://#diff-658c31270765045ced8e345710a8e043edba2d2c44c2950b456656e10a39be0cL137-R232)
* Improved the test logic to handle properties without default values by asserting their presence and null value, and to skip deprecated properties.
* Added utility mappers for new property types, such as sets of integers and doubles, to support the new configuration options in the test.

**Dependency updates:**

* Imported `Collectors` and `StreamSupport` to facilitate the new test utility functions.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
