### PR TITLE
test: only request as many process instances as will be returned

### DIFF
--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/Starter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/Starter.java
@@ -152,12 +152,14 @@ public class Starter extends App {
             Executors.newScheduledThreadPool(1),
             config.getMonitorDataAvailabilityInterval(),
             (listOfStartedInstances) -> {
+              final var limit = 100;
+              final var instanceIds = listOfStartedInstances.stream().limit(limit).toList();
               final CamundaFuture<SearchResponse<ProcessInstance>> send =
                   client
                       .newProcessInstanceSearchRequest()
-                      .filter((f) -> f.processInstanceKey(key -> key.in(listOfStartedInstances)))
+                      .filter((f) -> f.processInstanceKey(key -> key.in(instanceIds)))
                       .sort(ProcessInstanceSort::startDate)
-                      .page(p -> p.limit(100))
+                      .page(p -> p.limit(limit))
                       .send();
 
               return send.thenApply(


### PR DESCRIPTION
The availability checks only ask for 100 PIs at a time, so there's no point adding in the filters for any other PIs that are pending.  This should reduce the potential size of the request a little + avoids extra filtering we don't need to worry about.

Extract from https://github.com/camunda/camunda/pull/51072