### PR TITLE
refactor(cpt): Improve Spring client config

### DIFF
--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestDefaultConfiguration.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestDefaultConfiguration.java
@@ -36,8 +36,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Supplier;
 import org.apache.hc.client5.http.async.AsyncExecChainHandler;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
@@ -60,25 +60,6 @@ public class CamundaProcessTestDefaultConfiguration {
         .configure(ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT, true);
   }
 
-  @Bean(name = "camundaProcessTestClientScheduledExecutor")
-  @ConditionalOnMissingBean(CamundaClientBuilderFactory.class)
-  public ScheduledExecutorService camundaProcessTestScheduledExecutor(
-      final CamundaClientProperties clientProperties) {
-    return Executors.newScheduledThreadPool(clientProperties.getExecutionThreads());
-  }
-
-  @Bean(name = "camundaProcessTestOwnedClientExecutorService")
-  @ConditionalOnMissingBean(CamundaClientBuilderFactory.class)
-  public CamundaClientExecutorService camundaProcessTestOwnedClientExecutorService(
-      @Qualifier("camundaProcessTestClientScheduledExecutor")
-          final ScheduledExecutorService scheduledExecutor) {
-
-    // Use a dedicated executor with ownByCamundaClient=false to prevent closing the shared
-    // executor when a test client is closed. Each test creates and closes its own CamundaClient,
-    // and we reuse this executor across all clients within the test class.
-    return new CamundaClientExecutorService(scheduledExecutor, false);
-  }
-
   /**
    * Creates a {@link CamundaClientBuilderFactory} that configures the Camunda client using all
    * properties from the Spring configuration (e.g. {@code camunda.client.*}).
@@ -99,9 +80,15 @@ public class CamundaProcessTestDefaultConfiguration {
       final JobExceptionHandlerSupplier jobExceptionHandlingSupplier,
       final List<ClientInterceptor> interceptors,
       final List<AsyncExecChainHandler> chainHandlers,
-      @Qualifier("camundaProcessTestOwnedClientExecutorService")
-          final CamundaClientExecutorService executorService,
       final CamundaProcessTestRuntimeConfiguration runtimeConfiguration) {
+
+    // Use a dedicated executor with ownByCamundaClient=false to prevent closing the shared
+    // executor when a test client is closed. Each test creates and closes its own CamundaClient,
+    // and we reuse this executor across all clients within the test class.
+    final ScheduledExecutorService scheduledExecutor =
+        Executors.newScheduledThreadPool(clientProperties.getExecutionThreads());
+    final CamundaClientExecutorService executorService =
+        new CamundaClientExecutorService(scheduledExecutor, false);
 
     final SpringCamundaClientConfiguration configuration =
         new SpringCamundaClientConfiguration(
@@ -123,14 +110,32 @@ public class CamundaProcessTestDefaultConfiguration {
         Optional.ofNullable(remoteClientProperties.getRestAddress())
             .filter(address -> !address.equals(CamundaClientBuilderImpl.DEFAULT_REST_ADDRESS));
 
-    return () -> {
-      final CamundaClientBuilder builder = configuration.toBuilder();
-      // Backwards compatibility: apply remote client addresses only when explicitly configured
-      // (i.e. different from the default addresses of CamundaClientProperties).
-      // This matches the previously supported camunda.process-test.remote.client.* properties.
-      remoteGrpcAddress.ifPresent(builder::grpcAddress);
-      remoteRestAddress.ifPresent(builder::restAddress);
-      return builder;
-    };
+    return new DefaultCamundaClientBuilderFactory(
+        () -> {
+          final CamundaClientBuilder builder = configuration.toBuilder();
+          // Backwards compatibility: apply remote client addresses only when explicitly configured
+          // (i.e. different from the default addresses of CamundaClientProperties).
+          // This matches the previously supported camunda.process-test.remote.client.* properties.
+          remoteGrpcAddress.ifPresent(builder::grpcAddress);
+          remoteRestAddress.ifPresent(builder::restAddress);
+          return builder;
+        },
+        scheduledExecutor);
+  }
+
+  /** A wrapper around the client builder factory that closes the executor service. */
+  private record DefaultCamundaClientBuilderFactory(
+      Supplier<CamundaClientBuilder> builderSupplier, ScheduledExecutorService executorService)
+      implements CamundaClientBuilderFactory, AutoCloseable {
+
+    @Override
+    public CamundaClientBuilder get() {
+      return builderSupplier.get();
+    }
+
+    @Override
+    public void close() {
+      executorService.shutdown();
+    }
   }
 }

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/impl/config/CamundaProcessTestDefaultConfigurationTest.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/impl/config/CamundaProcessTestDefaultConfigurationTest.java
@@ -23,13 +23,8 @@ import io.camunda.client.CamundaClientConfiguration;
 import io.camunda.client.CredentialsProvider;
 import io.camunda.client.impl.NoopCredentialsProvider;
 import io.camunda.client.impl.oauth.OAuthCredentialsProvider;
