### PR TITLE
feat: introduce `BEFORE_ALL` execution listener event type

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/enums/ListenerEventType.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/enums/ListenerEventType.java
@@ -17,6 +17,7 @@ package io.camunda.client.api.search.enums;
 
 public enum ListenerEventType {
   ASSIGNING,
+  BEFORE_ALL,
   CANCELING,
   COMPLETING,
   CREATING,

--- a/clients/java/src/test/java/io/camunda/client/job/SearchJobTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/SearchJobTest.java
@@ -200,6 +200,24 @@ public class SearchJobTest extends ClientRestTest {
   }
 
   @Test
+  void shouldSearchJobFilterByBeforeAllListenerEventType() {
+    // when
+    client
+        .newJobSearchRequest()
+        .filter(filter -> filter.listenerEventType(f -> f.eq(ListenerEventType.BEFORE_ALL)))
+        .send()
+        .join();
+
+    // then
+    final JobSearchQuery request = gatewayService.getLastRequest(JobSearchQuery.class);
+    assertThat(request.getFilter()).isNotNull();
+    assertThat(request.getFilter())
+        .extracting(JobFilter::getListenerEventType)
+        .extracting(JobListenerEventTypeFilterProperty::get$Eq)
+        .isEqualTo(JobListenerEventTypeEnum.BEFORE_ALL);
+  }
+
+  @Test
   void shouldSearchJobWithFullSorting() {
     // when
     client

--- a/clients/java/src/test/java/io/camunda/client/job/rest/ActivateJobsRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/rest/ActivateJobsRestTest.java
@@ -173,6 +173,50 @@ public final class ActivateJobsRestTest extends ClientRestTest {
     assertThat(request.getWorker()).isEqualTo("worker1");
   }
 
+  @Test
+  void shouldActivateJobWithBeforeAllListenerEventType() {
+    // given
+    final ActivatedJobResult activatedJob =
+        new ActivatedJobResult()
+            .jobKey("99")
+            .type("before-all-type")
+            .processInstanceKey("100")
+            .processDefinitionId("process1")
+            .processDefinitionVersion(1)
+            .processDefinitionKey("200")
+            .elementId("element1")
+            .elementInstanceKey("300")
+            .customHeaders(singletonMap("header", "value"))
+            .worker("worker1")
+            .retries(3)
+            .deadline(5000L)
+            .variables(singletonMap("var", "val"))
+            .tenantId("default")
+            .kind(JobKindEnum.EXECUTION_LISTENER)
+            .listenerEventType(JobListenerEventTypeEnum.BEFORE_ALL)
+            .rootProcessInstanceKey("100");
+
+    gatewayService.onActivateJobsRequest(new JobActivationResult().addJobsItem(activatedJob));
+
+    // when
+    final ActivateJobsResponse response =
+        client
+            .newActivateJobsCommand()
+            .jobType("before-all-type")
+            .maxJobsToActivate(1)
+            .timeout(Duration.ofMillis(1000))
+            .workerName("worker1")
+            .send()
+            .join();
+
+    // then
+    assertThat(response.getJobs()).hasSize(1);
+    final io.camunda.client.api.response.ActivatedJob job = response.getJobs().get(0);
+    assertThat(job.getListenerEventType()).isEqualTo(ListenerEventType.BEFORE_ALL);
+    assertThat(job.getListenerEventType())
+        .isEqualTo(EnumUtil.convert(activatedJob.getListenerEventType(), ListenerEventType.class));
+  }
+
   @ParameterizedTest
   @MethodSource("userTaskPropertiesProvider")
   public void shouldActivateJobsWithUserTaskProperties(

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
@@ -14,6 +14,8 @@ import io.camunda.gateway.protocol.model.BatchOperationItemResponse;
 import io.camunda.gateway.protocol.model.BatchOperationItemResponse.StateEnum;
 import io.camunda.gateway.protocol.model.BatchOperationTypeEnum;
 import io.camunda.gateway.protocol.model.IncidentStateEnum;
+import io.camunda.gateway.protocol.model.JobListenerEventTypeEnum;
+import io.camunda.gateway.protocol.model.JobSearchQueryResult;
 import io.camunda.search.entities.AuditLogEntity;
 import io.camunda.search.entities.AuditLogEntity.AuditLogActorType;
 import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
@@ -778,5 +780,72 @@ class SearchQueryResponseMapperTest {
     assertThat(result.getC8Links())
         .containsEntry("operate", "https://operate.example.com")
         .containsEntry("tasklist", "https://tasklist.example.com");
+  }
+
+  @Test
+  void shouldMapJobSearchResultWithBeforeAllListenerEventType() {
+    // given
+    final JobEntity job =
+        new JobEntity.Builder()
+            .jobKey(1L)
+            .type("before-all-job")
+            .worker("worker1")
+            .state(JobState.CREATED)
+            .kind(JobKind.EXECUTION_LISTENER)
+            .listenerEventType(ListenerEventType.BEFORE_ALL)
+            .retries(3)
+            .hasFailedWithRetriesLeft(false)
+            .processDefinitionId("process1")
+            .processDefinitionKey(10L)
+            .processInstanceKey(20L)
+            .elementId("element1")
+            .elementInstanceKey(30L)
+            .tenantId("default")
+            .build();
+    final SearchQueryResult<JobEntity> result =
+        new SearchQueryResult<>(1, false, List.of(job), null, null);
+
+    // when
+    final JobSearchQueryResult response =
+        SearchQueryResponseMapper.toJobSearchQueryResponse(result);
+
+    // then
+    assertThat(response.getItems()).hasSize(1);
+    assertThat(response.getItems().getFirst().getListenerEventType())
+        .isEqualTo(JobListenerEventTypeEnum.BEFORE_ALL);
+  }
+
+  @Test
+  void shouldMapAllListenerEventTypesToJobSearchResult() {
+    // given / when / then
+    for (final ListenerEventType type : ListenerEventType.values()) {
+      final JobEntity job =
+          new JobEntity.Builder()
+              .jobKey(1L)
+              .type("job")
+              .worker("worker")
+              .state(JobState.CREATED)
+              .kind(JobKind.EXECUTION_LISTENER)
+              .listenerEventType(type)
+              .retries(1)
+              .hasFailedWithRetriesLeft(false)
+              .processDefinitionId("p1")
+              .processDefinitionKey(1L)
+              .processInstanceKey(2L)
+              .elementId("e1")
+              .elementInstanceKey(3L)
+              .tenantId("default")
+              .build();
+      final SearchQueryResult<JobEntity> result =
+          new SearchQueryResult<>(1, false, List.of(job), null, null);
+
+      final JobSearchQueryResult response =
+          SearchQueryResponseMapper.toJobSearchQueryResponse(result);
+
+      assertThat(response.getItems().getFirst().getListenerEventType())
+          .as("ListenerEventType.%s should map without error", type)
+          .isNotNull()
+          .isEqualTo(JobListenerEventTypeEnum.fromValue(type.name()));
+    }
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/JobEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/JobEntityTransformer.java
@@ -53,6 +53,7 @@ public class JobEntityTransformer
 
     return switch (value) {
       case "UNSPECIFIED" -> ListenerEventType.UNSPECIFIED;
+      case "BEFORE_ALL" -> ListenerEventType.BEFORE_ALL;
       case "START" -> ListenerEventType.START;
       case "END" -> ListenerEventType.END;
       case "CREATING" -> ListenerEventType.CREATING;

--- a/search/search-domain/src/main/java/io/camunda/search/entities/JobEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/JobEntity.java
@@ -246,6 +246,7 @@ public record JobEntity(
 
   public enum ListenerEventType {
     ASSIGNING,
+    BEFORE_ALL,
     CANCELING,
     COMPLETING,
     CREATING,

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/listener/ListenerEventType.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/listener/ListenerEventType.java
@@ -14,6 +14,7 @@ public enum ListenerEventType {
   // Execution Listener event types
   START,
   END,
+  BEFORE_ALL,
 
   // User Task Listener event types
   CREATING,

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -82,6 +82,7 @@ message ActivatedJob {
     START = 5;
     UNSPECIFIED = 6;
     UPDATING = 7;
+    BEFORE_ALL = 8;
   }
 
   // the key, a unique identifier for the job

--- a/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
@@ -1035,6 +1035,7 @@ components:
       type: string
       enum:
         - ASSIGNING
+        - BEFORE_ALL
         - CANCELING
         - COMPLETING
         - CREATING

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobListenerEventType.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobListenerEventType.java
@@ -26,6 +26,13 @@ public enum JobListenerEventType {
   // ---------------------------------------------------------------------------
 
   /**
+   * Represents the `beforeAll` event for an execution listener. This event type is used to indicate
+   * that the listener should be triggered before starting the execution, such as the composition
+   * of inputCollection for multi-instance cases
+   */
+  BEFORE_ALL,
+
+  /**
    * Represents the `start` event for an execution listener. This event type is used to indicate
    * that the listener should be triggered at the start of an execution, such as the beginning of a
    * process instance, sub-process or element (task, event, gateway).

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobListenerEventType.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobListenerEventType.java
@@ -27,8 +27,8 @@ public enum JobListenerEventType {
 
   /**
    * Represents the `beforeAll` event for an execution listener. This event type is used to indicate
-   * that the listener should be triggered before starting the execution, such as the composition
-   * of inputCollection for multi-instance cases
+   * that the listener should be triggered before instances are created, allowing variable
+   * initialization prior to element activation, such as in multi-instance bodies.
    */
   BEFORE_ALL,
 


### PR DESCRIPTION
## Description

`BEFORE_ALL` was added to the protocol's `JobListenerEventType` to support triggering execution listeners before the inputCollection composition in multi-instance scenarios. This change propagates it to all downstream enums (client SDK, search domain, webapps-schema, gRPC proto) so that jobs with this event type can be activated, searched, and filtered correctly through the REST API and Java client.

## Related issues

closes #51340
