### PR TITLE
feat: add decision instances batch deletion modal

### DIFF
--- a/operate/client/src/App/Decisions/InstancesTable/Toolbar/index.tsx
+++ b/operate/client/src/App/Decisions/InstancesTable/Toolbar/index.tsx
@@ -6,50 +6,108 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {TableToolbar, TableBatchAction, TableBatchActions} from '@carbon/react';
+import {
+  TableToolbar,
+  Modal,
+  TableBatchAction,
+  TableBatchActions,
+} from '@carbon/react';
 import {TrashCan} from '@carbon/react/icons';
 import {observer} from 'mobx-react';
+import {useState} from 'react';
 import {decisionInstancesSelectionStore} from 'modules/stores/instancesSelection';
+import {useDeleteDecisionInstancesBatchOperation} from 'modules/mutations/decisionInstances/useDeleteDecisionInstancesBatchOperation';
+import {useDeleteDecisionInstancesBatchOperationRequestBody} from 'modules/hooks/useBatchOperationMutationRequestBody';
+import {useBatchOperationSuccessNotification} from 'modules/hooks/useBatchOperationSuccessNotification';
+import {handleOperationError} from 'modules/utils/notifications';
+import {tracking} from 'modules/tracking';
+import pluralSuffix from 'modules/utils/pluralSuffix';
+import {IS_DELETE_DI_BATCH_OPERATION_ENABLED} from 'modules/feature-flags';
 
 type Props = {
   selectedCount: number;
 };
 
 const Toolbar: React.FC<Props> = observer(({selectedCount}) => {
+  const displaySuccessNotification = useBatchOperationSuccessNotification();
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const deleteRequestBody =
+    useDeleteDecisionInstancesBatchOperationRequestBody();
+
+  const deleteMutation = useDeleteDecisionInstancesBatchOperation({
+    onSuccess: ({batchOperationKey, batchOperationType}) => {
+      displaySuccessNotification(batchOperationType, batchOperationKey);
+      tracking.track({
+        eventName: 'batch-operation',
+        operationType: 'DELETE_DECISION_INSTANCE',
+      });
+      decisionInstancesSelectionStore.resetState();
+    },
+    onError: (error) => {
+      handleOperationError(error.response?.status);
+    },
+  });
+
   if (selectedCount === 0) {
     return null;
   }
 
   return (
-    <TableToolbar size="sm">
-      <TableBatchActions
-        shouldShowBatchActions
-        totalSelected={selectedCount}
-        onCancel={decisionInstancesSelectionStore.resetState}
-        translateWithId={(id) => {
-          switch (id) {
-            case 'carbon.table.batch.cancel':
-              return 'Discard';
-            case 'carbon.table.batch.items.selected':
-              return `${selectedCount} items selected`;
-            case 'carbon.table.batch.item.selected':
-              return `${selectedCount} item selected`;
-            case 'carbon.table.batch.selectAll':
-              return 'Select all items';
-            default:
-              return id;
-          }
-        }}
-      >
-        <TableBatchAction
-          renderIcon={TrashCan}
-          onClick={() => {}}
-          data-testid="delete-decision-instances-batch-operation"
+    <>
+      <TableToolbar size="sm">
+        <TableBatchActions
+          shouldShowBatchActions
+          totalSelected={selectedCount}
+          onCancel={decisionInstancesSelectionStore.resetState}
+          translateWithId={(id) => {
+            switch (id) {
+              case 'carbon.table.batch.cancel':
+                return 'Discard';
+              case 'carbon.table.batch.items.selected':
+                return `${selectedCount} items selected`;
+              case 'carbon.table.batch.item.selected':
+                return `${selectedCount} item selected`;
+              case 'carbon.table.batch.selectAll':
+                return 'Select all items';
+              default:
+                return id;
+            }
+          }}
         >
-          Delete
-        </TableBatchAction>
-      </TableBatchActions>
-    </TableToolbar>
+          {IS_DELETE_DI_BATCH_OPERATION_ENABLED && (
+            <TableBatchAction
+              renderIcon={TrashCan}
+              onClick={() => setShowDeleteModal(true)}
+            >
+              Delete
+            </TableBatchAction>
+          )}
+        </TableBatchActions>
+      </TableToolbar>
+
+      <Modal
+        open={showDeleteModal}
+        preventCloseOnClickOutside
+        modalHeading="Apply operation"
+        primaryButtonText="Delete"
+        danger
+        secondaryButtonText="Cancel"
+        onRequestSubmit={() => {
+          deleteMutation.mutate(deleteRequestBody);
+          setShowDeleteModal(false);
+        }}
+        onRequestClose={() => setShowDeleteModal(false)}
+        onSecondarySubmit={() => {
+          setShowDeleteModal(false);
+          decisionInstancesSelectionStore.resetState();
+        }}
+        size="md"
+      >
+        <p>
+          {`${pluralSuffix(selectedCount, 'instance')} selected for delete operation. This permanently deletes the selected decision instances and their history. This cannot be undone.`}
+        </p>
+      </Modal>
+    </>
   );
 });
 

