### PR TITLE
fix: log proxy 504 job stream errors at DEBUG only

### DIFF
--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -268,6 +268,18 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/clients/java/src/main/java/io/camunda/client/impl/worker/JobStreamerImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/worker/JobStreamerImpl.java
@@ -293,9 +293,29 @@ final class JobStreamerImpl implements JobStreamer {
         LOGGER.trace(errorMsg, jobType, workerName, error);
         return;
       }
+      if (isProxyGatewayTimeout(statusRuntimeException)) {
+        // An intermediary proxy (e.g. nginx) closed the idle streaming connection with HTTP 504.
+        // Log a concise hint at WARN; keep the raw gRPC details at DEBUG for investigation.
+        LOGGER.warn(
+            "Job stream for type '{}' to worker '{}' was closed by an upstream proxy (HTTP 504 Gateway Timeout). "
+                + "The stream will be reopened. To avoid this, configure a shorter stream timeout "
+                + "(JobWorkerBuilder#streamTimeout) below your ingress/proxy idle timeout.",
+            jobType,
+            workerName);
+        LOGGER.debug(errorMsg, jobType, workerName, error);
+        return;
+      }
     }
 
     LOGGER.warn(errorMsg, jobType, workerName, error);
+  }
+
+  private static boolean isProxyGatewayTimeout(final StatusRuntimeException error) {
+    if (error.getStatus().getCode() != Status.UNAVAILABLE.getCode()) {
+      return false;
+    }
+    final String description = error.getStatus().getDescription();
+    return description != null && description.contains("HTTP status code 504");
   }
 
   private static final class StreamingTimeoutException extends RuntimeException {}

--- a/clients/java/src/main/java/io/camunda/client/impl/worker/JobStreamerImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/worker/JobStreamerImpl.java
@@ -295,14 +295,14 @@ final class JobStreamerImpl implements JobStreamer {
       }
       if (isProxyGatewayTimeout(statusRuntimeException)) {
         // An intermediary proxy (e.g. nginx) closed the idle streaming connection with HTTP 504.
-        // Log a concise hint at WARN; keep the raw gRPC details at DEBUG for investigation.
-        LOGGER.warn(
+        // The stream is transparently reopened, so only log at DEBUG.
+        LOGGER.debug(
             "Job stream for type '{}' to worker '{}' was closed by an upstream proxy (HTTP 504 Gateway Timeout). "
                 + "The stream will be reopened. To avoid this, configure a shorter stream timeout "
                 + "(JobWorkerBuilder#streamTimeout) below your ingress/proxy idle timeout.",
             jobType,
-            workerName);
-        LOGGER.debug(errorMsg, jobType, workerName, error);
+            workerName,
+            error);
         return;
       }
     }

--- a/clients/java/src/test/java/io/camunda/client/impl/worker/JobStreamImplTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/worker/JobStreamImplTest.java
@@ -45,6 +45,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.appender.ListAppender;
 import org.jmock.lib.concurrent.DeterministicScheduler;
 import org.junit.Rule;
 import org.junit.jupiter.api.AfterEach;
