### PR TITLE
feat: POC - extract and expose input specification from root start events

### DIFF
--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
@@ -256,4 +256,15 @@
     </createIndex>
   </changeSet>
 
+  <changeSet id="add_message_subscription_input_specification_column" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="${prefix}MESSAGE_SUBSCRIPTION" columnName="INPUT_SPECIFICATION"/>
+      </not>
+    </preConditions>
+    <addColumn tableName="${prefix}MESSAGE_SUBSCRIPTION">
+      <column name="INPUT_SPECIFICATION" type="CLOB"/>
+    </addColumn>
+  </changeSet>
+
 </databaseChangeLog>

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/MessageSubscriptionEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/MessageSubscriptionEntityMapper.java
@@ -35,6 +35,7 @@ public class MessageSubscriptionEntityMapper {
         .toolProperties(messageSubscriptionDbModel.toolProperties())
         .toolName(messageSubscriptionDbModel.toolName())
         .inboundConnectorType(messageSubscriptionDbModel.inboundConnectorType())
+        .inputSpecification(messageSubscriptionDbModel.inputSpecification())
         .build();
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/MessageSubscriptionDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/MessageSubscriptionDbModel.java
@@ -7,12 +7,15 @@
  */
 package io.camunda.db.rdbms.write.domain;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import io.camunda.db.rdbms.write.util.MapSerializer;
 import io.camunda.db.rdbms.write.util.TruncateUtil;
+import io.camunda.search.entities.MessageSubscriptionEntity.InputSpecItem;
 import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionState;
 import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionType;
 import io.camunda.util.ObjectBuilder;
 import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -37,6 +40,8 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
   private Map<String, String> toolProperties;
   private String toolName;
   private String inboundConnectorType;
+  private String serializedInputSpecification;
+  private List<InputSpecItem> inputSpecification;
 
   public MessageSubscriptionDbModel(final Long messageSubscriptionKey) {
     this.messageSubscriptionKey = messageSubscriptionKey;
@@ -61,7 +66,8 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
       final Integer processDefinitionVersion,
       final Map<String, String> toolProperties,
       final String toolName,
-      final String inboundConnectorType) {
+      final String inboundConnectorType,
+      final List<InputSpecItem> inputSpecification) {
     this.messageSubscriptionKey = messageSubscriptionKey;
     this.processDefinitionId = processDefinitionId;
     this.processDefinitionKey = processDefinitionKey;
@@ -82,6 +88,8 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
     this.toolProperties = toolProperties;
     this.toolName = toolName;
     this.inboundConnectorType = inboundConnectorType;
+    serializedInputSpecification = serializeInputSpecification(inputSpecification);
+    this.inputSpecification = inputSpecification;
   }
 
   public Long messageSubscriptionKey() {
@@ -201,6 +209,19 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
     this.inboundConnectorType = inboundConnectorType;
   }
 
+  public String serializedInputSpecification() {
+    return serializedInputSpecification;
+  }
+
+  public void setSerializedInputSpecification(final String serializedInputSpecification) {
+    this.serializedInputSpecification = serializedInputSpecification;
+    inputSpecification = deserializeInputSpecification(serializedInputSpecification);
+  }
+
+  public List<InputSpecItem> inputSpecification() {
+    return inputSpecification;
+  }
+
   public OffsetDateTime dateTime() {
     return dateTime;
   }
@@ -279,7 +300,22 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
         .processDefinitionVersion(processDefinitionVersion)
         .toolProperties(toolProperties)
         .toolName(toolName)
-        .inboundConnectorType(inboundConnectorType);
+        .inboundConnectorType(inboundConnectorType)
+        .inputSpecification(inputSpecification);
+  }
+
+  private static String serializeInputSpecification(final List<InputSpecItem> items) {
+    if (items == null || items.isEmpty()) {
+      return null;
+    }
+    return MapSerializer.serialize(items);
+  }
+
+  private static List<InputSpecItem> deserializeInputSpecification(final String serialized) {
+    if (serialized == null || serialized.isEmpty()) {
+      return null;
+    }
+    return MapSerializer.deserialize(serialized, new TypeReference<>() {});
   }
 
   public static class Builder implements ObjectBuilder<MessageSubscriptionDbModel> {
@@ -302,6 +338,7 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
     private Map<String, String> toolProperties;
     private String toolName;
     private String inboundConnectorType;
+    private List<InputSpecItem> inputSpecification;
 
     public Builder messageSubscriptionKey(final Long messageSubscriptionKey) {
       this.messageSubscriptionKey = messageSubscriptionKey;
@@ -374,6 +411,11 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
       return this;
     }
 
+    public Builder inputSpecification(final List<InputSpecItem> inputSpecification) {
+      this.inputSpecification = inputSpecification;
+      return this;
+    }
+
     public Builder dateTime(final OffsetDateTime dateTime) {
       this.dateTime = dateTime;
       return this;
@@ -420,7 +462,8 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
           processDefinitionVersion,
           toolProperties,
           toolName,
-          inboundConnectorType);
+          inboundConnectorType,
+          inputSpecification);
     }
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/util/MapSerializer.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/util/MapSerializer.java
@@ -8,6 +8,7 @@
 package io.camunda.db.rdbms.write.util;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Map;
 import org.slf4j.Logger;
@@ -16,36 +17,37 @@ import org.slf4j.LoggerFactory;
 public class MapSerializer {
 
   private static final Logger LOG = LoggerFactory.getLogger(MapSerializer.class);
+  private static final ObjectMapper MAPPER = new ObjectMapper();
 
-  public static String serialize(final Map<String, String> map) {
+  public static String serialize(final Object map) {
     if (map == null) {
       return null;
     }
 
-    final ObjectMapper mapper = new ObjectMapper();
     String serialized = null;
     try {
-      serialized = mapper.writeValueAsString(map);
+      serialized = MAPPER.writeValueAsString(map);
     } catch (final JsonProcessingException e) {
-      LOG.error("Failed to serialize map!", e);
+      LOG.error("Failed to serialize object!", e);
     }
 
     return serialized;
   }
 
   public static Map<String, String> deserialize(final String serialized) {
-    final ObjectMapper mapper = new ObjectMapper();
+    return deserialize(serialized, new TypeReference<>() {});
+  }
+
+  public static <T> T deserialize(final String serialized, final TypeReference<T> type) {
     if (serialized == null || serialized.isEmpty()) {
       return null;
     }
 
-    Map<String, String> map = null;
     try {
-      map = mapper.readValue(serialized, Map.class);
+      return MAPPER.readValue(serialized, type);
     } catch (final JsonProcessingException e) {
       LOG.error("Failed to deserialize map!", e);
+      return null;
     }
-
-    return map;
   }
 }

--- a/db/rdbms/src/main/resources/mapper/MessageSubscriptionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/MessageSubscriptionMapper.xml
@@ -45,7 +45,8 @@
     PROCESS_DEFINITION_VERSION,
     TOOL_PROPERTIES,
     TOOL_NAME,
-    INBOUND_CONNECTOR_TYPE
+    INBOUND_CONNECTOR_TYPE,
+    INPUT_SPECIFICATION
     FROM ${prefix}MESSAGE_SUBSCRIPTION
 
     <include refid="io.camunda.db.rdbms.sql.MessageSubscriptionMapper.searchAndAuthFilter" />
@@ -197,6 +198,7 @@
     <result column="TOOL_PROPERTIES" property="serializedToolProperties" javaType="java.lang.String" />
     <result column="TOOL_NAME" property="toolName" javaType="java.lang.String" />
     <result column="INBOUND_CONNECTOR_TYPE" property="inboundConnectorType" javaType="java.lang.String" />
+    <result column="INPUT_SPECIFICATION" property="serializedInputSpecification" javaType="java.lang.String" />
   </resultMap>
 
 
@@ -220,7 +222,8 @@
                                                PROCESS_DEFINITION_VERSION,
                                                TOOL_PROPERTIES,
                                                TOOL_NAME,
-                                               INBOUND_CONNECTOR_TYPE
+                                               INBOUND_CONNECTOR_TYPE,
+                                               INPUT_SPECIFICATION
     )
     VALUES (
             #{messageSubscriptionKey},
@@ -241,7 +244,8 @@
             #{processDefinitionVersion},
             #{serializedToolProperties},
             #{toolName},
-            #{inboundConnectorType}
+            #{inboundConnectorType},
+            #{serializedInputSpecification}
     )
   </insert>
 
