### PR TITLE
fix: Remove Setting Archive Documents Response Early

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplier.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplier.java
@@ -80,9 +80,6 @@ public class ArchiveByIdTaskSupplier<SortFieldType> {
         .apply(getLastSearchPosition())
         .thenComposeAsync(
             response -> {
-              // we can set this in another stage (like after reindex/delete if we want retries)
-              lastSearchResponse.set(response);
-
               if (response.isEmpty()) {
                 finished.set(true);
                 return CompletableFuture.completedFuture(0L);


### PR DESCRIPTION


## Description

The last response should only be sent when reindex & deletion success.

(cherry picked from commit d108d0ffbc489178a93cf4e491fbda836b4ea05d)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
