### PR TITLE
test: assert actual ASSIGN wording for unassign not-found case

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-unassign-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-unassign-api-tests.spec.ts
@@ -79,8 +79,7 @@ test.describe.parallel('Unassign User Task Tests', () => {
     await assertUnauthorizedRequest(res);
   });
 
-  // Skipped due to bug #38880: https://github.com/camunda/camunda/issues/38880
-  test.skip('Unassign user task - not found', async ({request}) => {
+  test('Unassign user task - not found', async ({request}) => {
     const unknownUserTaskKey = '2251799813694876';
     const res = await request.delete(
       buildUrl(`/user-tasks/${unknownUserTaskKey}/assignee`),
@@ -88,9 +87,12 @@ test.describe.parallel('Unassign User Task Tests', () => {
         headers: jsonHeaders(),
       },
     );
+    // The rejection reads 'ASSIGN' (not 'UNASSIGN') by design: the engine has no
+    // separate UNASSIGN intent — unassignment is an ASSIGN command with an empty
+    // assignee. See issue #38880.
     await assertNotFoundRequest(
       res,
-      `Command 'UNASSIGN' rejected with code 'NOT_FOUND': Expected to unassign user task with key '${unknownUserTaskKey}', but no such user task was found`,
+      `Command 'ASSIGN' rejected with code 'NOT_FOUND': Expected to assign user task with key '${unknownUserTaskKey}', but no such user task was found`,
     );
   });
 


### PR DESCRIPTION
## Summary

- Un-skip the `Unassign user task - not found` e2e test.
- Update the expected rejection message to the actual engine wording (`Command 'ASSIGN' rejected ... Expected to assign user task ...`) and add an inline comment explaining why `ASSIGN` (not `UNASSIGN`) is correct.

Unassignment internally dispatches an `ASSIGN` command with an empty assignee — there is no separate `UNASSIGN` intent in `UserTaskIntent`, and the REST contract (`zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml`) does not guarantee any specific `Command 'X' rejected ...` phrasing. Introducing a dedicated intent purely for the cosmetic wording isn't worth the protocol-level surface area, so we align the test with the actual behavior instead.

Closes #38880