### PR TITLE
Fix part of flaky 8.10

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-search-incident-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/element-instance/element-instance-search-incident-api.spec.ts
@@ -215,7 +215,8 @@ test.describe('Element Instance Incident Search API', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Search for incidents of a specific element instance - ascending order by errorMessage - Success', async ({
+  //Skipped due to bug: 48703 https://github.com/camunda/camunda/issues/48703
+  test.skip('Search for incidents of a specific element instance - ascending order by errorMessage - Success', async ({
     request,
   }) => {
     const errorMessage1 =

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-error-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-error-api-tests.spec.ts
@@ -10,6 +10,7 @@ import {expect, test} from '@playwright/test';
 import {randomUUID} from 'crypto';
 import {
   assertBadRequest,
+  assertInvalidState,
   assertNotFoundRequest,
   assertStatusCode,
   buildUrl,
@@ -19,6 +20,7 @@ import {
   activateJobToObtainAValidJobKey,
   setupProcessInstanceForTests,
 } from '@requestHelpers';
+import {defaultAssertionOptions} from 'utils/constants';
 
 const runSuffix = randomUUID().slice(0, 8);
 const processId = `jobApiProcess-error-${runSuffix}`;
@@ -42,16 +44,18 @@ test.describe('Job Error API Tests', () => {
 
   test('Throw Error for Job - success', async ({request}) => {
     const jobKey = await activateJobToObtainAValidJobKey(request, taskType);
+    
+    await expect(async () => {
+      const errorRes = await request.post(buildUrl(`/jobs/${jobKey}/error`), {
+        headers: jsonHeaders(),
+        data: {
+          errorCode: 'ERROR_CODE_1',
+          errorMessage: 'Simulated Error',
+        },
+      });
 
-    const errorRes = await request.post(buildUrl(`/jobs/${jobKey}/error`), {
-      headers: jsonHeaders(),
-      data: {
-        errorCode: 'ERROR_CODE_1',
-        errorMessage: 'Simulated Error',
-      },
-    });
-
-    await assertStatusCode(errorRes, 204);
+      await assertStatusCode(errorRes, 204);
+    }).toPass(defaultAssertionOptions);
   });
 
   test('Throw Error for Job - not found', async ({request}) => {
@@ -95,29 +99,33 @@ test.describe('Job Error API Tests', () => {
 
     await test.step('Throw error for the job (first time) and expect 204', async () => {
       const jobKey = localState['jobKey'] as number;
-      const errorRes = await request.post(buildUrl(`/jobs/${jobKey}/error`), {
-        headers: jsonHeaders(),
-        data: {
-          errorCode: 'SIMULATED',
-          errorMessage: 'Simulated failure',
-        },
-      });
-      await assertStatusCode(errorRes, 204);
-    });
-
-    await test.step('Throw error again for the same job (should conflict 409)', async () => {
-      const jobKey = localState['jobKey'] as number;
-      const errorAgainRes = await request.post(
-        buildUrl(`/jobs/${jobKey}/error`),
-        {
+      await expect(async () => {
+        const errorRes = await request.post(buildUrl(`/jobs/${jobKey}/error`), {
           headers: jsonHeaders(),
           data: {
             errorCode: 'SIMULATED',
             errorMessage: 'Simulated failure',
           },
-        },
-      );
-      expect(errorAgainRes.status()).toBe(409);
+        });
+        await assertStatusCode(errorRes, 204);
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Throw error again for the same job (should conflict 409)', async () => {
+      const jobKey = localState['jobKey'] as number;
+      await expect(async () => {
+        const errorAgainRes = await request.post(
+          buildUrl(`/jobs/${jobKey}/error`),
+          {
+            headers: jsonHeaders(),
+            data: {
+              errorCode: 'SIMULATED',
+              errorMessage: 'Simulated failure',
+            },
+          },
+        );
+        await assertInvalidState(errorAgainRes, 409);
+      }).toPass(defaultAssertionOptions);
     });
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-error-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-error-api-tests.spec.ts
@@ -44,7 +44,6 @@ test.describe('Job Error API Tests', () => {
 
   test('Throw Error for Job - success', async ({request}) => {
     const jobKey = await activateJobToObtainAValidJobKey(request, taskType);
-    
     await expect(async () => {
       const errorRes = await request.post(buildUrl(`/jobs/${jobKey}/error`), {
         headers: jsonHeaders(),

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-failure-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-failure-api-tests.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {test} from '@playwright/test';
+import {expect, test} from '@playwright/test';
 import {randomUUID} from 'crypto';
 import {
   assertBadRequest,
@@ -19,6 +19,7 @@ import {
   activateJobToObtainAValidJobKey,
   setupProcessInstanceForTests,
 } from '@requestHelpers';
+import {defaultAssertionOptions} from 'utils/constants';
 
 const runSuffix = randomUUID().slice(0, 8);
 const processId = `jobApiProcess-failure-${runSuffix}`;
@@ -44,15 +45,17 @@ test.describe('Job Fail API Tests', () => {
     const jobKey = await activateJobToObtainAValidJobKey(request, taskType);
 
     // Now fail the job
-    const failRes = await request.post(buildUrl(`/jobs/${jobKey}/failure`), {
-      headers: jsonHeaders(),
-      data: {
-        retries: 0,
-        errorMessage: 'Simulated failure',
-      },
-    });
+    await expect(async () => {
+      const failRes = await request.post(buildUrl(`/jobs/${jobKey}/failure`), {
+        headers: jsonHeaders(),
+        data: {
+          retries: 0,
+          errorMessage: 'Simulated failure',
+        },
+      });
 
-    await assertStatusCode(failRes, 204);
+      await assertStatusCode(failRes, 204);
+    }).toPass(defaultAssertionOptions);
   });
 
   test('Fail Job - Job not found', async ({request}) => {
@@ -95,17 +98,19 @@ test.describe('Job Fail API Tests', () => {
     });
 
     await test.step('fail the job for the first time', async () => {
-      const failRes = await request.post(
-        buildUrl(`/jobs/${localState['jobKey']}/failure`),
-        {
-          headers: jsonHeaders(),
-          data: {
-            retries: 0,
-            errorMessage: 'Simulated failure',
+      await expect(async () => {
+        const failRes = await request.post(
+          buildUrl(`/jobs/${localState['jobKey']}/failure`),
+          {
+            headers: jsonHeaders(),
+            data: {
+              retries: 0,
+              errorMessage: 'Simulated failure',
+            },
           },
-        },
-      );
-      await assertStatusCode(failRes, 204);
+        );
+        await assertStatusCode(failRes, 204);
+      }).toPass(defaultAssertionOptions);
     });
 
     await test.step('fail the job for the second time', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-update-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-update-api-tests.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {test} from '@playwright/test';
+import {expect, test} from '@playwright/test';
 import {randomUUID} from 'crypto';
 import {
   assertBadRequest,
@@ -19,6 +19,7 @@ import {
   activateJobToObtainAValidJobKey,
   setupProcessInstanceForTests,
 } from '@requestHelpers';
+import {defaultAssertionOptions} from 'utils/constants';
 
 const runSuffix = randomUUID().slice(0, 8);
 const processId = `jobApiProcess-update-${runSuffix}`;
@@ -44,13 +45,15 @@ test.describe('Job Update API Tests', () => {
     const jobKey = await activateJobToObtainAValidJobKey(request, taskType);
 
     await test.step('PATCH update the job', async () => {
-      const updateRes = await request.patch(buildUrl(`/jobs/${jobKey}`), {
-        headers: jsonHeaders(),
-        data: {
-          changeset: {retries: 1, timeout: 9000},
-        },
-      });
-      await assertStatusCode(updateRes, 204);
+      await expect(async () => {
+        const updateRes = await request.patch(buildUrl(`/jobs/${jobKey}`), {
+          headers: jsonHeaders(),
+          data: {
+            changeset: {retries: 1, timeout: 9000},
+          },
+        });
+        await assertStatusCode(updateRes, 204);
+      }).toPass(defaultAssertionOptions);
     });
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-get-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-get-api.spec.ts
@@ -89,7 +89,7 @@ test.describe.parallel('Resource Get API', () => {
 
     await assertNotFoundRequest(
       res,
-      "Command 'FETCH' rejected with code 'NOT_FOUND': Expected to fetch resource but no resource found with key `2251799813733053`",
+      `Resource with key '${nonExistentResourceKey}' not found`,
     );
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-get-content-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/resource/resource-get-content-api.spec.ts
@@ -56,7 +56,7 @@ test.describe.parallel('Resource Get Content API', () => {
 
     await assertNotFoundRequest(
       res,
-      "Command 'FETCH' rejected with code 'NOT_FOUND': Expected to fetch resource but no resource found with key `2251799813733053`",
+      `Resource with key '${nonExistentResourceKey}' not found`,
     );
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/element-instance-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/element-instance-requestHelpers.ts
@@ -104,8 +104,8 @@ async function searchElementInstanceByFilter(
     });
     result.body = body;
   }).toPass({
-      intervals: [5_000, 10_000, 15_000],
-      timeout: 60_000,
+    ...defaultAssertionOptions,
+    timeout: 60_000,
   });
   return result;
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/element-instance-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/element-instance-requestHelpers.ts
@@ -103,6 +103,9 @@ async function searchElementInstanceByFilter(
       expect(body.items[0][filterKey]).toBe(filter[filterKey]);
     });
     result.body = body;
-  }).toPass(defaultAssertionOptions);
+  }).toPass({
+      intervals: [5_000, 10_000, 15_000],
+      timeout: 60_000,
+  });
   return result;
 }


### PR DESCRIPTION
## Description

This PR covers:

- For Job APIs tests: After activating the job it couldn't be found. So added `await expect().toPass()`, so it has some time to appear
- Skipped `Search for incidents of a specific element instance - ascending order by errorMessage - Success` - due to https://github.com/camunda/camunda/issues/48703 
- Resource APIs: error messages have changed, updated tests accordingly
-  "Update Element Instance - local update overrides global variable" - there also was timing issue that caused flakiness, added `await expect().toPass()` in `searchElementInstanceByFilter()`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

https://github.com/camunda/camunda/issues/48703 

## On demand workflow
[Was all green on APIs](https://github.com/camunda/camunda/actions/runs/24716252028)