@@ -57,6 +63,8 @@ import org.mockito.Mockito;
 @ExtendWith(ExternalResourceSupport.class)
 final class JobStreamImplTest {
 
+  private static final String JOB_WORKER_LOGGER_NAME = "io.camunda.client.job.worker";
+
   @Rule
   public final GrpcCleanupRule grpcRule =
       new GrpcCleanupRule().setTimeout(1, TimeUnit.MILLISECONDS);
@@ -65,6 +73,7 @@ final class JobStreamImplTest {
   private final DeterministicScheduler scheduler = new DeterministicScheduler();
   private JobClient client;
   private JobStreamerImpl jobStreamer;
+  private ListAppender logCapture;
 
   @BeforeEach
   void beforeEach() throws IOException {
@@ -83,12 +92,28 @@ final class JobStreamImplTest {
             new CamundaObjectMapper(),
             ignored -> false);
     jobStreamer = createStreamer(Duration.ofHours(8));
+
+    logCapture = new ListAppender("capture-" + JOB_WORKER_LOGGER_NAME);
+    logCapture.start();
+    final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+    ctx.getConfiguration()
+        .getLoggerConfig(JOB_WORKER_LOGGER_NAME)
+        .addAppender(logCapture, null, null);
+    ctx.updateLoggers();
   }
 
   @AfterEach
   void afterEach() {
     if (jobStreamer != null) {
       jobStreamer.close();
+    }
+    if (logCapture != null) {
+      final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+      ctx.getConfiguration()
+          .getLoggerConfig(JOB_WORKER_LOGGER_NAME)
+          .removeAppender(logCapture.getName());
+      ctx.updateLoggers();
+      logCapture.stop();
     }
   }
 
@@ -198,6 +223,76 @@ final class JobStreamImplTest {
     assertThat(recreatedStream).isNotNull().isNotEqualTo(initialStream);
     assertThat(initialStream.isCancelled()).isTrue();
     assertThat(recreatedStream.isCancelled()).isFalse();
+  }
+
+  @Test
+  void shouldLogProxy504AsWarnWithoutExceptionAndDebugWithException() {
+    // given - a realistic UNAVAILABLE status produced when an intermediary proxy (e.g. nginx)
+    // terminates the idle streaming connection with HTTP 504.
+    jobStreamer.openStreamer(ignored -> {});
+    final ServerCallStreamObserver<GatewayOuterClass.ActivatedJob> lastStream =
+        service.lastStream();
+
+    // when
+    lastStream.onError(
+        new StatusRuntimeException(
+            Status.UNAVAILABLE.withDescription(
+                "HTTP status code 504\n"
+                    + "invalid content-type: text/html\n"
+                    + "headers: Metadata(:status=504,content-type=text/html)\n"
+                    + "DATA-----------------------------\n"
+                    + "<html><body>504 Gateway Time-out</body></html>")));
+    scheduler.runUntilIdle();
+
+    // then
+    final List<LogEvent> warns = eventsAt(Level.WARN);
+    assertThat(warns).hasSize(1);
+    final LogEvent warn = warns.get(0);
+    assertThat(warn.getMessage().getFormattedMessage())
+        .contains("upstream proxy")
+        .contains("504")
+        .contains("streamTimeout");
+    assertThat(warn.getThrown())
+        .as("WARN should not dump the raw gRPC exception for proxy 504")
+        .isNull();
+
+    final List<LogEvent> debugs = eventsAt(Level.DEBUG);
+    assertThat(debugs)
+        .as("DEBUG should retain the full gRPC exception for investigation")
+        .anySatisfy(
+            e -> {
+              assertThat(e.getMessage().getFormattedMessage()).contains("Failed to stream jobs");
+              assertThat(e.getThrown()).isInstanceOf(StatusRuntimeException.class);
+            });
+  }
+
+  @Test
+  void shouldLogNonProxyUnavailableAsWarnWithException() {
+    // given - UNAVAILABLE for reasons other than an HTTP 504 from a proxy should continue to
+    // surface the full stack trace at WARN.
+    jobStreamer.openStreamer(ignored -> {});
+    final ServerCallStreamObserver<GatewayOuterClass.ActivatedJob> lastStream =
+        service.lastStream();
+
+    // when
+    lastStream.onError(
+        new StatusRuntimeException(Status.UNAVAILABLE.withDescription("io exception")));
+    scheduler.runUntilIdle();
+
+    // then
+    final List<LogEvent> warns = eventsAt(Level.WARN);
+    assertThat(warns).hasSize(1);
+    assertThat(warns.get(0).getThrown()).isInstanceOf(StatusRuntimeException.class);
+    assertThat(warns.get(0).getMessage().getFormattedMessage()).contains("Failed to stream jobs");
+  }
+
+  private List<LogEvent> eventsAt(final Level level) {
+    // ListAppender is attached to the nearest parent LoggerConfig (io.camunda.client), so filter
+    // by exact logger name to avoid cross-contamination from sibling loggers.
+    return logCapture.getEvents().stream()
+        .filter(e -> JOB_WORKER_LOGGER_NAME.equals(e.getLoggerName()))
+        .filter(e -> level.equals(e.getLevel()))
+        .collect(Collectors.toList());
   }
 
   private JobStreamerImpl createStreamer(final Duration streamingTimeout) {

--- a/clients/java/src/test/java/io/camunda/client/impl/worker/JobStreamImplTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/worker/JobStreamImplTest.java
@@ -226,7 +226,7 @@ final class JobStreamImplTest {
   }
 
   @Test
-  void shouldLogProxy504AsWarnWithoutExceptionAndDebugWithException() {
+  void shouldLogProxy504AtDebugOnlyWithException() {
     // given - a realistic UNAVAILABLE status produced when an intermediary proxy (e.g. nginx)
     // terminates the idle streaming connection with HTTP 504.
     jobStreamer.openStreamer(ignored -> {});
@@ -245,23 +245,16 @@ final class JobStreamImplTest {
     scheduler.runUntilIdle();
 
     // then
-    final List<LogEvent> warns = eventsAt(Level.WARN);
-    assertThat(warns).hasSize(1);
-    final LogEvent warn = warns.get(0);
-    assertThat(warn.getMessage().getFormattedMessage())
-        .contains("upstream proxy")
-        .contains("504")
-        .contains("streamTimeout");
-    assertThat(warn.getThrown())
-        .as("WARN should not dump the raw gRPC exception for proxy 504")
-        .isNull();
+    assertThat(eventsAt(Level.WARN)).as("proxy 504 should not produce a WARN").isEmpty();
 
-    final List<LogEvent> debugs = eventsAt(Level.DEBUG);
-    assertThat(debugs)
-        .as("DEBUG should retain the full gRPC exception for investigation")
+    assertThat(eventsAt(Level.DEBUG))
+        .as("DEBUG should carry the hint message and the full gRPC exception")
         .anySatisfy(
             e -> {
-              assertThat(e.getMessage().getFormattedMessage()).contains("Failed to stream jobs");
+              assertThat(e.getMessage().getFormattedMessage())
+                  .contains("upstream proxy")
+                  .contains("504")
+                  .contains("streamTimeout");
               assertThat(e.getThrown()).isInstanceOf(StatusRuntimeException.class);
             });
   }


### PR DESCRIPTION
## Description

When an intermediary proxy (e.g. nginx) terminates an idle streaming connection, gRPC surfaces it as `UNAVAILABLE: HTTP status code 504` with the raw HTML body attached. Previously this produced a `WARN` with the full body and gRPC stack trace on every occurrence — noisy, and not actionable because the stream is transparently reopened (see #35892).

This change detects the proxy-504 signature (`UNAVAILABLE` + description containing `HTTP status code 504`) in `JobStreamerImpl.logStreamError` and logs it at **DEBUG only**:

- A single DEBUG entry names the cause (upstream proxy, HTTP 504), states that the stream will be reopened, points at `JobWorkerBuilder#streamTimeout` as the workaround, and attaches the full `StatusRuntimeException` for investigation.
- No WARN is emitted for this case.

Other `UNAVAILABLE` reasons (genuine gateway downtime, connection refused, …) continue to surface at `WARN` with the stack trace, unchanged.

With #35892 proactively recreating the stream before `streamTimeout`, users who set `streamTimeout` below their ingress idle timeout avoid the 504 entirely. This PR handles the residual case without spamming the logs.

Per Falko's suggestion in https://github.com/camunda/camunda/issues/25535#issuecomment-2656273712.

## Related issues

Closes #25535
Related #31577 (closed by #35892)

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).