### PR TITLE
51307 exporter configuration kebab case

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/context/ExporterConfiguration.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/context/ExporterConfiguration.java
@@ -7,18 +7,39 @@
  */
 package io.camunda.zeebe.broker.exporter.context;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.json.JsonReadFeature;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.util.TokenBuffer;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.camunda.zeebe.exporter.api.context.Configuration;
+import io.camunda.zeebe.exporter.api.context.StrictConfiguration;
 import io.camunda.zeebe.util.ReflectUtil;
+import java.io.IOException;
+import java.lang.reflect.Array;
 import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public record ExporterConfiguration(String id, Map<String, Object> arguments)
     implements Configuration {
@@ -30,6 +51,10 @@ public record ExporterConfiguration(String id, Map<String, Object> arguments)
    * <p>Features:
    *
    * <ul>
+   *   <li>All incoming keys are normalised to lowercase with separators stripped ({@code
+   *       normalizeKeys}), so {@code myField}, {@code my-field}, {@code MY-FIELD}, and {@code
+   *       myfield} are all equivalent. {@code ACCEPT_CASE_INSENSITIVE_PROPERTIES} then matches the
+   *       normalised key to the Java field name.
    *   <li>Case-insensitive enum, property, and value matching
    *   <li>Custom List deserializer for Spring Boot indexed properties (myList[0]=value)
    *   <li>Custom Path module to preserve relative/absolute paths (no resolution)
@@ -37,7 +62,7 @@ public record ExporterConfiguration(String id, Map<String, Object> arguments)
    *   <li>JavaTimeModule for other temporal types (Instant, LocalDateTime, etc.)
    * </ul>
    */
-  public static final ObjectMapper MAPPER =
+  static final ObjectMapper MAPPER =
       JsonMapper.builder()
           .addModule(new JavaTimeModule())
           .addModule(createDurationModule())
@@ -51,6 +76,18 @@ public record ExporterConfiguration(String id, Map<String, Object> arguments)
           .enable(JsonReadFeature.ALLOW_SINGLE_QUOTES)
           .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
           .build();
+
+  private static final Logger LOG = LoggerFactory.getLogger(ExporterConfiguration.class);
+
+  /**
+   * Strict variant of {@link #MAPPER} that rejects unknown properties. Used in {@link
+   * #fromArgs(Class, Map)} to fail fast at startup when the exporter args contain a typo or an
+   * unsupported property name.
+   */
+  private static final ObjectMapper STRICT_MAPPER =
+      MAPPER.copy().enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+  private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
 
   @Override
   public String getId() {
@@ -69,12 +106,185 @@ public record ExporterConfiguration(String id, Map<String, Object> arguments)
 
   public static <T> T fromArgs(final Class<T> configClass, final Map<String, Object> values) {
     if (values != null) {
-      // Use MAPPER (with custom list deserializer) to properly handle Spring Boot indexed
-      // properties like myList[0]=value which are stored as Maps with numeric string keys
-      return MAPPER.convertValue(values, configClass);
+      // Normalize all keys to lowercase-no-separator so that camelCase, kebab-case, and the
+      // all-lowercase concatenated form produced by Spring Boot env var lowercasing are all
+      // equivalent. ACCEPT_CASE_INSENSITIVE_PROPERTIES then matches the normalised key to the
+      // Java field name regardless of original casing.
+      final var normalized = normalizeKeys(values, MAPPER.constructType(configClass));
+      final var mapper =
+          configClass.isAnnotationPresent(StrictConfiguration.class) ? STRICT_MAPPER : MAPPER;
+      try {
+        return mapper.convertValue(normalized, configClass);
+      } catch (final IllegalArgumentException e) {
+        if (e.getCause() instanceof final UnrecognizedPropertyException upe) {
+          // getReferringClass() is the actual class that owns the unrecognized property.
+          // When the typo is inside a nested object it differs from configClass, so prefer it;
+          // fall back to configClass only if Jackson did not populate it.
+          final var referringClass = upe.getReferringClass();
+          final var className =
+              referringClass != null ? referringClass.getSimpleName() : configClass.getSimpleName();
+          // getPathReference() produces a human-readable path like
+          // "ElasticsearchExporterConfiguration[\"index\"]->IndexConfiguration[\"unknownProp\"]"
+          // which lets users locate the typo even in deeply nested configs.
+          final var message =
+              "Unknown exporter configuration property '"
+                  + upe.getPropertyName()
+                  + "' in "
+                  + className
+                  + " (path: "
+                  + upe.getPathReference()
+                  + "); known properties: "
+                  + upe.getKnownPropertyIds();
+          LOG.error(message);
+          throw new IllegalArgumentException(message, upe);
+        }
+        throw e;
+      }
     } else {
       return ReflectUtil.newInstance(configClass);
     }
+  }
+
+  /**
+   * Normalises keys that represent configuration properties to lowercase with separators stripped,
+   * so that {@code myField}, {@code my-field}, {@code MY-FIELD}, and {@code myfield} all map to the
+   * same canonical key.
+   *
+   * <p>The normalisation is type-aware: object-property maps are normalised recursively, while map
+   * keys of {@code Map<K, V>} fields are preserved as user data.
+   *
+   * @param map the raw exporter args map
+   * @return the same structure with normalised lowercase keys
+   */
+  private static Map<String, Object> normalizeKeys(
+      final Map<String, Object> map, final JavaType targetType) {
+    final var result = new LinkedHashMap<String, Object>(map.size());
+    final var propertyTypesByKey = propertyTypesByNormalizedKey(targetType);
+    final var indexedElementType = indexedElementType(targetType, map);
+    for (final var entry : map.entrySet()) {
+      final var normalizedKey = normalizeKey(entry.getKey());
+      var propertyType = propertyTypesByKey.get(normalizedKey);
+      if (propertyType == null) {
+        propertyType = indexedElementType;
+      }
+      result.put(normalizedKey, normalizeValue(entry.getValue(), propertyType));
+    }
+    return result;
+  }
+
+  private static JavaType indexedElementType(
+      final JavaType targetType, final Map<String, Object> map) {
+    if (targetType == null || (!targetType.isCollectionLikeType() && !targetType.isArrayType())) {
+      return null;
+    }
+
+    var hasNumericKeys = false;
+    var hasNonNumericKeys = false;
+    for (final var key : map.keySet()) {
+      try {
+        Integer.parseInt(key);
+        hasNumericKeys = true;
+      } catch (final NumberFormatException e) {
+        hasNonNumericKeys = true;
+      }
+    }
+
+    if (hasNumericKeys && hasNonNumericKeys) {
+      throw new IllegalArgumentException(
+          "Cannot mix indexed (numeric) and named keys in configuration map targeting a collection: "
+              + map.keySet());
+    }
+
+    return hasNumericKeys ? targetType.getContentType() : null;
+  }
+
+  private static Map<String, JavaType> propertyTypesByNormalizedKey(final JavaType targetType) {
+    if (targetType == null || targetType.isMapLikeType() || targetType.isContainerType()) {
+      return Map.of();
+    }
+
+    final var properties =
+        MAPPER.getDeserializationConfig().introspect(targetType).findProperties();
+    if (properties.isEmpty()) {
+      return Map.of();
+    }
+
+    final var propertyTypes = new LinkedHashMap<String, JavaType>(properties.size());
+    for (final var property : properties) {
+      final var propertyType = property.getPrimaryType();
+      if (propertyType != null) {
+        propertyTypes.put(normalizeKey(property.getName()), propertyType);
+      }
+    }
+    return propertyTypes;
+  }
+
+  private static Object normalizeValue(final Object value, final JavaType targetType) {
+    if (value instanceof final Map<?, ?> nestedMap) {
+      return normalizeMapValue(nestedMap, targetType);
+    }
+
+    if (value instanceof final Iterable<?> iterable) {
+      return normalizeIterableValue(iterable, targetType);
+    }
+
+    if (value != null && value.getClass().isArray()) {
+      return normalizeArrayValue(value, targetType);
+    }
+
+    return value;
+  }
+
+  private static Object normalizeMapValue(final Map<?, ?> nestedMap, final JavaType targetType) {
+    if (targetType == null || targetType.hasRawClass(Object.class)) {
+      return nestedMap;
+    }
+
+    if (targetType.isMapLikeType()) {
+      return normalizeMapValues(nestedMap, targetType.getContentType());
+    }
+
+    @SuppressWarnings("unchecked")
+    final var typedNested = (Map<String, Object>) nestedMap;
+    return normalizeKeys(typedNested, targetType);
+  }
+
+  private static List<Object> normalizeIterableValue(
+      final Iterable<?> iterable, final JavaType targetType) {
+    final var contentType =
+        targetType != null && targetType.isCollectionLikeType()
+            ? targetType.getContentType()
+            : null;
+    final var normalized = new ArrayList<>();
+    for (final var item : iterable) {
+      normalized.add(normalizeValue(item, contentType));
+    }
+    return normalized;
+  }
+
+  private static Object[] normalizeArrayValue(final Object value, final JavaType targetType) {
+    final var length = Array.getLength(value);
+    final var contentType =
+        targetType != null && targetType.isArrayType() ? targetType.getContentType() : null;
+    final var normalized = new Object[length];
+    for (int i = 0; i < length; i++) {
+      normalized[i] = normalizeValue(Array.get(value, i), contentType);
+    }
+    return normalized;
+  }
+
+  private static Map<Object, Object> normalizeMapValues(
+      final Map<?, ?> map, final JavaType contentType) {
+    final var result = new LinkedHashMap<Object, Object>(map.size());
+    for (final var entry : map.entrySet()) {
+      result.put(entry.getKey(), normalizeValue(entry.getValue(), contentType));
+    }
+    return result;
+  }
+
+  /** Strips hyphens and lowercases a key so all naming styles map to the same canonical form. */
+  private static String normalizeKey(final String name) {
+    return name.replace("-", "").toLowerCase(Locale.ROOT);
   }
 
   /**
@@ -91,7 +301,7 @@ public record ExporterConfiguration(String id, Map<String, Object> arguments)
   }
 
   public static <T> Map<String, Object> asArgs(final T config) {
-    return MAPPER.convertValue(config, Map.class);
+    return MAPPER.convertValue(config, MAP_TYPE);
   }
 
   /**
@@ -105,44 +315,36 @@ public record ExporterConfiguration(String id, Map<String, Object> arguments)
   private static SimpleModule createDurationModule() {
     return new SimpleModule()
         .addSerializer(
-            java.time.Duration.class,
-            new com.fasterxml.jackson.databind.JsonSerializer<java.time.Duration>() {
+            Duration.class,
+            new JsonSerializer<>() {
               @Override
               public void serialize(
-                  final java.time.Duration value,
-                  final com.fasterxml.jackson.core.JsonGenerator gen,
-                  final com.fasterxml.jackson.databind.SerializerProvider serializers)
-                  throws java.io.IOException {
-                // Write as embedded POJO to preserve Duration object when using convertValue()
-                // For TokenBuffer (used by convertValue), this keeps the Duration object as-is
-                if (gen instanceof com.fasterxml.jackson.databind.util.TokenBuffer) {
+                  final Duration value,
+                  final JsonGenerator gen,
+                  final SerializerProvider serializers)
+                  throws IOException {
+                if (gen instanceof TokenBuffer) {
                   gen.writeEmbeddedObject(value);
                 } else {
-                  // For actual JSON output, write as ISO-8601 string
                   gen.writeString(value.toString());
                 }
               }
             })
         .addDeserializer(
-            java.time.Duration.class,
-            new com.fasterxml.jackson.databind.JsonDeserializer<java.time.Duration>() {
+            Duration.class,
+            new JsonDeserializer<>() {
               @Override
-              public java.time.Duration deserialize(
-                  final com.fasterxml.jackson.core.JsonParser p,
-                  final com.fasterxml.jackson.databind.DeserializationContext ctxt)
-                  throws java.io.IOException {
-                // Handle embedded Duration objects (from TokenBuffer used by convertValue)
-                if (p.currentToken()
-                    == com.fasterxml.jackson.core.JsonToken.VALUE_EMBEDDED_OBJECT) {
+              public Duration deserialize(final JsonParser p, final DeserializationContext ctxt)
+                  throws IOException {
+                if (p.currentToken() == JsonToken.VALUE_EMBEDDED_OBJECT) {
                   final Object embedded = p.getEmbeddedObject();
-                  if (embedded instanceof java.time.Duration) {
-                    return (java.time.Duration) embedded;
+                  if (embedded instanceof final Duration duration) {
+                    return duration;
                   }
                 }
-                // Parse from string format like "PT0.5S" (from Spring Boot properties)
                 final String text = p.getText();
                 if (text != null && !text.isEmpty()) {
-                  return java.time.Duration.parse(text);
+                  return Duration.parse(text);
                 }
                 return null;
               }
@@ -161,26 +363,20 @@ public record ExporterConfiguration(String id, Map<String, Object> arguments)
     return new SimpleModule()
         .addSerializer(
             Path.class,
-            new com.fasterxml.jackson.databind.JsonSerializer<Path>() {
+            new JsonSerializer<>() {
               @Override
               public void serialize(
-                  final Path value,
-                  final com.fasterxml.jackson.core.JsonGenerator gen,
-                  final com.fasterxml.jackson.databind.SerializerProvider serializers)
-                  throws java.io.IOException {
-                // Serialize Path as its string representation, preserving relative/absolute form
+                  final Path value, final JsonGenerator gen, final SerializerProvider serializers)
+                  throws IOException {
                 gen.writeString(value.toString());
               }
             })
         .addDeserializer(
             Path.class,
-            new com.fasterxml.jackson.databind.JsonDeserializer<Path>() {
+            new JsonDeserializer<>() {
               @Override
-              public Path deserialize(
-                  final com.fasterxml.jackson.core.JsonParser p,
-                  final com.fasterxml.jackson.databind.DeserializationContext ctxt)
-                  throws java.io.IOException {
-                // Deserialize string to Path using Path.of(), preserving relative/absolute form
+              public Path deserialize(final JsonParser p, final DeserializationContext ctxt)
+                  throws IOException {
                 return Path.of(p.getText());
               }
             });
@@ -204,7 +400,7 @@ public record ExporterConfiguration(String id, Map<String, Object> arguments)
      * @param consumer the consumer that modifies the configuration
      * @return this mapper for method chaining
      */
-    public ConfigurationMapper<T> apply(final java.util.function.Consumer<T> consumer) {
+    public ConfigurationMapper<T> apply(final Consumer<T> consumer) {
       consumer.accept(config);
       return this;
     }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/context/ExporterConfigurationListDeserializer.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/context/ExporterConfigurationListDeserializer.java
@@ -67,9 +67,12 @@ final class ExporterConfigurationListDeserializer<E> extends JsonDeserializer<Li
     return switch (p.currentToken()) {
       case START_ARRAY -> deserializeArray(p, ctxt);
       case START_OBJECT -> deserializeMapWithNumericKeys(p, ctxt);
+      // Spring Boot flattens an empty YAML list (`[]`) to an empty string in the args map.
+      // Treat any empty string value as an empty list rather than failing.
+      case VALUE_STRING -> p.getText().isEmpty() ? List.of() : deserializeSingletonList(p, ctxt);
       default ->
           throw new IllegalArgumentException(
-              "Expected START_ARRAY or START_OBJECT, got: " + p.currentToken());
+              "Expected START_ARRAY, START_OBJECT, or VALUE_STRING, got: " + p.currentToken());
     };
   }
 
@@ -85,6 +88,19 @@ final class ExporterConfigurationListDeserializer<E> extends JsonDeserializer<Li
       final E value = (E) ctxt.readValue(p, contentType);
       result.add(value);
     }
