### PR TITLE
feat: add --connectors-port flag to c8run

### DIFF
--- a/c8run/cmd/c8run/main.go
+++ b/c8run/cmd/c8run/main.go
@@ -75,6 +75,7 @@ Options:
   --keystore <path>         Enable HTTPS with a TLS certificate (JKS format)
   --keystorePassword <pw>  Password for the provided keystore
   --port <number>           Set the main Camunda port (default: 8080)
+  --connectors-port <number> Set the Connectors port (default: 8086)
   --log-level <level>       Set log level (e.g., info, debug)
 
 Examples:
@@ -173,6 +174,7 @@ func createStartFlagSet(settings *types.C8RunSettings) *flag.FlagSet {
 	startFlagSet.Var((*stringSliceFlag)(&settings.ExtraDrivers), "extra-driver", "Path to a JDBC driver jar to copy into the Camunda lib directory (repeatable).")
 	startFlagSet.BoolVar(&settings.Detached, "detached", false, "Starts Camunda Run as a detached process")
 	startFlagSet.IntVar(&settings.Port, "port", 8080, "Port to run Camunda on")
+	startFlagSet.IntVar(&settings.ConnectorsPort, "connectors-port", 8086, "Port to run Connectors on")
 	startFlagSet.StringVar(&settings.Keystore, "keystore", "", "Provide a JKS filepath to enable TLS")
 	startFlagSet.StringVar(&settings.KeystorePassword, "keystorePassword", "", "Provide a password to unlock your JKS keystore")
 	startFlagSet.StringVar(&settings.LogLevel, "log-level", "", "Adjust the log level of Camunda")

--- a/c8run/internal/health/camunda.go
+++ b/c8run/internal/health/camunda.go
@@ -59,8 +59,8 @@ var (
 )
 
 // QueryConnectors polls the Connectors health endpoint until it responds or retries are exhausted.
-func QueryConnectors(ctx context.Context, retries int) error {
-	healthEndpoint := fmt.Sprintf("http://localhost:%d/actuator/health", inboundConnectorsPort)
+func QueryConnectors(ctx context.Context, retries int, port int) error {
+	healthEndpoint := fmt.Sprintf("http://localhost:%d/actuator/health", port)
 	if isRunningFunc(ctx, "Connectors", healthEndpoint, retries, 5*time.Second) {
 		return nil
 	}
@@ -125,7 +125,10 @@ func isRunning(ctx context.Context, name, url string, retries int, delay time.Du
 }
 
 func PrintStatus(settings types.C8RunSettings) error {
-	operatePort, tasklistPort, adminPort, camundaPort := settings.Port, settings.Port, settings.Port, settings.Port
+	operatePort, tasklistPort, adminPort, camundaPort, connectorsPort := settings.Port, settings.Port, settings.Port, settings.Port, settings.ConnectorsPort
+	if connectorsPort == 0 {
+		connectorsPort = inboundConnectorsPort
+	}
 
 	username := settings.Username
 	if strings.TrimSpace(username) == "" {
@@ -151,7 +154,7 @@ func PrintStatus(settings types.C8RunSettings) error {
 		Password:             password,
 		OrchestrationAPI:     fmt.Sprintf("%s://localhost:%d/v2/", protocol, camundaPort),
 		OrchestrationMCP:     fmt.Sprintf("%s://localhost:%d/mcp/cluster", protocol, camundaPort),
-		InboundConnectorsAPI: fmt.Sprintf("http://localhost:%d/", inboundConnectorsPort),
+		InboundConnectorsAPI: fmt.Sprintf("http://localhost:%d/", connectorsPort),
 		ZeebeAPI:             zeebeAPIURL,
 		CamundaMetrics:       camundaMetricsURL,
 		DesktopModelerTarget: fmt.Sprintf("%s://localhost:%d/v2/", protocol, camundaPort),

--- a/c8run/internal/health/camunda_test.go
+++ b/c8run/internal/health/camunda_test.go
@@ -106,7 +106,7 @@ func TestQueryConnectorsShouldReturnNilWhenConnectorsAreHealthy(t *testing.T) {
 	}
 
 	// when
-	err := QueryConnectors(context.Background(), 0)
+	err := QueryConnectors(context.Background(), 0, 8086)
 
 	// then
 	if err != nil {
@@ -123,7 +123,7 @@ func TestQueryConnectorsShouldReturnErrorWhenConnectorsAreUnhealthy(t *testing.T
 	}
 
 	// when
-	err := QueryConnectors(context.Background(), 0)
+	err := QueryConnectors(context.Background(), 0, 8086)
 
 	// then
 	if err == nil {

--- a/c8run/internal/processmanagement/processhandler_test.go
+++ b/c8run/internal/processmanagement/processhandler_test.go
@@ -22,7 +22,7 @@ func (m *mockC8) ProcessTree(pid int) []int {
 	return nil
 }
 func (m *mockC8) VersionCmd(ctx context.Context, javaBinaryPath string) *exec.Cmd { return nil }
-func (m *mockC8) ConnectorsCmd(ctx context.Context, javaBinary string, parentDir string, connectorsVersion string, camundaPort int) *exec.Cmd {
+func (m *mockC8) ConnectorsCmd(ctx context.Context, javaBinary string, parentDir string, connectorsVersion string, camundaPort int, connectorsPort int) *exec.Cmd {
 	return nil
 }
 

--- a/c8run/internal/start/startuphandler.go
+++ b/c8run/internal/start/startuphandler.go
@@ -315,7 +315,7 @@ func (s *StartupHandler) StartCommand(wg *sync.WaitGroup, ctx context.Context, s
 	}
 
 	s.ProcessHandler.AttemptToStartProcess(processInfo.Connectors.PidPath, "Connectors", func() {
-		connectorsCmd := c8.ConnectorsCmd(ctx, javaBinary, parentDir, processInfo.Connectors.Version, state.Settings.Port)
+		connectorsCmd := c8.ConnectorsCmd(ctx, javaBinary, parentDir, processInfo.Connectors.Version, state.Settings.Port, state.Settings.ConnectorsPort)
 		connectorsLogPath := filepath.Join(parentDir, "log", "connectors.log")
 		err := s.startApplication(connectorsCmd, processInfo.Connectors.PidPath, connectorsLogPath, stop)
 		if err != nil {
@@ -344,7 +344,7 @@ func (s *StartupHandler) StartCommand(wg *sync.WaitGroup, ctx context.Context, s
 
 	// Connectors depends on Zeebe being available before reporting healthy, so
 	// check its health only after Camunda is confirmed up.
-	if err := health.QueryConnectors(ctx, 12); err != nil {
+	if err := health.QueryConnectors(ctx, 12, settings.ConnectorsPort); err != nil {
 		log.Err(err).Msg("Connectors did not start")
 		stop()
 		return

--- a/c8run/internal/types/types.go
+++ b/c8run/internal/types/types.go
@@ -9,7 +9,7 @@ type C8Run interface {
 	OpenBrowser(ctx context.Context, url string) error
 	ProcessTree(commandPid int) []int
 	VersionCmd(ctx context.Context, javaBinaryPath string) *exec.Cmd
-	ConnectorsCmd(ctx context.Context, javaBinary string, parentDir string, connectorsVersion string, camundaPort int) *exec.Cmd
+	ConnectorsCmd(ctx context.Context, javaBinary string, parentDir string, connectorsVersion string, camundaPort int, connectorsPort int) *exec.Cmd
 	CamundaCmd(ctx context.Context, camundaVersion string, parentDir string, extraArgs string, javaOpts string) *exec.Cmd
 }
 
@@ -18,6 +18,7 @@ type C8RunSettings struct {
 	ResolvedConfigPath   string
 	Detached             bool
 	Port                 int
+	ConnectorsPort       int
 	Keystore             string
 	KeystorePassword     string
 	LogLevel             string

--- a/c8run/internal/unix/stub.go
+++ b/c8run/internal/unix/stub.go
@@ -19,7 +19,7 @@ func (w *UnixC8Run) VersionCmd(ctx context.Context, javaBinaryPath string) *exec
 	panic("Platform was not built for unix")
 }
 
-func (w *UnixC8Run) ConnectorsCmd(ctx context.Context, javaBinary string, parentDir string, connectorsVersion string, camundaPort int) *exec.Cmd {
+func (w *UnixC8Run) ConnectorsCmd(ctx context.Context, javaBinary string, parentDir string, connectorsVersion string, camundaPort int, connectorsPort int) *exec.Cmd {
 	panic("Platform was not built for unix")
 }
 

--- a/c8run/internal/unix/types.go
+++ b/c8run/internal/unix/types.go
@@ -1,3 +1,5 @@
 package unix
 
+const defaultConnectorsPort = 8086
+
 type UnixC8Run struct{}

--- a/c8run/internal/unix/unix.go
+++ b/c8run/internal/unix/unix.go
@@ -42,14 +42,18 @@ func (w *UnixC8Run) VersionCmd(ctx context.Context, javaBinaryPath string) *exec
 	return exec.CommandContext(ctx, javaBinaryPath, "--version")
 }
 
-func (w *UnixC8Run) ConnectorsCmd(ctx context.Context, javaBinary string, parentDir string, connectorsVersion string, camundaPort int) *exec.Cmd {
+func (w *UnixC8Run) ConnectorsCmd(ctx context.Context, javaBinary string, parentDir string, connectorsVersion string, camundaPort int, connectorsPort int) *exec.Cmd {
 	classPath := parentDir + "/*:" + parentDir + "/custom_connectors/*"
 	mainClass := "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"
 	if connectors.UsePropertiesLauncher(connectorsVersion) {
 		mainClass = "org.springframework.boot.loader.launch.PropertiesLauncher"
 	}
 	springConfigLocation := "--spring.config.additional-location=" + parentDir + "/connectors-application.properties"
-	connectorsCmd := exec.CommandContext(ctx, javaBinary, "-cp", classPath, mainClass, springConfigLocation)
+	args := []string{"-cp", classPath, mainClass, springConfigLocation}
+	if connectorsPort != defaultConnectorsPort {
+		args = append(args, fmt.Sprintf("--server.port=%d", connectorsPort))
+	}
+	connectorsCmd := exec.CommandContext(ctx, javaBinary, args...)
 	connectorsCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	// Set default Zeebe REST address if the user has not provided one already.

--- a/c8run/internal/unix/unix_test.go
+++ b/c8run/internal/unix/unix_test.go
@@ -42,6 +42,7 @@ func TestConnectorsCmdWithCustomPort(t *testing.T) {
 				"/test/parent/dir",
 				"8.8.1",
 				tt.camundaPort,
+				8086,
 			)
 
 			// Check that the environment variable is set correctly
@@ -95,6 +96,7 @@ func TestConnectorsCmdPortNotInArgs(t *testing.T) {
 		"/test/parent/dir",
 		"8.8.1",
 		9000,
+		8086,
 	)
 
 	// The port should be in the environment variable, not in the command arguments
@@ -117,6 +119,7 @@ func TestConnectorsCmdRespectsExistingZeebeRestEnv(t *testing.T) {
 		"/test/parent/dir",
 		"8.8.1",
 		9000,
+		8086,
 	)
 
 	if cmd.Env != nil {
@@ -138,6 +141,7 @@ func TestConnectorsCmdUsesPropertiesLauncherWhenVersionRequiresIt(t *testing.T) 
 		"/test/parent/dir",
 		"8.9.0",
 		8080,
+		8086,
 	)
 
 	args := strings.Join(cmd.Args, " ")
@@ -146,5 +150,33 @@ func TestConnectorsCmdUsesPropertiesLauncherWhenVersionRequiresIt(t *testing.T) 
 	}
 	if strings.Contains(args, "io.camunda.connector.runtime.app.ConnectorRuntimeApplication") {
 		t.Fatalf("did not expect legacy main class when PropertiesLauncher is enabled")
+	}
+}
+
+func TestConnectorsCmdInjectsCustomConnectorsPort(t *testing.T) {
+	ctx := context.Background()
+	unixC8Run := &UnixC8Run{}
+
+	// when a non-default connectors port is provided
+	cmd := unixC8Run.ConnectorsCmd(ctx, "java", "/test/parent/dir", "8.8.1", 8080, 9000)
+
+	// then --server.port is passed as a Spring Boot arg
+	args := strings.Join(cmd.Args, " ")
+	if !strings.Contains(args, "--server.port=9000") {
+		t.Fatalf("expected --server.port=9000 in args when custom connectors port is set, got: %s", args)
+	}
+}
+
+func TestConnectorsCmdDoesNotInjectDefaultConnectorsPort(t *testing.T) {
+	ctx := context.Background()
+	unixC8Run := &UnixC8Run{}
+
+	// when the default connectors port is used
+	cmd := unixC8Run.ConnectorsCmd(ctx, "java", "/test/parent/dir", "8.8.1", 8080, 8086)
+
+	// then --server.port is not injected (connectors-application.properties already sets it)
+	args := strings.Join(cmd.Args, " ")
+	if strings.Contains(args, "--server.port=") {
+		t.Fatalf("expected no --server.port arg for default port, got: %s", args)
 	}
 }

--- a/c8run/internal/windows/stub.go
+++ b/c8run/internal/windows/stub.go
@@ -19,7 +19,7 @@ func (w *WindowsC8Run) VersionCmd(ctx context.Context, javaBinaryPath string) *e
 	panic("Platform was not built for windows")
 }
 
-func (w *WindowsC8Run) ConnectorsCmd(ctx context.Context, javaBinary string, parentDir string, connectorsVersion string, camundaPort int) *exec.Cmd {
+func (w *WindowsC8Run) ConnectorsCmd(ctx context.Context, javaBinary string, parentDir string, connectorsVersion string, camundaPort int, connectorsPort int) *exec.Cmd {
 	panic("Platform was not built for windows")
 }
 

--- a/c8run/internal/windows/windows.go
+++ b/c8run/internal/windows/windows.go
@@ -13,6 +13,8 @@ import (
 	"github.com/camunda/camunda/c8run/internal/connectors"
 )
 
+const defaultConnectorsPort = 8086
+
 func (w *WindowsC8Run) OpenBrowser(ctx context.Context, url string) error {
 	openBrowserCmdString := "start " + url
 	openBrowserCmd := exec.CommandContext(ctx, "cmd", "/C", openBrowserCmdString)
@@ -34,12 +36,16 @@ func (w *WindowsC8Run) VersionCmd(ctx context.Context, javaBinaryPath string) *e
 	return exec.CommandContext(ctx, "cmd", "/C", javaBinaryPath+" --version")
 }
 
-func (w *WindowsC8Run) ConnectorsCmd(ctx context.Context, javaBinary string, parentDir string, connectorsVersion string, camundaPort int) *exec.Cmd {
+func (w *WindowsC8Run) ConnectorsCmd(ctx context.Context, javaBinary string, parentDir string, connectorsVersion string, camundaPort int, connectorsPort int) *exec.Cmd {
 	mainClass := "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"
 	if connectors.UsePropertiesLauncher(connectorsVersion) {
 		mainClass = "org.springframework.boot.loader.launch.PropertiesLauncher"
 	}
-	connectorsCmd := exec.CommandContext(ctx, javaBinary, "-classpath", parentDir+"\\*;"+parentDir+"\\custom_connectors\\*", mainClass, "--spring.config.additional-location="+parentDir+"\\connectors-application.properties")
+	args := []string{"-classpath", parentDir + "\\*;" + parentDir + "\\custom_connectors\\*", mainClass, "--spring.config.additional-location=" + parentDir + "\\connectors-application.properties"}
+	if connectorsPort != defaultConnectorsPort {
+		args = append(args, fmt.Sprintf("--server.port=%d", connectorsPort))
+	}
+	connectorsCmd := exec.CommandContext(ctx, javaBinary, args...)
 	connectorsCmd.SysProcAttr = &syscall.SysProcAttr{
 		CreationFlags: 0x08000000 | 0x00000200, // CREATE_NO_WINDOW, CREATE_NEW_PROCESS_GROUP : https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags
 		// CreationFlags: 0x00000008 | 0x00000200, // DETACHED_PROCESS, CREATE_NEW_PROCESS_GROUP : https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags

--- a/c8run/internal/windows/windows_test.go
+++ b/c8run/internal/windows/windows_test.go
@@ -68,6 +68,7 @@ func TestConnectorsCmdWithCustomPort(t *testing.T) {
 				"C:\\test\\parent\\dir",
 				"8.8.1",
 				tt.camundaPort,
+				8086,
 			)
 
 			// Check that the environment variable is set correctly
@@ -121,6 +122,7 @@ func TestConnectorsCmdPortNotInArgs(t *testing.T) {
 		"C:\\test\\parent\\dir",
 		"8.8.1",
 		9000,
+		8086,
 	)
 
 	// The port should be in the environment variable, not in the command arguments
@@ -143,6 +145,7 @@ func TestConnectorsCmdRespectsExistingZeebeRestEnv(t *testing.T) {
 		"C:\\test\\parent\\dir",
 		"8.8.1",
 		9000,
+		8086,
 	)
 
 	if cmd.Env != nil {
@@ -164,6 +167,7 @@ func TestConnectorsCmdUsesPropertiesLauncherWhenVersionRequiresIt(t *testing.T) 
 		"C:\\test\\parent\\dir",
 		"8.9.0",
 		8080,
+		8086,
 	)
 
 	args := strings.Join(cmd.Args, " ")


### PR DESCRIPTION
## Summary

Closes #51422
Depends on #51386

- Adds `--connectors-port` flag to `c8run start` (default: `8086`) so users can override the Connectors server port when it conflicts with another service
- Threads the port through `ConnectorsCmd` on both Unix and Windows: injects `--server.port=<port>` as a Spring Boot arg when the value differs from the default (matching the pattern used for Camunda's `--port`)
- Updates `QueryConnectors` to accept the port as a parameter instead of hardcoding `8086`
- Updates `PrintStatus` so the displayed Inbound Connectors API URL reflects the configured port

## Test plan

- [ ] `TestConnectorsCmdInjectsCustomConnectorsPort` — `--server.port` arg is present for non-default port
- [ ] `TestConnectorsCmdDoesNotInjectDefaultConnectorsPort` — no `--server.port` arg when using default `8086`
- [ ] All existing `ConnectorsCmd` tests pass unchanged
- [ ] `go test ./...` passes