### PR TITLE
fix: update Operate E2E tests to use v2 API endpoints

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
@@ -17,6 +17,7 @@ import {
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {waitForAssertion} from 'utils/waitForAssertion';
+import {sleep} from 'utils/sleep';
 
 type ProcessInstance = {
   processInstanceKey: string;
@@ -40,8 +41,8 @@ test.beforeAll(async () => {
     operationsProcessB: processBId,
   });
 
-  // processWithAnIncident has a FEEL assertion (=assert(orderId, orderId!=null)) in its service
-  // task io mapping. Creating the instance without 'orderId' immediately raises an
+  // operationsProcessA has a FEEL assertion (=assert(orderId, orderId!=null)) in its
+  // service task io mapping. Creating the instance without 'orderId' immediately raises an
   // INPUT_OUTPUT_MAPPING_ERROR incident, which makes the Retry Instance button appear.
   const singleInstance = await createSingleInstance(processAId, 1);
   const batchInstances = await createInstances(processBId, 1, 10);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
@@ -8,11 +8,14 @@
 
 import {test} from 'fixtures';
 import {expect} from '@playwright/test';
-import {deploy, createInstances, createSingleInstance} from 'utils/zeebeClient';
+import {randomUUID} from 'crypto';
+import {
+  deployWithSubstitutions,
+  createInstances,
+  createSingleInstance,
+} from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {navigateToApp} from '@pages/UtilitiesPage';
-import {sleep} from 'utils/sleep';
-import {createDemoOperations} from 'utils/operations.helper';
 import {waitForAssertion} from 'utils/waitForAssertion';
 
 type ProcessInstance = {
@@ -25,31 +28,34 @@ let initialData: {
   batchOperationInstances: ProcessInstance[];
 };
 
-test.beforeAll(async ({request}) => {
-  await deploy([
-    './resources/operationsProcessA.bpmn',
-    './resources/operationsProcessB.bpmn',
-  ]);
+const runSuffix = randomUUID().slice(0, 8);
+const processAId = `operationsProcessA-${runSuffix}`;
+const processBId = `operationsProcessB-${runSuffix}`;
 
-  const singleInstance = await createSingleInstance('operationsProcessA', 1);
-  const batchInstances = await createInstances('operationsProcessB', 1, 10);
+test.beforeAll(async () => {
+  await deployWithSubstitutions('./resources/operationsProcessA.bpmn', {
+    operationsProcessA: processAId,
+  });
+  await deployWithSubstitutions('./resources/operationsProcessB.bpmn', {
+    operationsProcessB: processBId,
+  });
+
+  // processWithAnIncident has a FEEL assertion (=assert(orderId, orderId!=null)) in its service
+  // task io mapping. Creating the instance without 'orderId' immediately raises an
+  // INPUT_OUTPUT_MAPPING_ERROR incident, which makes the Retry Instance button appear.
+  const singleInstance = await createSingleInstance(processAId, 1);
+  const batchInstances = await createInstances(processBId, 1, 10);
 
   initialData = {
     singleOperationInstance: {
       processInstanceKey: singleInstance.processInstanceKey,
-      bpmnProcessId: 'operationsProcessA',
+      bpmnProcessId: processAId,
     },
     batchOperationInstances: batchInstances.map((instance) => ({
       processInstanceKey: instance.processInstanceKey,
-      bpmnProcessId: 'operationsProcessB',
+      bpmnProcessId: processBId,
     })),
   };
-  await sleep(2000);
-  await createDemoOperations(
-    request,
-    initialData.singleOperationInstance.processInstanceKey,
-    50,
-  );
 });
 
 test.describe('Operations', () => {
@@ -89,7 +95,9 @@ test.describe('Operations', () => {
       );
 
       await expect(operateProcessesPage.singleOperationSpinner).toBeVisible();
-      await expect(operateProcessesPage.singleOperationSpinner).toBeHidden();
+      await expect(operateProcessesPage.singleOperationSpinner).toBeHidden({
+        timeout: 60000,
+      });
     });
 
     await test.step('Cancel single instance using operation button', async () => {
@@ -106,6 +114,8 @@ test.describe('Operations', () => {
 
     await test.step('Validate canceled instance details', async () => {
       const instanceRow = operateProcessesPage.getInstanceRow(0);
+
+      await operateFiltersPanelPage.clickCanceledInstancesCheckbox();
 
       await expect(
         operateProcessesPage.getCanceledIcon(instance.processInstanceKey),

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/swagger.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/swagger.spec.ts
@@ -106,14 +106,16 @@ test.describe('Swagger UI Tests', () => {
       .filter({hasText: PROCESS_DEFINITION_API_PATH})
       .first();
     await expect(processDefinitionOperation).toBeVisible({timeout: 10_000});
-    await processDefinitionOperation.click();
+    // noWaitAfter prevents Playwright from hanging on Swagger UI's hash-navigation
+    // triggered by expanding the operation block.
+    await processDefinitionOperation.click({noWaitAfter: true});
 
     // Click "Try it out" so Swagger generates the request command preview
     const tryItOutButton = processDefinitionOperation.getByRole('button', {
       name: /try it out/i,
     });
     await expect(tryItOutButton).toBeVisible({timeout: 10_000});
-    await tryItOutButton.click();
+    await tryItOutButton.click({noWaitAfter: true});
 
     // Trigger generation of the curl/response section without inspecting network requests.
     const executeButton = processDefinitionOperation.getByRole('button', {
@@ -164,14 +166,16 @@ test.describe('Swagger UI Tests', () => {
       .filter({hasText: PROCESS_DEFINITION_API_PATH})
       .first();
     await expect(processDefinitionOperation).toBeVisible({timeout: 10_000});
-    await processDefinitionOperation.click();
+    // noWaitAfter prevents Playwright from hanging on Swagger UI's hash-navigation
+    // triggered by expanding the operation block.
+    await processDefinitionOperation.click({noWaitAfter: true});
 
     // Click "Try it out" so Swagger generates the request command preview
     const tryItOutButton = processDefinitionOperation.getByRole('button', {
       name: /try it out/i,
     });
     await expect(tryItOutButton).toBeVisible({timeout: 10_000});
-    await tryItOutButton.click();
+    await tryItOutButton.click({noWaitAfter: true});
 
     // Trigger generation of the curl/response section without inspecting network requests.
     const executeButton = processDefinitionOperation.getByRole('button', {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/swagger.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/swagger.spec.ts
@@ -100,7 +100,7 @@ test.describe('Swagger UI Tests', () => {
       timeout: 10_000,
     });
 
-    // Find the POST /v1/process-definitions/search operation block and expand it
+    // Find the POST /v2/process-definitions/search operation block and expand it
     const processDefinitionOperation = page
       .locator(PROCESS_DEFINITION_OPERATION_SELECTOR)
       .filter({hasText: PROCESS_DEFINITION_API_PATH})
@@ -158,7 +158,7 @@ test.describe('Swagger UI Tests', () => {
       timeout: 10_000,
     });
 
-    // Find the POST /v1/process-definitions/search operation block and expand it
+    // Find the POST /v2/process-definitions/search operation block and expand it
     const processDefinitionOperation = page
       .locator(PROCESS_DEFINITION_OPERATION_SELECTOR)
       .filter({hasText: PROCESS_DEFINITION_API_PATH})

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/swagger.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/swagger.spec.ts
@@ -15,7 +15,7 @@ import {LOGIN_CREDENTIALS} from '../../utils/constants';
 const SWAGGER_UI_URL = '/swagger-ui/index.html';
 const API_DOCS_URL = '/v3/api-docs';
 const CSRF_COOKIE_NAME = 'X-CSRF-TOKEN';
-const PROCESS_DEFINITION_API_PATH = '/v1/process-definitions/search';
+const PROCESS_DEFINITION_API_PATH = '/v2/process-definitions/search';
 const SWAGGER_UI_CONTAINER_SELECTOR = 'section.swagger-ui.swagger-container';
 const PROCESS_DEFINITION_OPERATION_SELECTOR = '.opblock.opblock-post';
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/operations.helper.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/operations.helper.ts
@@ -7,7 +7,7 @@
  */
 
 import {expect, APIRequestContext} from '@playwright/test';
-import {credentials, authHeaders} from './http';
+import {credentials, authHeaders, buildUrl} from './http';
 
 export async function createDemoOperations(
   request: APIRequestContext,
@@ -24,12 +24,11 @@ export async function createDemoOperations(
   await Promise.all(
     [...new Array(count)].map(async (_, index) => {
       const response = await request.post(
-        `${credentials.baseUrl}/api/process-instances/${processInstanceKey}/operation`,
+        buildUrl(
+          `/process-instances/${processInstanceKey}/incident-resolution`,
+        ),
         {
           ...requestHeaders,
-          data: {
-            operationType: 'RESOLVE_INCIDENT',
-          },
         },
       );
       if (!response.ok()) {
@@ -52,7 +51,7 @@ export async function createDemoOperations(
     .poll(
       async () => {
         const response = await request.post(
-          `${credentials.baseUrl}/v2/batch-operations/search`,
+          buildUrl('/batch-operations/search'),
           {
             ...requestHeaders,
             data: {


### PR DESCRIPTION
## Summary

Fixes two Operate E2E tests that were broken due to deprecated v1 API endpoints and unreliable test data setup.

### Changes

#### `tests/operate/swagger.spec.ts`
- Updated `PROCESS_DEFINITION_API_PATH` from `/v1/process-definitions/search` to `/v2/process-definitions/search` to align with the current API version exposed through the Swagger UI.

#### `tests/operate/operations.spec.ts`
- Replaced `deploy()` with `deployWithSubstitutions()` and a per-run UUID suffix, ensuring each test run deploys a fresh version 1 of each process (idempotent reruns).
- Removed `createDemoOperations()` call that was programmatically resolving incidents before the UI test could interact with them, making the Retry button unavailable.
- Removed `sleep(2000)` in favour of proper Playwright assertions.
- Added `clickCanceledInstancesCheckbox()` step to correctly filter and validate the canceled instance.
- Extended `singleOperationSpinner` hidden timeout to 60 s to accommodate slower environments.

#### `utils/operations.helper.ts`
- Replaced legacy `/api/process-instances/{key}/operation` (404 in current versions) with the v2 endpoint `POST /v2/process-instances/{key}/incident-resolution`.
- Switched hardcoded `baseUrl` concatenation to `buildUrl()` for consistency.


### Testing
https://github.com/camunda/camunda/actions/runs/24668566443/job/72132912354