### PR TITLE
Backport include optimize in monorepo release

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -76,8 +76,6 @@ env:
   RELEASE_BRANCH: ${{ inputs.releaseBranch != '' && inputs.releaseBranch || format('release-{0}', inputs.releaseVersion) }}
   RELEASE_VERSION: ${{ inputs.releaseVersion }}
   RELEASE_TAG: ${{ inputs.releaseProcessDryRun && format('dryrun-{0}', inputs.releaseVersion) || inputs.releaseVersion }}
-  # Always force includeOptimize to false to maintain consistent behavior - Optimize is always excluded
-  INCLUDE_OPTIMIZE: false
   GH_TOKEN: ${{ github.token }} # needs to be available for the gh CLI tool
 jobs:
   # Release job performs Maven prepare and perform release operations, managing release artifacts and repository changes.
@@ -253,7 +251,7 @@ jobs:
           echo "tagRevision=${TAG_REVISION}" >> "$GITHUB_OUTPUT"
           popd
       - name: Debug Optimize Versions after updating to development version
-        if: ${{ inputs.dryRun }}
+        if: ${{ inputs.includeOptimize && inputs.dryRun }}
         run: |
           echo "=== Optimize Version Information ==="
           echo "Optimize project.version:"
@@ -266,7 +264,7 @@ jobs:
           ./mvnw -f optimize/pom.xml help:evaluate -Dexpression=zeebe.version -q -DforceStdout || echo "Failed to get Zeebe version"
           echo ""
           echo "Identity version:"
-          ./mvnw -f optimize/pom.xml help:evaluate -Dexpression=version.identity -q -DforceStdout || echo "Failed to get Identity version"
+          ./mvnw help:effective-pom -pl optimize -DforceStdout | grep -oPm1 "(?<=<version.identity>)[^<]+" || echo "Failed to get Identity version"
           echo ""
       - name: Collect Release artifacts
         id: release-artifacts
@@ -685,7 +683,7 @@ jobs:
       PLATFORMS: "linux/amd64,linux/arm64"
       LOCAL_DOCKER_IMAGE: localhost:5000/camunda/optimize
       DOCKER_IMAGE: camunda/optimize
-      DOCKER_INFOSEC_REGISTRY_IMAGE: europe-west1-docker.pkg.dev/team-infosec/camunda/optimize-8 #todo check with InfoSec
+      DOCKER_INFOSEC_REGISTRY_IMAGE: europe-west1-docker.pkg.dev/team-infosec/camunda/optimize-8
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -953,6 +953,13 @@ jobs:
       releaseBodyUpdateOutcome: ${{ steps.update-github-release-body.outcome }}
     # Minor releases take more time since a lot of issues are included in the changelog
     timeout-minutes: 30