@@ -262,7 +266,8 @@
         PROCESS_DEFINITION_VERSION = #{processDefinitionVersion},
         TOOL_PROPERTIES = #{serializedToolProperties},
         TOOL_NAME = #{toolName},
-        INBOUND_CONNECTOR_TYPE = #{inboundConnectorType}
+        INBOUND_CONNECTOR_TYPE = #{inboundConnectorType},
+        INPUT_SPECIFICATION = #{serializedInputSpecification}
     WHERE MESSAGE_SUBSCRIPTION_KEY = #{messageSubscriptionKey}
   </update>
 

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/MessageSubscriptionEntityMapperTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/MessageSubscriptionEntityMapperTest.java
@@ -10,9 +10,11 @@ package io.camunda.db.rdbms.read.mapper;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.write.domain.MessageSubscriptionDbModel;
+import io.camunda.search.entities.MessageSubscriptionEntity.InputSpecItem;
 import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionState;
 import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionType;
 import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -38,6 +40,8 @@ public class MessageSubscriptionEntityMapperTest {
             .processDefinitionName("My Process")
             .processDefinitionVersion(2)
             .toolProperties(Map.of("key1", "value1"))
+            .inputSpecification(
+                List.of(new InputSpecItem("name1", "desc1", "type1", true, "schema1")))
             .build();
 
     // When
@@ -67,6 +71,7 @@ public class MessageSubscriptionEntityMapperTest {
             .processDefinitionName(null)
             .processDefinitionVersion(null)
             .toolProperties(null)
+            .inputSpecification(null)
             .build();
 
     // When
@@ -89,5 +94,6 @@ public class MessageSubscriptionEntityMapperTest {
         .isEqualTo(""); // Oracle treats empty strings as NULL, mapper converts back to ""
     assertThat(entity.processDefinitionVersion()).isNull();
     assertThat(entity.toolProperties()).isEqualTo(Map.of());
+    assertThat(entity.inputSpecification()).isEqualTo(List.of());
   }
 }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -89,6 +89,7 @@ import io.camunda.gateway.protocol.model.IncidentProcessInstanceStatisticsByErro
 import io.camunda.gateway.protocol.model.IncidentResult;
 import io.camunda.gateway.protocol.model.IncidentSearchQueryResult;
 import io.camunda.gateway.protocol.model.IncidentStateEnum;
+import io.camunda.gateway.protocol.model.InputSpecItem;
 import io.camunda.gateway.protocol.model.JobErrorStatisticsItem;
 import io.camunda.gateway.protocol.model.JobErrorStatisticsQueryResult;
 import io.camunda.gateway.protocol.model.JobKindEnum;
@@ -1225,6 +1226,7 @@ public final class SearchQueryResponseMapper {
         .elementInstanceKey(keyToStringOrNull(messageSubscription.flowNodeInstanceKey()))
         .toolProperties(messageSubscription.toolProperties())
         .inboundConnectorType(messageSubscription.inboundConnectorType())
+        .inputSpecification(toInputSpecItems(messageSubscription.inputSpecification()))
         // `dateTime` can be absent on subscriptions that predate the field being populated;
         // fall back to the epoch sentinel (see EPOCH_DATE_SENTINEL) rather than 500.
         .lastUpdatedDate(
@@ -1246,6 +1248,21 @@ public final class SearchQueryResponseMapper {
         .tenantId(messageSubscription.tenantId())
         .toolName(messageSubscription.toolName())
         .build();
+  }
+
+  private static List<InputSpecItem> toInputSpecItems(
+      final List<io.camunda.search.entities.MessageSubscriptionEntity.InputSpecItem> items) {
+    return items.stream()
+        .map(
+            i ->
+                InputSpecItem.Builder.create()
+                    .description(i.description())
+                    .name(i.name())
+                    .required(i.required())
+                    .schema(i.schema())
+                    .type(i.type())
+                    .build())
+        .toList();
   }
 
   private static List<CorrelatedMessageSubscriptionResult> toCorrelatedMessageSubscriptions(

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/processes/ProcessesToolRepository.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/processes/ProcessesToolRepository.java
@@ -10,6 +10,7 @@ package io.camunda.gateway.mcp.processes;
 import io.camunda.gateway.mcp.config.server.ToolRepository;
 import io.camunda.gateway.mcp.mapper.CallToolResultMapper;
 import io.camunda.search.entities.MessageSubscriptionEntity;
+import io.camunda.search.entities.MessageSubscriptionEntity.InputSpecItem;
 import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionState;
 import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionType;
 import io.camunda.search.filter.Operation;
@@ -25,6 +26,8 @@ import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecifi
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -32,6 +35,8 @@ import java.util.UUID;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 import org.jspecify.annotations.NonNull;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.json.JsonMapper;
 
 public class ProcessesToolRepository implements ToolRepository {
 
@@ -69,6 +74,8 @@ public class ProcessesToolRepository implements ToolRepository {
           Tuple.of(PROPERTY_WHEN_TO_USE, LABEL_WHEN_TO_USE),
           Tuple.of(PROPERTY_WHEN_NOT_TO_USE, LABEL_WHEN_NOT_TO_USE),
           Tuple.of(PROPERTY_RESULTS, LABEL_RESULTS));
+
+  private static final JsonMapper OBJECT_MAPPER = JsonMapper.shared();
 
   private final MessageSubscriptionServices messageSubscriptionServices;
   private final MessageServices messageServices;
@@ -174,11 +181,54 @@ public class ProcessesToolRepository implements ToolRepository {
   private static Tool buildTool(final MessageSubscriptionEntity entity) {
     final var name = buildToolName(entity);
     final var description = buildDescription(entity.toolProperties());
-    return Tool.builder(name, Map.of("type", "object"))
+    return Tool.builder(name, buildInputSchema(entity))
         .title(entity.toolName())
         .description(description)
         .outputSchema(TOOL_OUTPUT_SCHEMA)
         .build();
+  }
+
+  private static Map<String, Object> buildInputSchema(final MessageSubscriptionEntity entity) {
+    final var specs = entity.inputSpecification();
+    if (specs.isEmpty()) {
+      return Map.of("type", "object");
+    }
+
+    final Map<String, Object> properties = new HashMap<>();
+    final List<String> required = new ArrayList<>();
+
+    for (final InputSpecItem spec : specs) {
+      if (spec.name() == null || spec.name().isBlank()) {
+        continue;
+      }
+
+      final Map<String, Object> propSchema = new HashMap<>();
+
+      if (spec.schema() != null && !spec.schema().isBlank()) {
+        try {
+          final Map<String, Object> schemaOverride =
+              OBJECT_MAPPER.readValue(spec.schema(), new TypeReference<>() {});
+          propSchema.putAll(schemaOverride);
+        } catch (final Exception ignored) {
+          // invalid schema override — proceed without it
+        }
+      }
+
+      final String jsonType =
+          spec.type() != null && !spec.description().isBlank() ? spec.type() : "string";
+      propSchema.put("type", jsonType);
+
+      if (spec.description() != null && !spec.description().isBlank()) {
+        propSchema.put("description", spec.description());
+      }
+
+      properties.put(spec.name(), propSchema);
+      if (spec.required()) {
+        required.add(spec.name());
+      }
+    }
+
+    return Map.of("type", "object", "properties", properties, "required", required);
   }
 
   private static @NonNull String buildToolName(final MessageSubscriptionEntity entity) {

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/processes/ProcessesToolRepositoryTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/processes/ProcessesToolRepositoryTest.java
@@ -77,6 +77,24 @@ class ProcessesToolRepositoryTest {
         .build();
   }
 
+  private static MessageSubscriptionEntity buildEntityWithInputSpec(
+      final Long key,
+      final String toolName,
+      final List<MessageSubscriptionEntity.InputSpecItem> inputSpec) {
+    return MessageSubscriptionEntity.builder()
+        .messageSubscriptionKey(key)
+        .toolName(toolName)
+        .toolProperties(Map.of())
+        .messageName("msg")
+        .tenantId("<default>")
+        .messageSubscriptionState(MessageSubscriptionState.CREATED)
+        .messageSubscriptionType(MessageSubscriptionType.START_EVENT)
+        .processDefinitionId("myProcess_" + toolName)
+        .flowNodeId("start")
+        .inputSpecification(inputSpec)
+        .build();
+  }
+
   @Nested
   class DynamicTools {
 
@@ -395,6 +413,49 @@ class ProcessesToolRepositoryTest {
       // then
       assertThat(tools).hasSize(1);
       assertThat(tools.getFirst().name()).isEqualTo("correlatedTool_88");
+    }
+
+    @Test
+    void shouldBuildInputSchemaFromInputSpecification() {
+      // given
+      final var inputSpec =
+          List.of(
+              new MessageSubscriptionEntity.InputSpecItem(
+                  "orderId", "The order ID", "string", true, ""),
+              new MessageSubscriptionEntity.InputSpecItem(
+                  "amount", "Order amount", "integer", false, "{\"minimum\": 0}"));
+      final var entity = buildEntityWithInputSpec(42L, "createOrder", inputSpec);
+      when(messageSubscriptionServices.search(any(), any()))
+          .thenReturn(SearchQueryResult.of(entity));
+
+      // when
+      final var tools = repository.getTools(transportContext);
+
+      // then
+      assertThat(tools)
+          .singleElement()
+          .satisfies(
+              tool -> {
+                final var schema = tool.inputSchema();
+                assertThat(schema.get("type")).isEqualTo("object");
+
+                final Map<String, Object> props = (Map<String, Object>) schema.get("properties");
+                assertThat(props).containsKey("orderId");
+                assertThat(props).containsKey("amount");
+
+                @SuppressWarnings("unchecked")
+                final var orderIdProp = (Map<String, Object>) props.get("orderId");
+                assertThat(orderIdProp).containsEntry("type", "string");
+                assertThat(orderIdProp).containsEntry("description", "The order ID");
+
+                @SuppressWarnings("unchecked")
+                final var amountProp = (Map<String, Object>) props.get("amount");
+                assertThat(amountProp).containsEntry("type", "integer");
+                assertThat(amountProp).containsEntry("minimum", 0);
+
+                assertThat(schema.get("required")).isInstanceOf(List.class);
+                assertThat((List<String>) schema.get("required")).containsExactly("orderId");
+              });
     }
 
     @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/MessageSubscriptionFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/MessageSubscriptionFixtures.java
@@ -10,6 +10,7 @@ package io.camunda.it.rdbms.db.fixtures;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.db.rdbms.write.domain.MessageSubscriptionDbModel;
 import io.camunda.db.rdbms.write.domain.MessageSubscriptionDbModel.Builder;
+import io.camunda.search.entities.MessageSubscriptionEntity.InputSpecItem;
 import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionState;
 import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionType;
 import io.camunda.zeebe.test.util.Strings;
@@ -41,7 +42,11 @@ public final class MessageSubscriptionFixtures extends CommonFixtures {
             .processDefinitionVersion((int) (Math.random() * 50))
             .messageSubscriptionType(randomEnum(MessageSubscriptionType.class))
             .messageSubscriptionState(randomEnum(MessageSubscriptionState.class))
-            .toolProperties(Map.of("key-" + UUID.randomUUID(), "value-" + UUID.randomUUID()));
+            .toolProperties(Map.of("key-" + UUID.randomUUID(), "value-" + UUID.randomUUID()))
+            .inputSpecification(
+                List.of(
+                    new InputSpecItem(
+                        "name-" + UUID.randomUUID(), "desc", "type", true, "schema")));
 
     return builderFunction.apply(builder).build();
   }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/MessageSubscriptionEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/MessageSubscriptionEntityTransformer.java
@@ -8,9 +8,12 @@
 package io.camunda.search.clients.transformers.entity;
 
 import io.camunda.search.clients.transformers.ServiceTransformer;
+import io.camunda.search.entities.MessageSubscriptionEntity.InputSpecItem;
 import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionType;
 import io.camunda.webapps.schema.entities.messagesubscription.MessageSubscriptionEntity;
 import io.camunda.webapps.schema.entities.messagesubscription.MessageSubscriptionState;
+import java.util.List;
+import java.util.Objects;
 import org.apache.commons.lang3.EnumUtils;
 
 public class MessageSubscriptionEntityTransformer
@@ -38,7 +41,8 @@ public class MessageSubscriptionEntityTransformer
         value.getProcessDefinitionVersion(),
         value.getToolProperties(),
         value.getToolName(),
-        value.getInboundConnectorType());
+        value.getInboundConnectorType(),
+        toInputSpecItems(value.getInputSpecification()));
   }
 
   private io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionState
@@ -70,5 +74,19 @@ public class MessageSubscriptionEntityTransformer
           "Unknown MessageSubscriptionType: " + messageSubscriptionType);
     }
     return type;
+  }
+
+  private List<InputSpecItem> toInputSpecItems(
+      final List<MessageSubscriptionEntity.InputSpecItem> items) {
+    if (items == null) {
+      return null;
+    }
+    return items.stream()
+        .filter(Objects::nonNull)
+        .map(
+            i ->
+                new InputSpecItem(
+                    i.getName(), i.getDescription(), i.getType(), i.isRequired(), i.getSchema()))
+        .toList();
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/entities/MessageSubscriptionEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/MessageSubscriptionEntity.java
@@ -9,7 +9,9 @@ package io.camunda.search.entities;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import org.jspecify.annotations.Nullable;
@@ -34,7 +36,8 @@ public record MessageSubscriptionEntity(
     @Nullable Integer processDefinitionVersion,
     Map<String, String> toolProperties,
     @Nullable String toolName,
-    @Nullable String inboundConnectorType)
+    @Nullable String inboundConnectorType,
+    List<InputSpecItem> inputSpecification)
     implements TenantOwnedEntity {
 
   public MessageSubscriptionEntity {
@@ -48,6 +51,7 @@ public record MessageSubscriptionEntity(
     // <collection> result map or a LEFT JOIN) by calling .add() on the existing instance.
     // Immutable defaults (e.g. Map.of()) would cause UnsupportedOperationException at runtime.
     toolProperties = toolProperties != null ? toolProperties : new HashMap<>();
+    inputSpecification = inputSpecification != null ? inputSpecification : new ArrayList<>();
     // Pre-8.10 rows have no messageSubscriptionType stored; default them to PROCESS_EVENT.
     messageSubscriptionType =
         messageSubscriptionType != null
@@ -78,6 +82,7 @@ public record MessageSubscriptionEntity(
     private @Nullable Map<String, String> toolProperties;
     private @Nullable String toolName;
     private @Nullable String inboundConnectorType;
+    private @Nullable List<InputSpecItem> inputSpecification;
 
     public Builder messageSubscriptionKey(final Long messageSubscriptionKey) {
       this.messageSubscriptionKey = messageSubscriptionKey;
@@ -150,6 +155,11 @@ public record MessageSubscriptionEntity(
       return this;
     }
 
+    public Builder inputSpecification(final List<InputSpecItem> inputSpecification) {
+      this.inputSpecification = inputSpecification;
+      return this;
+    }
+
     public Builder dateTime(final OffsetDateTime dateTime) {
       this.dateTime = dateTime;
       return this;
@@ -190,7 +200,8 @@ public record MessageSubscriptionEntity(
           processDefinitionVersion,
           toolProperties,
           toolName,
-          inboundConnectorType);
+          inboundConnectorType,
+          inputSpecification);
     }
   }
 
@@ -204,5 +215,18 @@ public record MessageSubscriptionEntity(
   public enum MessageSubscriptionType {
     START_EVENT,
     PROCESS_EVENT
+  }
+
+  public record InputSpecItem(
+      String name,
+      @Nullable String description,
+      String type,
+      boolean required,
+      @Nullable String schema) {
+
+    public InputSpecItem {
+      Objects.requireNonNull(name, "name");
+      Objects.requireNonNull(type, "type");
+    }
   }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/MessageSubscriptionTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/MessageSubscriptionTemplate.java
@@ -112,6 +112,7 @@ public class MessageSubscriptionTemplate extends AbstractTemplateDescriptor
   public static final String MESSAGE_SUBSCRIPTION_TYPE = "messageSubscriptionType";
   public static final String TOOL_NAME = "toolName";
   public static final String INBOUND_CONNECTOR_TYPE = "inboundConnectorType";
+  public static final String INPUT_SPECIFICATION = "inputSpecification";
 
   public MessageSubscriptionTemplate(final String indexPrefix, final boolean isElasticsearch) {
     super(indexPrefix, isElasticsearch);

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/messagesubscription/MessageSubscriptionEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/messagesubscription/MessageSubscriptionEntity.java
@@ -13,6 +13,7 @@ import io.camunda.webapps.schema.entities.PartitionedEntity;
 import io.camunda.webapps.schema.entities.SinceVersion;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -71,6 +72,9 @@ public class MessageSubscriptionEntity
 
   @SinceVersion(value = "8.10.0", requireDefault = false)
   private String inboundConnectorType;
+
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private List<InputSpecItem> inputSpecification;
 
   /**
    * @deprecated since 8.9
@@ -275,6 +279,16 @@ public class MessageSubscriptionEntity
     return this;
   }
 
+  public List<InputSpecItem> getInputSpecification() {
+    return inputSpecification;
+  }
+
+  public MessageSubscriptionEntity setInputSpecification(
+      final List<InputSpecItem> inputSpecification) {
+    this.inputSpecification = inputSpecification;
+    return this;
+  }
+
   /**
    * @deprecated since 8.9
    */
@@ -369,7 +383,8 @@ public class MessageSubscriptionEntity
         toolProperties,
         messageSubscriptionType,
         toolName,
-        inboundConnectorType);
+        inboundConnectorType,
+        inputSpecification);
   }
 
   @Override
@@ -405,6 +420,60 @@ public class MessageSubscriptionEntity
         && Objects.equals(toolProperties, that.toolProperties)
         && Objects.equals(messageSubscriptionType, that.messageSubscriptionType)
         && Objects.equals(toolName, that.toolName)
-        && Objects.equals(inboundConnectorType, that.inboundConnectorType);
+        && Objects.equals(inboundConnectorType, that.inboundConnectorType)
+        && Objects.equals(inputSpecification, that.inputSpecification);
+  }
+
+  public static class InputSpecItem {
+    private String name;
+    private String description;
+    private String type;
+    private boolean required;
+    private String schema;
+
+    public String getName() {
+      return name;
+    }
+
+    public InputSpecItem setName(final String name) {
+      this.name = name;
+      return this;
+    }
+
+    public String getDescription() {
+      return description;
+    }
+
+    public InputSpecItem setDescription(final String description) {
+      this.description = description;
+      return this;
+    }
+
+    public String getType() {
+      return type;
+    }
+
+    public InputSpecItem setType(final String type) {
+      this.type = type;
+      return this;
+    }
+
+    public boolean isRequired() {
+      return required;
+    }
+
+    public InputSpecItem setRequired(final boolean required) {
+      this.required = required;
+      return this;
+    }
+
+    public String getSchema() {
+      return schema;
+    }
+
+    public InputSpecItem setSchema(final String schema) {
+      this.schema = schema;
+      return this;
+    }
   }
 }

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-event.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-event.json
@@ -112,6 +112,10 @@
       },
       "inboundConnectorType": {
         "type": "keyword"
+      },
+      "inputSpecification": {
+        "type": "object",
+        "enabled": false
       }
 		}
 	}

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-event.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-event.json
@@ -112,6 +112,10 @@
       },
       "inboundConnectorType": {
         "type": "keyword"
+      },
+      "inputSpecification": {
+        "type": "object",
+        "enabled": false
       }
 		}
 	}

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/cache/process/CachedInputSpecItem.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/cache/process/CachedInputSpecItem.java
@@ -7,15 +7,6 @@
  */
 package io.camunda.zeebe.exporter.common.cache.process;
 
