### PR TITLE
fix: return 404 instead of 500 when importing into a non-existent collection

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/service/entities/EntityImportService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/entities/EntityImportService.java
@@ -40,7 +40,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
@@ -79,13 +78,14 @@ public class EntityImportService {
 
   private List<EntityIdResponseDto> importValidatedEntities(
       final String collectionId, final Set<OptimizeEntityExportDto> entitiesToImport) {
+    final CollectionDefinitionDto collection =
+        getAndValidateCollectionExistsAndIsAccessibleOrFail(null, collectionId);
+
     final List<ReportDefinitionExportDto> reportsToImport =
         retrieveAllReportsToImport(entitiesToImport);
     final List<DashboardDefinitionExportDto> dashboardsToImport =
         retrieveAllDashboardsToImport(entitiesToImport);
 
-    final CollectionDefinitionDto collection =
-        getAndValidateCollectionExistsAndIsAccessibleOrFail(null, collectionId);
     reportImportService.validateAllReportsOrFail(collection, reportsToImport);
     dashboardImportService.validateAllDashboardsOrFail(dashboardsToImport);
 
@@ -190,17 +190,14 @@ public class EntityImportService {
 
   private CollectionDefinitionDto getAndValidateCollectionExistsAndIsAccessibleOrFail(
       final String userId, final String collectionId) {
-    return Optional.ofNullable(collectionId)
-        .map(
-            collId ->
-                Optional.ofNullable(userId)
-                    .map(
-                        user ->
-                            authorizedCollectionService
-                                .getAuthorizedCollectionDefinitionOrFail(user, collId)
-                                .getDefinitionDto())
-                    .orElse(collectionService.getCollectionDefinition(collId)))
-        .orElse(null);
+    if (collectionId == null) {
+      return null;
+    }
+    return userId != null
+        ? authorizedCollectionService
+            .getAuthorizedCollectionDefinitionOrFail(userId, collectionId)
+            .getDefinitionDto()
+        : collectionService.getCollectionDefinition(collectionId);
   }
 
   private void validateCompletenessOrFail(final Set<OptimizeEntityExportDto> entitiesToImport) {

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/entities/EntityImportServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/entities/EntityImportServiceTest.java
@@ -45,8 +45,7 @@ public class EntityImportServiceTest {
 
   @Test
   public void shouldValidateCollectionBeforeProcessingEntities() {
-    // given: a management report that would cause OptimizeValidationException if entity processing
-    // ran before the collection check
+    // given
     final ProcessReportDataDto managementReportData = new ProcessReportDataDto();
     managementReportData.setManagementReport(true);
     final Set<OptimizeEntityExportDto> entities =
@@ -55,8 +54,7 @@ public class EntityImportServiceTest {
     when(collectionService.getCollectionDefinition(anyString()))
         .thenThrow(new NotFoundException("Collection does not exist"));
 
-    // when / then: NotFoundException is thrown (not OptimizeValidationException), proving the
-    // collection check runs before entity pre-processing
+    // when / then
     assertThatThrownBy(() -> underTest.importEntities(NON_EXISTENT_COLLECTION_ID, entities))
         .isInstanceOf(NotFoundException.class);
   }
@@ -76,8 +74,7 @@ public class EntityImportServiceTest {
 
   @Test
   public void shouldValidateCollectionBeforeProcessingEntitiesForInstantPreviewImport() {
-    // given: a management report that would cause OptimizeValidationException if entity processing
-    // ran before the collection check
+    // given
     final ProcessReportDataDto managementReportData = new ProcessReportDataDto();
     managementReportData.setManagementReport(true);
     final Set<OptimizeEntityExportDto> entities =
@@ -86,8 +83,7 @@ public class EntityImportServiceTest {
     when(collectionService.getCollectionDefinition(anyString()))
         .thenThrow(new NotFoundException("Collection does not exist"));
 
-    // when / then: NotFoundException is thrown (not OptimizeValidationException), proving the
-    // collection check runs before entity pre-processing in the instant-preview path too
+    // when / then
     assertThatThrownBy(
             () -> underTest.importInstantPreviewEntities(NON_EXISTENT_COLLECTION_ID, entities))
         .isInstanceOf(NotFoundException.class);
@@ -95,7 +91,7 @@ public class EntityImportServiceTest {
 
   @Test
   public void shouldNotFallBackToDirectCollectionLookupWhenAuthenticatedUserIsProvided() {
-    // given: the authorized path succeeds
+    // given
     when(authorizedCollectionService.getAuthorizedCollectionDefinitionOrFail(
             anyString(), anyString()))
         .thenReturn(new AuthorizedCollectionDefinitionDto(new CollectionDefinitionDto()));
@@ -103,8 +99,7 @@ public class EntityImportServiceTest {
     // when
     underTest.importEntitiesAsUser(USER_ID, NON_EXISTENT_COLLECTION_ID, Set.of());
 
-    // then: the direct (non-authorized) collection lookup must never be invoked —
-    // guards against a regression of the eager-evaluation bug in the old Optional chain
+    // then
     verify(collectionService, never()).getCollectionDefinition(anyString());
   }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/entities/EntityImportServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/entities/EntityImportServiceTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.entities;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.optimize.dto.optimize.query.collection.CollectionDefinitionDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
+import io.camunda.optimize.dto.optimize.rest.AuthorizedCollectionDefinitionDto;
+import io.camunda.optimize.dto.optimize.rest.export.OptimizeEntityExportDto;
+import io.camunda.optimize.dto.optimize.rest.export.report.SingleProcessReportDefinitionExportDto;
+import io.camunda.optimize.rest.exceptions.NotFoundException;
+import io.camunda.optimize.service.collection.CollectionService;
+import io.camunda.optimize.service.entities.dashboard.DashboardImportService;
+import io.camunda.optimize.service.entities.report.ReportImportService;
+import io.camunda.optimize.service.security.AuthorizedCollectionService;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class EntityImportServiceTest {
+
+  private static final String NON_EXISTENT_COLLECTION_ID = "nonexistent-collection-id";
+  private static final String USER_ID = "testUser";
+
+  @Mock private ReportImportService reportImportService;
+  @Mock private DashboardImportService dashboardImportService;
+  @Mock private AuthorizedCollectionService authorizedCollectionService;
+  @Mock private CollectionService collectionService;
+
+  @InjectMocks private EntityImportService underTest;
+
+  @Test
+  public void shouldValidateCollectionBeforeProcessingEntities() {
+    // given: a management report that would cause OptimizeValidationException if entity processing
+    // ran before the collection check
+    final ProcessReportDataDto managementReportData = new ProcessReportDataDto();
+    managementReportData.setManagementReport(true);
+    final Set<OptimizeEntityExportDto> entities =
+        Set.of(new SingleProcessReportDefinitionExportDto(managementReportData));
+
+    when(collectionService.getCollectionDefinition(anyString()))
+        .thenThrow(new NotFoundException("Collection does not exist"));
+
+    // when / then: NotFoundException is thrown (not OptimizeValidationException), proving the
+    // collection check runs before entity pre-processing
+    assertThatThrownBy(() -> underTest.importEntities(NON_EXISTENT_COLLECTION_ID, entities))
+        .isInstanceOf(NotFoundException.class);
+  }
+
+  @Test
+  public void shouldThrowNotFoundExceptionWhenCollectionDoesNotExistForAuthenticatedImport() {
+    // given
+    when(authorizedCollectionService.getAuthorizedCollectionDefinitionOrFail(
+            anyString(), anyString()))
+        .thenThrow(new NotFoundException("Collection does not exist"));
+
+    // when / then
+    assertThatThrownBy(
+            () -> underTest.importEntitiesAsUser(USER_ID, NON_EXISTENT_COLLECTION_ID, Set.of()))
+        .isInstanceOf(NotFoundException.class);
+  }
+
+  @Test
+  public void shouldNotFallBackToDirectCollectionLookupWhenAuthenticatedUserIsProvided() {
+    // given: the authorized path succeeds
+    when(authorizedCollectionService.getAuthorizedCollectionDefinitionOrFail(
+            anyString(), anyString()))
+        .thenReturn(new AuthorizedCollectionDefinitionDto(new CollectionDefinitionDto()));
+
+    // when
+    underTest.importEntitiesAsUser(USER_ID, NON_EXISTENT_COLLECTION_ID, Set.of());
+
+    // then: the direct (non-authorized) collection lookup must never be invoked —
+    // guards against a regression of the eager-evaluation bug in the old Optional chain
+    verify(collectionService, never()).getCollectionDefinition(anyString());
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/entities/EntityImportServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/entities/EntityImportServiceTest.java
@@ -75,6 +75,25 @@ public class EntityImportServiceTest {
   }
 
   @Test
+  public void shouldValidateCollectionBeforeProcessingEntitiesForInstantPreviewImport() {
+    // given: a management report that would cause OptimizeValidationException if entity processing
+    // ran before the collection check
+    final ProcessReportDataDto managementReportData = new ProcessReportDataDto();
+    managementReportData.setManagementReport(true);
+    final Set<OptimizeEntityExportDto> entities =
+        Set.of(new SingleProcessReportDefinitionExportDto(managementReportData));
+
+    when(collectionService.getCollectionDefinition(anyString()))
+        .thenThrow(new NotFoundException("Collection does not exist"));
+
+    // when / then: NotFoundException is thrown (not OptimizeValidationException), proving the
+    // collection check runs before entity pre-processing in the instant-preview path too
+    assertThatThrownBy(
+            () -> underTest.importInstantPreviewEntities(NON_EXISTENT_COLLECTION_ID, entities))
+        .isInstanceOf(NotFoundException.class);
+  }
+
+  @Test
   public void shouldNotFallBackToDirectCollectionLookupWhenAuthenticatedUserIsProvided() {
     // given: the authorized path succeeds
     when(authorizedCollectionService.getAuthorizedCollectionDefinitionOrFail(


### PR DESCRIPTION
## Summary

- The public import API (`POST /api/public/import?collectionId=<id>`) was returning `HTTP 500` when the target collection did not exist; the expected behaviour per the API contract is `HTTP 404`.

- **Root cause 1:** `getAndValidateCollectionExistsAndIsAccessibleOrFail` used a nested `Optional` chain with eager `.orElse()`, which redundantly called `collectionService.getCollectionDefinition` even when the user-authorised path had already succeeded — any unexpected exception from that extra call propagated as `500` instead of `404`.

- **Root cause 2:** `importValidatedEntities` checked collection existence *after* entity pre-processing, inconsistent with `importEntitiesAsUser` (which validates collection first); an exception from the earlier steps could mask the missing-collection 404.

**Changes:**
- Replaced the nested `Optional`/`.orElse()` chain in `getAndValidateCollectionExistsAndIsAccessibleOrFail` with a simple null-guard + ternary, making the logic explicit and eliminating the redundant DB call.
- Moved the collection existence check to the top of `importValidatedEntities` so the method fails fast with `NotFoundException` (→ HTTP 404) before any entity work begins.
- Added `EntityImportServiceTest` covering both the public-API path (`importEntities`) and the authenticated path (`importEntitiesAsUser`) for a non-existent collection.

## Test plan

- [ ] New unit tests pass: `EntityImportServiceTest#shouldThrowNotFoundExceptionWhenCollectionDoesNotExistForPublicImport` and `#shouldThrowNotFoundExceptionWhenCollectionDoesNotExistForAuthenticatedImport`
- [ ] `POST /api/public/import?collectionId=<nonexistent-id>` returns HTTP 404 with `notFoundError` error code
- [ ] Cross-component test case [TC-1321135](https://camunda.testrail.com/index.php?/cases/view/1321135) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #40497