### PR TITLE
docs: emphasize that spotless:apply must be run before every commit

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -131,7 +131,11 @@ Types: `build`, `ci`, `deps`, `docs`, `feat`, `fix`, `merge`, `perf`, `refactor`
 
 ## Before Submitting
 
-1. Format code: `./mvnw license:format spotless:apply -T1C`
+Always run these steps before every commit — never skip them, even for "obvious" or single-line
+changes. Skipping formatting reliably breaks the `Java checks` CI job.
+
+1. Format code: `./mvnw license:format spotless:apply -T1C` — **mandatory** before every commit
+   that touches Java sources or `pom.xml` files. Run it again after any subsequent edit.
 2. Build the changed module (see "Module-scoped builds" above for commands)
 3. Run module tests and verify zero failures
 4. Commit with conventional commit format

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -135,7 +135,7 @@ Always run these steps before every commit — never skip them, even for "obviou
 changes. Skipping formatting reliably breaks the `Java checks` CI job.
 
 1. Format code: `./mvnw license:format spotless:apply -T1C` — **mandatory** before every commit
-   that touches Java sources or `pom.xml` files. Run it again after any subsequent edit.
+   that touches Java sources, markdown or `pom.xml` files. Run it again after any subsequent edit.
 2. Build the changed module (see "Module-scoped builds" above for commands)
 3. Run module tests and verify zero failures
 4. Commit with conventional commit format


### PR DESCRIPTION
## Description

Skipping the formatting step reliably breaks the Java checks CI job; make that explicit in github/copilot-instructions.md so future agent sessions cannot treat it as optional even for trivial-looking edits.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).