-import java.util.List;
-import java.util.Map;
-
-public record CachedProcessEntity(
-    String name,
-    int version,
-    String versionTag,
-    List<String> callElementIds,
-    Map<String, String> flowNodesMap,
-    boolean hasUserTasks,
-    Map<String, Map<String, String>> elementExtensionProperties,
-    Map<String, List<CachedInputSpecItem>> elementInputSpecifications) {}
+/** A single input parameter */
+public record CachedInputSpecItem(
+    String name, String description, String type, boolean required, String schema) {}

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/utils/ProcessCacheUtil.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/utils/ProcessCacheUtil.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.exporter.common.utils;
 
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
+import io.camunda.zeebe.exporter.common.cache.process.CachedInputSpecItem;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
 import io.camunda.zeebe.exporter.common.extensionproperty.ExtensionPropertyConfiguration;
 import io.camunda.zeebe.model.bpmn.instance.CallActivity;
@@ -115,6 +116,8 @@ public final class ProcessCacheUtil {
       final var extensionProperties =
           ProcessModelReader.extractExtensionProperties(
               flowNodes, extensionPropertiesConfiguration.extensionPropertyFilter());
+      final var elementInputSpecifications =
+          toCachedInputSpecMap(reader.extractAllElementInputSpecs());
       return new CachedProcessEntity(
           name,
           version,
@@ -122,9 +125,11 @@ public final class ProcessCacheUtil {
           callActivityIds,
           flowNodesMap,
           hasUserTasks,
-          extensionProperties);
+          extensionProperties,
+          elementInputSpecifications);
     }
