### PR TITLE
refactor: move ClusterMultiplePartitionsBatchOperationIT to orchestration package

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/ClusterMultiplePartitionsBatchOperationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/ClusterMultiplePartitionsBatchOperationIT.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.it.cluster;
+package io.camunda.it.orchestration;
 
 import static io.camunda.it.util.TestHelper.deployResource;
 import static io.camunda.it.util.TestHelper.getScopedVariables;


### PR DESCRIPTION
## Summary

- Moves `ClusterMultiplePartitionsBatchOperationIT` from `io.camunda.it.cluster` to `io.camunda.it.orchestration`
- Batch operations are a Core Features concern, not Distributed Systems — this clarifies test ownership and aligns attribution with the responsible team

## Test plan

- [ ] Verify the test still compiles and runs correctly under its new package

🤖 Generated with [Claude Code](https://claude.com/claude-code)