+    return result;
+  }
+
+  /**
+   * Wraps a single non-empty string value into a one-element list. Spring Boot may pass a plain
+   * string when only one value is configured without explicit YAML array syntax.
+   */
+  @SuppressWarnings("unchecked")
+  private List<E> deserializeSingletonList(final JsonParser p, final DeserializationContext ctxt)
+      throws IOException {
+    final E value = (E) ctxt.readValue(p, contentType);
+    final List<E> result = new ArrayList<>(1);
+    result.add(value);
     return result;
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/context/ExporterConfigurationListDeserializerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/context/ExporterConfigurationListDeserializerTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.exporter.context;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+/**
+ * Unit tests for {@link ExporterConfigurationListDeserializer}.
+ *
+ * <p>The deserializer handles four distinct token cases: a proper JSON array ({@code START_ARRAY}),
+ * a map with numeric keys ({@code START_OBJECT}), an empty string (Spring Boot flattens {@code []}
+ * to {@code ""}), and a non-empty string (Spring Boot single-value shorthand). An unexpected token
+ * type must throw immediately.
+ *
+ * <p>All scenarios are exercised through {@link ExporterConfiguration#fromArgs} because the
+ * deserializer is only registered on the package-private {@link ExporterConfiguration#MAPPER}.
+ */
+@Execution(ExecutionMode.CONCURRENT)
+final class ExporterConfigurationListDeserializerTest {
+
+  // ---------------------------------------------------------------------------
+  // START_ARRAY — standard JSON / YAML array syntax
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldDeserializeFromJsonArray() {
+    // given — List.of(...) goes through normalizeValue's Iterable branch and becomes an ArrayList,
+    // which Jackson serialises as a JSON array → START_ARRAY token hits deserializeArray()
+    final var args = Map.<String, Object>of("items", List.of("a", "b", "c"));
+
+    // when
+    final var instance = ExporterConfiguration.fromArgs(StringListConfig.class, args);
+
+    // then
+    assertThat(instance.items()).containsExactly("a", "b", "c");
+  }
+
+  @Test
+  void shouldDeserializeEmptyJsonArrayAsEmptyList() {
+    // given
+    final var args = Map.<String, Object>of("items", List.of());
+
+    // when
+    final var instance = ExporterConfiguration.fromArgs(StringListConfig.class, args);
+
+    // then
+    assertThat(instance.items()).isEmpty();
+  }
+
+  // ---------------------------------------------------------------------------
+  // START_OBJECT — Spring Boot indexed properties (myList[0]=value)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldDeserializeMapWithNumericKeysAsList() {
+    // given — Spring Boot flattens myList[0]=a, myList[1]=b to {"0": "a", "1": "b"}
+    final var args = Map.<String, Object>of("items", Map.of("0", "a", "1", "b"));
+
+    // when
+    final var instance = ExporterConfiguration.fromArgs(StringListConfig.class, args);
+
+    // then
+    assertThat(instance.items()).containsExactly("a", "b");
+  }
+
+  // ---------------------------------------------------------------------------
+  // VALUE_STRING — Spring Boot empty-list and single-value shorthands
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldDeserializeEmptyStringAsEmptyList() {
+    // given — Spring Boot flattens an empty YAML list (`items: []`) to an empty string
+    final var args = Map.<String, Object>of("items", "");
+
+    // when
+    final var instance = ExporterConfiguration.fromArgs(StringListConfig.class, args);
+
+    // then
+    assertThat(instance.items()).isEmpty();
+  }
+
+  @Test
+  void shouldDeserializeNonEmptyStringAsSingletonList() {
+    // given — Spring Boot may write a single value without array syntax (items: hello)
+    final var args = Map.<String, Object>of("items", "hello");
+
+    // when
+    final var instance = ExporterConfiguration.fromArgs(StringListConfig.class, args);
+
+    // then
+    assertThat(instance.items()).containsExactly("hello");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Unexpected token
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldThrowOnUnexpectedTokenType() {
+    // given — an integer is not a valid token type for List deserialization
+    final var args = Map.<String, Object>of("items", 42);
+
+    // when - then
+    assertThatCode(() -> ExporterConfiguration.fromArgs(StringListConfig.class, args))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Expected START_ARRAY, START_OBJECT, or VALUE_STRING");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Sparse / non-integer numeric key validation (map → list conversion)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldThrowOnSparseNumericKeys() {
+    // given — keys start at 1 (gap at 0) making list insertion fail with IndexOutOfBoundsException
+    final var args = Map.<String, Object>of("items", Map.of("1", "a", "2", "b"));
+
+    // when - then
+    assertThatCode(() -> ExporterConfiguration.fromArgs(StringListConfig.class, args))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasRootCauseInstanceOf(IndexOutOfBoundsException.class);
+  }
+
+  @Test
+  void shouldThrowOnNonNumericMapKeys() {
+    // given — non-integer keys cannot be interpreted as list indices
+    final var args = Map.<String, Object>of("items", Map.of("foo", "a", "bar", "b"));
+
+    // when - then
+    assertThatCode(() -> ExporterConfiguration.fromArgs(StringListConfig.class, args))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasRootCauseInstanceOf(NumberFormatException.class);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Test fixtures
+  // ---------------------------------------------------------------------------
+
+  private record StringListConfig(List<String> items) {}
+}

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/context/ExporterConfigurationTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/context/ExporterConfigurationTest.java
@@ -10,7 +10,11 @@ package io.camunda.zeebe.broker.exporter.context;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
+import io.camunda.zeebe.exporter.api.context.StrictConfiguration;
 import io.camunda.zeebe.test.util.junit.RegressionTest;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -21,8 +25,26 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 @Execution(ExecutionMode.CONCURRENT)
 final class ExporterConfigurationTest {
+
+  // ---------------------------------------------------------------------------
+  // fromArgs — key normalization
+  // ---------------------------------------------------------------------------
+
   @ParameterizedTest
-  @ValueSource(strings = {"numberofshards", "numberOfShards", "NUMBEROFSHARDS"})
+  @ValueSource(
+      strings = {
+        // kebab-case (hyphens stripped by normalizeKey)
+        "number-of-shards",
+        // camelCase (lowercased by normalizeKey)
+        "numberOfShards",
+        // uppercase kebab-case (hyphens stripped + lowercased by normalizeKey)
+        "NUMBER-OF-SHARDS",
+        // all-lowercase concatenated — the form produced by Spring Boot env var lowercasing
+        // e.g. ARGS_NUMBEROFSHARDS → Spring lowercases → numberofshards
+        "numberofshards",
+        // uppercase concatenated — matched via lowercase normalisation
+        "NUMBEROFSHARDS"
+      })
   void shouldInstantiateConfigWithCaseInsensitiveProperties(final String property) {
     // given
     final var args = Map.<String, Object>of(property, 1);
@@ -37,7 +59,14 @@ final class ExporterConfigurationTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"numberofshards", "numberOfShards", "NUMBEROFSHARDS"})
+  @ValueSource(
+      strings = {
+        "number-of-shards",
+        "numberOfShards",
+        "NUMBER-OF-SHARDS",
+        "numberofshards",
+        "NUMBEROFSHARDS"
+      })
   void shouldInstantiateNestedConfigWithCaseInsensitiveProperties(final String property) {
     // given
     final var args = Map.<String, Object>of("nested", Map.of(property, 1));
@@ -52,9 +81,93 @@ final class ExporterConfigurationTest {
   }
 
   @Test
+  void shouldPreserveMapPropertyKeys() {
+    // given — only object property names should be normalized; map keys are user data and must stay
+    // intact
+    final var args =
+        Map.<String, Object>of("LABELS", Map.of("Tenant-A", "alpha", "tenant-b", "beta"));
+    final var config = new ExporterConfiguration("id", args);
+
+    // when
+    final var instance = config.instantiate(LabelsConfig.class);
+
+    // then
+    assertThat(instance)
+        .isEqualTo(new LabelsConfig(Map.of("Tenant-A", "alpha", "tenant-b", "beta")));
+  }
+
+  @Test
+  void shouldNormalizeObjectValuesInsideMapProperty() {
+    // given — map keys are data and must stay unchanged, but nested object properties inside each
+    // value should still be normalized
+    final var args =
+        Map.<String, Object>of(
+            "configs",
+            Map.of(
+                "tenant-A", Map.of("NUMBER-OF-SHARDS", 1),
+                "tenant-B", Map.of("numberOfShards", 2)));
+    final var config = new ExporterConfiguration("id", args);
+
+    // when
+    final var instance = config.instantiate(NamedConfigs.class);
+
+    // then
+    assertThat(instance)
+        .isEqualTo(new NamedConfigs(Map.of("tenant-A", new Config(1), "tenant-B", new Config(2))));
+  }
+
+  @Test
+  void shouldNormalizeKeysInsideArrayValues() {
+    // given — camelCase keys inside maps that are elements of a Java array (not an Iterable)
+    final var element0 = Map.<String, Object>of("numberOfShards", 0);
+    final var element1 = Map.<String, Object>of("numberOfShards", 1);
+    // Object[] triggers the array branch in normalizeValue, distinct from the Iterable branch
+    final var args = Map.<String, Object>of("configs", new Object[] {element0, element1});
+    final var config = new ExporterConfiguration("id", args);
+
+    // when
+    final var instance = config.instantiate(ListConfig.class);
+
+    // then
+    assertThat(instance).isEqualTo(new ListConfig(List.of(new Config(0), new Config(1))));
+  }
+
+  @Test
+  void shouldPreserveNullValuesInArgs() {
+    // given — null value in args map must pass through normalizeValue unchanged
+    final Map<String, Object> args = new HashMap<>();
+    args.put("timeout", null);
+    final var config = new ExporterConfiguration("id", args);
+
+    // when
+    final var instance = ExporterConfiguration.fromArgs(DurationConfig.class, args);
+
+    // then
+    assertThat(instance.timeout()).isNull();
+  }
+
+  // ---------------------------------------------------------------------------
+  // fromArgs — null map
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldInstantiateDefaultsWhenArgsNull() {
+    // given — null map triggers ReflectUtil.newInstance which uses the no-arg constructor
+    // when
+    final var instance = ExporterConfiguration.fromArgs(DefaultableConfig.class, null);
+
+    // then
+    assertThat(instance.count).isEqualTo(42);
+  }
+
+  // ---------------------------------------------------------------------------
+  // fromArgs — error handling
+  // ---------------------------------------------------------------------------
+
+  @Test
   void shouldInstantiateConfigWithUnknownProperty() {
-    // given
-    final var args = Map.<String, Object>of("numberofshards", 1, "unknownProp", false);
+    // given — unannotated config class: unknown properties are silently ignored
+    final var args = Map.<String, Object>of("number-of-shards", 1, "unknownProp", false);
     final var expected = new Config(1);
     final var config = new ExporterConfiguration("id", args);
 
@@ -65,12 +178,218 @@ final class ExporterConfigurationTest {
     assertThat(instance).isEqualTo(expected);
   }
 
+  @Test
+  void shouldRejectStrictConfigWithUnknownProperty() {
+    // given — @StrictConfiguration: unknown properties must be rejected
+    final var args = Map.<String, Object>of("number-of-shards", 1, "unknownProp", false);
+    final var config = new ExporterConfiguration("id", args);
+
+    // when - then
+    assertThatCode(() -> config.instantiate(StrictConfig.class))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("unknownprop")
+        .hasMessageContaining("StrictConfig")
+        .hasMessageContaining("path:");
+  }
+
+  @Test
+  void shouldReportNestedClassNameWhenNestedPropertyIsUnrecognized() {
+    // given — the typo is inside the nested object, so the error must mention the nested class
+    // (StrictConfig), not the outer class (StrictContainerConfig)
+    final var args = Map.<String, Object>of("nested", Map.of("unknownProp", false));
+    final var config = new ExporterConfiguration("id", args);
+
+    // when - then
+    assertThatCode(() -> config.instantiate(StrictContainerConfig.class))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("unknownprop")
+        // The error message must name the actual class where the typo lives, not the outer wrapper
+        .hasMessageContaining("StrictConfig")
+        // The full JSON path must be present so users can locate the typo quickly
+        .hasMessageContaining("path:");
+  }
+
+  @Test
+  void shouldRethrowOnTypeConversionError() {
+    // given — type mismatch (string for int field) causes a non-UnrecognizedPropertyException;
+    // fromArgs must re-throw the original exception without wrapping it as an "unknown property"
+    final var args = Map.<String, Object>of("number-of-shards", "not-a-number");
+
+    // when - then
+    assertThatCode(() -> ExporterConfiguration.fromArgs(Config.class, args))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageNotContaining("Unknown exporter configuration property");
+  }
+
+  // ---------------------------------------------------------------------------
+  // asArgs — serialization
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldSerializeConfigToCamelCaseArgs() {
+    // given
+    final var config = new Config(5);
+
+    // when
+    final var args = ExporterConfiguration.asArgs(config);
+
+    // then — field "numberOfShards" is serialized as-is (camelCase, no naming strategy)
+    assertThat(args).containsEntry("numberOfShards", 5);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Duration module
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldDeserializeDurationFromEmbeddedObject() {
+    // given — Duration is passed as a Java object (not a string) in the args map;
+    // Jackson's convertValue goes through a TokenBuffer, so the serializer writes an embedded
+    // object and the deserializer reads it back via the VALUE_EMBEDDED_OBJECT path
+    final var duration = Duration.ofSeconds(30);
+    final var args = Map.<String, Object>of("timeout", duration);
+
+    // when
+    final var instance = ExporterConfiguration.fromArgs(DurationConfig.class, args);
+
+    // then
+    assertThat(instance.timeout()).isEqualTo(duration);
+  }
+
+  @Test
+  void shouldDeserializeDurationFromIsoString() {
+    // given — Duration arrives as an ISO-8601 string from Spring Boot YAML properties
+    final var args = Map.<String, Object>of("timeout", "PT30S");
+
+    // when
+    final var instance = ExporterConfiguration.fromArgs(DurationConfig.class, args);
+
+    // then
+    assertThat(instance.timeout()).isEqualTo(Duration.ofSeconds(30));
+  }
+
+  @Test
+  void shouldReturnNullDurationForEmptyString() {
+    // given — empty string is the value Spring Boot sets when no duration is configured
+    final var args = Map.<String, Object>of("timeout", "");
+
+    // when
+    final var instance = ExporterConfiguration.fromArgs(DurationConfig.class, args);
+
+    // then
+    assertThat(instance.timeout()).isNull();
+  }
+
+  @Test
+  void shouldRoundTripDurationViaArgs() {
+    // given
+    final var original = new DurationConfig(Duration.ofMillis(500));
+
+    // when — serialize to args map then deserialize back
+    final var args = ExporterConfiguration.asArgs(original);
+    final var roundTripped = ExporterConfiguration.fromArgs(DurationConfig.class, args);
+
+    // then
+    assertThat(roundTripped).isEqualTo(original);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Path module
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldRoundTripRelativePath() {
+    // given — relative path must be preserved without resolution to an absolute path
+    final var original = new PathConfig(Path.of("relative/path/to/file"));
+
+    // when
+    final var args = ExporterConfiguration.asArgs(original);
+    final var roundTripped = ExporterConfiguration.fromArgs(PathConfig.class, args);
+
+    // then
+    assertThat(roundTripped.filePath()).isEqualTo(original.filePath());
+    assertThat(roundTripped.filePath().isAbsolute()).isFalse();
+  }
+
+  @Test
+  void shouldRoundTripAbsolutePath() {
+    // given
+    final var original = new PathConfig(Path.of("/absolute/path/to/file"));
+
+    // when
+    final var args = ExporterConfiguration.asArgs(original);
+    final var roundTripped = ExporterConfiguration.fromArgs(PathConfig.class, args);
+
+    // then
+    assertThat(roundTripped.filePath()).isEqualTo(original.filePath());
+    assertThat(roundTripped.filePath().isAbsolute()).isTrue();
+  }
+
+  @Test
+  void shouldSerializePathFieldToCamelCaseKey() {
+    // given — field "filePath" is serialized as-is (camelCase, no naming strategy)
+    final var config = new PathConfig(Path.of("some/path"));
+
+    // when
+    final var args = ExporterConfiguration.asArgs(config);
+
+    // then
+    assertThat(args).containsKey("filePath");
+  }
+
+  // ---------------------------------------------------------------------------
+  // ConfigurationMapper (of / apply / get / toArgs)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldCreateConfigurationMapperViaOf() {
+    // given
+    final var args = Map.<String, Object>of("count", 5);
+
+    // when
+    final var mapper = ExporterConfiguration.of(MutableConfig.class, args);
+
+    // then
+    assertThat(mapper.get().count).isEqualTo(5);
+  }
+
+  @Test
+  void shouldApplyConsumerViaMapper() {
+    // given
+    final var mapper = ExporterConfiguration.of(MutableConfig.class, Map.of("count", 5));
+
+    // when
+    final var returned = mapper.apply(c -> c.count = 99);
+
+    // then — apply() must return the same mapper instance for chaining
+    assertThat(returned).isSameAs(mapper);
+    assertThat(mapper.get().count).isEqualTo(99);
+  }
+
+  @Test
+  void shouldConvertConfigToArgsViaMapper() {
+    // given
+    final var mapper = ExporterConfiguration.of(MutableConfig.class, Map.of("count", 5));
+    mapper.apply(c -> c.count = 7);
+
+    // when
+    final var args = mapper.toArgs();
+
+    // then
+    assertThat(args).containsEntry("count", 7);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Regression: Spring Boot indexed list properties (issue #4552)
+  // ---------------------------------------------------------------------------
+
   @RegressionTest("https://github.com/camunda/camunda/issues/4552")
   void shouldInstantiateMapOfIntegersAsList() {
     // given
     final var args =
         Map.<String, Object>of(
-            "configs", Map.of("0", Map.of("numberofshards", 0), "1", Map.of("numberofshards", 1)));
+            "configs",
+            Map.of("0", Map.of("number-of-shards", 0), "1", Map.of("number-of-shards", 1)));
     final var expected = new ListConfig(List.of(new Config(0), new Config(1)));
     final var config = new ExporterConfiguration("id", args);
 
@@ -85,7 +404,8 @@ final class ExporterConfigurationTest {
   void shouldInstantiateMapOfIntegersAsListNested() {
     // given
     final var serializedConfigs =
-        Map.<String, Object>of("0", Map.of("numberofshards", 0), "1", Map.of("numberofshards", 1));
+        Map.<String, Object>of(
+            "0", Map.of("number-of-shards", 0), "1", Map.of("number-of-shards", 1));
     final var args =
         Map.<String, Object>of("list", Map.of("0", Map.of("configs", serializedConfigs)));
     final var expected =
@@ -101,10 +421,11 @@ final class ExporterConfigurationTest {
 
   @RegressionTest("https://github.com/camunda/camunda/issues/4552")
   void shouldNotInstantiateSparseList() {
-    // given
+    // given — list indices start at 1 instead of 0, so insertion at index 1 fails
     final var args =
         Map.<String, Object>of(
-            "configs", Map.of("1", Map.of("numberofshards", 0), "2", Map.of("numberofshards", 1)));
+            "configs",
+            Map.of("1", Map.of("number-of-shards", 0), "2", Map.of("number-of-shards", 1)));
     final var config = new ExporterConfiguration("id", args);
 
     // when - then
@@ -115,11 +436,11 @@ final class ExporterConfigurationTest {
 
   @RegressionTest("https://github.com/camunda/camunda/issues/4552")
   void shouldNotInstantiateNonIntegerList() {
-    // given
+    // given — list indices are non-integer strings, so parsing to int fails
     final var args =
         Map.<String, Object>of(
             "configs",
-            Map.of("foo", Map.of("numberofshards", 0), "bar", Map.of("numberofshards", 1)));
+            Map.of("foo", Map.of("number-of-shards", 0), "bar", Map.of("number-of-shards", 1)));
     final var config = new ExporterConfiguration("id", args);
 
     // when - then
@@ -128,11 +449,63 @@ final class ExporterConfigurationTest {
         .hasRootCauseInstanceOf(NumberFormatException.class);
   }
 
+  @Test
+  void shouldRejectMixedIndexedAndNamedKeysForListProperties() {
+    // given — mixed numeric and named keys are ambiguous for list-style map conversion
+    final var args =
+        Map.<String, Object>of(
+            "configs",
+            Map.of(
+                "0", Map.of("number-of-shards", 0),
+                "tenant-a", Map.of("number-of-shards", 1)));
+    final var config = new ExporterConfiguration("id", args);
+
+    // when - then
+    assertThatCode(() -> config.instantiate(ListConfig.class))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Cannot mix indexed (numeric) and named keys");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Test fixtures
+  // ---------------------------------------------------------------------------
+
   private record Config(int numberOfShards) {}
 
+  @StrictConfiguration
+  private record StrictConfig(int numberOfShards) {}
+
+  @StrictConfiguration
+  private record StrictContainerConfig(StrictConfig nested) {}
+
   private record ContainerConfig(Config nested) {}
+
+  private record LabelsConfig(Map<String, String> labels) {}
+
+  private record NamedConfigs(Map<String, Config> configs) {}
 
   private record ListConfig(List<Config> configs) {}
 
   private record NestedListConfig(List<ListConfig> list) {}
+
+  private record DurationConfig(Duration timeout) {}
+
+  private record PathConfig(Path filePath) {}
+
+  /**
+   * POJO (not a record) so that {@code ReflectUtil.newInstance} can use the no-arg constructor.
+   * Must be {@code public} so that the generated default constructor is public and accessible via
+   * reflection without {@code setAccessible(true)}.
+   */
+  public static class DefaultableConfig {
+    public int count = 42;
+  }
+
+  /**
+   * Mutable POJO for {@link ExporterConfiguration.ConfigurationMapper} tests. Records are
+   * immutable, so a plain class is required to exercise {@code apply()}.
+   */
+  static class MutableConfig {
+    public int count;
+  }
 }

--- a/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/StrictConfiguration.java
+++ b/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/StrictConfiguration.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.exporter.api.context;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks an exporter configuration class as strict: when {@link Configuration#instantiate(Class)}
+ * maps the raw YAML args onto this class, any argument key that does not correspond to a known
+ * property after normalization (lowercasing and removing hyphens) is treated as an error. The
+ * application logs a human-readable message and refuses to start.
+ *
+ * <p>Exporter authors who want early feedback on typos or unsupported property names should
+ * annotate their configuration class with this annotation.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface StrictConfiguration {}

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -8,12 +8,14 @@
 package io.camunda.zeebe.exporter;
 
 import io.camunda.search.connect.plugin.PluginConfiguration;
+import io.camunda.zeebe.exporter.api.context.StrictConfiguration;
 import io.camunda.zeebe.exporter.filter.FilterConfiguration;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import java.util.ArrayList;
 import java.util.List;
 
+@StrictConfiguration
 public class ElasticsearchExporterConfiguration implements FilterConfiguration {
 
   private static final String DEFAULT_URL = "http://localhost:9200";

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchIndexConfigurationTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchIndexConfigurationTest.java
@@ -8,9 +8,11 @@
 package io.camunda.zeebe.exporter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 import io.camunda.zeebe.broker.exporter.context.ExporterConfiguration;
 import io.camunda.zeebe.exporter.ElasticsearchExporterConfiguration.IndexConfiguration;
+import io.camunda.zeebe.exporter.api.context.StrictConfiguration;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -22,6 +24,27 @@ import org.junit.jupiter.api.Test;
  * exact mapper the Zeebe broker uses to instantiate exporter configuration at runtime.
  */
 final class ElasticsearchIndexConfigurationTest {
+
+  // ---------------------------------------------------------------------------
+  // @StrictConfiguration — unknown properties must be rejected at startup
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldBeAnnotatedWithStrictConfiguration() {
+    assertThat(ElasticsearchExporterConfiguration.class).hasAnnotation(StrictConfiguration.class);
+  }
+
+  @Test
+  void shouldRejectUnknownPropertyOnInstantiate() {
+    // given
+    final var args = Map.<String, Object>of("unknownProp", "value");
+    final var config = new ExporterConfiguration("id", args);
+
+    // when - then
+    assertThatCode(() -> config.instantiate(ElasticsearchExporterConfiguration.class))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("unknownprop");
+  }
 
   // ---------------------------------------------------------------------------
   // exportLocalVariablesEnabled
@@ -38,7 +61,7 @@ final class ElasticsearchIndexConfigurationTest {
     final var args = Map.<String, Object>of("exportLocalVariablesEnabled", false);
 
     // when
-    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+    final var config = ExporterConfiguration.fromArgs(IndexConfiguration.class, args);
 
     // then
     assertThat(config.isExportLocalVariablesEnabled()).isFalse();
@@ -55,7 +78,7 @@ final class ElasticsearchIndexConfigurationTest {
         Map.<String, Object>of("localVariableNameInclusionExact", List.of("localVar", "other"));
 
     // when
-    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+    final var config = ExporterConfiguration.fromArgs(IndexConfiguration.class, args);
 
     // then
     assertThat(config.getLocalVariableNameInclusionExact()).containsExactly("localVar", "other");
@@ -68,7 +91,7 @@ final class ElasticsearchIndexConfigurationTest {
         Map.<String, Object>of("localVariableNameExclusionStartWith", List.of("debug_", "tmp_"));
 
     // when
-    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+    final var config = ExporterConfiguration.fromArgs(IndexConfiguration.class, args);
 
     // then
     assertThat(config.getLocalVariableNameExclusionStartWith()).containsExactly("debug_", "tmp_");
@@ -84,7 +107,7 @@ final class ElasticsearchIndexConfigurationTest {
     final var args = Map.<String, Object>of("rootVariableNameInclusionExact", List.of("rootVar"));
 
     // when
-    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+    final var config = ExporterConfiguration.fromArgs(IndexConfiguration.class, args);
 
     // then
     assertThat(config.getRootVariableNameInclusionExact()).containsExactly("rootVar");
@@ -96,7 +119,7 @@ final class ElasticsearchIndexConfigurationTest {
     final var args = Map.<String, Object>of("rootVariableNameExclusionEndWith", List.of("_secret"));
 
     // when
-    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+    final var config = ExporterConfiguration.fromArgs(IndexConfiguration.class, args);
 
     // then
     assertThat(config.getRootVariableNameExclusionEndWith()).containsExactly("_secret");
@@ -115,7 +138,7 @@ final class ElasticsearchIndexConfigurationTest {
             "rootVariableValueTypeExclusion", List.of("BOOLEAN"));
 
     // when
-    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+    final var config = ExporterConfiguration.fromArgs(IndexConfiguration.class, args);
 
     // then
     assertThat(config.getLocalVariableValueTypeInclusion()).containsExactly("NUMBER", "STRING");
@@ -162,7 +185,7 @@ final class ElasticsearchIndexConfigurationTest {
             "localVariableNameInclusionExact", Map.of("0", "localVar", "1", "other"));
 
     // when
-    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+    final var config = ExporterConfiguration.fromArgs(IndexConfiguration.class, args);
 
     // then
     assertThat(config.getLocalVariableNameInclusionExact()).containsExactly("localVar", "other");
@@ -176,7 +199,7 @@ final class ElasticsearchIndexConfigurationTest {
             "rootVariableNameExclusionExact", Map.of("0", "_secret", "1", "_internal"));
 
     // when
-    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+    final var config = ExporterConfiguration.fromArgs(IndexConfiguration.class, args);
 
     // then
     assertThat(config.getRootVariableNameExclusionExact()).containsExactly("_secret", "_internal");
@@ -190,9 +213,59 @@ final class ElasticsearchIndexConfigurationTest {
             "localVariableValueTypeInclusion", Map.of("0", "NUMBER", "1", "STRING"));
 
     // when
-    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+    final var config = ExporterConfiguration.fromArgs(IndexConfiguration.class, args);
 
     // then
     assertThat(config.getLocalVariableValueTypeInclusion()).containsExactly("NUMBER", "STRING");
+  }
+
+  @Test
+  void shouldDeserializeApplicationDevVariableFilterCases() {
+    // given
+    final var indexArgs =
+        Map.<String, Object>ofEntries(
+            Map.entry("export-local-variables-enabled", true),
+            Map.entry("root-variable-name-inclusion-exact", List.of("customerId", "orderId")),
+            Map.entry("rootVariableNameInclusionStartWith", List.of("REPORTING_", "order_")),
+            Map.entry("root-variable-name-inclusion-end-with", Map.of("0", "_Id", "1", "_Key")),
+            Map.entry("root-variable-name-exclusion-exact", ""),
+            Map.entry("rootVariableNameExclusionStartWith", ""),
+            Map.entry("root-variable-name-exclusion-end-with", "_tmp"),
+            Map.entry("localVariableNameInclusionExact", List.of("loopCounter", "taskResult")),
+            Map.entry("local-variable-name-inclusion-start-with", List.of("tmp_", "debug_")),
+            Map.entry("localVariableNameInclusionEndWith", Map.of("0", "_local")),
+            Map.entry("local-variable-name-exclusion-exact", ""),
+            Map.entry("localVariableNameExclusionStartWith", ""),
+            Map.entry("local-variable-name-exclusion-end-with", ""),
+            Map.entry("root-variable-value-type-inclusion", ""),
+            Map.entry("root-variable-value-type-exclusion", ""),
+            Map.entry("local-variable-value-type-inclusion", List.of("String", "Number")),
+            Map.entry("localVariableValueTypeExclusion", ""));
+    final var args = Map.<String, Object>of("url", "http://localhost:9200", "index", indexArgs);
+    final var exporterConfig = new ExporterConfiguration("id", args);
+
+    // when
+    final var config = exporterConfig.instantiate(ElasticsearchExporterConfiguration.class).index;
+
+    // then
+    assertThat(config.isExportLocalVariablesEnabled()).isTrue();
+    assertThat(config.getRootVariableNameInclusionExact()).containsExactly("customerId", "orderId");
+    assertThat(config.getRootVariableNameInclusionStartWith())
+        .containsExactly("REPORTING_", "order_");
+    assertThat(config.getRootVariableNameInclusionEndWith()).containsExactly("_Id", "_Key");
+    assertThat(config.getRootVariableNameExclusionExact()).isEmpty();
+    assertThat(config.getRootVariableNameExclusionStartWith()).isEmpty();
+    assertThat(config.getRootVariableNameExclusionEndWith()).containsExactly("_tmp");
+    assertThat(config.getLocalVariableNameInclusionExact())
+        .containsExactly("loopCounter", "taskResult");
+    assertThat(config.getLocalVariableNameInclusionStartWith()).containsExactly("tmp_", "debug_");
+    assertThat(config.getLocalVariableNameInclusionEndWith()).containsExactly("_local");
+    assertThat(config.getLocalVariableNameExclusionExact()).isEmpty();
+    assertThat(config.getLocalVariableNameExclusionStartWith()).isEmpty();
+    assertThat(config.getLocalVariableNameExclusionEndWith()).isEmpty();
+    assertThat(config.getRootVariableValueTypeInclusion()).isEmpty();
+    assertThat(config.getRootVariableValueTypeExclusion()).isEmpty();
+    assertThat(config.getLocalVariableValueTypeInclusion()).containsExactly("String", "Number");
+    assertThat(config.getLocalVariableValueTypeExclusion()).isEmpty();
   }
 }

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.exporter.opensearch;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.search.connect.plugin.PluginConfiguration;
+import io.camunda.zeebe.exporter.api.context.StrictConfiguration;
 import io.camunda.zeebe.exporter.filter.FilterConfiguration;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -18,6 +19,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+@StrictConfiguration
 public class OpensearchExporterConfiguration implements FilterConfiguration {
 
   private static final String DEFAULT_URL = "http://localhost:9200";

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchIndexConfigurationTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchIndexConfigurationTest.java
@@ -8,8 +8,10 @@
 package io.camunda.zeebe.exporter.opensearch;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 import io.camunda.zeebe.broker.exporter.context.ExporterConfiguration;
+import io.camunda.zeebe.exporter.api.context.StrictConfiguration;
 import io.camunda.zeebe.exporter.opensearch.OpensearchExporterConfiguration.IndexConfiguration;
 import java.util.List;
 import java.util.Map;
@@ -22,6 +24,27 @@ import org.junit.jupiter.api.Test;
  * exact mapper the Zeebe broker uses to instantiate exporter configuration at runtime.
  */
 final class OpensearchIndexConfigurationTest {
+
+  // ---------------------------------------------------------------------------
+  // @StrictConfiguration — unknown properties must be rejected at startup
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldBeAnnotatedWithStrictConfiguration() {
+    assertThat(OpensearchExporterConfiguration.class).hasAnnotation(StrictConfiguration.class);
+  }
+
+  @Test
+  void shouldRejectUnknownPropertyOnInstantiate() {
+    // given
+    final var args = Map.<String, Object>of("unknownProp", "value");
+    final var config = new ExporterConfiguration("id", args);
+
+    // when - then
+    assertThatCode(() -> config.instantiate(OpensearchExporterConfiguration.class))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("unknownprop");
+  }
 
   // ---------------------------------------------------------------------------
   // exportLocalVariablesEnabled
@@ -38,7 +61,7 @@ final class OpensearchIndexConfigurationTest {
     final var args = Map.<String, Object>of("exportLocalVariablesEnabled", false);
 
     // when
-    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+    final var config = ExporterConfiguration.fromArgs(IndexConfiguration.class, args);
 
     // then
     assertThat(config.isExportLocalVariablesEnabled()).isFalse();
@@ -55,7 +78,7 @@ final class OpensearchIndexConfigurationTest {
         Map.<String, Object>of("localVariableNameInclusionExact", List.of("localVar", "other"));
 
     // when
-    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+    final var config = ExporterConfiguration.fromArgs(IndexConfiguration.class, args);
 
     // then
     assertThat(config.getLocalVariableNameInclusionExact()).containsExactly("localVar", "other");
@@ -68,7 +91,7 @@ final class OpensearchIndexConfigurationTest {
         Map.<String, Object>of("localVariableNameExclusionStartWith", List.of("debug_", "tmp_"));
 
     // when
-    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+    final var config = ExporterConfiguration.fromArgs(IndexConfiguration.class, args);
 
     // then
     assertThat(config.getLocalVariableNameExclusionStartWith()).containsExactly("debug_", "tmp_");
@@ -84,7 +107,7 @@ final class OpensearchIndexConfigurationTest {
     final var args = Map.<String, Object>of("rootVariableNameInclusionExact", List.of("rootVar"));
 
     // when
-    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+    final var config = ExporterConfiguration.fromArgs(IndexConfiguration.class, args);
 
     // then
     assertThat(config.getRootVariableNameInclusionExact()).containsExactly("rootVar");
@@ -96,7 +119,7 @@ final class OpensearchIndexConfigurationTest {
     final var args = Map.<String, Object>of("rootVariableNameExclusionEndWith", List.of("_secret"));
 
     // when
-    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+    final var config = ExporterConfiguration.fromArgs(IndexConfiguration.class, args);
 
     // then
     assertThat(config.getRootVariableNameExclusionEndWith()).containsExactly("_secret");
@@ -115,7 +138,7 @@ final class OpensearchIndexConfigurationTest {
             "rootVariableValueTypeExclusion", List.of("BOOLEAN"));
 
     // when
-    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+    final var config = ExporterConfiguration.fromArgs(IndexConfiguration.class, args);
 
     // then
     assertThat(config.getLocalVariableValueTypeInclusion()).containsExactly("NUMBER", "STRING");
@@ -162,7 +185,7 @@ final class OpensearchIndexConfigurationTest {
             "localVariableNameInclusionExact", Map.of("0", "localVar", "1", "other"));
 
     // when
-    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+    final var config = ExporterConfiguration.fromArgs(IndexConfiguration.class, args);
 
     // then
     assertThat(config.getLocalVariableNameInclusionExact()).containsExactly("localVar", "other");
@@ -176,7 +199,7 @@ final class OpensearchIndexConfigurationTest {
             "rootVariableNameExclusionExact", Map.of("0", "_secret", "1", "_internal"));
 
     // when
-    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+    final var config = ExporterConfiguration.fromArgs(IndexConfiguration.class, args);
 
     // then
     assertThat(config.getRootVariableNameExclusionExact()).containsExactly("_secret", "_internal");
@@ -190,9 +213,59 @@ final class OpensearchIndexConfigurationTest {
             "localVariableValueTypeInclusion", Map.of("0", "NUMBER", "1", "STRING"));
 
     // when
-    final var config = ExporterConfiguration.MAPPER.convertValue(args, IndexConfiguration.class);
+    final var config = ExporterConfiguration.fromArgs(IndexConfiguration.class, args);
 
     // then
     assertThat(config.getLocalVariableValueTypeInclusion()).containsExactly("NUMBER", "STRING");
+  }
+
+  @Test
+  void shouldDeserializeApplicationDevVariableFilterCases() {
+    // given
+    final var indexArgs =
+        Map.<String, Object>ofEntries(
+            Map.entry("export-local-variables-enabled", true),
+            Map.entry("root-variable-name-inclusion-exact", List.of("customerId", "orderId")),
+            Map.entry("rootVariableNameInclusionStartWith", List.of("REPORTING_", "order_")),
+            Map.entry("root-variable-name-inclusion-end-with", Map.of("0", "_Id", "1", "_Key")),
+            Map.entry("root-variable-name-exclusion-exact", ""),
+            Map.entry("rootVariableNameExclusionStartWith", ""),
+            Map.entry("root-variable-name-exclusion-end-with", "_tmp"),
+            Map.entry("localVariableNameInclusionExact", List.of("loopCounter", "taskResult")),
+            Map.entry("local-variable-name-inclusion-start-with", List.of("tmp_", "debug_")),
+            Map.entry("localVariableNameInclusionEndWith", Map.of("0", "_local")),
+            Map.entry("local-variable-name-exclusion-exact", ""),
+            Map.entry("localVariableNameExclusionStartWith", ""),
+            Map.entry("local-variable-name-exclusion-end-with", ""),
+            Map.entry("root-variable-value-type-inclusion", ""),
+            Map.entry("root-variable-value-type-exclusion", ""),
+            Map.entry("local-variable-value-type-inclusion", List.of("String", "Number")),
+            Map.entry("localVariableValueTypeExclusion", ""));
+    final var args = Map.<String, Object>of("url", "http://localhost:9200", "index", indexArgs);
+    final var exporterConfig = new ExporterConfiguration("id", args);
+
+    // when
+    final var config = exporterConfig.instantiate(OpensearchExporterConfiguration.class).index;
+
+    // then
+    assertThat(config.isExportLocalVariablesEnabled()).isTrue();
+    assertThat(config.getRootVariableNameInclusionExact()).containsExactly("customerId", "orderId");
+    assertThat(config.getRootVariableNameInclusionStartWith())
+        .containsExactly("REPORTING_", "order_");
+    assertThat(config.getRootVariableNameInclusionEndWith()).containsExactly("_Id", "_Key");
+    assertThat(config.getRootVariableNameExclusionExact()).isEmpty();
+    assertThat(config.getRootVariableNameExclusionStartWith()).isEmpty();
+    assertThat(config.getRootVariableNameExclusionEndWith()).containsExactly("_tmp");
+    assertThat(config.getLocalVariableNameInclusionExact())
+        .containsExactly("loopCounter", "taskResult");
+    assertThat(config.getLocalVariableNameInclusionStartWith()).containsExactly("tmp_", "debug_");
+    assertThat(config.getLocalVariableNameInclusionEndWith()).containsExactly("_local");
+    assertThat(config.getLocalVariableNameExclusionExact()).isEmpty();
+    assertThat(config.getLocalVariableNameExclusionStartWith()).isEmpty();
+    assertThat(config.getLocalVariableNameExclusionEndWith()).isEmpty();
+    assertThat(config.getRootVariableValueTypeInclusion()).isEmpty();
+    assertThat(config.getRootVariableValueTypeExclusion()).isEmpty();
+    assertThat(config.getLocalVariableValueTypeInclusion()).containsExactly("String", "Number");
+    assertThat(config.getLocalVariableValueTypeExclusion()).isEmpty();
   }
 }


### PR DESCRIPTION
## Description

Exporter args are stored as a raw Map<String,Object> that Jackson binds directly, bypassing Spring Boot's relaxed binding. This meant that YAML properties written in kebab-case (e.g. number-of-shards) were silently ignored, and environment variables produced an all-lowercase concatenated key (e.g. numberofshards) that never matched any field. 

Fix key normalization (ExporterConfiguration): every incoming key is now stripped of hyphens and lowercased before Jackson processes it. camelCase, kebab-case, UPPERCASE-KEBAB, and the env-var concatenated form (e.g. ROOTVARIABLENAMEINCLUSIONEXACT) all resolve to the same field via ACCEPT_CASE_INSENSITIVE_PROPERTIES. The normalization is type-aware: keys inside a Java bean are normalized recursively, while keys of Map<K, V> fields are treated as user data and left unchanged.

Improve list deserialization (ExporterConfigurationListDeserializer): handle all token types Spring Boot can produce for a List field — normal YAML array, Spring indexed-map (myList[0]=value), empty string (Spring flattens [] to ""), and single-value string shorthand. Unknown token types now throw immediately with a clear message.

Add @StrictConfiguration (exporter API): opt-in annotation that makes unknown property names fail fast at broker startup. The error message includes the unrecognized property name, the class where it was found, the full JSON path for easy location in deeply nested configs, and the list of known properties on that class.

Apply @StrictConfiguration to ElasticsearchExporterConfiguration and OpensearchExporterConfiguration.

Expand test coverage for ES/OS index configuration: migrate existing tests from MAPPER.convertValue to ExporterConfiguration.fromArgs so they exercise the full normalization pipeline, and add cases for @StrictConfiguration rejection, mixed key styles (camelCase, kebab-case), and all list encodings (inline array, Spring indexed map, empty/singleton string) for the scope-aware variable filter fields.

## Backport note                                          

The fix: support flexible key formats in exporter configuration commit and its test commit are self-contained and can be cherry-picked to 8.9.1.

## Related issues

closes # #51307