-    return new CachedProcessEntity(name, version, versionTag, List.of(), Map.of(), true, Map.of());
+    return new CachedProcessEntity(
+        name, version, versionTag, List.of(), Map.of(), true, Map.of(), Map.of());
   }
 
   private static List<String> sortedCallActivityIds(final Collection<CallActivity> callActivities) {
@@ -152,5 +157,21 @@ public final class ProcessCacheUtil {
   private static Map<String, String> getFlowNodesMap(final Collection<FlowNode> flowNodes) {
     return flowNodes.stream()
         .collect(HashMap::new, (map, fn) -> map.put(fn.getId(), fn.getName()), HashMap::putAll);
+  }
+
+  public static Map<String, List<CachedInputSpecItem>> toCachedInputSpecMap(
+      final Map<String, List<ProcessModelReader.InputSpecItem>> source) {
+    final Map<String, List<CachedInputSpecItem>> result = new HashMap<>();
+    source.forEach(
+        (elementId, items) ->
+            result.put(
+                elementId,
+                items.stream()
+                    .map(
+                        i ->
+                            new CachedInputSpecItem(
+                                i.name(), i.description(), i.type(), i.required(), i.schema()))
+                    .toList()));
+    return result;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AbstractEventHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AbstractEventHandler.java
@@ -16,6 +16,7 @@ import static io.camunda.webapps.schema.descriptors.template.MessageSubscription
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.INBOUND_CONNECTOR_TYPE;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.INCIDENT_ERROR_MSG;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.INCIDENT_ERROR_TYPE;
+import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.INPUT_SPECIFICATION;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.JOB_CUSTOM_HEADERS;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.JOB_KEY;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.JOB_RETRIES;
@@ -35,6 +36,7 @@ import static io.camunda.webapps.schema.descriptors.template.MessageSubscription
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.messagesubscription.EventSourceType;
 import io.camunda.webapps.schema.entities.messagesubscription.MessageSubscriptionEntity;
+import io.camunda.webapps.schema.entities.messagesubscription.MessageSubscriptionEntity.InputSpecItem;
 import io.camunda.webapps.schema.entities.messagesubscription.MessageSubscriptionState;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
@@ -44,6 +46,7 @@ import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.util.modelreader.ProcessModelReader;
 import java.time.Instant;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public abstract class AbstractEventHandler<R extends RecordValue>
@@ -106,6 +109,7 @@ public abstract class AbstractEventHandler<R extends RecordValue>
     jsonMap.put(TOOL_PROPERTIES, entity.getToolProperties());
     jsonMap.put(TOOL_NAME, entity.getToolName());
     jsonMap.put(INBOUND_CONNECTOR_TYPE, entity.getInboundConnectorType());
+    jsonMap.put(INPUT_SPECIFICATION, entity.getInputSpecification());
     jsonMap.put(positionFieldName, positionFieldValue);
     if (entity.getMetadata() != null) {
       final Map<String, Object> metadataMap = new HashMap<>();
@@ -158,6 +162,25 @@ public abstract class AbstractEventHandler<R extends RecordValue>
           .setToolProperties(
               ProcessModelReader.extractExtensionProperties(
                   ext, extensionPropertyConfig.getToolPropertiesPrefix()));
+
+      final var cachedSpecs =
+          cached
+              .map(CachedProcessEntity::elementInputSpecifications)
+              .map(m -> m.get(elementId))
+              .orElse(List.of());
+      if (!cachedSpecs.isEmpty()) {
+        entity.setInputSpecification(
+            cachedSpecs.stream()
+                .map(
+                    s ->
+                        new InputSpecItem()
+                            .setName(s.name())
+                            .setDescription(s.description())
+                            .setType(s.type())
+                            .setRequired(s.required())
+                            .setSchema(s.schema()))
+                .toList());
+      }
     }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/cache/ProcessCacheImplIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/cache/ProcessCacheImplIT.java
@@ -118,6 +118,7 @@ class ProcessCacheImplIT {
             List.of("Banana", "Cherry", "apple"),
             expectedFlowNodesMap,
             false,
+            Map.of(),
             Map.of());
     assertThat(process).isPresent().get().isEqualTo(expectedCachedProcessEntity);
   }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/IncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/IncidentHandlerTest.java
@@ -323,12 +323,20 @@ public class IncidentHandlerTest {
             List.of("0", "1", "2", callActivityId1),
             Map.of("FI1", "FN1"),
             false,
+            Map.of(),
             Map.of()));
 
     processCache.put(
         processDefinitionKey2,
         new CachedProcessEntity(
-            null, 1, null, List.of("0", callActivityId2), Map.of("FI1", "FN1"), false, Map.of()));
+            null,
+            1,
+            null,
+            List.of("0", callActivityId2),
+            Map.of("FI1", "FN1"),
+            false,
+            Map.of(),
+            Map.of()));
 
     // when
     final IncidentEntity incidentEntity = new IncidentEntity();
