### PR TITLE
feat: Added x-added-in-version field to the zeebe V2 API yaml

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/audit-logs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/audit-logs.yaml
@@ -29,6 +29,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           description: An internal error occurred while processing the request.
+      x-added-in-version: "8.9"
 
   /audit-logs/{auditLogKey}:
     get:
@@ -64,6 +65,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/authentication.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/authentication.yaml
@@ -23,6 +23,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/authorizations.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/authorizations.yaml
@@ -37,6 +37,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
   /authorizations/{authorizationKey}:
     put:
@@ -74,6 +75,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
     get:
       x-eventually-consistent: true
@@ -108,6 +110,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
     delete:
       x-eventually-consistent: false
@@ -138,6 +141,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
   /authorizations/search:
     post:
@@ -167,6 +171,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
@@ -37,6 +37,7 @@ paths:
                 $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /batch-operations/search:
     post:
@@ -67,6 +68,7 @@ paths:
                 $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /batch-operations/{batchOperationKey}/cancellation:
     post:
@@ -105,6 +107,7 @@ paths:
                 $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /batch-operations/{batchOperationKey}/suspension:
     post:
@@ -145,6 +148,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
   /batch-operations/{batchOperationKey}/resumption:
     post:
@@ -185,6 +189,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
   /batch-operation-items/search:
     post:
@@ -215,6 +220,7 @@ paths:
                 $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/clock.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/clock.yaml
@@ -30,6 +30,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.6"
 
   /clock/reset:
     post:
@@ -52,6 +53,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.6"
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
@@ -30,6 +30,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
   /cluster-variables/tenants/{tenantId}:
     post:
       operationId: createTenantClusterVariable
@@ -72,6 +73,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
   /cluster-variables/search:
     post:
       tags:
@@ -107,6 +109,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
   /cluster-variables/global/{name}:
     get:
       operationId: getGlobalClusterVariable
@@ -143,6 +146,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
     put:
       operationId: updateGlobalClusterVariable
       x-eventually-consistent: false
@@ -186,6 +190,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
     delete:
       operationId: deleteGlobalClusterVariable
       x-eventually-consistent: false
@@ -217,6 +222,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
   /cluster-variables/tenants/{tenantId}/{name}:
     get:
       operationId: getTenantClusterVariable
@@ -259,6 +265,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
     put:
       operationId: updateTenantClusterVariable
       x-eventually-consistent: false
@@ -308,6 +315,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
     delete:
       operationId: deleteTenantClusterVariable
       x-eventually-consistent: false
@@ -345,6 +353,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
 
 components:
   schemas:

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
@@ -20,6 +20,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Unauthorized'
         "500":
             $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.5"
 
   /status:
     get:
@@ -34,6 +35,7 @@ paths:
           description: The cluster is UP and has at least one partition with a healthy leader.
         "503":
           description: The cluster is DOWN and does not have any partition with a healthy leader.
+      x-added-in-version: "8.8"
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/conditionals.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/conditionals.yaml
@@ -65,6 +65,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.9"
 
 components:
   schemas:

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-definitions.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-definitions.yaml
@@ -30,6 +30,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.6"
 
   /decision-definitions/{decisionDefinitionKey}:
     get:
@@ -69,6 +70,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /decision-definitions/{decisionDefinitionKey}/xml:
     get:
@@ -108,6 +110,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.6"
 
   /decision-definitions/evaluation:
     post:
@@ -157,6 +160,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.6"
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
@@ -30,6 +30,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.6"
 
   /decision-instances/{decisionEvaluationInstanceKey}:
     get:
@@ -69,6 +70,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /decision-instances/{decisionEvaluationKey}/deletion:
     post:
@@ -108,6 +110,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.9"
 
   /decision-instances/deletion:
     post:
@@ -146,6 +149,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-requirements.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-requirements.yaml
@@ -30,6 +30,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.6"
 
   /decision-requirements/{decisionRequirementsKey}:
     get:
@@ -69,6 +70,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /decision-requirements/{decisionRequirementsKey}/xml:
     get:
@@ -108,6 +110,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
@@ -41,6 +41,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InvalidData'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.6"
 
   /resources/{resourceKey}:
     get:
