### PR TITLE
Add toolName and inboundConnectorType in message subscriptions

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/MessageSubscriptionFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/MessageSubscriptionFilter.java
@@ -258,4 +258,36 @@ public interface MessageSubscriptionFilter extends SearchRequestFilter {
    * @return the updated filter
    */
   MessageSubscriptionFilter processDefinitionVersion(Consumer<IntegerProperty> fn);
+
+  /**
+   * Filter by tool name.
+   *
+   * @param toolName the tool name
+   * @return the updated filter
+   */
+  MessageSubscriptionFilter toolName(String toolName);
+
+  /**
+   * Filter by tool name using a {@link StringProperty} consumer.
+   *
+   * @param fn the tool name {@link StringProperty} consumer
+   * @return the updated filter
+   */
+  MessageSubscriptionFilter toolName(Consumer<StringProperty> fn);
+
+  /**
+   * Filter by inbound connector type.
+   *
+   * @param inboundConnectorType the inbound connector type
+   * @return the updated filter
+   */
+  MessageSubscriptionFilter inboundConnectorType(String inboundConnectorType);
+
+  /**
+   * Filter by inbound connector type using a {@link StringProperty} consumer.
+   *
+   * @param fn the inbound connector type {@link StringProperty} consumer
+   * @return the updated filter
+   */
+  MessageSubscriptionFilter inboundConnectorType(Consumer<StringProperty> fn);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/MessageSubscription.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/MessageSubscription.java
@@ -62,4 +62,8 @@ public interface MessageSubscription {
   Integer getProcessDefinitionVersion();
 
   Map<String, String> getExtensionProperties();
+
+  String getToolName();
+
+  String getInboundConnectorType();
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/MessageSubscriptionSort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/MessageSubscriptionSort.java
@@ -44,4 +44,8 @@ public interface MessageSubscriptionSort extends SearchRequestSort<MessageSubscr
   MessageSubscriptionSort processDefinitionName();
 
   MessageSubscriptionSort processDefinitionVersion();
+
+  MessageSubscriptionSort toolName();
+
+  MessageSubscriptionSort inboundConnectorType();
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/MessageSubscriptionFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/MessageSubscriptionFilterImpl.java
@@ -233,6 +233,32 @@ public class MessageSubscriptionFilterImpl
   }
 
   @Override
+  public MessageSubscriptionFilter toolName(final String toolName) {
+    return toolName(f -> f.eq(toolName));
+  }
+
+  @Override
+  public MessageSubscriptionFilter toolName(final Consumer<StringProperty> fn) {
+    final StringProperty property = new StringPropertyImpl();
+    fn.accept(property);
+    filter.setToolName(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  public MessageSubscriptionFilter inboundConnectorType(final String inboundConnectorType) {
+    return inboundConnectorType(f -> f.eq(inboundConnectorType));
+  }
+
+  @Override
+  public MessageSubscriptionFilter inboundConnectorType(final Consumer<StringProperty> fn) {
+    final StringProperty property = new StringPropertyImpl();
+    fn.accept(property);
+    filter.setInboundConnectorType(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
   protected io.camunda.client.protocol.rest.MessageSubscriptionFilter getSearchRequestProperty() {
     return filter;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/MessageSubscriptionImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/MessageSubscriptionImpl.java
@@ -43,6 +43,8 @@ public class MessageSubscriptionImpl implements MessageSubscription {
   private final String processDefinitionName;
   private final Integer processDefinitionVersion;
   private final Map<String, String> extensionProperties;
+  private final String toolName;
+  private final String inboundConnectorType;
 
   public MessageSubscriptionImpl(final MessageSubscriptionResult item) {
     messageSubscriptionKey = ParseUtil.parseLongOrNull(item.getMessageSubscriptionKey());
@@ -63,6 +65,8 @@ public class MessageSubscriptionImpl implements MessageSubscription {
     processDefinitionName = item.getProcessDefinitionName();
     processDefinitionVersion = item.getProcessDefinitionVersion();
     extensionProperties = item.getExtensionProperties();
+    toolName = item.getToolName();
+    inboundConnectorType = item.getInboundConnectorType();
   }
 
   @Override
@@ -146,6 +150,16 @@ public class MessageSubscriptionImpl implements MessageSubscription {
   }
 
   @Override
+  public String getToolName() {
+    return toolName;
+  }
+
+  @Override
+  public String getInboundConnectorType() {
+    return inboundConnectorType;
+  }
+
+  @Override
   public int hashCode() {
     return Objects.hash(
         messageSubscriptionKey,
@@ -163,7 +177,9 @@ public class MessageSubscriptionImpl implements MessageSubscription {
         tenantId,
         processDefinitionName,
         processDefinitionVersion,
-        extensionProperties);
+        extensionProperties,
+        toolName,
+        inboundConnectorType);
   }
 
   @Override
@@ -190,6 +206,8 @@ public class MessageSubscriptionImpl implements MessageSubscription {
         && Objects.equals(tenantId, subscription.tenantId)
         && Objects.equals(processDefinitionName, subscription.processDefinitionName)
         && Objects.equals(processDefinitionVersion, subscription.processDefinitionVersion)
-        && Objects.equals(extensionProperties, subscription.extensionProperties);
+        && Objects.equals(extensionProperties, subscription.extensionProperties)
+        && Objects.equals(toolName, subscription.toolName)
+        && Objects.equals(inboundConnectorType, subscription.inboundConnectorType);
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/sort/MessageSubscriptionSortImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/sort/MessageSubscriptionSortImpl.java
@@ -87,6 +87,16 @@ public class MessageSubscriptionSortImpl extends SearchRequestSortBase<MessageSu
   }
 
   @Override
+  public MessageSubscriptionSort toolName() {
+    return field("toolName");
+  }
+
+  @Override
+  public MessageSubscriptionSort inboundConnectorType() {
+    return field("inboundConnectorType");
+  }
+
+  @Override
   protected MessageSubscriptionSort self() {
     return this;
   }

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
@@ -76,4 +76,26 @@
     </addColumn>
   </changeSet>
 
+  <changeSet id="add_message_subscription_tool_name_column" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="${prefix}MESSAGE_SUBSCRIPTION" columnName="TOOL_NAME"/>
+      </not>
+    </preConditions>
+    <addColumn tableName="${prefix}MESSAGE_SUBSCRIPTION">
+      <column name="TOOL_NAME" type="NVARCHAR(${userCharColumnSize})"/>
+    </addColumn>
+  </changeSet>
+
+  <changeSet id="add_message_subscription_inbound_connector_type_column" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="${prefix}MESSAGE_SUBSCRIPTION" columnName="INBOUND_CONNECTOR_TYPE"/>
+      </not>
+    </preConditions>
+    <addColumn tableName="${prefix}MESSAGE_SUBSCRIPTION">
+      <column name="INBOUND_CONNECTOR_TYPE" type="NVARCHAR(${userCharColumnSize})"/>
+    </addColumn>
+  </changeSet>
+
 </databaseChangeLog>

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/MessageSubscriptionEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/MessageSubscriptionEntityMapper.java
@@ -33,6 +33,8 @@ public class MessageSubscriptionEntityMapper {
         .processDefinitionName(nullToEmpty(messageSubscriptionDbModel.processDefinitionName()))
         .processDefinitionVersion(messageSubscriptionDbModel.processDefinitionVersion())
         .extensionProperties(messageSubscriptionDbModel.extensionProperties())
+        .toolName(messageSubscriptionDbModel.toolName())
+        .inboundConnectorType(messageSubscriptionDbModel.inboundConnectorType())
         .build();
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/MessageSubscriptionColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/MessageSubscriptionColumn.java
@@ -23,7 +23,9 @@ public enum MessageSubscriptionColumn implements SearchColumn<MessageSubscriptio
   CORRELATION_KEY("correlationKey"),
   TENANT_ID("tenantId"),
   PROCESS_DEFINITION_NAME("processDefinitionName"),
-  PROCESS_DEFINITION_VERSION("processDefinitionVersion");
+  PROCESS_DEFINITION_VERSION("processDefinitionVersion"),
+  TOOL_NAME("toolName"),
+  INBOUND_CONNECTOR_TYPE("inboundConnectorType");
 
   private final String property;
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/MessageSubscriptionDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/MessageSubscriptionDbModel.java
@@ -34,6 +34,8 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
   private Integer processDefinitionVersion;
   private String serializedExtensionProperties;
   private Map<String, String> extensionProperties;
+  private String toolName;
+  private String inboundConnectorType;
 
   public MessageSubscriptionDbModel(final Long messageSubscriptionKey) {
     this.messageSubscriptionKey = messageSubscriptionKey;
@@ -56,7 +58,9 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
       final int partitionId,
       final String processDefinitionName,
       final Integer processDefinitionVersion,
-      final Map<String, String> extensionProperties) {
+      final Map<String, String> extensionProperties,
+      final String toolName,
+      final String inboundConnectorType) {
     this.messageSubscriptionKey = messageSubscriptionKey;
     this.processDefinitionId = processDefinitionId;
     this.processDefinitionKey = processDefinitionKey;
@@ -75,6 +79,8 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
     this.processDefinitionVersion = processDefinitionVersion;
     serializedExtensionProperties = MapSerializer.serialize(extensionProperties);
     this.extensionProperties = extensionProperties;
+    this.toolName = toolName;
+    this.inboundConnectorType = inboundConnectorType;
   }
 
   public Long messageSubscriptionKey() {
@@ -178,6 +184,22 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
     return extensionProperties;
   }
 
+  public String toolName() {
+    return toolName;
+  }
+
+  public void toolName(final String toolName) {
+    this.toolName = toolName;
+  }
+
+  public String inboundConnectorType() {
+    return inboundConnectorType;
+  }
+
+  public void inboundConnectorType(final String inboundConnectorType) {
+    this.inboundConnectorType = inboundConnectorType;
+  }
+
   public OffsetDateTime dateTime() {
     return dateTime;
   }
@@ -245,7 +267,9 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
         .partitionId(partitionId)
         .processDefinitionName(processDefinitionName)
         .processDefinitionVersion(processDefinitionVersion)
-        .extensionProperties(extensionProperties);
+        .extensionProperties(extensionProperties)
+        .toolName(toolName)
+        .inboundConnectorType(inboundConnectorType);
   }
 
   public static class Builder implements ObjectBuilder<MessageSubscriptionDbModel> {
@@ -266,6 +290,8 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
     private String processDefinitionName;
     private Integer processDefinitionVersion;
     private Map<String, String> extensionProperties;
+    private String toolName;
+    private String inboundConnectorType;
 
     public Builder messageSubscriptionKey(final Long messageSubscriptionKey) {
       this.messageSubscriptionKey = messageSubscriptionKey;
@@ -328,6 +354,16 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
       return this;
     }
 
+    public Builder toolName(final String toolName) {
+      this.toolName = toolName;
+      return this;
+    }
+
+    public Builder inboundConnectorType(final String inboundConnectorType) {
+      this.inboundConnectorType = inboundConnectorType;
+      return this;
+    }
+
     public Builder dateTime(final OffsetDateTime dateTime) {
       this.dateTime = dateTime;
       return this;
@@ -372,7 +408,9 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
           partitionId,
           processDefinitionName,
           processDefinitionVersion,
-          extensionProperties);
+          extensionProperties,
+          toolName,
+          inboundConnectorType);
     }
   }
 }

--- a/db/rdbms/src/main/resources/mapper/MessageSubscriptionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/MessageSubscriptionMapper.xml
@@ -43,7 +43,9 @@
     PARTITION_ID,
     PROCESS_DEFINITION_NAME,
     PROCESS_DEFINITION_VERSION,
-    EXTENSION_PROPERTIES
+    EXTENSION_PROPERTIES,
+    TOOL_NAME,
+    INBOUND_CONNECTOR_TYPE
     FROM ${prefix}MESSAGE_SUBSCRIPTION
 
     <include refid="io.camunda.db.rdbms.sql.MessageSubscriptionMapper.searchAndAuthFilter" />
@@ -159,6 +161,18 @@
         <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
       </foreach>
     </if>
+    <if test="filter.toolNameOperations != null and !filter.toolNameOperations.isEmpty()">
+      <foreach collection="filter.toolNameOperations" item="operation">
+        AND TOOL_NAME
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.inboundConnectorTypeOperations != null and !filter.inboundConnectorTypeOperations.isEmpty()">
+      <foreach collection="filter.inboundConnectorTypeOperations" item="operation">
+        AND INBOUND_CONNECTOR_TYPE
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
   </sql>
 
   <resultMap id="searchResultMap" type="io.camunda.db.rdbms.write.domain.MessageSubscriptionDbModel">
@@ -181,6 +195,8 @@
     <result column="PROCESS_DEFINITION_NAME" property="processDefinitionName" javaType="java.lang.String" />
     <result column="PROCESS_DEFINITION_VERSION" property="processDefinitionVersion" javaType="java.lang.Integer" />
     <result column="EXTENSION_PROPERTIES" property="serializedExtensionProperties" javaType="java.lang.String" />
+    <result column="TOOL_NAME" property="toolName" javaType="java.lang.String" />
+    <result column="INBOUND_CONNECTOR_TYPE" property="inboundConnectorType" javaType="java.lang.String" />
   </resultMap>
 
 
@@ -202,7 +218,9 @@
                                                PARTITION_ID,
                                                PROCESS_DEFINITION_NAME,
                                                PROCESS_DEFINITION_VERSION,
-                                               EXTENSION_PROPERTIES
+                                               EXTENSION_PROPERTIES,
+                                               TOOL_NAME,
+                                               INBOUND_CONNECTOR_TYPE
     )
     VALUES (
             #{messageSubscriptionKey},
@@ -221,7 +239,9 @@
             #{partitionId},
             #{processDefinitionName},
             #{processDefinitionVersion},
-            #{serializedExtensionProperties}
+            #{serializedExtensionProperties},
+            #{toolName},
+            #{inboundConnectorType}
     )
   </insert>
 
@@ -240,7 +260,9 @@
         TENANT_ID = #{tenantId},
         PROCESS_DEFINITION_NAME = #{processDefinitionName},
         PROCESS_DEFINITION_VERSION = #{processDefinitionVersion},
-        EXTENSION_PROPERTIES = #{serializedExtensionProperties}
+        EXTENSION_PROPERTIES = #{serializedExtensionProperties},
+        TOOL_NAME = #{toolName},
+        INBOUND_CONNECTOR_TYPE = #{inboundConnectorType}
     WHERE MESSAGE_SUBSCRIPTION_KEY = #{messageSubscriptionKey}
   </update>
 

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -1070,6 +1070,12 @@ public class SearchQueryFilterMapper {
       ofNullable(filter.getProcessDefinitionVersion())
           .map(mapToIntegerOperations("processDefinitionVersion", validationErrors))
           .ifPresent(builder::processDefinitionVersionOperations);
+      ofNullable(filter.getToolName())
+          .map(mapToStringOperations())
+          .ifPresent(builder::toolNameOperations);
+      ofNullable(filter.getInboundConnectorType())
+          .map(mapToStringOperations())
+          .ifPresent(builder::inboundConnectorTypeOperations);
     }
     return validationErrors.isEmpty()
         ? Either.right(builder.build())

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -1068,7 +1068,9 @@ public final class SearchQueryResponseMapper {
         .tenantId(messageSubscription.tenantId())
         .processDefinitionName(messageSubscription.processDefinitionName())
         .processDefinitionVersion(messageSubscription.processDefinitionVersion())
-        .extensionProperties(messageSubscription.extensionProperties());
+        .extensionProperties(messageSubscription.extensionProperties())
+        .toolName(messageSubscription.toolName())
+        .inboundConnectorType(messageSubscription.inboundConnectorType());
   }
 
   private static List<CorrelatedMessageSubscriptionResult> toCorrelatedMessageSubscriptions(

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQuerySortRequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQuerySortRequestMapper.java
@@ -797,6 +797,8 @@ public class SearchQuerySortRequestMapper {
         case TENANT_ID -> builder.tenantId();
         case PROCESS_DEFINITION_NAME -> builder.processDefinitionName();
         case PROCESS_DEFINITION_VERSION -> builder.processDefinitionVersion();
+        case TOOL_NAME -> builder.toolName();
+        case INBOUND_CONNECTOR_TYPE -> builder.inboundConnectorType();
         default -> validationErrors.add(ERROR_UNKNOWN_SORT_BY.formatted(field));
       }
     }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/MessageSubscriptionEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/MessageSubscriptionEntityTransformer.java
@@ -36,7 +36,9 @@ public class MessageSubscriptionEntityTransformer
         value.getTenantId(),
         value.getProcessDefinitionName(),
         value.getProcessDefinitionVersion(),
-        value.getExtensionProperties());
+        value.getExtensionProperties(),
+        value.getToolName(),
+        value.getInboundConnectorType());
   }
 
   private io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionState

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/MessageSubscriptionFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/MessageSubscriptionFilterTransformer.java
@@ -19,12 +19,14 @@ import static io.camunda.webapps.schema.descriptors.template.MessageSubscription
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.EVENT_SOURCE_TYPE;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.FLOW_NODE_ID;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.FLOW_NODE_INSTANCE_KEY;
+import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.INBOUND_CONNECTOR_TYPE;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.KEY;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.MESSAGE_SUBSCRIPTION_STATE;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.MESSAGE_SUBSCRIPTION_TYPE;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.PROCESS_DEFINITION_NAME;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.PROCESS_DEFINITION_VERSION;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.PROCESS_KEY;
+import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.TOOL_NAME;
 
 import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.search.filter.MessageSubscriptionFilter;
@@ -60,7 +62,9 @@ public class MessageSubscriptionFilterTransformer
         stringOperations("metadata.correlationKey", filter.correlationKeyOperations()),
         stringOperations(TENANT_ID, filter.tenantIdOperations()),
         stringOperations(PROCESS_DEFINITION_NAME, filter.processDefinitionNameOperations()),
-        intOperations(PROCESS_DEFINITION_VERSION, filter.processDefinitionVersionOperations()));
+        intOperations(PROCESS_DEFINITION_VERSION, filter.processDefinitionVersionOperations()),
+        stringOperations(TOOL_NAME, filter.toolNameOperations()),
+        stringOperations(INBOUND_CONNECTOR_TYPE, filter.inboundConnectorTypeOperations()));
   }
 
   @Override

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/MessageSubscriptionFieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/MessageSubscriptionFieldSortingTransformer.java
@@ -13,11 +13,13 @@ import static io.camunda.webapps.schema.descriptors.template.MessageSubscription
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.DATE_TIME;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.FLOW_NODE_ID;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.FLOW_NODE_INSTANCE_KEY;
+import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.INBOUND_CONNECTOR_TYPE;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.KEY;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.MESSAGE_SUBSCRIPTION_STATE;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.MESSAGE_SUBSCRIPTION_TYPE;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.PROCESS_DEFINITION_NAME;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.PROCESS_DEFINITION_VERSION;
+import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.TOOL_NAME;
 
 public class MessageSubscriptionFieldSortingTransformer implements FieldSortingTransformer {
 
@@ -37,6 +39,8 @@ public class MessageSubscriptionFieldSortingTransformer implements FieldSortingT
       case "messageName" -> "metadata.messageName";
       case "correlationKey" -> "metadata.correlationKey";
       case "tenantId" -> TENANT_ID;
+      case "toolName" -> TOOL_NAME;
+      case "inboundConnectorType" -> INBOUND_CONNECTOR_TYPE;
       default -> throw new IllegalArgumentException("Unknown field: " + domainField);
     };
   }

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/MessageSubscriptionQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/MessageSubscriptionQueryTransformerTest.java
@@ -163,7 +163,17 @@ public class MessageSubscriptionQueryTransformerTest extends AbstractTransformer
                     b.messageSubscriptionTypeOperations(
                         Operation.in(MessageSubscriptionType.PROCESS_EVENT.name())),
             "messageSubscriptionType",