@@ -375,7 +383,14 @@ public class IncidentHandlerTest {
     processCache.put(
         parentProcessDefinitionKey,
         new CachedProcessEntity(
-            null, 1, null, List.of(callActivityId), Map.of("FI1", "FN1"), false, Map.of()));
+            null,
+            1,
+            null,
+            List.of(callActivityId),
+            Map.of("FI1", "FN1"),
+            false,
+            Map.of(),
+            Map.of()));
 
     // when
     final IncidentEntity incidentEntity = new IncidentEntity();

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandlerTest.java
@@ -259,6 +259,7 @@ public class ListViewProcessInstanceFromProcessInstanceHandlerTest {
             new ArrayList<>(),
             Map.of(),
             false,
+            Map.of(),
             Map.of()));
 
     // when
@@ -363,12 +364,19 @@ public class ListViewProcessInstanceFromProcessInstanceHandlerTest {
     processCache.put(
         processDefinitionKey1,
         new CachedProcessEntity(
-            null, 1, null, List.of("0", "1", "2", callActivityId1), Map.of(), false, Map.of()));
+            null,
+            1,
+            null,
+            List.of("0", "1", "2", callActivityId1),
+            Map.of(),
+            false,
+            Map.of(),
+            Map.of()));
 
     processCache.put(
         processDefinitionKey2,
         new CachedProcessEntity(
-            null, 1, null, List.of("0", callActivityId2), Map.of(), false, Map.of()));
+            null, 1, null, List.of("0", callActivityId2), Map.of(), false, Map.of(), Map.of()));
 
     // when called process 3rd level
     final ProcessInstanceForListViewEntity processInstanceForListViewEntity3 =

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromMessageStartEventSubscriptionHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromMessageStartEventSubscriptionHandlerTest.java
@@ -164,7 +164,7 @@ final class MessageSubscriptionFromMessageStartEventSubscriptionHandlerTest {
         .thenReturn(
             Optional.of(
                 new CachedProcessEntity(
-                    processName, 3, "v3", List.of(), Map.of(), false, Map.of())));
+                    processName, 3, "v3", List.of(), Map.of(), false, Map.of(), Map.of())));
 
     final ImmutableMessageStartEventSubscriptionRecordValue value =
         ImmutableMessageStartEventSubscriptionRecordValue.builder()
