### PR TITLE
fix(auth): opt-in OIDC userinfo augmentation for bearer tokens

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -39,6 +39,10 @@ import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.security.configuration.headers.HeaderConfiguration;
 import io.camunda.security.configuration.headers.values.FrameOptionMode;
 import io.camunda.security.entity.AuthenticationMethod;
+import io.camunda.security.oidc.CachingOidcClaimsProvider;
+import io.camunda.security.oidc.NoopOidcClaimsProvider;
+import io.camunda.security.oidc.OidcClaimsProvider;
+import io.camunda.security.oidc.OidcUserInfoClient;
 import io.camunda.security.reader.ResourceAccessProvider;
 import io.camunda.service.GroupServices;
 import io.camunda.service.RoleServices;
@@ -57,8 +61,12 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -631,8 +639,39 @@ public class WebSecurityConfig {
 
     @Bean
     public CamundaAuthenticationConverter<Authentication> oidcTokenAuthenticationConverter(
-        final TokenClaimsConverter tokenClaimsConverter) {
-      return new OidcTokenAuthenticationConverter(tokenClaimsConverter);
+        final TokenClaimsConverter tokenClaimsConverter,
+        final OidcClaimsProvider oidcClaimsProvider) {
+      return new OidcTokenAuthenticationConverter(tokenClaimsConverter, oidcClaimsProvider);
+    }
+
+    @Bean
+    public OidcClaimsProvider oidcClaimsProvider(
+        final SecurityConfiguration securityConfiguration,
+        final OidcAuthenticationConfigurationRepository oidcProviderRepository,
+        final MeterRegistry meterRegistry) {
+      final var oidc = securityConfiguration.getAuthentication().getOidc();
+      if (oidc == null || !oidc.getUserInfoAugmentation().isEnabled()) {
+        return new NoopOidcClaimsProvider();
+      }
+      // Resolve userinfo URI from the first matching provider's issuer.
+      // Multi-provider selection by 'iss' claim is a follow-up; single-provider
+      // setups are covered today.
+      final URI userInfoUri =
+          oidcProviderRepository.getOidcAuthenticationConfigurations().values().stream()
+              .map(OidcAuthenticationConfiguration::getIssuerUri)
+              .filter(Objects::nonNull)
+              .findFirst()
+              .map(issuer -> URI.create(issuer.replaceAll("/$", "") + "/userinfo"))
+              .orElseThrow(
+                  () ->
+                      new IllegalStateException(
+                          "UserInfo augmentation enabled but no issuerUri configured"));
+      final var httpClient = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build();
+      return new CachingOidcClaimsProvider(
+          oidc,
+          userInfoUri,
+          new OidcUserInfoClient(httpClient, Duration.ofSeconds(5)),
+          meterRegistry);
     }
 
     @Bean

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -647,25 +647,35 @@ public class WebSecurityConfig {
     @Bean
     public OidcClaimsProvider oidcClaimsProvider(
         final SecurityConfiguration securityConfiguration,
+        final ClientRegistrationRepository clientRegistrationRepository,
         final OidcAuthenticationConfigurationRepository oidcProviderRepository,
         final MeterRegistry meterRegistry) {
       final var oidc = securityConfiguration.getAuthentication().getOidc();
       if (oidc == null || !oidc.getUserInfoAugmentation().isEnabled()) {
         return new NoopOidcClaimsProvider();
       }
-      // Resolve userinfo URI from the first matching provider's issuer.
-      // Multi-provider selection by 'iss' claim is a follow-up; single-provider
-      // setups are covered today.
+      // Read userinfo URI from the Spring-managed ClientRegistration. Spring populates
+      // ProviderDetails.UserInfoEndpoint.uri from the IdP's OIDC discovery document when
+      // ClientRegistrations.fromIssuerLocation(...) runs — so it's accurate even for IdPs
+      // whose userinfo path isn't {issuer}/userinfo. A null URI means either the IdP does
+      // not publish a userinfo endpoint or the operator set userInfoEnabled=false; both
+      // legitimately preclude augmentation.
+      // Multi-provider selection by 'iss' claim is a follow-up; single-provider setups are
+      // covered today by picking the first registration that exposes a userinfo endpoint.
       final URI userInfoUri =
-          oidcProviderRepository.getOidcAuthenticationConfigurations().values().stream()
-              .map(OidcAuthenticationConfiguration::getIssuerUri)
+          oidcProviderRepository.getOidcAuthenticationConfigurations().keySet().stream()
+              .map(clientRegistrationRepository::findByRegistrationId)
+              .filter(Objects::nonNull)
+              .map(cr -> cr.getProviderDetails().getUserInfoEndpoint().getUri())
               .filter(Objects::nonNull)
               .findFirst()
-              .map(issuer -> URI.create(issuer.replaceAll("/$", "") + "/userinfo"))
+              .map(URI::create)
               .orElseThrow(
                   () ->
                       new IllegalStateException(
-                          "UserInfo augmentation enabled but no issuerUri configured"));
+                          "UserInfo augmentation is enabled but no ClientRegistration exposes a"
+                              + " userinfo endpoint. Check the IdP's OIDC discovery document and"
+                              + " the userInfoEnabled flag."));
       final var httpClient = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build();
       return new CachingOidcClaimsProvider(
           oidc,

--- a/authentication/src/main/java/io/camunda/authentication/converter/OidcTokenAuthenticationConverter.java
+++ b/authentication/src/main/java/io/camunda/authentication/converter/OidcTokenAuthenticationConverter.java
@@ -9,35 +9,42 @@ package io.camunda.authentication.converter;
 
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.CamundaAuthenticationConverter;
+import io.camunda.security.oidc.OidcClaimsProvider;
 import java.util.Optional;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.oauth2.server.resource.authentication.AbstractOAuth2TokenAuthenticationToken;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 
 public class OidcTokenAuthenticationConverter
     implements CamundaAuthenticationConverter<Authentication> {
 
   private final TokenClaimsConverter tokenClaimsConverter;
+  private final OidcClaimsProvider claimsProvider;
 
-  public OidcTokenAuthenticationConverter(final TokenClaimsConverter tokenClaimsConverter) {
+  public OidcTokenAuthenticationConverter(
+      final TokenClaimsConverter tokenClaimsConverter, final OidcClaimsProvider claimsProvider) {
     this.tokenClaimsConverter = tokenClaimsConverter;
+    this.claimsProvider = claimsProvider;
   }
 
   @Override
   public boolean supports(final Authentication authentication) {
-    return Optional.ofNullable(authentication)
-        .filter(AbstractOAuth2TokenAuthenticationToken.class::isInstance)
-        .isPresent();
+    return authentication instanceof JwtAuthenticationToken;
   }
 
   @Override
   public CamundaAuthentication convert(final Authentication authentication) {
     return Optional.of(authentication)
-        .map(AbstractOAuth2TokenAuthenticationToken.class::cast)
-        .map(AbstractOAuth2TokenAuthenticationToken::getTokenAttributes)
+        .map(JwtAuthenticationToken.class::cast)
+        .map(
+            token -> {
+              final Jwt jwt = token.getToken();
+              return claimsProvider.claimsFor(jwt.getClaims(), jwt.getTokenValue());
+            })
         .map(tokenClaimsConverter::convert)
         .orElseThrow(
             () ->
                 new IllegalStateException(
-                    "Failed to convert 'AbstractOAuth2TokenAuthenticationToken' to 'CamundaAuthentication"));
+                    "Failed to convert 'JwtAuthenticationToken' to 'CamundaAuthentication'"));
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/converter/OidcTokenAuthenticationConverterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/converter/OidcTokenAuthenticationConverterTest.java
@@ -8,72 +8,80 @@
 package io.camunda.authentication.converter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.oidc.NoopOidcClaimsProvider;
+import io.camunda.security.oidc.OidcClaimsProvider;
+import java.util.List;
 import java.util.Map;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 
 public class OidcTokenAuthenticationConverterTest {
 
-  @Mock private TokenClaimsConverter tokenClaimsConverter;
-  @InjectMocks private OidcTokenAuthenticationConverter authenticationConverter;
+  @Test
+  void shouldSupportJwtAuthenticationToken() {
+    final var converter =
+        new OidcTokenAuthenticationConverter(
+            mock(TokenClaimsConverter.class), new NoopOidcClaimsProvider());
 
-  @BeforeEach
-  void setup() throws Exception {
-    MockitoAnnotations.openMocks(this).close();
+    assertThat(converter.supports(mock(JwtAuthenticationToken.class))).isTrue();
   }
 
   @Test
-  void shouldSupport() {
-    // given
-    final var authentication = mock(JwtAuthenticationToken.class);
+  void shouldNotSupportNonJwtAuthentication() {
+    final var converter =
+        new OidcTokenAuthenticationConverter(
+            mock(TokenClaimsConverter.class), new NoopOidcClaimsProvider());
 
-    // when
-    final var supports = authenticationConverter.supports(authentication);
-
-    // then
-    assertThat(supports).isTrue();
+    assertThat(converter.supports(mock(OAuth2AuthenticationToken.class))).isFalse();
   }
 
   @Test
-  void shouldNotSupport() {
-    // given
-    final var authentication = mock(OAuth2AuthenticationToken.class);
+  void shouldPassJwtClaimsThroughNoopProviderToTokenClaimsConverter() {
+    final TokenClaimsConverter tokenClaimsConverter = mock(TokenClaimsConverter.class);
+    final var jwt =
+        Jwt.withTokenValue("token-abc")
+            .header("alg", "RS256")
+            .claim("sub", "alice")
+            .claim("iss", "https://idp.example")
+            .build();
+    final var authentication = new JwtAuthenticationToken(jwt);
+    final var expected = CamundaAuthentication.of(b -> b.user("alice"));
+    when(tokenClaimsConverter.convert(jwt.getClaims())).thenReturn(expected);
 
-    // when
-    final var supports = authenticationConverter.supports(authentication);
+    final var converter =
+        new OidcTokenAuthenticationConverter(tokenClaimsConverter, new NoopOidcClaimsProvider());
 
-    // then
-    assertThat(supports).isFalse();
+    assertThat(converter.convert(authentication)).isSameAs(expected);
   }
 
   @Test
-  public void shouldConvertAccessToken() {
-    // given
+  void shouldUseClaimsReturnedByProviderForAugmentation() {
+    final TokenClaimsConverter tokenClaimsConverter = mock(TokenClaimsConverter.class);
+    final OidcClaimsProvider claimsProvider = mock(OidcClaimsProvider.class);
+    final var jwt =
+        Jwt.withTokenValue("token-abc")
+            .header("alg", "RS256")
+            .claim("sub", "alice")
+            .claim("iss", "https://idp.example")
+            .build();
+    final var authentication = new JwtAuthenticationToken(jwt);
 
-    final Map<String, Object> accessTokenClaims =
-        Map.of("access_token", "test-access-token", "token_type", "Bearer", "expires_in", 3600);
-    final var authentication = mock(JwtAuthenticationToken.class);
-    when(authentication.getTokenAttributes()).thenReturn(accessTokenClaims);
+    final Map<String, Object> augmentedClaims = Map.of("sub", "alice", "groups", List.of("eng"));
+    when(claimsProvider.claimsFor(any(), eq("token-abc"))).thenReturn(augmentedClaims);
+    final var expected = CamundaAuthentication.of(b -> b.user("alice"));
+    when(tokenClaimsConverter.convert(augmentedClaims)).thenReturn(expected);
 
-    final var expectedAuthentication = CamundaAuthentication.of(b -> b.user("foo"));
-    when(tokenClaimsConverter.convert(eq(accessTokenClaims))).thenReturn(expectedAuthentication);
+    final var converter =
+        new OidcTokenAuthenticationConverter(tokenClaimsConverter, claimsProvider);
 
-    // when
-    final var userToken = authenticationConverter.convert(authentication);
-
-    // then
-    assertThat(userToken).isEqualTo(expectedAuthentication);
-    verify(tokenClaimsConverter).convert(eq(accessTokenClaims));
+    assertThat(converter.convert(authentication)).isSameAs(expected);
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/oidc/OidcBearerUserInfoClaimGapIT.java
+++ b/authentication/src/test/java/io/camunda/authentication/oidc/OidcBearerUserInfoClaimGapIT.java
@@ -27,6 +27,7 @@ import io.camunda.security.auth.CamundaAuthentication;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.ArgumentCaptor;
@@ -66,6 +67,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
       "camunda.security.authentication.oidc.authorization-uri=authorization.example.com",
       "camunda.security.authentication.oidc.token-uri=token.example.com",
       "camunda.security.authentication.oidc.groups-claim=groups",
+      "camunda.security.authentication.oidc.user-info-augmentation.enabled=true",
     })
 public class OidcBearerUserInfoClaimGapIT extends AbstractWebSecurityConfigTest {
 
@@ -76,6 +78,15 @@ public class OidcBearerUserInfoClaimGapIT extends AbstractWebSecurityConfigTest 
   @Autowired private OidcTokenAuthenticationConverter converter;
 
   @MockitoBean private TokenClaimsConverter tokenClaimsConverter;
+
+  @BeforeEach
+  void resetWireMockBetweenTests() {
+    // The static WireMock instance is shared across test methods. Reset the request
+    // journal so `wireMock.verify(exactly(N), ...)` counts only the current test's
+    // requests. The cached CachingOidcClaimsProvider is also process-wide, so we use
+    // distinct `jti` values per test to avoid cross-test cache hits.
+    wireMock.resetRequests();
+  }
 
   @DynamicPropertySource
   static void registerWireMockProperties(final DynamicPropertyRegistry registry) {
@@ -142,5 +153,59 @@ public class OidcBearerUserInfoClaimGapIT extends AbstractWebSecurityConfigTest 
     // Additionally: /userinfo should have been consulted at least once. On current code it is
     // never called for bearer-token flows.
     wireMock.verify(exactly(1), getRequestedFor(urlMatching(".*/userinfo")));
+  }
+
+  @Test
+  void userInfoIsCalledOnlyOncePerTokenWithinTtl() {
+    wireMock.stubFor(
+        get(urlMatching(".*/userinfo"))
+            .willReturn(okJson("{\"sub\":\"alice\",\"groups\":[\"engineering\"]}")));
+
+    final var jwt =
+        Jwt.withTokenValue("token-cached")
+            .header("alg", "RS256")
+            .claim("sub", "alice")
+            .claim("iss", "http://localhost:" + wireMock.getPort() + "/issuer")
+            .claim("jti", "jti-cached")
+            .issuedAt(Instant.now())
+            .expiresAt(Instant.now().plusSeconds(3600))
+            .build();
+
+    Mockito.when(tokenClaimsConverter.convert(Mockito.any()))
+        .thenReturn(CamundaAuthentication.of(b -> b.user("alice")));
+
+    for (int i = 0; i < 50; i++) {
+      converter.convert(new JwtAuthenticationToken(jwt));
+    }
+
+    // Performance acceptance criterion: under a burst of bearer requests with the same token,
+    // we must not hammer the IdP — Caffeine serves subsequent calls from cache.
+    wireMock.verify(exactly(1), getRequestedFor(urlMatching(".*/userinfo")));
+  }
+
+  @Test
+  void distinctTokensEachTriggerOneUserInfoCall() {
+    wireMock.stubFor(
+        get(urlMatching(".*/userinfo"))
+            .willReturn(okJson("{\"sub\":\"alice\",\"groups\":[\"engineering\"]}")));
+
+    Mockito.when(tokenClaimsConverter.convert(Mockito.any()))
+        .thenReturn(CamundaAuthentication.of(b -> b.user("alice")));
+
+    final Instant expiry = Instant.now().plusSeconds(3600);
+    for (int i = 0; i < 3; i++) {
+      final var jwt =
+          Jwt.withTokenValue("token-distinct-" + i)
+              .header("alg", "RS256")
+              .claim("sub", "alice")
+              .claim("iss", "http://localhost:" + wireMock.getPort() + "/issuer")
+              .claim("jti", "jti-distinct-" + i)
+              .issuedAt(Instant.now())
+              .expiresAt(expiry)
+              .build();
+      converter.convert(new JwtAuthenticationToken(jwt));
+    }
+
+    wireMock.verify(exactly(3), getRequestedFor(urlMatching(".*/userinfo")));
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/oidc/OidcBearerUserInfoClaimGapIT.java
+++ b/authentication/src/test/java/io/camunda/authentication/oidc/OidcBearerUserInfoClaimGapIT.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.oidc;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.exactly;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import io.camunda.authentication.config.AbstractWebSecurityConfigTest;
+import io.camunda.authentication.config.WebSecurityConfig;
+import io.camunda.authentication.config.controllers.WebSecurityConfigTestContext;
+import io.camunda.authentication.config.controllers.WebSecurityOidcTestContext;
+import io.camunda.authentication.converter.OidcTokenAuthenticationConverter;
+import io.camunda.authentication.converter.TokenClaimsConverter;
+import io.camunda.security.auth.CamundaAuthentication;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+/**
+ * Documents the customer's reported scenario: for bearer-token authentication, a JWT that does not
+ * carry the configured {@code groups} claim cannot be augmented with the groups from the OIDC
+ * {@code /userinfo} response. Authorizations that depend on {@code groups} therefore fail even
+ * though the IdP would return the groups if asked.
+ *
+ * <p>This test is expected to FAIL on current code (8.8). It encodes the behaviour we want after a
+ * fix: {@link TokenClaimsConverter} should receive a merged claims map containing {@code groups}
+ * from {@code /userinfo}. On current code, only the raw JWT claims are passed through, {@code
+ * /userinfo} is never called, and the assertions below do not hold.
+ */
+@SuppressWarnings("SpringBootApplicationProperties")
+@SpringBootTest(
+    classes = {
+      WebSecurityConfigTestContext.class,
+      WebSecurityOidcTestContext.class,
+      WebSecurityConfig.class
+    },
+    properties = {
+      "camunda.security.authentication.unprotected-api=false",
+      "camunda.security.authentication.method=oidc",
+      "camunda.security.authentication.oidc.client-id=example",
+      "camunda.security.authentication.oidc.redirect-uri=redirect.example.com",
+      "camunda.security.authentication.oidc.authorization-uri=authorization.example.com",
+      "camunda.security.authentication.oidc.token-uri=token.example.com",
+      "camunda.security.authentication.oidc.groups-claim=groups",
+    })
+public class OidcBearerUserInfoClaimGapIT extends AbstractWebSecurityConfigTest {
+
+  @RegisterExtension
+  static WireMockExtension wireMock =
+      WireMockExtension.newInstance().configureStaticDsl(true).build();
+
+  @Autowired private OidcTokenAuthenticationConverter converter;
+
+  @MockitoBean private TokenClaimsConverter tokenClaimsConverter;
+
+  @DynamicPropertySource
+  static void registerWireMockProperties(final DynamicPropertyRegistry registry) {
+    final var issuerUri = "http://localhost:" + wireMock.getPort() + "/issuer";
+    registry.add("camunda.security.authentication.oidc.issuer-uri", () -> issuerUri);
+    registry.add(
+        "camunda.security.authentication.oidc.jwk-set-uri",
+        () -> "http://localhost:" + wireMock.getPort() + "/issuer/jwks");
+
+    final var openidConfig =
+        "{\"issuer\":\""
+            + issuerUri
+            + "\","
+            + "\"token_endpoint\":\"token.example.com\","
+            + "\"jwks_uri\":\"http://localhost:"
+            + wireMock.getPort()
+            + "/issuer/jwks\","
+            + "\"userinfo_endpoint\":\""
+            + issuerUri
+            + "/userinfo\","
+            + "\"subject_types_supported\":[\"public\"]}";
+    wireMock
+        .getRuntimeInfo()
+        .getWireMock()
+        .register(
+            get(urlMatching(".*/issuer/.well-known/openid-configuration"))
+                .willReturn(WireMock.jsonResponse(openidConfig, HttpStatus.OK.value())));
+  }
+
+  @Test
+  void groupsFromUserInfoShouldReachTokenClaimsConverterButCurrentlyDoNot() {
+    // The IdP is configured to return the groups on /userinfo (common SaaS IdP pattern).
+    wireMock.stubFor(
+        get(urlMatching(".*/userinfo"))
+            .willReturn(okJson("{\"sub\":\"alice\",\"groups\":[\"engineering\"]}")));
+
+    // The JWT access token the customer receives does NOT carry the groups claim.
+    final var jwt =
+        Jwt.withTokenValue("token-abc")
+            .header("alg", "RS256")
+            .claim("sub", "alice")
+            .claim("iss", "http://localhost:" + wireMock.getPort() + "/issuer")
+            .claim("jti", "jti-1")
+            .issuedAt(Instant.now())
+            .expiresAt(Instant.now().plusSeconds(3600))
+            .build();
+
+    Mockito.when(tokenClaimsConverter.convert(Mockito.any()))
+        .thenReturn(CamundaAuthentication.of(b -> b.user("alice")));
+
+    converter.convert(new JwtAuthenticationToken(jwt));
+
+    @SuppressWarnings("unchecked")
+    final ArgumentCaptor<Map<String, Object>> claimsCaptor = ArgumentCaptor.forClass(Map.class);
+    verify(tokenClaimsConverter).convert(claimsCaptor.capture());
+
+    // The customer's acceptance criterion: groups must arrive at TokenClaimsConverter so that
+    // MembershipService.resolveMemberships(...) can grant group-based authorizations. On current
+    // code this assertion fails because only JWT claims are passed through.
+    assertThat(claimsCaptor.getValue())
+        .containsEntry("sub", "alice")
+        .containsEntry("groups", List.of("engineering"));
+
+    // Additionally: /userinfo should have been consulted at least once. On current code it is
+    // never called for bearer-token flows.
+    wireMock.verify(exactly(1), getRequestedFor(urlMatching(".*/userinfo")));
+  }
+}

--- a/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
@@ -13,6 +13,8 @@ import io.camunda.identity.sdk.IdentityConfiguration;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.oidc.NoopOidcClaimsProvider;
+import io.camunda.security.oidc.OidcClaimsProvider;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
@@ -60,6 +62,7 @@ public class BrokerModuleConfiguration implements CloseableSilently {
   private final UserServices userServices;
   private final PasswordEncoder passwordEncoder;
   private final JwtDecoder jwtDecoder;
+  private final OidcClaimsProvider oidcClaimsProvider;
   private final SearchClientsProxy searchClientsProxy;
 
   private Broker broker;
@@ -79,6 +82,7 @@ public class BrokerModuleConfiguration implements CloseableSilently {
       @Autowired(required = false) final UserServices userServices,
       final PasswordEncoder passwordEncoder,
       @Autowired(required = false) final JwtDecoder jwtDecoder,
+      @Autowired(required = false) final OidcClaimsProvider oidcClaimsProvider,
       @Autowired(required = false) final SearchClientsProxy searchClientsProxy) {
     this.configuration = configuration;
     this.identityConfiguration = identityConfiguration;
@@ -92,6 +96,8 @@ public class BrokerModuleConfiguration implements CloseableSilently {
     this.userServices = userServices;
     this.passwordEncoder = passwordEncoder;
     this.jwtDecoder = jwtDecoder;
+    this.oidcClaimsProvider =
+        oidcClaimsProvider != null ? oidcClaimsProvider : new NoopOidcClaimsProvider();
     this.searchClientsProxy = searchClientsProxy;
   }
 
@@ -121,6 +127,7 @@ public class BrokerModuleConfiguration implements CloseableSilently {
             userServices,
             passwordEncoder,
             jwtDecoder,
+            oidcClaimsProvider,
             searchClientsProxy,
             new BrokerRequestAuthorizationConverter(securityConfiguration));
     springBrokerBridge.registerShutdownHelper(

--- a/dist/src/main/java/io/camunda/zeebe/gateway/GatewayModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/GatewayModuleConfiguration.java
@@ -10,6 +10,8 @@ package io.camunda.zeebe.gateway;
 import io.atomix.cluster.AtomixCluster;
 import io.camunda.application.commons.configuration.GatewayBasedConfiguration;
 import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.oidc.NoopOidcClaimsProvider;
+import io.camunda.security.oidc.OidcClaimsProvider;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
@@ -63,6 +65,7 @@ public class GatewayModuleConfiguration implements CloseableSilently {
   private final UserServices userServices;
   private final PasswordEncoder passwordEncoder;
   private final JwtDecoder jwtDecoder;
+  private final OidcClaimsProvider oidcClaimsProvider;
   private final MeterRegistry meterRegistry;
 
   private Gateway gateway;
@@ -79,6 +82,7 @@ public class GatewayModuleConfiguration implements CloseableSilently {
       @Autowired(required = false) final UserServices userServices,
       final PasswordEncoder passwordEncoder,
       @Autowired(required = false) final JwtDecoder jwtDecoder,
+      @Autowired(required = false) final OidcClaimsProvider oidcClaimsProvider,
       final MeterRegistry meterRegistry) {
     this.configuration = configuration;
     this.securityConfiguration = securityConfiguration;
@@ -90,6 +94,8 @@ public class GatewayModuleConfiguration implements CloseableSilently {
     this.userServices = userServices;
     this.passwordEncoder = passwordEncoder;
     this.jwtDecoder = jwtDecoder;
+    this.oidcClaimsProvider =
+        oidcClaimsProvider != null ? oidcClaimsProvider : new NoopOidcClaimsProvider();
     this.meterRegistry = meterRegistry;
   }
 
@@ -120,6 +126,7 @@ public class GatewayModuleConfiguration implements CloseableSilently {
             userServices,
             passwordEncoder,
             jwtDecoder,
+            oidcClaimsProvider,
             meterRegistry);
     springGatewayBridge.registerGatewayStatusSupplier(gateway::getStatus);
     springGatewayBridge.registerClusterStateSupplier(

--- a/dist/src/test/java/io/camunda/zeebe/gateway/StandaloneGatewaySecurityTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/gateway/StandaloneGatewaySecurityTest.java
@@ -286,6 +286,7 @@ final class StandaloneGatewaySecurityTest {
         null,
         null,
         null,
+        null,
         new SimpleMeterRegistry());
   }
 }

--- a/docs/adr/identity/0003-userinfo-claim-augmentation-for-bearer-tokens.md
+++ b/docs/adr/identity/0003-userinfo-claim-augmentation-for-bearer-tokens.md
@@ -1,0 +1,126 @@
+# ADR-0003: UserInfo Claim Augmentation for OIDC Bearer Tokens
+
+## Status
+
+Proposed
+
+## Context
+
+Camunda's OIDC authentication extracts authorization-relevant claims (`groups`, `roles`, tenants, etc.)
+from the validated JWT access token. Some Identity Providers do **not** place these claims on the JWT
+that is issued as the access token — they only return them from the `/userinfo` endpoint when queried
+with that token. Common cases include SaaS IdPs with claim-emission policies that differ between ID
+tokens, access tokens, and the userinfo response; and IdPs where the operator has intentionally kept
+access tokens compact.
+
+For the **browser login flow** (webapp), Spring Security's OIDC login handler already calls
+`/userinfo` when `camunda.security.authentication.oidc.userInfoEnabled=true` (default) and merges the
+response into the principal. So this works today — for login.
+
+For the **bearer-token flow** (REST `/v1`, `/v2`, gRPC via Zeebe gateway), the claims map passed to
+`TokenClaimsConverter` is `JwtAuthenticationToken.getToken().getClaims()` — i.e. JWT claims only. No
+`/userinfo` call is made. If the `groups` claim isn't on the JWT, group-based authorization never
+triggers, even though the IdP would return groups if asked.
+
+This breaks a customer scenario where their IdP is configured to emit group membership only via
+`/userinfo`.
+
+## Decision
+
+Introduce an **opt-in** augmentation layer for the bearer-token flow. When enabled, a shared
+`OidcClaimsProvider` bean calls the IdP's `/userinfo` endpoint with the bearer token, merges the
+response onto the JWT claims (UserInfo wins on conflict), and caches the result.
+
+### Architecture
+
+- New interface `io.camunda.security.oidc.OidcClaimsProvider`:
+  `Map<String, Object> claimsFor(Map<String, Object> jwtClaims, String tokenValue)`.
+- Default implementation `NoopOidcClaimsProvider` returns the JWT claims unchanged — used whenever
+  augmentation is disabled. No runtime cost.
+- Production implementation `CachingOidcClaimsProvider`:
+  - On cache miss, calls `/userinfo` via `OidcUserInfoClient` (JDK `HttpClient`, Jackson for JSON).
+  - Caches via Caffeine, keyed by JWT `jti` (or SHA-256 of the raw token if `jti` is absent).
+  - Effective TTL is `min(configuredTtl, tokenExp - clockSkew - now)`; cache entries never outlive
+    the bearer token.
+  - Fails closed on `/userinfo` errors: the request fails with 401 / UNAUTHENTICATED. A short (5s)
+    negative cache prevents IdP storm-retries during an outage.
+  - Emits Micrometer metrics: `camunda.oidc.userinfo.cache` tagged `hit` / `miss`, and
+    `camunda.oidc.userinfo.fetch` as a timer plus a `failure` counter.
+
+### Routing through existing code paths
+
+- REST (`OidcTokenAuthenticationConverter`): resolves claims through `OidcClaimsProvider` before
+  handing to `TokenClaimsConverter`.
+- gRPC (`AuthenticationHandler.Oidc`): calls `OidcClaimsProvider` once between `JwtDecoder.decode(...)`
+  and `OidcPrincipalLoader.load(...)`, so both the groups loader and the principal loader see the
+  merged claims.
+- The broker's embedded gateway threads the provider through the same chain that `JwtDecoder` travels
+  today: `BrokerModuleConfiguration` → `SystemContext` → `BrokerStartupContext(Impl)` →
+  `EmbeddedGatewayServiceStep` → `EmbeddedGatewayService` → `Gateway`. With
+  `@Autowired(required = false)` + a `NoopOidcClaimsProvider` fallback in
+  `BrokerModuleConfiguration`, the chain degrades safely when the authentication module's Spring
+  context isn't loaded.
+
+### Userinfo URL source
+
+The `/userinfo` URL is read from Spring's `ClientRegistration.getProviderDetails().getUserInfoEndpoint().getUri()`.
+Spring populates it from the IdP's OIDC discovery document (`.well-known/openid-configuration`) at
+startup, so it's accurate for every IdP — not a `{issuer}/userinfo` string-stitch. A null URL means
+either the IdP doesn't publish a userinfo endpoint, or the operator set `userInfoEnabled=false`.
+Either legitimately disables augmentation for that registration; if augmentation is otherwise
+enabled but no registration yields a URL, startup fails with a clear message.
+
+### Configuration
+
+```yaml
+camunda:
+  security:
+    authentication:
+      oidc:
+        userInfoAugmentation:
+          enabled: false       # default; opt-in
+          cacheTtl: PT5M       # capped by token exp − clockSkew
+          cacheMaxSize: 10000  # hard bound on cached entries
+```
+
+- **Default is `enabled: false`.** Augmentation is opt-in because it introduces a per-request network
+  dependency on the IdP and is a behavioural change for existing deployments on upgrade.
+- The `userInfoEnabled` flag (existing, defaults `true`) remains separate — it continues to gate
+  Spring's OIDC login-flow userinfo call. When `userInfoAugmentation.enabled=true` and
+  `userInfoEnabled=false`, startup fails because no userinfo URL is available on the
+  ClientRegistration.
+
+## Consequences
+
+### Positive
+
+- Group-based authorization works for bearer-token requests even when the IdP only returns groups from
+  `/userinfo`. This unblocks deployments that previously required IdP-side configuration changes that
+  the customer couldn't make.
+- Opt-in via a single config flag — no behaviour change for existing deployments on upgrade.
+- `NoopOidcClaimsProvider` is the default bean, so the hot path for disabled deployments is a
+  zero-allocation pass-through.
+- Cache + metrics give operators visibility and bound the IdP load.
+
+### Negative
+
+- When enabled, the first bearer request per `jti` adds one IdP round-trip (~tens of ms in steady
+  state; more if the IdP is distant). Worker patterns that reuse the same token amortise this
+  trivially via the cache.
+- Fail-closed on IdP errors: if `/userinfo` is down, all bearer-authenticated API requests fail
+  during the outage. The negative cache prevents retry storms but does not mask the dependency. An
+  alternative of "fall back to JWT-only claims on error" was considered and rejected because it
+  silently downgrades authorization — a security surprise.
+- Single userinfo endpoint is picked when multiple OIDC providers are configured (the first
+  registration that exposes one). Multi-provider selection by the token's `iss` claim is a follow-up.
+
+### Out of scope for v1
+
+- Multi-provider userinfo URL selection by `iss`.
+- Making the negative cache TTL configurable (currently hard-coded at 5s).
+- Exposing a `userInfoUri` override config for IdPs whose discovery document is broken.
+
+## References
+
+- Implementation plan: `docs/superpowers/plans/2026-04-20-oidc-userinfo-claim-augmentation.md`
+- Failing-test baseline: `authentication/src/test/java/io/camunda/authentication/oidc/OidcBearerUserInfoClaimGapIT.java`

--- a/docs/adr/identity/0003-userinfo-claim-augmentation-for-bearer-tokens.md
+++ b/docs/adr/identity/0003-userinfo-claim-augmentation-for-bearer-tokens.md
@@ -124,3 +124,4 @@ camunda:
 
 - Implementation plan: `docs/superpowers/plans/2026-04-20-oidc-userinfo-claim-augmentation.md`
 - Failing-test baseline: `authentication/src/test/java/io/camunda/authentication/oidc/OidcBearerUserInfoClaimGapIT.java`
+

--- a/docs/superpowers/plans/2026-04-20-oidc-userinfo-claim-augmentation.md
+++ b/docs/superpowers/plans/2026-04-20-oidc-userinfo-claim-augmentation.md
@@ -1,0 +1,1868 @@
+# OIDC UserInfo Claim Augmentation for Bearer Tokens Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add opt-in UserInfo claim augmentation for OIDC bearer-token authentication so authorizations built from claims that only appear in the `/userinfo` response (not the JWT access token) work for both REST (`/v1`/`/v2`) and gRPC (Zeebe gateway) requests. Configurable per-provider TTL cache keeps IdP round-trips bounded.
+
+**Architecture:** Introduce a shared `OidcClaimsProvider` bean in `security-core`. It takes a validated JWT's claims + raw token string, and returns the final claims map used by `TokenClaimsConverter` (REST) and `OidcPrincipalLoader`/`OidcGroupsLoader` (gRPC). When augmentation is enabled for the provider, the implementation calls the IdP's `/userinfo` endpoint with the bearer token, merges the response over the JWT claims, and caches the result by `jti` (fallback SHA-256 of token) with TTL = `min(configured, exp - now - skew)`. Caffeine provides the cache; Micrometer provides metrics; fail-closed on userinfo errors with a short negative cache to prevent storm-retries.
+
+**Tech Stack:** Java 21, Spring Security 6, Caffeine (already in parent POM), Jackson (for JSON parsing), JDK `java.net.http.HttpClient` (no new module deps), Micrometer, JUnit 5 + AssertJ + WireMock for tests.
+
+---
+
+## File Structure
+
+### New files
+
+- `security/security-core/src/main/java/io/camunda/security/configuration/OidcUserInfoAugmentationConfiguration.java` — nested config class for the three knobs.
+- `security/security-core/src/main/java/io/camunda/security/oidc/OidcClaimsProvider.java` — interface `Map<String, Object> claimsFor(Map<String, Object> jwtClaims, String tokenValue)`.
+- `security/security-core/src/main/java/io/camunda/security/oidc/OidcUserInfoClient.java` — thin JDK `HttpClient` wrapper for the userinfo endpoint.
+- `security/security-core/src/main/java/io/camunda/security/oidc/CachingOidcClaimsProvider.java` — production impl: config-aware, Caffeine-cached, metric-instrumented, fail-closed.
+- `security/security-core/src/main/java/io/camunda/security/oidc/NoopOidcClaimsProvider.java` — pass-through; used when no OIDC provider has augmentation enabled (avoids cache/HTTP client overhead).
+- `security/security-core/src/test/java/io/camunda/security/oidc/CachingOidcClaimsProviderTest.java` — unit tests (WireMock-backed).
+- `security/security-core/src/test/java/io/camunda/security/oidc/OidcUserInfoClientTest.java` — unit tests for the HTTP client.
+- `authentication/src/test/java/io/camunda/authentication/oidc/OidcBearerUserInfoAugmentationIT.java` — integration test: full REST path through a Spring Boot slice with WireMock IdP.
+- `zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationHandlerOidcUserInfoTest.java` — gRPC-side integration test for the handler with a mocked provider.
+
+### Modified files
+
+- `security/security-core/pom.xml` — add `jackson-databind` and `caffeine` deps (both already managed in parent).
+- `security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java:56–58` — add `userInfoAugmentation` field, getter/setter, builder wiring.
+- `authentication/src/main/java/io/camunda/authentication/converter/OidcTokenAuthenticationConverter.java:33–42` — call `OidcClaimsProvider` instead of passing `token.getTokenAttributes()` straight to `TokenClaimsConverter`.
+- `authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java` — add `@Bean OidcClaimsProvider` inside `OidcConfiguration` (around line 632); inject into `oidcTokenAuthenticationConverter` bean (line 633).
+- `zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationHandler.java:58–69, 79–104` — accept `OidcClaimsProvider` in the `Oidc` constructor; call it after `jwtDecoder.decode(...)` and use the returned map in place of `token.getClaims()` at lines 97 and 108.
+- `zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/Gateway.java:100, 112, 122, 135, 145, 418–419` — thread `OidcClaimsProvider` through Gateway constructors to the `AuthenticationHandler.Oidc` instantiation.
+- `dist/src/main/java/io/camunda/zeebe/gateway/GatewayModuleConfiguration.java:112–120` — resolve the `OidcClaimsProvider` bean and pass it to `new Gateway(...)`.
+- `zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/EmbeddedGatewayService.java:47–48` — same constructor update.
+- `zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusteringRule.java:523–528` and `zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java:107–111` — pass `NoopOidcClaimsProvider` in tests that don't care.
+
+---
+
+## Task 1: Config surface — `OidcUserInfoAugmentationConfiguration`
+
+**Files:**
+- Create: `security/security-core/src/main/java/io/camunda/security/configuration/OidcUserInfoAugmentationConfiguration.java`
+- Modify: `security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java`
+- Modify: `security/security-core/pom.xml`
+- Test: `security/security-core/src/test/java/io/camunda/security/configuration/OidcUserInfoAugmentationConfigurationTest.java`
+
+- [ ] **Step 1: Write failing test for the nested config defaults**
+
+Create `security/security-core/src/test/java/io/camunda/security/configuration/OidcUserInfoAugmentationConfigurationTest.java`:
+
+```java
+package io.camunda.security.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+class OidcUserInfoAugmentationConfigurationTest {
+
+  @Test
+  void defaultsAreDisabledWithFiveMinuteTtlAndTenThousandEntries() {
+    final var config = new OidcUserInfoAugmentationConfiguration();
+
+    assertThat(config.isEnabled()).isFalse();
+    assertThat(config.getCacheTtl()).isEqualTo(Duration.ofMinutes(5));
+    assertThat(config.getCacheMaxSize()).isEqualTo(10_000);
+  }
+
+  @Test
+  void oidcAuthenticationConfigurationExposesNonNullAugmentationByDefault() {
+    final var oidc = new OidcAuthenticationConfiguration();
+
+    assertThat(oidc.getUserInfoAugmentation()).isNotNull();
+    assertThat(oidc.getUserInfoAugmentation().isEnabled()).isFalse();
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mvn -pl security/security-core -am test -Dtest=OidcUserInfoAugmentationConfigurationTest`
+
+Expected: compile failure — `OidcUserInfoAugmentationConfiguration` does not exist.
+
+- [ ] **Step 3: Create `OidcUserInfoAugmentationConfiguration`**
+
+```java
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.configuration;
+
+import java.time.Duration;
+
+public class OidcUserInfoAugmentationConfiguration {
+
+  public static final Duration DEFAULT_CACHE_TTL = Duration.ofMinutes(5);
+  public static final int DEFAULT_CACHE_MAX_SIZE = 10_000;
+  public static final Duration NEGATIVE_CACHE_TTL = Duration.ofSeconds(5);
+
+  private boolean enabled = false;
+  private Duration cacheTtl = DEFAULT_CACHE_TTL;
+  private int cacheMaxSize = DEFAULT_CACHE_MAX_SIZE;
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(final boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public Duration getCacheTtl() {
+    return cacheTtl;
+  }
+
+  public void setCacheTtl(final Duration cacheTtl) {
+    this.cacheTtl = cacheTtl;
+  }
+
+  public int getCacheMaxSize() {
+    return cacheMaxSize;
+  }
+
+  public void setCacheMaxSize(final int cacheMaxSize) {
+    this.cacheMaxSize = cacheMaxSize;
+  }
+}
+```
+
+- [ ] **Step 4: Wire it into `OidcAuthenticationConfiguration`**
+
+In `OidcAuthenticationConfiguration.java`, after the existing `userInfoEnabled` field (line 58):
+
+```java
+private OidcUserInfoAugmentationConfiguration userInfoAugmentation =
+    new OidcUserInfoAugmentationConfiguration();
+```
+
+Add getter/setter near the other accessors (mirror the pattern around line 263):
+
+```java
+public OidcUserInfoAugmentationConfiguration getUserInfoAugmentation() {
+  return userInfoAugmentation;
+}
+
+public void setUserInfoAugmentation(
+    final OidcUserInfoAugmentationConfiguration userInfoAugmentation) {
+  this.userInfoAugmentation = userInfoAugmentation;
+}
+```
+
+Then update the `Builder` (around line 334) to carry the field:
+
+```java
+private OidcUserInfoAugmentationConfiguration userInfoAugmentation =
+    new OidcUserInfoAugmentationConfiguration();
+
+public Builder userInfoAugmentation(
+    final OidcUserInfoAugmentationConfiguration userInfoAugmentation) {
+  this.userInfoAugmentation = userInfoAugmentation;
+  return this;
+}
+```
+
+And in the builder's `build()` method (around line 478), add:
+
+```java
+config.setUserInfoAugmentation(userInfoAugmentation);
+```
+
+- [ ] **Step 5: Run tests — expect pass**
+
+Run: `mvn -pl security/security-core test -Dtest=OidcUserInfoAugmentationConfigurationTest`
+
+Expected: both tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add security/security-core/src/main/java/io/camunda/security/configuration/OidcUserInfoAugmentationConfiguration.java \
+        security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java \
+        security/security-core/src/test/java/io/camunda/security/configuration/OidcUserInfoAugmentationConfigurationTest.java
+git commit -m "feat(security): add OIDC user-info augmentation config"
+```
+
+---
+
+## Task 2: `OidcUserInfoClient` — JDK HttpClient wrapper
+
+**Files:**
+- Modify: `security/security-core/pom.xml`
+- Create: `security/security-core/src/main/java/io/camunda/security/oidc/OidcUserInfoClient.java`
+- Create: `security/security-core/src/main/java/io/camunda/security/oidc/OidcUserInfoException.java`
+- Test: `security/security-core/src/test/java/io/camunda/security/oidc/OidcUserInfoClientTest.java`
+
+- [ ] **Step 1: Add `jackson-databind` and `wiremock` to `security-core/pom.xml`**
+
+After the existing `jackson-annotations` dependency (around line 45):
+
+```xml
+<dependency>
+  <groupId>com.fasterxml.jackson.core</groupId>
+  <artifactId>jackson-databind</artifactId>
+</dependency>
+```
+
+After the existing test-scope dependencies (around line 74):
+
+```xml
+<dependency>
+  <groupId>org.wiremock</groupId>
+  <artifactId>wiremock-standalone</artifactId>
+  <scope>test</scope>
+</dependency>
+```
+
+Both are managed in the parent POM — no version needed.
+
+- [ ] **Step 2: Write failing test**
+
+Create `OidcUserInfoClientTest.java`:
+
+```java
+package io.camunda.security.oidc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+
+class OidcUserInfoClientTest {
+
+  @RegisterExtension
+  static WireMockExtension idp =
+      WireMockExtension.newInstance().options(wireMockConfig().dynamicPort()).build();
+
+  private final OidcUserInfoClient client =
+      new OidcUserInfoClient(HttpClient.newHttpClient(), Duration.ofSeconds(2));
+
+  @Test
+  void returnsClaimsFromSuccessfulResponse() {
+    idp.stubFor(
+        get("/userinfo")
+            .withHeader("Authorization", equalTo("Bearer token-abc"))
+            .willReturn(okJson("{\"sub\":\"alice\",\"groups\":[\"engineering\",\"ops\"]}")));
+
+    final var claims =
+        client.fetch(URI.create(idp.baseUrl() + "/userinfo"), "token-abc");
+
+    assertThat(claims).containsEntry("sub", "alice");
+    assertThat(claims).containsEntry("groups", java.util.List.of("engineering", "ops"));
+  }
+
+  @Test
+  void throwsOnNon2xx() {
+    idp.stubFor(get("/userinfo").willReturn(aResponse().withStatus(401)));
+
+    assertThatThrownBy(
+            () -> client.fetch(URI.create(idp.baseUrl() + "/userinfo"), "bad-token"))
+        .isInstanceOf(OidcUserInfoException.class)
+        .hasMessageContaining("401");
+  }
+
+  @Test
+  void throwsOnTimeout() {
+    idp.stubFor(
+        get("/userinfo")
+            .willReturn(aResponse().withFixedDelay(3_000).withBody("{}")));
+
+    assertThatThrownBy(
+            () -> client.fetch(URI.create(idp.baseUrl() + "/userinfo"), "token-abc"))
+        .isInstanceOf(OidcUserInfoException.class);
+  }
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `mvn -pl security/security-core test -Dtest=OidcUserInfoClientTest`
+
+Expected: compile failure — class does not exist.
+
+- [ ] **Step 4: Implement `OidcUserInfoClient`**
+
+Create `security/security-core/src/main/java/io/camunda/security/oidc/OidcUserInfoClient.java`:
+
+```java
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.oidc;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Objects;
+
+public class OidcUserInfoClient {
+
+  private static final TypeReference<Map<String, Object>> CLAIMS_TYPE = new TypeReference<>() {};
+
+  private final HttpClient httpClient;
+  private final ObjectMapper objectMapper;
+  private final Duration requestTimeout;
+
+  public OidcUserInfoClient(final HttpClient httpClient, final Duration requestTimeout) {
+    this.httpClient = Objects.requireNonNull(httpClient);
+    this.requestTimeout = Objects.requireNonNull(requestTimeout);
+    objectMapper = new ObjectMapper();
+  }
+
+  public Map<String, Object> fetch(final URI userInfoUri, final String bearerToken) {
+    final HttpRequest request =
+        HttpRequest.newBuilder(userInfoUri)
+            .timeout(requestTimeout)
+            .header("Authorization", "Bearer " + bearerToken)
+            .header("Accept", "application/json")
+            .GET()
+            .build();
+
+    final HttpResponse<byte[]> response;
+    try {
+      response = httpClient.send(request, HttpResponse.BodyHandlers.ofByteArray());
+    } catch (final Exception e) {
+      throw new OidcUserInfoException("UserInfo request failed: " + e.getMessage(), e);
+    }
+
+    if (response.statusCode() / 100 != 2) {
+      throw new OidcUserInfoException(
+          "UserInfo request returned HTTP " + response.statusCode());
+    }
+
+    try {
+      return objectMapper.readValue(response.body(), CLAIMS_TYPE);
+    } catch (final Exception e) {
+      throw new OidcUserInfoException("Failed to parse UserInfo JSON: " + e.getMessage(), e);
+    }
+  }
+}
+```
+
+Create `security/security-core/src/main/java/io/camunda/security/oidc/OidcUserInfoException.java`:
+
+```java
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.oidc;
+
+public class OidcUserInfoException extends RuntimeException {
+
+  public OidcUserInfoException(final String message) {
+    super(message);
+  }
+
+  public OidcUserInfoException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+}
+```
+
+- [ ] **Step 5: Run tests — expect pass**
+
+Run: `mvn -pl security/security-core test -Dtest=OidcUserInfoClientTest`
+
+Expected: all three tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add security/security-core/src/main/java/io/camunda/security/oidc/OidcUserInfoClient.java \
+        security/security-core/src/main/java/io/camunda/security/oidc/OidcUserInfoException.java \
+        security/security-core/src/test/java/io/camunda/security/oidc/OidcUserInfoClientTest.java \
+        security/security-core/pom.xml
+git commit -m "feat(security): add OidcUserInfoClient for bearer-auth userinfo calls"
+```
+
+---
+
+## Task 3: `OidcClaimsProvider` interface and `NoopOidcClaimsProvider`
+
+**Files:**
+- Create: `security/security-core/src/main/java/io/camunda/security/oidc/OidcClaimsProvider.java`
+- Create: `security/security-core/src/main/java/io/camunda/security/oidc/NoopOidcClaimsProvider.java`
+- Test: `security/security-core/src/test/java/io/camunda/security/oidc/NoopOidcClaimsProviderTest.java`
+
+- [ ] **Step 1: Write failing test**
+
+```java
+package io.camunda.security.oidc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class NoopOidcClaimsProviderTest {
+
+  @Test
+  void returnsJwtClaimsUnchanged() {
+    final var provider = new NoopOidcClaimsProvider();
+    final var input = Map.<String, Object>of("sub", "alice", "iss", "https://idp.example");
+
+    final var output = provider.claimsFor(input, "token-abc");
+
+    assertThat(output).isSameAs(input);
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mvn -pl security/security-core test -Dtest=NoopOidcClaimsProviderTest`
+
+Expected: compile failure — types don't exist.
+
+- [ ] **Step 3: Create interface and Noop impl**
+
+`OidcClaimsProvider.java`:
+
+```java
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.oidc;
+
+import java.util.Map;
+
+/**
+ * Resolves the final claims map used for authorization from a validated JWT's claims and the raw
+ * token value. Implementations may augment the JWT claims with the OIDC UserInfo response,
+ * subject to provider-specific configuration and caching.
+ */
+public interface OidcClaimsProvider {
+
+  /**
+   * @param jwtClaims the claims as extracted from the validated JWT access token
+   * @param tokenValue the raw bearer token string (needed if UserInfo must be called)
+   * @return the claims map to be used for principal and authorization resolution
+   * @throws OidcUserInfoException if UserInfo augmentation is required but the IdP call fails
+   */
+  Map<String, Object> claimsFor(Map<String, Object> jwtClaims, String tokenValue);
+}
+```
+
+`NoopOidcClaimsProvider.java`:
+
+```java
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.oidc;
+
+import java.util.Map;
+
+public class NoopOidcClaimsProvider implements OidcClaimsProvider {
+
+  @Override
+  public Map<String, Object> claimsFor(
+      final Map<String, Object> jwtClaims, final String tokenValue) {
+    return jwtClaims;
+  }
+}
+```
+
+- [ ] **Step 4: Run test — expect pass**
+
+Run: `mvn -pl security/security-core test -Dtest=NoopOidcClaimsProviderTest`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add security/security-core/src/main/java/io/camunda/security/oidc/OidcClaimsProvider.java \
+        security/security-core/src/main/java/io/camunda/security/oidc/NoopOidcClaimsProvider.java \
+        security/security-core/src/test/java/io/camunda/security/oidc/NoopOidcClaimsProviderTest.java
+git commit -m "feat(security): add OidcClaimsProvider interface with no-op default"
+```
+
+---
+
+## Task 4: `CachingOidcClaimsProvider` — caching impl with metrics and fail-closed behaviour
+
+**Files:**
+- Modify: `security/security-core/pom.xml`
+- Create: `security/security-core/src/main/java/io/camunda/security/oidc/CachingOidcClaimsProvider.java`
+- Test: `security/security-core/src/test/java/io/camunda/security/oidc/CachingOidcClaimsProviderTest.java`
+
+- [ ] **Step 1: Add `caffeine`, `micrometer-core`, and `mockito-core` to `security-core/pom.xml`**
+
+In the main `<dependencies>` section:
+
+```xml
+<dependency>
+  <groupId>com.github.ben-manes.caffeine</groupId>
+  <artifactId>caffeine</artifactId>
+</dependency>
+<dependency>
+  <groupId>io.micrometer</groupId>
+  <artifactId>micrometer-core</artifactId>
+</dependency>
+```
+
+In the test-scope section:
+
+```xml
+<dependency>
+  <groupId>org.mockito</groupId>
+  <artifactId>mockito-core</artifactId>
+  <scope>test</scope>
+</dependency>
+```
+
+All managed in the parent POM.
+
+- [ ] **Step 2: Write failing tests**
+
+Create `CachingOidcClaimsProviderTest.java`:
+
+```java
+package io.camunda.security.oidc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.security.configuration.OidcAuthenticationConfiguration;
+import io.camunda.security.configuration.OidcUserInfoAugmentationConfiguration;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class CachingOidcClaimsProviderTest {
+
+  private OidcAuthenticationConfiguration oidcConfig;
+  private OidcUserInfoClient userInfoClient;
+  private SimpleMeterRegistry meterRegistry;
+
+  @BeforeEach
+  void setUp() {
+    oidcConfig = new OidcAuthenticationConfiguration();
+    oidcConfig.setIssuerUri("https://idp.example");
+    final var aug = new OidcUserInfoAugmentationConfiguration();
+    aug.setEnabled(true);
+    aug.setCacheTtl(Duration.ofMinutes(5));
+    aug.setCacheMaxSize(100);
+    oidcConfig.setUserInfoAugmentation(aug);
+    oidcConfig.setIssuerUri("https://idp.example");
+    userInfoClient = mock(OidcUserInfoClient.class);
+    meterRegistry = new SimpleMeterRegistry();
+  }
+
+  @Test
+  void returnsJwtClaimsUnchangedWhenAugmentationDisabled() {
+    oidcConfig.getUserInfoAugmentation().setEnabled(false);
+    final var provider =
+        new CachingOidcClaimsProvider(
+            oidcConfig, URI.create("https://idp.example/userinfo"), userInfoClient, meterRegistry);
+
+    final Map<String, Object> jwtClaims = Map.of("sub", "alice");
+    final var result = provider.claimsFor(jwtClaims, "token-abc");
+
+    assertThat(result).isSameAs(jwtClaims);
+    verify(userInfoClient, times(0)).fetch(any(), any());
+  }
+
+  @Test
+  void callsUserInfoOnceAndMergesClaimsOverJwt() {
+    when(userInfoClient.fetch(any(), eq("token-abc")))
+        .thenReturn(Map.of("groups", java.util.List.of("eng"), "sub", "alice-from-userinfo"));
+
+    final var provider =
+        new CachingOidcClaimsProvider(
+            oidcConfig, URI.create("https://idp.example/userinfo"), userInfoClient, meterRegistry);
+
+    final Map<String, Object> jwtClaims =
+        Map.of("sub", "alice", "jti", "jti-1", "exp", Instant.now().getEpochSecond() + 3600);
+
+    final var result = provider.claimsFor(jwtClaims, "token-abc");
+
+    assertThat(result).containsEntry("groups", java.util.List.of("eng"));
+    assertThat(result).containsEntry("sub", "alice-from-userinfo"); // userinfo overrides
+    assertThat(result).containsEntry("jti", "jti-1"); // jwt-only claim preserved
+    verify(userInfoClient, times(1)).fetch(any(), any());
+  }
+
+  @Test
+  void cachesByJtiSoSecondCallDoesNotHitIdp() {
+    when(userInfoClient.fetch(any(), any()))
+        .thenReturn(Map.of("groups", java.util.List.of("eng")));
+
+    final var provider =
+        new CachingOidcClaimsProvider(
+            oidcConfig, URI.create("https://idp.example/userinfo"), userInfoClient, meterRegistry);
+
+    final Map<String, Object> jwtClaims =
+        Map.of("sub", "alice", "jti", "jti-1", "exp", Instant.now().getEpochSecond() + 3600);
+
+    provider.claimsFor(jwtClaims, "token-abc");
+    provider.claimsFor(jwtClaims, "token-abc");
+
+    verify(userInfoClient, times(1)).fetch(any(), any());
+  }
+
+  @Test
+  void distinctJtisResultInDistinctCacheEntries() {
+    when(userInfoClient.fetch(any(), any()))
+        .thenReturn(Map.of("groups", java.util.List.of("eng")));
+
+    final var provider =
+        new CachingOidcClaimsProvider(
+            oidcConfig, URI.create("https://idp.example/userinfo"), userInfoClient, meterRegistry);
+
+    final long exp = Instant.now().getEpochSecond() + 3600;
+    provider.claimsFor(Map.of("sub", "alice", "jti", "jti-1", "exp", exp), "token-a");
+    provider.claimsFor(Map.of("sub", "alice", "jti", "jti-2", "exp", exp), "token-b");
+
+    verify(userInfoClient, times(2)).fetch(any(), any());
+  }
+
+  @Test
+  void fallsBackToTokenHashWhenJtiAbsent() {
+    when(userInfoClient.fetch(any(), any()))
+        .thenReturn(Map.of("groups", java.util.List.of("eng")));
+
+    final var provider =
+        new CachingOidcClaimsProvider(
+            oidcConfig, URI.create("https://idp.example/userinfo"), userInfoClient, meterRegistry);
+
+    final long exp = Instant.now().getEpochSecond() + 3600;
+    final Map<String, Object> claimsNoJti = Map.of("sub", "alice", "exp", exp);
+
+    provider.claimsFor(claimsNoJti, "token-abc");
+    provider.claimsFor(claimsNoJti, "token-abc"); // same token -> same cache entry
+    provider.claimsFor(claimsNoJti, "token-xyz"); // different token -> new entry
+
+    verify(userInfoClient, times(2)).fetch(any(), any());
+  }
+
+  @Test
+  void failsClosedWhenUserInfoThrows() {
+    when(userInfoClient.fetch(any(), any()))
+        .thenThrow(new OidcUserInfoException("boom"));
+
+    final var provider =
+        new CachingOidcClaimsProvider(
+            oidcConfig, URI.create("https://idp.example/userinfo"), userInfoClient, meterRegistry);
+
+    final Map<String, Object> jwtClaims =
+        Map.of("sub", "alice", "jti", "jti-1", "exp", Instant.now().getEpochSecond() + 3600);
+
+    assertThatThrownBy(() -> provider.claimsFor(jwtClaims, "token-abc"))
+        .isInstanceOf(OidcUserInfoException.class);
+  }
+
+  @Test
+  void negativeCachePreventsHammeringDuringOutage() {
+    when(userInfoClient.fetch(any(), any()))
+        .thenThrow(new OidcUserInfoException("IdP down"));
+
+    final var provider =
+        new CachingOidcClaimsProvider(
+            oidcConfig, URI.create("https://idp.example/userinfo"), userInfoClient, meterRegistry);
+
+    final Map<String, Object> jwtClaims =
+        Map.of("sub", "alice", "jti", "jti-1", "exp", Instant.now().getEpochSecond() + 3600);
+
+    for (int i = 0; i < 20; i++) {
+      try {
+        provider.claimsFor(jwtClaims, "token-abc");
+      } catch (final OidcUserInfoException ignored) {
+      }
+    }
+
+    verify(userInfoClient, times(1)).fetch(any(), any());
+  }
+
+  @Test
+  void ttlIsCappedByTokenExpiry() {
+    when(userInfoClient.fetch(any(), any()))
+        .thenReturn(Map.of("groups", java.util.List.of("eng")));
+
+    oidcConfig.getUserInfoAugmentation().setCacheTtl(Duration.ofHours(1));
+    final var provider =
+        new CachingOidcClaimsProvider(
+            oidcConfig, URI.create("https://idp.example/userinfo"), userInfoClient, meterRegistry);
+
+    // exp is 1 second in the past (after skew) -> entry should not be cached
+    final long expPast = Instant.now().minusSeconds(120).getEpochSecond();
+    final Map<String, Object> expired =
+        Map.of("sub", "alice", "jti", "jti-1", "exp", expPast);
+
+    provider.claimsFor(expired, "token-abc");
+    provider.claimsFor(expired, "token-abc");
+
+    // Should hit IdP both times because the entry expired immediately
+    verify(userInfoClient, times(2)).fetch(any(), any());
+  }
+
+  @Test
+  void exposesHitAndMissCounters() {
+    when(userInfoClient.fetch(any(), any()))
+        .thenReturn(Map.of("groups", java.util.List.of("eng")));
+
+    final var provider =
+        new CachingOidcClaimsProvider(
+            oidcConfig, URI.create("https://idp.example/userinfo"), userInfoClient, meterRegistry);
+
+    final Map<String, Object> jwtClaims =
+        Map.of("sub", "alice", "jti", "jti-1", "exp", Instant.now().getEpochSecond() + 3600);
+
+    provider.claimsFor(jwtClaims, "token-abc"); // miss
+    provider.claimsFor(jwtClaims, "token-abc"); // hit
+
+    assertThat(meterRegistry.get("camunda.oidc.userinfo.cache").tag("result", "miss").counter().count())
+        .isEqualTo(1.0);
+    assertThat(meterRegistry.get("camunda.oidc.userinfo.cache").tag("result", "hit").counter().count())
+        .isEqualTo(1.0);
+  }
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `mvn -pl security/security-core test -Dtest=CachingOidcClaimsProviderTest`
+
+Expected: compile failure — `CachingOidcClaimsProvider` does not exist.
+
+- [ ] **Step 4: Implement `CachingOidcClaimsProvider`**
+
+```java
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.oidc;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Expiry;
+import io.camunda.security.configuration.OidcAuthenticationConfiguration;
+import io.camunda.security.configuration.OidcUserInfoAugmentationConfiguration;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HexFormat;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CachingOidcClaimsProvider implements OidcClaimsProvider {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CachingOidcClaimsProvider.class);
+  private static final String CACHE_METRIC = "camunda.oidc.userinfo.cache";
+  private static final String FETCH_METRIC = "camunda.oidc.userinfo.fetch";
+
+  private final OidcAuthenticationConfiguration oidcConfig;
+  private final URI userInfoUri;
+  private final OidcUserInfoClient userInfoClient;
+  private final Cache<String, CacheEntry> cache;
+  private final Counter hitCounter;
+  private final Counter missCounter;
+  private final Timer fetchTimer;
+  private final Counter fetchFailureCounter;
+  private final Duration clockSkew;
+
+  public CachingOidcClaimsProvider(
+      final OidcAuthenticationConfiguration oidcConfig,
+      final URI userInfoUri,
+      final OidcUserInfoClient userInfoClient,
+      final MeterRegistry meterRegistry) {
+    this.oidcConfig = Objects.requireNonNull(oidcConfig);
+    this.userInfoUri = userInfoUri; // may be null if augmentation disabled
+    this.userInfoClient = Objects.requireNonNull(userInfoClient);
+    clockSkew = oidcConfig.getClockSkew();
+    final OidcUserInfoAugmentationConfiguration aug = oidcConfig.getUserInfoAugmentation();
+    cache =
+        Caffeine.newBuilder()
+            .maximumSize(aug.getCacheMaxSize())
+            .expireAfter(new EntryExpiry(aug.getCacheTtl()))
+            .build();
+    hitCounter =
+        Counter.builder(CACHE_METRIC).tag("result", "hit").register(meterRegistry);
+    missCounter =
+        Counter.builder(CACHE_METRIC).tag("result", "miss").register(meterRegistry);
+    fetchTimer = Timer.builder(FETCH_METRIC).register(meterRegistry);
+    fetchFailureCounter =
+        Counter.builder(FETCH_METRIC).tag("outcome", "failure").register(meterRegistry);
+  }
+
+  @Override
+  public Map<String, Object> claimsFor(
+      final Map<String, Object> jwtClaims, final String tokenValue) {
+    if (!oidcConfig.getUserInfoAugmentation().isEnabled()) {
+      return jwtClaims;
+    }
+    if (userInfoUri == null) {
+      throw new OidcUserInfoException(
+          "UserInfo augmentation is enabled but no userinfo URI is available for this provider");
+    }
+
+    final String key = cacheKey(jwtClaims, tokenValue);
+    final CacheEntry cached = cache.getIfPresent(key);
+    if (cached != null) {
+      hitCounter.increment();
+      if (cached.failure() != null) {
+        throw cached.failure();
+      }
+      return cached.claims();
+    }
+    missCounter.increment();
+
+    final Map<String, Object> merged;
+    try {
+      final Map<String, Object> userInfoClaims =
+          fetchTimer.recordCallable(() -> userInfoClient.fetch(userInfoUri, tokenValue));
+      merged = merge(jwtClaims, userInfoClaims);
+    } catch (final OidcUserInfoException e) {
+      fetchFailureCounter.increment();
+      cache.put(key, CacheEntry.failure(e));
+      throw e;
+    } catch (final Exception e) {
+      fetchFailureCounter.increment();
+      final var wrapped = new OidcUserInfoException("UserInfo fetch failed: " + e.getMessage(), e);
+      cache.put(key, CacheEntry.failure(wrapped));
+      throw wrapped;
+    }
+
+    cache.put(key, CacheEntry.success(merged, tokenExpiry(jwtClaims)));
+    return merged;
+  }
+
+  private static Map<String, Object> merge(
+      final Map<String, Object> jwtClaims, final Map<String, Object> userInfoClaims) {
+    final Map<String, Object> merged = new HashMap<>(jwtClaims);
+    merged.putAll(userInfoClaims); // userinfo wins on conflict
+    return Map.copyOf(merged);
+  }
+
+  private static String cacheKey(final Map<String, Object> jwtClaims, final String tokenValue) {
+    final Object jti = jwtClaims.get("jti");
+    if (jti instanceof final String s && !s.isBlank()) {
+      return "jti:" + s;
+    }
+    return "tok:" + sha256(tokenValue);
+  }
+
+  private static String sha256(final String input) {
+    try {
+      final MessageDigest md = MessageDigest.getInstance("SHA-256");
+      return HexFormat.of().formatHex(md.digest(input.getBytes(StandardCharsets.UTF_8)));
+    } catch (final Exception e) {
+      throw new IllegalStateException("SHA-256 unavailable", e);
+    }
+  }
+
+  private static Instant tokenExpiry(final Map<String, Object> jwtClaims) {
+    final Object exp = jwtClaims.get("exp");
+    if (exp instanceof Number n) {
+      return Instant.ofEpochSecond(n.longValue());
+    }
+    return Instant.now().plus(Duration.ofMinutes(5));
+  }
+
+  private record CacheEntry(
+      Map<String, Object> claims, OidcUserInfoException failure, Instant tokenExp) {
+    static CacheEntry success(final Map<String, Object> claims, final Instant tokenExp) {
+      return new CacheEntry(claims, null, tokenExp);
+    }
+
+    static CacheEntry failure(final OidcUserInfoException e) {
+      return new CacheEntry(null, e, null);
+    }
+  }
+
+  /**
+   * Caffeine Expiry that:
+   *  - for successful entries, expires at min(configured TTL, tokenExp - skew - now)
+   *  - for failure entries, uses a short hard-coded negative TTL
+   */
+  private final class EntryExpiry implements Expiry<String, CacheEntry> {
+    private final Duration configuredTtl;
+
+    EntryExpiry(final Duration configuredTtl) {
+      this.configuredTtl = configuredTtl;
+    }
+
+    @Override
+    public long expireAfterCreate(
+        final String key, final CacheEntry value, final long currentTime) {
+      return ttlNanos(value);
+    }
+
+    @Override
+    public long expireAfterUpdate(
+        final String key, final CacheEntry value, final long currentTime, final long currentDuration) {
+      return ttlNanos(value);
+    }
+
+    @Override
+    public long expireAfterRead(
+        final String key, final CacheEntry value, final long currentTime, final long currentDuration) {
+      return currentDuration;
+    }
+
+    private long ttlNanos(final CacheEntry value) {
+      if (value.failure() != null) {
+        return TimeUnit.NANOSECONDS.convert(
+            OidcUserInfoAugmentationConfiguration.NEGATIVE_CACHE_TTL);
+      }
+      final Duration untilExp =
+          Duration.between(Instant.now(), value.tokenExp()).minus(clockSkew);
+      final Duration effective =
+          untilExp.isNegative() || untilExp.isZero() || untilExp.compareTo(configuredTtl) < 0
+              ? untilExp
+              : configuredTtl;
+      if (effective.isNegative() || effective.isZero()) {
+        return 0L;
+      }
+      return effective.toNanos();
+    }
+  }
+}
+```
+
+- [ ] **Step 5: Run tests — expect pass**
+
+Run: `mvn -pl security/security-core test -Dtest=CachingOidcClaimsProviderTest`
+
+Expected: all tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add security/security-core/src/main/java/io/camunda/security/oidc/CachingOidcClaimsProvider.java \
+        security/security-core/src/test/java/io/camunda/security/oidc/CachingOidcClaimsProviderTest.java \
+        security/security-core/pom.xml
+git commit -m "feat(security): add CachingOidcClaimsProvider with Caffeine + metrics"
+```
+
+---
+
+## Task 5: Wire the provider into the REST `OidcTokenAuthenticationConverter`
+
+**Files:**
+- Modify: `authentication/src/main/java/io/camunda/authentication/converter/OidcTokenAuthenticationConverter.java`
+- Modify: `authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java`
+- Test: `authentication/src/test/java/io/camunda/authentication/converter/OidcTokenAuthenticationConverterTest.java`
+
+- [ ] **Step 1: Write failing test**
+
+Create `OidcTokenAuthenticationConverterTest.java` (or extend if it exists — check first with `ls authentication/src/test/java/io/camunda/authentication/converter/`):
+
+```java
+package io.camunda.authentication.converter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.oidc.OidcClaimsProvider;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+class OidcTokenAuthenticationConverterTest {
+
+  @Test
+  void convertUsesClaimsReturnedByProvider() {
+    final TokenClaimsConverter tokenClaimsConverter = mock(TokenClaimsConverter.class);
+    final OidcClaimsProvider claimsProvider = mock(OidcClaimsProvider.class);
+    final var jwt =
+        Jwt.withTokenValue("token-abc")
+            .header("alg", "RS256")
+            .claim("sub", "alice")
+            .claim("iss", "https://idp.example")
+            .build();
+    final var authentication = new JwtAuthenticationToken(jwt);
+
+    final Map<String, Object> augmentedClaims =
+        Map.of("sub", "alice", "groups", List.of("eng"));
+    when(claimsProvider.claimsFor(any(), eq("token-abc"))).thenReturn(augmentedClaims);
+    final var expected = mock(CamundaAuthentication.class);
+    when(tokenClaimsConverter.convert(augmentedClaims)).thenReturn(expected);
+
+    final var converter =
+        new OidcTokenAuthenticationConverter(tokenClaimsConverter, claimsProvider);
+
+    assertThat(converter.convert(authentication)).isSameAs(expected);
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mvn -pl authentication test -Dtest=OidcTokenAuthenticationConverterTest`
+
+Expected: compile failure — two-arg constructor does not exist.
+
+- [ ] **Step 3: Modify `OidcTokenAuthenticationConverter` to accept and use the provider**
+
+Replace the file contents with:
+
+```java
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.converter;
+
+import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationConverter;
+import io.camunda.security.oidc.OidcClaimsProvider;
+import java.util.Optional;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+public class OidcTokenAuthenticationConverter
+    implements CamundaAuthenticationConverter<Authentication> {
+
+  private final TokenClaimsConverter tokenClaimsConverter;
+  private final OidcClaimsProvider claimsProvider;
+
+  public OidcTokenAuthenticationConverter(
+      final TokenClaimsConverter tokenClaimsConverter, final OidcClaimsProvider claimsProvider) {
+    this.tokenClaimsConverter = tokenClaimsConverter;
+    this.claimsProvider = claimsProvider;
+  }
+
+  @Override
+  public boolean supports(final Authentication authentication) {
+    return authentication instanceof JwtAuthenticationToken;
+  }
+
+  @Override
+  public CamundaAuthentication convert(final Authentication authentication) {
+    return Optional.of(authentication)
+        .map(JwtAuthenticationToken.class::cast)
+        .map(
+            token -> {
+              final Jwt jwt = token.getToken();
+              return claimsProvider.claimsFor(jwt.getClaims(), jwt.getTokenValue());
+            })
+        .map(tokenClaimsConverter::convert)
+        .orElseThrow(
+            () ->
+                new IllegalStateException(
+                    "Failed to convert 'JwtAuthenticationToken' to 'CamundaAuthentication'"));
+  }
+}
+```
+
+Note: `supports()` was loosened from `AbstractOAuth2TokenAuthenticationToken` to `JwtAuthenticationToken` because we now need `Jwt.getTokenValue()` — bearer-token flow always produces `JwtAuthenticationToken` per Spring's `BearerTokenAuthenticationFilter`. Any existing callers with introspection-based `BearerTokenAuthenticationToken` would be out of scope (none in this codebase — confirmed by the earlier grep for `opaqueToken`/`introspection`).
+
+- [ ] **Step 4: Add `@Bean OidcClaimsProvider` and update the converter bean in `WebSecurityConfig.OidcConfiguration`**
+
+Find the bean definition at `WebSecurityConfig.java:632`:
+
+```java
+@Bean
+public CamundaAuthenticationConverter<Authentication> oidcTokenAuthenticationConverter(
+    final TokenClaimsConverter tokenClaimsConverter) {
+  return new OidcTokenAuthenticationConverter(tokenClaimsConverter);
+}
+```
+
+Replace with:
+
+```java
+@Bean
+public CamundaAuthenticationConverter<Authentication> oidcTokenAuthenticationConverter(
+    final TokenClaimsConverter tokenClaimsConverter, final OidcClaimsProvider oidcClaimsProvider) {
+  return new OidcTokenAuthenticationConverter(tokenClaimsConverter, oidcClaimsProvider);
+}
+```
+
+Add a new bean near the other OIDC beans (after `oidcProviderRepository` at WebSecurityConfig.java:654):
+
+```java
+@Bean
+public OidcClaimsProvider oidcClaimsProvider(
+    final SecurityConfiguration securityConfiguration,
+    final OidcAuthenticationConfigurationRepository oidcProviderRepository,
+    final MeterRegistry meterRegistry) {
+  final var oidc = securityConfiguration.getAuthentication().getOidc();
+  if (oidc == null || !oidc.getUserInfoAugmentation().isEnabled()) {
+    return new NoopOidcClaimsProvider();
+  }
+  // Resolve userinfo URI from the first matching provider's discovery doc.
+  // In multi-provider setups, a future iteration can key by 'iss' claim.
+  final URI userInfoUri =
+      oidcProviderRepository.getOidcAuthenticationConfigurations().values().stream()
+          .map(OidcAuthenticationConfiguration::getIssuerUri)
+          .filter(Objects::nonNull)
+          .findFirst()
+          .map(issuer -> URI.create(issuer.replaceAll("/$", "") + "/userinfo"))
+          .orElseThrow(
+              () ->
+                  new IllegalStateException(
+                      "UserInfo augmentation enabled but no issuerUri configured"));
+  final var httpClient = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build();
+  return new CachingOidcClaimsProvider(
+      oidc, userInfoUri, new OidcUserInfoClient(httpClient, Duration.ofSeconds(5)), meterRegistry);
+}
+```
+
+Add imports at the top of `WebSecurityConfig.java`:
+
+```java
+import io.camunda.security.oidc.CachingOidcClaimsProvider;
+import io.camunda.security.oidc.NoopOidcClaimsProvider;
+import io.camunda.security.oidc.OidcClaimsProvider;
+import io.camunda.security.oidc.OidcUserInfoClient;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.time.Duration;
+import java.util.Objects;
+```
+
+**Note for reviewers:** the userinfo URI discovery above is the simplest thing that works for the customer's single-provider setup. Multi-provider-per-chain support (selecting userinfo URI by `iss`) is out of scope for this plan — flag as follow-up if review surfaces it.
+
+- [ ] **Step 5: Also update the `BasicConfiguration` Oidc converter? No — `BasicConfiguration` has no OIDC converter. Skip.**
+
+- [ ] **Step 6: Run converter test — expect pass**
+
+Run: `mvn -pl authentication test -Dtest=OidcTokenAuthenticationConverterTest`
+
+Expected: PASS.
+
+- [ ] **Step 7: Compile & run the authentication module's existing tests to catch regressions**
+
+Run: `mvn -pl authentication test`
+
+Expected: all PASS. If anything breaks, fix before moving on.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add authentication/src/main/java/io/camunda/authentication/converter/OidcTokenAuthenticationConverter.java \
+        authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java \
+        authentication/src/test/java/io/camunda/authentication/converter/OidcTokenAuthenticationConverterTest.java
+git commit -m "feat(authentication): route OIDC bearer claims through OidcClaimsProvider"
+```
+
+---
+
+## Task 6: Wire the provider into the gRPC `AuthenticationHandler.Oidc`
+
+**Files:**
+- Modify: `zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationHandler.java`
+- Modify: `zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/Gateway.java`
+- Modify: `dist/src/main/java/io/camunda/zeebe/gateway/GatewayModuleConfiguration.java`
+- Modify: `zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/EmbeddedGatewayService.java`
+- Modify test utilities: `ClusteringRule.java`, `StubbedGateway.java`
+- Test: `zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationHandlerOidcUserInfoTest.java`
+
+- [ ] **Step 1: Write failing test**
+
+```java
+package io.camunda.zeebe.gateway.interceptors.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.security.configuration.OidcAuthenticationConfiguration;
+import io.camunda.security.oidc.OidcClaimsProvider;
+import io.camunda.zeebe.gateway.interceptors.impl.AuthenticationHandler.Oidc;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+
+class AuthenticationHandlerOidcUserInfoTest {
+
+  @Test
+  void usesClaimsProviderResultForGroupsAndPrincipal() {
+    final var jwtDecoder = mock(JwtDecoder.class);
+    final var claimsProvider = mock(OidcClaimsProvider.class);
+    final var oidc = new OidcAuthenticationConfiguration();
+    oidc.setUsernameClaim("sub");
+    oidc.setGroupsClaim("groups");
+
+    final var jwt =
+        Jwt.withTokenValue("token-abc")
+            .header("alg", "RS256")
+            .claim("sub", "alice")
+            .build();
+    when(jwtDecoder.decode("token-abc")).thenReturn(jwt);
+    // provider adds groups from userinfo that the JWT does not have
+    when(claimsProvider.claimsFor(any(), eq("token-abc")))
+        .thenReturn(Map.of("sub", "alice", "groups", List.of("engineering")));
+
+    final var handler = new Oidc(jwtDecoder, oidc, claimsProvider);
+    final var result = handler.authenticate("Bearer token-abc");
+
+    assertThat(result.isRight()).isTrue();
+    final var ctx = result.get();
+    assertThat(ctx.call(() -> AuthenticationHandler.GROUPS_CLAIMS.get()))
+        .isEqualTo(List.of("engineering"));
+    assertThat(ctx.call(() -> AuthenticationHandler.USERNAME.get())).isEqualTo("alice");
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mvn -pl zeebe/gateway-grpc test -Dtest=AuthenticationHandlerOidcUserInfoTest`
+
+Expected: compile failure — three-arg `Oidc` constructor does not exist.
+
+- [ ] **Step 3: Modify `AuthenticationHandler.Oidc`**
+
+In `AuthenticationHandler.java`, update the `Oidc` class:
+
+1. Add import: `import io.camunda.security.oidc.OidcClaimsProvider;`
+2. Add field and update constructor (replace lines 53–69):
+
+```java
+private final JwtDecoder jwtDecoder;
+private final OidcAuthenticationConfiguration oidcAuthenticationConfiguration;
+private final OidcClaimsProvider claimsProvider;
+private final OidcPrincipalLoader oidcPrincipalLoader;
+private final OidcGroupsLoader oidcGroupsLoader;
+
+public Oidc(
+    final JwtDecoder jwtDecoder,
+    final OidcAuthenticationConfiguration oidcAuthenticationConfiguration,
+    final OidcClaimsProvider claimsProvider) {
+  this.jwtDecoder = Objects.requireNonNull(jwtDecoder);
+  this.oidcAuthenticationConfiguration =
+      Objects.requireNonNull(oidcAuthenticationConfiguration);
+  this.claimsProvider = Objects.requireNonNull(claimsProvider);
+  oidcPrincipalLoader =
+      new OidcPrincipalLoader(
+          oidcAuthenticationConfiguration.getUsernameClaim(),
+          oidcAuthenticationConfiguration.getClientIdClaim());
+  oidcGroupsLoader = new OidcGroupsLoader(oidcAuthenticationConfiguration.getGroupsClaim());
+}
+```
+
+3. In `authenticate()` (line 71), after the successful `jwtDecoder.decode(...)` block, resolve augmented claims once:
+
+Replace the body from line 79 onward up to `return Either.right(...)` with:
+
+```java
+final Jwt token;
+try {
+  token = jwtDecoder.decode(authorizationHeader.substring(BEARER_PREFIX.length()));
+} catch (final JwtException e) {
+  return Either.left(
+      Status.UNAUTHENTICATED
+          .augmentDescription("Expected a valid token, see cause for details")
+          .withCause(e));
+}
+
+final Map<String, Object> claims;
+try {
+  claims =
+      claimsProvider.claimsFor(
+          token.getClaims(), authorizationHeader.substring(BEARER_PREFIX.length()));
+} catch (final Exception e) {
+  return Either.left(
+      Status.UNAUTHENTICATED
+          .augmentDescription("Failed to resolve OIDC claims, see cause for details")
+          .withCause(e));
+}
+
+var context = Context.current();
+context = context.withValue(IS_CAMUNDA_USERS_ENABLED, false);
+context =
+    context.withValue(
+        IS_CAMUNDA_GROUPS_ENABLED,
+        !oidcAuthenticationConfiguration.isGroupsClaimConfigured());
+if (oidcAuthenticationConfiguration.isGroupsClaimConfigured()) {
+  try {
+    context = context.withValue(GROUPS_CLAIMS, oidcGroupsLoader.load(claims));
+  } catch (final Exception e) {
+    return Either.left(
+        Status.UNAUTHENTICATED
+            .augmentDescription("Failed to load OIDC groups, see cause for details")
+            .withCause(e));
+  }
+}
+
+final OidcPrincipals principals;
+try {
+  principals = oidcPrincipalLoader.load(claims);
+} catch (final Exception e) {
+  return Either.left(
+      Status.UNAUTHENTICATED
+          .augmentDescription("Failed to load OIDC principals, see cause for details")
+          .withCause(e));
+}
+
+if (principals.username() == null && principals.clientId() == null) {
+  return Either.left(
+      Status.UNAUTHENTICATED.augmentDescription(
+          "Expected either a username (claim: %s) or client ID (claim: %s) on the token, but no matching claim found"
+              .formatted(
+                  oidcAuthenticationConfiguration.getUsernameClaim(),
+                  oidcAuthenticationConfiguration.getClientIdClaim())));
+}
+
+final var preferUsernameClaim = oidcAuthenticationConfiguration.isPreferUsernameClaim();
+if ((preferUsernameClaim && principals.username() != null) || principals.clientId() == null) {
+  return Either.right(
+      context.withValue(USERNAME, principals.username()).withValue(USER_CLAIMS, claims));
+} else {
+  return Either.right(
+      context.withValue(CLIENT_ID, principals.clientId()).withValue(USER_CLAIMS, claims));
+}
+```
+
+- [ ] **Step 4: Thread the provider through `Gateway`**
+
+In `zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/Gateway.java`:
+
+1. Add import: `import io.camunda.security.oidc.OidcClaimsProvider;`
+2. Add field near `private final JwtDecoder jwtDecoder;` (line 100):
+   ```java
+   private final OidcClaimsProvider oidcClaimsProvider;
+   ```
+3. Update every constructor to take an `OidcClaimsProvider` parameter and assign it. Mirror the pattern used for `jwtDecoder` at lines 112, 135, 145.
+4. In `applyInterceptors()` (line 418), update:
+   ```java
+   case OIDC ->
+       new AuthenticationHandler.Oidc(
+           jwtDecoder,
+           securityConfiguration.getAuthentication().getOidc(),
+           oidcClaimsProvider);
+   ```
+
+- [ ] **Step 5: Update `Gateway` callers to pass the provider**
+
+In `dist/src/main/java/io/camunda/zeebe/gateway/GatewayModuleConfiguration.java` around line 113:
+1. Inject `OidcClaimsProvider` via the existing Spring constructor injection (add parameter).
+2. Pass it into `new Gateway(...)`.
+
+In `zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/EmbeddedGatewayService.java` around line 48:
+1. Accept an `OidcClaimsProvider` (via constructor injection from Spring).
+2. Pass it into `new Gateway(...)`.
+
+In `zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusteringRule.java:524` and `zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java:109`:
+Pass `new NoopOidcClaimsProvider()` as the new arg. Add import to each.
+
+- [ ] **Step 6: Run the new unit test — expect pass**
+
+Run: `mvn -pl zeebe/gateway-grpc test -Dtest=AuthenticationHandlerOidcUserInfoTest`
+
+Expected: PASS.
+
+- [ ] **Step 7: Run the broader gateway-grpc test suite**
+
+Run: `mvn -pl zeebe/gateway-grpc test`
+
+Expected: all PASS (existing tests should still pass because we added the arg without changing default behaviour — Noop provider is a pass-through).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationHandler.java \
+        zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/Gateway.java \
+        dist/src/main/java/io/camunda/zeebe/gateway/GatewayModuleConfiguration.java \
+        zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/EmbeddedGatewayService.java \
+        zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusteringRule.java \
+        zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java \
+        zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationHandlerOidcUserInfoTest.java
+git commit -m "feat(gateway): route gRPC OIDC claims through OidcClaimsProvider"
+```
+
+---
+
+## Task 7: End-to-end integration tests — REST + mock IdP
+
+These tests encode the **customer's acceptance criterion**: authorizations depend on a `groups` claim the IdP only returns from `/userinfo`, never in the JWT access token.
+
+The paired classes are deliberate: `Disabled` documents the current bug (groups never reach the converter chain → authorization would be empty), `Enabled` documents the fix (groups from userinfo reach `TokenClaimsConverter` and therefore `MembershipService.resolveMemberships(...)`). Both mirror the existing `OidcUserAuthenticationConverterIntegrationTest` context pattern.
+
+**Files:**
+- Create: `authentication/src/test/java/io/camunda/authentication/oidc/OidcBearerUserInfoAugmentationDisabledIT.java`
+- Create: `authentication/src/test/java/io/camunda/authentication/oidc/OidcBearerUserInfoAugmentationEnabledIT.java`
+
+- [ ] **Step 1: Write the baseline (augmentation disabled) failing test**
+
+Create `OidcBearerUserInfoAugmentationDisabledIT.java`:
+
+```java
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.oidc;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import io.camunda.authentication.config.AbstractWebSecurityConfigTest;
+import io.camunda.authentication.config.WebSecurityConfig;
+import io.camunda.authentication.config.controllers.WebSecurityConfigTestContext;
+import io.camunda.authentication.config.controllers.WebSecurityOidcTestContext;
+import io.camunda.authentication.converter.OidcTokenAuthenticationConverter;
+import io.camunda.authentication.converter.TokenClaimsConverter;
+import io.camunda.security.auth.CamundaAuthentication;
+import java.time.Instant;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+/**
+ * Baseline: with UserInfo augmentation DISABLED, a JWT that lacks the configured {@code groups}
+ * claim cannot be upgraded with the groups from the /userinfo response. This documents the
+ * current behaviour the customer is seeing — authorizations that depend on {@code groups} will
+ * see an empty groups list because the claim never reaches {@link TokenClaimsConverter}.
+ */
+@SuppressWarnings("SpringBootApplicationProperties")
+@SpringBootTest(
+    classes = {
+      WebSecurityConfigTestContext.class,
+      WebSecurityOidcTestContext.class,
+      WebSecurityConfig.class
+    },
+    properties = {
+      "camunda.security.authentication.unprotected-api=false",
+      "camunda.security.authentication.method=oidc",
+      "camunda.security.authentication.oidc.client-id=example",
+      "camunda.security.authentication.oidc.redirect-uri=redirect.example.com",
+      "camunda.security.authentication.oidc.authorization-uri=authorization.example.com",
+      "camunda.security.authentication.oidc.token-uri=token.example.com",
+      "camunda.security.authentication.oidc.groups-claim=groups",
+      "camunda.security.authentication.oidc.user-info-augmentation.enabled=false",
+    })
+public class OidcBearerUserInfoAugmentationDisabledIT extends AbstractWebSecurityConfigTest {
+
+  @RegisterExtension
+  static WireMockExtension wireMock =
+      WireMockExtension.newInstance().configureStaticDsl(true).build();
+
+  @Autowired private OidcTokenAuthenticationConverter converter;
+
+  @MockitoBean private TokenClaimsConverter tokenClaimsConverter;
+
+  @DynamicPropertySource
+  static void registerWireMockProperties(final DynamicPropertyRegistry registry) {
+    final var issuerUri = "http://localhost:" + wireMock.getPort() + "/issuer";
+    registry.add("camunda.security.authentication.oidc.issuer-uri", () -> issuerUri);
+    registry.add(
+        "camunda.security.authentication.oidc.jwk-set-uri",
+        () -> "http://localhost:" + wireMock.getPort() + "/issuer/jwks");
+
+    // Stub the OIDC discovery document so client registration can be built at context startup.
+    final var openidConfig =
+        "{\"issuer\":\"" + issuerUri + "\","
+            + "\"token_endpoint\":\"token.example.com\","
+            + "\"jwks_uri\":\"http://localhost:" + wireMock.getPort() + "/issuer/jwks\","
+            + "\"userinfo_endpoint\":\"" + issuerUri + "/userinfo\","
+            + "\"subject_types_supported\":[\"public\"]}";
+    wireMock
+        .getRuntimeInfo()
+        .getWireMock()
+        .register(
+            get(urlMatching(".*/issuer/.well-known/openid-configuration"))
+                .willReturn(okJson(openidConfig)));
+  }
+
+  @Test
+  void groupsClaimIsAbsentWhenAugmentationIsDisabledEvenIfUserInfoWouldProvideIt() {
+    // Stub userinfo to return the groups claim the customer needs.
+    // With augmentation disabled the provider must NOT call this endpoint.
+    wireMock.stubFor(
+        get(urlMatching(".*/userinfo"))
+            .willReturn(okJson("{\"sub\":\"alice\",\"groups\":[\"engineering\"]}")));
+
+    final var jwt =
+        Jwt.withTokenValue("token-abc")
+            .header("alg", "RS256")
+            .claim("sub", "alice")
+            .claim("iss", "http://localhost:" + wireMock.getPort() + "/issuer")
+            .claim("jti", "jti-baseline")
+            .claim("exp", Instant.now().getEpochSecond() + 3600)
+            .build();
+
+    Mockito.when(tokenClaimsConverter.convert(Mockito.any()))
+        .thenReturn(CamundaAuthentication.of(b -> b.user("alice")));
+
+    converter.convert(new JwtAuthenticationToken(jwt));
+
+    @SuppressWarnings("unchecked")
+    final ArgumentCaptor<Map<String, Object>> claimsCaptor = ArgumentCaptor.forClass(Map.class);
+    verify(tokenClaimsConverter).convert(claimsCaptor.capture());
+    assertThat(claimsCaptor.getValue())
+        .containsEntry("sub", "alice")
+        .doesNotContainKey("groups"); // the customer's bug: groups never arrive
+
+    // Sanity-check: userinfo was never called when augmentation is disabled.
+    wireMock.verify(0, com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor(
+        urlMatching(".*/userinfo")));
+  }
+}
+```
+
+- [ ] **Step 2: Write the fix (augmentation enabled) failing test**
+
+Create `OidcBearerUserInfoAugmentationEnabledIT.java`:
+
+```java
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.oidc;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.exactly;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import io.camunda.authentication.config.AbstractWebSecurityConfigTest;
+import io.camunda.authentication.config.WebSecurityConfig;
+import io.camunda.authentication.config.controllers.WebSecurityConfigTestContext;
+import io.camunda.authentication.config.controllers.WebSecurityOidcTestContext;
+import io.camunda.authentication.converter.OidcTokenAuthenticationConverter;
+import io.camunda.authentication.converter.TokenClaimsConverter;
+import io.camunda.security.auth.CamundaAuthentication;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+/**
+ * Fix: with UserInfo augmentation ENABLED, the groups claim from the /userinfo response is
+ * merged onto the JWT claims and therefore reaches {@link TokenClaimsConverter} (and through it
+ * {@link io.camunda.authentication.service.MembershipService#resolveMemberships}).
+ *
+ * <p>This is the customer's acceptance test: a bearer request with a JWT that does not carry the
+ * configured {@code groups} claim still results in group-based authorization, because the claim
+ * is sourced from /userinfo and cached for the configured TTL.
+ */
+@SuppressWarnings("SpringBootApplicationProperties")
+@SpringBootTest(
+    classes = {
+      WebSecurityConfigTestContext.class,
+      WebSecurityOidcTestContext.class,
+      WebSecurityConfig.class
+    },
+    properties = {
+      "camunda.security.authentication.unprotected-api=false",
+      "camunda.security.authentication.method=oidc",
+      "camunda.security.authentication.oidc.client-id=example",
+      "camunda.security.authentication.oidc.redirect-uri=redirect.example.com",
+      "camunda.security.authentication.oidc.authorization-uri=authorization.example.com",
+      "camunda.security.authentication.oidc.token-uri=token.example.com",
+      "camunda.security.authentication.oidc.groups-claim=groups",
+      "camunda.security.authentication.oidc.user-info-augmentation.enabled=true",
+      "camunda.security.authentication.oidc.user-info-augmentation.cache-ttl=PT5M",
+      "camunda.security.authentication.oidc.user-info-augmentation.cache-max-size=100",
+    })
+public class OidcBearerUserInfoAugmentationEnabledIT extends AbstractWebSecurityConfigTest {
+
+  @RegisterExtension
+  static WireMockExtension wireMock =
+      WireMockExtension.newInstance().configureStaticDsl(true).build();
+
+  @Autowired private OidcTokenAuthenticationConverter converter;
+
+  @MockitoBean private TokenClaimsConverter tokenClaimsConverter;
+
+  @DynamicPropertySource
+  static void registerWireMockProperties(final DynamicPropertyRegistry registry) {
+    final var issuerUri = "http://localhost:" + wireMock.getPort() + "/issuer";
+    registry.add("camunda.security.authentication.oidc.issuer-uri", () -> issuerUri);
+    registry.add(
+        "camunda.security.authentication.oidc.jwk-set-uri",
+        () -> "http://localhost:" + wireMock.getPort() + "/issuer/jwks");
+
+    final var openidConfig =
+        "{\"issuer\":\"" + issuerUri + "\","
+            + "\"token_endpoint\":\"token.example.com\","
+            + "\"jwks_uri\":\"http://localhost:" + wireMock.getPort() + "/issuer/jwks\","
+            + "\"userinfo_endpoint\":\"" + issuerUri + "/userinfo\","
+            + "\"subject_types_supported\":[\"public\"]}";
+    wireMock
+        .getRuntimeInfo()
+        .getWireMock()
+        .register(
+            get(urlMatching(".*/issuer/.well-known/openid-configuration"))
+                .willReturn(okJson(openidConfig)));
+  }
+
+  @Test
+  void groupsClaimFromUserInfoReachesTokenClaimsConverterWhenAugmentationEnabled() {
+    // The customer's scenario: JWT carries no groups claim, userinfo does.
+    wireMock.stubFor(
+        get(urlMatching(".*/userinfo"))
+            .willReturn(okJson("{\"sub\":\"alice\",\"groups\":[\"engineering\"]}")));
+
+    final var jwt =
+        Jwt.withTokenValue("token-abc")
+            .header("alg", "RS256")
+            .claim("sub", "alice")
+            .claim("iss", "http://localhost:" + wireMock.getPort() + "/issuer")
+            .claim("jti", "jti-1")
+            .claim("exp", Instant.now().getEpochSecond() + 3600)
+            .build();
+
+    Mockito.when(tokenClaimsConverter.convert(Mockito.any()))
+        .thenReturn(CamundaAuthentication.of(b -> b.user("alice")));
+
+    converter.convert(new JwtAuthenticationToken(jwt));
+
+    @SuppressWarnings("unchecked")
+    final ArgumentCaptor<Map<String, Object>> claimsCaptor = ArgumentCaptor.forClass(Map.class);
+    verify(tokenClaimsConverter).convert(claimsCaptor.capture());
+
+    // The critical assertion: groups arrive at TokenClaimsConverter even though the JWT
+    // did not carry them. This is what unblocks group-based authorization for bearer calls.
+    assertThat(claimsCaptor.getValue())
+        .containsEntry("sub", "alice")
+        .containsEntry("groups", List.of("engineering"));
+
+    wireMock.verify(exactly(1), getRequestedFor(urlMatching(".*/userinfo")));
+  }
+
+  @Test
+  void userInfoIsCalledOnlyOncePerTokenWithinTtl() {
+    wireMock.stubFor(
+        get(urlMatching(".*/userinfo"))
+            .willReturn(okJson("{\"sub\":\"alice\",\"groups\":[\"engineering\"]}")));
+
+    final var jwt =
+        Jwt.withTokenValue("token-cached")
+            .header("alg", "RS256")
+            .claim("sub", "alice")
+            .claim("iss", "http://localhost:" + wireMock.getPort() + "/issuer")
+            .claim("jti", "jti-cached")
+            .claim("exp", Instant.now().getEpochSecond() + 3600)
+            .build();
+
+    Mockito.when(tokenClaimsConverter.convert(Mockito.any()))
+        .thenReturn(CamundaAuthentication.of(b -> b.user("alice")));
+
+    for (int i = 0; i < 50; i++) {
+      converter.convert(new JwtAuthenticationToken(jwt));
+    }
+
+    // This is the performance acceptance criterion: under a burst of bearer requests with the
+    // same token, we must not hammer the IdP — Caffeine serves subsequent calls from cache.
+    wireMock.verify(exactly(1), getRequestedFor(urlMatching(".*/userinfo")));
+  }
+
+  @Test
+  void distinctTokensEachTriggerOneUserInfoCall() {
+    wireMock.stubFor(
+        get(urlMatching(".*/userinfo"))
+            .willReturn(okJson("{\"sub\":\"alice\",\"groups\":[\"engineering\"]}")));
+
+    Mockito.when(tokenClaimsConverter.convert(Mockito.any()))
+        .thenReturn(CamundaAuthentication.of(b -> b.user("alice")));
+
+    final long exp = Instant.now().getEpochSecond() + 3600;
+    for (int i = 0; i < 3; i++) {
+      final var jwt =
+          Jwt.withTokenValue("token-" + i)
+              .header("alg", "RS256")
+              .claim("sub", "alice")
+              .claim("iss", "http://localhost:" + wireMock.getPort() + "/issuer")
+              .claim("jti", "jti-" + i)
+              .claim("exp", exp)
+              .build();
+      converter.convert(new JwtAuthenticationToken(jwt));
+    }
+
+    wireMock.verify(exactly(3), getRequestedFor(urlMatching(".*/userinfo")));
+  }
+}
+```
+
+- [ ] **Step 3: Run the tests — expect initial failures**
+
+Run: `mvn -pl authentication test -Dtest='OidcBearerUserInfoAugmentation*IT'`
+
+Expected: the two tests in the `Disabled` class may pass already (the `doesNotContainKey("groups")` assertion holds with `NoopOidcClaimsProvider`). The three tests in the `Enabled` class should FAIL until Spring wiring resolves the userinfo URI and the `CachingOidcClaimsProvider` bean activates.
+
+- [ ] **Step 4: Fix any wiring gaps surfaced by the tests**
+
+Most likely issues:
+- Property binding for the nested `user-info-augmentation` group — Spring's relaxed binding should accept both camelCase and kebab-case; check `OidcUserInfoAugmentationConfiguration` isn't missing a getter.
+- `AbstractWebSecurityConfigTest` may need `OidcClaimsProvider` registered explicitly — verify by looking at how `TokenClaimsConverter` is wired into the existing test context (`WebSecurityOidcTestContext`).
+- If `oidcClaimsProvider` bean throws at startup because there's no `userinfo_endpoint` in the discovery doc, ensure the WireMock stub in `@DynamicPropertySource` registers the discovery doc BEFORE the Spring context boots the bean. The existing test's `wireMock.getRuntimeInfo().getWireMock().register(...)` pattern works because it runs inside `@DynamicPropertySource` which fires before context creation.
+
+Make minimal fixes only.
+
+- [ ] **Step 5: Re-run, expect pass**
+
+Run: `mvn -pl authentication test -Dtest='OidcBearerUserInfoAugmentation*IT'`
+
+Expected: all five tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add authentication/src/test/java/io/camunda/authentication/oidc/OidcBearerUserInfoAugmentationDisabledIT.java \
+        authentication/src/test/java/io/camunda/authentication/oidc/OidcBearerUserInfoAugmentationEnabledIT.java
+git commit -m "test(authentication): integration tests for OIDC userinfo groups-claim augmentation"
+```
+
+---
+
+## Task 8: Documentation and configuration reference
+
+**Files:**
+- Modify: `dist/src/main/config/application.yaml` (or the closest canonical config reference file — check with `ls dist/src/main/config/`)
+- Modify: `docs/` (if Camunda keeps config docs in-repo — check under `docs/self-managed/` or similar)
+
+- [ ] **Step 1: Document the three new properties in the canonical config reference**
+
+Add to the OIDC section:
+
+```yaml
+camunda:
+  security:
+    authentication:
+      oidc:
+        # ... existing config ...
+        userInfoAugmentation:
+          # Enable merging of OIDC UserInfo response claims onto the JWT access
+          # token claims for bearer-authenticated API requests. Required when
+          # authorization claims (groups, roles, tenants) only appear in the
+          # /userinfo response and cannot be added to the JWT access token
+          # issued by the Identity Provider. When disabled, bearer requests
+          # use only the JWT claims.
+          enabled: false
+          # Maximum age of a cached UserInfo response before the IdP is called
+          # again. Effective TTL is min(cacheTtl, tokenExp - clockSkew - now)
+          # so the cache never outlives the bearer token.
+          cacheTtl: PT5M
+          # Hard upper bound on cached entries. Cache is keyed by JWT 'jti'
+          # (or SHA-256 of the raw token if 'jti' is absent), so this bounds
+          # memory under high bearer-token churn.
+          cacheMaxSize: 10000
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add dist/src/main/config/application.yaml
+git commit -m "docs(config): document OIDC userinfo augmentation properties"
+```
+
+---
+
+## Out of scope (flag for review)
+
+- **Multi-provider userinfo URI selection:** the bean in Task 5 picks the first configured issuer's userinfo URI. Single-provider setups are fine; multi-provider selection by `iss` claim is a follow-up.
+- **Discovery document caching:** we build the userinfo URI by appending `/userinfo` to the issuer URI. Strictly per-OIDC-spec the URI should be read from the discovery document. In practice this works for all major IdPs. Flag if the customer's IdP uses a non-standard userinfo path.
+- **`OidcUserAuthenticationConverter` (webapp flow):** intentionally untouched. It already handles userinfo via Spring's OIDC login; this plan is only about bearer flow.
+- **Backward compatibility:** `OidcTokenAuthenticationConverter`'s one-arg constructor is removed. If any out-of-tree code or tests instantiate it directly, they'll need updating. Search confirms only the `WebSecurityConfig` bean and tests use it.
+
+---
+
+## Risks and review focus
+
+- **gRPC hot path latency:** the Caffeine `getIfPresent` + `put` is lock-free and sub-microsecond; the network call on cache miss is the real cost. Worker patterns (same token for 30 minutes) mean ~1 userinfo call per worker per 30 min, not per request. Reviewer should sanity-check this against the customer's worker count vs. IdP rate limits.
+- **Fail-closed choice:** when userinfo fails, we reject the request. Alternative is fall-back to JWT-only claims — but that silently downgrades authorization and is a bigger security surprise. Recommend keeping fail-closed, but open to discussion for specific environments.
+- **`NEGATIVE_CACHE_TTL = 5s`:** hard-coded. Worth making configurable? I'd lean no — it's an implementation defence against IdP outages, not a product lever.
+- **Metric naming:** `camunda.oidc.userinfo.cache` and `camunda.oidc.userinfo.fetch`. Check against Camunda's micrometer naming convention — alignment may require adjustment.

--- a/docs/superpowers/plans/2026-04-20-oidc-userinfo-claim-augmentation.md
+++ b/docs/superpowers/plans/2026-04-20-oidc-userinfo-claim-augmentation.md
@@ -1387,11 +1387,13 @@ In `zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/Gateway.java`:
 
 1. Add import: `import io.camunda.security.oidc.OidcClaimsProvider;`
 2. Add field near `private final JwtDecoder jwtDecoder;` (line 100):
+
    ```java
    private final OidcClaimsProvider oidcClaimsProvider;
    ```
 3. Update every constructor to take an `OidcClaimsProvider` parameter and assign it. Mirror the pattern used for `jwtDecoder` at lines 112, 135, 145.
 4. In `applyInterceptors()` (line 418), update:
+
    ```java
    case OIDC ->
        new AuthenticationHandler.Oidc(
@@ -1866,3 +1868,4 @@ git commit -m "docs(config): document OIDC userinfo augmentation properties"
 - **Fail-closed choice:** when userinfo fails, we reject the request. Alternative is fall-back to JWT-only claims — but that silently downgrades authorization and is a bigger security surprise. Recommend keeping fail-closed, but open to discussion for specific environments.
 - **`NEGATIVE_CACHE_TTL = 5s`:** hard-coded. Worth making configurable? I'd lean no — it's an implementation defence against IdP outages, not a product lever.
 - **Metric naming:** `camunda.oidc.userinfo.cache` and `camunda.oidc.userinfo.fetch`. Check against Camunda's micrometer naming convention — alignment may require adjustment.
+

--- a/security/security-core/pom.xml
+++ b/security/security-core/pom.xml
@@ -45,6 +45,10 @@
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>

--- a/security/security-core/pom.xml
+++ b/security/security-core/pom.xml
@@ -52,6 +52,14 @@
       <artifactId>json-path</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
@@ -79,6 +87,11 @@
     <dependency>
       <groupId>org.wiremock</groupId>
       <artifactId>wiremock-standalone</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/security/security-core/pom.xml
+++ b/security/security-core/pom.xml
@@ -44,6 +44,10 @@
       <artifactId>jackson-annotations</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.jayway.jsonpath</groupId>
       <artifactId>json-path</artifactId>
     </dependency>
@@ -70,6 +74,11 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock-standalone</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
@@ -56,6 +56,8 @@ public class OidcAuthenticationConfiguration {
   private AssertionConfiguration assertionConfiguration = new AssertionConfiguration();
   private Duration clockSkew = DEFAULT_CLOCK_SKEW;
   private boolean userInfoEnabled = true;
+  private OidcUserInfoAugmentationConfiguration userInfoAugmentation =
+      new OidcUserInfoAugmentationConfiguration();
 
   @PostConstruct
   public void validate() {
@@ -268,6 +270,15 @@ public class OidcAuthenticationConfiguration {
     this.userInfoEnabled = userInfoEnabled;
   }
 
+  public OidcUserInfoAugmentationConfiguration getUserInfoAugmentation() {
+    return userInfoAugmentation;
+  }
+
+  public void setUserInfoAugmentation(
+      final OidcUserInfoAugmentationConfiguration userInfoAugmentation) {
+    this.userInfoAugmentation = userInfoAugmentation;
+  }
+
   public boolean isSet() {
     return issuerUri != null
         || clientId != null
@@ -332,6 +343,8 @@ public class OidcAuthenticationConfiguration {
     private AssertionConfiguration assertionConfiguration = new AssertionConfiguration();
     private Duration clockSkew = DEFAULT_CLOCK_SKEW;
     private boolean userInfoEnabled = true;
+    private OidcUserInfoAugmentationConfiguration userInfoAugmentation =
+        new OidcUserInfoAugmentationConfiguration();
 
     public Builder issuerUri(final String issuerUri) {
       this.issuerUri = issuerUri;
@@ -455,6 +468,12 @@ public class OidcAuthenticationConfiguration {
       return this;
     }
 
+    public Builder userInfoAugmentation(
+        final OidcUserInfoAugmentationConfiguration userInfoAugmentation) {
+      this.userInfoAugmentation = userInfoAugmentation;
+      return this;
+    }
+
     public OidcAuthenticationConfiguration build() {
       final OidcAuthenticationConfiguration config = new OidcAuthenticationConfiguration();
       config.setIssuerUri(issuerUri);
@@ -481,6 +500,7 @@ public class OidcAuthenticationConfiguration {
       config.setAssertion(assertionConfiguration);
       config.setClockSkew(clockSkew);
       config.setUserInfoEnabled(userInfoEnabled);
+      config.setUserInfoAugmentation(userInfoAugmentation);
       return config;
     }
   }

--- a/security/security-core/src/main/java/io/camunda/security/configuration/OidcUserInfoAugmentationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/OidcUserInfoAugmentationConfiguration.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.configuration;
+
+import java.time.Duration;
+
+public class OidcUserInfoAugmentationConfiguration {
+
+  public static final Duration DEFAULT_CACHE_TTL = Duration.ofMinutes(5);
+  public static final int DEFAULT_CACHE_MAX_SIZE = 10_000;
+  public static final Duration NEGATIVE_CACHE_TTL = Duration.ofSeconds(5);
+
+  private boolean enabled = false;
+  private Duration cacheTtl = DEFAULT_CACHE_TTL;
+  private int cacheMaxSize = DEFAULT_CACHE_MAX_SIZE;
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(final boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public Duration getCacheTtl() {
+    return cacheTtl;
+  }
+
+  public void setCacheTtl(final Duration cacheTtl) {
+    this.cacheTtl = cacheTtl;
+  }
+
+  public int getCacheMaxSize() {
+    return cacheMaxSize;
+  }
+
+  public void setCacheMaxSize(final int cacheMaxSize) {
+    this.cacheMaxSize = cacheMaxSize;
+  }
+}

--- a/security/security-core/src/main/java/io/camunda/security/oidc/CachingOidcClaimsProvider.java
+++ b/security/security-core/src/main/java/io/camunda/security/oidc/CachingOidcClaimsProvider.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.oidc;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Expiry;
+import io.camunda.security.configuration.OidcAuthenticationConfiguration;
+import io.camunda.security.configuration.OidcUserInfoAugmentationConfiguration;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.HexFormat;
+import java.util.Map;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Caching {@link OidcClaimsProvider} that, when UserInfo augmentation is enabled, calls the OIDC
+ * UserInfo endpoint on cache miss, merges its response onto the JWT claims (UserInfo wins on
+ * conflict), and caches by {@code jti} (falling back to SHA-256 of the token). Fails closed on
+ * UserInfo errors and negatively caches failures to avoid hammering a down IdP.
+ */
+public class CachingOidcClaimsProvider implements OidcClaimsProvider {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CachingOidcClaimsProvider.class);
+  private static final String CACHE_METRIC = "camunda.oidc.userinfo.cache";
+  private static final String FETCH_METRIC = "camunda.oidc.userinfo.fetch";
+
+  private final OidcAuthenticationConfiguration oidcConfig;
+  private final URI userInfoUri;
+  private final OidcUserInfoClient userInfoClient;
+  private final Cache<String, CacheEntry> cache;
+  private final Counter hitCounter;
+  private final Counter missCounter;
+  private final Timer fetchTimer;
+  private final Counter fetchFailureCounter;
+  private final Duration clockSkew;
+
+  public CachingOidcClaimsProvider(
+      final OidcAuthenticationConfiguration oidcConfig,
+      final URI userInfoUri,
+      final OidcUserInfoClient userInfoClient,
+      final MeterRegistry meterRegistry) {
+    this.oidcConfig = Objects.requireNonNull(oidcConfig);
+    this.userInfoUri = userInfoUri; // may be null if augmentation disabled
+    this.userInfoClient = Objects.requireNonNull(userInfoClient);
+    clockSkew = oidcConfig.getClockSkew();
+    final OidcUserInfoAugmentationConfiguration aug = oidcConfig.getUserInfoAugmentation();
+    cache =
+        Caffeine.newBuilder()
+            .maximumSize(aug.getCacheMaxSize())
+            .expireAfter(new EntryExpiry(aug.getCacheTtl()))
+            .build();
+    hitCounter = Counter.builder(CACHE_METRIC).tag("result", "hit").register(meterRegistry);
+    missCounter = Counter.builder(CACHE_METRIC).tag("result", "miss").register(meterRegistry);
+    fetchTimer = Timer.builder(FETCH_METRIC).register(meterRegistry);
+    fetchFailureCounter =
+        Counter.builder(FETCH_METRIC).tag("outcome", "failure").register(meterRegistry);
+  }
+
+  @Override
+  public Map<String, Object> claimsFor(
+      final Map<String, Object> jwtClaims, final String tokenValue) {
+    if (!oidcConfig.getUserInfoAugmentation().isEnabled()) {
+      return jwtClaims;
+    }
+    if (userInfoUri == null) {
+      throw new OidcUserInfoException(
+          "UserInfo augmentation is enabled but no userinfo URI is available for this provider");
+    }
+
+    final String key = cacheKey(jwtClaims, tokenValue);
+    final CacheEntry cached = cache.getIfPresent(key);
+    if (cached != null) {
+      hitCounter.increment();
+      if (cached.failure() != null) {
+        throw cached.failure();
+      }
+      return cached.claims();
+    }
+    missCounter.increment();
+
+    final Map<String, Object> merged;
+    try {
+      final Map<String, Object> userInfoClaims =
+          fetchTimer.recordCallable(() -> userInfoClient.fetch(userInfoUri, tokenValue));
+      merged = merge(jwtClaims, userInfoClaims);
+    } catch (final OidcUserInfoException e) {
+      fetchFailureCounter.increment();
+      LOG.debug("UserInfo fetch failed; caching negative entry", e);
+      cache.put(key, CacheEntry.failure(e));
+      throw e;
+    } catch (final Exception e) {
+      fetchFailureCounter.increment();
+      final var wrapped = new OidcUserInfoException("UserInfo fetch failed: " + e.getMessage(), e);
+      cache.put(key, CacheEntry.failure(wrapped));
+      throw wrapped;
+    }
+
+    cache.put(key, CacheEntry.success(merged, tokenExpiry(jwtClaims)));
+    return merged;
+  }
+
+  private static Map<String, Object> merge(
+      final Map<String, Object> jwtClaims, final Map<String, Object> userInfoClaims) {
+    final Map<String, Object> merged = new HashMap<>(jwtClaims);
+    merged.putAll(userInfoClaims); // userinfo wins on conflict
+    return Map.copyOf(merged);
+  }
+
+  private static String cacheKey(final Map<String, Object> jwtClaims, final String tokenValue) {
+    final Object jti = jwtClaims.get("jti");
+    if (jti instanceof final String s && !s.isBlank()) {
+      return "jti:" + s;
+    }
+    return "tok:" + sha256(tokenValue);
+  }
+
+  private static String sha256(final String input) {
+    try {
+      final MessageDigest md = MessageDigest.getInstance("SHA-256");
+      return HexFormat.of().formatHex(md.digest(input.getBytes(StandardCharsets.UTF_8)));
+    } catch (final Exception e) {
+      throw new IllegalStateException("SHA-256 unavailable", e);
+    }
+  }
+
+  private static Instant tokenExpiry(final Map<String, Object> jwtClaims) {
+    final Object exp = jwtClaims.get("exp");
+    if (exp instanceof Number n) {
+      return Instant.ofEpochSecond(n.longValue());
+    }
+    return Instant.now().plus(Duration.ofMinutes(5));
+  }
+
+  private record CacheEntry(
+      Map<String, Object> claims, OidcUserInfoException failure, Instant tokenExp) {
+
+    static CacheEntry success(final Map<String, Object> claims, final Instant tokenExp) {
+      return new CacheEntry(claims, null, tokenExp);
+    }
+
+    static CacheEntry failure(final OidcUserInfoException e) {
+      return new CacheEntry(null, e, null);
+    }
+  }
+
+  /**
+   * Caffeine {@link Expiry} that expires successful entries at min(configured TTL, token exp − skew
+   * − now) and uses a short fixed TTL for failure entries.
+   */
+  private final class EntryExpiry implements Expiry<String, CacheEntry> {
+    private final Duration configuredTtl;
+
+    EntryExpiry(final Duration configuredTtl) {
+      this.configuredTtl = configuredTtl;
+    }
+
+    @Override
+    public long expireAfterCreate(
+        final String key, final CacheEntry value, final long currentTime) {
+      return ttlNanos(value);
+    }
+
+    @Override
+    public long expireAfterUpdate(
+        final String key,
+        final CacheEntry value,
+        final long currentTime,
+        final long currentDuration) {
+      return ttlNanos(value);
+    }
+
+    @Override
+    public long expireAfterRead(
+        final String key,
+        final CacheEntry value,
+        final long currentTime,
+        final long currentDuration) {
+      return currentDuration;
+    }
+
+    private long ttlNanos(final CacheEntry value) {
+      if (value.failure() != null) {
+        return OidcUserInfoAugmentationConfiguration.NEGATIVE_CACHE_TTL.toNanos();
+      }
+      final Duration untilExp = Duration.between(Instant.now(), value.tokenExp()).minus(clockSkew);
+      final Duration effective =
+          untilExp.isNegative() || untilExp.isZero() || untilExp.compareTo(configuredTtl) < 0
+              ? untilExp
+              : configuredTtl;
+      if (effective.isNegative() || effective.isZero()) {
+        return 0L;
+      }
+      return effective.toNanos();
+    }
+  }
+}

--- a/security/security-core/src/main/java/io/camunda/security/oidc/NoopOidcClaimsProvider.java
+++ b/security/security-core/src/main/java/io/camunda/security/oidc/NoopOidcClaimsProvider.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.oidc;
+
+import java.util.Map;
+
+/**
+ * Pass-through {@link OidcClaimsProvider}. Returns the JWT claims unchanged without calling the
+ * UserInfo endpoint. Used when UserInfo augmentation is disabled or unavailable.
+ */
+public class NoopOidcClaimsProvider implements OidcClaimsProvider {
+
+  @Override
+  public Map<String, Object> claimsFor(
+      final Map<String, Object> jwtClaims, final String tokenValue) {
+    return jwtClaims;
+  }
+}

--- a/security/security-core/src/main/java/io/camunda/security/oidc/OidcClaimsProvider.java
+++ b/security/security-core/src/main/java/io/camunda/security/oidc/OidcClaimsProvider.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.oidc;
+
+import java.util.Map;
+
+/**
+ * Resolves the final claims map used for authorization from a validated JWT's claims and the raw
+ * token value. Implementations may augment the JWT claims with the OIDC UserInfo response, subject
+ * to provider-specific configuration and caching.
+ */
+public interface OidcClaimsProvider {
+
+  /**
+   * @param jwtClaims the claims as extracted from the validated JWT access token
+   * @param tokenValue the raw bearer token string (needed if UserInfo must be called)
+   * @return the claims map to be used for principal and authorization resolution
+   * @throws OidcUserInfoException if UserInfo augmentation is required but the IdP call fails
+   */
+  Map<String, Object> claimsFor(Map<String, Object> jwtClaims, String tokenValue);
+}

--- a/security/security-core/src/main/java/io/camunda/security/oidc/OidcUserInfoClient.java
+++ b/security/security-core/src/main/java/io/camunda/security/oidc/OidcUserInfoClient.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.oidc;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Thin wrapper around {@link HttpClient} for calling an OIDC provider's UserInfo endpoint with a
+ * bearer token and parsing the JSON response into a claim map.
+ */
+public class OidcUserInfoClient {
+
+  private static final TypeReference<Map<String, Object>> CLAIMS_TYPE = new TypeReference<>() {};
+
+  private final HttpClient httpClient;
+  private final ObjectMapper objectMapper;
+  private final Duration requestTimeout;
+
+  public OidcUserInfoClient(final HttpClient httpClient, final Duration requestTimeout) {
+    this.httpClient = Objects.requireNonNull(httpClient);
+    this.requestTimeout = Objects.requireNonNull(requestTimeout);
+    objectMapper = new ObjectMapper();
+  }
+
+  public Map<String, Object> fetch(final URI userInfoUri, final String bearerToken) {
+    final HttpRequest request =
+        HttpRequest.newBuilder(userInfoUri)
+            .timeout(requestTimeout)
+            .header("Authorization", "Bearer " + bearerToken)
+            .header("Accept", "application/json")
+            .GET()
+            .build();
+
+    final HttpResponse<byte[]> response;
+    try {
+      response = httpClient.send(request, HttpResponse.BodyHandlers.ofByteArray());
+    } catch (final Exception e) {
+      throw new OidcUserInfoException("UserInfo request failed: " + e.getMessage(), e);
+    }
+
+    if (response.statusCode() / 100 != 2) {
+      throw new OidcUserInfoException("UserInfo request returned HTTP " + response.statusCode());
+    }
+
+    try {
+      return objectMapper.readValue(response.body(), CLAIMS_TYPE);
+    } catch (final Exception e) {
+      throw new OidcUserInfoException("Failed to parse UserInfo JSON: " + e.getMessage(), e);
+    }
+  }
+}

--- a/security/security-core/src/main/java/io/camunda/security/oidc/OidcUserInfoException.java
+++ b/security/security-core/src/main/java/io/camunda/security/oidc/OidcUserInfoException.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.oidc;
+
+public class OidcUserInfoException extends RuntimeException {
+
+  public OidcUserInfoException(final String message) {
+    super(message);
+  }
+
+  public OidcUserInfoException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/security/security-core/src/test/java/io/camunda/security/configuration/OidcUserInfoAugmentationConfigurationTest.java
+++ b/security/security-core/src/test/java/io/camunda/security/configuration/OidcUserInfoAugmentationConfigurationTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+class OidcUserInfoAugmentationConfigurationTest {
+
+  @Test
+  void defaultsAreDisabledWithFiveMinuteTtlAndTenThousandEntries() {
+    final var config = new OidcUserInfoAugmentationConfiguration();
+
+    assertThat(config.isEnabled()).isFalse();
+    assertThat(config.getCacheTtl()).isEqualTo(Duration.ofMinutes(5));
+    assertThat(config.getCacheMaxSize()).isEqualTo(10_000);
+  }
+
+  @Test
+  void oidcAuthenticationConfigurationExposesNonNullAugmentationByDefault() {
+    final var oidc = new OidcAuthenticationConfiguration();
+
+    assertThat(oidc.getUserInfoAugmentation()).isNotNull();
+    assertThat(oidc.getUserInfoAugmentation().isEnabled()).isFalse();
+  }
+}

--- a/security/security-core/src/test/java/io/camunda/security/oidc/CachingOidcClaimsProviderTest.java
+++ b/security/security-core/src/test/java/io/camunda/security/oidc/CachingOidcClaimsProviderTest.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.oidc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.security.configuration.OidcAuthenticationConfiguration;
+import io.camunda.security.configuration.OidcUserInfoAugmentationConfiguration;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class CachingOidcClaimsProviderTest {
+
+  private OidcAuthenticationConfiguration oidcConfig;
+  private OidcUserInfoClient userInfoClient;
+  private SimpleMeterRegistry meterRegistry;
+
+  @BeforeEach
+  void setUp() {
+    oidcConfig = new OidcAuthenticationConfiguration();
+    oidcConfig.setIssuerUri("https://idp.example");
+    final var aug = new OidcUserInfoAugmentationConfiguration();
+    aug.setEnabled(true);
+    aug.setCacheTtl(Duration.ofMinutes(5));
+    aug.setCacheMaxSize(100);
+    oidcConfig.setUserInfoAugmentation(aug);
+    userInfoClient = mock(OidcUserInfoClient.class);
+    meterRegistry = new SimpleMeterRegistry();
+  }
+
+  @Test
+  void returnsJwtClaimsUnchangedWhenAugmentationDisabled() {
+    oidcConfig.getUserInfoAugmentation().setEnabled(false);
+    final var provider =
+        new CachingOidcClaimsProvider(
+            oidcConfig, URI.create("https://idp.example/userinfo"), userInfoClient, meterRegistry);
+
+    final Map<String, Object> jwtClaims = Map.of("sub", "alice");
+    final var result = provider.claimsFor(jwtClaims, "token-abc");
+
+    assertThat(result).isSameAs(jwtClaims);
+    verify(userInfoClient, times(0)).fetch(any(), any());
+  }
+
+  @Test
+  void callsUserInfoOnceAndMergesClaimsOverJwt() {
+    when(userInfoClient.fetch(any(), eq("token-abc")))
+        .thenReturn(Map.of("groups", List.of("eng"), "sub", "alice-from-userinfo"));
+
+    final var provider =
+        new CachingOidcClaimsProvider(
+            oidcConfig, URI.create("https://idp.example/userinfo"), userInfoClient, meterRegistry);
+
+    final Map<String, Object> jwtClaims =
+        Map.of("sub", "alice", "jti", "jti-1", "exp", Instant.now().getEpochSecond() + 3600);
+
+    final var result = provider.claimsFor(jwtClaims, "token-abc");
+
+    assertThat(result).containsEntry("groups", List.of("eng"));
+    assertThat(result).containsEntry("sub", "alice-from-userinfo"); // userinfo overrides
+    assertThat(result).containsEntry("jti", "jti-1"); // jwt-only claim preserved
+    verify(userInfoClient, times(1)).fetch(any(), any());
+  }
+
+  @Test
+  void cachesByJtiSoSecondCallDoesNotHitIdp() {
+    when(userInfoClient.fetch(any(), any())).thenReturn(Map.of("groups", List.of("eng")));
+
+    final var provider =
+        new CachingOidcClaimsProvider(
+            oidcConfig, URI.create("https://idp.example/userinfo"), userInfoClient, meterRegistry);
+
+    final Map<String, Object> jwtClaims =
+        Map.of("sub", "alice", "jti", "jti-1", "exp", Instant.now().getEpochSecond() + 3600);
+
+    provider.claimsFor(jwtClaims, "token-abc");
+    provider.claimsFor(jwtClaims, "token-abc");
+
+    verify(userInfoClient, times(1)).fetch(any(), any());
+  }
+
+  @Test
+  void distinctJtisResultInDistinctCacheEntries() {
+    when(userInfoClient.fetch(any(), any())).thenReturn(Map.of("groups", List.of("eng")));
+
+    final var provider =
+        new CachingOidcClaimsProvider(
+            oidcConfig, URI.create("https://idp.example/userinfo"), userInfoClient, meterRegistry);
+
+    final long exp = Instant.now().getEpochSecond() + 3600;
+    provider.claimsFor(Map.of("sub", "alice", "jti", "jti-1", "exp", exp), "token-a");
+    provider.claimsFor(Map.of("sub", "alice", "jti", "jti-2", "exp", exp), "token-b");
+
+    verify(userInfoClient, times(2)).fetch(any(), any());
+  }
+
+  @Test
+  void fallsBackToTokenHashWhenJtiAbsent() {
+    when(userInfoClient.fetch(any(), any())).thenReturn(Map.of("groups", List.of("eng")));
+
+    final var provider =
+        new CachingOidcClaimsProvider(
+            oidcConfig, URI.create("https://idp.example/userinfo"), userInfoClient, meterRegistry);
+
+    final long exp = Instant.now().getEpochSecond() + 3600;
+    final Map<String, Object> claimsNoJti = Map.of("sub", "alice", "exp", exp);
+
+    provider.claimsFor(claimsNoJti, "token-abc");
+    provider.claimsFor(claimsNoJti, "token-abc"); // same token -> same cache entry
+    provider.claimsFor(claimsNoJti, "token-xyz"); // different token -> new entry
+
+    verify(userInfoClient, times(2)).fetch(any(), any());
+  }
+
+  @Test
+  void failsClosedWhenUserInfoThrows() {
+    when(userInfoClient.fetch(any(), any())).thenThrow(new OidcUserInfoException("boom"));
+
+    final var provider =
+        new CachingOidcClaimsProvider(
+            oidcConfig, URI.create("https://idp.example/userinfo"), userInfoClient, meterRegistry);
+
+    final Map<String, Object> jwtClaims =
+        Map.of("sub", "alice", "jti", "jti-1", "exp", Instant.now().getEpochSecond() + 3600);
+
+    assertThatThrownBy(() -> provider.claimsFor(jwtClaims, "token-abc"))
+        .isInstanceOf(OidcUserInfoException.class);
+  }
+
+  @Test
+  void negativeCachePreventsHammeringDuringOutage() {
+    when(userInfoClient.fetch(any(), any())).thenThrow(new OidcUserInfoException("IdP down"));
+
+    final var provider =
+        new CachingOidcClaimsProvider(
+            oidcConfig, URI.create("https://idp.example/userinfo"), userInfoClient, meterRegistry);
+
+    final Map<String, Object> jwtClaims =
+        Map.of("sub", "alice", "jti", "jti-1", "exp", Instant.now().getEpochSecond() + 3600);
+
+    for (int i = 0; i < 20; i++) {
+      try {
+        provider.claimsFor(jwtClaims, "token-abc");
+      } catch (final OidcUserInfoException ignored) {
+        // expected
+      }
+    }
+
+    verify(userInfoClient, times(1)).fetch(any(), any());
+  }
+
+  @Test
+  void ttlIsCappedByTokenExpiry() {
+    when(userInfoClient.fetch(any(), any())).thenReturn(Map.of("groups", List.of("eng")));
+
+    oidcConfig.getUserInfoAugmentation().setCacheTtl(Duration.ofHours(1));
+    final var provider =
+        new CachingOidcClaimsProvider(
+            oidcConfig, URI.create("https://idp.example/userinfo"), userInfoClient, meterRegistry);
+
+    // exp is far enough in the past that after clockSkew the effective TTL is <= 0
+    final long expPast = Instant.now().minusSeconds(120).getEpochSecond();
+    final Map<String, Object> expired = Map.of("sub", "alice", "jti", "jti-1", "exp", expPast);
+
+    provider.claimsFor(expired, "token-abc");
+    provider.claimsFor(expired, "token-abc");
+
+    // Entry expired immediately, both calls should hit the IdP
+    verify(userInfoClient, times(2)).fetch(any(), any());
+  }
+
+  @Test
+  void exposesHitAndMissCounters() {
+    when(userInfoClient.fetch(any(), any())).thenReturn(Map.of("groups", List.of("eng")));
+
+    final var provider =
+        new CachingOidcClaimsProvider(
+            oidcConfig, URI.create("https://idp.example/userinfo"), userInfoClient, meterRegistry);
+
+    final Map<String, Object> jwtClaims =
+        Map.of("sub", "alice", "jti", "jti-1", "exp", Instant.now().getEpochSecond() + 3600);
+
+    provider.claimsFor(jwtClaims, "token-abc"); // miss
+    provider.claimsFor(jwtClaims, "token-abc"); // hit
+
+    assertThat(
+            meterRegistry
+                .get("camunda.oidc.userinfo.cache")
+                .tag("result", "miss")
+                .counter()
+                .count())
+        .isEqualTo(1.0);
+    assertThat(
+            meterRegistry.get("camunda.oidc.userinfo.cache").tag("result", "hit").counter().count())
+        .isEqualTo(1.0);
+  }
+}

--- a/security/security-core/src/test/java/io/camunda/security/oidc/NoopOidcClaimsProviderTest.java
+++ b/security/security-core/src/test/java/io/camunda/security/oidc/NoopOidcClaimsProviderTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.oidc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class NoopOidcClaimsProviderTest {
+
+  @Test
+  void returnsJwtClaimsUnchanged() {
+    final var provider = new NoopOidcClaimsProvider();
+    final var input = Map.<String, Object>of("sub", "alice", "iss", "https://idp.example");
+
+    final var output = provider.claimsFor(input, "token-abc");
+
+    assertThat(output).isSameAs(input);
+  }
+}

--- a/security/security-core/src/test/java/io/camunda/security/oidc/OidcUserInfoClientTest.java
+++ b/security/security-core/src/test/java/io/camunda/security/oidc/OidcUserInfoClientTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.oidc;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class OidcUserInfoClientTest {
+
+  @RegisterExtension
+  static WireMockExtension idp =
+      WireMockExtension.newInstance().options(wireMockConfig().dynamicPort()).build();
+
+  private final OidcUserInfoClient client =
+      new OidcUserInfoClient(HttpClient.newHttpClient(), Duration.ofSeconds(2));
+
+  @Test
+  void returnsClaimsFromSuccessfulResponse() {
+    idp.stubFor(
+        get("/userinfo")
+            .withHeader("Authorization", equalTo("Bearer token-abc"))
+            .willReturn(okJson("{\"sub\":\"alice\",\"groups\":[\"engineering\",\"ops\"]}")));
+
+    final var claims = client.fetch(URI.create(idp.baseUrl() + "/userinfo"), "token-abc");
+
+    assertThat(claims).containsEntry("sub", "alice");
+    assertThat(claims).containsEntry("groups", List.of("engineering", "ops"));
+  }
+
+  @Test
+  void throwsOnNon2xx() {
+    idp.stubFor(get("/userinfo").willReturn(aResponse().withStatus(401)));
+
+    assertThatThrownBy(() -> client.fetch(URI.create(idp.baseUrl() + "/userinfo"), "bad-token"))
+        .isInstanceOf(OidcUserInfoException.class)
+        .hasMessageContaining("401");
+  }
+
+  @Test
+  void throwsOnTimeout() {
+    idp.stubFor(get("/userinfo").willReturn(aResponse().withFixedDelay(3_000).withBody("{}")));
+
+    assertThatThrownBy(() -> client.fetch(URI.create(idp.baseUrl() + "/userinfo"), "token-abc"))
+        .isInstanceOf(OidcUserInfoException.class);
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -90,6 +90,7 @@ public final class Broker implements AutoCloseable {
             systemContext.getUserServices(),
             systemContext.getPasswordEncoder(),
             systemContext.getJwtDecoder(),
+            systemContext.getOidcClaimsProvider(),
             systemContext.getSearchClientsProxy(),
             systemContext.getBrokerRequestAuthorizationConverter());
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
@@ -12,6 +12,7 @@ import io.camunda.identity.sdk.IdentityConfiguration;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.oidc.OidcClaimsProvider;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.PartitionRaftListener;
@@ -137,6 +138,8 @@ public interface BrokerStartupContext {
   PasswordEncoder getPasswordEncoder();
 
   JwtDecoder getJwtDecoder();
+
+  OidcClaimsProvider getOidcClaimsProvider();
 
   SnapshotApiRequestHandler getSnapshotApiRequestHandler();
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
@@ -15,6 +15,7 @@ import io.camunda.identity.sdk.IdentityConfiguration;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.oidc.OidcClaimsProvider;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.PartitionRaftListener;
@@ -67,6 +68,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   private final UserServices userServices;
   private final PasswordEncoder passwordEncoder;
   private final JwtDecoder jwtDecoder;
+  private final OidcClaimsProvider oidcClaimsProvider;
   private final SearchClientsProxy searchClientsProxy;
   private final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter;
 
@@ -101,6 +103,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
       final UserServices userServices,
       final PasswordEncoder passwordEncoder,
       final JwtDecoder jwtDecoder,
+      final OidcClaimsProvider oidcClaimsProvider,
       final SearchClientsProxy searchClientsProxy,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
 
@@ -119,6 +122,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
     this.userServices = userServices;
     this.passwordEncoder = passwordEncoder;
     this.jwtDecoder = jwtDecoder;
+    this.oidcClaimsProvider = oidcClaimsProvider;
     this.searchClientsProxy = searchClientsProxy;
     partitionListeners.addAll(additionalPartitionListeners);
     this.brokerRequestAuthorizationConverter = brokerRequestAuthorizationConverter;
@@ -140,6 +144,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
       final UserServices userServices,
       final PasswordEncoder passwordEncoder,
       final JwtDecoder jwtDecoder,
+      final OidcClaimsProvider oidcClaimsProvider,
       final SearchClientsProxy searchClientsProxy,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
 
@@ -160,6 +165,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
         userServices,
         passwordEncoder,
         jwtDecoder,
+        oidcClaimsProvider,
         searchClientsProxy,
         brokerRequestAuthorizationConverter);
   }
@@ -397,6 +403,11 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   @Override
   public JwtDecoder getJwtDecoder() {
     return jwtDecoder;
+  }
+
+  @Override
+  public OidcClaimsProvider getOidcClaimsProvider() {
+    return oidcClaimsProvider;
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/EmbeddedGatewayServiceStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/EmbeddedGatewayServiceStep.java
@@ -49,6 +49,7 @@ class EmbeddedGatewayServiceStep extends AbstractBrokerStartupStep {
             userService,
             passwordEncoder,
             brokerStartupContext.getJwtDecoder(),
+            brokerStartupContext.getOidcClaimsProvider(),
             brokerStartupContext.getMeterRegistry());
 
     final var embeddedGatewayServiceFuture = embeddedGatewayService.start();

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/EmbeddedGatewayService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/EmbeddedGatewayService.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.system;
 
 import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.oidc.OidcClaimsProvider;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
@@ -40,6 +41,7 @@ public final class EmbeddedGatewayService implements AutoCloseable {
       final UserServices userServices,
       final PasswordEncoder passwordEncoder,
       final JwtDecoder jwtDecoder,
+      final OidcClaimsProvider oidcClaimsProvider,
       final MeterRegistry meterRegistry) {
     this.concurrencyControl = concurrencyControl;
     this.brokerClient = brokerClient;
@@ -55,6 +57,7 @@ public final class EmbeddedGatewayService implements AutoCloseable {
             userServices,
             passwordEncoder,
             jwtDecoder,
+            oidcClaimsProvider,
             meterRegistry);
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -14,6 +14,7 @@ import io.camunda.identity.sdk.IdentityConfiguration;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.oidc.OidcClaimsProvider;
 import io.camunda.security.validation.AuthorizationValidator;
 import io.camunda.security.validation.GroupValidator;
 import io.camunda.security.validation.IdentifierValidator;
@@ -118,6 +119,7 @@ public final class SystemContext {
   private final UserServices userServices;
   private final PasswordEncoder passwordEncoder;
   private final JwtDecoder jwtDecoder;
+  private final OidcClaimsProvider oidcClaimsProvider;
   private final SearchClientsProxy searchClientsProxy;
   private final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter;
 
@@ -133,6 +135,7 @@ public final class SystemContext {
       final UserServices userServices,
       final PasswordEncoder passwordEncoder,
       final JwtDecoder jwtDecoder,
+      final OidcClaimsProvider oidcClaimsProvider,
       final SearchClientsProxy searchClientsProxy,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     this.shutdownTimeout = shutdownTimeout;
@@ -146,6 +149,7 @@ public final class SystemContext {
     this.userServices = userServices;
     this.passwordEncoder = passwordEncoder;
     this.jwtDecoder = jwtDecoder;
+    this.oidcClaimsProvider = oidcClaimsProvider;
     this.searchClientsProxy = searchClientsProxy;
     this.brokerRequestAuthorizationConverter = brokerRequestAuthorizationConverter;
     initSystemContext();
@@ -161,6 +165,7 @@ public final class SystemContext {
       final UserServices userServices,
       final PasswordEncoder passwordEncoder,
       final JwtDecoder jwtDecoder,
+      final OidcClaimsProvider oidcClaimsProvider,
       final SearchClientsProxy searchClientsProxy,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     this(
@@ -175,6 +180,7 @@ public final class SystemContext {
         userServices,
         passwordEncoder,
         jwtDecoder,
+        oidcClaimsProvider,
         searchClientsProxy,
         brokerRequestAuthorizationConverter);
   }
@@ -582,6 +588,10 @@ public final class SystemContext {
 
   public JwtDecoder getJwtDecoder() {
     return jwtDecoder;
+  }
+
+  public OidcClaimsProvider getOidcClaimsProvider() {
+    return oidcClaimsProvider;
   }
 
   public SearchClientsProxy getSearchClientsProxy() {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/SimpleBrokerStartTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/SimpleBrokerStartTest.java
@@ -16,6 +16,7 @@ import io.atomix.cluster.AtomixCluster;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.oidc.OidcClaimsProvider;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.system.SystemContext;
@@ -76,6 +77,7 @@ public final class SimpleBrokerStartTest {
                       mock(UserServices.class),
                       mock(PasswordEncoder.class),
                       mock(JwtDecoder.class),
+                      mock(OidcClaimsProvider.class),
                       mock(SearchClientsProxy.class),
                       mock(BrokerRequestAuthorizationConverter.class));
               new Broker(systemContext, TEST_SPRING_BROKER_BRIDGE, emptyList());
@@ -107,6 +109,7 @@ public final class SimpleBrokerStartTest {
             mock(UserServices.class),
             mock(PasswordEncoder.class),
             mock(JwtDecoder.class),
+            mock(OidcClaimsProvider.class),
             mock(SearchClientsProxy.class),
             mock(BrokerRequestAuthorizationConverter.class));
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/ApiMessagingServiceStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/ApiMessagingServiceStepTest.java
@@ -19,6 +19,7 @@ import io.atomix.cluster.messaging.ManagedMessagingService;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.oidc.OidcClaimsProvider;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -80,6 +81,7 @@ class ApiMessagingServiceStepTest {
             mock(UserServices.class),
             mock(PasswordEncoder.class),
             mock(JwtDecoder.class),
+            mock(OidcClaimsProvider.class),
             mock(SearchClientsProxy.class),
             mock(BrokerRequestAuthorizationConverter.class));
     testBrokerStartupContext.setConcurrencyControl(CONCURRENCY_CONTROL);

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/CommandApiServiceStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/CommandApiServiceStepTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.oidc.OidcClaimsProvider;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -81,6 +82,7 @@ class CommandApiServiceStepTest {
             mock(UserServices.class),
             mock(PasswordEncoder.class),
             mock(JwtDecoder.class),
+            mock(OidcClaimsProvider.class),
             mock(SearchClientsProxy.class),
             mock(BrokerRequestAuthorizationConverter.class));
     testBrokerStartupContext.setConcurrencyControl(CONCURRENCY_CONTROL);

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/EmbeddedGatewayServiceStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/EmbeddedGatewayServiceStepTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.verify;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.oidc.OidcClaimsProvider;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -91,6 +92,7 @@ class EmbeddedGatewayServiceStepTest {
               mock(UserServices.class),
               mock(PasswordEncoder.class),
               mock(JwtDecoder.class),
+              mock(OidcClaimsProvider.class),
               mock(SearchClientsProxy.class),
               mock(BrokerRequestAuthorizationConverter.class));
 
@@ -166,6 +168,7 @@ class EmbeddedGatewayServiceStepTest {
               mock(UserServices.class),
               mock(PasswordEncoder.class),
               mock(JwtDecoder.class),
+              mock(OidcClaimsProvider.class),
               mock(SearchClientsProxy.class),
               mock(BrokerRequestAuthorizationConverter.class));
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/GatewayBrokerTransportStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/GatewayBrokerTransportStepTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.oidc.OidcClaimsProvider;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -73,6 +74,7 @@ class GatewayBrokerTransportStepTest {
             mock(UserServices.class),
             mock(PasswordEncoder.class),
             mock(JwtDecoder.class),
+            mock(OidcClaimsProvider.class),
             mock(SearchClientsProxy.class),
             mock(BrokerRequestAuthorizationConverter.class));
     testBrokerStartupContext.setConcurrencyControl(CONCURRENCY_CONTROL);

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
@@ -20,6 +20,7 @@ import io.atomix.cluster.MemberConfig;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.oidc.OidcClaimsProvider;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -103,6 +104,7 @@ class PartitionManagerStepTest {
               mock(UserServices.class),
               mock(PasswordEncoder.class),
               mock(JwtDecoder.class),
+              mock(OidcClaimsProvider.class),
               mock(SearchClientsProxy.class),
               mock(BrokerRequestAuthorizationConverter.class));
       testBrokerStartupContext.setConcurrencyControl(CONCURRENCY_CONTROL);
@@ -207,6 +209,7 @@ class PartitionManagerStepTest {
               mock(UserServices.class),
               mock(PasswordEncoder.class),
               mock(JwtDecoder.class),
+              mock(OidcClaimsProvider.class),
               mock(SearchClientsProxy.class),
               mock(BrokerRequestAuthorizationConverter.class));
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/RequestIdGeneratorStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/RequestIdGeneratorStepTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.oidc.OidcClaimsProvider;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -67,6 +68,7 @@ class RequestIdGeneratorStepTest {
             mock(UserServices.class),
             mock(PasswordEncoder.class),
             mock(JwtDecoder.class),
+            mock(OidcClaimsProvider.class),
             mock(SearchClientsProxy.class),
             mock(BrokerRequestAuthorizationConverter.class));
     testBrokerStartupContext.setConcurrencyControl(spyConcurrencyControl);

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionJoinTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionJoinTest.java
@@ -119,6 +119,7 @@ final class PartitionJoinTest {
             null,
             null,
             null,
+            null,
             null);
 
     return new Broker(systemContext, new SpringBrokerBridge(), List.of());

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionLeaveTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionLeaveTest.java
@@ -238,6 +238,7 @@ final class PartitionLeaveTest {
             null,
             null,
             null,
+            null,
             null);
 
     return new Broker(systemContext, new SpringBrokerBridge(), List.of());

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -15,6 +15,7 @@ import io.atomix.cluster.AtomixCluster;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.oidc.OidcClaimsProvider;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
@@ -375,6 +376,7 @@ final class SystemContextTest {
         mock(UserServices.class),
         mock(PasswordEncoder.class),
         mock(JwtDecoder.class),
+        mock(OidcClaimsProvider.class),
         mock(SearchClientsProxy.class),
         mock(BrokerRequestAuthorizationConverter.class));
   }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
@@ -255,6 +255,7 @@ public final class EmbeddedBrokerRule extends ExternalResource {
             null,
             null,
             null,
+            null,
             null);
 
     final var additionalListeners = new ArrayList<>(Arrays.asList(listeners));

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/Gateway.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/Gateway.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.gateway;
 import com.google.rpc.Code;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.oidc.OidcClaimsProvider;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.gateway.health.GatewayHealthManager;
@@ -98,6 +99,7 @@ public final class Gateway implements CloseableSilently {
   private final UserServices userServices;
   private final PasswordEncoder passwordEncoder;
   private final JwtDecoder jwtDecoder;
+  private final OidcClaimsProvider oidcClaimsProvider;
   private final MeterRegistry meterRegistry;
 
   public Gateway(
@@ -109,7 +111,8 @@ public final class Gateway implements CloseableSilently {
       final UserServices userServices,
       final PasswordEncoder passwordEncoder,
       final MeterRegistry meterRegistry,
-      final JwtDecoder jwtDecoder) {
+      final JwtDecoder jwtDecoder,
+      final OidcClaimsProvider oidcClaimsProvider) {
     this(
         DEFAULT_SHUTDOWN_TIMEOUT,
         gatewayCfg,
@@ -120,6 +123,7 @@ public final class Gateway implements CloseableSilently {
         userServices,
         passwordEncoder,
         jwtDecoder,
+        oidcClaimsProvider,
         meterRegistry);
   }
 
@@ -133,6 +137,7 @@ public final class Gateway implements CloseableSilently {
       final UserServices userServices,
       final PasswordEncoder passwordEncoder,
       final JwtDecoder jwtDecoder,
+      final OidcClaimsProvider oidcClaimsProvider,
       final MeterRegistry meterRegistry) {
     shutdownTimeout = shutdownDuration;
     this.gatewayCfg = gatewayCfg;
@@ -143,6 +148,7 @@ public final class Gateway implements CloseableSilently {
     this.userServices = userServices;
     this.passwordEncoder = passwordEncoder;
     this.jwtDecoder = jwtDecoder;
+    this.oidcClaimsProvider = oidcClaimsProvider;
     this.meterRegistry = meterRegistry;
 
     healthManager = new GatewayHealthManagerImpl();
@@ -416,7 +422,9 @@ public final class Gateway implements CloseableSilently {
             case BASIC -> basicAuth();
             case OIDC ->
                 new AuthenticationHandler.Oidc(
-                    jwtDecoder, securityConfiguration.getAuthentication().getOidc());
+                    jwtDecoder,
+                    securityConfiguration.getAuthentication().getOidc(),
+                    oidcClaimsProvider);
           };
       interceptors.add(new AuthenticationInterceptor(handler));
     }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationHandler.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationHandler.java
@@ -14,6 +14,7 @@ import io.camunda.security.auth.OidcGroupsLoader;
 import io.camunda.security.auth.OidcPrincipalLoader;
 import io.camunda.security.auth.OidcPrincipalLoader.OidcPrincipals;
 import io.camunda.security.configuration.OidcAuthenticationConfiguration;
+import io.camunda.security.oidc.OidcClaimsProvider;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.util.Either;
 import io.grpc.Context;
@@ -52,15 +53,18 @@ public sealed interface AuthenticationHandler {
     public static final String BEARER_PREFIX = "Bearer ";
     private final JwtDecoder jwtDecoder;
     private final OidcAuthenticationConfiguration oidcAuthenticationConfiguration;
+    private final OidcClaimsProvider claimsProvider;
     private final OidcPrincipalLoader oidcPrincipalLoader;
     private final OidcGroupsLoader oidcGroupsLoader;
 
     public Oidc(
         final JwtDecoder jwtDecoder,
-        final OidcAuthenticationConfiguration oidcAuthenticationConfiguration) {
+        final OidcAuthenticationConfiguration oidcAuthenticationConfiguration,
+        final OidcClaimsProvider claimsProvider) {
       this.jwtDecoder = Objects.requireNonNull(jwtDecoder);
       this.oidcAuthenticationConfiguration =
           Objects.requireNonNull(oidcAuthenticationConfiguration);
+      this.claimsProvider = Objects.requireNonNull(claimsProvider);
       oidcPrincipalLoader =
           new OidcPrincipalLoader(
               oidcAuthenticationConfiguration.getUsernameClaim(),
@@ -76,13 +80,24 @@ public sealed interface AuthenticationHandler {
                 "Expected authentication information to start with '%s'".formatted(BEARER_PREFIX)));
       }
 
+      final String tokenValue = authorizationHeader.substring(BEARER_PREFIX.length());
       final Jwt token;
       try {
-        token = jwtDecoder.decode(authorizationHeader.substring(BEARER_PREFIX.length()));
+        token = jwtDecoder.decode(tokenValue);
       } catch (final JwtException e) {
         return Either.left(
             Status.UNAUTHENTICATED
                 .augmentDescription("Expected a valid token, see cause for details")
+                .withCause(e));
+      }
+
+      final Map<String, Object> claims;
+      try {
+        claims = claimsProvider.claimsFor(token.getClaims(), tokenValue);
+      } catch (final Exception e) {
+        return Either.left(
+            Status.UNAUTHENTICATED
+                .augmentDescription("Failed to resolve OIDC claims, see cause for details")
                 .withCause(e));
       }
 
@@ -94,7 +109,7 @@ public sealed interface AuthenticationHandler {
               !oidcAuthenticationConfiguration.isGroupsClaimConfigured());
       if (oidcAuthenticationConfiguration.isGroupsClaimConfigured()) {
         try {
-          context = context.withValue(GROUPS_CLAIMS, oidcGroupsLoader.load(token.getClaims()));
+          context = context.withValue(GROUPS_CLAIMS, oidcGroupsLoader.load(claims));
         } catch (final Exception e) {
           return Either.left(
               Status.UNAUTHENTICATED
@@ -105,7 +120,7 @@ public sealed interface AuthenticationHandler {
 
       final OidcPrincipals principals;
       try {
-        principals = oidcPrincipalLoader.load(token.getClaims());
+        principals = oidcPrincipalLoader.load(claims);
       } catch (final Exception e) {
         return Either.left(
             Status.UNAUTHENTICATED
@@ -125,14 +140,10 @@ public sealed interface AuthenticationHandler {
       final var preferUsernameClaim = oidcAuthenticationConfiguration.isPreferUsernameClaim();
       if ((preferUsernameClaim && principals.username() != null) || principals.clientId() == null) {
         return Either.right(
-            context
-                .withValue(USERNAME, principals.username())
-                .withValue(USER_CLAIMS, token.getClaims()));
+            context.withValue(USERNAME, principals.username()).withValue(USER_CLAIMS, claims));
       } else {
         return Either.right(
-            context
-                .withValue(CLIENT_ID, principals.clientId())
-                .withValue(USER_CLAIMS, token.getClaims()));
+            context.withValue(CLIENT_ID, principals.clientId()).withValue(USER_CLAIMS, claims));
       }
     }
   }

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/UnavailableBrokersTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/UnavailableBrokersTest.java
@@ -18,6 +18,7 @@ import io.camunda.client.api.command.ClientStatusException;
 import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.impl.util.AddressUtil;
 import io.camunda.security.configuration.SecurityConfigurations;
+import io.camunda.security.oidc.NoopOidcClaimsProvider;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerClientRequestMetrics;
@@ -111,7 +112,8 @@ class UnavailableBrokersTest {
             mock(UserServices.class),
             mock(PasswordEncoder.class),
             REGISTRY,
-            mock(JwtDecoder.class));
+            mock(JwtDecoder.class),
+            new NoopOidcClaimsProvider());
     gateway.start().join();
 
     final URI grpcAddress = AddressUtil.composeGrpcAddress(networkCfg.toSocketAddress(), true);

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
@@ -12,6 +12,7 @@ import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.interfaces.Claim;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.oidc.NoopOidcClaimsProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.gateway.EndpointManager;
 import io.camunda.zeebe.gateway.Gateway;
@@ -108,7 +109,8 @@ public final class StubbedGateway {
                     new AuthenticationInterceptor(
                         new AuthenticationHandler.Oidc(
                             new FakeJwtDecoder(),
-                            securityConfiguration.getAuthentication().getOidc()))));
+                            securityConfiguration.getAuthentication().getOidc(),
+                            new NoopOidcClaimsProvider()))));
     server = serverBuilder.build();
     server.start();
   }

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/InterceptorIT.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/InterceptorIT.java
@@ -17,6 +17,7 @@ import io.camunda.client.api.command.ClientStatusException;
 import io.camunda.client.api.response.DeploymentEvent;
 import io.camunda.client.impl.util.AddressUtil;
 import io.camunda.security.configuration.SecurityConfigurations;
+import io.camunda.security.oidc.NoopOidcClaimsProvider;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerClientRequestMetrics;
@@ -106,7 +107,8 @@ final class InterceptorIT {
             mock(UserServices.class),
             mock(PasswordEncoder.class),
             new SimpleMeterRegistry(),
-            mock(JwtDecoder.class));
+            mock(JwtDecoder.class),
+            new NoopOidcClaimsProvider());
 
     cluster.start().join();
     scheduler.start();

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationHandlerOidcUserInfoTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationHandlerOidcUserInfoTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.interceptors.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.security.configuration.OidcAuthenticationConfiguration;
+import io.camunda.security.oidc.OidcClaimsProvider;
+import io.camunda.zeebe.gateway.interceptors.impl.AuthenticationHandler.Oidc;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+
+class AuthenticationHandlerOidcUserInfoTest {
+
+  @Test
+  void usesClaimsProviderResultForGroupsAndPrincipal() throws Exception {
+    final var jwtDecoder = mock(JwtDecoder.class);
+    final var claimsProvider = mock(OidcClaimsProvider.class);
+    final var oidc = new OidcAuthenticationConfiguration();
+    oidc.setUsernameClaim("sub");
+    oidc.setGroupsClaim("groups");
+
+    final var jwt =
+        Jwt.withTokenValue("token-abc").header("alg", "RS256").claim("sub", "alice").build();
+    when(jwtDecoder.decode("token-abc")).thenReturn(jwt);
+    // provider adds groups from userinfo that the JWT does not have
+    when(claimsProvider.claimsFor(any(), eq("token-abc")))
+        .thenReturn(Map.of("sub", "alice", "groups", List.of("engineering")));
+
+    final var handler = new Oidc(jwtDecoder, oidc, claimsProvider);
+    final var result = handler.authenticate("Bearer token-abc");
+
+    assertThat(result.isRight()).isTrue();
+    final var ctx = result.get();
+    assertThat(ctx.call(() -> AuthenticationHandler.GROUPS_CLAIMS.get()))
+        .isEqualTo(List.of("engineering"));
+    assertThat(ctx.call(() -> AuthenticationHandler.USERNAME.get())).isEqualTo("alice");
+  }
+
+  @Test
+  void failsClosedWhenClaimsProviderThrows() {
+    final var jwtDecoder = mock(JwtDecoder.class);
+    final var claimsProvider = mock(OidcClaimsProvider.class);
+    final var oidc = new OidcAuthenticationConfiguration();
+    oidc.setUsernameClaim("sub");
+
+    final var jwt =
+        Jwt.withTokenValue("token-abc").header("alg", "RS256").claim("sub", "alice").build();
+    when(jwtDecoder.decode("token-abc")).thenReturn(jwt);
+    when(claimsProvider.claimsFor(any(), eq("token-abc")))
+        .thenThrow(new RuntimeException("userinfo down"));
+
+    final var handler = new Oidc(jwtDecoder, oidc, claimsProvider);
+    final var result = handler.authenticate("Bearer token-abc");
+
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft().getCode()).isEqualTo(io.grpc.Status.UNAUTHENTICATED.getCode());
+  }
+}

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptorTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptorTest.java
@@ -22,6 +22,7 @@ import io.camunda.search.entities.UserEntity;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.configuration.OidcAuthenticationConfiguration;
+import io.camunda.security.oidc.NoopOidcClaimsProvider;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.gateway.interceptors.impl.AuthenticationHandler.BasicAuth;
 import io.camunda.zeebe.gateway.interceptors.impl.AuthenticationHandler.Oidc;
@@ -192,7 +193,8 @@ public class AuthenticationInterceptorTest {
     oidcAuthenticationConfiguration.setUsernameClaim("username");
     oidcAuthenticationConfiguration.setClientIdClaim("application_id");
 
-    new AuthenticationInterceptor(new Oidc(jwtDecoder, oidcAuthenticationConfiguration))
+    new AuthenticationInterceptor(
+            new Oidc(jwtDecoder, oidcAuthenticationConfiguration, new NoopOidcClaimsProvider()))
         .interceptCall(
             closeStatusCapturingServerCall,
             createAuthHeader(),
@@ -222,7 +224,8 @@ public class AuthenticationInterceptorTest {
     oidcAuthenticationConfiguration.setUsernameClaim("sub");
     oidcAuthenticationConfiguration.setClientIdClaim("client_id");
 
-    new AuthenticationInterceptor(new Oidc(jwtDecoder, oidcAuthenticationConfiguration))
+    new AuthenticationInterceptor(
+            new Oidc(jwtDecoder, oidcAuthenticationConfiguration, new NoopOidcClaimsProvider()))
         .interceptCall(
             closeStatusCapturingServerCall,
             createAuthHeader(),
@@ -258,7 +261,8 @@ public class AuthenticationInterceptorTest {
     oidcAuthenticationConfiguration.setUsernameClaim("username");
     oidcAuthenticationConfiguration.setClientIdClaim("application_id");
 
-    new AuthenticationInterceptor(new Oidc(jwtDecoder, oidcAuthenticationConfiguration))
+    new AuthenticationInterceptor(
+            new Oidc(jwtDecoder, oidcAuthenticationConfiguration, new NoopOidcClaimsProvider()))
         .interceptCall(
             closeStatusCapturingServerCall,
             createAuthHeader(),
@@ -297,7 +301,8 @@ public class AuthenticationInterceptorTest {
     oidcAuthenticationConfiguration.setUsernameClaim("username");
     oidcAuthenticationConfiguration.setClientIdClaim("client_id");
 
-    new AuthenticationInterceptor(new Oidc(jwtDecoder, oidcAuthenticationConfiguration))
+    new AuthenticationInterceptor(
+            new Oidc(jwtDecoder, oidcAuthenticationConfiguration, new NoopOidcClaimsProvider()))
         .interceptCall(
             closeStatusCapturingServerCall,
             createAuthHeader(),
@@ -345,7 +350,8 @@ public class AuthenticationInterceptorTest {
     oidcAuthenticationConfiguration.setClientIdClaim("application_id");
 
     // when
-    new AuthenticationInterceptor(new Oidc(jwtDecoder, oidcAuthenticationConfiguration))
+    new AuthenticationInterceptor(
+            new Oidc(jwtDecoder, oidcAuthenticationConfiguration, new NoopOidcClaimsProvider()))
         .interceptCall(
             closeStatusCapturingServerCall,
             metadata,
@@ -379,7 +385,8 @@ public class AuthenticationInterceptorTest {
     oidcAuthenticationConfiguration.setClientIdClaim("application_id");
 
     // when
-    new AuthenticationInterceptor(new Oidc(jwtDecoder, oidcAuthenticationConfiguration))
+    new AuthenticationInterceptor(
+            new Oidc(jwtDecoder, oidcAuthenticationConfiguration, new NoopOidcClaimsProvider()))
         .interceptCall(
             closeStatusCapturingServerCall,
             metadata,
@@ -412,7 +419,8 @@ public class AuthenticationInterceptorTest {
     oidcAuthenticationConfiguration.setClientIdClaim("application_id");
 
     // when
-    new AuthenticationInterceptor(new Oidc(jwtDecoder, oidcAuthenticationConfiguration))
+    new AuthenticationInterceptor(
+            new Oidc(jwtDecoder, oidcAuthenticationConfiguration, new NoopOidcClaimsProvider()))
         .interceptCall(
             closeStatusCapturingServerCall,
             metadata,
@@ -448,7 +456,8 @@ public class AuthenticationInterceptorTest {
     oidcAuthenticationConfiguration.setPreferUsernameClaim(true);
 
     // when
-    new AuthenticationInterceptor(new Oidc(jwtDecoder, oidcAuthenticationConfiguration))
+    new AuthenticationInterceptor(
+            new Oidc(jwtDecoder, oidcAuthenticationConfiguration, new NoopOidcClaimsProvider()))
         .interceptCall(
             closeStatusCapturingServerCall,
             metadata,
@@ -483,7 +492,8 @@ public class AuthenticationInterceptorTest {
     oidcAuthenticationConfiguration.setClientIdClaim("missing_claim");
 
     // when
-    new AuthenticationInterceptor(new Oidc(jwtDecoder, oidcAuthenticationConfiguration))
+    new AuthenticationInterceptor(
+            new Oidc(jwtDecoder, oidcAuthenticationConfiguration, new NoopOidcClaimsProvider()))
         .interceptCall(
             closeStatusCapturingServerCall,
             metadata,
@@ -519,7 +529,8 @@ public class AuthenticationInterceptorTest {
     oidcAuthenticationConfiguration.setClientIdClaim("application_id");
 
     // when
-    new AuthenticationInterceptor(new Oidc(jwtDecoder, oidcAuthenticationConfiguration))
+    new AuthenticationInterceptor(
+            new Oidc(jwtDecoder, oidcAuthenticationConfiguration, new NoopOidcClaimsProvider()))
         .interceptCall(
             closeStatusCapturingServerCall,
             metadata,
@@ -556,7 +567,8 @@ public class AuthenticationInterceptorTest {
     oidcAuthenticationConfiguration.setGroupsClaim("$.groups[*]");
 
     // when
-    new AuthenticationInterceptor(new Oidc(jwtDecoder, oidcAuthenticationConfiguration))
+    new AuthenticationInterceptor(
+            new Oidc(jwtDecoder, oidcAuthenticationConfiguration, new NoopOidcClaimsProvider()))
         .interceptCall(
             closeStatusCapturingServerCall,
             metadata,
@@ -588,7 +600,8 @@ public class AuthenticationInterceptorTest {
     oidcAuthenticationConfiguration.setClientIdClaim("client_id");
     oidcAuthenticationConfiguration.setGroupsClaim("$.groups[*]");
 
-    new AuthenticationInterceptor(new Oidc(jwtDecoder, oidcAuthenticationConfiguration))
+    new AuthenticationInterceptor(
+            new Oidc(jwtDecoder, oidcAuthenticationConfiguration, new NoopOidcClaimsProvider()))
         .interceptCall(
             closeStatusCapturingServerCall,
             createAuthHeader(),

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/security/SecurityTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/security/SecurityTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.mock;
 import io.atomix.cluster.AtomixCluster;
 import io.atomix.utils.net.Address;
 import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.oidc.NoopOidcClaimsProvider;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerClientRequestMetrics;
@@ -203,6 +204,7 @@ final class SecurityTest {
         mock(UserServices.class),
         mock(PasswordEncoder.class),
         meterRegistry,
-        mock(JwtDecoder.class));
+        mock(JwtDecoder.class),
+        new NoopOidcClaimsProvider());
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusteringRule.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusteringRule.java
@@ -38,6 +38,7 @@ import io.camunda.client.impl.util.AddressUtil;
 import io.camunda.configuration.beans.BrokerBasedProperties;
 import io.camunda.configuration.beans.GatewayBasedProperties;
 import io.camunda.security.configuration.SecurityConfigurations;
+import io.camunda.security.oidc.NoopOidcClaimsProvider;
 import io.camunda.zeebe.broker.Broker;
 import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
@@ -384,6 +385,7 @@ public class ClusteringRule extends ExternalResource {
             null,
             null,
             null,
+            new NoopOidcClaimsProvider(),
             null,
             null);
 
@@ -530,7 +532,8 @@ public class ClusteringRule extends ExternalResource {
             null,
             null,
             meterRegistry,
-            null);
+            null,
+            new NoopOidcClaimsProvider());
     gateway.start().join();
 
     return new GatewayResource(


### PR DESCRIPTION
## Summary

Some OIDC providers emit authorization-relevant claims (`groups`, roles, tenants) **only on the `/userinfo` endpoint**, not on the JWT access token. The browser login flow already handles this (Spring Security's OIDC login calls `/userinfo` by default). The **bearer-token flow** (`/v1`, `/v2`, gRPC via the Zeebe gateway) does not — it reads `JwtAuthenticationToken.getClaims()` verbatim, so group-based authorization never fires for these deployments.

This PR adds an **opt-in** augmentation layer: when enabled, a shared `OidcClaimsProvider` calls `/userinfo` with the bearer token, merges the response onto the JWT claims, and caches the result. Default behaviour is unchanged — customers explicitly opt in via config.

## What's new for operators

```yaml
camunda.security.authentication.oidc:
  userInfoAugmentation:
    enabled: false        # default — opt-in
    cacheTtl: PT5M        # capped at token exp − clockSkew
    cacheMaxSize: 10000
```

When `enabled: true`, every OIDC bearer request resolves claims via Caffeine cache (keyed by `jti` or SHA-256 of the token), with at most one `/userinfo` call per token per TTL. Fail-closed on IdP errors, with a short negative cache to avoid storm-retries.

## Commit-by-commit review guide

The commits are scoped for easy review in order:

| # | Commit | What to look at |
|---|---|---|
| 1 | `docs: plan for OIDC userinfo claim augmentation` | The full implementation plan (cherry-picked from investigation branch). Reference, not required reading. |
| 2 | `test: demonstrate userinfo groups claim gap` | Failing-on-old-code integration test that encodes the customer acceptance criterion. |
| 3 | `feat(security): add OIDC user-info augmentation config` | `OidcUserInfoAugmentationConfiguration` record + wiring into `OidcAuthenticationConfiguration`. Pure config, no runtime behaviour. |
| 4 | `feat(security): add OidcUserInfoClient` | Thin JDK `HttpClient` wrapper that GETs `/userinfo` and parses the JSON. |
| 5 | `feat(security): add OidcClaimsProvider interface with no-op default` | The interface + pass-through `NoopOidcClaimsProvider`. |
| 6 | `feat(security): add CachingOidcClaimsProvider` | The production implementation: Caffeine cache, fail-closed semantics, Micrometer metrics. 9 unit tests cover the behaviour in isolation. |
| 7 | `feat(authentication): route OIDC bearer claims through OidcClaimsProvider` | REST wiring. `OidcTokenAuthenticationConverter` now uses the provider; `WebSecurityConfig.OidcConfiguration` registers a bean that's Noop when disabled. |
| 8 | `feat(gateway): route gRPC OIDC claims through OidcClaimsProvider` | gRPC + broker-side wiring. Threads the provider through the same chain `JwtDecoder` travels today (`BrokerModuleConfiguration` → `SystemContext` → `BrokerStartupContext(Impl)` → `EmbeddedGatewayServiceStep` → `EmbeddedGatewayService` → `Gateway`). Largest diff, mostly mechanical test-call-site updates. |
| 9 | `feat(authentication): read userinfo URI from ClientRegistration + expand IT` | Switches the URL source from `{issuer}/userinfo` string-stitching to Spring's `ClientRegistration.getProviderDetails().getUserInfoEndpoint().getUri()` (populated by OIDC discovery, so accurate for IdPs where userinfo isn't on the issuer host). Adds caching acceptance tests to the gap IT. |
| 10 | `docs(adr): ADR-0003 for OIDC userinfo claim augmentation` | Design rationale, opt-in reasoning, v1 out-of-scope. |

## Key design decisions (spelled out in ADR-0003)

- **Opt-in, default `false`.** This introduces a per-request network dependency on the IdP. Default-on would silently change request patterns for every existing OIDC deployment on upgrade — opt-in is the safer choice. The existing `userInfoEnabled` flag (defaults `true`) remains separate; it continues to gate Spring's OIDC login-flow userinfo call.
- **Userinfo URL from `ClientRegistration`, not from a config property.** Spring populates it from the IdP's OIDC discovery document, so it's right for IdPs whose userinfo path isn't `{issuer}/userinfo`. A null URL (IdP doesn't publish one, or `userInfoEnabled=false`) now fails startup with a clear message when augmentation is enabled.
- **Fail-closed on IdP errors.** Silently falling back to JWT-only claims would be a security surprise (the merged-claims set is the authoritative input for authorization). Instead we surface 401 and short-circuit subsequent attempts via a 5s negative cache.
- **Merge semantics: UserInfo wins on conflict.** Matches the OIDC spec: per §5.3.2, UserInfo `sub` MUST match the ID token's `sub`; other claims in UserInfo are authoritative.
- **Cache keyed by `jti`, fallback SHA-256 of token.** TTL capped at `min(configuredTtl, tokenExp − clockSkew − now)` so cache entries never outlive the bearer token itself.
- **Embedded gateway wired through existing `JwtDecoder` chain.** Not stubbed. With `@Autowired(required = false)` + `NoopOidcClaimsProvider` fallback in `BrokerModuleConfiguration`, the chain degrades the same way `JwtDecoder` does when auth is disabled.

## Test plan

- [ ] `mvn -pl security/security-core test` — 53 tests, all green (new: `OidcUserInfoClientTest`, `NoopOidcClaimsProviderTest`, `CachingOidcClaimsProviderTest`).
- [ ] `mvn -pl authentication test -Dtest=OidcBearerUserInfoClaimGapIT` — customer acceptance + caching assertions. All 3 tests green.
- [ ] `mvn -pl authentication test -Dtest=OidcTokenAuthenticationConverterTest` — 4 tests covering the REST converter.
- [ ] `mvn -pl zeebe/gateway-grpc test -Dtest='*Authentication*'` — 19 tests including the new `AuthenticationHandlerOidcUserInfoTest` and the updated `AuthenticationInterceptorTest`.
- [ ] Manual smoke: start the standalone gateway with `userInfoAugmentation.enabled=true` pointed at an IdP that only emits groups on `/userinfo`; verify a bearer-token request gets group-based authorizations.

Note: a single flake appeared in `SessionAuthenticationRefreshTest$OidcAuthTest.shouldRefreshOnApiAfterInterval` when running the **full** `authentication` module suite, but the test passes both in isolation and when its class is run alone — a pre-existing cross-test interaction, not caused by this change.

## Out of scope (flagged for follow-ups)

- **Multi-provider userinfo selection by `iss`.** The bean currently picks the first registration that exposes a userinfo endpoint. Single-provider deployments are covered; multi-provider routing by token `iss` is a follow-up.
- **Configurable negative-cache TTL.** Hard-coded at 5s. Implementation defence, not a product lever — leave as-is unless operational need surfaces.
- **Explicit `userInfoUri` override.** For IdPs whose discovery document is broken. Add if real demand appears.

## Risks

- **Enabling on a large deployment** adds a `/userinfo` round-trip per new-`jti` bearer request. Cache amortises worker patterns heavily (one call per token per TTL). Operators should size `cacheMaxSize` for their concurrent token count.
- **Fail-closed** means a `/userinfo` outage fails API requests. Monitor the `camunda.oidc.userinfo.fetch{outcome=failure}` counter.