+    if: ${{ always() && !cancelled() && 
+      needs.release.result == 'success' &&
+      needs.zeebe-docker.result == 'success' &&
+      needs.operate-docker.result == 'success' &&
+      needs.tasklist-docker.result == 'success' &&
+      (needs.optimize-docker.result == 'success' || needs.optimize-docker.result == 'skipped') &&
+      needs.camunda-docker.result == 'success' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -1101,6 +1108,14 @@ jobs:
     name: Create FOSSA releases and generate attribution/SBOM reports
     runs-on: ubuntu-latest
     needs: [release, github, zeebe-docker, operate-docker, tasklist-docker, optimize-docker, camunda-docker]
+    if: ${{ always() && !cancelled() && 
+      needs.release.result == 'success' &&
+      needs.github.result == 'success' &&
+      needs.zeebe-docker.result == 'success' &&
+      needs.operate-docker.result == 'success' &&
+      needs.tasklist-docker.result == 'success' &&
+      (needs.optimize-docker.result == 'success' || needs.optimize-docker.result == 'skipped') &&
+      needs.camunda-docker.result == 'success' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -33,9 +33,8 @@ on:
         type: boolean
         default: false
       includeOptimize:
-        description: 'Legacy parameter for backward compatibility. Optimize is always excluded from the release process regardless of this value. This parameter exists only to prevent failures in older dispatch calls.'
+        description: 'Whether to include Optimize in the release process. When true, Optimize is included in Maven prepare/perform steps. Defaults to false for backward compatibility.'
         type: boolean
-        required: false
         default: false
   workflow_dispatch:
     inputs:
@@ -66,9 +65,8 @@ on:
         type: boolean
         default: false
       includeOptimize:
-        description: 'Legacy parameter for backward compatibility. Optimize is always excluded from the release process regardless of this value. This parameter exists only to prevent failures in older dispatch calls.'
+        description: 'Whether to include Optimize in the release process. When true, Optimize is included in Maven prepare/perform steps. Defaults to false for backward compatibility.'
         type: boolean
-        required: false
         default: false
 defaults:
   run:
@@ -184,6 +182,16 @@ jobs:
           #   Additional arguments to pass to the Maven executions, separated by spaces.
           #   Per default it is not required, but the release plugin is configured in the camunda release plugin (and this property is used)
           #   This is the reason why we have to set it at least as empty string.
+
+          # Conditionally set profile flags based on includeOptimize input
+          if [[ "${{ inputs.includeOptimize }}" == "true" ]]; then
+            PROFILE_FLAGS=""
+            ARGUMENTS_PROFILE=""
+          else
+            PROFILE_FLAGS="-P\!include-optimize"
+            ARGUMENTS_PROFILE="-P!include-optimize"
+          fi          
+
           ./mvnw release:prepare -B \
             -Dresume=false \
             -Dtag="${RELEASE_TAG}" \
@@ -194,8 +202,8 @@ jobs:
             -DcompletionGoals="spotless:apply" \
             -P-autoFormat \
             -DpreparationGoals="spotless:apply" \
-            -P\!include-optimize \
-            -Darguments='-P!include-optimize'
+            ${PROFILE_FLAGS} \
+            -Darguments="${ARGUMENTS_PROFILE}"
 
       - name: Maven Perform Release
         id: maven-perform-release
@@ -218,7 +226,14 @@ jobs:
           #   In order to disable QA/IT and the auto formatting during the release.
           #   It is unnecessary to release integration tests, and we don't want to run the auto-formatting unnecessarily.
 
-          
+          # Conditionally set profile flags based on includeOptimize input
+          if [[ "${{ inputs.includeOptimize }}" == "true" ]]; then
+            PROFILE_FLAGS=""
+            ARGUMENTS_PROFILE=""
+          else
+            PROFILE_FLAGS="-P\!include-optimize"
+            ARGUMENTS_PROFILE="-P!include-optimize"
+          fi
 
           # shellcheck disable=SC2016
           ./mvnw release:perform -B \
@@ -227,8 +242,8 @@ jobs:
             -DlocalCheckout="${{ inputs.dryRun }}" \
             -DskipQaBuild=true \
             -P-autoFormat \
-            -P\!include-optimize \
-            -Darguments='-P-autoFormat -DskipQaBuild=true -DskipChecks=true -DskipTests=true -Dskip.fe.build=false -Dspotless.apply.skip=false -Dskip.central.release=${SKIP_CENTRAL_RELEASE} -Dskip.camunda.release=${SKIP_CAMUNDA_RELEASE} -DwaitMaxTime=${CENTRAL_WAIT_MAX_TIME} -P!include-optimize -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}"'
+            ${PROFILE_FLAGS} \
+            -Darguments="-P-autoFormat -DskipQaBuild=true -DskipChecks=true -DskipTests=true -Dskip.fe.build=false -Dspotless.apply.skip=false -Dskip.central.release=${SKIP_CENTRAL_RELEASE} -Dskip.camunda.release=${SKIP_CAMUNDA_RELEASE} -DwaitMaxTime=${CENTRAL_WAIT_MAX_TIME} ${ARGUMENTS_PROFILE} -Dgpg.passphrase=\"${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}\""
 
           # switch to the directory to which maven checks out the release tag
           # see https://maven.apache.org/maven-release/maven-release-plugin/perform-mojo.html#workingDirectory
@@ -237,23 +252,6 @@ jobs:
           export TAG_REVISION
           echo "tagRevision=${TAG_REVISION}" >> "$GITHUB_OUTPUT"
           popd
-      - name: Update Optimize parent to development version
-        run: |
-          # After release process completes, update Optimize parent to nextDevelopmentVersion
-          # This ensures Optimize stays aligned with the main project for future development
-          echo "Updating Optimize parent version to ${DEVELOPMENT_VERSION} for future development"
-          
-          # Update the parent version using a more precise sed command
-          sed -i "/<parent>/,/<\/parent>/ {
-            /<artifactId>zeebe-parent<\/artifactId>/ {
-              n
-              s/<version>[^<]*<\/version>/<version>${DEVELOPMENT_VERSION}<\/version>/
-            }
-          }" optimize/pom.xml
-          
-          # Verify the change
-          new_version=$(grep -A2 '<artifactId>zeebe-parent</artifactId>' optimize/pom.xml | grep '<version>' | sed 's/.*<version>\(.*\)<\/version>.*/\1/' | tr -d ' ')
-          echo "Updated parent version to: ${new_version}"
       - name: Debug Optimize Versions after updating to development version
         if: ${{ inputs.dryRun }}
         run: |
@@ -276,6 +274,12 @@ jobs:
           ARTIFACT_DIR=$(mktemp -d)
           cp target/checkout/dist/target/camunda-zeebe-"${RELEASE_VERSION}".tar.gz "${ARTIFACT_DIR}/"
           cp target/checkout/dist/target/camunda-zeebe-"${RELEASE_VERSION}".zip "${ARTIFACT_DIR}/"
+
+          # Include Optimize artifacts if Optimize is included in the release
+          if [[ "${{ inputs.includeOptimize }}" == "true" ]]; then
+            cp target/checkout/optimize-distro/target/camunda-optimize-"${RELEASE_VERSION}"-production.tar.gz "${ARTIFACT_DIR}/"
+          fi
+
           echo "dir=${ARTIFACT_DIR}" >> "$GITHUB_OUTPUT"
       - name: Upload Release Artifacts
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
@@ -660,6 +664,145 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
+  optimize-docker:
+    needs: release
+    name: Optimize Docker Image Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: ${{ inputs.includeOptimize }}
+    permissions:
+      contents: "write"
+      id-token: "write"
+    services:
+      # Local registry is used as multi arch images cannot be loaded locally but only pushed to a
+      # registry. As we want to verify the images first before pushing them to dockerhub though,
+      # a local registry is used and if verification passes images are pushed to the remote registry.
+      registry:
+        image: registry:3
+        ports:
+          - 5000:5000
+    env:
+      PLATFORMS: "linux/amd64,linux/arm64"
+      LOCAL_DOCKER_IMAGE: localhost:5000/camunda/optimize
+      DOCKER_IMAGE: camunda/optimize
+      DOCKER_INFOSEC_REGISTRY_IMAGE: europe-west1-docker.pkg.dev/team-infosec/camunda/optimize-8 #todo check with InfoSec
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ env.RELEASE_BRANCH }}
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/optimize/ci/camunda-optimize REGISTRY_HUB_DOCKER_COM_USR;
+            secret/data/products/optimize/ci/camunda-optimize REGISTRY_HUB_DOCKER_COM_PSW;
+            secret/data/products/camunda/ci/github-actions REGISTRY_MINIMUS_PSW | minimus-token
+      - name: Login to DockerHub
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          username: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_USR }}
+          password: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_PSW }}
+      - name: Login to Minimus
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: reg.mini.dev
+          username: minimus
+          password: ${{ steps.secrets.outputs.minimus-token }}
+      - id: "auth"
+        name: "Authenticate to Google Cloud"
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          token_format: "access_token"
+          workload_identity_provider: "projects/271764561088/locations/global/workloadIdentityPools/github/providers/camunda"
+          service_account: "github-actions-camunda@team-infosec.iam.gserviceaccount.com"
+      - name: Login to infosec registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: europe-west1-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
+      - name: Download Release Artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-artifacts-${{ inputs.releaseVersion }}
+      - name: Build Optimize Docker Image
+        uses: ./.github/actions/build-platform-docker
+        id: build-optimize-docker
+        with:
+          repository: ${{ env.LOCAL_DOCKER_IMAGE }}
+          version: ${{ inputs.releaseVersion }}
+          revision: ${{ needs.release.outputs.releaseTagRevision }}
+          # pushes to local registry for verification prior pushing to remote
+          push: true
+          distball: camunda-optimize-${{ inputs.releaseVersion }}-production.tar.gz
+          platforms: ${{ env.PLATFORMS }}
+          dockerfile: optimize.Dockerfile
+          # turns on BuildKit debug logging
+          debug: 'true'
+      - name: Verify Optimize Docker image
+        uses: ./.github/actions/verify-platform-docker
+        with:
+          imageName: ${{ env.LOCAL_DOCKER_IMAGE }}
+          date: ${{ steps.build-optimize-docker.outputs.date }}
+          revision: ${{ needs.release.outputs.releaseTagRevision }}
+          version: ${{ inputs.releaseVersion }}
+          platforms: ${{ env.PLATFORMS }}
+          dockerfile: optimize.Dockerfile
+          goldenfile: optimize-docker-labels.golden.json
+      - name: Sync Optimize Docker Image to DockerHub
+        if: ${{ !inputs.dryRun && !inputs.releaseProcessDryRun }}
+        # see https://docs.docker.com/build/ci/github-actions/examples/#copy-images-between-registries
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          max_attempts: 3
+          retry_on: error
+          retry_wait_seconds: 15
+          timeout_minutes: 10
+          command: |
+            docker -D buildx imagetools create \
+              --tag ${{ env.DOCKER_IMAGE }}:${{ env.RELEASE_VERSION }} \
+              ${{ steps.build-optimize-docker.outputs.image }}
+      - name: Sync Latest Optimize Docker Image to DockerHub
+        if: ${{ !inputs.dryRun && !inputs.releaseProcessDryRun && inputs.isLatest }}
+        # see https://docs.docker.com/build/ci/github-actions/examples/#copy-images-between-registries
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          max_attempts: 3
+          retry_on: error
+          retry_wait_seconds: 15
+          timeout_minutes: 10
+          command: |
+            docker -D buildx imagetools create \
+              --tag ${{ env.DOCKER_IMAGE }}:latest \
+              ${{ steps.build-optimize-docker.outputs.image }}
+      - name: Sync Optimize Docker Image to Internal Registry
+        if: ${{ !inputs.dryRun && !inputs.releaseProcessDryRun }}
+        # see https://docs.docker.com/build/ci/github-actions/examples/#copy-images-between-registries
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          max_attempts: 3
+          retry_on: error
+          retry_wait_seconds: 15
+          timeout_minutes: 10
+          command: |
+            docker -D buildx imagetools create \
+              --tag ${{ env.DOCKER_INFOSEC_REGISTRY_IMAGE }}:${{ env.RELEASE_VERSION }} \
+              ${{ steps.build-optimize-docker.outputs.image }}
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+
   camunda-docker:
     needs: release
     name: Camunda Docker Image Release
