### PR TITLE
fix: switch RocksDB from OptimisticTransactionDB to TransactionDB

### DIFF
--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -343,8 +343,9 @@ public final class ProcessingStateMachine {
    *
    * <p>Should be called after processing or error handling is done.
    */
-  private void finalizeCommandProcessing() {
-    lastProcessedPositionState.markAsProcessed(typedCommand.getPosition());
+  private void finalizeCommandProcessing() throws Exception {
+    zeebeDbTransaction.run(
+        () -> lastProcessedPositionState.markAsProcessed(typedCommand.getPosition()));
     processedCommandsCount = 0;
   }
 
@@ -463,6 +464,7 @@ public final class ProcessingStateMachine {
         updateStateRetryStrategy.runWithRetry(
             () -> {
               zeebeDbTransaction.rollback();
+              zeebeDbTransaction = transactionContext.getCurrentTransaction();
               return true;
             },
             abortCondition);
@@ -551,7 +553,7 @@ public final class ProcessingStateMachine {
     updateErrorHandlingPhase(nextPhase);
   }
 
-  private void tryRejectingIfUserCommand(final String errorMessage) {
+  private void tryRejectingIfUserCommand(final String errorMessage) throws Exception {
     final var rejectionReason = errorMessage != null ? errorMessage : "";
     final ProcessingResultBuilder processingResultBuilder =
         newProcessingResultBuilder(typedCommand);

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/DefaultTransactionContext.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/DefaultTransactionContext.java
@@ -60,10 +60,12 @@ public final class DefaultTransactionContext implements TransactionContext {
     try {
       transaction.resetTransaction();
       operations.run();
-      transaction.commitInternal();
-      committed = true;
+      if (transaction.isInCurrentTransaction()) {
+        transaction.commitInternal();
+        committed = true;
+      }
     } finally {
-      if (!committed) {
+      if (!committed && transaction.isInCurrentTransaction()) {
         transaction.rollbackInternal();
       }
     }

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/DefaultTransactionContext.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/DefaultTransactionContext.java
@@ -56,12 +56,16 @@ public final class DefaultTransactionContext implements TransactionContext {
   }
 
   private void runInNewTransaction(final TransactionOperation operations) throws Exception {
+    boolean committed = false;
     try {
       transaction.resetTransaction();
       operations.run();
       transaction.commitInternal();
+      committed = true;
     } finally {
-      transaction.rollbackInternal();
+      if (!committed) {
+        transaction.rollbackInternal();
+      }
     }
   }
 

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ZeebeTransaction.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ZeebeTransaction.java
@@ -164,6 +164,7 @@ public class ZeebeTransaction implements ZeebeDbTransaction, AutoCloseable {
   void commitInternal() throws RocksDBException {
     inCurrentTransaction = false;
     transaction.commit();
+    transaction = transactionRenovator.renewTransaction(transaction);
   }
 
   void rollbackInternal() throws RocksDBException {

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ZeebeTransaction.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ZeebeTransaction.java
@@ -164,7 +164,6 @@ public class ZeebeTransaction implements ZeebeDbTransaction, AutoCloseable {
   void commitInternal() throws RocksDBException {
     inCurrentTransaction = false;
     transaction.commit();
-    transaction = transactionRenovator.renewTransaction(transaction);
   }
 
   void rollbackInternal() throws RocksDBException {

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ZeebeTransactionDb.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ZeebeTransactionDb.java
@@ -37,12 +37,13 @@ import java.util.function.Supplier;
 import org.rocksdb.Checkpoint;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
-import org.rocksdb.OptimisticTransactionDB;
 import org.rocksdb.ReadOptions;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.RocksObject;
 import org.rocksdb.Transaction;
+import org.rocksdb.TransactionDB;
+import org.rocksdb.TransactionDBOptions;
 import org.rocksdb.WriteOptions;
 import org.slf4j.Logger;
 
@@ -53,7 +54,7 @@ public class ZeebeTransactionDb<
   private static final Logger LOG = Loggers.DB_LOGGER;
   private static final String ERROR_MESSAGE_CLOSE_RESOURCE =
       "Expected to close RocksDB resource successfully, but exception was thrown. Will continue to close remaining resources.";
-  private final OptimisticTransactionDB optimisticTransactionDB;
+  private final TransactionDB transactionDB;
   private final List<AutoCloseable> closables;
   private final ReadOptions prefixReadOptions;
   private final ReadOptions defaultReadOptions;
@@ -67,7 +68,7 @@ public class ZeebeTransactionDb<
 
   protected ZeebeTransactionDb(
       final ColumnFamilyHandle defaultHandle,
-      final OptimisticTransactionDB optimisticTransactionDB,
+      final TransactionDB transactionDB,
       final List<AutoCloseable> closables,
       final RocksDbConfiguration rocksDbConfiguration,
       final ConsistencyChecksSettings consistencyChecksSettings,
@@ -75,7 +76,7 @@ public class ZeebeTransactionDb<
       final MeterRegistry meterRegistry) {
     this.defaultHandle = defaultHandle;
     defaultNativeHandle = getNativeHandle(defaultHandle);
-    this.optimisticTransactionDB = optimisticTransactionDB;
+    this.transactionDB = transactionDB;
     this.closables = closables;
     this.consistencyChecksSettings = consistencyChecksSettings;
     this.accessMetricsConfiguration = accessMetricsConfiguration;
@@ -105,9 +106,12 @@ public class ZeebeTransactionDb<
         Arrays.asList( // todo: could consider using List.of
             new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY, options.cfOptions()));
     final List<ColumnFamilyHandle> cfHandles = new ArrayList<>();
-    final OptimisticTransactionDB optimisticTransactionDB =
-        OptimisticTransactionDB.open(options.dbOptions(), path, cfDescriptors, cfHandles);
-    closables.add(optimisticTransactionDB);
+    final var transactionDbOptions = new TransactionDBOptions();
+    closables.add(transactionDbOptions);
+    final TransactionDB transactionDB =
+        TransactionDB.open(
+            options.dbOptions(), transactionDbOptions, path, cfDescriptors, cfHandles);
+    closables.add(transactionDB);
 
     if (cfHandles.size() != 1) {
       throw new IllegalStateException(
@@ -123,7 +127,7 @@ public class ZeebeTransactionDb<
 
     return new ZeebeTransactionDb<>(
         defaultColumnFamilyHandle,
-        optimisticTransactionDB,
+        transactionDB,
         closables,
         rocksDbConfiguration,
         consistencyChecksSettings,
@@ -180,7 +184,7 @@ public class ZeebeTransactionDb<
 
   @Override
   public void createSnapshot(final File snapshotDir) {
-    try (final Checkpoint checkpoint = Checkpoint.create(optimisticTransactionDB)) {
+    try (final Checkpoint checkpoint = Checkpoint.create(transactionDB)) {
       try {
         checkpoint.createCheckpoint(snapshotDir.getAbsolutePath());
       } catch (final RocksDBException rocksException) {
@@ -194,7 +198,7 @@ public class ZeebeTransactionDb<
   public Optional<String> getProperty(final String propertyName) {
     String propertyValue = null;
     try {
-      propertyValue = optimisticTransactionDB.getProperty(defaultHandle, propertyName);
+      propertyValue = transactionDB.getProperty(defaultHandle, propertyName);
     } catch (final RocksDBException rde) {
       LOG.debug(rde.getMessage(), rde);
     }
@@ -203,7 +207,7 @@ public class ZeebeTransactionDb<
 
   @Override
   public TransactionContext createContext() {
-    final Transaction transaction = optimisticTransactionDB.beginTransaction(defaultWriteOptions);
+    final Transaction transaction = transactionDB.beginTransaction(defaultWriteOptions);
     final ZeebeTransaction zeebeTransaction = new ZeebeTransaction(transaction, this);
     closables.add(zeebeTransaction);
     return new DefaultTransactionContext(zeebeTransaction);
@@ -223,12 +227,12 @@ public class ZeebeTransactionDb<
 
   @Override
   public void exportMetrics() {
-    metricExporter.exportMetrics(optimisticTransactionDB);
+    metricExporter.exportMetrics(transactionDB);
   }
 
   @Override
   public Transaction renewTransaction(final Transaction oldTransaction) {
-    return optimisticTransactionDB.beginTransaction(defaultWriteOptions, oldTransaction);
+    return transactionDB.beginTransaction(defaultWriteOptions, oldTransaction);
   }
 
   @Override

--- a/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/RocksDBSnapshotCopyTest.java
+++ b/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/RocksDBSnapshotCopyTest.java
@@ -168,8 +168,9 @@ public class RocksDBSnapshotCopyTest {
       final var fromCtx = fromDB.createContext();
       fromCtx.runInTransaction(
           () -> {
-            final var ctx = (ZeebeTransaction) fromCtx.getCurrentTransaction();
             for (final ZbColumnFamilies cf : ZbColumnFamilies.values()) {
+              // renews the transaction on every loop
+              final var ctx = (ZeebeTransaction) fromCtx.getCurrentTransaction();
               final var transactionalColumnFamily = new RawTransactionalColumnFamily(fromDB, cf);
               for (int i = 0; i < rowsPerCF; i++) {
                 // the key must be big enough to avoid generating duplicates.

--- a/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ZeebeRocksDbTransactionTest.java
+++ b/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ZeebeRocksDbTransactionTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.db.impl.rocksdb.transaction;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -20,92 +21,101 @@ import io.camunda.zeebe.db.impl.DefaultColumnFamily;
 import io.camunda.zeebe.db.impl.DefaultZeebeDbFactory;
 import io.camunda.zeebe.util.exception.RecoverableException;
 import java.io.File;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.Status;
 import org.rocksdb.Status.Code;
 import org.rocksdb.Status.SubCode;
 
-public final class ZeebeRocksDbTransactionTest {
+final class ZeebeRocksDbTransactionTest {
 
-  @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @TempDir File tempDir;
   private final ZeebeDbFactory<DefaultColumnFamily> dbFactory =
       DefaultZeebeDbFactory.getDefaultFactory();
 
   private TransactionContext transactionContext;
 
-  @Before
-  public void setup() throws Exception {
-    final File pathName = temporaryFolder.newFolder();
-    final ZeebeDb<DefaultColumnFamily> zeebeDb = dbFactory.createDb(pathName);
+  @BeforeEach
+  void setup() throws Exception {
+    final ZeebeDb<DefaultColumnFamily> zeebeDb = dbFactory.createDb(tempDir);
     transactionContext = zeebeDb.createContext();
   }
 
-  @Test(expected = ZeebeDbException.class)
-  public void shouldThrowRecoverableException() {
+  @Test
+  void shouldThrowRecoverableException() {
     // given
     final Status status = new Status(Code.IOError, SubCode.None, "");
 
-    // when
-    transactionContext.runInTransaction(
-        () -> {
-          throw new RocksDBException("expected", status);
-        });
+    // when / then
+    assertThatThrownBy(
+            () ->
+                transactionContext.runInTransaction(
+                    () -> {
+                      throw new RocksDBException("expected", status);
+                    }))
+        .isInstanceOf(ZeebeDbException.class);
   }
 
-  @Test(expected = RecoverableException.class)
-  public void shouldReThrowRecoverableException() {
+  @Test
+  void shouldReThrowRecoverableException() {
     // given
     final Status status = new Status(Code.IOError, SubCode.None, "");
 
-    // when
-    transactionContext.runInTransaction(
-        () -> {
-          throw new RecoverableException(new RocksDBException("expected", status));
-        });
+    // when / then
+    assertThatThrownBy(
+            () ->
+                transactionContext.runInTransaction(
+                    () -> {
+                      throw new RecoverableException(new RocksDBException("expected", status));
+                    }))
+        .isInstanceOf(RecoverableException.class);
   }
 
-  @Test(expected = RuntimeException.class)
-  public void shouldWrapExceptionInRuntimeException() {
+  @Test
+  void shouldWrapExceptionInRuntimeException() {
     // given
     final Status status = new Status(Code.NotSupported, SubCode.None, "");
 
-    // when
-    transactionContext.runInTransaction(
-        () -> {
-          throw new RocksDBException("expected", status);
-        });
+    // when / then
+    assertThatThrownBy(
+            () ->
+                transactionContext.runInTransaction(
+                    () -> {
+                      throw new RocksDBException("expected", status);
+                    }))
+        .isInstanceOf(RuntimeException.class);
   }
 
-  @Test(expected = ZeebeDbException.class)
-  public void shouldThrowRecoverableExceptionOnCommit() throws Exception {
+  @Test
+  void shouldThrowRecoverableExceptionOnCommit() throws Exception {
     // given
     final ZeebeTransaction transaction = mock(ZeebeTransaction.class);
     final TransactionContext newContext = new DefaultTransactionContext(transaction);
     final Status status = new Status(Code.IOError, SubCode.None, "");
     doThrow(new RocksDBException("expected", status)).when(transaction).commitInternal();
 
-    // when
-    newContext.runInTransaction(() -> {});
+    // when / then
+    assertThatThrownBy(() -> newContext.runInTransaction(() -> {}))
+        .isInstanceOf(ZeebeDbException.class);
   }
 
-  @Test(expected = RuntimeException.class)
-  public void shouldWrapExceptionInRuntimeExceptionOnCommit() throws Exception {
+  @Test
+  void shouldWrapExceptionInRuntimeExceptionOnCommit() throws Exception {
     // given
     final ZeebeTransaction transaction = mock(ZeebeTransaction.class);
     final TransactionContext newContext = new DefaultTransactionContext(transaction);
     final Status status = new Status(Code.NotSupported, SubCode.None, "");
     doThrow(new RocksDBException("expected", status)).when(transaction).commitInternal();
 
-    // when
-    newContext.runInTransaction(() -> {});
+    // when / then
+    assertThatThrownBy(() -> newContext.runInTransaction(() -> {}))
+        .isInstanceOf(RuntimeException.class);
   }
 
-  @Test(expected = ZeebeDbException.class)
-  public void shouldThrowRecoverableExceptionOnRollback() throws Exception {
+  @Test
+  void shouldThrowRecoverableExceptionOnRollback() throws Exception {
     // given - commit fails (triggering rollback), and rollback also fails with a recoverable error
     final ZeebeTransaction transaction = mock(ZeebeTransaction.class);
     final TransactionContext newContext = new DefaultTransactionContext(transaction);
@@ -116,13 +126,15 @@ public final class ZeebeRocksDbTransactionTest {
         .when(transaction)
         .rollbackInternal();
 
-    // when
-    newContext.runInTransaction(() -> {});
+    // when / then
+    assertThatThrownBy(() -> newContext.runInTransaction(() -> {}))
+        .isInstanceOf(ZeebeDbException.class);
   }
 
-  @Test(expected = RuntimeException.class)
-  public void shouldWrapExceptionInRuntimeExceptionOnRollback() throws Exception {
-    // given - commit fails (triggering rollback), and rollback also fails with a non-recoverable error
+  @Test
+  void shouldWrapExceptionInRuntimeExceptionOnRollback() throws Exception {
+    // given - commit fails (triggering rollback), and rollback also fails with a non-recoverable
+    // error
     final ZeebeTransaction transaction = mock(ZeebeTransaction.class);
     final TransactionContext newContext = new DefaultTransactionContext(transaction);
     final Status commitStatus = new Status(Code.IOError, SubCode.None, "");
@@ -132,94 +144,104 @@ public final class ZeebeRocksDbTransactionTest {
         .when(transaction)
         .rollbackInternal();
 
-    // when
-    newContext.runInTransaction(() -> {});
+    // when / then
+    assertThatThrownBy(() -> newContext.runInTransaction(() -> {}))
+        .isInstanceOf(RuntimeException.class);
   }
 
-  @Test(expected = ZeebeDbException.class)
-  public void shouldThrowRecoverableExceptionInTransactionRun() throws Exception {
+  @Test
+  void shouldThrowRecoverableExceptionInTransactionRun() throws Exception {
     // given
     final Status status = new Status(Code.IOError, SubCode.None, "");
 
-    // when
+    // when / then
     final ZeebeDbTransaction currentTransaction = transactionContext.getCurrentTransaction();
-    currentTransaction.run(
-        () -> {
-          throw new RocksDBException("expected", status);
-        });
+    assertThatThrownBy(
+            () ->
+                currentTransaction.run(
+                    () -> {
+                      throw new RocksDBException("expected", status);
+                    }))
+        .isInstanceOf(ZeebeDbException.class);
   }
 
-  @Test(expected = RecoverableException.class)
-  public void shouldReThrowRecoverableExceptionInTransactionRun() throws Exception {
+  @Test
+  void shouldReThrowRecoverableExceptionInTransactionRun() throws Exception {
     // given
     final Status status = new Status(Code.IOError, SubCode.None, "");
 
-    // when
+    // when / then
     final ZeebeDbTransaction currentTransaction = transactionContext.getCurrentTransaction();
-    currentTransaction.run(
-        () -> {
-          throw new RecoverableException(new RocksDBException("expected", status));
-        });
+    assertThatThrownBy(
+            () ->
+                currentTransaction.run(
+                    () -> {
+                      throw new RecoverableException(new RocksDBException("expected", status));
+                    }))
+        .isInstanceOf(RecoverableException.class);
   }
 
-  @Test(expected = RocksDBException.class)
-  public void shouldReThrowExceptionFromTransactionRun() throws Exception {
+  @Test
+  void shouldReThrowExceptionFromTransactionRun() throws Exception {
     // given
     final Status status = new Status(Code.NotSupported, SubCode.None, "");
 
-    // when
+    // when / then
     final ZeebeDbTransaction currentTransaction = transactionContext.getCurrentTransaction();
-    currentTransaction.run(
-        () -> {
-          throw new RocksDBException("expected", status);
-        });
+    assertThatThrownBy(
+            () ->
+                currentTransaction.run(
+                    () -> {
+                      throw new RocksDBException("expected", status);
+                    }))
+        .isInstanceOf(RocksDBException.class);
   }
 
-  @Test(expected = ZeebeDbException.class)
-  public void shouldThrowRecoverableExceptionInTransactionCommit() throws Exception {
+  @Test
+  void shouldThrowRecoverableExceptionInTransactionCommit() throws Exception {
     // given
     final Status status = new Status(Code.IOError, SubCode.None, "");
     final ZeebeTransaction currentTransaction =
         spy((ZeebeTransaction) transactionContext.getCurrentTransaction());
     doThrow(new RocksDBException("expected", status)).when(currentTransaction).commitInternal();
 
-    // when
-    currentTransaction.commit();
+    // when / then
+    assertThatThrownBy(currentTransaction::commit).isInstanceOf(ZeebeDbException.class);
   }
 
-  @Test(expected = RocksDBException.class)
-  public void shouldReThrowExceptionFromTransactionCommit() throws Exception {
+  @Test
+  void shouldReThrowExceptionFromTransactionCommit() throws Exception {
     // given
     final Status status = new Status(Code.NotSupported, SubCode.None, "");
     final ZeebeTransaction currentTransaction =
         spy((ZeebeTransaction) transactionContext.getCurrentTransaction());
     doThrow(new RocksDBException("expected", status)).when(currentTransaction).commitInternal();
 
-    // when
-    currentTransaction.commit();
+    // when / then
+    assertThatThrownBy(currentTransaction::commit).isInstanceOf(RocksDBException.class);
   }
 
-  @Test(expected = ZeebeDbException.class)
-  public void shouldThrowRecoverableExceptionInTransactionRollback() throws Exception {
+  @Test
+  void shouldThrowRecoverableExceptionInTransactionRollback() throws Exception {
     // given
     final Status status = new Status(Code.IOError, SubCode.None, "");
     final ZeebeTransaction currentTransaction =
         spy((ZeebeTransaction) transactionContext.getCurrentTransaction());
     doThrow(new RocksDBException("expected", status)).when(currentTransaction).rollbackInternal();
 
-    // when
-    currentTransaction.rollback();
+    // when / then
+    assertThatThrownBy(currentTransaction::rollback).isInstanceOf(ZeebeDbException.class);
   }
 
-  @Test(expected = RocksDBException.class)
-  public void shouldReThrowExceptionFromTransactionRollback() throws Exception {
+  @Test
+  void shouldReThrowExceptionFromTransactionRollback() throws Exception {
     // given
     final Status status = new Status(Code.NotSupported, SubCode.None, "");
     final ZeebeTransaction currentTransaction =
         spy((ZeebeTransaction) transactionContext.getCurrentTransaction());
     doThrow(new RocksDBException("expected", status)).when(currentTransaction).rollbackInternal();
 
-    // when
-    currentTransaction.rollback();
+    // when / then
+    assertThatThrownBy(currentTransaction::rollback).isInstanceOf(RocksDBException.class);
   }
 }

--- a/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ZeebeRocksDbTransactionTest.java
+++ b/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ZeebeRocksDbTransactionTest.java
@@ -106,11 +106,15 @@ public final class ZeebeRocksDbTransactionTest {
 
   @Test(expected = ZeebeDbException.class)
   public void shouldThrowRecoverableExceptionOnRollback() throws Exception {
-    // given
+    // given - commit fails (triggering rollback), and rollback also fails with a recoverable error
     final ZeebeTransaction transaction = mock(ZeebeTransaction.class);
     final TransactionContext newContext = new DefaultTransactionContext(transaction);
-    final Status status = new Status(Code.IOError, SubCode.None, "");
-    doThrow(new RocksDBException("expected", status)).when(transaction).rollbackInternal();
+    final Status commitStatus = new Status(Code.IOError, SubCode.None, "");
+    final Status rollbackStatus = new Status(Code.IOError, SubCode.None, "");
+    doThrow(new RocksDBException("commit failed", commitStatus)).when(transaction).commitInternal();
+    doThrow(new RocksDBException("rollback failed", rollbackStatus))
+        .when(transaction)
+        .rollbackInternal();
 
     // when
     newContext.runInTransaction(() -> {});
@@ -118,11 +122,15 @@ public final class ZeebeRocksDbTransactionTest {
 
   @Test(expected = RuntimeException.class)
   public void shouldWrapExceptionInRuntimeExceptionOnRollback() throws Exception {
-    // given
+    // given - commit fails (triggering rollback), and rollback also fails with a non-recoverable error
     final ZeebeTransaction transaction = mock(ZeebeTransaction.class);
     final TransactionContext newContext = new DefaultTransactionContext(transaction);
-    final Status status = new Status(Code.NotSupported, SubCode.None, "");
-    doThrow(new RocksDBException("expected", status)).when(transaction).rollbackInternal();
+    final Status commitStatus = new Status(Code.IOError, SubCode.None, "");
+    final Status rollbackStatus = new Status(Code.NotSupported, SubCode.None, "");
+    doThrow(new RocksDBException("commit failed", commitStatus)).when(transaction).commitInternal();
+    doThrow(new RocksDBException("rollback failed", rollbackStatus))
+        .when(transaction)
+        .rollbackInternal();
 
     // when
     newContext.runInTransaction(() -> {});

--- a/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ZeebeRocksDbTransactionTest.java
+++ b/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ZeebeRocksDbTransactionTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
@@ -21,6 +22,7 @@ import io.camunda.zeebe.db.impl.DefaultColumnFamily;
 import io.camunda.zeebe.db.impl.DefaultZeebeDbFactory;
 import io.camunda.zeebe.util.exception.RecoverableException;
 import java.io.File;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -35,11 +37,15 @@ final class ZeebeRocksDbTransactionTest {
   private final ZeebeDbFactory<DefaultColumnFamily> dbFactory =
       DefaultZeebeDbFactory.getDefaultFactory();
 
+  @SuppressWarnings("FieldCanBeLocal")
+  @AutoClose
+  private ZeebeDb<DefaultColumnFamily> zeebeDb;
+
   private TransactionContext transactionContext;
 
   @BeforeEach
   void setup() throws Exception {
-    final ZeebeDb<DefaultColumnFamily> zeebeDb = dbFactory.createDb(tempDir);
+    zeebeDb = dbFactory.createDb(tempDir);
     transactionContext = zeebeDb.createContext();
   }
 
@@ -94,6 +100,9 @@ final class ZeebeRocksDbTransactionTest {
     final ZeebeTransaction transaction = mock(ZeebeTransaction.class);
     final TransactionContext newContext = new DefaultTransactionContext(transaction);
     final Status status = new Status(Code.IOError, SubCode.None, "");
+    // first call: not in transaction (triggers runInNewTransaction); second: in transaction
+    // (triggers commit)
+    when(transaction.isInCurrentTransaction()).thenReturn(false, true);
     doThrow(new RocksDBException("expected", status)).when(transaction).commitInternal();
 
     // when / then
@@ -107,6 +116,7 @@ final class ZeebeRocksDbTransactionTest {
     final ZeebeTransaction transaction = mock(ZeebeTransaction.class);
     final TransactionContext newContext = new DefaultTransactionContext(transaction);
     final Status status = new Status(Code.NotSupported, SubCode.None, "");
+    when(transaction.isInCurrentTransaction()).thenReturn(false, true);
     doThrow(new RocksDBException("expected", status)).when(transaction).commitInternal();
 
     // when / then
@@ -121,6 +131,7 @@ final class ZeebeRocksDbTransactionTest {
     final TransactionContext newContext = new DefaultTransactionContext(transaction);
     final Status commitStatus = new Status(Code.IOError, SubCode.None, "");
     final Status rollbackStatus = new Status(Code.IOError, SubCode.None, "");
+    when(transaction.isInCurrentTransaction()).thenReturn(false, true);
     doThrow(new RocksDBException("commit failed", commitStatus)).when(transaction).commitInternal();
     doThrow(new RocksDBException("rollback failed", rollbackStatus))
         .when(transaction)
@@ -139,6 +150,7 @@ final class ZeebeRocksDbTransactionTest {
     final TransactionContext newContext = new DefaultTransactionContext(transaction);
     final Status commitStatus = new Status(Code.IOError, SubCode.None, "");
     final Status rollbackStatus = new Status(Code.NotSupported, SubCode.None, "");
+    when(transaction.isInCurrentTransaction()).thenReturn(false, true);
     doThrow(new RocksDBException("commit failed", commitStatus)).when(transaction).commitInternal();
     doThrow(new RocksDBException("rollback failed", rollbackStatus))
         .when(transaction)


### PR DESCRIPTION
## Summary

Fixes #50958 — partitions blocked by an endless `Caught recoverable exception` retry loop when RocksDB runs low on MemTable capacity.

### Root cause

`OptimisticTransactionDB` detects write-write conflicts at **commit time** by scanning the MemTable. Under memory pressure, old MemTable entries are flushed to SST files before a transaction commits, making conflict detection impossible — RocksDB returns `TryAgain`, which Zeebe classifies as recoverable and retries indefinitely.

### Fix

Switch from `OptimisticTransactionDB` to `TransactionDB`. The pessimistic variant acquires locks at **write time**, so conflict detection never depends on MemTable availability. Zeebe's single-writer-per-partition model means there is zero lock contention, so the behavioral change is invisible at the application level.

### Changes

**`ZeebeTransactionDb`**: open a `TransactionDB` instead of `OptimisticTransactionDB`; `TransactionDBOptions` is added to `closables` (not try-with-resources) to ensure it outlives the DB handle.

**`ZeebeTransaction`**: `commitInternal()` eagerly renews the transaction after each commit. `TransactionDB` marks a committed transaction object as read-only; code throughout the engine (e.g. `ProcessingStateMachine.updateState()`) commits the transaction again after `runInTransaction` already committed it, relying on renewal to provide a fresh object for that second call. It's possible that we don't need the eager renewal and we can simply refactor usage of the transaction in the engine, but that would be scope creep here and possibly introduce more behavioral changes, so better to leave that as a follow up to minimize risk with the fix.

**`DefaultTransactionContext`**:
- Added `committed` boolean flag to `runInNewTransaction` so the `finally` block only calls `rollbackInternal()` on failure, avoiding "transaction already committed" errors from `TransactionDB`.
- Added guard to skip the outer `commitInternal()` when `isInCurrentTransaction()` is false after the lambda returns — this happens when the lambda commits explicitly (e.g. `RocksDBSnapshotCopyTest`), preventing a redundant empty commit and renewal.

**`ZeebeRocksDbTransactionTest`**: migrated from JUnit 4 to JUnit 5; updated mock-based tests to correctly simulate the `resetTransaction()` state transition; uses `@AutoClose` for DB lifecycle management.

Closes #50958