### PR TITLE
fix: pin all client-side dependencies in Spring Boot starter compatibility tests

### DIFF
--- a/.github/workflows/camunda-spring-boot-starter-compatibility-test.yml
+++ b/.github/workflows/camunda-spring-boot-starter-compatibility-test.yml
@@ -349,8 +349,13 @@ jobs:
 
       - name: Override spring client version for compatibility testing
         run: |
-          # Inject an explicit <version> on camunda-spring-boot-starter to override the parent-managed version
-          sed -i '/<artifactId>camunda-spring-boot-starter<\/artifactId>/a\      <version>${{ matrix.client }}<\/version>' qa/compatibility-test/pom.xml
+          # Inject an explicit <version> on all Camunda client-side dependencies to override
+          # the parent-managed SNAPSHOT version. This ensures the entire client stack (starter,
+          # process-test framework, and client library) is at the released version being tested,
+          # while the server (Docker image) runs the SNAPSHOT version.
+          for artifact in camunda-spring-boot-starter camunda-process-test-spring camunda-process-test-java camunda-client-java; do
+            sed -i "/<artifactId>${artifact}<\/artifactId>/a\\      <version>${{ matrix.client }}<\/version>" qa/compatibility-test/pom.xml
+          done
 
       - name: Run compatibility tests
         uses: ./.github/actions/run-maven


### PR DESCRIPTION
## Description

The compatibility test workflow only overrode camunda-spring-boot-starter to the released client version, while camunda-process-test-spring, camunda-process-test-java, and camunda-client-java remained at SNAPSHOT. This caused NoSuchMethodError when SNAPSHOT's CamundaProcessTestDefaultConfiguration called SpringCamundaClientConfiguration.toBuilder() — a method not present in 8.9.0.

Pin all four Camunda client-side dependencies to the released version so the entire client stack is consistent. The server Docker image still runs the newer version, which is the actual compatibility being validated.

## Related issues

related to https://camunda.slack.com/archives/C0A2AGG2Q2E/p1776656355200669
