### PR TITLE
refactor: fix memory leaks and improve performance

### DIFF
--- a/operate/client/src/App/Decisions/Decision/tests/index.test.tsx
+++ b/operate/client/src/App/Decisions/Decision/tests/index.test.tsx
@@ -29,9 +29,6 @@ describe('<Decision />', () => {
   });
 
   it('should render decision table and panel header', async () => {
-    const originalWindowPrompt = window.prompt;
-    window.prompt = vi.fn();
-
     mockFetchDecisionDefinitionXML().withSuccess(mockDmnXml);
 
     const {user} = render(<Decision />, {
@@ -55,8 +52,6 @@ describe('<Decision />', () => {
     );
 
     expect(await screen.findByText('Copied to clipboard')).toBeInTheDocument();
-
-    window.prompt = originalWindowPrompt;
   });
 
   it('should render text when no decision is selected', async () => {

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/adHocSubProcess.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/adHocSubProcess.test.tsx
@@ -10,7 +10,7 @@ import {render, screen} from 'modules/testing-library';
 import {open} from 'modules/mocks/diagrams';
 import {searchResult} from 'modules/testUtils';
 import {
-  Wrapper,
+  getWrapper,
   adHocNodeElementInstances,
   mockAdHocSubProcessesInstance,
 } from './mocks';
@@ -44,7 +44,7 @@ describe('ElementInstancesTree - Ad Hoc Sub Process', () => {
         businessObjects={businessObjects}
       />,
       {
-        wrapper: Wrapper,
+        wrapper: getWrapper(),
       },
     );
 

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/adHocSubProcessInnerInstance.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/adHocSubProcessInnerInstance.test.tsx
@@ -11,7 +11,7 @@ import {notificationsStore} from 'modules/stores/notifications';
 import {adHocSubProcessInnerInstance, searchResult} from 'modules/testUtils';
 import {ElementInstancesTree} from './index';
 import {
-  Wrapper,
+  getWrapper,
   mockAdHocSubProcessInnerInstanceProcessInstance,
   adHocSubProcessInnerInstanceElementInstances,
 } from './mocks';
@@ -60,7 +60,7 @@ describe('ElementInstancesTree - Ad Hoc Sub Process Inner Instance', () => {
         businessObjects={businessObjects}
       />,
       {
-        wrapper: Wrapper,
+        wrapper: getWrapper(),
       },
     );
 
@@ -104,7 +104,7 @@ describe('ElementInstancesTree - Ad Hoc Sub Process Inner Instance', () => {
         businessObjects={businessObjects}
       />,
       {
-        wrapper: Wrapper,
+        wrapper: getWrapper(),
       },
     );
 
@@ -163,7 +163,7 @@ describe('ElementInstancesTree - Ad Hoc Sub Process Inner Instance', () => {
         businessObjects={businessObjects}
       />,
       {
-        wrapper: Wrapper,
+        wrapper: getWrapper(),
       },
     );
     const originalSearch = screen.getByTestId('search').textContent;
@@ -202,7 +202,7 @@ describe('ElementInstancesTree - Ad Hoc Sub Process Inner Instance', () => {
         businessObjects={businessObjects}
       />,
       {
-        wrapper: Wrapper,
+        wrapper: getWrapper(),
       },
     );
     const originalSearch = screen.getByTestId('search').textContent;

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/elementInstancesTreeStore.ts
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/elementInstancesTreeStore.ts
@@ -394,6 +394,7 @@ class ElementInstancesTreeStore extends NetworkReconnectionHandler {
     this.state.rootScopeKey = null;
     this.state.nodes.clear();
     this.state.expandedNodes.clear();
+    this.isPollRequestRunning = false;
   }
 
   private hasRunningChildren = (scopeKey: string): boolean => {

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/eventSubprocess.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/eventSubprocess.test.tsx
@@ -10,7 +10,7 @@ import {render, screen} from 'modules/testing-library';
 import {ElementInstancesTree} from './index';
 import {
   eventSubProcessElementInstances,
-  Wrapper,
+  getWrapper,
   mockEventSubprocessInstance,
 } from './mocks';
 import {eventSubProcess, searchResult} from 'modules/testUtils';
@@ -44,7 +44,7 @@ describe('ElementInstancesTree - Event Subprocess', () => {
         businessObjects={businessObjects}
       />,
       {
-        wrapper: Wrapper,
+        wrapper: getWrapper(),
       },
     );
 

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/mocks.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/mocks.tsx
@@ -8,7 +8,7 @@
 
 import {instanceHistoryModificationStore} from 'modules/stores/instanceHistoryModification';
 import {modificationsStore} from 'modules/stores/modifications';
-import {useEffect, useState} from 'react';
+import {useEffect} from 'react';
 import {TreeView} from '@carbon/react';
 import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 import {QueryClientProvider} from '@tanstack/react-query';
@@ -1198,37 +1198,41 @@ const adHocSubProcessInnerInstanceElementInstances = {
   },
 } satisfies Record<string, QueryElementInstancesResponseBody>;
 
-const Wrapper = ({children}: {children?: React.ReactNode}) => {
-  const [queryClient] = useState(() => getMockQueryClient());
+const getWrapper = () => {
+  const queryClient = getMockQueryClient();
 
-  useEffect(() => {
-    return () => {
-      modificationsStore.reset();
-      instanceHistoryModificationStore.reset();
-    };
-  });
+  const Wrapper = ({children}: {children?: React.ReactNode}) => {
+    useEffect(() => {
+      return () => {
+        modificationsStore.reset();
+        instanceHistoryModificationStore.reset();
+      };
+    });
 
-  return (
-    <ProcessDefinitionKeyContext.Provider value="123">
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter initialEntries={[Paths.processInstance('1')]}>
-          <Routes>
-            <Route
-              path={Paths.processInstance()}
-              element={
-                <>
-                  <TreeView label={'instance history'} hideLabel>
-                    {children}
-                  </TreeView>
-                  <LocationLog />
-                </>
-              }
-            />
-          </Routes>
-        </MemoryRouter>
-      </QueryClientProvider>
-    </ProcessDefinitionKeyContext.Provider>
-  );
+    return (
+      <ProcessDefinitionKeyContext.Provider value="123">
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter initialEntries={[Paths.processInstance('1')]}>
+            <Routes>
+              <Route
+                path={Paths.processInstance()}
+                element={
+                  <>
+                    <TreeView label={'instance history'} hideLabel>
+                      {children}
+                    </TreeView>
+                    <LocationLog />
+                  </>
+                }
+              />
+            </Routes>
+          </MemoryRouter>
+        </QueryClientProvider>
+      </ProcessDefinitionKeyContext.Provider>
+    );
+  };
+
+  return Wrapper;
 };
 
 export {
@@ -1244,5 +1248,5 @@ export {
   multipleSubprocessesWithTwoRunningScopesMock,
   mockAdHocSubProcessInnerInstanceProcessInstance,
   adHocSubProcessInnerInstanceElementInstances,
-  Wrapper,
+  getWrapper,
 };

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/mocks.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/mocks.tsx
@@ -8,7 +8,7 @@
 
 import {instanceHistoryModificationStore} from 'modules/stores/instanceHistoryModification';
 import {modificationsStore} from 'modules/stores/modifications';
-import {useEffect} from 'react';
+import {useEffect, useState} from 'react';
 import {TreeView} from '@carbon/react';
 import {ProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 import {QueryClientProvider} from '@tanstack/react-query';
@@ -1199,6 +1199,8 @@ const adHocSubProcessInnerInstanceElementInstances = {
 } satisfies Record<string, QueryElementInstancesResponseBody>;
 
 const Wrapper = ({children}: {children?: React.ReactNode}) => {
+  const [queryClient] = useState(() => getMockQueryClient());
+
   useEffect(() => {
     return () => {
       modificationsStore.reset();
@@ -1208,7 +1210,7 @@ const Wrapper = ({children}: {children?: React.ReactNode}) => {
 
   return (
     <ProcessDefinitionKeyContext.Provider value="123">
-      <QueryClientProvider client={getMockQueryClient()}>
+      <QueryClientProvider client={queryClient}>
         <MemoryRouter initialEntries={[Paths.processInstance('1')]}>
           <Routes>
             <Route

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/modificationPlaceholders.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/modificationPlaceholders.test.tsx
@@ -15,7 +15,7 @@ import {ElementInstancesTree} from './index';
 import {
   multipleSubprocessesWithNoRunningScopeMock,
   multipleSubprocessesWithOneRunningScopeMock,
-  Wrapper,
+  getWrapper,
   mockMultiInstanceProcessInstance,
   mockNestedSubProcessInstance,
 } from './mocks';
@@ -67,7 +67,7 @@ describe('ElementInstancesTree - Modification placeholders', () => {
         businessObjects={nestedSubprocessBusinessObjects}
       />,
       {
-        wrapper: Wrapper,
+        wrapper: getWrapper(),
       },
     );
 
@@ -293,7 +293,7 @@ describe('ElementInstancesTree - Modification placeholders', () => {
         businessObjects={multiInstanceProcessBusinessObjects}
       />,
       {
-        wrapper: Wrapper,
+        wrapper: getWrapper(),
       },
     );
 
@@ -408,7 +408,7 @@ describe('ElementInstancesTree - Modification placeholders', () => {
         businessObjects={multiInstanceProcessBusinessObjects}
       />,
       {
-        wrapper: Wrapper,
+        wrapper: getWrapper(),
       },
     );
 
@@ -457,7 +457,7 @@ describe('ElementInstancesTree - Modification placeholders', () => {
         businessObjects={nestedSubprocessBusinessObjects}
       />,
       {
-        wrapper: Wrapper,
+        wrapper: getWrapper(),
       },
     );
 

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/modificationPlaceholders.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/modificationPlaceholders.test.tsx
@@ -467,8 +467,6 @@ describe('ElementInstancesTree - Modification placeholders', () => {
       }),
     ).toHaveLength(2);
 
-    const businessObjects = await parseDiagramXML(mockNestedSubprocess);
-
     act(() => {
       modificationsStore.enableModificationMode();
       modificationsStore.addModification({
@@ -480,7 +478,7 @@ describe('ElementInstancesTree - Modification placeholders', () => {
           affectedTokenCount: 1,
           visibleAffectedTokenCount: 1,
           parentScopeIds: generateParentScopeIds(
-            businessObjects.elementsById,
+            mockNestedSubprocessDiagramModel.elementsById,
             'user_task',
             'nested_sub_process',
           ),
@@ -495,7 +493,7 @@ describe('ElementInstancesTree - Modification placeholders', () => {
           affectedTokenCount: 1,
           visibleAffectedTokenCount: 1,
           parentScopeIds: generateParentScopeIds(
-            businessObjects.elementsById,
+            mockNestedSubprocessDiagramModel.elementsById,
             'user_task',
             'nested_sub_process',
           ),

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/modificationsWithAncestorSelection.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/modificationsWithAncestorSelection.test.tsx
@@ -13,7 +13,7 @@ import {ElementInstancesTree} from './index';
 import {
   multipleSubprocessesWithTwoRunningScopesMock,
   mockNestedSubProcessInstance,
-  Wrapper,
+  getWrapper,
 } from './mocks';
 import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
@@ -59,7 +59,7 @@ describe.todo(
           businessObjects={businessObjects}
         />,
         {
-          wrapper: Wrapper,
+          wrapper: getWrapper(),
         },
       );
 
@@ -155,7 +155,7 @@ describe.todo(
           businessObjects={businessObjects}
         />,
         {
-          wrapper: Wrapper,
+          wrapper: getWrapper(),
         },
       );
 
@@ -323,7 +323,7 @@ describe.todo(
           businessObjects={businessObjects}
         />,
         {
-          wrapper: Wrapper,
+          wrapper: getWrapper(),
         },
       );
 
@@ -505,7 +505,7 @@ describe.todo(
           businessObjects={businessObjects}
         />,
         {
-          wrapper: Wrapper,
+          wrapper: getWrapper(),
         },
       );
 

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/multiInstanceSubprocess.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/multiInstanceSubprocess.test.tsx
@@ -9,7 +9,7 @@
 import {render, screen, within} from 'modules/testing-library';
 import {multiInstanceProcess, searchResult} from 'modules/testUtils';
 import {ElementInstancesTree} from './index';
-import {Wrapper, mockMultiInstanceProcessInstance} from './mocks';
+import {getWrapper, mockMultiInstanceProcessInstance} from './mocks';
 import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
 import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
 import {mockFetchElementInstancesStatistics} from 'modules/mocks/api/v2/elementInstances/elementInstancesStatistics/fetchElementInstancesStatistics';
@@ -98,7 +98,7 @@ describe('ElementInstancesTree - Multi Instance Subprocess', () => {
         businessObjects={businessObjects}
       />,
       {
-        wrapper: Wrapper,
+        wrapper: getWrapper(),
       },
     );
 
@@ -123,7 +123,7 @@ describe('ElementInstancesTree - Multi Instance Subprocess', () => {
         businessObjects={businessObjects}
       />,
       {
-        wrapper: Wrapper,
+        wrapper: getWrapper(),
       },
     );
 
@@ -226,7 +226,7 @@ describe('ElementInstancesTree - Multi Instance Subprocess', () => {
         businessObjects={businessObjects}
       />,
       {
-        wrapper: Wrapper,
+        wrapper: getWrapper(),
       },
     );
 

--- a/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/nestedSubprocess.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ElementInstanceLog/ElementInstancesTree/nestedSubprocess.test.tsx
@@ -9,7 +9,7 @@
 import {act} from 'react';
 import {render, screen} from 'modules/testing-library';
 import {open} from 'modules/mocks/diagrams';
-import {Wrapper, mockNestedSubProcessesInstance} from './mocks';
+import {getWrapper, mockNestedSubProcessesInstance} from './mocks';
 import {ElementInstancesTree} from './index';
 import {modificationsStore} from 'modules/stores/modifications';
 import {generateUniqueID} from 'modules/utils/generateUniqueID';
@@ -97,7 +97,7 @@ describe('ElementInstancesTree - Nested Subprocesses', () => {
         businessObjects={businessObjects}
       />,
       {
-        wrapper: Wrapper,
+        wrapper: getWrapper(),
       },
     );
 
@@ -163,7 +163,7 @@ describe('ElementInstancesTree - Nested Subprocesses', () => {
         businessObjects={businessObjects}
       />,
       {
-        wrapper: Wrapper,
+        wrapper: getWrapper(),
       },
     );
 

--- a/operate/client/src/modules/stores/networkReconnectionHandler.ts
+++ b/operate/client/src/modules/stores/networkReconnectionHandler.ts
@@ -29,6 +29,7 @@ class NetworkReconnectionHandler {
   }
   reset() {
     window.removeEventListener('online', this.handleReconnection);
+    this.boundCallback = undefined;
   }
 }
 export {NetworkReconnectionHandler};

--- a/operate/client/src/modules/stores/notifications.tsx
+++ b/operate/client/src/modules/stores/notifications.tsx
@@ -28,6 +28,7 @@ type Notification = {
 class Notifications {
   notifications: Notification[] = [];
   #notificationsQueue: Notification[] = [];
+  #activeIntervalIds: Set<ReturnType<typeof setInterval>> = new Set();
 
   constructor() {
     makeObservable(this, {
@@ -77,7 +78,7 @@ class Notifications {
     let intervalId: ReturnType<typeof setInterval>;
     let time = NOTIFICATION_TIMEOUT;
 
-    intervalId = setInterval(function () {
+    intervalId = setInterval(() => {
       if (document.hidden) {
         return;
       }
@@ -86,9 +87,11 @@ class Notifications {
 
       if (time <= 0) {
         clearInterval(intervalId);
+        this.#activeIntervalIds.delete(intervalId);
         notification.hideNotification();
       }
     }, delta);
+    this.#activeIntervalIds.add(intervalId);
   };
 
   hideNotification = (notificationId: string) => {
@@ -106,6 +109,9 @@ class Notifications {
 
   reset = () => {
     this.notifications = [];
+    this.#notificationsQueue = [];
+    this.#activeIntervalIds.forEach((id) => clearInterval(id));
+    this.#activeIntervalIds.clear();
   };
 }
 

--- a/operate/client/src/modules/stores/notifications.tsx
+++ b/operate/client/src/modules/stores/notifications.tsx
@@ -28,7 +28,7 @@ type Notification = {
 class Notifications {
   notifications: Notification[] = [];
   #notificationsQueue: Notification[] = [];
-  #activeIntervalIds: Set<ReturnType<typeof setInterval>> = new Set();
+  #activeIntervalIds: Map<string, ReturnType<typeof setInterval>> = new Map();
 
   constructor() {
     makeObservable(this, {
@@ -75,10 +75,9 @@ class Notifications {
 
   #addAutoRemovalInterval = (notification: Notification) => {
     const delta = 100;
-    let intervalId: ReturnType<typeof setInterval>;
     let time = NOTIFICATION_TIMEOUT;
 
-    intervalId = setInterval(() => {
+    const intervalId = setInterval(() => {
       if (document.hidden) {
         return;
       }
@@ -87,14 +86,20 @@ class Notifications {
 
       if (time <= 0) {
         clearInterval(intervalId);
-        this.#activeIntervalIds.delete(intervalId);
+        this.#activeIntervalIds.delete(notification.id);
         notification.hideNotification();
       }
     }, delta);
-    this.#activeIntervalIds.add(intervalId);
+    this.#activeIntervalIds.set(notification.id, intervalId);
   };
 
   hideNotification = (notificationId: string) => {
+    const intervalId = this.#activeIntervalIds.get(notificationId);
+    if (intervalId !== undefined) {
+      clearInterval(intervalId);
+      this.#activeIntervalIds.delete(notificationId);
+    }
+
     const queuedNotification = this.#dequeueNotification();
 
     this.notifications = this.notifications.filter(

--- a/operate/client/src/setupTests.tsx
+++ b/operate/client/src/setupTests.tsx
@@ -205,6 +205,9 @@ beforeAll(() => {
 
   // temporary fix while jsdom doesn't implement this: https://github.com/jsdom/jsdom/issues/1695
   window.HTMLElement.prototype.scrollIntoView = function () {};
+
+  // jsdom doesn't implement window.prompt, needed by copy-to-clipboard (used by Carbon CodeSnippet)
+  window.prompt = vi.fn();
 });
 afterEach(() => mockServer.resetHandlers());
 afterAll(() => mockServer.close());

--- a/operate/client/vite.config.ts
+++ b/operate/client/vite.config.ts
@@ -90,7 +90,6 @@ export default defineConfig(({mode}) => ({
     resetMocks: true,
     unstubEnvs: true,
     retry: process.env['CI'] ? 3 : 0,
-    dangerouslyIgnoreUnhandledErrors: Boolean(process.env['CI']),
     ...getReporters(),
     server: {
       deps: {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Unit tests were running out of memory in CI.

The CI configuration (`--maxWorkers=1 --no-file-parallelism --shard=3/4`) executes ~60 test files sequentially within a single process. Over time, memory accumulates from sources like JSDOM environments, `BpmnModdle` circular reference graphs, and MSW handlers.

When memory pressure increases and a test fails or times out, `retry: 3` re-runs the same file in the *same process*. This leads to a compounding effect, eventually causing an OOM crash (~8GB).

## Improvements

This PR removes key sources of cumulative memory leaks that build up across sequential test execution:

* Orphaned `setInterval` handles
* Stale closure references
* Duplicate `QueryClient` instances

These issues were especially problematic when retries re-executed failing tests in the same process, amplifying memory usage.

## Benchmark Results

**Shard 3/4 (previously resulted in OOM crash)**

| Metric    | Before | After  | Delta   |
| --------- | ------ | ------ | ------- |
| Peak heap | 300 MB | 295 MB | -5 MB   |
| 2nd peak  | 295 MB | 181 MB | -114 MB |
| 3rd peak  | 289 MB | 181 MB | -108 MB |
| Average   | 111 MB | 105 MB | -6 MB   |

### Notes

* Shard 1/4 did not show noticeable improvements.
* Locally, OOM is not reproducible due to:

  * No retry loops
  * Less restrictive memory limits compared to CI

## Additional Fix

Resolved an error in shard 2/4:

```
Error: Not implemented: window.prompt
```

This was caused by Carbon’s `CodeSnippet` copy button falling back to `window.prompt()` in JSDOM. The issue has been addressed in this PR.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

See slack discussion:
https://camunda.slack.com/archives/C071KP5BTHB/p1776673179148269?thread_ts=1776667462.389809&cid=C071KP5BTHB
