### PR TITLE
fix: properly set tenant id on the PendingSubscription

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageSubscriptionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageSubscriptionState.java
@@ -98,7 +98,9 @@ public final class DbMessageSubscriptionState
           if (subscription.isCorrelating()) {
             transientState.add(
                 new PendingSubscription(
-                    elementInstanceKey.getValue(), messageName.toString(), tenantIdKey.toString()),
+                    elementInstanceKey.getValue(),
+                    subscription.getRecord().getMessageName(),
+                    subscription.getRecord().getTenantId()),
                 clock.millis());
           }
         });

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/message/ProcessMessageSubscriptionStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/message/ProcessMessageSubscriptionStateTest.java
@@ -11,13 +11,17 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.cloneBuffer;
 import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.engine.state.immutable.PendingProcessMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessMessageSubscriptionState;
 import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscriptionRecord;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.util.collection.Tuple;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
 import org.agrona.DirectBuffer;
 import org.junit.Before;
 import org.junit.Rule;
@@ -28,10 +32,12 @@ public final class ProcessMessageSubscriptionStateTest {
   @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
 
   private MutableProcessMessageSubscriptionState state;
+  private PendingProcessMessageSubscriptionState pendingState;
 
   @Before
   public void setUp() {
     state = stateRule.getProcessingState().getProcessMessageSubscriptionState();
+    pendingState = stateRule.getProcessingState().getPendingProcessMessageSubscriptionState();
   }
 
   @Test
@@ -156,6 +162,30 @@ public final class ProcessMessageSubscriptionStateTest {
 
     // then
     assertThat(subscription).isNull();
+  }
+
+  @Test
+  public void shouldRepopulateTransientStateWithCorrectMessageNameAndTenantIdOnRecovery() {
+    // given
+    final ProcessMessageSubscriptionRecord record = subscriptionRecordWithElementInstanceKey(1L);
+    record.setTenantId(UUID.randomUUID().toString());
+    state.put(1L, record);
+
+    // when
+    ((StreamProcessorLifecycleAware) state).onRecovered(null);
+
+    // then
+    final AtomicReference<String> tenantId = new AtomicReference<>();
+    final AtomicReference<String> messageName = new AtomicReference<>();
+    pendingState.visitPending(
+        Long.MAX_VALUE,
+        s -> {
+          messageName.set(s.getRecord().getMessageName());
+          tenantId.set(s.getRecord().getTenantId());
+          return true;
+        });
+    assertThat(tenantId.get()).isEqualTo(record.getTenantId());
+    assertThat(messageName.get()).isEqualTo(record.getMessageName());
   }
 
   private ProcessMessageSubscriptionRecord subscriptionRecordWithElementInstanceKey(


### PR DESCRIPTION
## Description

The `tenantIdKey` is never wrapped, nor is it part of the `subscriptionColumnFamily`. Hence, we don't properly set the tenant on these pending subscriptions.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #50655