@@ -803,7 +946,7 @@ jobs:
   # - Uses RELEASE_TAG for versioning (prefixed with 'dryrun-' when releaseProcessDryRun=true)
   # The job generates changelog, checksums artifacts, and determines pre-release status
   github:
-    needs: [release, zeebe-docker, operate-docker, tasklist-docker, camunda-docker]
+    needs: [release, zeebe-docker, operate-docker, tasklist-docker, optimize-docker, camunda-docker]
     name: Github Release
     runs-on: ubuntu-latest
     outputs:
@@ -957,7 +1100,7 @@ jobs:
   fossa-release:
     name: Create FOSSA releases and generate attribution/SBOM reports
     runs-on: ubuntu-latest
-    needs: [release, github, zeebe-docker, operate-docker, tasklist-docker, camunda-docker]
+    needs: [release, github, zeebe-docker, operate-docker, tasklist-docker, optimize-docker, camunda-docker]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -1017,7 +1160,7 @@ jobs:
   notify-on-success:
     name: Send Slack notification on success
     runs-on: ubuntu-latest
-    needs: [release, github, zeebe-docker, operate-docker, tasklist-docker, camunda-docker, snyk]
+    needs: [release, github, zeebe-docker, operate-docker, tasklist-docker, optimize-docker, camunda-docker, snyk]
     # Report release result to C8 always (including dry-runs)
     # Slack notifications are skipped for dry-runs to reduce noise
     if: ${{ always() && (
@@ -1026,6 +1169,7 @@ jobs:
       needs.zeebe-docker.result == 'success' &&
       needs.operate-docker.result == 'success' &&
       needs.tasklist-docker.result == 'success' &&
+      (needs.optimize-docker.result == 'success' || needs.optimize-docker.result == 'skipped') &&
       needs.camunda-docker.result == 'success' &&
       (needs.snyk.result == 'success' || needs.snyk.result == 'skipped')
       ) }}
