### PR TITLE
fix: truncated variables create/update stuck in loading state

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/VariablesTable.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/VariablesTable.tsx
@@ -120,7 +120,7 @@ const VariablesTable: React.FC<Props> = ({
                         isFetchingNextPage || form.getState().submitting
                       }
                       onClick={async () => {
-                        form.reset({name, value});
+                        form.reset({name, value, variableKey});
                         form.change('value', value);
                       }}
                       hasIconOnly

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/ViewFullVariableButton/Show/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/ViewFullVariableButton/Show/index.tsx
@@ -57,7 +57,11 @@ const ViewFullVariableButtonShow: React.FC<ViewFullVariableButtonShowProps> = ({
           allowModeToggle={canEdit}
           onClose={() => setIsModalVisible(false)}
           onApply={(value) => {
-            form.reset({name: variableName, value: fullVariableValue});
+            form.reset({
+              name: variableName,
+              value: fullVariableValue,
+              variableKey,
+            });
             form.change(variableEditor.fieldName, value);
             if (shouldSubmitOnApply) {
               form.submit();

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/VariablesFinalForm.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/VariablesFinalForm.tsx
@@ -63,9 +63,10 @@ const VariablesFinalForm: React.FC<Props> = ({scopeKey}) => {
         const {initialValues} = form.getState();
         const isNewVariable = initialValues?.name === '';
         const {name, value} = values;
+        const variableKey = initialValues?.variableKey;
 
         await mutateAsyncVariables(
-          {name, value: JSON.stringify(JSON.parse(value))},
+          {name, value: JSON.stringify(JSON.parse(value)), variableKey},
           {
             onSuccess: () => {
               notificationsStore.displayNotification({

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/addVariable.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/addVariable.test.tsx
@@ -586,21 +586,6 @@ describe('Add variable', () => {
         hasMoreTotalItems: false,
       },
     });
-    mockSearchVariables().withSuccess({
-      items: [
-        createVariable({
-          name: 'largeVariable',
-          value: '"truncated-preview"',
-          isTruncated: true,
-        }),
-      ],
-      page: {
-        totalItems: 1,
-        startCursor: null,
-        endCursor: null,
-        hasMoreTotalItems: false,
-      },
-    });
     mockSearchJobs().withSuccess({
       items: [],
       page: {

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/addVariable.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/addVariable.test.tsx
@@ -13,7 +13,16 @@ import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinit
 import {mockSearchVariables} from 'modules/mocks/api/v2/variables/searchVariables';
 import {mockSearchJobs} from 'modules/mocks/api/v2/jobs/searchJobs';
 import {mockVariables} from './index.setup';
+import {createVariable} from 'modules/testUtils';
 import {VariablesTab} from '../index';
+import {notificationsStore} from 'modules/stores/notifications';
+import {mockUpdateElementInstanceVariables} from 'modules/mocks/api/v2/elementInstances/updateElementInstanceVariables';
+
+vi.mock('modules/stores/notifications', () => ({
+  notificationsStore: {
+    displayNotification: vi.fn(() => () => {}),
+  },
+}));
 
 describe('Add variable', () => {
   beforeEach(() => {
@@ -535,5 +544,81 @@ describe('Add variable', () => {
     expect(
       await within(screen.getByRole('dialog')).findByTestId('monaco-editor'),
     ).toBeInTheDocument();
+  });
+
+  it('should save a large new variable even when search response is truncated', async () => {
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+    mockSearchVariables().withSuccess(mockVariables);
+    mockSearchVariables().withSuccess(mockVariables);
+
+    const {user} = render(<VariablesTab />, {wrapper: getWrapper()});
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', {name: /add variable/i}));
+    await user.type(
+      screen.getByRole('textbox', {name: /name/i}),
+      'largeVariable',
+    );
+    await user.type(
+      screen.getByRole('textbox', {name: /value/i}),
+      '"large-value"',
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', {name: /save/i})).toBeEnabled();
+    });
+
+    mockUpdateElementInstanceVariables(':1').withDelay(null);
+    mockSearchVariables().withSuccess({
+      items: [
+        createVariable({
+          name: 'largeVariable',
+          value: '"truncated-preview"',
+          isTruncated: true,
+        }),
+      ],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchVariables().withSuccess({
+      items: [
+        createVariable({
+          name: 'largeVariable',
+          value: '"truncated-preview"',
+          isTruncated: true,
+        }),
+      ],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    await user.click(screen.getByRole('button', {name: /save/i}));
+
+    await waitFor(() => {
+      expect(notificationsStore.displayNotification).toHaveBeenCalledWith({
+        kind: 'success',
+        title: 'Variable added',
+        isDismissable: true,
+      });
+    });
   });
 });

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/editVariable.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/editVariable.test.tsx
@@ -375,21 +375,6 @@ describe('Edit variable', () => {
         hasMoreTotalItems: false,
       },
     });
-    mockSearchVariables().withSuccess({
-      items: [
-        createVariable({
-          name: 'clientNo',
-          value: '"value-preview"',
-          isTruncated: true,
-        }),
-      ],
-      page: {
-        totalItems: 1,
-        startCursor: null,
-        endCursor: null,
-        hasMoreTotalItems: false,
-      },
-    });
 
     const {user} = render(<VariablesTab />, {wrapper: getWrapper()});
     await waitFor(() => {

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/editVariable.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/editVariable.test.tsx
@@ -358,6 +358,114 @@ describe('Edit variable', () => {
     expect(notificationsStore.displayNotification).not.toHaveBeenCalled();
   });
 
+  it('should save an edited truncated variable using full variable verification', async () => {
+    mockFetchProcessInstance().withSuccess(mockProcessInstance);
+    mockSearchVariables().withSuccess({
+      items: [
+        createVariable({
+          name: 'clientNo',
+          value: '"value-preview"',
+          isTruncated: true,
+        }),
+      ],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchVariables().withSuccess({
+      items: [
+        createVariable({
+          name: 'clientNo',
+          value: '"value-preview"',
+          isTruncated: true,
+        }),
+      ],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    const {user} = render(<VariablesTab />, {wrapper: getWrapper()});
+    await waitFor(() => {
+      expect(screen.getByTestId('variables-list')).toBeInTheDocument();
+    });
+
+    mockGetVariable().withSuccess(
+      createVariable({
+        name: 'clientNo',
+        value: '"full-value-before-edit"',
+        isTruncated: false,
+      }),
+    );
+
+    const variableRow = await screen.findByTestId('variable-clientNo');
+    mockFetchProcessDefinitionXml().withSuccess('');
+    await user.click(
+      within(variableRow).getByRole('button', {
+        name: /edit/i,
+      }),
+    );
+
+    const input = await within(variableRow).findByTestId('edit-variable-value');
+    await user.clear(input);
+    await user.type(input, '"updated-full-value"');
+
+    await waitFor(() => {
+      expect(
+        within(variableRow).getByRole('button', {name: /save/i}),
+      ).toBeEnabled();
+    });
+
+    mockUpdateElementInstanceVariables('1').withDelay(null);
+    mockGetVariable().withSuccess(
+      createVariable({
+        name: 'clientNo',
+        value: '"updated-full-value"',
+        isTruncated: false,
+      }),
+    );
+    mockSearchVariables().withSuccess({
+      items: [
+        createVariable({
+          name: 'clientNo',
+          value: '"updated-preview"',
+          isTruncated: true,
+        }),
+      ],
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+    mockSearchJobs().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    await user.click(within(variableRow).getByRole('button', {name: /save/i}));
+
+    await waitFor(() => {
+      expect(notificationsStore.displayNotification).toHaveBeenCalledWith({
+        kind: 'success',
+        title: 'Variable updated',
+        isDismissable: true,
+      });
+    });
+  });
+
   it('should display notification if error occurs when getting single variable details', async () => {
     mockSearchVariables().withSuccess({
       items: [

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/editVariable.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/editVariable.test.tsx
@@ -119,7 +119,13 @@ describe('Edit variable', () => {
     });
 
     mockUpdateElementInstanceVariables('1').withDelay(null);
-    mockSearchVariables().withSuccess(mockVariables);
+    mockGetVariable().withSuccess(
+      createVariable({
+        name: 'firstVariable',
+        value: '"updated-value"',
+        isTruncated: false,
+      }),
+    );
     mockSearchVariables().withSuccess(mockVariables);
     mockSearchJobs().withSuccess({
       items: [],

--- a/operate/client/src/modules/mutations/elementInstances/useElementInstanceVariables.tsx
+++ b/operate/client/src/modules/mutations/elementInstances/useElementInstanceVariables.tsx
@@ -41,8 +41,15 @@ function useElementInstanceVariables(
       }
 
       if (variable.variableKey !== undefined) {
+        const variableQueryKey = queryKeys.variable.get(variable.variableKey);
+
+        queryClient.removeQueries({
+          queryKey: variableQueryKey,
+          exact: true,
+        });
+
         await queryClient.fetchQuery({
-          queryKey: queryKeys.variable.get(variable.variableKey),
+          queryKey: variableQueryKey,
           queryFn: async () => {
             const {response, error} = await getVariable(variable.variableKey!);
 
@@ -56,6 +63,7 @@ function useElementInstanceVariables(
 
             return response;
           },
+          staleTime: 0,
           retry: true,
           retryDelay: 1000,
         });

--- a/operate/client/src/modules/mutations/elementInstances/useElementInstanceVariables.tsx
+++ b/operate/client/src/modules/mutations/elementInstances/useElementInstanceVariables.tsx
@@ -41,15 +41,8 @@ function useElementInstanceVariables(
       }
 
       if (variable.variableKey !== undefined) {
-        const variableQueryKey = queryKeys.variable.get(variable.variableKey);
-
-        queryClient.removeQueries({
-          queryKey: variableQueryKey,
-          exact: true,
-        });
-
         await queryClient.fetchQuery({
-          queryKey: variableQueryKey,
+          queryKey: queryKeys.variable.get(variable.variableKey),
           queryFn: async () => {
             const {response, error} = await getVariable(variable.variableKey!);
 
@@ -63,7 +56,6 @@ function useElementInstanceVariables(
 
             return response;
           },
-          staleTime: 0,
           retry: true,
           retryDelay: 1000,
         });

--- a/operate/client/src/modules/mutations/elementInstances/useElementInstanceVariables.tsx
+++ b/operate/client/src/modules/mutations/elementInstances/useElementInstanceVariables.tsx
@@ -10,6 +10,7 @@ import {useMutation, useQueryClient} from '@tanstack/react-query';
 import {updateElementInstanceVariables} from 'modules/api/v2/elementInstances/updateElementInstanceVariables';
 import type {ElementInstance} from '@camunda/camunda-api-zod-schemas/8.10';
 import {searchVariables} from 'modules/api/v2/variables/searchVariables';
+import {getVariable} from 'modules/api/v2/variables/getVariable';
 import {queryKeys} from 'modules/queries/queryKeys';
 
 function useElementInstanceVariables(
@@ -21,7 +22,7 @@ function useElementInstanceVariables(
   return useMutation<
     void,
     {status: number; statusText: string},
-    {name: string; value: string}
+    {name: string; value: string; variableKey?: string}
   >({
     mutationFn: async (variable) => {
       const response = await updateElementInstanceVariables(
@@ -39,36 +40,55 @@ function useElementInstanceVariables(
         };
       }
 
-      await queryClient.fetchQuery({
-        queryKey: queryKeys.variables.searchWithFilter({
-          processInstanceKey,
-          scopeKey: elementInstanceKey,
-          name: variable.name,
-          value: variable.value,
-        }),
-        queryFn: async () => {
-          const {response, error} = await searchVariables({
-            filter: {
-              name: variable.name,
-              value: variable.value,
-              processInstanceKey,
-              scopeKey: elementInstanceKey,
-            },
-          });
+      if (variable.variableKey !== undefined) {
+        await queryClient.fetchQuery({
+          queryKey: queryKeys.variable.get(variable.variableKey),
+          queryFn: async () => {
+            const {response, error} = await getVariable(variable.variableKey!);
 
-          if (error) {
-            throw new Error(error.response?.statusText);
-          }
+            if (error) {
+              throw new Error(error.response?.statusText);
+            }
 
-          if (response.items.length === 0) {
-            throw new Error('Variable not found');
-          }
+            if (response.value !== variable.value) {
+              throw new Error('Variable not updated yet');
+            }
 
-          return response;
-        },
-        retry: true,
-        retryDelay: 1000,
-      });
+            return response;
+          },
+          retry: true,
+          retryDelay: 1000,
+        });
+      } else {
+        await queryClient.fetchQuery({
+          queryKey: queryKeys.variables.searchWithFilter({
+            processInstanceKey,
+            scopeKey: elementInstanceKey,
+            name: variable.name,
+          }),
+          queryFn: async () => {
+            const {response, error} = await searchVariables({
+              filter: {
+                name: variable.name,
+                processInstanceKey,
+                scopeKey: elementInstanceKey,
+              },
+            });
+
+            if (error) {
+              throw new Error(error.response?.statusText);
+            }
+
+            if (response.items.length === 0) {
+              throw new Error('Variable not found');
+            }
+
+            return response;
+          },
+          retry: true,
+          retryDelay: 1000,
+        });
+      }
 
       return;
     },

--- a/operate/client/src/modules/types/variables.ts
+++ b/operate/client/src/modules/types/variables.ts
@@ -9,6 +9,7 @@
 type VariableFormValues = {
   name: string;
   value: string;
+  variableKey?: string;
   newVariables?: {id: string; name: string; value: string}[];
   [key: `#${string}`]: string;
 };


### PR DESCRIPTION
## Summary

  - Fix infinite loading state when editing a large (truncated) variable in the Variables tab
  - Fix the same issue when adding a new variable with a large value

  ## Changes

  After a successful variable update, the polling strategy now depends on the operation:

  - **Edit:** polls `GET /v2/variables/{variableKey}` (returns full value) and compares against the submitted value — replaces the broken `searchVariables` approach which compared against the truncated stored value
  - **Add:** polls `searchVariables` by name only, without a value filter — finding the variable by name is sufficient confirmation for a new variable

  ## How to test

  1. Open a process instance with a variable where `isTruncated: true`
  2. Edit it, change the value, click Save → loading should resolve and "Variable updated" should appear
  3. Add a new variable with a large value → same result
  4. Edit/add a small variable → behaviour unchanged

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #51469 
