### PR TITLE
feat: make in-memory OAuth credentials cache the default

### DIFF
--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/CamundaClientAuthProperties.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/CamundaClientAuthProperties.java
@@ -102,8 +102,12 @@ public class CamundaClientAuthProperties {
   /** The truststore password for the OAuth identity provider. */
   private String truststorePassword;
 
-  /** The path to the credentials cache file. */
-  private String credentialsCachePath = DEFAULT_CREDENTIALS_CACHE_PATH;
+  /**
+   * The path to the credentials cache file. If unset or empty, the OAuth provider caches
+   * credentials only in memory and does not persist them across restarts. Set this to a writable
+   * path to opt in to persistent file-based caching. See issue #13124.
+   */
+  private String credentialsCachePath;
 
   /** The connection timeout for requests to the OAuth credentials provider. */
   private Duration connectTimeout = DEFAULT_CONNECT_TIMEOUT;

--- a/clients/camunda-spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/clients/camunda-spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -183,8 +183,7 @@
       "defaultValue": "PT5S"
     },
     {
-      "name": "camunda.client.auth.credentials-cache-path",
-      "defaultValue": "$HOME/.camunda/credentials"
+      "name": "camunda.client.auth.credentials-cache-path"
     },
     {
       "name": "camunda.client.max-metadata-size",

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configurationMetadata/AlignmentTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configurationMetadata/AlignmentTest.java
@@ -15,7 +15,6 @@
  */
 package io.camunda.client.spring.configurationMetadata;
 
-import static io.camunda.client.impl.oauth.OAuthCredentialsProviderBuilder.DEFAULT_CREDENTIALS_CACHE_PATH;
 import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -80,10 +79,6 @@ public class AlignmentTest {
               "camunda.client.request-timeout-offset",
               new Getter(CamundaClientProperties::getRequestTimeoutOffset, DURATION_MAPPER)),
           entry("camunda.client.tenant-id", new Getter(CamundaClientProperties::getTenantId)),
-          entry(
-              "camunda.client.auth.credentials-cache-path",
-              new Getter(
-                  p -> p.getAuth().getCredentialsCachePath(), p -> DEFAULT_CREDENTIALS_CACHE_PATH)),
           entry(
               "camunda.client.auth.connect-timeout",
               new Getter(p -> p.getAuth().getConnectTimeout(), DURATION_MAPPER)),

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/properties/CamundaClientPropertiesPostProcessorTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/properties/CamundaClientPropertiesPostProcessorTest.java
@@ -966,6 +966,19 @@ public class CamundaClientPropertiesPostProcessorTest {
       }
 
       @Nested
+      @SpringBootTest
+      class DefaultCredentialsCachePath {
+        @Autowired CamundaClientProperties camundaClientProperties;
+
+        @Test
+        void shouldDefaultCredentialsCachePathToNull() {
+          // Opt-in file cache: without a path, the provider uses in-memory caching only
+          // so it does not write to the filesystem (see issue #13124).
+          assertThat(camundaClientProperties.getAuth().getCredentialsCachePath()).isNull();
+        }
+      }
+
+      @Nested
       @SpringBootTest(
           properties = "spring.config.location=classpath:properties/8.7/execution-threads.yaml")
       class ExecutionThreads {

--- a/clients/java/src/main/java/io/camunda/client/impl/oauth/OAuthCredentialsCache.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/oauth/OAuthCredentialsCache.java
@@ -69,12 +69,31 @@ public final class OAuthCredentialsCache {
    */
   private final AtomicLong refreshGeneration = new AtomicLong(0);
 
+  /**
+   * Creates an in-memory-only credentials cache. Equivalent to {@link #OAuthCredentialsCache(File)}
+   * with {@code null} — no filesystem persistence; tokens live only for the lifetime of this
+   * instance.
+   */
+  public OAuthCredentialsCache() {
+    this(null);
+  }
+
+  /**
+   * Creates a credentials cache backed by {@code cacheFile}. If {@code cacheFile} is {@code null},
+   * the cache operates in memory only: {@link #readCache()} and {@link #writeCache()} become no-ops
+   * and tokens are not persisted across restarts. If {@code cacheFile} is non-null, the file (and
+   * its parent directories, if missing) are created on first write and used to round-trip
+   * credentials between runs.
+   */
   public OAuthCredentialsCache(final File cacheFile) {
     this.cacheFile = cacheFile;
     credentialsByClientId = new AtomicReference<>(new HashMap<>());
   }
 
   public OAuthCredentialsCache readCache() throws IOException {
+    if (cacheFile == null) {
+      return this;
+    }
     READ_LOCK.lock();
     try {
       if (!cacheFile.exists() || cacheFile.length() == 0) {
@@ -91,6 +110,9 @@ public final class OAuthCredentialsCache {
   }
 
   public void writeCache() throws IOException {
+    if (cacheFile == null) {
+      return;
+    }
     final Map<String, OAuthCachedCredentials> values = credentialsByClientId.get();
 
     final Map<String, Map<String, OAuthCachedCredentials>> cache = new HashMap<>(values.size());

--- a/clients/java/src/main/java/io/camunda/client/impl/oauth/OAuthCredentialsProviderBuilder.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/oauth/OAuthCredentialsProviderBuilder.java
@@ -79,10 +79,19 @@ public final class OAuthCredentialsProviderBuilder {
   public static final Duration DEFAULT_CONNECT_TIMEOUT = Duration.ofSeconds(5);
   public static final Duration DEFAULT_READ_TIMEOUT = DEFAULT_CONNECT_TIMEOUT;
   public static final Duration DEFAULT_PROACTIVE_TOKEN_REFRESH_THRESHOLD = Duration.ofSeconds(30);
+
+  /**
+   * Historical default path for the persistent credentials cache file. This path is <b>not</b>
+   * applied automatically; file-based caching is opt-in and activates only when {@link
+   * #credentialsCachePath(String)} is set to a non-empty value (directly, via Spring property, or
+   * via {@code CAMUNDA_CLIENT_CONFIG_PATH}). Callers wanting to reproduce the pre-8.10 default
+   * behavior can reference this constant explicitly.
+   */
   public static final String DEFAULT_CREDENTIALS_CACHE_PATH =
       Paths.get(System.getProperty("user.home"), ".camunda", "credentials")
           .toAbsolutePath()
           .toString();
+
   public static final String DEFAULT_AUTHZ_SERVER = "https://login.cloud.camunda.io/oauth/token/";
   public static final int DEFAULT_TOKEN_FETCH_MAX_RETRIES = 5;
   public static final Duration DEFAULT_TOKEN_FETCH_INITIAL_BACKOFF = Duration.ofSeconds(1);
@@ -299,8 +308,10 @@ public final class OAuthCredentialsProviderBuilder {
   }
 
   /**
-   * The location for the credentials cache file. If none (or null) is specified the default will be
-   * $HOME/.camunda/credentials
+   * The location for the persistent credentials cache file. If unset or empty, the provider caches
+   * credentials only in memory and does not persist them across restarts — this is the default. Set
+   * this to a writable path to opt in to file-based caching; the path must be writable or the first
+   * cache write will fail.
    */
   public OAuthCredentialsProviderBuilder credentialsCachePath(final String cachePath) {
     credentialsCachePath = cachePath;
@@ -310,7 +321,7 @@ public final class OAuthCredentialsProviderBuilder {
   /**
    * @see OAuthCredentialsProviderBuilder#credentialsCachePath(String)
    */
-  File getCredentialsCache() {
+  public File getCredentialsCache() {
     return credentialsCache;
   }
 
@@ -767,10 +778,6 @@ public final class OAuthCredentialsProviderBuilder {
   }
 
   private void applyDefaults() {
-    if (credentialsCachePath == null) {
-      credentialsCachePath = DEFAULT_CREDENTIALS_CACHE_PATH;
-    }
-
     if (connectTimeout == null) {
       connectTimeout = DEFAULT_CONNECT_TIMEOUT;
     }
@@ -830,11 +837,16 @@ public final class OAuthCredentialsProviderBuilder {
         throw new IllegalArgumentException("Truststore path does not exist: " + keystorePath);
       }
 
-      credentialsCache = new File(credentialsCachePath);
+      if (credentialsCachePath != null && !credentialsCachePath.isEmpty()) {
+        credentialsCache = new File(credentialsCachePath);
 
-      if (credentialsCache.isDirectory()) {
-        throw new IllegalArgumentException(
-            "Expected specified credentials cache to be a file but found directory instead.");
+        if (credentialsCache.isDirectory()) {
+          throw new IllegalArgumentException(
+              "Expected specified credentials cache to be a file but found directory instead.");
+        }
+      } else {
+        // Clear any file from a previous build() so reused builders do not leak stale state.
+        credentialsCache = null;
       }
       validateTimeout(connectTimeout, "ConnectTimeout");
       validateTimeout(readTimeout, "ReadTimeout");

--- a/clients/java/src/test/java/io/camunda/client/OAuthCredentialsProviderBuilderTest.java
+++ b/clients/java/src/test/java/io/camunda/client/OAuthCredentialsProviderBuilderTest.java
@@ -319,6 +319,86 @@ public final class OAuthCredentialsProviderBuilderTest {
   }
 
   @Test
+  void shouldDefaultToNoCredentialsCacheFile() {
+    // given — no credentialsCachePath set, env overrides disabled to keep the assertion hermetic
+    final OAuthCredentialsProviderBuilder builder =
+        new OAuthCredentialsProviderBuilder()
+            .applyEnvironmentOverrides(false)
+            .audience("a")
+            .clientId("b")
+            .clientSecret("c")
+            .authorizationServerUrl("http://some.url");
+
+    // when
+    builder.build();
+
+    // then — no file is configured; the provider falls back to the in-memory cache only
+    assertThat(builder.getCredentialsCache()).isNull();
+  }
+
+  @Test
+  void shouldTreatEmptyCredentialsCachePathAsUnset() {
+    // given
+    final OAuthCredentialsProviderBuilder builder =
+        new OAuthCredentialsProviderBuilder()
+            .applyEnvironmentOverrides(false)
+            .audience("a")
+            .clientId("b")
+            .clientSecret("c")
+            .credentialsCachePath("")
+            .authorizationServerUrl("http://some.url");
+
+    // when
+    builder.build();
+
+    // then
+    assertThat(builder.getCredentialsCache()).isNull();
+  }
+
+  @Test
+  void shouldUseCredentialsCacheFileWhenPathIsSet(@TempDir final Path tmpDir) {
+    // given
+    final Path cachePath = tmpDir.resolve("credentials");
+    final OAuthCredentialsProviderBuilder builder =
+        new OAuthCredentialsProviderBuilder()
+            .applyEnvironmentOverrides(false)
+            .audience("a")
+            .clientId("b")
+            .clientSecret("c")
+            .credentialsCachePath(cachePath.toString())
+            .authorizationServerUrl("http://some.url");
+
+    // when
+    builder.build();
+
+    // then
+    assertThat(builder.getCredentialsCache()).isNotNull();
+    assertThat(builder.getCredentialsCache().getAbsolutePath()).isEqualTo(cachePath.toString());
+  }
+
+  @Test
+  void shouldClearCredentialsCacheWhenPathIsUnsetOnRebuild(@TempDir final Path tmpDir) {
+    // given — a builder first built with an explicit cache path
+    final Path cachePath = tmpDir.resolve("credentials");
+    final OAuthCredentialsProviderBuilder builder =
+        new OAuthCredentialsProviderBuilder()
+            .applyEnvironmentOverrides(false)
+            .audience("a")
+            .clientId("b")
+            .clientSecret("c")
+            .credentialsCachePath(cachePath.toString())
+            .authorizationServerUrl("http://some.url");
+    builder.build();
+    assertThat(builder.getCredentialsCache()).isNotNull();
+
+    // when — the same builder is reconfigured to clear the path and built again
+    builder.credentialsCachePath(null).build();
+
+    // then — the stale cache file from the first build is gone
+    assertThat(builder.getCredentialsCache()).isNull();
+  }
+
+  @Test
   void shouldUseDefaultAuthorizationServerUrl() {
     // given
     final OAuthCredentialsProviderBuilder builder =

--- a/clients/java/src/test/java/io/camunda/client/impl/oauth/OAuthCredentialsCacheTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/oauth/OAuthCredentialsCacheTest.java
@@ -473,6 +473,99 @@ public final class OAuthCredentialsCacheTest {
   }
 
   @Test
+  public void shouldConstructWithNullCacheFile() {
+    // given / when
+    final OAuthCredentialsCache cache = new OAuthCredentialsCache();
+
+    // then — no eager disk access at construction time
+    assertThat(cache.size()).isZero();
+  }
+
+  @Test
+  public void shouldReadCacheAsNoOpWhenCacheFileIsNull() throws IOException {
+    // given
+    final OAuthCredentialsCache cache = new OAuthCredentialsCache();
+    cache.put(WOMBAT_CLIENT_ID, WOMBAT);
+
+    // when — readCache must not touch disk, and must not clobber the in-memory state
+    cache.readCache();
+
+    // then
+    assertThat(cache.get(WOMBAT_CLIENT_ID)).contains(WOMBAT);
+  }
+
+  @Test
+  public void shouldWriteCacheAsNoOpWhenCacheFileIsNull() throws IOException {
+    // given
+    final OAuthCredentialsCache cache = new OAuthCredentialsCache();
+    cache.put(WOMBAT_CLIENT_ID, WOMBAT);
+
+    // when — writeCache must not throw when no file is configured
+    cache.writeCache();
+
+    // then — in-memory state is preserved
+    assertThat(cache.get(WOMBAT_CLIENT_ID)).contains(WOMBAT);
+  }
+
+  @Test
+  public void shouldComputeIfMissingOrInvalidWithoutTouchingDiskWhenCacheFileIsNull()
+      throws IOException {
+    // given
+    final OAuthCredentialsCache cache = new OAuthCredentialsCache();
+    final AtomicInteger fetchCount = new AtomicInteger(0);
+
+    // when — first call triggers the supplier, second call serves from in-memory
+    final CamundaClientCredentials first =
+        cache.computeIfMissingOrInvalid(
+            WOMBAT_CLIENT_ID,
+            () -> {
+              fetchCount.incrementAndGet();
+              return WOMBAT;
+            });
+    final CamundaClientCredentials second =
+        cache.computeIfMissingOrInvalid(
+            WOMBAT_CLIENT_ID,
+            () -> {
+              fetchCount.incrementAndGet();
+              return WOMBAT;
+            });
+
+    // then
+    assertThat(first).isEqualTo(WOMBAT);
+    assertThat(second).isEqualTo(WOMBAT);
+    assertThat(fetchCount.get()).isEqualTo(1);
+  }
+
+  @Test
+  public void shouldForceRefreshIfChangedWithoutTouchingDiskWhenCacheFileIsNull()
+      throws IOException {
+    // given
+    final OAuthCredentialsCache cache = new OAuthCredentialsCache();
+    cache.put(WOMBAT_CLIENT_ID, WOMBAT);
+    final CamundaClientCredentials refreshed =
+        new CamundaClientCredentials("refreshed", EXPIRY, "Bearer");
+
+    // when
+    final boolean changed = cache.forceRefreshIfChanged(WOMBAT_CLIENT_ID, () -> refreshed);
+
+    // then
+    assertThat(changed).isTrue();
+    assertThat(cache.get(WOMBAT_CLIENT_ID)).contains(refreshed);
+  }
+
+  @Test
+  public void shouldPutAndWriteWithoutTouchingDiskWhenCacheFileIsNull() throws IOException {
+    // given
+    final OAuthCredentialsCache cache = new OAuthCredentialsCache();
+
+    // when
+    cache.putAndWrite(WOMBAT_CLIENT_ID, WOMBAT);
+
+    // then
+    assertThat(cache.get(WOMBAT_CLIENT_ID)).contains(WOMBAT);
+  }
+
+  @Test
   public void shouldBeThreadSafe() throws InterruptedException {
     // given
     final OAuthCredentialsCache cache = new OAuthCredentialsCache(cacheFile);


### PR DESCRIPTION
## Summary

Flip the Java client's OAuth credentials cache default from file-based (`$HOME/.camunda/credentials`) to in-memory. The file cache remains available as an opt-in — set a path via the builder, the Spring property `camunda.client.auth.credentials-cache-path`, or the env var `CAMUNDA_CLIENT_CONFIG_PATH`.

### Why

- The unconditional file cache breaks on read-only container filesystems (OpenShift, hardened pod security contexts). Affected users hit `IOException`s at first cache write and have to apply non-obvious workarounds (mount an `emptyDir` + point the env var at it).
- The file cache has a history of latent corruption when multiple JVMs share `$HOME` — the on-disk YAML is not a serializable contract across concurrent writers.
- The original motivation (avoiding repeat token fetches across restarts for SaaS cost, see #3009) no longer justifies a default that trips up common deployment topologies. Operators can still opt in when they need persistence.

### What changed

- `OAuthCredentialsProviderBuilder.applyDefaults()` no longer defaults `credentialsCachePath`.
- `OAuthCredentialsProviderBuilder.validate()` builds the backing `File` only when the path is non-null and non-empty.
- `OAuthCredentialsCache` tolerates a `null` `cacheFile`: `readCache()` and `writeCache()` are no-ops in that mode; the in-memory `AtomicReference<HashMap>` remains the sole source of truth. All existing synchronization, lock, and stampede-prevention logic is preserved.
- `CamundaClientAuthProperties.credentialsCachePath` defaults to `null`; the corresponding entry in `additional-spring-configuration-metadata.json` drops its `defaultValue` (no documented default when caching is opt-in).
- `DEFAULT_CREDENTIALS_CACHE_PATH` is retained as a `public static final` constant so callers wanting the pre-8.10 behavior can reference it explicitly.
- Empty string is treated identically to unset, so `CAMUNDA_CLIENT_CONFIG_PATH=` (defined but empty) now yields the in-memory default instead of failing on `new File("")`.
- `getCredentialsCache()` on the builder is promoted to `public` for consistency with the other getters in the same file and to keep the new tests in-package.

### Behavior change (user-visible)

- Default: tokens are fetched fresh on every JVM restart. The running process still benefits from the in-memory cache and proactive refresh.
- Opt-in: setting the path via any of the three existing mechanisms restores the current file-cache behavior verbatim. No API break.

### Alternatives considered

- Add a new boolean `credentialsCacheEnabled` / `persistCredentialsCache`. Rejected: doubles the config surface with no user benefit; path-presence already signals opt-in.
- Extract `OAuthCredentialsCache` as an interface with file and in-memory implementations. Rejected: only one caller, no third backend on the horizon — unwarranted abstraction.

### Not in this PR

- Docs update in `camunda/camunda-docs` (follow-up).
- Backport to stable branches — behavior change, not a bugfix; customers have a documented workaround. Not labeled for backport.

Closes #13124

## Follow-up

- [ ] Announce change in 8.10 docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)