@@ -1107,7 +1251,7 @@ jobs:
   notify-if-failed:
     name: Send Slack notification on failure
     runs-on: ubuntu-latest
-    needs: [release, github, zeebe-docker, operate-docker, tasklist-docker, camunda-docker, snyk]
+    needs: [release, github, zeebe-docker, operate-docker, tasklist-docker, optimize-docker, camunda-docker, snyk]
     # Report release result to C8 always (including dry-runs)
     # Slack notifications are skipped for dry-runs to reduce noise
     if: ${{ always() && (
@@ -1116,6 +1260,7 @@ jobs:
         needs.zeebe-docker.result == 'failure' ||
         needs.operate-docker.result == 'failure' ||
         needs.tasklist-docker.result == 'failure' ||
+        needs.optimize-docker.result == 'failure' ||
         needs.camunda-docker.result == 'failure' ||
         needs.snyk.result == 'failure'
         ) && !inputs.dryRun && !inputs.releaseProcessDryRun }}

--- a/.github/workflows/optimize-create-release-branch.yml
+++ b/.github/workflows/optimize-create-release-branch.yml
@@ -1,4 +1,6 @@
 # type: Release
+# DEPRECATED: This workflow is deprecated and should be removed when 8.7 reaches EOL in favor of Monorepo Release Process camunda/40184.
+
 name: Optimize Create Release Branch
 on:
   workflow_dispatch:

--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -1,4 +1,6 @@
 # type: Release
+# DEPRECATED: This workflow is deprecated and should be removed when 8.7 reaches EOL in favor of Monorepo Release Process camunda/40184.
+
 name: Optimize Release Camunda Optimize C8
 
 on:

--- a/optimize-distro/pom.xml
+++ b/optimize-distro/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>optimize-parent</artifactId>
-    <version>8.8.23-SNAPSHOT</version>
+    <version>8.8.24-SNAPSHOT</version>
     <relativePath>../optimize/pom.xml</relativePath>
   </parent>
 

--- a/optimize-distro/pom.xml
+++ b/optimize-distro/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>optimize-parent</artifactId>
-    <version>8.8.9-SNAPSHOT</version>
+    <version>8.8.23-SNAPSHOT</version>
     <relativePath>../optimize/pom.xml</relativePath>
   </parent>
 

--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>optimize-parent</artifactId>
-    <version>8.8.9-SNAPSHOT</version>
+    <version>8.8.23-SNAPSHOT</version>
   </parent>
 
   <artifactId>optimize-backend</artifactId>

--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>optimize-parent</artifactId>
-    <version>8.8.23-SNAPSHOT</version>
+    <version>8.8.24-SNAPSHOT</version>
   </parent>
 
   <artifactId>optimize-backend</artifactId>

