### PR TITLE
fix: reset task assign button state on task change

### DIFF
--- a/tasklist/client/src/Tasks/Task/Details/Header.tsx
+++ b/tasklist/client/src/Tasks/Task/Details/Header.tsx
@@ -171,6 +171,7 @@ const AssignButton: React.FC<{
 
   return (
     <AsyncActionButton
+      key={id}
       inlineLoadingProps={{
         description:
           assignmentStatus === 'off'


### PR DESCRIPTION
## Description

Backport #50988 to 8.7

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #49133
