### PR TITLE
ci: add smoke load test for load-test infra changes

### DIFF
--- a/.github/workflows/camunda-smoke-load-test.yml
+++ b/.github/workflows/camunda-smoke-load-test.yml
@@ -1,0 +1,143 @@
+# description: Smoke-tests the load-test setup on every push that touches load-test infra.
+#              Deploys a minimal load test from the pushed ref, waits for pod readiness and
+#              gateway connectivity, then deletes the namespace. Fails loudly on Slack so
+#              breakages in load-test infra are caught immediately on main/stable branches.
+# calls: camunda-load-test.yml (scenario: realistic),
+#        camunda-verify-and-cleanup-load-test.yml (verify + delete namespace)
+# notifications: Slack (#reliability-testing-alerts) on failure only
+# type: CI
+# owner: @camunda/reliability-testing
+name: Camunda Smoke Load Test
+on:
+  push:
+    branches:
+      - main
+      - 'stable/**'
+    paths:
+      - 'load-tests/**'
+      - '.github/workflows/camunda-load-test.yml'
+      - '.github/workflows/camunda-verify-and-cleanup-load-test.yml'
+      - '.github/workflows/camunda-smoke-load-test.yml'
+  workflow_dispatch: {}
+
+concurrency:
+  group: smoke-load-test-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    # use bash shell by default to ensure pipefail behavior is the default
+    # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+    shell: bash
+
+jobs:
+  sanitize-ref-name:
+    name: Sanitize Ref Name
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    outputs:
+      sanitized-name: c8-smoke-${{ steps.sanitize.outputs.branch_name }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - id: sanitize
+        uses: camunda/infra-global-github-actions/sanitize-branch-name@main
+        with:
+          branch: ${{ github.ref_name }}
+          # reduced to account for smoke-load-test prefix "c8-smoke-" and potential suffixes for uniqueness
+          max_length: 40
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
+  smoke-install:
+    name: Smoke Install
+    needs: sanitize-ref-name
+    uses: ./.github/workflows/camunda-load-test.yml
+    secrets: inherit
+    with:
+      name: ${{ needs.sanitize-ref-name.outputs.sanitized-name }}
+      ref: ${{ github.ref_name }}
+      scenario: realistic
+      # Short TTL acts as a safety net; verify-and-cleanup deletes the namespace explicitly.
+      ttl: 1
+
+  verify-and-cleanup:
+    name: Verify and cleanup
+    needs: [sanitize-ref-name, smoke-install]
+    if: always()
+    uses: ./.github/workflows/camunda-verify-and-cleanup-load-test.yml
+    secrets: inherit
+    with:
+      namespace: ${{ needs.sanitize-ref-name.outputs.sanitized-name }}
+
+  notify-on-failure:
+    name: Notify on failure
+    runs-on: ubuntu-latest
+    needs: [sanitize-ref-name, smoke-install, verify-and-cleanup]
+    if: >-
+      always() &&
+      (needs.smoke-install.result == 'failure' ||
+      needs.verify-and-cleanup.result == 'failure')
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Import Slack webhook from Vault
+        id: slack-secrets
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_ZEEBOT_RELIABILITY_TESTING_ALERTS_WEBHOOK_URL;
+      - id: slack-notify
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
+        with:
+          webhook: ${{ steps.slack-secrets.outputs.SLACK_ZEEBOT_RELIABILITY_TESTING_ALERTS_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":alarm: *Smoke load test failed on `${{ github.ref_name }}`*"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Job results:*\n- smoke-install: ${{ needs.smoke-install.result }}\n- verify-and-cleanup: ${{ needs.verify-and-cleanup.result }}\n\n*Namespace:* `${{ needs.sanitize-ref-name.outputs.sanitized-name }}`"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "@reliability-testing-team Please check: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                  }
+                }
+              ]
+            }
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/camunda-smoke-load-test.yml
+++ b/.github/workflows/camunda-smoke-load-test.yml
@@ -41,7 +41,11 @@ jobs:
     timeout-minutes: 5
     permissions: {}
     outputs:
-      sanitized-name: c8-smoke-${{ steps.sanitize.outputs.branch_name }}
+      # Namespace is unique per run (run_id suffix) so a canceled run's lingering Helm/kubectl
+      # operations cannot stomp on the namespace of the next run that cancel-in-progress starts.
+      # Total length: "c8-smoke-" (9) + branch (≤30) + "-" (1) + run_id (~11) = ≤51, well under the
+      # 63-char DNS-1123 namespace limit.
+      sanitized-name: c8-smoke-${{ steps.sanitize.outputs.branch_name }}-${{ github.run_id }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -49,8 +53,8 @@ jobs:
         uses: camunda/infra-global-github-actions/sanitize-branch-name@main
         with:
           branch: ${{ github.ref_name }}
-          # reduced to account for smoke-load-test prefix "c8-smoke-" and potential suffixes for uniqueness
-          max_length: 40
+          # reduced to account for "c8-smoke-" prefix (9) and "-<run_id>" suffix (~12)
+          max_length: 30
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/camunda-smoke-load-test.yml
+++ b/.github/workflows/camunda-smoke-load-test.yml
@@ -15,6 +15,10 @@ on:
       - 'stable/**'
     paths:
       - 'load-tests/**'
+      # Docs-only changes under load-tests/ don't affect the install path — skip the smoke run.
+      - '!load-tests/README.md'
+      - '!load-tests/**/README.md'
+      - '!load-tests/docs/**'
       - '.github/workflows/camunda-load-test.yml'
       - '.github/workflows/camunda-verify-and-cleanup-load-test.yml'
       - '.github/workflows/camunda-smoke-load-test.yml'

--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -47,6 +47,7 @@ graph TD
 
     subgraph "Event Triggers"
         PR["camunda-pr-load-test.yaml<br/><i>PR label: benchmark</i>"]
+        SMOKE["camunda-smoke-load-test.yml<br/><i>push to main/stable/**<br/>on load-test paths</i>"]
         ADHOC["Manual workflow_dispatch"]
     end
 
@@ -73,6 +74,8 @@ graph TD
     RELEASE -- "scenario: realistic<br/>orchestration-tag" --> CORE
     PR -- "scenario: max" --> CORE
     PR -- "after 15min wait" --> PROFILE
+    SMOKE -- "scenario: realistic" --> CORE
+    SMOKE -- "verify + delete namespace" --> VERIFY
     ADHOC --> CORE
     ADHOC --> RELEASE
 


### PR DESCRIPTION
## Description

Adds a new CI workflow that smoke-tests the load-test install path whenever load-test infrastructure changes. Today, breakages in `load-tests/` or the shared load-test workflow files are only surfaced by the nightly scheduled release tests, meaning a regression can sit on `main` or a `stable/**` branch for up to a day before anyone notices. This PR closes that gap by deploying a minimal load test on every push that touches load-test infra and tearing it down once pod readiness and gateway connectivity are confirmed.

### What it does

- New workflow: `.github/workflows/camunda-smoke-load-test.yml`
- **Triggers** on `push` to `main` and `stable/**` when any of these paths change:
  - `load-tests/**`
  - `.github/workflows/camunda-load-test.yml`
  - `.github/workflows/camunda-verify-and-cleanup-load-test.yml`
  - `.github/workflows/camunda-smoke-load-test.yml`
- Also dispatchable via `workflow_dispatch` for ad-hoc verification.
- **Scenario:** `realistic` (matches scheduled-release and weekly test baseline — production-like install, not throughput-heavy).
- **Concurrency:** keyed on `github.ref` with `cancel-in-progress: true`, so back-to-back pushes to the same branch supersede each other but pushes to different branches run independently.
- **Namespace:** `c8-smoke-<sanitized-ref>` (e.g., `c8-smoke-main`, `c8-smoke-stable-8-9`). Uses the same `camunda/infra-global-github-actions/sanitize-branch-name` action already used by `camunda-pr-load-test.yaml`.

### Reuses existing building blocks

- `camunda-load-test.yml` — central reusable workflow that builds images from the pushed ref and deploys via `make install`.
- `camunda-verify-and-cleanup-load-test.yml` — waits for pod readiness + gRPC Topology probe, then deletes the namespace (with `if: always()`, so broken installs still get cleaned up).
- `ttl: 1` on the install acts as a safety net in case explicit cleanup fails; the daily `camunda-load-test-clean-up.yml` will garbage-collect it.

### Notifications

Slack posts to `#reliability-testing-alerts` on **failure only** (success is silent). Mirrors the Vault + webhook block from `camunda-scheduled-release-load-tests.yml`.

### Why `push` and not `pull_request`?

Per the issue proposal and discussion: this is a post-merge detection workflow, not a merge gate. Every PR touching `load-tests/**` would otherwise have to wait 15–30 min on a GKE install before merging, which is too heavy for a lightweight safety net. If post-merge detection turns out to be too late in practice, upgrading to a required PR check is a small follow-up (change the trigger, add a branch-protection rule).

### Branch strategy

Ships on `main` first. Backporting to `stable/8.6–8.8` will require adapting the `paths:` filter from `load-tests/**` to `zeebe/benchmarks/**` (the load-test directory was restructured in 8.9). This is documented in `load-tests/docs/directory-structure.md` and flagged as out-of-scope for this PR.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #43116