-import io.camunda.client.spring.configuration.CamundaClientAllAutoConfiguration;
-import io.camunda.client.spring.configuration.MetricsDefaultConfiguration;
-import io.camunda.client.spring.testsupport.CamundaSpringProcessTestContext;
 import io.camunda.process.test.api.CamundaClientBuilderFactory;
-import io.camunda.process.test.impl.configuration.CamundaProcessTestDefaultConfiguration;
-import io.camunda.process.test.impl.configuration.CamundaProcessTestRuntimeConfiguration;
-import io.camunda.process.test.impl.configuration.LegacyCamundaProcessTestRuntimeConfiguration;
+import io.camunda.process.test.impl.configuration.CamundaProcessTestAutoConfiguration;
 import java.net.URI;
 import java.time.Duration;
 import org.junit.jupiter.api.Nested;
@@ -37,22 +32,26 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
-@ContextConfiguration(classes = CamundaProcessTestDefaultConfigurationTest.TestConfig.class)
-@EnableConfigurationProperties({
-  CamundaProcessTestRuntimeConfiguration.class,
-  LegacyCamundaProcessTestRuntimeConfiguration.class
-})
+@ContextConfiguration(classes = CamundaProcessTestAutoConfiguration.class)
 public class CamundaProcessTestDefaultConfigurationTest {
+
+  @Configuration
+  static class CustomFactoryConfig {
+    @Bean
+    public CamundaClientBuilderFactory customCamundaClientBuilderFactory() {
+      return () ->
+          CamundaClient.newClientBuilder()
+              .restAddress(URI.create("http://custom-factory-host:9999"))
+              .grpcAddress(URI.create("http://custom-factory-host:26500"));
+    }
+  }
 
   @Nested
   @TestPropertySource(
@@ -208,10 +207,7 @@ public class CamundaProcessTestDefaultConfigurationTest {
 
   @Nested
   @ContextConfiguration(
-      classes = {
-        CamundaProcessTestDefaultConfigurationTest.TestConfig.class,
-        CamundaProcessTestDefaultConfigurationTest.CustomFactoryConfig.class
-      })
+      classes = {CamundaProcessTestDefaultConfigurationTest.CustomFactoryConfig.class})
   class ShouldUseCustomCamundaClientBuilderFactory {
 
     @Autowired
@@ -229,30 +225,6 @@ public class CamundaProcessTestDefaultConfigurationTest {
       try (final CamundaClient client = builder.build()) {
         return client.getConfiguration();
       }
-    }
-  }
-
-  @Configuration
-  @Import(CamundaProcessTestDefaultConfiguration.class)
-  @ImportAutoConfiguration({
-    CamundaClientAllAutoConfiguration.class,
-    MetricsDefaultConfiguration.class
-  })
-  static class TestConfig {
-    @Bean
-    public CamundaSpringProcessTestContext enableTestContext() {
-      return new CamundaSpringProcessTestContext();
-    }
-  }
-
-  @Configuration
-  static class CustomFactoryConfig {
-    @Bean
-    public CamundaClientBuilderFactory customCamundaClientBuilderFactory() {
-      return () ->
-          CamundaClient.newClientBuilder()
-              .restAddress(URI.create("http://custom-factory-host:9999"))
-              .grpcAddress(URI.create("http://custom-factory-host:26500"));
     }
   }
 }


### PR DESCRIPTION
## Description

This pull request refactors the configuration and test setup for the Camunda process test Spring integration. The main focus is simplifying the bean lifecycle for executor services used by the test client, and streamlining the test configuration to use the new auto-configuration. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

related to https://github.com/camunda/camunda/pull/50959
