### PR TITLE
feat: add `beforeAll` event type to BPMN model

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractActivityBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractActivityBuilder.java
@@ -171,6 +171,16 @@ public abstract class AbstractActivityBuilder<
   }
 
   @Override
+  public B zeebeBeforeAllExecutionListener(final String type, final String retries) {
+    return zeebeExecutionListenersBuilder.zeebeBeforeAllExecutionListener(type, retries);
+  }
+
+  @Override
+  public B zeebeBeforeAllExecutionListener(final String type) {
+    return zeebeExecutionListenersBuilder.zeebeBeforeAllExecutionListener(type);
+  }
+
+  @Override
   public B zeebeStartExecutionListener(final String type, final String retries) {
     return zeebeExecutionListenersBuilder.zeebeStartExecutionListener(type, retries);
   }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ZeebeExecutionListenersBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ZeebeExecutionListenersBuilder.java
@@ -20,6 +20,14 @@ import java.util.function.Consumer;
 /** A fluent builder for elements with execution listeners. */
 public interface ZeebeExecutionListenersBuilder<B> {
 
+  default B zeebeBeforeAllExecutionListener(final String type, final String retries) {
+    throw new UnsupportedOperationException("Please use concrete implementation");
+  }
+
+  default B zeebeBeforeAllExecutionListener(final String type) {
+    throw new UnsupportedOperationException("Please use concrete implementation");
+  }
+
   B zeebeStartExecutionListener(String type, String retries);
 
   B zeebeStartExecutionListener(String type);

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ZeebeExecutionListenersBuilderImpl.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ZeebeExecutionListenersBuilderImpl.java
@@ -30,6 +30,21 @@ public class ZeebeExecutionListenersBuilderImpl<B extends AbstractBaseElementBui
   }
 
   @Override
