### PR TITLE
fix: add spring boot starter virtual threads to bom

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -96,6 +96,12 @@
 
       <dependency>
         <groupId>io.camunda</groupId>
+        <artifactId>camunda-spring-boot-starter-virtual-threads</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
         <artifactId>camunda-spring-boot-3-starter</artifactId>
         <version>${project.version}</version>
       </dependency>


### PR DESCRIPTION
## Description

This pull request adds a new dependency to the project’s BOM to support virtual threads in Spring Boot applications.

Dependency management:

* Added the `camunda-spring-boot-starter-virtual-threads` dependency to `bom/pom.xml` to enable virtual thread support version management for Camunda Spring Boot projects.
<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