-            "PROCESS_EVENT"));
+            "PROCESS_EVENT"),
+        Arguments.of(
+            (Function<MessageSubscriptionFilter.Builder, ObjectBuilder<MessageSubscriptionFilter>>)
+                b -> b.toolNames("myTool"),
+            "toolName",
+            "myTool"),
+        Arguments.of(
+            (Function<MessageSubscriptionFilter.Builder, ObjectBuilder<MessageSubscriptionFilter>>)
+                b -> b.inboundConnectorTypes("io.camunda:http-webhook:1"),
+            "inboundConnectorType",
+            "io.camunda:http-webhook:1"));
   }
 
   @Test

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/MessageSubscriptionSortTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/MessageSubscriptionSortTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.sort;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.query.MessageSubscriptionQuery;
+import io.camunda.search.sort.MessageSubscriptionSort;
+import io.camunda.search.sort.SearchSortOptions;
+import io.camunda.search.sort.SortOrder;
+import io.camunda.util.ObjectBuilder;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class MessageSubscriptionSortTest extends AbstractSortTransformerTest {
+
+  private static Stream<Arguments> provideSortParameters() {
+    return Stream.of(
+        new TestArguments("key", SortOrder.ASC, s -> s.messageSubscriptionKey().asc()),
+        new TestArguments("bpmnProcessId", SortOrder.ASC, s -> s.processDefinitionId().asc()),
+        new TestArguments("processInstanceKey", SortOrder.ASC, s -> s.processInstanceKey().asc()),
+        new TestArguments("flowNodeId", SortOrder.ASC, s -> s.flowNodeId().asc()),
+        new TestArguments("flowNodeInstanceKey", SortOrder.ASC, s -> s.flowNodeInstanceKey().asc()),
+        new TestArguments("eventType", SortOrder.ASC, s -> s.messageSubscriptionState().asc()),
+        new TestArguments(
+            "messageSubscriptionType", SortOrder.ASC, s -> s.messageSubscriptionType().asc()),
+        new TestArguments(
+            "processDefinitionName", SortOrder.ASC, s -> s.processDefinitionName().asc()),
+        new TestArguments(
+            "processDefinitionVersion", SortOrder.ASC, s -> s.processDefinitionVersion().asc()),
+        new TestArguments("dateTime", SortOrder.ASC, s -> s.dateTime().asc()),
+        new TestArguments("metadata.messageName", SortOrder.ASC, s -> s.messageName().asc()),
+        new TestArguments("metadata.correlationKey", SortOrder.ASC, s -> s.correlationKey().asc()),
+        new TestArguments("tenantId", SortOrder.ASC, s -> s.tenantId().asc()),
+        new TestArguments("toolName", SortOrder.ASC, s -> s.toolName().asc()),
+        new TestArguments(
+            "inboundConnectorType", SortOrder.DESC, s -> s.inboundConnectorType().desc()));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideSortParameters")
+  public void shouldSortByField(
+      final String expectedField,
+      final SortOrder sortOrder,
+      final Function<MessageSubscriptionSort.Builder, ObjectBuilder<MessageSubscriptionSort>> fn) {
+    // when
+    final var request = MessageSubscriptionQuery.of(q -> q.sort(fn));
+    final var sort = transformRequest(request);
+
+    // then
+    assertThat(sort).hasSize(2);
+    assertThat(sort.get(0))
+        .isInstanceOfSatisfying(
+            SearchSortOptions.class,
+            t -> {
+              assertThat(t.field().field()).isEqualTo(expectedField);
+              assertThat(t.field().order()).isEqualTo(sortOrder);
+            });
+    assertThat(sort.get(1))
+        .isInstanceOfSatisfying(
+            SearchSortOptions.class,
+            t -> {
+              assertThat(t.field().field()).isEqualTo("key");
+              assertThat(t.field().order()).isEqualTo(SortOrder.ASC);
+            });
+  }
+
+  private record TestArguments(
+      String field,
+      SortOrder sortOrder,
+      Function<MessageSubscriptionSort.Builder, ObjectBuilder<MessageSubscriptionSort>> fn)
+      implements Arguments {
+
+    @Override
+    public Object[] get() {
+      return new Object[] {field, sortOrder, fn};
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/entities/MessageSubscriptionEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/MessageSubscriptionEntity.java
@@ -29,7 +29,9 @@ public record MessageSubscriptionEntity(
     String tenantId,
     String processDefinitionName,
     Integer processDefinitionVersion,
-    Map<String, String> extensionProperties)
+    Map<String, String> extensionProperties,
+    String toolName,
+    String inboundConnectorType)
     implements TenantOwnedEntity {
 
   public MessageSubscriptionEntity {
@@ -65,6 +67,8 @@ public record MessageSubscriptionEntity(
     private String processDefinitionName;
     private Integer processDefinitionVersion;
     private Map<String, String> extensionProperties;
+    private String toolName;
+    private String inboundConnectorType;
 
     public Builder messageSubscriptionKey(final Long messageSubscriptionKey) {
       this.messageSubscriptionKey = messageSubscriptionKey;
@@ -127,6 +131,16 @@ public record MessageSubscriptionEntity(
       return this;
     }
 
+    public Builder toolName(final String toolName) {
+      this.toolName = toolName;
+      return this;
+    }
+
+    public Builder inboundConnectorType(final String inboundConnectorType) {
+      this.inboundConnectorType = inboundConnectorType;
+      return this;
+    }
+
     public Builder dateTime(final OffsetDateTime dateTime) {
       this.dateTime = dateTime;
       return this;
@@ -164,7 +178,9 @@ public record MessageSubscriptionEntity(
           tenantId,
           processDefinitionName,
           processDefinitionVersion,
-          extensionProperties);
+          extensionProperties,
+          toolName,
+          inboundConnectorType);
     }
   }
 

--- a/search/search-domain/src/main/java/io/camunda/search/filter/MessageSubscriptionFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/MessageSubscriptionFilter.java
@@ -31,7 +31,9 @@ public record MessageSubscriptionFilter(
     List<Operation<String>> correlationKeyOperations,
     List<Operation<String>> tenantIdOperations,
     List<Operation<String>> processDefinitionNameOperations,
-    List<Operation<Integer>> processDefinitionVersionOperations)
+    List<Operation<Integer>> processDefinitionVersionOperations,
+    List<Operation<String>> toolNameOperations,
+    List<Operation<String>> inboundConnectorTypeOperations)
     implements FilterBase {
 
   public static final class Builder implements ObjectBuilder<MessageSubscriptionFilter> {
@@ -50,6 +52,8 @@ public record MessageSubscriptionFilter(
     private List<Operation<String>> tenantIdOperations;
     private List<Operation<String>> processDefinitionNameOperations;
     private List<Operation<Integer>> processDefinitionVersionOperations;
+    private List<Operation<String>> toolNameOperations;
+    private List<Operation<String>> inboundConnectorTypeOperations;
 
     public Builder messageSubscriptionKeys(final Long value, final Long... values) {
       return messageSubscriptionKeyOperations(FilterUtil.mapDefaultToOperation(value, values));
@@ -265,6 +269,36 @@ public record MessageSubscriptionFilter(
       return correlationKeyOperations(collectValues(operation, operations));
     }
 
+    public Builder toolNames(final String value, final String... values) {
+      return toolNameOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    @SafeVarargs
+    public final Builder toolNameOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return toolNameOperations(collectValues(operation, operations));
+    }
+
+    public Builder toolNameOperations(final List<Operation<String>> operations) {
+      toolNameOperations = addValuesToList(toolNameOperations, operations);
+      return this;
+    }
+
+    public Builder inboundConnectorTypes(final String value, final String... values) {
+      return inboundConnectorTypeOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    @SafeVarargs
+    public final Builder inboundConnectorTypeOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return inboundConnectorTypeOperations(collectValues(operation, operations));
+    }
+
+    public Builder inboundConnectorTypeOperations(final List<Operation<String>> operations) {
+      inboundConnectorTypeOperations = addValuesToList(inboundConnectorTypeOperations, operations);
+      return this;
+    }
+
     @Override
     public MessageSubscriptionFilter build() {
       return new MessageSubscriptionFilter(
@@ -281,7 +315,9 @@ public record MessageSubscriptionFilter(
           Objects.requireNonNullElse(correlationKeyOperations, Collections.emptyList()),
           Objects.requireNonNullElse(tenantIdOperations, Collections.emptyList()),
           Objects.requireNonNullElse(processDefinitionNameOperations, Collections.emptyList()),
-          Objects.requireNonNullElse(processDefinitionVersionOperations, Collections.emptyList()));
+          Objects.requireNonNullElse(processDefinitionVersionOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(toolNameOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(inboundConnectorTypeOperations, Collections.emptyList()));
     }
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/sort/MessageSubscriptionSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/MessageSubscriptionSort.java
@@ -92,6 +92,16 @@ public record MessageSubscriptionSort(List<FieldSorting> orderings) implements S
       return this;
     }
 
+    public Builder toolName() {
+      currentOrdering = new FieldSorting("toolName", null);
+      return this;
+    }
+
+    public Builder inboundConnectorType() {
+      currentOrdering = new FieldSorting("inboundConnectorType", null);
+      return this;
+    }
+
     @Override
     protected MessageSubscriptionSort.Builder self() {
       return this;

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/MessageSubscriptionBuilder.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/MessageSubscriptionBuilder.java
@@ -39,6 +39,8 @@ public class MessageSubscriptionBuilder implements MessageSubscription {
   private String processDefinitionName;
   private Integer processDefinitionVersion;
   private Map<String, String> extensionProperties;
+  private String toolName;
+  private String inboundConnectorType;
 
   @Override
   public Long getMessageSubscriptionKey() {
@@ -118,6 +120,16 @@ public class MessageSubscriptionBuilder implements MessageSubscription {
   @Override
   public Map<String, String> getExtensionProperties() {
     return extensionProperties;
+  }
+
+  @Override
+  public String getToolName() {
+    return toolName;
+  }
+
+  @Override
+  public String getInboundConnectorType() {
+    return inboundConnectorType;
   }
 
   public MessageSubscriptionBuilder setExtensionProperties(
@@ -201,6 +213,16 @@ public class MessageSubscriptionBuilder implements MessageSubscription {
 
   public MessageSubscriptionBuilder setMessageSubscriptionKey(final Long messageSubscriptionKey) {
     this.messageSubscriptionKey = messageSubscriptionKey;
+    return this;
+  }
+
+  public MessageSubscriptionBuilder setToolName(final String toolName) {
+    this.toolName = toolName;
+    return this;
+  }
+
+  public MessageSubscriptionBuilder setInboundConnectorType(final String inboundConnectorType) {
+    this.inboundConnectorType = inboundConnectorType;
     return this;
   }
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/MessageSubscriptionTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/MessageSubscriptionTemplate.java
@@ -110,6 +110,8 @@ public class MessageSubscriptionTemplate extends AbstractTemplateDescriptor
   public static final String PROCESS_DEFINITION_VERSION = "processDefinitionVersion";
   public static final String EXTENSION_PROPERTIES = "extensionProperties";
   public static final String MESSAGE_SUBSCRIPTION_TYPE = "messageSubscriptionType";
+  public static final String TOOL_NAME = "toolName";
+  public static final String INBOUND_CONNECTOR_TYPE = "inboundConnectorType";
 
   public MessageSubscriptionTemplate(final String indexPrefix, final boolean isElasticsearch) {
     super(indexPrefix, isElasticsearch);

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/messagesubscription/MessageSubscriptionEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/messagesubscription/MessageSubscriptionEntity.java
@@ -66,6 +66,12 @@ public class MessageSubscriptionEntity
   @SinceVersion(value = "8.10.0", requireDefault = false)
   private String messageSubscriptionType;
 
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private String toolName;
+
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private String inboundConnectorType;
+
   /**
    * @deprecated since 8.9
    */
@@ -252,6 +258,24 @@ public class MessageSubscriptionEntity
     return this;
   }
 
+  public String getToolName() {
+    return toolName;
+  }
+
+  public MessageSubscriptionEntity setToolName(final String toolName) {
+    this.toolName = toolName;
+    return this;
+  }
+
+  public String getInboundConnectorType() {
+    return inboundConnectorType;
+  }
+
+  public MessageSubscriptionEntity setInboundConnectorType(final String inboundConnectorType) {
+    this.inboundConnectorType = inboundConnectorType;
+    return this;
+  }
+
   /**
    * @deprecated since 8.9
    */
@@ -344,7 +368,9 @@ public class MessageSubscriptionEntity
         processDefinitionName,
         processDefinitionVersion,
         extensionProperties,
-        messageSubscriptionType);
+        messageSubscriptionType,
+        toolName,
+        inboundConnectorType);
   }
 
   @Override
@@ -378,6 +404,8 @@ public class MessageSubscriptionEntity
         && Objects.equals(processDefinitionName, that.processDefinitionName)
         && Objects.equals(processDefinitionVersion, that.processDefinitionVersion)
         && Objects.equals(extensionProperties, that.extensionProperties)
-        && Objects.equals(messageSubscriptionType, that.messageSubscriptionType);
+        && Objects.equals(messageSubscriptionType, that.messageSubscriptionType)
+        && Objects.equals(toolName, that.toolName)
+        && Objects.equals(inboundConnectorType, that.inboundConnectorType);
   }
 }

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-event.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-event.json
@@ -106,6 +106,12 @@
       },
       "messageSubscriptionType": {
         "type": "keyword"
+      },
+      "toolName": {
+        "type": "keyword"
+      },
+      "inboundConnectorType": {
+        "type": "keyword"
       }
 		}
 	}

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-event.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-event.json
@@ -106,6 +106,12 @@
       },
       "messageSubscriptionType": {
         "type": "keyword"
+      },
+      "toolName": {
+        "type": "keyword"
+      },
+      "inboundConnectorType": {
+        "type": "keyword"
       }
 		}
 	}

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/utils/ProcessCacheUtil.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/utils/ProcessCacheUtil.java
@@ -22,6 +22,8 @@ import org.slf4j.LoggerFactory;
 
 public final class ProcessCacheUtil {
 
+  public static final String EXTENSION_PROPERTY_CAMUNDA_TOOL_NAME = "io.camunda.tool:name";
+  public static final String EXTENSION_PROPERTY_INBOUND_TYPE = "inbound.type";
   private static final Logger LOGGER = LoggerFactory.getLogger(ProcessCacheUtil.class);
 
   private ProcessCacheUtil() {
@@ -155,5 +157,19 @@ public final class ProcessCacheUtil {
   public static Map<String, String> getFlowNodesMap(final Collection<FlowNode> flowNodes) {
     return flowNodes.stream()
         .collect(HashMap::new, (map, fn) -> map.put(fn.getId(), fn.getName()), HashMap::putAll);
+  }
+
+  public static String getToolName(final Map<String, String> extensionProperties) {
+    if (extensionProperties == null) {
+      return null;
+    }
+    return extensionProperties.get(EXTENSION_PROPERTY_CAMUNDA_TOOL_NAME);
+  }
+
+  public static String getInboundConnectorType(final Map<String, String> extensionProperties) {
+    if (extensionProperties == null) {
+      return null;
+    }
+    return extensionProperties.get(EXTENSION_PROPERTY_INBOUND_TYPE);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AbstractEventHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AbstractEventHandler.java
@@ -14,6 +14,7 @@ import static io.camunda.webapps.schema.descriptors.template.MessageSubscription
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.EVENT_SOURCE_TYPE;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.EXTENSION_PROPERTIES;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.FLOW_NODE_ID;
+import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.INBOUND_CONNECTOR_TYPE;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.INCIDENT_ERROR_MSG;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.INCIDENT_ERROR_TYPE;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.JOB_CUSTOM_HEADERS;
@@ -29,6 +30,7 @@ import static io.camunda.webapps.schema.descriptors.template.MessageSubscription
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.PROCESS_DEFINITION_NAME;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.PROCESS_DEFINITION_VERSION;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.PROCESS_KEY;
+import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.TOOL_NAME;
 
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.messagesubscription.EventSourceType;
@@ -97,6 +99,8 @@ public abstract class AbstractEventHandler<R extends RecordValue>
     jsonMap.put(PROCESS_DEFINITION_NAME, entity.getProcessDefinitionName());
     jsonMap.put(PROCESS_DEFINITION_VERSION, entity.getProcessDefinitionVersion());
     jsonMap.put(EXTENSION_PROPERTIES, entity.getExtensionProperties());
+    jsonMap.put(TOOL_NAME, entity.getToolName());
+    jsonMap.put(INBOUND_CONNECTOR_TYPE, entity.getInboundConnectorType());
     jsonMap.put(positionFieldName, positionFieldValue);
     if (entity.getMetadata() != null) {
       final Map<String, Object> metadataMap = new HashMap<>();
@@ -137,11 +141,15 @@ public abstract class AbstractEventHandler<R extends RecordValue>
       entity.setProcessDefinitionName(
           cached.map(CachedProcessEntity::name).filter(s -> !s.isBlank()).orElse(null));
       entity.setProcessDefinitionVersion(cached.map(CachedProcessEntity::version).orElse(null));
-      entity.setExtensionProperties(
+      final Map<String, String> ext =
           cached
               .map(CachedProcessEntity::elementExtensionProperties)
               .map(p -> p.get(elementId))
-              .orElse(Map.of()));
+              .orElse(Map.of());
+      entity
+          .setExtensionProperties(ext)
+          .setToolName(ext.get("io.camunda.tool:name"))
+          .setInboundConnectorType(ext.get("inbound.type"));
     }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AbstractEventHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AbstractEventHandler.java
@@ -38,6 +38,7 @@ import io.camunda.webapps.schema.entities.messagesubscription.MessageSubscriptio
 import io.camunda.webapps.schema.entities.messagesubscription.MessageSubscriptionState;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
+import io.camunda.zeebe.exporter.common.utils.ProcessCacheUtil;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import java.time.Instant;
@@ -148,8 +149,8 @@ public abstract class AbstractEventHandler<R extends RecordValue>
               .orElse(Map.of());
       entity
           .setExtensionProperties(ext)
-          .setToolName(ext.get("io.camunda.tool:name"))
-          .setInboundConnectorType(ext.get("inbound.type"));
+          .setToolName(ProcessCacheUtil.getToolName(ext))
+          .setInboundConnectorType(ProcessCacheUtil.getInboundConnectorType(ext));
     }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromMessageStartEventSubscriptionHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromMessageStartEventSubscriptionHandlerTest.java
@@ -191,6 +191,53 @@ final class MessageSubscriptionFromMessageStartEventSubscriptionHandlerTest {
   }
 
   @Test
+  void shouldExtractToolNameAndInboundConnectorTypeFromCache() {
+    // given
+    final long processDefinitionKey = 100L;
+    final String startEventId = "StartEvent_1";
+    final Map<String, String> extProps =
+        Map.of("io.camunda.tool:name", "myTool", "inbound.type", "io.camunda:http-webhook:1");
+    Mockito.when(processCache.get(processDefinitionKey))
+        .thenReturn(
+            Optional.of(
+                new CachedProcessEntity(
+                    "Process",
+                    1,
+                    null,
+                    List.of(),
+                    Map.of(),
+                    false,
+                    Map.of(startEventId, extProps))));
+
+    final ImmutableMessageStartEventSubscriptionRecordValue value =
+        ImmutableMessageStartEventSubscriptionRecordValue.builder()
+            .withProcessDefinitionKey(processDefinitionKey)
+            .withBpmnProcessId("proc")
+            .withStartEventId(startEventId)
+            .withMessageName("msg")
+            .withTenantId("<default>")
+            .withProcessInstanceKey(-1L)
+            .withCorrelationKey("")
+            .withMessageKey(-1L)
+            .build();
+
+    final Record<MessageStartEventSubscriptionRecordValue> record =
+        factory.generateRecord(
+            ValueType.MESSAGE_START_EVENT_SUBSCRIPTION,
+            r -> r.withIntent(MessageStartEventSubscriptionIntent.CREATED).withValue(value));
+
+    final MessageSubscriptionEntity entity = new MessageSubscriptionEntity();
+
+    // when
+    underTest.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getToolName()).isEqualTo("myTool");
+    assertThat(entity.getInboundConnectorType()).isEqualTo("io.camunda:http-webhook:1");
+    assertThat(entity.getExtensionProperties()).isEqualTo(extProps);
+  }
+
+  @Test
   void shouldHandleMissingProcessCacheGracefully() {
     // given
     Mockito.when(processCache.get(Mockito.anyLong())).thenReturn(Optional.empty());
@@ -218,6 +265,8 @@ final class MessageSubscriptionFromMessageStartEventSubscriptionHandlerTest {
     underTest.updateEntity(record, entity);
     assertThat(entity.getProcessDefinitionName()).isNull();
     assertThat(entity.getProcessDefinitionVersion()).isNull();
+    assertThat(entity.getToolName()).isNull();
+    assertThat(entity.getInboundConnectorType()).isNull();
   }
 
   @Test
@@ -255,6 +304,8 @@ final class MessageSubscriptionFromMessageStartEventSubscriptionHandlerTest {
     expectedUpdateFields.put("processDefinitionName", null);
     expectedUpdateFields.put("processDefinitionVersion", null);
     expectedUpdateFields.put("extensionProperties", null);
+    expectedUpdateFields.put("toolName", null);
+    expectedUpdateFields.put("inboundConnectorType", null);
     expectedUpdateFields.put("metadata", metadataMap);
     final BatchRequest mockRequest = Mockito.mock(BatchRequest.class);
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromProcessMessageSubscriptionHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromProcessMessageSubscriptionHandlerTest.java
@@ -335,6 +335,47 @@ final class MessageSubscriptionFromProcessMessageSubscriptionHandlerTest {
   }
 
   @Test
+  void shouldExtractToolNameAndInboundConnectorTypeFromCache() {
+    // given
+    final long processDefinitionKey = 100L;
+    final String elementId = "Event_1";
+    final Map<String, String> extProps =
+        Map.of("io.camunda.tool:name", "myTool", "inbound.type", "io.camunda:http-webhook:1");
+    Mockito.when(processCache.get(processDefinitionKey))
+        .thenReturn(
+            Optional.of(
+                new CachedProcessEntity(
+                    "Process", 1, null, List.of(), Map.of(), false, Map.of(elementId, extProps))));
+
+    final ImmutableProcessMessageSubscriptionRecordValue value =
+        ImmutableProcessMessageSubscriptionRecordValue.builder()
+            .withProcessDefinitionKey(processDefinitionKey)
+            .withBpmnProcessId("proc")
+            .withElementId(elementId)
+            .withMessageName("msg")
+            .withTenantId("<default>")
+            .withProcessInstanceKey(15L)
+            .withCorrelationKey("")
+            .withMessageKey(-1L)
+            .build();
+
+    final Record<ProcessMessageSubscriptionRecordValue> record =
+        factory.generateRecord(
+            ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
+            r -> r.withIntent(ProcessMessageSubscriptionIntent.CREATED).withValue(value));
+
+    final MessageSubscriptionEntity entity = new MessageSubscriptionEntity();
+
+    // when
+    underTest.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getToolName()).isEqualTo("myTool");
+    assertThat(entity.getInboundConnectorType()).isEqualTo("io.camunda:http-webhook:1");
+    assertThat(entity.getExtensionProperties()).isEqualTo(extProps);
+  }
+
+  @Test
   void shouldHandleMissingProcessCacheGracefully() {
     // given
     Mockito.when(processCache.get(Mockito.anyLong())).thenReturn(Optional.empty());
@@ -362,6 +403,8 @@ final class MessageSubscriptionFromProcessMessageSubscriptionHandlerTest {
     underTest.updateEntity(record, entity);
     assertThat(entity.getProcessDefinitionName()).isNull();
     assertThat(entity.getProcessDefinitionVersion()).isNull();
+    assertThat(entity.getToolName()).isNull();
+    assertThat(entity.getInboundConnectorType()).isNull();
   }
 
   @Test
@@ -399,6 +442,8 @@ final class MessageSubscriptionFromProcessMessageSubscriptionHandlerTest {
     expectedUpdateFields.put("processDefinitionName", null);
     expectedUpdateFields.put("processDefinitionVersion", null);
     expectedUpdateFields.put("extensionProperties", null);
+    expectedUpdateFields.put("toolName", null);
+    expectedUpdateFields.put("inboundConnectorType", null);
     expectedUpdateFields.put("metadata", metadataMap);
 
     final BatchRequest mockRequest = Mockito.mock(BatchRequest.class);

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionExportHandler.java
@@ -70,6 +70,11 @@ public class MessageSubscriptionExportHandler
     final ProcessMessageSubscriptionRecordValue value = record.getValue();
     final long pdKey = value.getProcessDefinitionKey();
     final Optional<CachedProcessEntity> cached = processCache.get(pdKey);
+    final var ext =
+        cached
+            .map(CachedProcessEntity::elementExtensionProperties)
+            .map(p -> p.get(value.getElementId()))
+            .orElse(Map.of());
     return new MessageSubscriptionDbModel.Builder()
         .messageSubscriptionKey(record.getKey())
         .processDefinitionId(value.getBpmnProcessId())
@@ -88,11 +93,9 @@ public class MessageSubscriptionExportHandler
         .processDefinitionName(
             cached.map(CachedProcessEntity::name).filter(s -> !s.isBlank()).orElse(null))
         .processDefinitionVersion(cached.map(CachedProcessEntity::version).orElse(null))
-        .extensionProperties(
-            cached
-                .map(CachedProcessEntity::elementExtensionProperties)
-                .map(p -> p.get(value.getElementId()))
-                .orElse(Map.of()))
+        .extensionProperties(ext)
+        .toolName(ext.get("io.camunda.tool:name"))
+        .inboundConnectorType(ext.get("inbound.type"))
         .build();
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionExportHandler.java
@@ -16,6 +16,7 @@ import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionS
 import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionType;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
+import io.camunda.zeebe.exporter.common.utils.ProcessCacheUtil;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
@@ -94,8 +95,8 @@ public class MessageSubscriptionExportHandler
             cached.map(CachedProcessEntity::name).filter(s -> !s.isBlank()).orElse(null))
         .processDefinitionVersion(cached.map(CachedProcessEntity::version).orElse(null))
         .extensionProperties(ext)
-        .toolName(ext.get("io.camunda.tool:name"))
-        .inboundConnectorType(ext.get("inbound.type"))
+        .toolName(ProcessCacheUtil.getToolName(ext))
+        .inboundConnectorType(ProcessCacheUtil.getInboundConnectorType(ext))
         .build();
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionFromMessageStartEventSubscriptionExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionFromMessageStartEventSubscriptionExportHandler.java
@@ -16,6 +16,7 @@ import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionS
 import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionType;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
+import io.camunda.zeebe.exporter.common.utils.ProcessCacheUtil;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
@@ -93,8 +94,8 @@ public class MessageSubscriptionFromMessageStartEventSubscriptionExportHandler
             cached.map(CachedProcessEntity::name).filter(s -> !s.isBlank()).orElse(null))
         .processDefinitionVersion(cached.map(CachedProcessEntity::version).orElse(null))
         .extensionProperties(ext)
-        .toolName(ext.get("io.camunda.tool:name"))
-        .inboundConnectorType(ext.get("inbound.type"))
+        .toolName(ProcessCacheUtil.getToolName(ext))
+        .inboundConnectorType(ProcessCacheUtil.getInboundConnectorType(ext))
         .build();
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionFromMessageStartEventSubscriptionExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionFromMessageStartEventSubscriptionExportHandler.java
@@ -69,6 +69,11 @@ public class MessageSubscriptionFromMessageStartEventSubscriptionExportHandler
     final var value = record.getValue();
     final long pdKey = value.getProcessDefinitionKey();
     final Optional<CachedProcessEntity> cached = processCache.get(pdKey);
+    final var ext =
+        cached
+            .map(CachedProcessEntity::elementExtensionProperties)
+            .map(p -> p.get(value.getStartEventId()))
+            .orElse(Map.of());
     return new MessageSubscriptionDbModel.Builder()
         .messageSubscriptionKey(record.getKey())
         .processDefinitionId(value.getBpmnProcessId())
@@ -87,11 +92,9 @@ public class MessageSubscriptionFromMessageStartEventSubscriptionExportHandler
         .processDefinitionName(
             cached.map(CachedProcessEntity::name).filter(s -> !s.isBlank()).orElse(null))
         .processDefinitionVersion(cached.map(CachedProcessEntity::version).orElse(null))
-        .extensionProperties(
-            cached
-                .map(CachedProcessEntity::elementExtensionProperties)
-                .map(p -> p.get(value.getStartEventId()))
-                .orElse(Map.of()))
+        .extensionProperties(ext)
+        .toolName(ext.get("io.camunda.tool:name"))
+        .inboundConnectorType(ext.get("inbound.type"))
         .build();
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/message/MessageSubscriptionExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/message/MessageSubscriptionExportHandlerTest.java
@@ -139,7 +139,8 @@ final class MessageSubscriptionExportHandlerTest {
     final String tenantId = "tenant-1";
     final String processName = "Process One";
     final int processVersion = 2;
-    final Map<String, String> extProps = Map.of("io.camunda.tool:name", "myTool");
+    final Map<String, String> extProps =
+        Map.of("io.camunda.tool:name", "myTool", "inbound.type", "io.camunda:http-webhook:1");
 
     final var recordValue =
         ImmutableProcessMessageSubscriptionRecordValue.builder()
@@ -195,6 +196,8 @@ final class MessageSubscriptionExportHandlerTest {
     assertThat(model.processDefinitionName()).isEqualTo(processName);
     assertThat(model.processDefinitionVersion()).isEqualTo(processVersion);
     assertThat(model.extensionProperties()).isEqualTo(extProps);
+    assertThat(model.toolName()).isEqualTo("myTool");
+    assertThat(model.inboundConnectorType()).isEqualTo("io.camunda:http-webhook:1");
   }
 
   private static Stream<Arguments> provideTestRoutines() {
@@ -243,5 +246,7 @@ final class MessageSubscriptionExportHandlerTest {
     assertThat(model.processDefinitionName()).isNull();
     assertThat(model.processDefinitionVersion()).isNull();
     assertThat(model.extensionProperties()).isEqualTo(Map.of());
+    assertThat(model.toolName()).isNull();
+    assertThat(model.inboundConnectorType()).isNull();
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/message/MessageSubscriptionFromMessageStartEventSubscriptionExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/message/MessageSubscriptionFromMessageStartEventSubscriptionExportHandlerTest.java
@@ -134,7 +134,8 @@ final class MessageSubscriptionFromMessageStartEventSubscriptionExportHandlerTes
     final String tenantId = "tenant-1";
     final String processName = "Process One";
     final int processVersion = 2;
-    final Map<String, String> extProps = Map.of("io.camunda.tool:name", "myTool");
+    final Map<String, String> extProps =
+        Map.of("io.camunda.tool:name", "myTool", "inbound.type", "io.camunda:http-webhook:1");
 
     final var recordValue =
         ImmutableMessageStartEventSubscriptionRecordValue.builder()
@@ -187,6 +188,8 @@ final class MessageSubscriptionFromMessageStartEventSubscriptionExportHandlerTes
     assertThat(model.processDefinitionName()).isEqualTo(processName);
     assertThat(model.processDefinitionVersion()).isEqualTo(processVersion);
     assertThat(model.extensionProperties()).isEqualTo(extProps);
+    assertThat(model.toolName()).isEqualTo("myTool");
+    assertThat(model.inboundConnectorType()).isEqualTo("io.camunda:http-webhook:1");
   }
 
   private static Stream<Arguments> provideTestRoutines() {
@@ -230,5 +233,7 @@ final class MessageSubscriptionFromMessageStartEventSubscriptionExportHandlerTes
     assertThat(model.processDefinitionName()).isNull();
     assertThat(model.processDefinitionVersion()).isNull();
     assertThat(model.extensionProperties()).isEqualTo(Map.of());
+    assertThat(model.toolName()).isNull();
+    assertThat(model.inboundConnectorType()).isNull();
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
@@ -272,6 +272,7 @@ components:
         - elementId
         - elementInstanceKey
         - extensionProperties
+        - inboundConnectorType
         - lastUpdatedDate
         - messageName
         - messageSubscriptionKey
@@ -283,6 +284,7 @@ components:
         - processDefinitionVersion
         - processInstanceKey
         - tenantId
+        - toolName
       properties:
         messageSubscriptionKey:
           allOf:
@@ -354,6 +356,18 @@ components:
           format: int32
           nullable: true
           description: The version of the process definition associated with this message subscription.
+        toolName:
+          type: string
+          nullable: true
+          description: |
+            Tool name extracted from the `io.camunda.tool:name` zeebe:property.
+            Null when the property is absent.
+        inboundConnectorType:
+          type: string
+          nullable: true
+          description: |
+            Inbound connector type extracted from the `inbound.type` zeebe:property.
+            Null when the property is absent.
         tenantId:
           $ref: 'identifiers.yaml#/components/schemas/TenantId'
 
@@ -377,6 +391,8 @@ components:
             - messageName
             - correlationKey
             - tenantId
+            - toolName
+            - inboundConnectorType
         order:
           $ref: 'search-models.yaml#/components/schemas/SortOrderEnum'
       required:
@@ -461,6 +477,14 @@ components:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/IntegerFilterProperty'
           description: The version of the process definition associated with this message subscription.
+        toolName:
+          allOf:
+            - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
+          description: Filter by tool name extracted from the `io.camunda.tool:name` zeebe:property.
+        inboundConnectorType:
+          allOf:
+            - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
+          description: Filter by inbound connector type extracted from the `inbound.type` zeebe:property.
 
     CorrelatedMessageSubscriptionSearchQueryResult:
       required:

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/MessageSubscriptionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/MessageSubscriptionQueryControllerTest.java
@@ -52,7 +52,9 @@ public class MessageSubscriptionQueryControllerTest extends RestControllerTest {
                   "rootProcessInstanceKey": null,
                   "extensionProperties": {},
                   "processDefinitionName": null,
-                  "processDefinitionVersion": null
+                  "processDefinitionVersion": null,
+                  "toolName": null,
+                  "inboundConnectorType": null
                 }
             ],
             "page": {
@@ -221,7 +223,9 @@ public class MessageSubscriptionQueryControllerTest extends RestControllerTest {
                 "lastUpdatedDate": "2025-07-05T12:11:00.975Z",
                 "correlationKey": "test",
                 "messageName": "test-message",
-                "tenantId": "test-tenant"
+                "tenantId": "test-tenant",
+                "toolName": "myTool",
+                "inboundConnectorType": "io.camunda:http-webhook:1"
               }
             }""")
         .exchange()
@@ -255,7 +259,9 @@ public class MessageSubscriptionQueryControllerTest extends RestControllerTest {
                                 .dateTimes(OffsetDateTime.parse("2025-07-05T12:11:00.975Z"))
                                 .correlationKeys("test")
                                 .messageNames("test-message")
-                                .tenantIds("test-tenant"))
+                                .tenantIds("test-tenant")
+                                .toolNames("myTool")
+                                .inboundConnectorTypes("io.camunda:http-webhook:1"))
                     .build()),
             any());
   }
@@ -326,6 +332,14 @@ public class MessageSubscriptionQueryControllerTest extends RestControllerTest {
                 {
                   "field": "tenantId",
                   "order": "asc"
+                },
+                {
+                  "field": "toolName",
+                  "order": "asc"
+                },
+                {
+                  "field": "inboundConnectorType",
+                  "order": "desc"
                 }
               ]
             }""")
@@ -368,7 +382,11 @@ public class MessageSubscriptionQueryControllerTest extends RestControllerTest {
                                 .messageName()
                                 .desc()
                                 .tenantId()
-                                .asc())
+                                .asc()
+                                .toolName()
+                                .asc()
+                                .inboundConnectorType()
+                                .desc())
                     .build()),
             any());
   }


### PR DESCRIPTION
## Summary

- Promotes `toolName` (from `io.camunda.tool:name` zeebe:property) and `inboundConnectorType` (from `inbound.type` zeebe:property) to first-class searchable/filterable/sortable String attributes on `MessageSubscriptionEntity`
- Both fields are extracted at export time from the already-stored `extensionProperties` map; they are `null` when the respective key is absent
- Changes span all layers: ES/OS keyword index mappings, RDBMS `TOOL_NAME`/`INBOUND_CONNECTOR_TYPE` columns (via Liquibase), exporter handlers (ES/OS + RDBMS), search domain entity/filter/sort, filter/sort/entity transformers, REST API result + filter + sort, and Java client

Closes #51448

https://claude.ai/code/session_01Mg8FB2hxEZvHofDTcSU5yx