+  public B zeebeBeforeAllExecutionListener(final String type, final String retries) {
+    final ZeebeExecutionListener listener = createZeebeExecutionListener();
+    listener.setEventType(ZeebeExecutionListenerEventType.beforeAll);
+    listener.setType(type);
+    listener.setRetries(retries);
+
+    return elementBuilder;
+  }
+
+  @Override
+  public B zeebeBeforeAllExecutionListener(final String type) {
+    return zeebeBeforeAllExecutionListener(type, ZeebeExecutionListener.DEFAULT_RETRIES);
+  }
+
+  @Override
   public B zeebeStartExecutionListener(final String type, final String retries) {
     final ZeebeExecutionListener listener = createZeebeExecutionListener();
     listener.setEventType(ZeebeExecutionListenerEventType.start);

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeExecutionListenerEventType.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeExecutionListenerEventType.java
@@ -20,6 +20,7 @@ package io.camunda.zeebe.model.bpmn.instance.zeebe;
  * (beginning) or at the end (completion) of an element's processing.
  */
 public enum ZeebeExecutionListenerEventType {
+  beforeAll,
   start,
   end
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ExecutionListenersValidator.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ExecutionListenersValidator.java
@@ -16,7 +16,10 @@
 package io.camunda.zeebe.model.bpmn.validation.zeebe;
 
 import io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants;
+import io.camunda.zeebe.model.bpmn.instance.Activity;
+import io.camunda.zeebe.model.bpmn.instance.MultiInstanceLoopCharacteristics;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListener;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListenerEventType;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListeners;
 import java.util.Arrays;
 import java.util.Collection;
@@ -26,6 +29,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import org.camunda.bpm.model.xml.instance.ModelElementInstance;
 import org.camunda.bpm.model.xml.validation.ModelElementValidator;
 import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
 
@@ -74,8 +78,8 @@ public class ExecutionListenersValidator implements ModelElementValidator<ZeebeE
       return;
     }
 
-    final String parentElementTypeName =
-        element.getParentElement().getParentElement().getElementType().getTypeName();
+    final ModelElementInstance bpmnElement = element.getParentElement().getParentElement();
+    final String parentElementTypeName = bpmnElement.getElementType().getTypeName();
     if (!ELEMENTS_THAT_SUPPORT_EXECUTION_LISTENERS.contains(parentElementTypeName)) {
       final String errorMessage =
           String.format(
@@ -84,6 +88,8 @@ public class ExecutionListenersValidator implements ModelElementValidator<ZeebeE
       validationResultCollector.addError(0, errorMessage);
       return;
     }
+
+    validateBeforeAllListeners(executionListeners, bpmnElement, validationResultCollector);
 
     final Function<ZeebeExecutionListener, String> eventTypeAndTypeClassifier =
         listener -> listener.getEventType() + "|" + listener.getType();
@@ -96,6 +102,34 @@ public class ExecutionListenersValidator implements ModelElementValidator<ZeebeE
     listenersGroupedByType.values().stream()
         .filter(duplicates -> duplicates.size() > 1)
         .forEach(duplicates -> reportDuplicateListeners(duplicates, validationResultCollector));
+  }
+
+  /**
+   * Validates that {@code beforeAll} execution listeners are only used on multi-instance activities
+   * (i.e., activities with a {@link MultiInstanceLoopCharacteristics}). Using {@code beforeAll} on
+   * any other element type is an error because the semantics — running before the input collection
+   * is evaluated — only apply to the enclosing multi-instance body.
+   */
+  private void validateBeforeAllListeners(
+      final Collection<ZeebeExecutionListener> executionListeners,
+      final ModelElementInstance bpmnElement,
+      final ValidationResultCollector validationResultCollector) {
+
+    final boolean hasBeforeAllOnNonMultiInstance =
+        executionListeners.stream()
+                .anyMatch(l -> l.getEventType() == ZeebeExecutionListenerEventType.beforeAll)
+            && !(bpmnElement instanceof Activity
+                && ((Activity) bpmnElement).getLoopCharacteristics()
+                    instanceof MultiInstanceLoopCharacteristics);
+
+    if (hasBeforeAllOnNonMultiInstance) {
+      validationResultCollector.addError(
+          0,
+          "Execution listeners with event type 'beforeAll' are only supported on multi-instance "
+              + "activities and are not valid on '"
+              + bpmnElement.getElementType().getTypeName()
+              + "'");
+    }
   }
 
   private void reportDuplicateListeners(

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/ServiceTaskBuilderTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/ServiceTaskBuilderTest.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.model.bpmn.builder;
 
+import static io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListenerEventType.beforeAll;
 import static io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListenerEventType.end;
 import static io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListenerEventType.start;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -121,6 +122,59 @@ public class ServiceTaskBuilderTest {
                 assertThat(listener.getTaskHeaders().getHeaders())
                     .extracting(ZeebeHeader::getKey, ZeebeHeader::getValue)
                     .containsExactly(tuple("aKey", "aValue"), tuple("bKey", "bValue")));
+  }
+
+  @Test
+  void shouldDefineBeforeAllExecutionListenerWithCustomRetries() {
+    // given
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask(
+                "task",
+                task ->
+                    task.zeebeJobType("service_task_type")
+                        .multiInstance(b -> b.zeebeInputCollectionExpression("items"))
+                        .zeebeBeforeAllExecutionListener("el_before_all_type", "5"))
+            .done();
+
+    // then
+    assertThat(getExecutionListeners(instance.getModelElementById("task")))
+        .singleElement()
+        .extracting(
+            ZeebeExecutionListener::getEventType,
+            ZeebeExecutionListener::getType,
+            ZeebeExecutionListener::getRetries)
+        .containsExactly(beforeAll, "el_before_all_type", "5");
+  }
+
+  @Test
+  void shouldDefineBeforeAllStartAndEndExecutionListenersTogether() {
+    // given
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask(
+                "task",
+                task ->
+                    task.zeebeJobType("service_task_type")
+                        .multiInstance(b -> b.zeebeInputCollectionExpression("items"))
+                        .zeebeBeforeAllExecutionListener("el_before_all")
+                        .zeebeStartExecutionListener("el_start")
+                        .zeebeEndExecutionListener("el_end"))
+            .done();
+
+    // then
+    assertThat(getExecutionListeners(instance.getModelElementById("task")))
+        .hasSize(3)
+        .extracting(
+            ZeebeExecutionListener::getEventType,
+            ZeebeExecutionListener::getType,
+            ZeebeExecutionListener::getRetries)
+        .containsExactly(
+            tuple(beforeAll, "el_before_all", ZeebeExecutionListener.DEFAULT_RETRIES),
+            tuple(start, "el_start", ZeebeExecutionListener.DEFAULT_RETRIES),
+            tuple(end, "el_end", ZeebeExecutionListener.DEFAULT_RETRIES));
   }
 
   private Collection<ZeebeExecutionListener> getExecutionListeners(

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeExecutionListenersValidationTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeExecutionListenersValidationTest.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.model.bpmn.builder.AbstractFlowNodeBuilder;
 import io.camunda.zeebe.model.bpmn.builder.AbstractTaskBuilder;
 import io.camunda.zeebe.model.bpmn.builder.StartEventBuilder;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListener;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListenerEventType;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListeners;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -36,6 +37,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class ZeebeExecutionListenersValidationTest {
   private static final String PROCESS_ID = "process";
   private static final String SERVICE_TASK_TYPE = "service_task_job";
+  private static final String BEFORE_ALL_EL_TYPE = "before_all_execution_listener_job";
   private static final String START_EL_TYPE = "start_execution_listener_job";
   private static final String END_EL_TYPE = "end_execution_listener_job";
 
@@ -197,5 +199,117 @@ public class ZeebeExecutionListenersValidationTest {
             ZeebeExecutionListeners.class,
             "Found '2' duplicates based on eventType[start] and type[type_A], these combinations should be unique."),
         expect(ZeebeExecutionListener.class, "Attribute 'type' must be present and not empty"));
+  }
+
+  @Test
+  @DisplayName("beforeAll listener on a multi-instance service task passes validation")
+  void shouldAllowBeforeAllListenerOnMultiInstanceServiceTask() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .serviceTask(
+                "task",
+                task ->
+                    task.zeebeJobType(SERVICE_TASK_TYPE)
+                        .multiInstance(b -> b.zeebeInputCollectionExpression("items"))
+                        .zeebeBeforeAllExecutionListener(BEFORE_ALL_EL_TYPE))
+            .endEvent()
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessIsValid(process);
+  }
+
+  @Test
+  @DisplayName(
+      "beforeAll listener on a multi-instance service task combined with start/end listeners passes validation")
+  void shouldAllowBeforeAllWithStartAndEndListenersOnMultiInstanceServiceTask() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .serviceTask(
+                "task",
+                task ->
+                    task.zeebeJobType(SERVICE_TASK_TYPE)
+                        .multiInstance(b -> b.zeebeInputCollectionExpression("items"))
+                        .zeebeBeforeAllExecutionListener(BEFORE_ALL_EL_TYPE)
+                        .zeebeStartExecutionListener(START_EL_TYPE)
+                        .zeebeEndExecutionListener(END_EL_TYPE))
+            .endEvent()
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessIsValid(process);
+  }
+
+  @Test
+  @DisplayName("beforeAll listener on a plain (non-multi-instance) service task fails validation")
+  void shouldRejectBeforeAllListenerOnNonMultiInstanceServiceTask() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .serviceTask(
+                "task",
+                task ->
+                    task.zeebeJobType(SERVICE_TASK_TYPE)
+                        .zeebeBeforeAllExecutionListener(BEFORE_ALL_EL_TYPE))
+            .endEvent()
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(
+            ZeebeExecutionListeners.class,
+            "Execution listeners with event type 'beforeAll' are only supported on multi-instance "
+                + "activities and are not valid on 'serviceTask'"));
+  }
+
+  @Test
+  @DisplayName("beforeAll listener on a gateway fails validation")
+  void shouldRejectBeforeAllListenerOnGateway() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .exclusiveGateway("gateway")
+            .zeebeExecutionListener(
+                l ->
+                    l.eventType(ZeebeExecutionListenerEventType.beforeAll).type(BEFORE_ALL_EL_TYPE))
+            .endEvent()
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(
+            ZeebeExecutionListeners.class,
+            "Execution listeners with event type 'beforeAll' are only supported on multi-instance "
+                + "activities and are not valid on 'exclusiveGateway'"));
+  }
+
+  @Test
+  @DisplayName("beforeAll listener on process (non-Activity) fails validation")
+  void shouldRejectBeforeAllListenerOnProcess() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .zeebeExecutionListener(
+                l ->
+                    l.eventType(ZeebeExecutionListenerEventType.beforeAll).type(BEFORE_ALL_EL_TYPE))
+            .startEvent()
+            .endEvent()
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(
+            ZeebeExecutionListeners.class,
+            "Execution listeners with event type 'beforeAll' are only supported on multi-instance "
+                + "activities and are not valid on 'process'"));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -388,6 +388,7 @@ public final class BpmnJobBehavior {
   private static JobListenerEventType fromExecutionListenerEventType(
       final ZeebeExecutionListenerEventType eventType) {
     return switch (eventType) {
+      case beforeAll -> JobListenerEventType.BEFORE_ALL;
       case start -> JobListenerEventType.START;
       case end -> JobListenerEventType.END;
     };


### PR DESCRIPTION
## Description

Add `beforeAll` event type to BPMN model, builder API, and deployment-time validator

- add `ZeebeExecutionListenerEventType.beforeAll` enum value
- introduce `zeebeBeforeAllExecutionListener()` methods
- add validator rule in `ExecutionListenersValidator` rejecting `beforeAll` on NON-MI activities
- add unit tests for the builder and validator (valid MI case, invalid non-MI case)

## Related issues

closes #51348