--- a/optimize/client/pom.xml
+++ b/optimize/client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>optimize-parent</artifactId>
-    <version>8.8.23-SNAPSHOT</version>
+    <version>8.8.24-SNAPSHOT</version>
   </parent>
 
   <name>Optimize Client</name>

--- a/optimize/client/pom.xml
+++ b/optimize/client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>optimize-parent</artifactId>
-    <version>8.8.9-SNAPSHOT</version>
+    <version>8.8.23-SNAPSHOT</version>
   </parent>
 
   <name>Optimize Client</name>

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>io.camunda.optimize</groupId>
   <artifactId>optimize-parent</artifactId>
-  <version>8.8.24-SNAPSHOT</version> <!-- todo: inform Optimize team that we bumped from 8.8.24-SNAPSHOT to 8.8.24-SNAPSHOT + MRM to update the GH release: https://camunda.slack.com/archives/C09PLKZG42H/p1770982545619319?thread_ts=1770812189.206739&cid=C09PLKZG42H  -->
+  <version>8.8.24-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Optimize Parent</name>
 

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -48,7 +48,7 @@
     <project.previousVersion>8.7.0</project.previousVersion>
     <camunda.maven.artifacts.version>7.22.0</camunda.maven.artifacts.version>
 
-    <zeebe.version>${project.parent.version}</zeebe.version>
+    <zeebe.version>${project.version}</zeebe.version>
     <!-- We use this for the Zeebe test container version only -->
     <zeebe.docker.version>8.7.0-alpha4</zeebe.docker.version>
 

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>io.camunda.optimize</groupId>
   <artifactId>optimize-parent</artifactId>
-  <version>8.8.9-SNAPSHOT</version>
+  <version>8.8.23-SNAPSHOT</version> <!-- todo: inform Optimize team that we bumped from 8.8.23-SNAPSHOT to 8.8.23-SNAPSHOT + MRM to update the GH release: https://camunda.slack.com/archives/C09PLKZG42H/p1770982545619319?thread_ts=1770812189.206739&cid=C09PLKZG42H  -->
   <packaging>pom</packaging>
   <name>Optimize Parent</name>
 
@@ -48,7 +48,7 @@
     <project.previousVersion>8.7.0</project.previousVersion>
     <camunda.maven.artifacts.version>7.22.0</camunda.maven.artifacts.version>
 
-    <zeebe.version>${project.version}</zeebe.version>
+    <zeebe.version>8.8.23-SNAPSHOT</zeebe.version>
     <!-- We use this for the Zeebe test container version only -->
     <zeebe.docker.version>8.7.0-alpha4</zeebe.docker.version>
 

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>io.camunda.optimize</groupId>
   <artifactId>optimize-parent</artifactId>
-  <version>8.8.23-SNAPSHOT</version> <!-- todo: inform Optimize team that we bumped from 8.8.23-SNAPSHOT to 8.8.23-SNAPSHOT + MRM to update the GH release: https://camunda.slack.com/archives/C09PLKZG42H/p1770982545619319?thread_ts=1770812189.206739&cid=C09PLKZG42H  -->
+  <version>8.8.24-SNAPSHOT</version> <!-- todo: inform Optimize team that we bumped from 8.8.24-SNAPSHOT to 8.8.24-SNAPSHOT + MRM to update the GH release: https://camunda.slack.com/archives/C09PLKZG42H/p1770982545619319?thread_ts=1770812189.206739&cid=C09PLKZG42H  -->
   <packaging>pom</packaging>
   <name>Optimize Parent</name>
 
@@ -48,7 +48,7 @@
     <project.previousVersion>8.7.0</project.previousVersion>
     <camunda.maven.artifacts.version>7.22.0</camunda.maven.artifacts.version>
 
-    <zeebe.version>8.8.23-SNAPSHOT</zeebe.version>
+    <zeebe.version>8.8.24-SNAPSHOT</zeebe.version>
     <!-- We use this for the Zeebe test container version only -->
     <zeebe.docker.version>8.7.0-alpha4</zeebe.docker.version>
 