@@ -210,7 +210,8 @@ final class MessageSubscriptionFromMessageStartEventSubscriptionHandlerTest {
                     List.of(),
                     Map.of(),
                     false,
-                    Map.of(startEventId, extProps))));
+                    Map.of(startEventId, extProps),
+                    Map.of())));
 
     final ImmutableMessageStartEventSubscriptionRecordValue value =
         ImmutableMessageStartEventSubscriptionRecordValue.builder()
@@ -309,6 +310,7 @@ final class MessageSubscriptionFromMessageStartEventSubscriptionHandlerTest {
     expectedUpdateFields.put("toolName", null);
     expectedUpdateFields.put("inboundConnectorType", null);
     expectedUpdateFields.put("toolProperties", null);
+    expectedUpdateFields.put("inputSpecification", null);
     expectedUpdateFields.put("metadata", metadataMap);
     final BatchRequest mockRequest = Mockito.mock(BatchRequest.class);
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromProcessMessageSubscriptionHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromProcessMessageSubscriptionHandlerTest.java
@@ -307,7 +307,7 @@ final class MessageSubscriptionFromProcessMessageSubscriptionHandlerTest {
         .thenReturn(
             Optional.of(
                 new CachedProcessEntity(
-                    processName, 3, "v3", List.of(), Map.of(), false, Map.of())));
+                    processName, 3, "v3", List.of(), Map.of(), false, Map.of(), Map.of())));
 
     final ImmutableProcessMessageSubscriptionRecordValue value =
         ImmutableProcessMessageSubscriptionRecordValue.builder()
@@ -347,7 +347,14 @@ final class MessageSubscriptionFromProcessMessageSubscriptionHandlerTest {
         .thenReturn(
             Optional.of(
                 new CachedProcessEntity(
-                    "Process", 1, null, List.of(), Map.of(), false, Map.of(elementId, extProps))));
+                    "Process",
+                    1,
+                    null,
+                    List.of(),
+                    Map.of(),
+                    false,
+                    Map.of(elementId, extProps),
+                    Map.of())));
 
     final ImmutableProcessMessageSubscriptionRecordValue value =
         ImmutableProcessMessageSubscriptionRecordValue.builder()
