### PR TITLE
fix: include Optimize on stable (8.9 and 8.8) dry-runs

### DIFF
--- a/.github/workflows/zeebe-release-stable-dry-run.yml
+++ b/.github/workflows/zeebe-release-stable-dry-run.yml
@@ -74,6 +74,7 @@ jobs:
       nextDevelopmentVersion: 0.0.0-SNAPSHOT
       isLatest: true
       dryRun: true
+      includeOptimize: true
   dry-run-release-88:
     name: "Release from stable/8.8"
     needs: create-dry-run-branches
@@ -88,6 +89,7 @@ jobs:
       nextDevelopmentVersion: 0.0.0-SNAPSHOT
       isLatest: true
       dryRun: true
+      includeOptimize: true
   dry-run-release-87:
     name: "Release from stable/8.7"
     needs: create-dry-run-branches


### PR DESCRIPTION
## Description

This pull request makes a small update to the Zeebe release dry run workflow configuration. The only change is the addition of the `includeOptimize: true` parameter to the dry run release jobs for stable/8.9 and stable/8.8 branches, ensuring that the Optimize component is included in these dry runs.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
