### PR TITLE
fix(operate): use unique process ID to fix flaky internal API permission tests

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateInternalApiGroupPermissionsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateInternalApiGroupPermissionsIT.java
@@ -63,7 +63,7 @@ public class OperateInternalApiGroupPermissionsIT {
           .withAdditionalProfile(Profile.OPERATE);
 
   private static final String BASE_PATH = "api/process-instances";
-  private static final String PROCESS_ID = "processId";
+  private static final String PROCESS_ID = "process-" + Strings.newRandomValidIdentityId();
   private static final String ADMIN_USERNAME = "admin";
   private static final String AUTHORIZED_USERNAME = "authorized";
   private static final String UNAUTHORIZED_USERNAME = "unauthorized";

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateInternalApiRolePermissionsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/operate/OperateInternalApiRolePermissionsIT.java
@@ -63,7 +63,7 @@ public class OperateInternalApiRolePermissionsIT {
           .withAdditionalProfile(Profile.OPERATE);
 
   private static final String BASE_PATH = "api/process-instances";
-  private static final String PROCESS_ID = "processId";
+  private static final String PROCESS_ID = "process-" + Strings.newRandomValidIdentityId();
   private static final String ADMIN_USERNAME = "admin";
   private static final String AUTHORIZED_USERNAME = "authorized";
   private static final String UNAUTHORIZED_USERNAME = "unauthorized";


### PR DESCRIPTION
## Summary

Fixes flakiness in `OperateInternalApiGroupPermissionsIT` and `OperateInternalApiRolePermissionsIT` on `stable/8.9`.

Both classes had a hardcoded `PROCESS_ID = "processId"`. The `shouldBePermittedToSearchUsingInternalApi` test searches the Operate internal API filtering only by `bpmnProcessId` — not by `processInstanceKey`. When both classes run in the same CI suite, each `@BeforeAll` deploys and starts a new process instance with the same ID. The search then returns 2 instances instead of 1, causing `assertThat(count.totalCount).isEqualTo(1)` to fail intermittently.

**Fix:** Initialize `PROCESS_ID` with a unique value per class:
```java
private static final String PROCESS_ID = "process-" + Strings.newRandomValidIdentityId();
```
`Strings` is already imported and used in `@BeforeAll`. All three uses of `PROCESS_ID` within each class (deploy, create instance, search query) remain consistent.

Closes #50863

🤖 Generated with [Claude Code](https://claude.com/claude-code)