--- a/operate/client/src/App/Decisions/InstancesTable/Toolbar/index.tsx
+++ b/operate/client/src/App/Decisions/InstancesTable/Toolbar/index.tsx
@@ -21,7 +21,7 @@ import {useDeleteDecisionInstancesBatchOperationRequestBody} from 'modules/hooks
 import {useBatchOperationSuccessNotification} from 'modules/hooks/useBatchOperationSuccessNotification';
 import {handleOperationError} from 'modules/utils/notifications';
 import {tracking} from 'modules/tracking';
-import pluralSuffix from 'modules/utils/pluralSuffix';
+import {pluralSuffix} from 'modules/utils/pluralSuffix';
 import {IS_DELETE_DI_BATCH_OPERATION_ENABLED} from 'modules/feature-flags';
 
 type Props = {

--- a/operate/client/src/App/Decisions/InstancesTable/Toolbar/tests/index.test.tsx
+++ b/operate/client/src/App/Decisions/InstancesTable/Toolbar/tests/index.test.tsx
@@ -37,7 +37,7 @@ vi.mock('modules/stores/notifications', () => ({
   },
 }));
 
-const Wrapper = ({children}: Props) => {
+const Wrapper: React.FC<Props> = ({children}) => {
   return (
     <QueryClientProvider client={getMockQueryClient()}>
       <MemoryRouter initialEntries={['/decisions?evaluated=true&failed=true']}>
@@ -49,8 +49,6 @@ const Wrapper = ({children}: Props) => {
 
 describe('<Toolbar />', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-
     mockDeleteDecisionInstancesBatchOperation().withSuccess({
       batchOperationKey: 'delete-operation-123',
       batchOperationType: 'DELETE_DECISION_INSTANCE',
@@ -74,7 +72,6 @@ describe('<Toolbar />', () => {
   });
 
   afterEach(() => {
-    vi.resetAllMocks();
     decisionInstancesSelectionStore.reset();
   });
 

--- a/operate/client/src/App/Decisions/InstancesTable/Toolbar/tests/index.test.tsx
+++ b/operate/client/src/App/Decisions/InstancesTable/Toolbar/tests/index.test.tsx
@@ -1,0 +1,139 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {render, screen, within} from 'modules/testing-library';
+import {Toolbar} from '../index';
+import {MemoryRouter} from 'react-router-dom';
+import {decisionInstancesSelectionStore} from 'modules/stores/instancesSelection';
+import {notificationsStore} from 'modules/stores/notifications';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {mockDeleteDecisionInstancesBatchOperation} from 'modules/mocks/api/v2/decisionInstances/deleteDecisionInstancesBatchOperation';
+import {mockQueryBatchOperations} from 'modules/mocks/api/v2/batchOperations/queryBatchOperations';
+import {tracking} from 'modules/tracking';
+
+type Props = {
+  children?: React.ReactNode;
+};
+
+vi.mock('modules/feature-flags', () => ({
+  IS_DELETE_DI_BATCH_OPERATION_ENABLED: true,
+}));
+
+vi.mock('modules/tracking', () => ({
+  tracking: {
+    track: vi.fn(),
+  },
+}));
+
+vi.mock('modules/stores/notifications', () => ({
+  notificationsStore: {
+    displayNotification: vi.fn(() => () => {}),
+  },
+}));
+
+const Wrapper = ({children}: Props) => {
+  return (
+    <QueryClientProvider client={getMockQueryClient()}>
+      <MemoryRouter initialEntries={['/decisions?evaluated=true&failed=true']}>
+        {children}
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+};
+
+describe('<Toolbar />', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockDeleteDecisionInstancesBatchOperation().withSuccess({
+      batchOperationKey: 'delete-operation-123',
+      batchOperationType: 'DELETE_DECISION_INSTANCE',
+    });
+    mockQueryBatchOperations().withSuccess({
+      items: [],
+      page: {
+        totalItems: 0,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    decisionInstancesSelectionStore.setRuntime({
+      totalCount: 2,
+      visibleIds: ['1', '2'],
+    });
+    decisionInstancesSelectionStore.select('1');
+    decisionInstancesSelectionStore.select('2');
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+    decisionInstancesSelectionStore.reset();
+  });
+
+  it('should not display toolbar if selected count is 0', () => {
+    render(<Toolbar selectedCount={0} />, {wrapper: Wrapper});
+
+    expect(screen.queryByText(/items selected/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: 'Delete'}),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: 'Discard'}),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should display toolbar with Delete button', () => {
+    render(<Toolbar selectedCount={1} />, {
+      wrapper: Wrapper,
+    });
+
+    expect(screen.getByRole('button', {name: 'Delete'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Discard'})).toBeInTheDocument();
+    expect(screen.getByText('1 item selected')).toBeInTheDocument();
+  });
+
+  it('should perform delete batch operation successfully', async () => {
+    vi.useFakeTimers({shouldAdvanceTime: true});
+
+    const trackSpy = vi.spyOn(tracking, 'track');
+
+    const {user} = render(<Toolbar selectedCount={2} />, {wrapper: Wrapper});
+
+    await user.click(screen.getByRole('button', {name: 'Delete'}));
+
+    const modal = screen.getByRole('dialog');
+    expect(
+      within(modal).getByText(
+        /2 instances selected for delete operation\. This permanently deletes/i,
+      ),
+    ).toBeInTheDocument();
+
+    await user.click(within(modal).getByRole('button', {name: /delete/i}));
+
+    vi.runOnlyPendingTimers();
+
+    expect(trackSpy).toHaveBeenCalledWith({
+      eventName: 'batch-operation',
+      operationType: 'DELETE_DECISION_INSTANCE',
+    });
+
+    expect(notificationsStore.displayNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'success',
+      }),
+    );
+    expect(notificationsStore.displayNotification).not.toHaveBeenCalledWith(
+      expect.objectContaining({kind: 'error'}),
+    );
+
+    vi.useRealTimers();
+  });
+});

--- a/operate/client/src/App/Decisions/InstancesTable/index.test.tsx
+++ b/operate/client/src/App/Decisions/InstancesTable/index.test.tsx
@@ -379,7 +379,7 @@ describe('<InstancesTable />', () => {
     await user.click(firstRowCheckbox!);
 
     expect(screen.getByText('1 item selected')).toBeInTheDocument();
-    expect(screen.getByRole('button', {name: /delete/i})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Delete'})).toBeInTheDocument();
 
     await user.click(screen.getByRole('button', {name: 'Discard'}));
 

--- a/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/index.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/index.tsx
@@ -71,7 +71,7 @@ const Toolbar: React.FC<Props> = observer(({selectedInstancesCount}) => {
         eventName: 'batch-operation',
         operationType: 'CANCEL_PROCESS_INSTANCE',
       });
-      processInstancesSelectionStore.reset();
+      processInstancesSelectionStore.resetState();
     },
     onError: (error) => {
       handleOperationError(error.response?.status);
@@ -85,7 +85,7 @@ const Toolbar: React.FC<Props> = observer(({selectedInstancesCount}) => {
         eventName: 'batch-operation',
         operationType: 'RESOLVE_INCIDENT',
       });
-      processInstancesSelectionStore.reset();
+      processInstancesSelectionStore.resetState();
     },
     onError: (error) => {
       handleOperationError(error.response?.status);
@@ -99,7 +99,7 @@ const Toolbar: React.FC<Props> = observer(({selectedInstancesCount}) => {
         eventName: 'batch-operation',
         operationType: 'DELETE_PROCESS_INSTANCE',
       });
-      processInstancesSelectionStore.reset();
+      processInstancesSelectionStore.resetState();
     },
     onError: (error) => {
       handleOperationError(error.response?.status);
@@ -124,7 +124,7 @@ const Toolbar: React.FC<Props> = observer(({selectedInstancesCount}) => {
 
   const handleCancelClick = () => {
     closeModal();
-    processInstancesSelectionStore.reset();
+    processInstancesSelectionStore.resetState();
   };
 
   const getBodyText = () => {

--- a/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/index.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/index.tsx
@@ -26,7 +26,7 @@ import {tracking} from 'modules/tracking';
 import {handleOperationError} from 'modules/utils/notifications';
 import {
   useBatchOperationMutationRequestBody,
-  useDeleteBatchOperationMutationRequestBody,
+  useDeleteProcessInstancesBatchOperationMutationRequestBody,
 } from 'modules/hooks/useBatchOperationMutationRequestBody';
 import {useBatchOperationSuccessNotification} from 'modules/hooks/useBatchOperationSuccessNotification';
 import {processInstancesSelectionStore} from 'modules/stores/instancesSelection';
@@ -62,7 +62,7 @@ const Toolbar: React.FC<Props> = observer(({selectedInstancesCount}) => {
     useBatchOperationMutationRequestBody();
 
   const deleteBatchOperationMutationRequestBody =
-    useDeleteBatchOperationMutationRequestBody();
+    useDeleteProcessInstancesBatchOperationMutationRequestBody();
 
   const cancelMutation = useCancelProcessInstancesBatchOperation({
     onSuccess: ({batchOperationKey, batchOperationType}) => {

--- a/operate/client/src/modules/hooks/useBatchOperationMutationRequestBody.ts
+++ b/operate/client/src/modules/hooks/useBatchOperationMutationRequestBody.ts
@@ -8,8 +8,14 @@
 
 import {useSearchParams} from 'react-router-dom';
 import {variableFilterStore} from 'modules/stores/variableFilter';
-import {processInstancesSelectionStore} from 'modules/stores/instancesSelection';
+import {
+  processInstancesSelectionStore,
+  decisionInstancesSelectionStore,
+} from 'modules/stores/instancesSelection';
 import {buildMutationRequestBody} from 'modules/utils/buildMutationRequestBody';
+import {parseDecisionInstancesSearchFilter} from 'modules/utils/filter/decisionsFilter';
+import {buildInstanceKeyCriterion} from 'modules/utils/instances/buildInstanceKeyCriterion';
+import type {CreateDecisionInstancesDeletionBatchOperationRequestBody} from '@camunda/camunda-api-zod-schemas/8.10';
 
 const useBatchOperationMutationRequestBody = () => {
   const variable = variableFilterStore.variable;
@@ -33,7 +39,7 @@ const useBatchOperationMutationRequestBody = () => {
  * Unlike running operations (cancel, retry), delete operations only work on
  * finished instances (COMPLETED or TERMINATED).
  */
-const useDeleteBatchOperationMutationRequestBody = () => {
+const useDeleteProcessInstancesBatchOperationMutationRequestBody = () => {
   const variable = variableFilterStore.variable;
   const [searchParams] = useSearchParams();
 
@@ -50,7 +56,26 @@ const useDeleteBatchOperationMutationRequestBody = () => {
   });
 };
 
+const useDeleteDecisionInstancesBatchOperationRequestBody =
+  (): CreateDecisionInstancesDeletionBatchOperationRequestBody => {
+    const [searchParams] = useSearchParams();
+
+    const {selectedIds, excludedIds, checkedIds} =
+      decisionInstancesSelectionStore;
+
+    const includeIds = selectedIds.length > 0 ? checkedIds : [];
+    const keyCriterion = buildInstanceKeyCriterion(includeIds, excludedIds);
+
+    const baseFilter = parseDecisionInstancesSearchFilter(searchParams) ?? {};
+    const filter = keyCriterion
+      ? {...baseFilter, decisionEvaluationInstanceKey: keyCriterion}
+      : baseFilter;
+
+    return {filter};
+  };
+
 export {
   useBatchOperationMutationRequestBody,
-  useDeleteBatchOperationMutationRequestBody,
+  useDeleteProcessInstancesBatchOperationMutationRequestBody,
+  useDeleteDecisionInstancesBatchOperationRequestBody,
 };

--- a/operate/client/src/modules/mocks/api/v2/decisionInstances/deleteDecisionInstancesBatchOperation.ts
+++ b/operate/client/src/modules/mocks/api/v2/decisionInstances/deleteDecisionInstancesBatchOperation.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {mockPostRequest} from '../../mockRequest';
+import {
+  endpoints,
+  type CreateDecisionInstancesDeletionBatchOperationResponseBody,
+} from '@camunda/camunda-api-zod-schemas/8.10';
+
+const mockDeleteDecisionInstancesBatchOperation = () =>
+  mockPostRequest<CreateDecisionInstancesDeletionBatchOperationResponseBody>(
+    endpoints.createDecisionInstancesDeletionBatchOperation.getUrl(),
+  );
+
+export {mockDeleteDecisionInstancesBatchOperation};

--- a/operate/client/src/modules/utils/buildMutationRequestBody.ts
+++ b/operate/client/src/modules/utils/buildMutationRequestBody.ts
@@ -11,7 +11,7 @@ import type {
   CreateIncidentResolutionBatchOperationRequestBody,
 } from '@camunda/camunda-api-zod-schemas/8.10';
 import {parseProcessInstancesSearchFilter} from 'modules/utils/filter/processInstancesSearch';
-import {buildProcessInstanceKeyCriterion} from 'modules/mutations/processes/buildProcessInstanceKeyCriterion';
+import {buildInstanceKeyCriterion} from 'modules/utils/instances/buildInstanceKeyCriterion';
 import {getValidVariableValues} from 'modules/utils/filter/getValidVariableValues';
 import type {Variable} from 'modules/stores/variableFilter';
 
@@ -32,7 +32,7 @@ const buildMutationRequestBody = ({
 }: BuildMutationRequestBodyParams) => {
   const baseFilter = parseProcessInstancesSearchFilter(searchParams);
 
-  const keyCriterion = buildProcessInstanceKeyCriterion(includeIds, excludeIds);
+  const keyCriterion = buildInstanceKeyCriterion(includeIds, excludeIds);
 
   let filter = baseFilter ?? {};
 

--- a/operate/client/src/modules/utils/filter/processInstanceFilterBuilder.ts
+++ b/operate/client/src/modules/utils/filter/processInstanceFilterBuilder.ts
@@ -11,7 +11,7 @@ import {formatToISO} from 'modules/utils/date/formatDate';
 import type {ProcessInstanceFilters} from 'modules/utils/filter/shared';
 import type {RequestFilters} from 'modules/utils/filter';
 import {getValidVariableValues} from 'modules/utils/filter/getValidVariableValues';
-import {buildProcessInstanceKeyCriterion} from 'modules/mutations/processes/buildProcessInstanceKeyCriterion';
+import {buildInstanceKeyCriterion} from 'modules/utils/instances/buildInstanceKeyCriterion';
 import type {QueryProcessInstancesRequestBody} from '@camunda/camunda-api-zod-schemas/8.10';
 import type {BusinessObjects} from 'bpmn-js/lib/NavigatedViewer';
 import {getElementInstanceStateFilter} from './getElementInstanceStateFilter';
@@ -296,7 +296,7 @@ const buildProcessInstanceFilter = (
     query.processInstanceKey = {$in: normalizedFilters.processInstanceKey};
   }
 
-  const processInstanceKeyCriterion = buildProcessInstanceKeyCriterion(
+  const processInstanceKeyCriterion = buildInstanceKeyCriterion(
     options.includeIds,
     options.excludeIds,
   );

--- a/operate/client/src/modules/utils/instances/buildInstanceKeyCriterion.test.ts
+++ b/operate/client/src/modules/utils/instances/buildInstanceKeyCriterion.test.ts
@@ -6,35 +6,35 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {buildProcessInstanceKeyCriterion} from './buildProcessInstanceKeyCriterion';
+import {buildInstanceKeyCriterion} from './buildInstanceKeyCriterion';
 
-describe('buildProcessInstanceKeyCriterion', () => {
+describe('buildInstanceKeyCriterion', () => {
   it('returns undefined when both arrays are empty/omitted', () => {
-    expect(buildProcessInstanceKeyCriterion()).toBeUndefined();
-    expect(buildProcessInstanceKeyCriterion([], [])).toBeUndefined();
+    expect(buildInstanceKeyCriterion()).toBeUndefined();
+    expect(buildInstanceKeyCriterion([], [])).toBeUndefined();
   });
 
   it('maps includeIds to $in', () => {
-    expect(buildProcessInstanceKeyCriterion(['1', '2'], [])).toEqual({
+    expect(buildInstanceKeyCriterion(['1', '2'], [])).toEqual({
       $in: ['1', '2'],
     });
   });
 
   it('maps excludeIds to $notIn', () => {
-    expect(buildProcessInstanceKeyCriterion([], ['3', '4'])).toEqual({
+    expect(buildInstanceKeyCriterion([], ['3', '4'])).toEqual({
       $notIn: ['3', '4'],
     });
   });
 
   it('combines includeIds and excludeIds', () => {
-    expect(buildProcessInstanceKeyCriterion(['1', '2'], ['3'])).toEqual({
+    expect(buildInstanceKeyCriterion(['1', '2'], ['3'])).toEqual({
       $in: ['1', '2'],
       $notIn: ['3'],
     });
   });
 
   it('handles single-element arrays', () => {
-    expect(buildProcessInstanceKeyCriterion(['only'], ['x'])).toEqual({
+    expect(buildInstanceKeyCriterion(['only'], ['x'])).toEqual({
       $in: ['only'],
       $notIn: ['x'],
     });

--- a/operate/client/src/modules/utils/instances/buildInstanceKeyCriterion.ts
+++ b/operate/client/src/modules/utils/instances/buildInstanceKeyCriterion.ts
@@ -8,7 +8,7 @@
 
 type IdCriterion = {$in?: string[]; $notIn?: string[]};
 
-const buildProcessInstanceKeyCriterion = (
+const buildInstanceKeyCriterion = (
   includeIds: string[] = [],
   excludeIds: string[] = [],
 ): IdCriterion | undefined => {
@@ -22,4 +22,4 @@ const buildProcessInstanceKeyCriterion = (
   return Object.keys(criterion).length > 0 ? criterion : undefined;
 };
 
-export {buildProcessInstanceKeyCriterion};
+export {buildInstanceKeyCriterion};


### PR DESCRIPTION
## Description

- Make buildProcessInstanceKey generic and move to `modules/utils/instances`
- Add batch deletion modal
- Add useDeleteDecisionInstancesBatchOperationRequestBody hook
- Fix selection state reset after process instances batch operation success 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #51068 