@@ -76,6 +77,7 @@ paths:
                 $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.7"
 
   /resources/{resourceKey}/content:
     get:
@@ -112,6 +114,7 @@ paths:
                 $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.7"
 
   /resources/{resourceKey}/deletion:
     post:
@@ -169,6 +172,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.6"
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/documents.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/documents.yaml
@@ -56,6 +56,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InvalidData'
         "415":
           $ref: 'common-responses.yaml#/components/responses/UnsupportedMediaType'
+      x-added-in-version: "8.6"
 
   /documents/batch:
     post:
@@ -135,6 +136,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InvalidData'
         "415":
           $ref: 'common-responses.yaml#/components/responses/UnsupportedMediaType'
+      x-added-in-version: "8.7"
 
   /documents/{documentId}:
     get:
@@ -185,6 +187,7 @@ paths:
                 $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.6"
 
     delete:
       x-eventually-consistent: false
@@ -220,6 +223,7 @@ paths:
                 $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.6"
 
   /documents/{documentId}/links:
     post:
@@ -269,6 +273,7 @@ paths:
                 $ref: '#/components/schemas/DocumentLink'
         "400":
           $ref: 'common-responses.yaml#/components/responses/InvalidData'
+      x-added-in-version: "8.7"
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
@@ -30,6 +30,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /element-instances/{elementInstanceKey}:
     get:
@@ -69,6 +70,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /element-instances/{elementInstanceKey}/variables:
     put:
@@ -111,6 +113,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
         "504":
           $ref: 'common-responses.yaml#/components/responses/GatewayTimeoutTaskListenerBlocking'
+      x-added-in-version: "8.6"
 
   /element-instances/{elementInstanceKey}/incidents/search:
     post:
@@ -161,6 +164,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
 
   /element-instances/ad-hoc-activities/{adHocSubProcessInstanceKey}/activation:
     post:
@@ -206,6 +210,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/expression.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/expression.yaml
@@ -30,6 +30,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
 
 components:
   schemas:

--- a/zeebe/gateway-protocol/src/main/proto/v2/global-listeners.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/global-listeners.yaml
@@ -38,6 +38,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.9"
 
   /global-task-listeners/{id}:
     get:
@@ -73,6 +74,7 @@ paths:
                 $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
 
     put:
       x-eventually-consistent: false
@@ -117,6 +119,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.9"
 
     delete:
       x-eventually-consistent: false
@@ -151,6 +154,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.9"
 
   /global-task-listeners/search:
     post:
@@ -180,6 +184,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/groups.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/groups.yaml
@@ -30,6 +30,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
   /groups/search:
     post:
@@ -60,6 +61,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /groups/{groupId}:
     get:
@@ -95,6 +97,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
     put:
       x-eventually-consistent: false
@@ -137,6 +140,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
     delete:
       x-eventually-consistent: false
@@ -167,6 +171,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
   /groups/{groupId}/users/{username}:
     put:
@@ -214,6 +219,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
     delete:
       x-eventually-consistent: false
@@ -254,6 +260,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
   /groups/{groupId}/users/search:
     post:
@@ -297,6 +304,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /groups/{groupId}/clients/{clientId}:
     put:
@@ -344,6 +352,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
     delete:
       x-eventually-consistent: false
@@ -384,6 +393,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
   /groups/{groupId}/clients/search:
     post:
@@ -427,6 +437,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /groups/{groupId}/mapping-rules/{mappingRuleId}:
     put:
@@ -472,6 +483,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
     delete:
       x-eventually-consistent: false
@@ -510,6 +522,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
   /groups/{groupId}/mapping-rules/search:
     post:
@@ -553,6 +566,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /groups/{groupId}/roles/search:
     post:
@@ -596,6 +610,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/incidents.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/incidents.yaml
@@ -31,6 +31,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.6"
 
   /incidents/{incidentKey}:
     get:
@@ -69,6 +70,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.6"
 
   /incidents/{incidentKey}/resolution:
     post:
@@ -116,6 +118,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.6"
 
   /incidents/statistics/process-instances-by-error:
     post:
@@ -150,6 +153,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
 
   /incidents/statistics/process-instances-by-definition:
     post:
@@ -185,6 +189,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/job-metrics.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/job-metrics.yaml
@@ -51,6 +51,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
 
   /jobs/statistics/by-types:
     post:
@@ -82,6 +83,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
 
   /jobs/statistics/by-workers:
     post:
@@ -113,6 +115,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
 
   /jobs/statistics/time-series:
     post:
@@ -146,6 +149,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
 
   /jobs/statistics/errors:
     post:
@@ -177,6 +181,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
@@ -31,6 +31,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.6"
 
   /jobs/search:
     post:
@@ -61,6 +62,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /jobs/{jobKey}/failure:
     post:
@@ -110,6 +112,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.6"
 
   /jobs/{jobKey}/error:
     post:
@@ -157,6 +160,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.6"
 
   /jobs/{jobKey}/completion:
     post:
@@ -203,6 +207,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.6"
 
   /jobs/{jobKey}:
     patch:
@@ -248,6 +253,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.6"
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/licenses.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/licenses.yaml
@@ -18,6 +18,7 @@ paths:
                 $ref: '#/components/schemas/LicenseResponse'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.6"
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/mapping-rules.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/mapping-rules.yaml
@@ -40,6 +40,7 @@ paths:
                 $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
         "500":
           $ref: "common-responses.yaml#/components/responses/InternalServerError"
+      x-added-in-version: "8.8"
   /mapping-rules/{mappingRuleId}:
     put:
       x-eventually-consistent: false
@@ -88,6 +89,7 @@ paths:
           $ref: "common-responses.yaml#/components/responses/InternalServerError"
         "503":
           $ref: "common-responses.yaml#/components/responses/ServiceUnavailable"
+      x-added-in-version: "8.8"
     delete:
       x-eventually-consistent: false
       tags:
@@ -118,6 +120,7 @@ paths:
           $ref: "common-responses.yaml#/components/responses/InternalServerError"
         "503":
           $ref: "common-responses.yaml#/components/responses/ServiceUnavailable"
+      x-added-in-version: "8.8"
     get:
       x-eventually-consistent: true
       tags:
@@ -150,6 +153,7 @@ paths:
                 $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
         "500":
           $ref: "common-responses.yaml#/components/responses/InternalServerError"
+      x-added-in-version: "8.8"
   /mapping-rules/search:
     post:
       x-eventually-consistent: true
@@ -179,6 +183,7 @@ paths:
           $ref: "common-responses.yaml#/components/responses/Forbidden"
         "500":
           $ref: "common-responses.yaml#/components/responses/InternalServerError"
+      x-added-in-version: "8.8"
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
@@ -33,6 +33,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.6"
 
   /messages/correlation:
     post:
@@ -73,6 +74,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.6"
 
   /message-subscriptions/search:
     post:
@@ -103,6 +105,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /correlated-message-subscriptions/search:
     post:
@@ -133,6 +136,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-definitions.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-definitions.yaml
@@ -30,6 +30,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /process-definitions/{processDefinitionKey}:
     get:
@@ -71,6 +72,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /process-definitions/{processDefinitionKey}/xml:
     get:
@@ -117,6 +119,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /process-definitions/{processDefinitionKey}/form:
     get:
@@ -158,6 +161,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /process-definitions/{processDefinitionKey}/statistics/element-instances:
     post:
@@ -195,6 +199,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /process-definitions/statistics/message-subscriptions:
     post:
@@ -226,6 +231,7 @@ paths:
           $ref: "common-responses.yaml#/components/responses/Forbidden"
         "500":
           $ref: "common-responses.yaml#/components/responses/InternalServerError"
+      x-added-in-version: "8.9"
 
   /process-definitions/statistics/process-instances:
     post:
@@ -257,6 +263,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
 
   /process-definitions/statistics/process-instances-by-version:
     post:
@@ -289,6 +296,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
@@ -66,6 +66,7 @@ paths:
             application/problem+json:
               schema:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+      x-added-in-version: "8.6"
 
   /process-instances/{processInstanceKey}:
     get:
@@ -103,6 +104,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /process-instances/{processInstanceKey}/sequence-flows:
     get:
@@ -134,6 +136,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /process-instances/{processInstanceKey}/statistics/element-instances:
     get:
@@ -165,6 +168,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /process-instances/search:
     post:
@@ -195,6 +199,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.6"
 
   /process-instances/{processInstanceKey}/incidents/search:
     post:
@@ -244,6 +249,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /process-instances/{processInstanceKey}/incident-resolution:
     post:
@@ -281,6 +287,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.9"
 
   /process-instances/{processInstanceKey}/cancellation:
     post:
@@ -325,6 +332,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
         "504":
           $ref: 'common-responses.yaml#/components/responses/GatewayTimeoutTaskListenerBlocking'
+      x-added-in-version: "8.6"
 
   /process-instances/cancellation:
     post:
@@ -365,6 +373,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /process-instances/incident-resolution:
     post:
@@ -405,6 +414,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /process-instances/migration:
     post:
@@ -445,6 +455,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /process-instances/modification:
     post:
@@ -487,6 +498,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /process-instances/{processInstanceKey}/deletion:
     post:
@@ -532,6 +544,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.9"
 
   /process-instances/deletion:
     post:
@@ -571,6 +584,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
 
   /process-instances/{processInstanceKey}/migration:
     post:
@@ -623,6 +637,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.6"
 
   /process-instances/{processInstanceKey}/modification:
     post:
@@ -666,6 +681,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.6"
 
   /process-instances/{processInstanceKey}/call-hierarchy:
     get:
@@ -705,6 +721,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/roles.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/roles.yaml
@@ -31,6 +31,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
   /roles/search:
     post:
@@ -61,6 +62,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /roles/{roleId}:
     get:
@@ -96,6 +98,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
     put:
       x-eventually-consistent: false
@@ -138,6 +141,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
     delete:
       x-eventually-consistent: false
@@ -168,6 +172,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
   /roles/{roleId}/users/{username}:
     put:
@@ -213,6 +218,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
     delete:
       x-eventually-consistent: false
@@ -251,6 +257,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
   /roles/{roleId}/users/search:
     post:
@@ -294,6 +301,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /roles/{roleId}/clients/{clientId}:
     put:
@@ -339,6 +347,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
     delete:
       x-eventually-consistent: false
@@ -377,6 +386,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
   /roles/{roleId}/clients/search:
     post:
@@ -420,6 +430,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /roles/{roleId}/groups/{groupId}:
     put:
@@ -465,6 +476,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
     delete:
       x-eventually-consistent: false
@@ -503,6 +515,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
   /roles/{roleId}/groups/search:
     post:
@@ -546,6 +559,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /roles/{roleId}/mapping-rules/{mappingRuleId}:
     put:
@@ -591,6 +605,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
     delete:
       x-eventually-consistent: false
@@ -629,6 +644,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
   /roles/{roleId}/mapping-rules/search:
     post:
@@ -672,6 +688,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/setup.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/setup.yaml
@@ -30,3 +30,4 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"

--- a/zeebe/gateway-protocol/src/main/proto/v2/signals.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/signals.yaml
@@ -34,6 +34,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.6"
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/system.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/system.yaml
@@ -77,6 +77,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
   /system/configuration:
     get:
       tags:
@@ -111,6 +112,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Unauthorized'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
 
 
 ## Schema definitions

--- a/zeebe/gateway-protocol/src/main/proto/v2/tenants.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/tenants.yaml
@@ -38,6 +38,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
   /tenants/search:
     post:
@@ -74,6 +75,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /tenants/{tenantId}:
     get:
@@ -111,6 +113,7 @@ paths:
                 $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
     put:
       x-eventually-consistent: false
@@ -153,6 +156,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
     delete:
       x-eventually-consistent: false
@@ -185,6 +189,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
   /tenants/{tenantId}/users/{username}:
     put:
@@ -224,6 +229,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
     delete:
       x-eventually-consistent: false
@@ -264,6 +270,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
   /tenants/{tenantId}/users/search:
     post:
@@ -293,6 +300,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TenantUserSearchResult'
+      x-added-in-version: "8.8"
 
   /tenants/{tenantId}/clients/{clientId}:
     put:
@@ -334,6 +342,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
     delete:
       x-eventually-consistent: false
@@ -374,6 +383,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
   /tenants/{tenantId}/clients/search:
     post:
@@ -403,6 +413,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TenantClientSearchResult'
+      x-added-in-version: "8.8"
 
   /tenants/{tenantId}/groups/{groupId}:
     put:
@@ -444,6 +455,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
     delete:
       x-eventually-consistent: false
@@ -484,6 +496,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
   /tenants/{tenantId}/groups/search:
     post:
@@ -513,6 +526,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TenantGroupSearchResult'
+      x-added-in-version: "8.8"
 
   /tenants/{tenantId}/roles/search:
     post:
@@ -542,6 +556,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TenantRoleSearchResult'
+      x-added-in-version: "8.8"
 
   /tenants/{tenantId}/roles/{roleId}:
     put:
@@ -583,6 +598,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
     delete:
       x-eventually-consistent: false
@@ -624,6 +640,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
   /tenants/{tenantId}/mapping-rules/{mappingRuleId}:
     put:
@@ -663,6 +680,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
     delete:
       x-eventually-consistent: false
@@ -701,6 +719,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
   /tenants/{tenantId}/mapping-rules/search:
     post:
@@ -730,6 +749,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TenantMappingRuleSearchResult'
+      x-added-in-version: "8.8"
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
@@ -51,6 +51,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
         "504":
           $ref: 'common-responses.yaml#/components/responses/GatewayTimeoutTaskListenerBlocking'
+      x-added-in-version: "8.5"
 
   /user-tasks/{userTaskKey}/assignment:
     post:
@@ -103,6 +104,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
         "504":
           $ref: 'common-responses.yaml#/components/responses/GatewayTimeoutTaskListenerBlocking'
+      x-added-in-version: "8.5"
 
   /user-tasks/{userTaskKey}:
     get:
@@ -140,6 +142,7 @@ paths:
                 $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
     patch:
       x-eventually-consistent: false
@@ -190,6 +193,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
         "504":
           $ref: 'common-responses.yaml#/components/responses/GatewayTimeoutTaskListenerBlocking'
+      x-added-in-version: "8.5"
 
   /user-tasks/{userTaskKey}/form:
     get:
@@ -231,6 +235,7 @@ paths:
                 $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /user-tasks/{userTaskKey}/assignee:
     delete:
@@ -277,6 +282,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
         "504":
           $ref: 'common-responses.yaml#/components/responses/GatewayTimeoutTaskListenerBlocking'
+      x-added-in-version: "8.5"
 
   /user-tasks/search:
     post:
@@ -307,6 +313,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.6"
 
   /user-tasks/{userTaskKey}/variables/search:
     post:
@@ -353,6 +360,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InvalidData'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /user-tasks/{userTaskKey}/effective-variables/search:
     post:
@@ -398,6 +406,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InvalidData'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /user-tasks/{userTaskKey}/audit-logs/search:
     post:
@@ -431,6 +440,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InvalidData'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/users.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/users.yaml
@@ -38,6 +38,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
   /users/search:
     post:
@@ -67,6 +68,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /users/{username}:
     get:
@@ -102,6 +104,7 @@ paths:
                 $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
     put:
       x-eventually-consistent: false
@@ -144,6 +147,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
     delete:
       x-eventually-consistent: false
@@ -174,6 +178,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
 ## Schema definitions
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/variables.yaml
@@ -46,6 +46,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /variables/{variableKey}:
     get:
@@ -88,6 +89,7 @@ paths:
                 $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
 ## Schema definitions
 


### PR DESCRIPTION
## Description
API changes between server versions have impacts on customer application migration, expected behavioural, and type-safety.

We want to communicate this explicitly and clearly in SDKs and in the API Documentation on docs.camunda.io.

Hence, as the first step, we added `x-added-in-version`, annotation field to the zeebe V2 API yaml. We did regression analysis all the way back to version 8.5. 

`x-added-in-version` is an Extension Field.

<!-- Describe the goal and purpose of this PR. -->

## Related issues
Partially Completes [#46745](https://github.com/camunda/camunda/issues/46745)
