### PR TITLE
docs: clarify semantics of VersionUtil.getPreviousVersion()

### DIFF
--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/VersionUtil.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/VersionUtil.java
@@ -68,7 +68,30 @@ public final class VersionUtil {
   }
 
   /**
-   * @return the previous stable version or null if none was found.
+   * Returns the configured backwards-compatibility baseline version used by Zeebe tests and RevAPI
+   * checks.
+   *
+   * <p>The value is read from the {@code zeebe.last.version} property of {@code
+   * /zeebe-util.properties}, which is populated at build time from the Maven property {@code
+   * backwards.compat.version} declared in {@code parent/pom.xml} (commented there as "version
+   * against which backwards compatibility is checked").
+   *
+   * <p>By convention:
+   *
+   * <ul>
+   *   <li>On {@code main}, this baseline points to a release of the previous minor version (e.g.
+   *       while {@code main} targets 8.8.x, the baseline is an 8.7.x release).
+   *   <li>On a stable branch (e.g. {@code stable/8.7}), it points to a release of the previous
+   *       stable minor (e.g. an 8.6.x release).
+   * </ul>
+   *
+   * <p>The property is a <em>manually maintained</em> baseline, not "the latest previous patch at
+   * the moment of invocation" -- its value is only updated when a new baseline is intentionally
+   * chosen, and it can legitimately differ between branches. This method is currently referenced
+   * from tests only.
+   *
+   * @return the configured backwards-compatibility baseline, or {@code null} if the property is not
+   *     set or the properties file cannot be read.
    */
   public static String getPreviousVersion() {
     if (lastVersion == null) {


### PR DESCRIPTION
## Description

Closes #37828.

The existing Javadoc on `VersionUtil.getPreviousVersion()` --

```java
/**
 * @return the previous stable version or null if none was found.
 */
```

-- left the questions raised in #37828 unanswered:

- Which "previous" is this? The latest patch of the previous minor? The latest stable patch? Something else?
- Where does the value come from?
- Why does it legitimately differ between `main` and the `stable/*` branches?

This PR keeps the behaviour exactly as-is (callers still get `null` when the property is absent) and rewrites the Javadoc to document:

1. **The property chain** -- `zeebe.last.version` in `zeebe-util.properties` is populated at build time from the Maven property `backwards.compat.version` declared in `parent/pom.xml` (commented there as "version against which backwards compatibility is checked").
2. **The per-branch convention** -- on `main`, the baseline points to a release of the previous minor (e.g. while `main` targets 8.8.x, the baseline is an 8.7.x release); on `stable/x.y` branches it points to a release of the previous stable minor.
3. **That the value is a manually maintained baseline**, not "the latest previous patch at the moment of invocation" -- which is why the property can legitimately diverge between branches, and why #37828 observed inconsistent values.
4. **That the method is currently used from tests only** (and should be treated as a RevAPI/test baseline rather than a live "what's the previous release" lookup).

## Why this is the right scope for a GFI

The issue explicitly asked for clarification of the ambiguous behaviour. The actual version-selection policy (what the Maven property _should_ hold on each branch) is a release-engineering decision that lives in `parent/pom.xml` and the release workflows; changing that is out of scope for a docs-only GFI. If the team later wants to enforce the convention (e.g. via a build-time assertion that `backwards.compat.version` matches a specific pattern), the clarified Javadoc gives future callers a clear spec to target.

## Checklist

- [x] Commit follows Conventional Commits (`docs(zeebe): ...`)
- [x] CLA signed (previously, for #50439/#50440/#50438)
- [x] No behavioural change -- pure Javadoc edit in `zeebe/util/src/main/java/io/camunda/zeebe/util/VersionUtil.java`
- [x] No new/changed tests needed (Javadoc only)
- [x] Closes the linked issue

Happy to reword, shorten, or split further if the maintainers prefer a different tone or length.
