### PR TITLE
feat: add new MCP Processes page to Admin

### DIFF
--- a/identity/client/src/components/global/routePaths.ts
+++ b/identity/client/src/components/global/routePaths.ts
@@ -40,6 +40,9 @@ export const Paths = {
   operationsLog() {
     return "/operations-log";
   },
+  mcpProcesses() {
+    return "/mcp-processes";
+  },
   globalTaskListeners() {
     return "/global-task-listeners";
   },

--- a/identity/client/src/components/global/useGlobalRoutes.tsx
+++ b/identity/client/src/components/global/useGlobalRoutes.tsx
@@ -25,7 +25,6 @@ import {
   isTenantsApiEnabled,
 } from "src/configuration";
 import { Paths } from "src/components/global/routePaths";
-import { IS_MCP_PROCESSES_VIEW_ENABLED } from "src/feature-flags";
 
 export const useGlobalRoutes = () => {
   const { t } = useTranslate();
@@ -73,17 +72,6 @@ export const useGlobalRoutes = () => {
       ]
     : [];
 
-  const mcpProcessesRoutes = IS_MCP_PROCESSES_VIEW_ENABLED
-    ? [
-        {
-          path: `${Paths.mcpProcesses()}/*`,
-          key: Paths.mcpProcesses(),
-          label: t("mcpProcesses"),
-          element: <McpProcesses />,
-        },
-      ]
-    : [];
-
   const routes = [
     ...OIDCDependentRoutes,
     ...camundaGroupsDependentRoutes,
@@ -112,7 +100,12 @@ export const useGlobalRoutes = () => {
       label: t("clusterVariables"),
       element: <ClusterVariables />,
     },
-    ...mcpProcessesRoutes,
+    {
+      path: `${Paths.mcpProcesses()}/*`,
+      key: Paths.mcpProcesses(),
+      label: t("mcpProcesses"),
+      element: <McpProcesses />,
+    },
     {
       path: `${Paths.operationsLog()}/*`,
       key: Paths.operationsLog(),

--- a/identity/client/src/components/global/useGlobalRoutes.tsx
+++ b/identity/client/src/components/global/useGlobalRoutes.tsx
@@ -17,6 +17,7 @@ import Authorizations from "src/pages/authorizations";
 import ClusterVariables from "src/pages/cluster-variables";
 import OperationsLog from "src/pages/operations-log";
 import GlobalTaskListeners from "src/pages/global-task-listeners";
+import McpProcesses from "src/pages/mcp-processes";
 import {
   isCamundaGroupsEnabled,
   isOIDC,
@@ -24,6 +25,7 @@ import {
   isTenantsApiEnabled,
 } from "src/configuration";
 import { Paths } from "src/components/global/routePaths";
+import { IS_MCP_PROCESSES_VIEW_ENABLED } from "src/feature-flags";
 
 export const useGlobalRoutes = () => {
   const { t } = useTranslate();
@@ -71,6 +73,17 @@ export const useGlobalRoutes = () => {
       ]
     : [];
 
+  const mcpProcessesRoutes = IS_MCP_PROCESSES_VIEW_ENABLED
+    ? [
+        {
+          path: `${Paths.mcpProcesses()}/*`,
+          key: Paths.mcpProcesses(),
+          label: t("mcpProcesses"),
+          element: <McpProcesses />,
+        },
+      ]
+    : [];
+
   const routes = [
     ...OIDCDependentRoutes,
     ...camundaGroupsDependentRoutes,
@@ -99,6 +112,7 @@ export const useGlobalRoutes = () => {
       label: t("clusterVariables"),
       element: <ClusterVariables />,
     },
+    ...mcpProcessesRoutes,
     {
       path: `${Paths.operationsLog()}/*`,
       key: Paths.operationsLog(),

--- a/identity/client/src/feature-flags.ts
+++ b/identity/client/src/feature-flags.ts
@@ -7,5 +7,3 @@
  */
 
 export const featureFlags = [];
-
-export const IS_MCP_PROCESSES_VIEW_ENABLED = true;

--- a/identity/client/src/pages/mcp-processes/List.tsx
+++ b/identity/client/src/pages/mcp-processes/List.tsx
@@ -11,16 +11,12 @@ import { Loading } from "@carbon/react";
 import useTranslate from "src/utility/localization";
 import Page, { PageHeader } from "src/components/layout/Page";
 import { TranslatedErrorInlineNotification } from "src/components/notifications/InlineNotification";
-import { useApi } from "src/utility/api";
-import { searchMessageSubscriptions } from "src/utility/api/message-subscriptions";
+import { useMcpProcessTools } from "./useMcpProcessTools";
 
 const List: FC = () => {
   const { t } = useTranslate();
 
-  const { data, loading, success, reload } = useApi(
-    searchMessageSubscriptions,
-    { filter: {} },
-  );
+  const { processTools, loading, success, reload } = useMcpProcessTools();
 
   return (
     <Page>
@@ -30,7 +26,9 @@ const List: FC = () => {
         shouldShowDocumentationLink={false}
       />
       {loading && <Loading withOverlay={false} />}
-      {!loading && success && <pre>{JSON.stringify(data, null, 2)}</pre>}
+      {!loading && success && (
+        <pre>{JSON.stringify(processTools, null, 2)}</pre>
+      )}
       {!loading && !success && (
         <TranslatedErrorInlineNotification
           title={t("errorOccurred")}

--- a/identity/client/src/pages/mcp-processes/List.tsx
+++ b/identity/client/src/pages/mcp-processes/List.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { FC, useMemo } from "react";
+import { FC, useCallback, useMemo, useState } from "react";
 import useTranslate from "src/utility/localization";
 import Page, { PageHeader } from "src/components/layout/Page";
 import EntityList, {
@@ -38,6 +38,23 @@ const List: FC = () => {
     return columns;
   }, [t]);
 
+  // Note: Filtering by tool name is currently not supported by the API.
+  const [toolNameSearch, setToolNameSearch] = useState("");
+  const handleSearch = useCallback(
+    (value: Record<string, string> | undefined) => {
+      const toolName = value?.toolName.trim().toLowerCase();
+      setToolNameSearch(toolName ?? "");
+    },
+    [],
+  );
+
+  const filteredTools = useMemo(() => {
+    if (!toolNameSearch) return processTools;
+    return processTools.filter((tool) =>
+      tool.toolName.toLowerCase().includes(toolNameSearch),
+    );
+  }, [processTools, toolNameSearch]);
+
   return (
     <Page>
       <PageHeader
@@ -46,10 +63,13 @@ const List: FC = () => {
         shouldShowDocumentationLink={false}
       />
       <EntityList
-        data={processTools}
+        data={filteredTools}
         headers={headers}
         loading={loading}
+        searchKey="toolName"
+        searchPlaceholder={t("searchByToolName")}
         {...paginationProps}
+        setSearch={handleSearch}
       />
       {!loading && !success && (
         <TranslatedErrorInlineNotification

--- a/identity/client/src/pages/mcp-processes/List.tsx
+++ b/identity/client/src/pages/mcp-processes/List.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+import { Loading } from "@carbon/react";
+import useTranslate from "src/utility/localization";
+import Page, { PageHeader } from "src/components/layout/Page";
+import { TranslatedErrorInlineNotification } from "src/components/notifications/InlineNotification";
+import { useApi } from "src/utility/api";
+import { searchMessageSubscriptions } from "src/utility/api/message-subscriptions";
+
+const List: FC = () => {
+  const { t } = useTranslate();
+
+  const { data, loading, success, reload } = useApi(
+    searchMessageSubscriptions,
+    { filter: {} },
+  );
+
+  return (
+    <Page>
+      <PageHeader
+        title={t("mcpProcesses")}
+        linkText={t("mcpProcesses").toLowerCase()}
+        shouldShowDocumentationLink={false}
+      />
+      {loading && <Loading withOverlay={false} />}
+      {!loading && success && <pre>{JSON.stringify(data, null, 2)}</pre>}
+      {!loading && !success && (
+        <TranslatedErrorInlineNotification
+          title={t("errorOccurred")}
+          actionButton={{ label: t("retry"), onClick: reload }}
+        />
+      )}
+    </Page>
+  );
+};
+
+export default List;

--- a/identity/client/src/pages/mcp-processes/List.tsx
+++ b/identity/client/src/pages/mcp-processes/List.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { FC, useCallback, useMemo, useState } from "react";
+import { FC, useMemo } from "react";
 import useTranslate from "src/utility/localization";
 import Page, { PageHeader } from "src/components/layout/Page";
 import EntityList, {
@@ -38,23 +38,6 @@ const List: FC = () => {
     return columns;
   }, [t]);
 
-  // Note: Filtering by tool name is currently not supported by the API.
-  const [toolNameSearch, setToolNameSearch] = useState("");
-  const handleSearch = useCallback(
-    (value: Record<string, string> | undefined) => {
-      const toolName = value?.toolName.trim().toLowerCase();
-      setToolNameSearch(toolName ?? "");
-    },
-    [],
-  );
-
-  const filteredTools = useMemo(() => {
-    if (!toolNameSearch) return processTools;
-    return processTools.filter((tool) =>
-      tool.toolName.toLowerCase().includes(toolNameSearch),
-    );
-  }, [processTools, toolNameSearch]);
-
   return (
     <Page>
       <PageHeader
@@ -63,13 +46,12 @@ const List: FC = () => {
         shouldShowDocumentationLink={false}
       />
       <EntityList
-        data={filteredTools}
+        data={processTools}
         headers={headers}
         loading={loading}
         searchKey="toolName"
         searchPlaceholder={t("searchByToolName")}
         {...paginationProps}
-        setSearch={handleSearch}
       />
       {!loading && !success && (
         <TranslatedErrorInlineNotification

--- a/identity/client/src/pages/mcp-processes/List.tsx
+++ b/identity/client/src/pages/mcp-processes/List.tsx
@@ -6,33 +6,55 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { FC } from "react";
-import { Loading } from "@carbon/react";
+import { FC, useMemo } from "react";
 import useTranslate from "src/utility/localization";
 import Page, { PageHeader } from "src/components/layout/Page";
+import EntityList, {
+  type DataTableHeader,
+} from "src/components/entityList/EntityList";
 import { TranslatedErrorInlineNotification } from "src/components/notifications/InlineNotification";
-import { useMcpProcessTools } from "./useMcpProcessTools";
+import { isTenantsApiEnabled } from "src/configuration";
+import { useMcpProcessTools, type McpProcessTool } from "./useMcpProcessTools";
 
 const List: FC = () => {
-  const { t } = useTranslate();
+  const { t } = useTranslate("mcpProcesses");
+  const { t: tComponents } = useTranslate();
 
-  const { processTools, loading, success, reload } = useMcpProcessTools();
+  const { processTools, loading, success, reload, ...paginationProps } =
+    useMcpProcessTools();
+
+  const headers = useMemo<DataTableHeader<McpProcessTool>[]>(() => {
+    const columns: DataTableHeader<McpProcessTool>[] = [
+      { header: t("toolName"), key: "toolName" },
+      { header: t("toolDescription"), key: "toolDescription" },
+      { header: t("processName"), key: "processDefinitionName" },
+      { header: t("version"), key: "processDefinitionVersion" },
+    ];
+
+    if (isTenantsApiEnabled) {
+      columns.push({ header: t("tenant"), key: "tenantId" });
+    }
+
+    return columns;
+  }, [t]);
 
   return (
     <Page>
       <PageHeader
-        title={t("mcpProcesses")}
-        linkText={t("mcpProcesses").toLowerCase()}
+        title={tComponents("mcpProcesses")}
+        linkText={tComponents("mcpProcesses").toLowerCase()}
         shouldShowDocumentationLink={false}
       />
-      {loading && <Loading withOverlay={false} />}
-      {!loading && success && (
-        <pre>{JSON.stringify(processTools, null, 2)}</pre>
-      )}
+      <EntityList
+        data={processTools}
+        headers={headers}
+        loading={loading}
+        {...paginationProps}
+      />
       {!loading && !success && (
         <TranslatedErrorInlineNotification
-          title={t("errorOccurred")}
-          actionButton={{ label: t("retry"), onClick: reload }}
+          title={t("mcpProcessesCouldNotLoad")}
+          actionButton={{ label: tComponents("retry"), onClick: reload }}
         />
       )}
     </Page>

--- a/identity/client/src/pages/mcp-processes/List.tsx
+++ b/identity/client/src/pages/mcp-processes/List.tsx
@@ -25,7 +25,7 @@ const List: FC = () => {
 
   const headers = useMemo<DataTableHeader<McpProcessTool>[]>(() => {
     const columns: DataTableHeader<McpProcessTool>[] = [
-      { header: t("toolName"), key: "toolName" },
+      { header: t("toolName"), key: "toolName", isSortable: true },
       { header: t("toolDescription"), key: "toolDescription" },
       { header: t("processName"), key: "processDefinitionName" },
       { header: t("version"), key: "processDefinitionVersion" },

--- a/identity/client/src/pages/mcp-processes/index.tsx
+++ b/identity/client/src/pages/mcp-processes/index.tsx
@@ -6,6 +6,12 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-export const featureFlags = [];
+import { FC } from "react";
+import Lazy from "src/components/router/Lazy";
+import PageRoutes from "src/components/router/PageRoutes";
 
-export const IS_MCP_PROCESSES_VIEW_ENABLED = true;
+const McpProcesses: FC = () => (
+  <PageRoutes indexElement={<Lazy load={() => import("./List")} />} />
+);
+
+export default McpProcesses;

--- a/identity/client/src/pages/mcp-processes/useMcpProcessTools.ts
+++ b/identity/client/src/pages/mcp-processes/useMcpProcessTools.ts
@@ -6,18 +6,14 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { useMemo } from "react";
-import { z } from "zod";
+import { useCallback, useMemo } from "react";
 import { usePaginatedApi } from "src/utility/api";
 import {
   searchMessageSubscriptions,
   type MessageSubscription,
 } from "src/utility/api/message-subscriptions";
 
-const mcpExtensionPropertiesSchema = z.object({
-  "io.camunda.tool:name": z.string(),
-  "io.camunda.tool:purpose": z.string(),
-});
+const TOOL_PURPOSE_KEY = "io.camunda.tool:purpose";
 
 export type McpProcessTool = {
   id: string;
@@ -33,15 +29,13 @@ export type McpProcessTool = {
 const mapSubscriptionToProcessTool = (
   sub: MessageSubscription,
 ): McpProcessTool | null => {
-  const result = mcpExtensionPropertiesSchema.safeParse(
-    sub.extensionProperties,
-  );
-  if (!result.success) return null;
+  // `toolName` is expected to exists based on the filter supplied to the backend.
+  if (!sub.toolName) return null;
 
   return {
     id: sub.messageSubscriptionKey,
-    toolName: result.data["io.camunda.tool:name"],
-    toolDescription: result.data["io.camunda.tool:purpose"],
+    toolName: sub.toolName,
+    toolDescription: sub.extensionProperties?.[TOOL_PURPOSE_KEY] ?? "-",
     processDefinitionKey: sub.processDefinitionKey,
     processDefinitionId: sub.processDefinitionId,
     processDefinitionName: sub.processDefinitionName ?? sub.processDefinitionId,
@@ -51,9 +45,33 @@ const mapSubscriptionToProcessTool = (
 };
 
 export const useMcpProcessTools = () => {
-  const { data, ...rest } = usePaginatedApi(searchMessageSubscriptions, {
-    filter: { messageSubscriptionType: "START_EVENT" },
-  });
+  const { data, setSearch, ...rest } = usePaginatedApi(
+    searchMessageSubscriptions,
+    {
+      filter: {
+        messageSubscriptionType: "START_EVENT",
+        messageSubscriptionState: { $neq: "DELETED" },
+        toolName: { $exists: true },
+      },
+    },
+  );
+
+  const handleSearch = useCallback(
+    (value: Record<string, string> | undefined) => {
+      const term = value?.toolName?.trim();
+      if (!term) {
+        setSearch(undefined);
+        return;
+      }
+      // `setSearch` is typed as `Record<string, string>`, but the value is
+      // merged into the request `filter`, which supports advanced string
+      // filters like `$like`.
+      setSearch({
+        toolName: { $like: `*${term}*` },
+      } as unknown as Record<string, string>);
+    },
+    [setSearch],
+  );
 
   const processTools = useMemo<McpProcessTool[]>(() => {
     if (!data?.items || data.items.length === 0) {
@@ -67,6 +85,7 @@ export const useMcpProcessTools = () => {
 
   return {
     processTools,
+    setSearch: handleSearch,
     ...rest,
   };
 };

--- a/identity/client/src/pages/mcp-processes/useMcpProcessTools.ts
+++ b/identity/client/src/pages/mcp-processes/useMcpProcessTools.ts
@@ -7,10 +7,46 @@
  */
 
 import { useMemo } from "react";
+import { z } from "zod";
 import { useApi } from "src/utility/api";
-import { searchMessageSubscriptions } from "src/utility/api/message-subscriptions";
+import {
+  searchMessageSubscriptions,
+  type MessageSubscription,
+} from "src/utility/api/message-subscriptions";
 
-const MCP_TOOL_NAME_PROPERTY = "io.camunda.tool:name";
+const mcpExtensionPropertiesSchema = z.object({
+  "io.camunda.tool:name": z.string(),
+  "io.camunda.tool:purpose": z.string(),
+});
+
+export interface ProcessTool {
+  toolKey: string;
+  toolName: string;
+  toolDescription: string;
+  processDefinitionKey: string;
+  processDefinitionName: string;
+  processDefinitionVersion: number | null;
+  tenantId: string | null;
+}
+
+const mapSubscriptionToProcessTool = (
+  sub: MessageSubscription,
+): ProcessTool | null => {
+  const result = mcpExtensionPropertiesSchema.safeParse(
+    sub.extensionProperties,
+  );
+  if (!result.success) return null;
+
+  return {
+    toolKey: sub.messageSubscriptionKey,
+    toolName: result.data["io.camunda.tool:name"],
+    toolDescription: result.data["io.camunda.tool:purpose"],
+    processDefinitionKey: sub.processDefinitionKey,
+    processDefinitionName: sub.processDefinitionName ?? sub.processDefinitionId,
+    processDefinitionVersion: sub.processDefinitionVersion,
+    tenantId: sub.tenantId,
+  };
+};
 
 export const useMcpProcessTools = () => {
   const { data, loading, success, error, reload } = useApi(
@@ -18,13 +54,15 @@ export const useMcpProcessTools = () => {
     { filter: { messageSubscriptionType: "START_EVENT" } },
   );
 
-  const processTools = useMemo(
-    () =>
-      data?.items.filter(
-        (sub) => MCP_TOOL_NAME_PROPERTY in (sub.extensionProperties ?? {}),
-      ) ?? [],
-    [data],
-  );
+  const processTools = useMemo<ProcessTool[]>(() => {
+    if (!data?.items || data.items.length === 0) {
+      return [];
+    }
+
+    return data?.items
+      .map(mapSubscriptionToProcessTool)
+      .filter((p) => p !== null);
+  }, [data]);
 
   return { processTools, loading, success, error, reload };
 };

--- a/identity/client/src/pages/mcp-processes/useMcpProcessTools.ts
+++ b/identity/client/src/pages/mcp-processes/useMcpProcessTools.ts
@@ -8,7 +8,7 @@
 
 import { useMemo } from "react";
 import { z } from "zod";
-import { useApi } from "src/utility/api";
+import { usePaginatedApi } from "src/utility/api";
 import {
   searchMessageSubscriptions,
   type MessageSubscription,
@@ -19,50 +19,54 @@ const mcpExtensionPropertiesSchema = z.object({
   "io.camunda.tool:purpose": z.string(),
 });
 
-export interface ProcessTool {
-  toolKey: string;
+export type McpProcessTool = {
+  id: string;
   toolName: string;
   toolDescription: string;
   processDefinitionKey: string;
+  processDefinitionId: string;
   processDefinitionName: string;
-  processDefinitionVersion: number | null;
-  tenantId: string | null;
-}
+  processDefinitionVersion: number | string;
+  tenantId: string;
+};
 
 const mapSubscriptionToProcessTool = (
   sub: MessageSubscription,
-): ProcessTool | null => {
+): McpProcessTool | null => {
   const result = mcpExtensionPropertiesSchema.safeParse(
     sub.extensionProperties,
   );
   if (!result.success) return null;
 
   return {
-    toolKey: sub.messageSubscriptionKey,
+    id: sub.messageSubscriptionKey,
     toolName: result.data["io.camunda.tool:name"],
     toolDescription: result.data["io.camunda.tool:purpose"],
     processDefinitionKey: sub.processDefinitionKey,
+    processDefinitionId: sub.processDefinitionId,
     processDefinitionName: sub.processDefinitionName ?? sub.processDefinitionId,
-    processDefinitionVersion: sub.processDefinitionVersion,
+    processDefinitionVersion: sub.processDefinitionVersion ?? "-",
     tenantId: sub.tenantId,
   };
 };
 
 export const useMcpProcessTools = () => {
-  const { data, loading, success, error, reload } = useApi(
-    searchMessageSubscriptions,
-    { filter: { messageSubscriptionType: "START_EVENT" } },
-  );
+  const { data, ...rest } = usePaginatedApi(searchMessageSubscriptions, {
+    filter: { messageSubscriptionType: "START_EVENT" },
+  });
 
-  const processTools = useMemo<ProcessTool[]>(() => {
+  const processTools = useMemo<McpProcessTool[]>(() => {
     if (!data?.items || data.items.length === 0) {
       return [];
     }
 
-    return data?.items
+    return data.items
       .map(mapSubscriptionToProcessTool)
       .filter((p) => p !== null);
   }, [data]);
 
-  return { processTools, loading, success, error, reload };
+  return {
+    processTools,
+    ...rest,
+  };
 };

--- a/identity/client/src/pages/mcp-processes/useMcpProcessTools.ts
+++ b/identity/client/src/pages/mcp-processes/useMcpProcessTools.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { useMemo } from "react";
+import { useApi } from "src/utility/api";
+import { searchMessageSubscriptions } from "src/utility/api/message-subscriptions";
+
+const MCP_TOOL_NAME_PROPERTY = "io.camunda.tool:name";
+
+export const useMcpProcessTools = () => {
+  const { data, loading, success, error, reload } = useApi(
+    searchMessageSubscriptions,
+    { filter: { messageSubscriptionType: "START_EVENT" } },
+  );
+
+  const processTools = useMemo(
+    () =>
+      data?.items.filter(
+        (sub) => MCP_TOOL_NAME_PROPERTY in (sub.extensionProperties ?? {}),
+      ) ?? [],
+    [data],
+  );
+
+  return { processTools, loading, success, error, reload };
+};

--- a/identity/client/src/pages/mcp-processes/useMcpProcessTools.ts
+++ b/identity/client/src/pages/mcp-processes/useMcpProcessTools.ts
@@ -6,14 +6,18 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { useCallback, useMemo } from "react";
-import { usePaginatedApi } from "src/utility/api";
+import { useMemo } from "react";
+import { useApi, usePagination } from "src/utility/api";
 import {
   searchMessageSubscriptions,
   type MessageSubscription,
+  type QueryMessageSubscriptionsRequestBody,
 } from "src/utility/api/message-subscriptions";
 
 const TOOL_PURPOSE_KEY = "io.camunda.tool:purpose";
+
+type Sort = NonNullable<QueryMessageSubscriptionsRequestBody["sort"]>;
+const DEFAULT_SORT: Sort = [{ field: "toolName", order: "asc" }];
 
 export type McpProcessTool = {
   id: string;
@@ -29,7 +33,7 @@ export type McpProcessTool = {
 const mapSubscriptionToProcessTool = (
   sub: MessageSubscription,
 ): McpProcessTool | null => {
-  // `toolName` is expected to exists based on the filter supplied to the backend.
+  // `toolName` is expected to exist based on the filter supplied to the backend.
   if (!sub.toolName) return null;
 
   return {
@@ -45,33 +49,27 @@ const mapSubscriptionToProcessTool = (
 };
 
 export const useMcpProcessTools = () => {
-  const { data, setSearch, ...rest } = usePaginatedApi(
-    searchMessageSubscriptions,
-    {
-      filter: {
-        messageSubscriptionType: "START_EVENT",
-        messageSubscriptionState: { $neq: "DELETED" },
-        toolName: { $exists: true },
-      },
-    },
-  );
+  const { pageParams, page, ...paginationRest } = usePagination();
 
-  const handleSearch = useCallback(
-    (value: Record<string, string> | undefined) => {
-      const term = value?.toolName?.trim();
-      if (!term) {
-        setSearch(undefined);
-        return;
-      }
-      // `setSearch` is typed as `Record<string, string>`, but the value is
-      // merged into the request `filter`, which supports advanced string
-      // filters like `$like`.
-      setSearch({
-        toolName: { $like: `*${term}*` },
-      } as unknown as Record<string, string>);
+  const searchTermsFilter = useMemo(() => {
+    const term = pageParams.filter?.toolName?.trim();
+    if (!term) return undefined;
+    return { toolName: { $like: `*${term}*` } };
+  }, [pageParams.filter]);
+
+  const { data, ...apiRest } = useApi(searchMessageSubscriptions, {
+    sort: (pageParams.sort ?? DEFAULT_SORT) as Sort,
+    filter: {
+      messageSubscriptionType: "START_EVENT",
+      messageSubscriptionState: { $neq: "DELETED" },
+      toolName: { $exists: true },
+      ...searchTermsFilter,
     },
-    [setSearch],
-  );
+    page: {
+      from: pageParams.page.from,
+      limit: pageParams.page.limit,
+    },
+  });
 
   const processTools = useMemo<McpProcessTool[]>(() => {
     if (!data?.items || data.items.length === 0) {
@@ -85,7 +83,8 @@ export const useMcpProcessTools = () => {
 
   return {
     processTools,
-    setSearch: handleSearch,
-    ...rest,
+    page: { ...page, ...data?.page },
+    ...paginationRest,
+    ...apiRest,
   };
 };

--- a/identity/client/src/utility/api/message-subscriptions/index.ts
+++ b/identity/client/src/utility/api/message-subscriptions/index.ts
@@ -48,6 +48,9 @@ type AdvancedStringFilter =
 type BaseMessageSubscriptionFilter = NonNullable<
   BaseQueryMessageSubscriptionsRequestBody["filter"]
 >;
+type BaseMessageSubscriptionSort = NonNullable<
+  BaseQueryMessageSubscriptionsRequestBody["sort"]
+>[number];
 
 interface MessageSubscriptionFilter extends BaseMessageSubscriptionFilter {
   messageSubscriptionType?: MessageSubscriptionType;
@@ -55,11 +58,19 @@ interface MessageSubscriptionFilter extends BaseMessageSubscriptionFilter {
   inboundConnectorType?: AdvancedStringFilter;
 }
 
+interface MessageSubscriptionSort extends Omit<
+  BaseMessageSubscriptionSort,
+  "field"
+> {
+  field: BaseMessageSubscriptionSort["field"] | "toolName";
+}
+
 export interface QueryMessageSubscriptionsRequestBody extends Omit<
   BaseQueryMessageSubscriptionsRequestBody,
-  "filter"
+  "filter" | "sort"
 > {
   filter?: MessageSubscriptionFilter;
+  sort?: MessageSubscriptionSort[];
 }
 
 export interface QueryMessageSubscriptionsResponseBody extends Omit<

--- a/identity/client/src/utility/api/message-subscriptions/index.ts
+++ b/identity/client/src/utility/api/message-subscriptions/index.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {
+  QueryMessageSubscriptionsRequestBody,
+  QueryMessageSubscriptionsResponseBody,
+} from "@camunda/camunda-api-zod-schemas/8.10";
+import { ApiDefinition, apiPost } from "src/utility/api/request";
+
+export const MESSAGE_SUBSCRIPTIONS_ENDPOINT = "/message-subscriptions";
+
+export const searchMessageSubscriptions: ApiDefinition<
+  QueryMessageSubscriptionsResponseBody,
+  QueryMessageSubscriptionsRequestBody | undefined
+> = (params) => apiPost(`${MESSAGE_SUBSCRIPTIONS_ENDPOINT}/search`, params);

--- a/identity/client/src/utility/api/message-subscriptions/index.ts
+++ b/identity/client/src/utility/api/message-subscriptions/index.ts
@@ -30,7 +30,20 @@ export interface MessageSubscription extends BaseMessageSubscription {
   extensionProperties: Record<string, string>;
   processDefinitionName: string | null;
   processDefinitionVersion: number | null;
+  toolName: string | null;
+  inboundConnectorType: string | null;
 }
+
+type AdvancedStringFilter =
+  | string
+  | {
+      $eq?: string;
+      $neq?: string;
+      $exists?: boolean;
+      $in?: string[];
+      $notIn?: string[];
+      $like?: string;
+    };
 
 type BaseMessageSubscriptionFilter = NonNullable<
   BaseQueryMessageSubscriptionsRequestBody["filter"]
@@ -38,6 +51,8 @@ type BaseMessageSubscriptionFilter = NonNullable<
 
 interface MessageSubscriptionFilter extends BaseMessageSubscriptionFilter {
   messageSubscriptionType?: MessageSubscriptionType;
+  toolName?: AdvancedStringFilter;
+  inboundConnectorType?: AdvancedStringFilter;
 }
 
 export interface QueryMessageSubscriptionsRequestBody extends Omit<

--- a/identity/client/src/utility/api/message-subscriptions/index.ts
+++ b/identity/client/src/utility/api/message-subscriptions/index.ts
@@ -7,8 +7,9 @@
  */
 
 import type {
-  QueryMessageSubscriptionsRequestBody,
-  QueryMessageSubscriptionsResponseBody,
+  MessageSubscription as BaseMessageSubscription,
+  QueryMessageSubscriptionsRequestBody as BaseQueryMessageSubscriptionsRequestBody,
+  QueryMessageSubscriptionsResponseBody as BaseQueryMessageSubscriptionsResponseBody,
 } from "@camunda/camunda-api-zod-schemas/8.10";
 import { ApiDefinition, apiPost } from "src/utility/api/request";
 
@@ -18,3 +19,37 @@ export const searchMessageSubscriptions: ApiDefinition<
   QueryMessageSubscriptionsResponseBody,
   QueryMessageSubscriptionsRequestBody | undefined
 > = (params) => apiPost(`${MESSAGE_SUBSCRIPTIONS_ENDPOINT}/search`, params);
+
+// TODO: Remove extended types once API is stabilized and schema merged back into @camunda/camunda-api-zod-schemas.
+// https://github.com/camunda/camunda/issues/51241
+
+type MessageSubscriptionType = "START_EVENT" | "PROCESS_EVENT";
+
+export interface MessageSubscription extends BaseMessageSubscription {
+  messageSubscriptionType: MessageSubscriptionType;
+  extensionProperties: Record<string, string>;
+  processDefinitionName: string | null;
+  processDefinitionVersion: number | null;
+}
+
+type BaseMessageSubscriptionFilter = NonNullable<
+  BaseQueryMessageSubscriptionsRequestBody["filter"]
+>;
+
+interface MessageSubscriptionFilter extends BaseMessageSubscriptionFilter {
+  messageSubscriptionType?: MessageSubscriptionType;
+}
+
+export interface QueryMessageSubscriptionsRequestBody extends Omit<
+  BaseQueryMessageSubscriptionsRequestBody,
+  "filter"
+> {
+  filter?: MessageSubscriptionFilter;
+}
+
+export interface QueryMessageSubscriptionsResponseBody extends Omit<
+  BaseQueryMessageSubscriptionsResponseBody,
+  "items"
+> {
+  items: MessageSubscription[];
+}

--- a/identity/client/src/utility/localization/en/components.json
+++ b/identity/client/src/utility/localization/en/components.json
@@ -16,6 +16,7 @@
   "clusterVariables": "Cluster variables",
   "clusterVariable": "Cluster variable",
   "operationsLog": "Operations Log",
+  "mcpProcesses": "MCP Processes",
   "globalTaskListeners": "Global user task listeners",
   "globalTaskListener": "Global user task listener",
   "unauthorized": "Unauthorized",

--- a/identity/client/src/utility/localization/en/index.ts
+++ b/identity/client/src/utility/localization/en/index.ts
@@ -18,6 +18,7 @@ import clusterVariables from "./clusterVariables.json";
 import operationsLog from "./operationsLog.json";
 import authentication from "./authentication.json";
 import globalTaskListeners from "./globalTaskListeners.json";
+import mcpProcesses from "./mcpProcesses.json";
 
 export default {
   components,
@@ -32,4 +33,5 @@ export default {
   operationsLog,
   authentication,
   globalTaskListeners,
+  mcpProcesses,
 };

--- a/identity/client/src/utility/localization/en/mcpProcesses.json
+++ b/identity/client/src/utility/localization/en/mcpProcesses.json
@@ -1,0 +1,8 @@
+{
+  "toolName": "Tool Name",
+  "toolDescription": "Tool Description",
+  "processName": "Process Name",
+  "version": "Version",
+  "tenant": "Tenant",
+  "mcpProcessesCouldNotLoad": "MCP Processes could not be loaded."
+}

--- a/identity/client/src/utility/localization/en/mcpProcesses.json
+++ b/identity/client/src/utility/localization/en/mcpProcesses.json
@@ -4,5 +4,6 @@
   "processName": "Process Name",
   "version": "Version",
   "tenant": "Tenant",
+  "searchByToolName": "Search by tool name",
   "mcpProcessesCouldNotLoad": "MCP Processes could not be loaded."
 }


### PR DESCRIPTION
## Description

### Changes

- ~~Adds a `IS_MCP_PROCESSES_VIEW_ENABLED` feature flag for the MCP Processes page.~~
- Adds a new "MCP Processes" header link between "Cluster Variables" and "Operations Log" (similar to Wireframe in #51241).
- Loads data from `POST /v2/message-subscriptions/search` and maps them into client-optimized `McpProcessTools` for display.
  - Uses the `io.camunda.tool:purpose` extended property as the tool description.
- Displays `McpProcessTools` in an `EntityTable`
- Supports server-side pagination
- Supports server-side filtering by tool-name through a `$like: *${term}*` filter query
- Supports server-side sorting for the `toolName` field

> [!NOTE]
> Tests are added in a follow-up PR: https://github.com/camunda/camunda/pull/51538
> Zod schemas get synced back in a follow-up PR: https://github.com/camunda/camunda/pull/51592

<img width="1761" height="992" alt="Screenshot 2026-04-21 at 11 08 12" src="https://github.com/user-attachments/assets/fa2cf8f6-2e64-4268-9be6-7ff78c1b9549" />

## Checklist

- [ ] Backend API changes **MUST** be merged before merging this PR 
- [ ] This branch requires changes that will be introduced https://github.com/camunda/camunda/pull/51449. Locally testing it required a backend started from that branch.

## Related issues

closes #51241