--- a/optimize/qa/pom.xml
+++ b/optimize/qa/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>optimize-parent</artifactId>
-    <version>8.8.9-SNAPSHOT</version>
+    <version>8.8.23-SNAPSHOT</version>
   </parent>
 
   <artifactId>optimize-qa</artifactId>

--- a/optimize/qa/pom.xml
+++ b/optimize/qa/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>optimize-parent</artifactId>
-    <version>8.8.23-SNAPSHOT</version>
+    <version>8.8.24-SNAPSHOT</version>
   </parent>
 
   <artifactId>optimize-qa</artifactId>

--- a/optimize/qa/schema-integrity-tests/pom.xml
+++ b/optimize/qa/schema-integrity-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>optimize-qa</artifactId>
-    <version>8.8.23-SNAPSHOT</version>
+    <version>8.8.24-SNAPSHOT</version>
   </parent>
 
   <artifactId>optimize-schema-integrity-tests</artifactId>

--- a/optimize/qa/schema-integrity-tests/pom.xml
+++ b/optimize/qa/schema-integrity-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>optimize-qa</artifactId>
-    <version>8.8.9-SNAPSHOT</version>
+    <version>8.8.23-SNAPSHOT</version>
   </parent>
 
   <artifactId>optimize-schema-integrity-tests</artifactId>

--- a/optimize/upgrade/pom.xml
+++ b/optimize/upgrade/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>optimize-parent</artifactId>
-    <version>8.8.23-SNAPSHOT</version>
+    <version>8.8.24-SNAPSHOT</version>
   </parent>
 
   <artifactId>upgrade-optimize</artifactId>

--- a/optimize/upgrade/pom.xml
+++ b/optimize/upgrade/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>optimize-parent</artifactId>
-    <version>8.8.9-SNAPSHOT</version>
+    <version>8.8.23-SNAPSHOT</version>
   </parent>
 
   <artifactId>upgrade-optimize</artifactId>

--- a/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/plan/factories/Upgrade888to8824PlanFactory.java
+++ b/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/plan/factories/Upgrade888to8824PlanFactory.java
@@ -11,10 +11,10 @@ import io.camunda.optimize.upgrade.plan.UpgradeExecutionDependencies;
 import io.camunda.optimize.upgrade.plan.UpgradePlan;
 import io.camunda.optimize.upgrade.plan.UpgradePlanBuilder;
 
