### PR TITLE
data availability in max benchmarks

### DIFF
--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/config/StarterProperties.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/config/StarterProperties.java
@@ -16,6 +16,7 @@ public class StarterProperties {
   private String processId = "benchmark";
   private double rate = 300;
   private Duration rateDuration = Duration.ofSeconds(1);
+  private int processStarterConcurrency = 100;
   private int threads = 2;
   private String bpmnXmlPath = "bpmn/one_task.bpmn";
   private List<String> extraBpmnModels = List.of();
@@ -53,6 +54,14 @@ public class StarterProperties {
 
   public double getRatePerSecond() {
     return rate / (rateDuration.toNanos() / 1_000_000_000.0);
+  }
+
+  public int getProcessStarterConcurrency() {
+    return processStarterConcurrency;
+  }
+
+  public void setProcessStarterConcurrency(final int processStarterConcurrency) {
+    this.processStarterConcurrency = processStarterConcurrency;
   }
 
   public int getThreads() {

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/metrics/ProcessInstanceStartMeter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/metrics/ProcessInstanceStartMeter.java
@@ -85,24 +85,22 @@ public class ProcessInstanceStartMeter implements AutoCloseable {
     }
 
     LOG.debug("Current instances awaiting {}", startedInstances.size());
+    final List<Long> availableInstances;
     final var startQueryTime = clock.getNanos();
-    availabilityChecker
-        .findAvailableInstances(List.copyOf(startedInstances.keySet()))
-        .whenCompleteAsync(
-            (availableInstances, error) -> {
-              final var endQueryTime = clock.getNanos();
-              dataAvailabilityQueryDurationTimer.record(
-                  endQueryTime - startQueryTime, TimeUnit.NANOSECONDS);
+    try {
+      availableInstances =
+          availabilityChecker
+              .findAvailableInstances(List.copyOf(startedInstances.keySet()))
+              .toCompletableFuture()
+              .join();
+    } finally {
+      final var endQueryTime = clock.getNanos();
+      dataAvailabilityQueryDurationTimer.record(
+          endQueryTime - startQueryTime, TimeUnit.NANOSECONDS);
+    }
 
-              if (error != null) {
-                LOG.error("Error while checking for available process instances", error);
-                return;
-              }
-
-              LOG.debug("Available process instances items: {}", availableInstances.size());
-              processAvailableInstances(availableInstances);
-            },
-            piCheckExecutorService);
+    LOG.debug("Available process instances items: {}", availableInstances.size());
+    processAvailableInstances(availableInstances);
   }
 
   private void processAvailableInstances(final List<Long> availableInstances) {

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/metrics/ProcessInstanceStartMeter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/metrics/ProcessInstanceStartMeter.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 
 public class ProcessInstanceStartMeter implements AutoCloseable {
   private static final int MAX_PENDING_INSTANCES = 1000;
+  private static final long STALE_THRESHOLD_NANOS = Duration.ofSeconds(90).toNanos();
   private static final Logger LOG = LoggerFactory.getLogger(ProcessInstanceStartMeter.class);
   private final ConcurrentHashMap<Integer, Timer> partitionToTimerMap;
   private final Map<Long, PiCreationResult> startedInstances;
@@ -97,10 +98,24 @@ public class ProcessInstanceStartMeter implements AutoCloseable {
       final var endQueryTime = clock.getNanos();
       dataAvailabilityQueryDurationTimer.record(
           endQueryTime - startQueryTime, TimeUnit.NANOSECONDS);
+      checkForStaleProcesses();
     }
 
     LOG.debug("Available process instances items: {}", availableInstances.size());
     processAvailableInstances(availableInstances);
+  }
+
+  private void checkForStaleProcesses() {
+    final long nanoTime = clock.getNanos();
+    for (final var piCreationResult : startedInstances.values()) {
+      final long ageNanos = nanoTime - piCreationResult.startTimeNanos;
+      if (ageNanos > STALE_THRESHOLD_NANOS) {
+        // NB not actually removing it as we want to ensure it's obvious we
+        // have instances that are not available still (as that implies something
+        // is broken)
+        recordDataAvailabilityLatency(piCreationResult, ageNanos);
+      }
+    }
   }
 
   private void processAvailableInstances(final List<Long> availableInstances) {
@@ -114,11 +129,17 @@ public class ProcessInstanceStartMeter implements AutoCloseable {
                   "Process instance {} retrieved in {} ms",
                   piResults.processInstanceKey,
                   TimeUnit.NANOSECONDS.toMillis(durationNanos));
-              recordInstanceAvailable(piResults, durationNanos);
+              recordInstanceAvailableAndRemove(piResults, durationNanos);
             });
   }
 
-  private void recordInstanceAvailable(
+  private void recordInstanceAvailableAndRemove(
+      final PiCreationResult awaitingPI, final long durationNanos) {
+    recordDataAvailabilityLatency(awaitingPI, durationNanos);
+    startedInstances.remove(awaitingPI.processInstanceKey);
+  }
+
+  private void recordDataAvailabilityLatency(
       final PiCreationResult awaitingPI, final long durationNanos) {
     final int partitionId = Protocol.decodePartitionId(awaitingPI.processInstanceKey);
     partitionToTimerMap
@@ -129,7 +150,6 @@ public class ProcessInstanceStartMeter implements AutoCloseable {
                     .tag(StarterMetricKeyNames.PARTITION.asString(), Integer.toString(key))
                     .register(registry))
         .record(durationNanos, TimeUnit.NANOSECONDS);
-    startedInstances.remove(awaitingPI.processInstanceKey);
   }
 
   public void recordProcessInstanceStart(final long processInstanceKey, final long startTimeNanos) {

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/metrics/ProcessInstanceStartMeter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/metrics/ProcessInstanceStartMeter.java
@@ -24,7 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ProcessInstanceStartMeter implements AutoCloseable {
-  private static final long MAX_DURATION = Duration.ofSeconds(90).toNanos();
+  private static final int MAX_PENDING_INSTANCES = 1000;
   private static final Logger LOG = LoggerFactory.getLogger(ProcessInstanceStartMeter.class);
   private final ConcurrentHashMap<Integer, Timer> partitionToTimerMap;
   private final Map<Long, PiCreationResult> startedInstances;
@@ -96,33 +96,13 @@ public class ProcessInstanceStartMeter implements AutoCloseable {
 
               if (error != null) {
                 LOG.error("Error while checking for available process instances", error);
-                cleanUpStaleInstances();
                 return;
               }
 
               LOG.debug("Available process instances items: {}", availableInstances.size());
               processAvailableInstances(availableInstances);
-              cleanUpStaleInstances();
             },
             piCheckExecutorService);
-  }
-
-  private void cleanUpStaleInstances() {
-    // clean up stale instances which exceeded the max duration - to save memory
-    final long nanoTime = clock.getNanos();
-    final var instancesWhereTimeExceededDeadline =
-        startedInstances.values().stream()
-            .filter(piCreationResult -> nanoTime - piCreationResult.startTimeNanos > MAX_DURATION)
-            .toList();
-    instancesWhereTimeExceededDeadline.forEach(
-        piResults -> {
-          final long durationNanos = clock.getNanos() - piResults.startTimeNanos;
-          LOG.debug(
-              "Process instance {} was not retrieved after {} ms, removing it from the awaiting list.",
-              piResults.processInstanceKey,
-              TimeUnit.NANOSECONDS.toMillis(durationNanos));
-          recordInstanceAvailable(piResults, durationNanos);
-        });
   }
 
   private void processAvailableInstances(final List<Long> availableInstances) {
@@ -155,8 +135,14 @@ public class ProcessInstanceStartMeter implements AutoCloseable {
   }
 
   public void recordProcessInstanceStart(final long processInstanceKey, final long startTimeNanos) {
-    startedInstances.put(
-        processInstanceKey, new PiCreationResult(processInstanceKey, startTimeNanos));
+    // under load we'll drop new instances as we might as well
+    // focus on what we're already checking (and more instances will arrive pretty quickly anyway)
+    // otherwise with a max benchmark we can easily end up with 20 thousand instances to check
+    // within a minute or two
+    if (startedInstances.size() < MAX_PENDING_INSTANCES) {
+      startedInstances.put(
+          processInstanceKey, new PiCreationResult(processInstanceKey, startTimeNanos));
+    }
   }
 
   private record PiCreationResult(long processInstanceKey, long startTimeNanos) {}

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/starter/Starter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/starter/Starter.java
@@ -18,7 +18,6 @@ import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.client.api.search.response.ProcessInstance;
 import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.client.api.search.sort.ProcessInstanceSort;
-import io.camunda.client.impl.CamundaClientBuilderImpl;
 import io.camunda.zeebe.config.LoadTesterProperties;
 import io.camunda.zeebe.config.StarterProperties;
 import io.camunda.zeebe.metrics.ConnectionMonitor;
@@ -100,7 +99,7 @@ public class Starter implements CommandLineRunner {
     this.registry = registry;
     this.payloadReader = payloadReader;
     this.connectionMonitor = connectionMonitor;
-    processStartingSemaphore = new Semaphore(maxProcessStartingConcurrency());
+    processStartingSemaphore = new Semaphore(starterCfg.getProcessStarterConcurrency());
   }
 
   @Override
@@ -333,10 +332,6 @@ public class Starter implements CommandLineRunner {
       LOG.error("Failed to parse variables '{}'.", variablesString, e);
       throw new RuntimeException(e);
     }
-  }
-
-  private int maxProcessStartingConcurrency() {
-    return CamundaClientBuilderImpl.DEFAULT_MAX_HTTP_CONNECTIONS;
   }
 
   private void deployProcess() {

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/starter/Starter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/starter/Starter.java
@@ -18,6 +18,7 @@ import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.client.api.search.response.ProcessInstance;
 import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.client.api.search.sort.ProcessInstanceSort;
+import io.camunda.client.impl.CamundaClientBuilderImpl;
 import io.camunda.zeebe.config.LoadTesterProperties;
 import io.camunda.zeebe.config.StarterProperties;
 import io.camunda.zeebe.metrics.ConnectionMonitor;
@@ -46,6 +47,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -79,6 +81,7 @@ public class Starter implements CommandLineRunner {
   private final AtomicLong lastProcessInstanceKey = new AtomicLong(0);
   private final AtomicReference<Instant> lastProcessInstanceKeyTimestamp =
       new AtomicReference<>(Instant.now());
+  private final Semaphore processStartingSemaphore;
 
   private Timer responseLatencyTimer;
   private ScheduledExecutorService executorService;
@@ -97,6 +100,7 @@ public class Starter implements CommandLineRunner {
     this.registry = registry;
     this.payloadReader = payloadReader;
     this.connectionMonitor = connectionMonitor;
+    processStartingSemaphore = new Semaphore(maxProcessStartingConcurrency());
   }
 
   @Override
@@ -220,6 +224,16 @@ public class Starter implements CommandLineRunner {
             return;
           }
 
+          // ensure we don't have too many pending requests
+          // as this can lead to us seeing much worse availability times
+          // than expected
+          try {
+            processStartingSemaphore.acquire();
+          } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return;
+          }
+
           try {
             final var vars = new HashMap<>(baseVariables);
             vars.put(starterCfg.getBusinessKey(), businessKey.incrementAndGet());
@@ -235,6 +249,7 @@ public class Starter implements CommandLineRunner {
             }
             requestFuture.whenComplete(
                 (noop, error) -> {
+                  processStartingSemaphore.release();
                   final long durationNanos = System.nanoTime() - startTime;
                   responseLatencyTimer.record(durationNanos, TimeUnit.NANOSECONDS);
                   if (error instanceof final StatusRuntimeException statusRuntimeException) {
@@ -248,6 +263,7 @@ public class Starter implements CommandLineRunner {
                 });
           } catch (final Exception e) {
             THROTTLED_LOGGER.error("Error on creating new process instance", e);
+            processStartingSemaphore.release();
           }
         },
         0,
@@ -317,6 +333,10 @@ public class Starter implements CommandLineRunner {
       LOG.error("Failed to parse variables '{}'.", variablesString, e);
       throw new RuntimeException(e);
     }
+  }
+
+  private int maxProcessStartingConcurrency() {
+    return CamundaClientBuilderImpl.DEFAULT_MAX_HTTP_CONNECTIONS;
   }
 
   private void deployProcess() {

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/starter/Starter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/starter/Starter.java
@@ -163,12 +163,13 @@ public class Starter implements CommandLineRunner {
             Executors.newScheduledThreadPool(1),
             properties.getMonitorDataAvailabilityInterval(),
             (listOfStartedInstances) -> {
+              final var limit = Math.min(listOfStartedInstances.size(), 1000);
               final CamundaFuture<SearchResponse<ProcessInstance>> send =
                   client
                       .newProcessInstanceSearchRequest()
                       .filter((f) -> f.processInstanceKey(key -> key.in(listOfStartedInstances)))
                       .sort(ProcessInstanceSort::startDate)
-                      .page(p -> p.limit(100))
+                      .page(p -> p.limit(limit))
                       .send();
 
               return send.thenApply(

--- a/load-tests/load-tester/src/main/resources/application.yaml
+++ b/load-tests/load-tester/src/main/resources/application.yaml
@@ -45,6 +45,7 @@ camunda:
     use-client-side-load-balancing: true
     # Since the starter doesn't need any job worker execution threads
     execution-threads: 0
+    max-http-connections: 105 # more than process-starter-concurrency to allow for monitoring availability calls
     auth:
       method: ${ZEEBE_AUTH_METHOD:none}
       username: ${ZEEBE_AUTH_USERNAME:demo}
@@ -91,6 +92,7 @@ load-tester:
     duration-limit: ${LOAD_TESTER_STARTER_DURATION_LIMIT:0}
     msg-name: msg
     start-via-message: false
+    process-starter-concurrency: 100 # less than the number of http connections to avoid saturating the pool and causing timeouts
   # Worker-specific properties consumed by Worker.java.
   # These control what the job handler does (completion delay, message publishing, payload).
   # Connection properties (type, name, threads, capacity, polling, streaming, timeout)

--- a/load-tests/load-tester/src/test/java/io/camunda/zeebe/metrics/ProcessInstanceStartMeterTest.java
+++ b/load-tests/load-tester/src/test/java/io/camunda/zeebe/metrics/ProcessInstanceStartMeterTest.java
@@ -294,7 +294,7 @@ class ProcessInstanceStartMeterTest {
                     .get(StarterLatencyMetricsDoc.DATA_AVAILABILITY_LATENCY.getName())
                     .timer()
                     .count(),
-            (count) -> assertThat(count).isOne());
+            (count) -> assertThat(count).isGreaterThan(1L));
     assertThat(
             meterRegistry
                 .get(StarterLatencyMetricsDoc.DATA_AVAILABILITY_LATENCY.getName())


### PR DESCRIPTION
This should deal with a bunch of issues related to an massive increase in the reported data availability metric when running `max` benchmarks.

The problem started with the switch to the REST API.  The basic problem is that the we end up blocked waiting for http connections on the client side.

To fix that:

* use a separate client for starting processes and monitoring availability (so availability calls are never blocked)
* only make one call to check availability at a time (previously these calls could back up and increase the number of concurrent connections)
* allow for more http connections at once
* directly limit how many concurrent calls we make to start processes (so the start time we record no longer includes the time waiting for http connections to be available)

Also:

* drop extra PIs when we already have more than enough waiting to be checked (instead of removing those that are stale after 90 seconds), so we should no longer have a 90 second hard cut off for the metric.
* still record PIs that are older than 90 seconds, but do not remove them - so it's clear when we have stuck PIs and things are broken.


Side benefits:

* the direct limiting on concurrent API calls when starting should help makes things more stable as we'll no longer end up with a massive backlog (which could lead to memory issues etc)

Refs: #43121