@@ -446,6 +453,7 @@ final class MessageSubscriptionFromProcessMessageSubscriptionHandlerTest {
     expectedUpdateFields.put("toolName", null);
     expectedUpdateFields.put("inboundConnectorType", null);
     expectedUpdateFields.put("toolProperties", null);
+    expectedUpdateFields.put("inputSpecification", null);
     expectedUpdateFields.put("metadata", metadataMap);
 
     final BatchRequest mockRequest = Mockito.mock(BatchRequest.class);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskCreatingHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskCreatingHandlerTest.java
@@ -242,7 +242,14 @@ public class UserTaskCreatingHandlerTest {
     processCache.put(
         processDefinitionKey,
         new CachedProcessEntity(
-            "my-process", 1, "v1", List.of(), Map.of(elementId, "my-flow-node"), false, Map.of()));
+            "my-process",
+            1,
+            "v1",
+            List.of(),
+            Map.of(elementId, "my-flow-node"),
+            false,
+            Map.of(),
+            Map.of()));
 
     // when
     final TaskEntity taskEntity =

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskJobBasedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskJobBasedHandlerTest.java
@@ -328,7 +328,14 @@ public class UserTaskJobBasedHandlerTest {
     processCache.put(
         processDefinitionKey,
         new CachedProcessEntity(
-            "my-process", 1, "v1", List.of(), Map.of(elementId, "my-flow-node"), false, Map.of()));
+            "my-process",
+            1,
+            "v1",
+            List.of(),
+            Map.of(elementId, "my-flow-node"),
+            false,
+            Map.of(),
+            Map.of()));
 
     // when
     final TaskEntity taskEntity = new TaskEntity().setId(String.valueOf(recordKey));

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskVariableHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskVariableHandlerTest.java
@@ -82,7 +82,7 @@ public class UserTaskVariableHandlerTest {
     final long processDefinitionKey = 789L;
     processCache.put(
         processDefinitionKey,
-        new CachedProcessEntity("test", 1, null, List.of(), Map.of(), false, Map.of()));
+        new CachedProcessEntity("test", 1, null, List.of(), Map.of(), false, Map.of(), Map.of()));
 
     final Record<VariableRecordValue> variableRecord =
         factory.generateRecord(
@@ -105,7 +105,7 @@ public class UserTaskVariableHandlerTest {
     final long processDefKey = 123L;
     processCache.put(
         processDefKey,
-        new CachedProcessEntity("test", 1, null, List.of(), Map.of(), true, Map.of()));
+        new CachedProcessEntity("test", 1, null, List.of(), Map.of(), true, Map.of(), Map.of()));
 
     final Record<VariableRecordValue> variableRecord =
         factory.generateRecord(
@@ -131,7 +131,7 @@ public class UserTaskVariableHandlerTest {
     final long processDefinitionKey = 789L;
     processCache.put(
         processDefinitionKey,
-        new CachedProcessEntity("test", 1, null, List.of(), Map.of(), false, Map.of()));
+        new CachedProcessEntity("test", 1, null, List.of(), Map.of(), false, Map.of(), Map.of()));
 
     final Record<VariableRecordValue> variableRecord =
         factory.generateRecord(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/notifier/IncidentNotifierTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/notifier/IncidentNotifierTest.java
@@ -103,7 +103,14 @@ class IncidentNotifierTest {
         .thenReturn(
             Optional.of(
                 new CachedProcessEntity(
-                    processName, processVersion, processVersionTag, null, null, false, Map.of())));
+                    processName,
+                    processVersion,
+                    processVersionTag,
+                    null,
+                    null,
+                    false,
+                    Map.of(),
+                    Map.of())));
   }
 
   @Test

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionFromMessageStartEventSubscriptionExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionFromMessageStartEventSubscriptionExportHandler.java
@@ -12,6 +12,7 @@ import static io.camunda.exporter.rdbms.utils.DateUtil.toOffsetDateTime;
 import io.camunda.db.rdbms.write.domain.MessageSubscriptionDbModel;
 import io.camunda.db.rdbms.write.service.MessageSubscriptionWriter;
 import io.camunda.exporter.rdbms.RdbmsExportHandler;
+import io.camunda.search.entities.MessageSubscriptionEntity.InputSpecItem;
 import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionState;
 import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionType;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
@@ -23,6 +24,7 @@ import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionInte
 import io.camunda.zeebe.protocol.record.value.MessageStartEventSubscriptionRecordValue;
 import io.camunda.zeebe.util.modelreader.ProcessModelReader;
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -102,6 +104,19 @@ public class MessageSubscriptionFromMessageStartEventSubscriptionExportHandler
                 ext, extensionPropertyConfig.getToolPropertiesPrefix()))
         .toolName(ext.get(extensionPropertyConfig.getToolNameProperty()))
         .inboundConnectorType(ext.get(extensionPropertyConfig.getInboundConnectorTypeProperty()))
+        .inputSpecification(
+            toInputSpecItems(
+                cached
+                    .map(CachedProcessEntity::elementInputSpecifications)
+                    .map(m -> m.get(value.getStartEventId()))
+                    .orElse(List.of())))
         .build();
+  }
+
+  private List<InputSpecItem> toInputSpecItems(
+      final List<io.camunda.zeebe.exporter.common.cache.process.CachedInputSpecItem> cached) {
+    return cached.stream()
+        .map(s -> new InputSpecItem(s.name(), s.description(), s.type(), s.required(), s.schema()))
+        .toList();
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/IncidentExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/IncidentExportHandlerTest.java
@@ -87,7 +87,7 @@ class IncidentExportHandlerTest {
         .thenReturn(
             Optional.of(
                 new CachedProcessEntity(
-                    null, 1, null, List.of(callActivityId), Map.of(), false, Map.of())));
+                    null, 1, null, List.of(callActivityId), Map.of(), false, Map.of(), Map.of())));
 
     // when
     handler.export(record);

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/message/MessageSubscriptionExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/message/MessageSubscriptionExportHandlerTest.java
@@ -169,7 +169,14 @@ final class MessageSubscriptionExportHandlerTest {
 
     final CachedProcessEntity cached =
         new CachedProcessEntity(
-            processName, processVersion, null, null, null, false, Map.of(elementId, extProps));
+            processName,
+            processVersion,
+            null,
+            null,
+            null,
+            false,
+            Map.of(elementId, extProps),
+            Map.of());
     when(processCache.get(pdKey)).thenReturn(Optional.of(cached));
 
     // when

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/message/MessageSubscriptionFromMessageStartEventSubscriptionExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/message/MessageSubscriptionFromMessageStartEventSubscriptionExportHandlerTest.java
@@ -161,7 +161,14 @@ final class MessageSubscriptionFromMessageStartEventSubscriptionExportHandlerTes
 
     final CachedProcessEntity cached =
         new CachedProcessEntity(
-            processName, processVersion, null, null, null, false, Map.of(elementId, extProps));
+            processName,
+            processVersion,
+            null,
+            null,
+            null,
+            false,
+            Map.of(elementId, extProps),
+            Map.of());
     when(processCache.get(pdKey)).thenReturn(Optional.of(cached));
 
     // when

--- a/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
@@ -277,6 +277,7 @@ components:
         - elementInstanceKey
         - toolProperties
         - inboundConnectorType
+        - inputSpecification
         - lastUpdatedDate
         - messageName
         - messageSubscriptionKey
@@ -375,6 +376,12 @@ components:
             Null when the property is absent.
         tenantId:
           $ref: 'identifiers.yaml#/components/schemas/TenantId'
+        inputSpecification:
+          type: array
+          items:
+            $ref: '#/components/schemas/InputSpecItem'
+          description: |
+            The input specification items declared on the element this message subscription belongs to.
       x-properties-added-in-version:
         - propertyName: rootProcessInstanceKey
           addedInVersion: "8.9"
@@ -390,6 +397,35 @@ components:
           addedInVersion: "8.10"
         - propertyName: inboundConnectorType
           addedInVersion: "8.10"
+        - propertyName: inputSpecification
+          addedInVersion: "8.10"
+
+    InputSpecItem:
+      type: object
+      required:
+        - description
+        - name
+        - required
+        - schema
+        - type
+      properties:
+        name:
+          type: string
+          description: The parameter name.
+        description:
+          type: string
+          nullable: true
+          description: Human-readable description of the parameter.
+        type:
+          type: string
+          description: The data type (e.g. "string", "integer", "boolean").
+        required:
+          type: boolean
+          description: Whether the parameter is mandatory.
+        schema:
+          type: string
+          nullable: true
+          description: Optional JSON schema fragment.
 
     MessageSubscriptionSearchQuerySortRequest:
       type: object

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/MessageSubscriptionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/MessageSubscriptionQueryControllerTest.java
@@ -54,7 +54,8 @@ public class MessageSubscriptionQueryControllerTest extends RestControllerTest {
                   "processDefinitionName": null,
                   "processDefinitionVersion": null,
                   "toolName": null,
-                  "inboundConnectorType": null
+                  "inboundConnectorType": null,
+                  "inputSpecification": []
                 }
             ],
             "page": {

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/modelreader/ProcessModelReader.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/modelreader/ProcessModelReader.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeUserTaskForm;
 import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -30,6 +31,7 @@ import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
+import org.camunda.bpm.model.xml.instance.DomElement;
 import org.camunda.bpm.model.xml.instance.ModelElementInstance;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -146,6 +148,40 @@ public final class ProcessModelReader {
               return map;
             })
         .orElseGet(HashMap::new);