-public class Upgrade888to889PlanFactory implements UpgradePlanFactory {
+public class Upgrade888to8824PlanFactory implements UpgradePlanFactory {
 
   @Override
   public UpgradePlan createUpgradePlan(final UpgradeExecutionDependencies dependencies) {
-    return UpgradePlanBuilder.createUpgradePlan().fromVersion("8.8.8").toVersion("8.8.9").build();
+    return UpgradePlanBuilder.createUpgradePlan().fromVersion("8.8.8").toVersion("8.8.24").build();
   }
 }

--- a/optimize/util/optimize-commons/pom.xml
+++ b/optimize/util/optimize-commons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>util</artifactId>
-    <version>8.8.23-SNAPSHOT</version>
+    <version>8.8.24-SNAPSHOT</version>
   </parent>
 
   <artifactId>optimize-commons</artifactId>

--- a/optimize/util/optimize-commons/pom.xml
+++ b/optimize/util/optimize-commons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>util</artifactId>
-    <version>8.8.9-SNAPSHOT</version>
+    <version>8.8.23-SNAPSHOT</version>
   </parent>
 
   <artifactId>optimize-commons</artifactId>

--- a/optimize/util/pom.xml
+++ b/optimize/util/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>optimize-parent</artifactId>
-    <version>8.8.23-SNAPSHOT</version>
+    <version>8.8.24-SNAPSHOT</version>
   </parent>
 
   <artifactId>util</artifactId>

--- a/optimize/util/pom.xml
+++ b/optimize/util/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>optimize-parent</artifactId>
-    <version>8.8.9-SNAPSHOT</version>
+    <version>8.8.23-SNAPSHOT</version>
   </parent>
 
   <artifactId>util</artifactId>


### PR DESCRIPTION
## Description

This pull request introduces significant improvements to the release process for Camunda Optimize within the monorepo, including making Optimize an optional part of the main release workflow, adding conditional Docker image publishing for Optimize, and deprecating legacy Optimize-specific workflows. It also updates versioning in `optimize/pom.xml` and improves dependency management. 

**Monorepo Release Workflow Enhancements:**

* The `includeOptimize` parameter in `.github/workflows/camunda-platform-release.yml` is now used to conditionally include Optimize in the release process, affecting Maven commands and artifact handling. Following https://github.com/camunda/camunda/pull/41961
* A new `optimize-docker` job is added, which builds, verifies, and publishes the Optimize Docker image only if `includeOptimize` is true. This job handles authentication, multi-platform builds, and publishing to DockerHub and internal registries. Following https://github.com/camunda/camunda/pull/41961
* Downstream jobs (`github`, `fossa-release`, `notify-on-success`, `notify-if-failed`) are updated to depend on `optimize-docker` and handle its conditional execution status, ensuring correct release orchestration. 

**Deprecation of Legacy Workflows:**

* The `optimize-create-release-branch.yml` and `optimize-release-optimize-c8-only.yml` workflows are marked as deprecated, to be removed once 8.7 reaches EOL, or earlier, in favor of the new monorepo release process.

**Optimize Project Versioning and Dependency Updates:**

* The `optimize-parent` version in `optimize/pom.xml` is bumped from `8.8.9-SNAPSHOT` to `8.8.24-SNAPSHOT`, and the `zeebe.version` property now references the project version instead of the parent version, improving dependency management. Following https://github.com/camunda/camunda/pull/45437/changes#r2789565489

**Other Notable Changes:**

* The step to update the Optimize parent to the development version after release is removed, as this is now handled differently in the monorepo process. Following https://github.com/camunda/camunda/pull/45959
* Optimize artifacts are now conditionally included in the release artifacts only if Optimize is part of the release. Following https://github.com/camunda/camunda/pull/41961

These changes modernize the release process, reduce maintenance overhead, and ensure Optimize is released consistently with other platform components.

# :test_tube:  Dry-run

https://github.com/camunda/camunda/actions/runs/24689216525/job/72206451272
https://github.com/camunda/camunda/actions/runs/24795496043/job/72564028715

<img width="955" height="444" alt="image" src="https://github.com/user-attachments/assets/1dfa72ae-8858-4a3b-bdc0-792587e2a45a" />


> [!WARNING]
> @camunda/optimize and @camunda/monorepo-release-manager once this is merged we MUST pay attention to the Optimize versioning. It MUST be aligned with the rest of the modules. If a new version is released for 8.8, and Optimize is still NOT INCLUDED, once IT IS INCLUDED, we must bump the versions like I did [here](https://github.com/camunda/camunda/pull/51445/changes/5dc9bc3bd673c833b19d0ca0e66f184b08136ab5). Also, as a side effect aligned [here](https://camunda.slack.com/archives/C09PLKZG42H/p1770982545619319?thread_ts=1770812189.206739&cid=C09PLKZG42H), https://github.com/camunda/camunda/issues/45791 must be done during the release, and the upgrade plan should be manually attached to the GH release page related to that release.
> **When Optimize will be available for 8.8?**
> After:
> - PR is merged 
> - [#46523](https://github.com/camunda/camunda/pull/46523) is backported to `8.8`
> - [#47166](https://github.com/camunda/camunda/pull/47166) is backported to `8.8`
> - Optimize is enabled for 8.8 on the release process ([PR merged](https://github.com/camunda/camunda-release/pull/44))


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

Relates to https://github.com/camunda/camunda/issues/40184?reload=1, and starts the last integration step for 8.8
