### PR TITLE
User dropdown search for user resource types when creating Authorizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,6 @@ cmd/renovate/renovate*/
 .c8dev
 /output/
 scripts/codeowners-utils/output/
+
+# playwright test output
+**/test-results

--- a/identity/client/src/components/form/DropdownSearch.tsx
+++ b/identity/client/src/components/form/DropdownSearch.tsx
@@ -24,12 +24,24 @@ type DropdownSearchProps<Item extends Record<string, unknown>> = {
   onSelect: (item: Item) => unknown;
   filter?: (item: Item) => boolean;
   autoFocus?: boolean;
+  invalid?: boolean;
 };
 
 type ItemWithTitleAndSubTitle<Item> = Item & {
   title: string;
   subTitle?: string;
 };
+
+const InvalidSearchWrapper = styled.div<{ $invalid: boolean }>`
+  ${({ $invalid }) =>
+    $invalid &&
+    `
+    .cds--search-input {
+      outline: 2px solid var(--cds-support-error, #da1e28);
+      outline-offset: -2px;
+    }
+  `}
+`;
 
 const ListStyleWrapper = styled.div`
   & .cds--list-box__menu-item,
@@ -56,6 +68,7 @@ const DropdownSearch = <Item extends Record<string, unknown>>({
   onSelect,
   filter = () => true, // We require a filter to allow the parent to remove items with accumulated state. See comment below for details.
   autoFocus = false,
+  invalid = false,
 }: DropdownSearchProps<Item>) => {
   const debounce = useDebounce();
   const [search, setSearch] = useState("");
@@ -164,15 +177,17 @@ const DropdownSearch = <Item extends Record<string, unknown>>({
 
   return (
     <ListBox disabled={false} type="inline" isOpen>
-      <Search
-        labelText={placeholder}
-        placeholder={placeholder}
-        onChange={handleChange}
-        onClear={handleClear}
-        value={search}
-        autoFocus={autoFocus}
-        onKeyDown={handleKeyDown}
-      />
+      <InvalidSearchWrapper $invalid={invalid}>
+        <Search
+          labelText={placeholder}
+          placeholder={placeholder}
+          onChange={handleChange}
+          onClear={handleClear}
+          value={search}
+          autoFocus={autoFocus}
+          onKeyDown={handleKeyDown}
+        />
+      </InvalidSearchWrapper>
       {search && (
         <ListStyleWrapper>
           <ListBox.Menu id="list-box">

--- a/identity/client/src/pages/authorizations/modals/owner-selection/OwnerSelectionSearch.tsx
+++ b/identity/client/src/pages/authorizations/modals/owner-selection/OwnerSelectionSearch.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { FC, useState } from "react";
+import { FC, useEffect, useState } from "react";
 import { FormLabel, Tag } from "@carbon/react";
 import { useApi } from "src/utility/api";
 import { searchUser } from "src/utility/api/users";
@@ -16,11 +16,13 @@ import type { User } from "@camunda/camunda-api-zod-schemas/8.10";
 
 type OwnerSelectionSearchProps = {
   onChange: (ownerId: string) => void;
+  ownerId?: string;
   isEmpty?: boolean;
 };
 
 const OwnerSelectionSearch: FC<OwnerSelectionSearchProps> = ({
   onChange,
+  ownerId,
   isEmpty = false,
 }) => {
   const { t } = useTranslate("authorizations");
@@ -30,6 +32,12 @@ const OwnerSelectionSearch: FC<OwnerSelectionSearchProps> = ({
     page: { limit: USER_SEARCH_PAGE_LIMIT },
   });
   const [selectedUser, setSelectedUser] = useState<User | null>(null);
+
+  useEffect(() => {
+    if (!ownerId) {
+      setSelectedUser(null);
+    }
+  }, [ownerId]);
 
   const handleSearchChange = (searchText: string) => {
     if (searchText === "") {

--- a/identity/client/src/pages/authorizations/modals/owner-selection/OwnerSelectionSearch.tsx
+++ b/identity/client/src/pages/authorizations/modals/owner-selection/OwnerSelectionSearch.tsx
@@ -1,0 +1,98 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC, useState } from "react";
+import { FormLabel, Tag } from "@carbon/react";
+import { useApi } from "src/utility/api";
+import { searchUser } from "src/utility/api/users";
+import useTranslate from "src/utility/localization";
+import DropdownSearch from "src/components/form/DropdownSearch";
+import type { User } from "@camunda/camunda-api-zod-schemas/8.10";
+
+type OwnerSelectionSearchProps = {
+  onChange: (ownerId: string) => void;
+  isEmpty?: boolean;
+};
+
+const OwnerSelectionSearch: FC<OwnerSelectionSearchProps> = ({
+  onChange,
+  isEmpty = false,
+}) => {
+  const { t } = useTranslate("authorizations");
+  const [hasSearchText, setHasSearchText] = useState(false);
+  const USER_SEARCH_PAGE_LIMIT = 50;
+  const [search, setSearch] = useState<Record<string, unknown>>({
+    page: { limit: USER_SEARCH_PAGE_LIMIT },
+  });
+  const [selectedUser, setSelectedUser] = useState<User | null>(null);
+
+  const handleSearchChange = (searchText: string) => {
+    if (searchText === "") {
+      setSearch({ page: { limit: USER_SEARCH_PAGE_LIMIT } });
+      setHasSearchText(false);
+      return;
+    }
+
+    setHasSearchText(true);
+    setSearch({
+      filter: { username: { $like: `*${searchText}*` } },
+      page: { limit: USER_SEARCH_PAGE_LIMIT },
+    });
+  };
+
+  const { data: userSearchResults } = useApi(searchUser, search, {
+    paramsValid: hasSearchText,
+  });
+
+  const handleSelect = (user: User) => {
+    setSelectedUser(user);
+    onChange(user.username);
+  };
+
+  const handleClear = () => {
+    setSelectedUser(null);
+    onChange("");
+  };
+
+  return (
+    <div>
+      <FormLabel>{t("owner")}</FormLabel>
+      {selectedUser ? (
+        <div style={{ marginTop: "0.5rem" }}>
+          <Tag filter onClose={handleClear} type="blue" size="md">
+            {selectedUser.name || selectedUser.username}
+          </Tag>
+        </div>
+      ) : (
+        <DropdownSearch
+          items={userSearchResults?.items || []}
+          keyAttribute="username"
+          itemTitle={({ username }) => username}
+          itemSubTitle={({ email }) => email}
+          placeholder={t("searchByOwnerId")}
+          onSelect={handleSelect}
+          onChange={handleSearchChange}
+          invalid={isEmpty}
+        />
+      )}
+      {isEmpty && (
+        <p
+          style={{
+            color: "var(--cds-text-error, #da1e28)",
+            fontSize: "0.75rem",
+            marginTop: "0.25rem",
+          }}
+        >
+          {t("ownerRequired")}
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default OwnerSelectionSearch;

--- a/identity/client/src/pages/authorizations/modals/owner-selection/index.tsx
+++ b/identity/client/src/pages/authorizations/modals/owner-selection/index.tsx
@@ -78,7 +78,11 @@ const Selection: FC<SelectionProps> = ({
       }
       return (
         <div onBlur={onBlur}>
-          <OwnerSelectionSearch onChange={onChange} isEmpty={isEmpty} />
+          <OwnerSelectionSearch
+            onChange={onChange}
+            ownerId={ownerId}
+            isEmpty={isEmpty}
+          />
         </div>
       );
     case "GROUP":

--- a/identity/client/src/pages/authorizations/modals/owner-selection/index.tsx
+++ b/identity/client/src/pages/authorizations/modals/owner-selection/index.tsx
@@ -7,12 +7,12 @@
  */
 
 import { FC } from "react";
-import { searchUser } from "src/utility/api/users";
 import { searchGroups } from "src/utility/api/groups";
 import { searchMappingRule } from "src/utility/api/mapping-rules";
 import { searchRoles } from "src/utility/api/roles";
 import useTranslate from "src/utility/localization";
 import OwnerSelection from "./OwnerSelection";
+import OwnerSelectionSearch from "./OwnerSelectionSearch";
 import TextField from "src/components/form/TextField";
 import { isCamundaGroupsEnabled, isOIDC } from "src/configuration";
 import { Caption } from "src/pages/authorizations/modals/components.tsx";
@@ -77,15 +77,9 @@ const Selection: FC<SelectionProps> = ({
         );
       }
       return (
-        <OwnerSelection
-          id="userSelection"
-          onChange={onChange}
-          onBlur={onBlur}
-          searchFn={searchUser}
-          getId={(user) => user.username}
-          itemToString={(user) => user.name || user.username}
-          isEmpty={isEmpty}
-        />
+        <div onBlur={onBlur}>
+          <OwnerSelectionSearch onChange={onChange} isEmpty={isEmpty} />
+        </div>
       );
     case "GROUP":
       if (isCamundaGroupsEnabled) {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuthorizationsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityAuthorizationsPage.ts
@@ -17,6 +17,7 @@ export class IdentityAuthorizationsPage {
   readonly authorizationsList: Locator;
   readonly createAuthorizationModal: Locator;
   readonly createAuthorizationOwnerComboBox: Locator;
+  readonly createAuthorizationOwnerSearchInput: Locator;
   readonly createAuthorizationOwnerOption: (name: string) => Locator;
   readonly createAuthorizationResourceIdField: Locator;
   readonly createAuthorizationAccessPermission: (name: string) => Locator;
@@ -52,6 +53,8 @@ export class IdentityAuthorizationsPage {
     });
     this.createAuthorizationOwnerComboBox =
       this.createAuthorizationModal.getByPlaceholder('Select an owner');
+    this.createAuthorizationOwnerSearchInput =
+      this.createAuthorizationModal.getByPlaceholder('Search by owner ID');
     this.createAuthorizationOwnerOption = (name) =>
       this.createAuthorizationModal.getByRole('option', {
         name,
@@ -218,7 +221,12 @@ export class IdentityAuthorizationsPage {
 
   async selectResourceType(resourceType: string) {
     await this.resourceTypeComboBox.click({timeout: 90000});
-    await this.resourceTypeOption(resourceType).click();
+    try {
+      await this.resourceTypeOption(resourceType).click({timeout: 5000});
+    } catch {
+      await this.resourceTypeComboBox.click();
+      await this.resourceTypeOption(resourceType).click();
+    }
   }
 
   async selectAuthorizationOwnerType(authorization: {ownerType: string}) {
@@ -226,9 +234,27 @@ export class IdentityAuthorizationsPage {
     await this.createAuthorizationOwnerTypeOption(
       authorization.ownerType,
     ).click();
+    if (authorization.ownerType !== 'User') {
+      await this.createAuthorizationOwnerComboBox.waitFor({
+        state: 'visible',
+        timeout: 5000,
+      });
+    }
   }
 
   async selectAuthorizationOwner(authorization: {ownerId: string}) {
+    if (await this.createAuthorizationOwnerSearchInput.isVisible()) {
+      await this.createAuthorizationOwnerSearchInput.fill(
+        authorization.ownerId,
+      );
+      await this.createAuthorizationModal
+        .locator('.cds--list-box__menu-item')
+        .filter({hasText: authorization.ownerId})
+        .first()
+        .click({timeout: 20000});
+      return;
+    }
+
     await this.createAuthorizationOwnerComboBox.click();
     try {
       await this.createAuthorizationOwnerOption(authorization.ownerId).click({
@@ -237,6 +263,7 @@ export class IdentityAuthorizationsPage {
     } catch (error) {
       console.log('Error while selecting owner' + error);
       await this.createAuthorizationOwnerComboBox.fill(authorization.ownerId);
+      await this.createAuthorizationOwnerComboBox.press('Tab');
     }
   }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/authorizations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/authorizations.spec.ts
@@ -269,7 +269,7 @@ test.describe('authorization scenarios', () => {
     await test.step(`Create component authorization for user`, async () => {
       await identityAuthorizationsPage.createAuthorization({
         ownerType: 'User',
-        ownerId: testUser.name,
+        ownerId: testUser.username,
         resourceType: 'Component',
         resourceId: '*',
         accessPermissions: ['Access'],


### PR DESCRIPTION


## Description

There is a bug where not all users show up when creating a user Authorization. This PR updates the modal to use the dropdwon search component instead.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/37106 