+  }
+
+  public Map<String, List<InputSpecItem>> extractAllElementInputSpecs() {
+    final Map<String, List<InputSpecItem>> result = new HashMap<>();
+    for (final FlowNode flowNode : extractFlowNodes()) {
+      final List<InputSpecItem> specs = extractInputSpecItems(flowNode);
+      if (!specs.isEmpty()) {
+        result.put(flowNode.getId(), specs);
+      }
+    }
+    return result;
+  }
+
+  private List<InputSpecItem> extractInputSpecItems(final BaseElement element) {
+    return getExtensionElements(element)
+        .map(ext -> ext.getDomElement().getChildElements())
+        .orElse(Collections.emptyList())
+        .stream()
+        .filter(child -> "externalParameters".equals(child.getLocalName()))
+        .flatMap(
+            extParams ->
+                extParams.getChildElements().stream()
+                    .filter(specEl -> "inputSpecification".equals(specEl.getLocalName()))
+                    .map(this::domElementToInputSpecItem))
+        .toList();
+  }
+
+  private InputSpecItem domElementToInputSpecItem(final DomElement el) {
+    return new InputSpecItem(
+        el.getAttribute(null, "name"),
+        el.getAttribute(null, "description"),
+        el.getAttribute(null, "type"),
+        Boolean.parseBoolean(el.getAttribute(null, "required")),
+        el.getAttribute(null, "schema"));
   }
 
   private boolean isPublic(final ZeebeProperties properties) {
@@ -268,4 +304,7 @@ public final class ProcessModelReader {
   public record EmbeddedForm(String id, String schema) {}
 
   public record StartFormLink(String formId, String formKey) {}
+
+  public record InputSpecItem(
+      String name, String description, String type, boolean required, String schema) {}
 }

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/modelreader/ProcessModelReaderTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/modelreader/ProcessModelReaderTest.java
@@ -340,6 +340,50 @@ public class ProcessModelReaderTest {
     assertThat(startEventProps).doesNotContainKey(null); // no null keys
   }
 
+  @Test
+  void shouldExtractInputSpecification() throws IOException {
+    // given
+    final String processId = "inputSpecProcess";
+    final var bpmnBytes = parseBpmnResourceXml("process-with-input-spec.bpmn");
+
+    // when
+    final var reader = ProcessModelReader.of(bpmnBytes, processId);
+    assertThat(reader).isPresent();
+    final var allSpecs = reader.get().extractAllElementInputSpecs();
+
+    // then
+    assertThat(allSpecs).containsKey("start_via_agent");
+    final var specs = allSpecs.get("start_via_agent");
+    assertThat(specs).hasSize(2);
+
+    final var firstName = specs.getFirst();
+    assertThat(firstName.name()).isEqualTo("firstName");
+    assertThat(firstName.description()).isEqualTo("The first name");
+    assertThat(firstName.type()).isEqualTo("string");
+    assertThat(firstName.required()).isFalse();
+
+    final var amount = specs.get(1);
+    assertThat(amount.name()).isEqualTo("amount");
+    assertThat(amount.description()).isEqualTo("The amount to withdraw");
+    assertThat(amount.type()).isEqualTo("integer");
+    assertThat(amount.required()).isTrue();
+  }
+
+  @Test
+  void shouldReturnEmptyMapWhenNoInputSpecification() throws IOException {
+    // given — process-with-form-key-reference.bpmn has no specext:externalParameters
+    final String processId = "formProcess";
+    final var bpmnBytes = parseBpmnResourceXml("process-with-form-key-reference.bpmn");
+
+    // when
+    final var reader = ProcessModelReader.of(bpmnBytes, processId);
+    assertThat(reader).isPresent();
+    final var allSpecs = reader.get().extractAllElementInputSpecs();
+
+    // then
+    assertThat(allSpecs).isEmpty();
+  }
+
   private String formOneJson() {
     return
 """

--- a/zeebe/util/src/test/resources/process/process-with-input-spec.bpmn
+++ b/zeebe/util/src/test/resources/process/process-with-input-spec.bpmn
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  xmlns:specext="http://camunda.org/schema/spec-extension/1.0"
+                  id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="inputSpecProcess" name="Process With Input Spec" isExecutable="true">
+    <bpmn:startEvent id="start_via_agent" name="Start via Agent">
+      <bpmn:extensionElements>
+        <specext:externalParameters>
+          <specext:inputSpecification name="firstName" description="The first name" type="string" required="false" schema="" />
+          <specext:inputSpecification name="amount" description="The amount to withdraw" type="integer" required="true" schema="" />
+        </specext:externalParameters>
+        <zeebe:properties>
+          <zeebe:property name="io.camunda.tool:name" value="money_withdrawal" />
+        </zeebe:properties>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="end_event">
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="start_via_agent" targetRef="end_event" />
+  </bpmn:process>
+</bpmn:definitions>


### PR DESCRIPTION
This pull request introduces support for an `inputSpecification` field for message subscriptions, including full end-to-end handling: database schema, Java domain model, serialization, MyBatis mapping, and gateway mapping. The changes ensure that message subscriptions can now store and retrieve structured input specification data, with proper serialization and deserialization, and that this data flows through the system from persistence to API response.

**Database and Persistence Layer Updates:**
- Added a new `INPUT_SPECIFICATION` column (of type `CLOB`) to the `MESSAGE_SUBSCRIPTION` table, with corresponding changes in the Liquibase changelog.
- Updated the MyBatis XML mapper to read, write, and update the new `INPUT_SPECIFICATION` column for message subscriptions.

**Java Domain Model and Serialization:**
- Extended `MessageSubscriptionDbModel` to include an `inputSpecification` field (as a list of `InputSpecItem`), with serialization to and from JSON, and updated builder and constructors accordingly.
- Generalized the `MapSerializer` utility to support serialization/deserialization of arbitrary objects, not just maps, using Jackson's `TypeReference`.

**Mapping and API Layer:**
- Updated the entity mapper and gateway response mappers to include the new `inputSpecification` field, ensuring it is available in API responses. 
- Added conversion utilities to map between internal `InputSpecItem` and API model representations.

**Testing:**
- Extended tests to cover the new `inputSpecification` field, including cases with populated and null values. 

**Gateway MCP Preparation:**
- Added imports and setup in the MCP gateway to prepare for handling `InputSpecItem` in the processes tool repository. 