### PR TITLE
feat: opt-in OIDC userinfo augmentation for bearer tokens

### DIFF
--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -54,6 +54,10 @@
     </dependency>
     <dependency>
       <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
       <artifactId>micrometer-observation</artifactId>
     </dependency>
     <dependency>

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -49,6 +49,7 @@ import io.camunda.spring.utils.ConditionalOnSecondaryStorageDisabled;
 import io.camunda.spring.utils.ConditionalOnSecondaryStorageEnabled;
 import io.micrometer.common.KeyValues;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.micrometer.observation.ObservationRegistry;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.FilterChain;
@@ -644,6 +645,18 @@ public class WebSecurityConfig {
         final TokenClaimsConverter tokenClaimsConverter,
         final OidcClaimsProvider oidcClaimsProvider) {
       return new OidcTokenAuthenticationConverter(tokenClaimsConverter, oidcClaimsProvider);
+    }
+
+    /**
+     * Fallback {@link MeterRegistry} for test / minimal Spring contexts that don't configure the
+     * standard Spring Boot auto-configured {@code CompositeMeterRegistry}. In real deployments the
+     * app-wide registry wins via {@link ConditionalOnMissingBean} and metrics land on a scraped
+     * backend (Prometheus / OTLP / etc.) rather than the in-memory sink.
+     */
+    @Bean
+    @ConditionalOnMissingBean(MeterRegistry.class)
+    public MeterRegistry oidcFallbackMeterRegistry() {
+      return new SimpleMeterRegistry();
     }
 
     /**

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -49,7 +49,6 @@ import io.camunda.spring.utils.ConditionalOnSecondaryStorageDisabled;
 import io.camunda.spring.utils.ConditionalOnSecondaryStorageEnabled;
 import io.micrometer.common.KeyValues;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.micrometer.observation.ObservationRegistry;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.FilterChain;
@@ -645,18 +644,6 @@ public class WebSecurityConfig {
         final TokenClaimsConverter tokenClaimsConverter,
         final OidcClaimsProvider oidcClaimsProvider) {
       return new OidcTokenAuthenticationConverter(tokenClaimsConverter, oidcClaimsProvider);
-    }
-
-    /**
-     * Fallback {@link MeterRegistry} for test / minimal Spring contexts that don't configure the
-     * standard Spring Boot auto-configured {@code CompositeMeterRegistry}. In real deployments the
-     * app-wide registry wins via {@link ConditionalOnMissingBean} and metrics land on a scraped
-     * backend (Prometheus / OTLP / etc.) rather than the in-memory sink.
-     */
-    @Bean
-    @ConditionalOnMissingBean(MeterRegistry.class)
-    public MeterRegistry oidcFallbackMeterRegistry() {
-      return new SimpleMeterRegistry();
     }
 
     /**

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -37,6 +37,10 @@ import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.security.configuration.headers.HeaderConfiguration;
 import io.camunda.security.configuration.headers.values.FrameOptionMode;
 import io.camunda.security.entity.AuthenticationMethod;
+import io.camunda.security.oidc.CachingOidcClaimsProvider;
+import io.camunda.security.oidc.NoopOidcClaimsProvider;
+import io.camunda.security.oidc.OidcClaimsProvider;
+import io.camunda.security.oidc.OidcUserInfoClient;
 import io.camunda.security.reader.ResourceAccessProvider;
 import io.camunda.service.GroupServices;
 import io.camunda.service.RoleServices;
@@ -44,6 +48,7 @@ import io.camunda.service.TenantServices;
 import io.camunda.spring.utils.ConditionalOnSecondaryStorageDisabled;
 import io.camunda.spring.utils.ConditionalOnSecondaryStorageEnabled;
 import io.micrometer.common.KeyValues;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.observation.ObservationRegistry;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.FilterChain;
@@ -51,6 +56,9 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -628,8 +636,39 @@ public class WebSecurityConfig {
 
     @Bean
     public CamundaAuthenticationConverter<Authentication> oidcTokenAuthenticationConverter(
-        final TokenClaimsConverter tokenClaimsConverter) {
-      return new OidcTokenAuthenticationConverter(tokenClaimsConverter);
+        final TokenClaimsConverter tokenClaimsConverter,
+        final OidcClaimsProvider oidcClaimsProvider) {
+      return new OidcTokenAuthenticationConverter(tokenClaimsConverter, oidcClaimsProvider);
+    }
+
+    @Bean
+    public OidcClaimsProvider oidcClaimsProvider(
+        final SecurityConfiguration securityConfiguration,
+        final OidcAuthenticationConfigurationRepository oidcProviderRepository,
+        final MeterRegistry meterRegistry) {
+      final var oidc = securityConfiguration.getAuthentication().getOidc();
+      if (oidc == null || !oidc.getUserInfoAugmentation().isEnabled()) {
+        return new NoopOidcClaimsProvider();
+      }
+      // Resolve userinfo URI from the first matching provider's issuer.
+      // Multi-provider selection by 'iss' claim is a follow-up; single-provider
+      // setups are covered today.
+      final URI userInfoUri =
+          oidcProviderRepository.getOidcAuthenticationConfigurations().values().stream()
+              .map(OidcAuthenticationConfiguration::getIssuerUri)
+              .filter(Objects::nonNull)
+              .findFirst()
+              .map(issuer -> URI.create(issuer.replaceAll("/$", "") + "/userinfo"))
+              .orElseThrow(
+                  () ->
+                      new IllegalStateException(
+                          "UserInfo augmentation enabled but no issuerUri configured"));
+      final var httpClient = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build();
+      return new CachingOidcClaimsProvider(
+          oidc,
+          userInfoUri,
+          new OidcUserInfoClient(httpClient, Duration.ofSeconds(5)),
+          meterRegistry);
     }
 
     @Bean

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -673,10 +673,15 @@ public class WebSecurityConfig {
     @ConditionalOnMissingBean(name = "oidcUserInfoHttpClient")
     public HttpClient oidcUserInfoHttpClient(
         @Autowired(required = false) final SslBundles sslBundles) {
+      // Redirects are NOT followed. The JDK HttpClient would re-send the Authorization: Bearer
+      // header to the redirect target, which would leak the access token to an attacker-controlled
+      // URL if the IdP's /userinfo responded with a 3xx (misconfiguration, open-redirect vuln,
+      // hijacked CDN). OIDC Core does not require redirects on /userinfo; any 3xx surfaces as a
+      // non-2xx via OidcUserInfoClient.fetch() and degrades to JWT-only claims.
       final HttpClient.Builder builder =
           HttpClient.newBuilder()
               .connectTimeout(Duration.ofSeconds(2))
-              .followRedirects(HttpClient.Redirect.NORMAL);
+              .followRedirects(HttpClient.Redirect.NEVER);
       if (sslBundles != null) {
         try {
           final var bundle = sslBundles.getBundle("oidc-userinfo");

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -49,6 +49,7 @@ import io.camunda.spring.utils.ConditionalOnSecondaryStorageDisabled;
 import io.camunda.spring.utils.ConditionalOnSecondaryStorageEnabled;
 import io.micrometer.common.KeyValues;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.micrometer.observation.ObservationRegistry;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.FilterChain;
@@ -69,8 +70,13 @@ import java.util.stream.StreamSupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.actuate.logging.LoggersEndpoint;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.security.autoconfigure.actuate.web.servlet.EndpointRequest;
+import org.springframework.boot.ssl.NoSuchSslBundleException;
+import org.springframework.boot.ssl.SslBundles;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -641,33 +647,90 @@ public class WebSecurityConfig {
       return new OidcTokenAuthenticationConverter(tokenClaimsConverter, oidcClaimsProvider);
     }
 
+    /**
+     * Fallback {@link MeterRegistry} for test / minimal Spring contexts that don't configure the
+     * standard Spring Boot auto-configured {@code CompositeMeterRegistry}. In real deployments the
+     * app-wide registry wins via {@link ConditionalOnMissingBean} and metrics land on a scraped
+     * backend (Prometheus / OTLP / etc.) rather than the in-memory sink.
+     */
     @Bean
+    @ConditionalOnMissingBean(MeterRegistry.class)
+    public MeterRegistry oidcFallbackMeterRegistry() {
+      return new SimpleMeterRegistry();
+    }
+
+    /**
+     * HTTP client used by {@link OidcClaimsProvider} implementations to call the IdP's {@code
+     * /userinfo} endpoint. Registered as a Spring-managed bean so its lifecycle is bound to the
+     * application context — {@code close()} on shutdown releases the JDK selector + executor
+     * threads. Can be overridden by registering a bean of the same name.
+     *
+     * <p>SSL context is sourced from the {@code oidc-userinfo} entry in {@link SslBundles} when
+     * present, so enterprise deployments with custom CA trust under {@code spring.ssl.bundle.*}
+     * apply automatically. Falls back to JDK default.
+     */
+    @Bean(destroyMethod = "close", name = "oidcUserInfoHttpClient")
+    @ConditionalOnMissingBean(name = "oidcUserInfoHttpClient")
+    public HttpClient oidcUserInfoHttpClient(
+        @Autowired(required = false) final SslBundles sslBundles) {
+      final HttpClient.Builder builder =
+          HttpClient.newBuilder()
+              .connectTimeout(Duration.ofSeconds(2))
+              .followRedirects(HttpClient.Redirect.NORMAL);
+      if (sslBundles != null) {
+        try {
+          final var bundle = sslBundles.getBundle("oidc-userinfo");
+          builder.sslContext(bundle.createSslContext());
+          LOG.info(
+              "OIDC UserInfo HTTP client using SSL bundle 'oidc-userinfo' "
+                  + "(custom truststore / trust material)");
+        } catch (final NoSuchSslBundleException e) {
+          LOG.debug(
+              "No 'oidc-userinfo' SSL bundle configured; OIDC UserInfo HTTP client "
+                  + "uses JDK default SSLContext");
+        }
+      }
+      return builder.build();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(OidcClaimsProvider.class)
     public OidcClaimsProvider oidcClaimsProvider(
         final SecurityConfiguration securityConfiguration,
+        final ClientRegistrationRepository clientRegistrationRepository,
         final OidcAuthenticationConfigurationRepository oidcProviderRepository,
+        @Qualifier("oidcUserInfoHttpClient") final HttpClient oidcUserInfoHttpClient,
         final MeterRegistry meterRegistry) {
       final var oidc = securityConfiguration.getAuthentication().getOidc();
       if (oidc == null || !oidc.getUserInfoAugmentation().isEnabled()) {
         return new NoopOidcClaimsProvider();
       }
-      // Resolve userinfo URI from the first matching provider's issuer.
-      // Multi-provider selection by 'iss' claim is a follow-up; single-provider
-      // setups are covered today.
-      final URI userInfoUri =
-          oidcProviderRepository.getOidcAuthenticationConfigurations().values().stream()
-              .map(OidcAuthenticationConfiguration::getIssuerUri)
+      // Build a map of issuer -> userinfo URI from the Spring-managed ClientRegistrations.
+      // Each ClientRegistration's ProviderDetails.getIssuerUri() is the canonical 'iss' claim
+      // the IdP emits on its tokens, and UserInfoEndpoint.getUri() is the userinfo URL from
+      // the same discovery document. CachingOidcClaimsProvider uses this to route each
+      // token to its own issuer's userinfo endpoint — never cross-wired.
+      final Map<String, URI> userInfoUriByIssuer =
+          oidcProviderRepository.getOidcAuthenticationConfigurations().keySet().stream()
+              .map(clientRegistrationRepository::findByRegistrationId)
               .filter(Objects::nonNull)
-              .findFirst()
-              .map(issuer -> URI.create(issuer.replaceAll("/$", "") + "/userinfo"))
-              .orElseThrow(
-                  () ->
-                      new IllegalStateException(
-                          "UserInfo augmentation enabled but no issuerUri configured"));
-      final var httpClient = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build();
+              .filter(cr -> cr.getProviderDetails().getIssuerUri() != null)
+              .filter(cr -> cr.getProviderDetails().getUserInfoEndpoint().getUri() != null)
+              .collect(
+                  toMap(
+                      cr -> cr.getProviderDetails().getIssuerUri(),
+                      cr -> URI.create(cr.getProviderDetails().getUserInfoEndpoint().getUri()),
+                      (existing, replacement) -> existing));
+      if (userInfoUriByIssuer.isEmpty()) {
+        throw new IllegalStateException(
+            "UserInfo augmentation is enabled but no ClientRegistration exposes a userinfo "
+                + "endpoint. Check the IdP's OIDC discovery document and the userInfoEnabled "
+                + "flag.");
+      }
       return new CachingOidcClaimsProvider(
           oidc,
-          userInfoUri,
-          new OidcUserInfoClient(httpClient, Duration.ofSeconds(5)),
+          userInfoUriByIssuer,
+          new OidcUserInfoClient(oidcUserInfoHttpClient, Duration.ofSeconds(2)),
           meterRegistry);
     }
 

--- a/authentication/src/main/java/io/camunda/authentication/converter/OidcTokenAuthenticationConverter.java
+++ b/authentication/src/main/java/io/camunda/authentication/converter/OidcTokenAuthenticationConverter.java
@@ -9,35 +9,42 @@ package io.camunda.authentication.converter;
 
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.CamundaAuthenticationConverter;
+import io.camunda.security.oidc.OidcClaimsProvider;
 import java.util.Optional;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.oauth2.server.resource.authentication.AbstractOAuth2TokenAuthenticationToken;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 
 public class OidcTokenAuthenticationConverter
     implements CamundaAuthenticationConverter<Authentication> {
 
   private final TokenClaimsConverter tokenClaimsConverter;
+  private final OidcClaimsProvider claimsProvider;
 
-  public OidcTokenAuthenticationConverter(final TokenClaimsConverter tokenClaimsConverter) {
+  public OidcTokenAuthenticationConverter(
+      final TokenClaimsConverter tokenClaimsConverter, final OidcClaimsProvider claimsProvider) {
     this.tokenClaimsConverter = tokenClaimsConverter;
+    this.claimsProvider = claimsProvider;
   }
 
   @Override
   public boolean supports(final Authentication authentication) {
-    return Optional.ofNullable(authentication)
-        .filter(AbstractOAuth2TokenAuthenticationToken.class::isInstance)
-        .isPresent();
+    return authentication instanceof JwtAuthenticationToken;
   }
 
   @Override
   public CamundaAuthentication convert(final Authentication authentication) {
     return Optional.of(authentication)
-        .map(AbstractOAuth2TokenAuthenticationToken.class::cast)
-        .map(AbstractOAuth2TokenAuthenticationToken::getTokenAttributes)
+        .map(JwtAuthenticationToken.class::cast)
+        .map(
+            token -> {
+              final Jwt jwt = token.getToken();
+              return claimsProvider.claimsFor(jwt.getClaims(), jwt.getTokenValue());
+            })
         .map(tokenClaimsConverter::convert)
         .orElseThrow(
             () ->
                 new IllegalStateException(
-                    "Failed to convert 'AbstractOAuth2TokenAuthenticationToken' to 'CamundaAuthentication"));
+                    "Failed to convert 'JwtAuthenticationToken' to 'CamundaAuthentication'"));
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/config/controllers/WebSecurityOidcTestContext.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/controllers/WebSecurityOidcTestContext.java
@@ -14,9 +14,6 @@ import io.camunda.service.GroupServices;
 import io.camunda.service.MappingRuleServices;
 import io.camunda.service.RoleServices;
 import io.camunda.service.TenantServices;
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -39,16 +36,5 @@ public class WebSecurityOidcTestContext {
       final SecurityConfiguration securityConfiguration) {
     return new DefaultMembershipService(
         mappingRuleServices, tenantServices, roleServices, groupServices, securityConfiguration);
-  }
-
-  /**
-   * Sliced @SpringBootTest contexts used for the OIDC ITs bypass Spring Boot's
-   * MetricsAutoConfiguration, so no {@link MeterRegistry} is otherwise available. Production wiring
-   * is unaffected — the Actuator-provided {@code CompositeMeterRegistry} owns metrics there.
-   */
-  @Bean
-  @ConditionalOnMissingBean(MeterRegistry.class)
-  public MeterRegistry testMeterRegistry() {
-    return new SimpleMeterRegistry();
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/config/controllers/WebSecurityOidcTestContext.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/controllers/WebSecurityOidcTestContext.java
@@ -14,6 +14,9 @@ import io.camunda.service.GroupServices;
 import io.camunda.service.MappingRuleServices;
 import io.camunda.service.RoleServices;
 import io.camunda.service.TenantServices;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -36,5 +39,16 @@ public class WebSecurityOidcTestContext {
       final SecurityConfiguration securityConfiguration) {
     return new DefaultMembershipService(
         mappingRuleServices, tenantServices, roleServices, groupServices, securityConfiguration);
+  }
+
+  /**
+   * Sliced @SpringBootTest contexts used for the OIDC ITs bypass Spring Boot's
+   * MetricsAutoConfiguration, so no {@link MeterRegistry} is otherwise available. Production wiring
+   * is unaffected — the Actuator-provided {@code CompositeMeterRegistry} owns metrics there.
+   */
+  @Bean
+  @ConditionalOnMissingBean(MeterRegistry.class)
+  public MeterRegistry testMeterRegistry() {
+    return new SimpleMeterRegistry();
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/converter/OidcTokenAuthenticationConverterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/converter/OidcTokenAuthenticationConverterTest.java
@@ -8,72 +8,80 @@
 package io.camunda.authentication.converter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.oidc.NoopOidcClaimsProvider;
+import io.camunda.security.oidc.OidcClaimsProvider;
+import java.util.List;
 import java.util.Map;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 
 public class OidcTokenAuthenticationConverterTest {
 
-  @Mock private TokenClaimsConverter tokenClaimsConverter;
-  @InjectMocks private OidcTokenAuthenticationConverter authenticationConverter;
+  @Test
+  void shouldSupportJwtAuthenticationToken() {
+    final var converter =
+        new OidcTokenAuthenticationConverter(
+            mock(TokenClaimsConverter.class), new NoopOidcClaimsProvider());
 
-  @BeforeEach
-  void setup() throws Exception {
-    MockitoAnnotations.openMocks(this).close();
+    assertThat(converter.supports(mock(JwtAuthenticationToken.class))).isTrue();
   }
 
   @Test
-  void shouldSupport() {
-    // given
-    final var authentication = mock(JwtAuthenticationToken.class);
+  void shouldNotSupportNonJwtAuthentication() {
+    final var converter =
+        new OidcTokenAuthenticationConverter(
+            mock(TokenClaimsConverter.class), new NoopOidcClaimsProvider());
 
-    // when
-    final var supports = authenticationConverter.supports(authentication);
-
-    // then
-    assertThat(supports).isTrue();
+    assertThat(converter.supports(mock(OAuth2AuthenticationToken.class))).isFalse();
   }
 
   @Test
-  void shouldNotSupport() {
-    // given
-    final var authentication = mock(OAuth2AuthenticationToken.class);
+  void shouldPassJwtClaimsThroughNoopProviderToTokenClaimsConverter() {
+    final TokenClaimsConverter tokenClaimsConverter = mock(TokenClaimsConverter.class);
+    final var jwt =
+        Jwt.withTokenValue("token-abc")
+            .header("alg", "RS256")
+            .claim("sub", "alice")
+            .claim("iss", "https://idp.example")
+            .build();
+    final var authentication = new JwtAuthenticationToken(jwt);
+    final var expected = CamundaAuthentication.of(b -> b.user("alice"));
+    when(tokenClaimsConverter.convert(jwt.getClaims())).thenReturn(expected);
 
-    // when
-    final var supports = authenticationConverter.supports(authentication);
+    final var converter =
+        new OidcTokenAuthenticationConverter(tokenClaimsConverter, new NoopOidcClaimsProvider());
 
-    // then
-    assertThat(supports).isFalse();
+    assertThat(converter.convert(authentication)).isSameAs(expected);
   }
 
   @Test
-  public void shouldConvertAccessToken() {
-    // given
+  void shouldUseClaimsReturnedByProviderForAugmentation() {
+    final TokenClaimsConverter tokenClaimsConverter = mock(TokenClaimsConverter.class);
+    final OidcClaimsProvider claimsProvider = mock(OidcClaimsProvider.class);
+    final var jwt =
+        Jwt.withTokenValue("token-abc")
+            .header("alg", "RS256")
+            .claim("sub", "alice")
+            .claim("iss", "https://idp.example")
+            .build();
+    final var authentication = new JwtAuthenticationToken(jwt);
 
-    final Map<String, Object> accessTokenClaims =
-        Map.of("access_token", "test-access-token", "token_type", "Bearer", "expires_in", 3600);
-    final var authentication = mock(JwtAuthenticationToken.class);
-    when(authentication.getTokenAttributes()).thenReturn(accessTokenClaims);
+    final Map<String, Object> augmentedClaims = Map.of("sub", "alice", "groups", List.of("eng"));
+    when(claimsProvider.claimsFor(any(), eq("token-abc"))).thenReturn(augmentedClaims);
+    final var expected = CamundaAuthentication.of(b -> b.user("alice"));
+    when(tokenClaimsConverter.convert(augmentedClaims)).thenReturn(expected);
 
-    final var expectedAuthentication = CamundaAuthentication.of(b -> b.user("foo"));
-    when(tokenClaimsConverter.convert(eq(accessTokenClaims))).thenReturn(expectedAuthentication);
+    final var converter =
+        new OidcTokenAuthenticationConverter(tokenClaimsConverter, claimsProvider);
 
-    // when
-    final var userToken = authenticationConverter.convert(authentication);
-
-    // then
-    assertThat(userToken).isEqualTo(expectedAuthentication);
-    verify(tokenClaimsConverter).convert(eq(accessTokenClaims));
+    assertThat(converter.convert(authentication)).isSameAs(expected);
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/oidc/OidcBearerUserInfoClaimGapIT.java
+++ b/authentication/src/test/java/io/camunda/authentication/oidc/OidcBearerUserInfoClaimGapIT.java
@@ -24,9 +24,12 @@ import io.camunda.authentication.config.controllers.WebSecurityOidcTestContext;
 import io.camunda.authentication.converter.OidcTokenAuthenticationConverter;
 import io.camunda.authentication.converter.TokenClaimsConverter;
 import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.oidc.CachingOidcClaimsProvider;
+import io.camunda.security.oidc.OidcClaimsProvider;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.ArgumentCaptor;
@@ -66,6 +69,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
       "camunda.security.authentication.oidc.authorization-uri=authorization.example.com",
       "camunda.security.authentication.oidc.token-uri=token.example.com",
       "camunda.security.authentication.oidc.groups-claim=groups",
+      "camunda.security.authentication.oidc.user-info-augmentation.enabled=true",
     })
 public class OidcBearerUserInfoClaimGapIT extends AbstractWebSecurityConfigTest {
 
@@ -74,8 +78,21 @@ public class OidcBearerUserInfoClaimGapIT extends AbstractWebSecurityConfigTest 
       WireMockExtension.newInstance().configureStaticDsl(true).build();
 
   @Autowired private OidcTokenAuthenticationConverter converter;
+  @Autowired private OidcClaimsProvider oidcClaimsProvider;
 
   @MockitoBean private TokenClaimsConverter tokenClaimsConverter;
+
+  @BeforeEach
+  void resetStateBetweenTests() {
+    // Reset both the shared WireMock request journal and the process-wide
+    // CachingOidcClaimsProvider cache so test methods don't observe state from
+    // previous tests. This lets tests choose arbitrary jti / sub values without
+    // worrying about cross-test cache collisions.
+    wireMock.resetRequests();
+    if (oidcClaimsProvider instanceof final CachingOidcClaimsProvider caching) {
+      caching.invalidateCache();
+    }
+  }
 
   @DynamicPropertySource
   static void registerWireMockProperties(final DynamicPropertyRegistry registry) {
@@ -118,6 +135,7 @@ public class OidcBearerUserInfoClaimGapIT extends AbstractWebSecurityConfigTest 
             .header("alg", "RS256")
             .claim("sub", "alice")
             .claim("iss", "http://localhost:" + wireMock.getPort() + "/issuer")
+            .claim("scope", "openid")
             .claim("jti", "jti-1")
             .issuedAt(Instant.now())
             .expiresAt(Instant.now().plusSeconds(3600))
@@ -142,5 +160,61 @@ public class OidcBearerUserInfoClaimGapIT extends AbstractWebSecurityConfigTest 
     // Additionally: /userinfo should have been consulted at least once. On current code it is
     // never called for bearer-token flows.
     wireMock.verify(exactly(1), getRequestedFor(urlMatching(".*/userinfo")));
+  }
+
+  @Test
+  void userInfoIsCalledOnlyOncePerTokenWithinTtl() {
+    wireMock.stubFor(
+        get(urlMatching(".*/userinfo"))
+            .willReturn(okJson("{\"sub\":\"alice\",\"groups\":[\"engineering\"]}")));
+
+    final var jwt =
+        Jwt.withTokenValue("token-cached")
+            .header("alg", "RS256")
+            .claim("sub", "alice")
+            .claim("iss", "http://localhost:" + wireMock.getPort() + "/issuer")
+            .claim("scope", "openid")
+            .claim("jti", "jti-cached")
+            .issuedAt(Instant.now())
+            .expiresAt(Instant.now().plusSeconds(3600))
+            .build();
+
+    Mockito.when(tokenClaimsConverter.convert(Mockito.any()))
+        .thenReturn(CamundaAuthentication.of(b -> b.user("alice")));
+
+    for (int i = 0; i < 50; i++) {
+      converter.convert(new JwtAuthenticationToken(jwt));
+    }
+
+    // Performance acceptance criterion: under a burst of bearer requests with the same token,
+    // we must not hammer the IdP — Caffeine serves subsequent calls from cache.
+    wireMock.verify(exactly(1), getRequestedFor(urlMatching(".*/userinfo")));
+  }
+
+  @Test
+  void distinctTokensEachTriggerOneUserInfoCall() {
+    wireMock.stubFor(
+        get(urlMatching(".*/userinfo"))
+            .willReturn(okJson("{\"sub\":\"alice\",\"groups\":[\"engineering\"]}")));
+
+    Mockito.when(tokenClaimsConverter.convert(Mockito.any()))
+        .thenReturn(CamundaAuthentication.of(b -> b.user("alice")));
+
+    final Instant expiry = Instant.now().plusSeconds(3600);
+    for (int i = 0; i < 3; i++) {
+      final var jwt =
+          Jwt.withTokenValue("token-distinct-" + i)
+              .header("alg", "RS256")
+              .claim("sub", "alice")
+              .claim("iss", "http://localhost:" + wireMock.getPort() + "/issuer")
+              .claim("scope", "openid")
+              .claim("jti", "jti-distinct-" + i)
+              .issuedAt(Instant.now())
+              .expiresAt(expiry)
+              .build();
+      converter.convert(new JwtAuthenticationToken(jwt));
+    }
+
+    wireMock.verify(exactly(3), getRequestedFor(urlMatching(".*/userinfo")));
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/oidc/OidcBearerUserInfoClaimGapIT.java
+++ b/authentication/src/test/java/io/camunda/authentication/oidc/OidcBearerUserInfoClaimGapIT.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.oidc;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.exactly;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import io.camunda.authentication.config.AbstractWebSecurityConfigTest;
+import io.camunda.authentication.config.WebSecurityConfig;
+import io.camunda.authentication.config.controllers.WebSecurityConfigTestContext;
+import io.camunda.authentication.config.controllers.WebSecurityOidcTestContext;
+import io.camunda.authentication.converter.OidcTokenAuthenticationConverter;
+import io.camunda.authentication.converter.TokenClaimsConverter;
+import io.camunda.security.auth.CamundaAuthentication;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+/**
+ * Documents the customer's reported scenario: for bearer-token authentication, a JWT that does not
+ * carry the configured {@code groups} claim cannot be augmented with the groups from the OIDC
+ * {@code /userinfo} response. Authorizations that depend on {@code groups} therefore fail even
+ * though the IdP would return the groups if asked.
+ *
+ * <p>This test is expected to FAIL on current code (8.8). It encodes the behaviour we want after a
+ * fix: {@link TokenClaimsConverter} should receive a merged claims map containing {@code groups}
+ * from {@code /userinfo}. On current code, only the raw JWT claims are passed through, {@code
+ * /userinfo} is never called, and the assertions below do not hold.
+ */
+@SuppressWarnings("SpringBootApplicationProperties")
+@SpringBootTest(
+    classes = {
+      WebSecurityConfigTestContext.class,
+      WebSecurityOidcTestContext.class,
+      WebSecurityConfig.class
+    },
+    properties = {
+      "camunda.security.authentication.unprotected-api=false",
+      "camunda.security.authentication.method=oidc",
+      "camunda.security.authentication.oidc.client-id=example",
+      "camunda.security.authentication.oidc.redirect-uri=redirect.example.com",
+      "camunda.security.authentication.oidc.authorization-uri=authorization.example.com",
+      "camunda.security.authentication.oidc.token-uri=token.example.com",
+      "camunda.security.authentication.oidc.groups-claim=groups",
+    })
+public class OidcBearerUserInfoClaimGapIT extends AbstractWebSecurityConfigTest {
+
+  @RegisterExtension
+  static WireMockExtension wireMock =
+      WireMockExtension.newInstance().configureStaticDsl(true).build();
+
+  @Autowired private OidcTokenAuthenticationConverter converter;
+
+  @MockitoBean private TokenClaimsConverter tokenClaimsConverter;
+
+  @DynamicPropertySource
+  static void registerWireMockProperties(final DynamicPropertyRegistry registry) {
+    final var issuerUri = "http://localhost:" + wireMock.getPort() + "/issuer";
+    registry.add("camunda.security.authentication.oidc.issuer-uri", () -> issuerUri);
+    registry.add(
+        "camunda.security.authentication.oidc.jwk-set-uri",
+        () -> "http://localhost:" + wireMock.getPort() + "/issuer/jwks");
+
+    final var openidConfig =
+        "{\"issuer\":\""
+            + issuerUri
+            + "\","
+            + "\"token_endpoint\":\"token.example.com\","
+            + "\"jwks_uri\":\"http://localhost:"
+            + wireMock.getPort()
+            + "/issuer/jwks\","
+            + "\"userinfo_endpoint\":\""
+            + issuerUri
+            + "/userinfo\","
+            + "\"subject_types_supported\":[\"public\"]}";
+    wireMock
+        .getRuntimeInfo()
+        .getWireMock()
+        .register(
+            get(urlMatching(".*/issuer/.well-known/openid-configuration"))
+                .willReturn(WireMock.jsonResponse(openidConfig, HttpStatus.OK.value())));
+  }
+
+  @Test
+  void groupsFromUserInfoShouldReachTokenClaimsConverterButCurrentlyDoNot() {
+    // The IdP is configured to return the groups on /userinfo (common SaaS IdP pattern).
+    wireMock.stubFor(
+        get(urlMatching(".*/userinfo"))
+            .willReturn(okJson("{\"sub\":\"alice\",\"groups\":[\"engineering\"]}")));
+
+    // The JWT access token the customer receives does NOT carry the groups claim.
+    final var jwt =
+        Jwt.withTokenValue("token-abc")
+            .header("alg", "RS256")
+            .claim("sub", "alice")
+            .claim("iss", "http://localhost:" + wireMock.getPort() + "/issuer")
+            .claim("jti", "jti-1")
+            .issuedAt(Instant.now())
+            .expiresAt(Instant.now().plusSeconds(3600))
+            .build();
+
+    Mockito.when(tokenClaimsConverter.convert(Mockito.any()))
+        .thenReturn(CamundaAuthentication.of(b -> b.user("alice")));
+
+    converter.convert(new JwtAuthenticationToken(jwt));
+
+    @SuppressWarnings("unchecked")
+    final ArgumentCaptor<Map<String, Object>> claimsCaptor = ArgumentCaptor.forClass(Map.class);
+    verify(tokenClaimsConverter).convert(claimsCaptor.capture());
+
+    // The customer's acceptance criterion: groups must arrive at TokenClaimsConverter so that
+    // MembershipService.resolveMemberships(...) can grant group-based authorizations. On current
+    // code this assertion fails because only JWT claims are passed through.
+    assertThat(claimsCaptor.getValue())
+        .containsEntry("sub", "alice")
+        .containsEntry("groups", List.of("engineering"));
+
+    // Additionally: /userinfo should have been consulted at least once. On current code it is
+    // never called for bearer-token flows.
+    wireMock.verify(exactly(1), getRequestedFor(urlMatching(".*/userinfo")));
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/oidc/OidcBearerUserInfoClaimGapIT.java
+++ b/authentication/src/test/java/io/camunda/authentication/oidc/OidcBearerUserInfoClaimGapIT.java
@@ -44,15 +44,13 @@ import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 /**
- * Documents the customer's reported scenario: for bearer-token authentication, a JWT that does not
- * carry the configured {@code groups} claim cannot be augmented with the groups from the OIDC
- * {@code /userinfo} response. Authorizations that depend on {@code groups} therefore fail even
- * though the IdP would return the groups if asked.
+ * Regression test for the customer's reported bearer-token scenario: when a JWT does not carry the
+ * configured {@code groups} claim and UserInfo augmentation is enabled, the missing {@code groups}
+ * claim is obtained from the OIDC {@code /userinfo} response and merged into the claims passed to
+ * {@link TokenClaimsConverter}. Authorizations that depend on {@code groups} therefore work for
+ * bearer-token authentication as expected.
  *
- * <p>This test is expected to FAIL on current code (8.8). It encodes the behaviour we want after a
- * fix: {@link TokenClaimsConverter} should receive a merged claims map containing {@code groups}
- * from {@code /userinfo}. On current code, only the raw JWT claims are passed through, {@code
- * /userinfo} is never called, and the assertions below do not hold.
+ * <p>Also verifies the cache is consulted for repeated calls with the same token within the TTL.
  */
 @SuppressWarnings("SpringBootApplicationProperties")
 @SpringBootTest(

--- a/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
@@ -13,6 +13,8 @@ import io.camunda.identity.sdk.IdentityConfiguration;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.oidc.NoopOidcClaimsProvider;
+import io.camunda.security.oidc.OidcClaimsProvider;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
@@ -64,6 +66,7 @@ public class BrokerModuleConfiguration implements CloseableSilently {
   private final UserServices userServices;
   private final PasswordEncoder passwordEncoder;
   private final JwtDecoder jwtDecoder;
+  private final OidcClaimsProvider oidcClaimsProvider;
   private final SearchClientsProxy searchClientsProxy;
   private final NodeIdProvider nodeIdProvider;
 
@@ -84,6 +87,7 @@ public class BrokerModuleConfiguration implements CloseableSilently {
       @Autowired(required = false) final UserServices userServices,
       final PasswordEncoder passwordEncoder,
       @Autowired(required = false) final JwtDecoder jwtDecoder,
+      @Autowired(required = false) final OidcClaimsProvider oidcClaimsProvider,
       @Autowired(required = false) final SearchClientsProxy searchClientsProxy,
       final NodeIdProvider nodeIdProvider) {
     this.configuration = configuration;
@@ -98,6 +102,8 @@ public class BrokerModuleConfiguration implements CloseableSilently {
     this.userServices = userServices;
     this.passwordEncoder = passwordEncoder;
     this.jwtDecoder = jwtDecoder;
+    this.oidcClaimsProvider =
+        oidcClaimsProvider != null ? oidcClaimsProvider : new NoopOidcClaimsProvider();
     this.searchClientsProxy = searchClientsProxy;
     this.nodeIdProvider = nodeIdProvider;
   }
@@ -128,6 +134,7 @@ public class BrokerModuleConfiguration implements CloseableSilently {
             userServices,
             passwordEncoder,
             jwtDecoder,
+            oidcClaimsProvider,
             searchClientsProxy,
             new BrokerRequestAuthorizationConverter(securityConfiguration),
             nodeIdProvider);

--- a/dist/src/main/java/io/camunda/zeebe/gateway/GatewayModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/GatewayModuleConfiguration.java
@@ -10,6 +10,8 @@ package io.camunda.zeebe.gateway;
 import io.atomix.cluster.AtomixCluster;
 import io.camunda.application.commons.configuration.GatewayBasedConfiguration;
 import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.oidc.NoopOidcClaimsProvider;
+import io.camunda.security.oidc.OidcClaimsProvider;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
@@ -64,6 +66,7 @@ public class GatewayModuleConfiguration implements CloseableSilently {
   private final UserServices userServices;
   private final PasswordEncoder passwordEncoder;
   private final JwtDecoder jwtDecoder;
+  private final OidcClaimsProvider oidcClaimsProvider;
   private final MeterRegistry meterRegistry;
   private final int maxVariableNameLength;
 
@@ -81,6 +84,7 @@ public class GatewayModuleConfiguration implements CloseableSilently {
       @Autowired(required = false) final UserServices userServices,
       final PasswordEncoder passwordEncoder,
       @Autowired(required = false) final JwtDecoder jwtDecoder,
+      @Autowired(required = false) final OidcClaimsProvider oidcClaimsProvider,
       final MeterRegistry meterRegistry,
       final GatewayRestConfiguration gatewayRestConfiguration) {
     this.configuration = configuration;
@@ -93,6 +97,8 @@ public class GatewayModuleConfiguration implements CloseableSilently {
     this.userServices = userServices;
     this.passwordEncoder = passwordEncoder;
     this.jwtDecoder = jwtDecoder;
+    this.oidcClaimsProvider =
+        oidcClaimsProvider != null ? oidcClaimsProvider : new NoopOidcClaimsProvider();
     this.meterRegistry = meterRegistry;
     maxVariableNameLength = gatewayRestConfiguration.getMaxNameFieldLength();
   }
@@ -124,6 +130,7 @@ public class GatewayModuleConfiguration implements CloseableSilently {
             userServices,
             passwordEncoder,
             jwtDecoder,
+            oidcClaimsProvider,
             meterRegistry,
             maxVariableNameLength);
     springGatewayBridge.registerGatewayStatusSupplier(gateway::getStatus);

--- a/dist/src/test/java/io/camunda/zeebe/gateway/StandaloneGatewaySecurityTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/gateway/StandaloneGatewaySecurityTest.java
@@ -289,6 +289,7 @@ final class StandaloneGatewaySecurityTest {
         null,
         null,
         null,
+        null,
         new SimpleMeterRegistry(),
         gatewayRestConfiguration);
   }

--- a/docs/monorepo-docs/architecture/components/identity/adr/0006-userinfo-claim-augmentation-for-bearer-tokens.md
+++ b/docs/monorepo-docs/architecture/components/identity/adr/0006-userinfo-claim-augmentation-for-bearer-tokens.md
@@ -147,6 +147,11 @@ values.
   limit the synchronous blocking exposure on the gRPC interceptor thread.
 - Clients without `openid` scope (typically M2M / client-credentials tokens) skip augmentation
   silently — UserInfo is only defined for openid-scope tokens per OIDC Core §5.3.
+- `HttpClient.Redirect.NEVER`: the JDK HTTP client does not follow 3xx redirects on the
+  `/userinfo` request. Following a redirect would cause the client to re-send the
+  `Authorization: Bearer` header to the redirect target, leaking the access token on an open
+  redirect, hijacked CDN, or misconfigured IdP. OIDC Core does not require redirects on the
+  UserInfo endpoint; any 3xx surfaces as a non-2xx error and degrades to JWT-only claims.
 
 ### Configuration
 

--- a/docs/monorepo-docs/architecture/components/identity/adr/0006-userinfo-claim-augmentation-for-bearer-tokens.md
+++ b/docs/monorepo-docs/architecture/components/identity/adr/0006-userinfo-claim-augmentation-for-bearer-tokens.md
@@ -137,7 +137,10 @@ values.
 ### Defences in OidcUserInfoClient
 
 - Response body size capped at 1 MiB (`OidcUserInfoClient.MAX_BODY_BYTES`). Oversized responses
-  are rejected before parsing.
+  are rejected before parsing. Note: `HttpResponse.BodyHandlers.ofByteArray()` buffers the full
+  response before the check, so worst-case heap is `MAX_BODY_BYTES` per concurrent uncached
+  fetch. A streaming `BodySubscriber` with an in-stream cap is a documented follow-up for a
+  future iteration.
 - `Content-Type: application/jwt` rejected with a clear error — signed UserInfo responses per
   OIDC Core §5.3.2 are not supported in this version.
 - Request + connect timeouts are 2 seconds each, tightened from an earlier 5-second default to

--- a/docs/monorepo-docs/architecture/components/identity/adr/0006-userinfo-claim-augmentation-for-bearer-tokens.md
+++ b/docs/monorepo-docs/architecture/components/identity/adr/0006-userinfo-claim-augmentation-for-bearer-tokens.md
@@ -1,0 +1,213 @@
+# ADR-0006: UserInfo Claim Augmentation for OIDC Bearer Tokens
+
+## Status
+
+Proposed
+
+## Context
+
+Camunda's OIDC authentication extracts authorization-relevant claims (`groups`, `roles`, tenants,
+etc.) from the validated JWT access token. Some Identity Providers do **not** place these claims
+on the JWT that is issued as the access token — they only return them from the `/userinfo`
+endpoint when queried with that token. Common cases include SaaS IdPs with claim-emission
+policies that differ between ID tokens, access tokens, and the userinfo response; and IdPs where
+the operator has intentionally kept access tokens compact.
+
+For the **browser login flow** (webapp), Spring Security's OIDC login handler already calls
+`/userinfo` when `camunda.security.authentication.oidc.userInfoEnabled=true` (default) and merges
+the response into the principal. So this works today — for login.
+
+For the **bearer-token flow** (REST `/v1`, `/v2`, gRPC via Zeebe gateway), the claims map passed
+to `TokenClaimsConverter` is `JwtAuthenticationToken.getToken().getClaims()` — i.e. JWT claims
+only. No `/userinfo` call is made. If the `groups` claim isn't on the JWT, group-based
+authorization never triggers, even though the IdP would return groups if asked.
+
+This breaks a customer scenario where their IdP is configured to emit group membership only via
+`/userinfo`. Before adopting this feature, operators should confirm they cannot configure the IdP
+to emit the missing claim on the access token directly (most major IdPs — Keycloak, Okta, Auth0,
+Azure AD, PingFederate — support this via scopes, claim mappers, or access-token policies).
+Fixing at the IdP is strictly cheaper because it avoids the new runtime dependency described
+below; this feature exists for deployments where that path is not available.
+
+## Decision
+
+Introduce an **opt-in** augmentation layer for the bearer-token flow. When enabled, a shared
+`OidcClaimsProvider` bean calls the IdP's `/userinfo` endpoint with the bearer token and
+**additively** merges the response onto the JWT claims: the JWT wins on every conflict; UserInfo
+contributes only claims absent from the JWT. The result is cached per-token.
+
+### Architecture
+
+- New interface `io.camunda.security.oidc.OidcClaimsProvider`:
+  `Map<String, Object> claimsFor(Map<String, Object> jwtClaims, String tokenValue)`.
+- Default implementation `NoopOidcClaimsProvider` returns the JWT claims unchanged — used
+  whenever augmentation is disabled. No runtime cost.
+- Production implementation `CachingOidcClaimsProvider`:
+  - On cache miss, calls `/userinfo` via `OidcUserInfoClient` (JDK `HttpClient`, Jackson for JSON).
+  - Uses Caffeine's atomic `cache.get(key, loader)` so concurrent misses on the same key
+    coalesce — exactly one `/userinfo` call per (key, TTL) window even under burst load.
+  - Keyed by `jti:{iss}:{jti}` when the JWT has a `jti`, otherwise `sie:{iss}:{sub}:{iat}:{exp}`.
+    The `iss` prefix is required because `jti` is only unique per-issuer (RFC 7519); without it,
+    two providers in a multi-provider deployment can legitimately issue tokens with identical
+    `jti` values and collide. The fallback of `sub+iat+exp` is chosen deliberately over
+    `SHA-256(token)`: a heap dump or metrics leak of the key itself reveals only auth metadata,
+    not a token-correlatable fingerprint.
+  - Effective TTL for successful entries is `min(configuredTtl, tokenExp − clockSkew − now)`;
+    cache entries never outlive the bearer token.
+  - Emits Micrometer metrics: `camunda.oidc.userinfo.cache` tagged `hit` / `miss`, and
+    `camunda.oidc.userinfo.fetch` as a timer plus a `failure` counter.
+
+### Merge semantics — JWT wins, additive only
+
+UserInfo responses are HTTP payloads, not signed JWTs. Letting `/userinfo` override JWT claims
+would let a compromised or misconfigured IdP shadow the signed token's authorization-relevant
+fields — `sub`, `iss`, `aud`, `exp`, `jti`, etc. The merge instead preserves every JWT claim and
+adds UserInfo claims only where the JWT is silent. This keeps the cryptographic guarantee of the
+signed token load-bearing for identity and lifetime while still benefiting from `/userinfo`'s
+richer (optional) group data.
+
+Per OIDC Core §5.3.2 the UserInfo `sub` MUST equal the JWT `sub`. If they differ (IdP
+misconfiguration, mis-federation, or worse), the provider logs ERROR, increments the failure
+counter, and returns JWT-only claims without merging — the UserInfo response is treated as a
+degradation event.
+
+### Routing through existing code paths
+
+- REST (`OidcTokenAuthenticationConverter`): resolves claims through `OidcClaimsProvider` before
+  handing to `TokenClaimsConverter`.
+- gRPC (`AuthenticationHandler.Oidc`): calls `OidcClaimsProvider` once between
+  `JwtDecoder.decode(...)` and `OidcPrincipalLoader.load(...)`, so both the groups loader and
+  the principal loader see the merged claims. Catch blocks return a generic 401 status and log
+  the underlying exception server-side rather than attaching it via `.withCause(e)` — so IdP
+  URLs and internal diagnostic strings don't leak to gRPC clients.
+- The broker's embedded gateway threads the provider through the same chain that `JwtDecoder`
+  travels today: `BrokerModuleConfiguration` → `SystemContext` → `BrokerStartupContext(Impl)` →
+  `EmbeddedGatewayServiceStep` → `EmbeddedGatewayService` → `Gateway`. With
+  `@Autowired(required = false)` + a `NoopOidcClaimsProvider` fallback in
+  `BrokerModuleConfiguration`, the chain degrades safely when the authentication module's
+  Spring context isn't loaded.
+
+`OidcTokenAuthenticationConverter.supports(...)` checks for `JwtAuthenticationToken`
+specifically. Camunda does not configure Spring's `OpaqueTokenIntrospector` anywhere, so every
+bearer-authenticated request produces a `JwtAuthenticationToken`; if opaque-token introspection
+is ever added, `supports()` would need to widen to `AbstractOAuth2TokenAuthenticationToken`.
+
+### Userinfo URL source — per-issuer map
+
+`CachingOidcClaimsProvider` holds a `Map<issuer, URI>` built at startup from the Spring-managed
+`ClientRegistrationRepository`. Each registration contributes its
+`ProviderDetails.getIssuerUri()` → `UserInfoEndpoint.getUri()` — both populated by Spring from
+the IdP's OIDC discovery document. At request time, the provider looks up the URL by the JWT's
+`iss` claim. This guarantees tokens are always sent back to the same IdP that signed them; a
+token from provider A cannot be routed to provider B's `/userinfo` in a multi-provider
+deployment.
+
+A null URL at startup (no registration publishes a userinfo endpoint, or the operator set
+`userInfoEnabled=false` on all providers) fails application startup — aligned with the existing
+`ClientRegistrations.fromIssuerLocation(...)` failure precedent for unreachable IdPs. At
+request time, a token with an unknown `iss` degrades to JWT-only claims rather than guessing an
+endpoint or sending the bearer token to the wrong IdP.
+
+### Failure-mode asymmetry — startup fail-fast, runtime fail-open
+
+The two failure modes are orthogonal and treated differently on purpose:
+
+- **Startup** is a configuration surface. Camunda already fails fast when
+  `ClientRegistrations.fromIssuerLocation(...)` can't reach the IdP (see
+  `WebSecurityConfig.createClientRegistration`). The UserInfo bean follows suit: if augmentation
+  is enabled but no registration exposes a userinfo URL, `IllegalStateException` aborts startup
+  with an operator-facing message. Permanent misconfiguration is surfaced loudly.
+- **Runtime** is a liveness surface. A `/userinfo` call that fails (network, non-2xx, parse
+  failure, body too large, `application/jwt` signed response, or UserInfo `sub` mismatch) logs
+  ERROR, increments `camunda.oidc.userinfo.fetch{outcome=failure}`, and returns JWT-only claims
+  for that request. The degraded outcome is cached negatively for
+  `negativeCacheTtl` (default 5s; configurable) to prevent retry storms during an IdP outage.
+  Operators who want tighter recovery after an outage can shorten the negative TTL; those who
+  want heavier dampening can extend it.
+
+An earlier version of the design proposed fail-closed at runtime (reject with 401 on any IdP
+error). That was changed because it turned every IdP blip into an estate-wide bearer-auth
+outage — unacceptable for a stable-line release. The operational trade-off of the current
+design: during a `/userinfo` outage, authorization checks that depend on claims *only* present
+in UserInfo (e.g. `groups`) will evaluate against JWT-only claims and may deny operations that
+would otherwise succeed. This is a strict degradation: no privilege escalation, only loss of
+capability. Operators should monitor the failure counter and alert on sustained non-zero
+values.
+
+### Defences in OidcUserInfoClient
+
+- Response body size capped at 1 MiB (`OidcUserInfoClient.MAX_BODY_BYTES`). Oversized responses
+  are rejected before parsing.
+- `Content-Type: application/jwt` rejected with a clear error — signed UserInfo responses per
+  OIDC Core §5.3.2 are not supported in this version.
+- Request + connect timeouts are 2 seconds each, tightened from an earlier 5-second default to
+  limit the synchronous blocking exposure on the gRPC interceptor thread.
+- Clients without `openid` scope (typically M2M / client-credentials tokens) skip augmentation
+  silently — UserInfo is only defined for openid-scope tokens per OIDC Core §5.3.
+
+### Configuration
+
+```yaml
+camunda:
+  security:
+    authentication:
+      oidc:
+        userInfoAugmentation:
+          enabled: false              # default; opt-in
+          cacheTtl: PT5M              # capped by (tokenExp − clockSkew)
+          cacheMaxSize: 10000         # hard bound on cached entries
+          negativeCacheTtl: PT5S      # TTL for degraded (fail-open) entries
+```
+
+- **Default is `enabled: false`.** Augmentation is opt-in because it introduces a per-request
+  network dependency on the IdP and is a behavioural change for existing deployments on
+  upgrade.
+- The `userInfoEnabled` flag (existing, defaults `true`) remains separate — it continues to
+  gate Spring's OIDC login-flow userinfo call. When `userInfoAugmentation.enabled=true` and
+  `userInfoEnabled=false`, startup fails because no userinfo URL is populated on the
+  `ClientRegistration`.
+- An `HttpClient` bean `oidcUserInfoHttpClient` is registered with Spring (not constructed
+  inline); it inherits the `oidc-userinfo` entry from `spring.ssl.bundle.*` when configured,
+  so enterprise deployments with custom CA trust apply automatically. The client can be
+  overridden by registering another bean with the same name.
+
+## Consequences
+
+### Positive
+
+- Group-based authorization works for bearer-token requests even when the IdP only returns
+  groups from `/userinfo`. This unblocks deployments that previously required IdP-side
+  configuration changes they couldn't make.
+- Opt-in via a single config flag — no behaviour change for existing deployments on upgrade.
+- `NoopOidcClaimsProvider` is the default bean, so the hot path for disabled deployments is a
+  zero-allocation pass-through.
+- JWT's signed claims remain authoritative. The design deliberately cannot escalate privilege
+  via UserInfo; only claims absent from the JWT are contributed.
+- Cache + metrics give operators visibility and bound the IdP load; per-issuer URL routing and
+  the atomic loader keep the feature correct under multi-provider deployments and burst
+  concurrency.
+
+### Negative
+
+- When enabled, the first bearer request per (iss, jti) adds one IdP round-trip (~tens of ms
+  in steady state; more if the IdP is distant). Worker patterns that reuse the same token
+  amortise this trivially via the cache.
+- During a `/userinfo` outage, authorization checks that depend on UserInfo-only claims degrade
+  to "missing" rather than 401. This is documented fail-open behaviour, not a bug; operators
+  monitoring the fetch-failure counter are the primary alerting surface.
+- The gRPC interceptor call is synchronous; under sustained IdP latency the 2s timeout is the
+  primary bound on thread-tie-up. A future improvement could introduce a circuit breaker that
+  short-circuits augmentation entirely after N consecutive failures in a window, but that's
+  out of scope for this PR.
+
+### Out of scope for v1
+
+- A circuit breaker around the fetch path (supplementary to the negative cache).
+- Supporting signed UserInfo responses (`application/jwt`).
+- An explicit `userInfoUri` override config for IdPs whose discovery document is broken.
+- Async I/O on the gRPC interceptor thread.
+
+## References
+
+- Failing-test baseline: `authentication/src/test/java/io/camunda/authentication/oidc/OidcBearerUserInfoClaimGapIT.java`
+

--- a/security/security-core/pom.xml
+++ b/security/security-core/pom.xml
@@ -45,6 +45,10 @@
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>

--- a/security/security-core/pom.xml
+++ b/security/security-core/pom.xml
@@ -52,6 +52,14 @@
       <artifactId>json-path</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
@@ -79,6 +87,11 @@
     <dependency>
       <groupId>org.wiremock</groupId>
       <artifactId>wiremock-standalone</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/security/security-core/pom.xml
+++ b/security/security-core/pom.xml
@@ -44,6 +44,10 @@
       <artifactId>jackson-annotations</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.jayway.jsonpath</groupId>
       <artifactId>json-path</artifactId>
     </dependency>
@@ -70,6 +74,11 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock-standalone</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
@@ -58,6 +58,8 @@ public class OidcAuthenticationConfiguration {
   private Duration clockSkew = DEFAULT_CLOCK_SKEW;
   private boolean idpLogoutEnabled = true;
   private boolean userInfoEnabled = true;
+  private OidcUserInfoAugmentationConfiguration userInfoAugmentation =
+      new OidcUserInfoAugmentationConfiguration();
 
   @PostConstruct
   public void validate() {
@@ -286,6 +288,15 @@ public class OidcAuthenticationConfiguration {
     this.userInfoEnabled = userInfoEnabled;
   }
 
+  public OidcUserInfoAugmentationConfiguration getUserInfoAugmentation() {
+    return userInfoAugmentation;
+  }
+
+  public void setUserInfoAugmentation(
+      final OidcUserInfoAugmentationConfiguration userInfoAugmentation) {
+    this.userInfoAugmentation = userInfoAugmentation;
+  }
+
   public boolean isSet() {
     return issuerUri != null
         || clientId != null
@@ -353,6 +364,8 @@ public class OidcAuthenticationConfiguration {
     private Duration clockSkew = DEFAULT_CLOCK_SKEW;
     private boolean idpLogoutEnabled = true;
     private boolean userInfoEnabled = true;
+    private OidcUserInfoAugmentationConfiguration userInfoAugmentation =
+        new OidcUserInfoAugmentationConfiguration();
 
     public Builder issuerUri(final String issuerUri) {
       this.issuerUri = issuerUri;
@@ -486,6 +499,12 @@ public class OidcAuthenticationConfiguration {
       return this;
     }
 
+    public Builder userInfoAugmentation(
+        final OidcUserInfoAugmentationConfiguration userInfoAugmentation) {
+      this.userInfoAugmentation = userInfoAugmentation;
+      return this;
+    }
+
     public OidcAuthenticationConfiguration build() {
       final OidcAuthenticationConfiguration config = new OidcAuthenticationConfiguration();
       config.setIssuerUri(issuerUri);
@@ -514,6 +533,7 @@ public class OidcAuthenticationConfiguration {
       config.setClockSkew(clockSkew);
       config.setIdpLogoutEnabled(idpLogoutEnabled);
       config.setUserInfoEnabled(userInfoEnabled);
+      config.setUserInfoAugmentation(userInfoAugmentation);
       return config;
     }
   }

--- a/security/security-core/src/main/java/io/camunda/security/configuration/OidcUserInfoAugmentationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/OidcUserInfoAugmentationConfiguration.java
@@ -13,11 +13,12 @@ public class OidcUserInfoAugmentationConfiguration {
 
   public static final Duration DEFAULT_CACHE_TTL = Duration.ofMinutes(5);
   public static final int DEFAULT_CACHE_MAX_SIZE = 10_000;
-  public static final Duration NEGATIVE_CACHE_TTL = Duration.ofSeconds(5);
+  public static final Duration DEFAULT_NEGATIVE_CACHE_TTL = Duration.ofSeconds(5);
 
   private boolean enabled = false;
   private Duration cacheTtl = DEFAULT_CACHE_TTL;
   private int cacheMaxSize = DEFAULT_CACHE_MAX_SIZE;
+  private Duration negativeCacheTtl = DEFAULT_NEGATIVE_CACHE_TTL;
 
   public boolean isEnabled() {
     return enabled;
@@ -41,5 +42,19 @@ public class OidcUserInfoAugmentationConfiguration {
 
   public void setCacheMaxSize(final int cacheMaxSize) {
     this.cacheMaxSize = cacheMaxSize;
+  }
+
+  /**
+   * TTL for "degraded" cache entries — entries that hold JWT-only claims because the UserInfo fetch
+   * or merge failed (IdP down, non-2xx, parse failure, {@code sub} mismatch). Lower values recover
+   * faster once the IdP returns; higher values dampen retry traffic harder during an outage.
+   * Default {@link #DEFAULT_NEGATIVE_CACHE_TTL}.
+   */
+  public Duration getNegativeCacheTtl() {
+    return negativeCacheTtl;
+  }
+
+  public void setNegativeCacheTtl(final Duration negativeCacheTtl) {
+    this.negativeCacheTtl = negativeCacheTtl;
   }
 }

--- a/security/security-core/src/main/java/io/camunda/security/configuration/OidcUserInfoAugmentationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/OidcUserInfoAugmentationConfiguration.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.configuration;
+
+import java.time.Duration;
+
+public class OidcUserInfoAugmentationConfiguration {
+
+  public static final Duration DEFAULT_CACHE_TTL = Duration.ofMinutes(5);
+  public static final int DEFAULT_CACHE_MAX_SIZE = 10_000;
+  public static final Duration NEGATIVE_CACHE_TTL = Duration.ofSeconds(5);
+
+  private boolean enabled = false;
+  private Duration cacheTtl = DEFAULT_CACHE_TTL;
+  private int cacheMaxSize = DEFAULT_CACHE_MAX_SIZE;
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(final boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public Duration getCacheTtl() {
+    return cacheTtl;
+  }
+
+  public void setCacheTtl(final Duration cacheTtl) {
+    this.cacheTtl = cacheTtl;
+  }
+
+  public int getCacheMaxSize() {
+    return cacheMaxSize;
+  }
+
+  public void setCacheMaxSize(final int cacheMaxSize) {
+    this.cacheMaxSize = cacheMaxSize;
+  }
+}

--- a/security/security-core/src/main/java/io/camunda/security/oidc/CachingOidcClaimsProvider.java
+++ b/security/security-core/src/main/java/io/camunda/security/oidc/CachingOidcClaimsProvider.java
@@ -12,16 +12,14 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.Expiry;
 import io.camunda.security.configuration.OidcAuthenticationConfiguration;
 import io.camunda.security.configuration.OidcUserInfoAugmentationConfiguration;
+import io.camunda.zeebe.util.VisibleForTesting;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
-import java.util.HexFormat;
 import java.util.Map;
 import java.util.Objects;
 import org.slf4j.Logger;
@@ -29,9 +27,15 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Caching {@link OidcClaimsProvider} that, when UserInfo augmentation is enabled, calls the OIDC
- * UserInfo endpoint on cache miss, merges its response onto the JWT claims (UserInfo wins on
- * conflict), and caches by {@code jti} (falling back to SHA-256 of the token). Fails closed on
- * UserInfo errors and negatively caches failures to avoid hammering a down IdP.
+ * UserInfo endpoint on cache miss and <em>additively</em> merges claims onto the JWT: JWT wins on
+ * every conflict, UserInfo only contributes claims absent from the JWT. This preserves the
+ * cryptographic guarantee of the signed token — UserInfo cannot override {@code sub}, {@code iss},
+ * {@code aud}, {@code exp}, or any other JWT-supplied claim.
+ *
+ * <p>Runtime fail-open on IdP errors: a {@code /userinfo} fetch failure (network, non-2xx, parse
+ * failure, or UserInfo {@code sub} mismatch per OIDC Core §5.3.2) is logged at ERROR and the
+ * provider returns the JWT claims unchanged. Degraded entries are negatively cached for a short TTL
+ * ({@link OidcUserInfoAugmentationConfiguration#NEGATIVE_CACHE_TTL}) to avoid hammering a down IdP.
  */
 public class CachingOidcClaimsProvider implements OidcClaimsProvider {
 
@@ -40,7 +44,7 @@ public class CachingOidcClaimsProvider implements OidcClaimsProvider {
   private static final String FETCH_METRIC = "camunda.oidc.userinfo.fetch";
 
   private final OidcAuthenticationConfiguration oidcConfig;
-  private final URI userInfoUri;
+  private final Map<String, URI> userInfoUriByIssuer;
   private final OidcUserInfoClient userInfoClient;
   private final Cache<String, CacheEntry> cache;
   private final Counter hitCounter;
@@ -51,11 +55,12 @@ public class CachingOidcClaimsProvider implements OidcClaimsProvider {
 
   public CachingOidcClaimsProvider(
       final OidcAuthenticationConfiguration oidcConfig,
-      final URI userInfoUri,
+      final Map<String, URI> userInfoUriByIssuer,
       final OidcUserInfoClient userInfoClient,
       final MeterRegistry meterRegistry) {
     this.oidcConfig = Objects.requireNonNull(oidcConfig);
-    this.userInfoUri = userInfoUri; // may be null if augmentation disabled
+    this.userInfoUriByIssuer =
+        userInfoUriByIssuer == null ? Map.of() : Map.copyOf(userInfoUriByIssuer);
     this.userInfoClient = Objects.requireNonNull(userInfoClient);
     clockSkew = oidcConfig.getClockSkew();
     final OidcUserInfoAugmentationConfiguration aug = oidcConfig.getUserInfoAugmentation();
@@ -77,90 +82,217 @@ public class CachingOidcClaimsProvider implements OidcClaimsProvider {
     if (!oidcConfig.getUserInfoAugmentation().isEnabled()) {
       return jwtClaims;
     }
-    if (userInfoUri == null) {
-      throw new OidcUserInfoException(
-          "UserInfo augmentation is enabled but no userinfo URI is available for this provider");
+
+    // OIDC Core §5.3 — the UserInfo endpoint is only defined for tokens that were issued with
+    // the 'openid' scope. Tokens from a client-credentials / M2M flow typically lack it;
+    // calling /userinfo with them either fails or returns stub claims. Skip augmentation
+    // silently in that case.
+    if (!hasOpenidScope(jwtClaims)) {
+      LOG.debug(
+          "Skipping UserInfo augmentation: bearer token lacks 'openid' scope (likely a "
+              + "client-credentials / M2M token). Returning JWT-only claims.");
+      return jwtClaims;
     }
 
-    final String key = cacheKey(jwtClaims, tokenValue);
+    // Resolve the userinfo URI per-token by the JWT's 'iss' claim. This guarantees we always
+    // hand the token to the same IdP that signed it — critical in multi-provider setups where
+    // tokens from provider A must not be sent to provider B's /userinfo endpoint.
+    final Object issClaim = jwtClaims.get("iss");
+    final URI userInfoUri = issClaim instanceof final String s ? userInfoUriByIssuer.get(s) : null;
+    if (userInfoUri == null) {
+      // Either the JWT has no 'iss', or no registration matches it. Degrade rather than 500.
+      LOG.error(
+          "UserInfo augmentation enabled but no userinfo URI is registered for issuer '{}'; "
+              + "returning JWT-only claims",
+          issClaim);
+      return jwtClaims;
+    }
+
+    final String key = cacheKey(jwtClaims);
+    if (key == null) {
+      // Neither 'jti' nor (sub+iat+exp) are usable as a cache key for this token.
+      // Bypass the cache entirely — fetch + merge once, don't store. Rare in practice
+      // (every mainstream IdP emits at least sub+iat+exp on access tokens) but keeps
+      // the feature correct for malformed JWTs.
+      return loadEntry(jwtClaims, tokenValue, userInfoUri).claims();
+    }
+    // Fast-path: was it already cached? If so, record the hit and return.
+    // Narrow race: a concurrent thread may populate between this check and the load below,
+    // in which case our load() sees the populated entry and returns without running the
+    // loader. Counter bookkeeping may skew by one under pure load but functional behaviour
+    // (single fetch per key) is preserved by Caffeine's atomic loading contract.
     final CacheEntry cached = cache.getIfPresent(key);
     if (cached != null) {
       hitCounter.increment();
-      if (cached.failure() != null) {
-        throw cached.failure();
-      }
       return cached.claims();
     }
-    missCounter.increment();
+    // Miss — use Caffeine's atomic cache.get(key, loader) so concurrent misses on the same
+    // key coalesce: exactly one thread runs the loader; the others wait for the result.
+    final CacheEntry entry =
+        cache.get(
+            key,
+            k -> {
+              missCounter.increment();
+              return loadEntry(jwtClaims, tokenValue, userInfoUri);
+            });
+    return entry.claims();
+  }
 
-    final Map<String, Object> merged;
+  private CacheEntry loadEntry(
+      final Map<String, Object> jwtClaims, final String tokenValue, final URI userInfoUri) {
     try {
       final Map<String, Object> userInfoClaims =
           fetchTimer.recordCallable(() -> userInfoClient.fetch(userInfoUri, tokenValue));
-      merged = merge(jwtClaims, userInfoClaims);
-    } catch (final OidcUserInfoException e) {
+      return mergeEntry(jwtClaims, userInfoClaims);
+    } catch (final InterruptedException e) {
+      // Restore interrupt flag so the calling thread can terminate cleanly.
+      Thread.currentThread().interrupt();
       fetchFailureCounter.increment();
-      LOG.debug("UserInfo fetch failed; caching negative entry", e);
-      cache.put(key, CacheEntry.failure(e));
-      throw e;
+      LOG.error("UserInfo fetch interrupted; returning JWT-only claims", e);
+      return CacheEntry.degraded(jwtClaims);
     } catch (final Exception e) {
       fetchFailureCounter.increment();
-      final var wrapped = new OidcUserInfoException("UserInfo fetch failed: " + e.getMessage(), e);
-      cache.put(key, CacheEntry.failure(wrapped));
-      throw wrapped;
-    }
-
-    cache.put(key, CacheEntry.success(merged, tokenExpiry(jwtClaims)));
-    return merged;
-  }
-
-  private static Map<String, Object> merge(
-      final Map<String, Object> jwtClaims, final Map<String, Object> userInfoClaims) {
-    final Map<String, Object> merged = new HashMap<>(jwtClaims);
-    merged.putAll(userInfoClaims); // userinfo wins on conflict
-    return Map.copyOf(merged);
-  }
-
-  private static String cacheKey(final Map<String, Object> jwtClaims, final String tokenValue) {
-    final Object jti = jwtClaims.get("jti");
-    if (jti instanceof final String s && !s.isBlank()) {
-      return "jti:" + s;
-    }
-    return "tok:" + sha256(tokenValue);
-  }
-
-  private static String sha256(final String input) {
-    try {
-      final MessageDigest md = MessageDigest.getInstance("SHA-256");
-      return HexFormat.of().formatHex(md.digest(input.getBytes(StandardCharsets.UTF_8)));
-    } catch (final Exception e) {
-      throw new IllegalStateException("SHA-256 unavailable", e);
-    }
-  }
-
-  private static Instant tokenExpiry(final Map<String, Object> jwtClaims) {
-    final Object exp = jwtClaims.get("exp");
-    if (exp instanceof Number n) {
-      return Instant.ofEpochSecond(n.longValue());
-    }
-    return Instant.now().plus(Duration.ofMinutes(5));
-  }
-
-  private record CacheEntry(
-      Map<String, Object> claims, OidcUserInfoException failure, Instant tokenExp) {
-
-    static CacheEntry success(final Map<String, Object> claims, final Instant tokenExp) {
-      return new CacheEntry(claims, null, tokenExp);
-    }
-
-    static CacheEntry failure(final OidcUserInfoException e) {
-      return new CacheEntry(null, e, null);
+      LOG.error(
+          "UserInfo augmentation failed for bearer request; continuing with JWT-only claims. "
+              + "Authorization may be incomplete if required claims are only available via "
+              + "/userinfo. Ensure IdP availability is monitored.",
+          e);
+      return CacheEntry.degraded(jwtClaims);
     }
   }
 
   /**
-   * Caffeine {@link Expiry} that expires successful entries at min(configured TTL, token exp − skew
-   * − now) and uses a short fixed TTL for failure entries.
+   * Drop every cached entry. Used by integration tests to isolate state between test methods when
+   * the provider is a Spring-managed singleton.
+   */
+  @VisibleForTesting
+  public void invalidateCache() {
+    cache.invalidateAll();
+  }
+
+  /**
+   * Apply additive merge: JWT wins on every conflict, UserInfo contributes only claims absent from
+   * the JWT. Before merging, enforce OIDC Core §5.3.2 — UserInfo {@code sub} MUST equal JWT {@code
+   * sub}. A mismatch is treated as a degradation event (fail-open, JWT-only claims).
+   */
+  private CacheEntry mergeEntry(
+      final Map<String, Object> jwtClaims, final Map<String, Object> userInfoClaims) {
+    final Object userInfoSub = userInfoClaims.get("sub");
+    if (userInfoSub != null && !userInfoSub.equals(jwtClaims.get("sub"))) {
+      fetchFailureCounter.increment();
+      LOG.error(
+          "UserInfo 'sub' did not match JWT 'sub' (OIDC Core §5.3.2 violation); "
+              + "returning JWT-only claims. Possible IdP misconfiguration.");
+      return CacheEntry.degraded(jwtClaims);
+    }
+    // Start with UserInfo, let JWT overwrite — JWT wins on every key they share.
+    final Map<String, Object> merged = new HashMap<>(userInfoClaims);
+    merged.putAll(jwtClaims);
+    return CacheEntry.augmented(Map.copyOf(merged), tokenExpiry(jwtClaims));
+  }
+
+  /**
+   * Build a cache key that is unique per (issuer, token) pair but stores no bearer-token material.
+   * Returns null when neither {@code jti} nor (sub + iat + exp) are usable — callers should bypass
+   * the cache for that request.
+   *
+   * <p>The {@code iss} prefix is required because {@code jti} is only required to be unique per
+   * issuer (RFC 7519); two providers can legitimately issue tokens with identical {@code jti}
+   * values, which would otherwise collide and leak claims across issuers.
+   *
+   * <p>When {@code jti} is absent the fallback uses {@code sub + iat + exp} — identifiers already
+   * present on every standard access token. This is a far better cache-key choice than {@code
+   * SHA-256(token)} because a heap dump or metrics leak of the key itself reveals only auth
+   * metadata ("alice had a token valid for this window"), not a token-correlatable fingerprint.
+   */
+  private static String cacheKey(final Map<String, Object> jwtClaims) {
+    final Object iss = jwtClaims.get("iss");
+    if (!(iss instanceof final String issuer) || issuer.isBlank()) {
+      return null;
+    }
+    final Object jti = jwtClaims.get("jti");
+    if (jti instanceof final String s && !s.isBlank()) {
+      return "jti:" + issuer + ":" + s;
+    }
+    final Object sub = jwtClaims.get("sub");
+    final Long iat = epochSecond(jwtClaims.get("iat"));
+    final Long exp = epochSecond(jwtClaims.get("exp"));
+    if (sub instanceof String && iat != null && exp != null) {
+      return "sie:" + issuer + ":" + sub + ":" + iat + ":" + exp;
+    }
+    return null;
+  }
+
+  private static Long epochSecond(final Object value) {
+    if (value instanceof final Instant i) {
+      return i.getEpochSecond();
+    }
+    if (value instanceof final Number n) {
+      return n.longValue();
+    }
+    return null;
+  }
+
+  /**
+   * Best-effort check that the JWT was issued with the {@code openid} scope, regardless of how the
+   * decoder surfaces the scope claim. JWTs may carry scope under {@code scope} (space- separated
+   * string per RFC 8693 convention) or {@code scp} (array on some IdPs), and Spring's claim
+   * converter can surface the value as either a {@link String} or a {@link Collection}.
+   */
+  private static boolean hasOpenidScope(final Map<String, Object> jwtClaims) {
+    final Object scope =
+        jwtClaims.get("scope") != null ? jwtClaims.get("scope") : jwtClaims.get("scp");
+    if (scope instanceof final String s) {
+      for (final String candidate : s.split("\\s+")) {
+        if ("openid".equals(candidate)) {
+          return true;
+        }
+      }
+      return false;
+    }
+    if (scope instanceof final java.util.Collection<?> c) {
+      return c.contains("openid");
+    }
+    return false;
+  }
+
+  private static Instant tokenExpiry(final Map<String, Object> jwtClaims) {
+    // Spring's NimbusJwtDecoder + MappedJwtClaimSetConverter converts 'exp' to java.time.Instant,
+    // so that branch must come first. The Number branch covers test fixtures and decoders that
+    // surface the raw epoch-seconds value.
+    final Object exp = jwtClaims.get("exp");
+    if (exp instanceof final Instant i) {
+      return i;
+    }
+    if (exp instanceof final Number n) {
+      return Instant.ofEpochSecond(n.longValue());
+    }
+    LOG.warn(
+        "JWT 'exp' claim is neither Instant nor Number (was {}); "
+            + "falling back to 5-minute cache TTL for this token",
+        exp == null ? "null" : exp.getClass().getSimpleName());
+    return Instant.now().plus(Duration.ofMinutes(5));
+  }
+
+  /**
+   * Cache entry. A {@code degraded} entry represents a fail-open outcome: we couldn't fetch (or
+   * validate) UserInfo, so we returned JWT claims unchanged and cached that decision for the
+   * negative-cache TTL to prevent hammering the IdP.
+   */
+  private record CacheEntry(Map<String, Object> claims, Instant tokenExp, boolean degraded) {
+
+    static CacheEntry augmented(final Map<String, Object> claims, final Instant tokenExp) {
+      return new CacheEntry(claims, tokenExp, false);
+    }
+
+    static CacheEntry degraded(final Map<String, Object> jwtClaims) {
+      return new CacheEntry(jwtClaims, null, true);
+    }
+  }
+
+  /**
+   * Caffeine {@link Expiry} that expires augmented entries at min(configured TTL, token exp − skew
+   * − now) and degraded entries at a short fixed negative-cache TTL.
    */
   private final class EntryExpiry implements Expiry<String, CacheEntry> {
     private final Duration configuredTtl;
@@ -194,8 +326,8 @@ public class CachingOidcClaimsProvider implements OidcClaimsProvider {
     }
 
     private long ttlNanos(final CacheEntry value) {
-      if (value.failure() != null) {
-        return OidcUserInfoAugmentationConfiguration.NEGATIVE_CACHE_TTL.toNanos();
+      if (value.degraded()) {
+        return oidcConfig.getUserInfoAugmentation().getNegativeCacheTtl().toNanos();
       }
       final Duration untilExp = Duration.between(Instant.now(), value.tokenExp()).minus(clockSkew);
       final Duration effective =

--- a/security/security-core/src/main/java/io/camunda/security/oidc/CachingOidcClaimsProvider.java
+++ b/security/security-core/src/main/java/io/camunda/security/oidc/CachingOidcClaimsProvider.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.oidc;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Expiry;
+import io.camunda.security.configuration.OidcAuthenticationConfiguration;
+import io.camunda.security.configuration.OidcUserInfoAugmentationConfiguration;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.HexFormat;
+import java.util.Map;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Caching {@link OidcClaimsProvider} that, when UserInfo augmentation is enabled, calls the OIDC
+ * UserInfo endpoint on cache miss, merges its response onto the JWT claims (UserInfo wins on
+ * conflict), and caches by {@code jti} (falling back to SHA-256 of the token). Fails closed on
+ * UserInfo errors and negatively caches failures to avoid hammering a down IdP.
+ */
+public class CachingOidcClaimsProvider implements OidcClaimsProvider {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CachingOidcClaimsProvider.class);
+  private static final String CACHE_METRIC = "camunda.oidc.userinfo.cache";
+  private static final String FETCH_METRIC = "camunda.oidc.userinfo.fetch";
+
+  private final OidcAuthenticationConfiguration oidcConfig;
+  private final URI userInfoUri;
+  private final OidcUserInfoClient userInfoClient;
+  private final Cache<String, CacheEntry> cache;
+  private final Counter hitCounter;
+  private final Counter missCounter;
+  private final Timer fetchTimer;
+  private final Counter fetchFailureCounter;
+  private final Duration clockSkew;
+
+  public CachingOidcClaimsProvider(
+      final OidcAuthenticationConfiguration oidcConfig,
+      final URI userInfoUri,
+      final OidcUserInfoClient userInfoClient,
+      final MeterRegistry meterRegistry) {
+    this.oidcConfig = Objects.requireNonNull(oidcConfig);
+    this.userInfoUri = userInfoUri; // may be null if augmentation disabled
+    this.userInfoClient = Objects.requireNonNull(userInfoClient);
+    clockSkew = oidcConfig.getClockSkew();
+    final OidcUserInfoAugmentationConfiguration aug = oidcConfig.getUserInfoAugmentation();
+    cache =
+        Caffeine.newBuilder()
+            .maximumSize(aug.getCacheMaxSize())
+            .expireAfter(new EntryExpiry(aug.getCacheTtl()))
+            .build();
+    hitCounter = Counter.builder(CACHE_METRIC).tag("result", "hit").register(meterRegistry);
+    missCounter = Counter.builder(CACHE_METRIC).tag("result", "miss").register(meterRegistry);
+    fetchTimer = Timer.builder(FETCH_METRIC).register(meterRegistry);
+    fetchFailureCounter =
+        Counter.builder(FETCH_METRIC).tag("outcome", "failure").register(meterRegistry);
+  }
+
+  @Override
+  public Map<String, Object> claimsFor(
+      final Map<String, Object> jwtClaims, final String tokenValue) {
+    if (!oidcConfig.getUserInfoAugmentation().isEnabled()) {
+      return jwtClaims;
+    }
+    if (userInfoUri == null) {
+      throw new OidcUserInfoException(
+          "UserInfo augmentation is enabled but no userinfo URI is available for this provider");
+    }
+
+    final String key = cacheKey(jwtClaims, tokenValue);
+    final CacheEntry cached = cache.getIfPresent(key);
+    if (cached != null) {
+      hitCounter.increment();
+      if (cached.failure() != null) {
+        throw cached.failure();
+      }
+      return cached.claims();
+    }
+    missCounter.increment();
+
+    final Map<String, Object> merged;
+    try {
+      final Map<String, Object> userInfoClaims =
+          fetchTimer.recordCallable(() -> userInfoClient.fetch(userInfoUri, tokenValue));
+      merged = merge(jwtClaims, userInfoClaims);
+    } catch (final OidcUserInfoException e) {
+      fetchFailureCounter.increment();
+      LOG.debug("UserInfo fetch failed; caching negative entry", e);
+      cache.put(key, CacheEntry.failure(e));
+      throw e;
+    } catch (final Exception e) {
+      fetchFailureCounter.increment();
+      final var wrapped = new OidcUserInfoException("UserInfo fetch failed: " + e.getMessage(), e);
+      cache.put(key, CacheEntry.failure(wrapped));
+      throw wrapped;
+    }
+
+    cache.put(key, CacheEntry.success(merged, tokenExpiry(jwtClaims)));
+    return merged;
+  }
+
+  private static Map<String, Object> merge(
+      final Map<String, Object> jwtClaims, final Map<String, Object> userInfoClaims) {
+    final Map<String, Object> merged = new HashMap<>(jwtClaims);
+    merged.putAll(userInfoClaims); // userinfo wins on conflict
+    return Map.copyOf(merged);
+  }
+
+  private static String cacheKey(final Map<String, Object> jwtClaims, final String tokenValue) {
+    final Object jti = jwtClaims.get("jti");
+    if (jti instanceof final String s && !s.isBlank()) {
+      return "jti:" + s;
+    }
+    return "tok:" + sha256(tokenValue);
+  }
+
+  private static String sha256(final String input) {
+    try {
+      final MessageDigest md = MessageDigest.getInstance("SHA-256");
+      return HexFormat.of().formatHex(md.digest(input.getBytes(StandardCharsets.UTF_8)));
+    } catch (final Exception e) {
+      throw new IllegalStateException("SHA-256 unavailable", e);
+    }
+  }
+
+  private static Instant tokenExpiry(final Map<String, Object> jwtClaims) {
+    final Object exp = jwtClaims.get("exp");
+    if (exp instanceof Number n) {
+      return Instant.ofEpochSecond(n.longValue());
+    }
+    return Instant.now().plus(Duration.ofMinutes(5));
+  }
+
+  private record CacheEntry(
+      Map<String, Object> claims, OidcUserInfoException failure, Instant tokenExp) {
+
+    static CacheEntry success(final Map<String, Object> claims, final Instant tokenExp) {
+      return new CacheEntry(claims, null, tokenExp);
+    }
+
+    static CacheEntry failure(final OidcUserInfoException e) {
+      return new CacheEntry(null, e, null);
+    }
+  }
+
+  /**
+   * Caffeine {@link Expiry} that expires successful entries at min(configured TTL, token exp − skew
+   * − now) and uses a short fixed TTL for failure entries.
+   */
+  private final class EntryExpiry implements Expiry<String, CacheEntry> {
+    private final Duration configuredTtl;
+
+    EntryExpiry(final Duration configuredTtl) {
+      this.configuredTtl = configuredTtl;
+    }
+
+    @Override
+    public long expireAfterCreate(
+        final String key, final CacheEntry value, final long currentTime) {
+      return ttlNanos(value);
+    }
+
+    @Override
+    public long expireAfterUpdate(
+        final String key,
+        final CacheEntry value,
+        final long currentTime,
+        final long currentDuration) {
+      return ttlNanos(value);
+    }
+
+    @Override
+    public long expireAfterRead(
+        final String key,
+        final CacheEntry value,
+        final long currentTime,
+        final long currentDuration) {
+      return currentDuration;
+    }
+
+    private long ttlNanos(final CacheEntry value) {
+      if (value.failure() != null) {
+        return OidcUserInfoAugmentationConfiguration.NEGATIVE_CACHE_TTL.toNanos();
+      }
+      final Duration untilExp = Duration.between(Instant.now(), value.tokenExp()).minus(clockSkew);
+      final Duration effective =
+          untilExp.isNegative() || untilExp.isZero() || untilExp.compareTo(configuredTtl) < 0
+              ? untilExp
+              : configuredTtl;
+      if (effective.isNegative() || effective.isZero()) {
+        return 0L;
+      }
+      return effective.toNanos();
+    }
+  }
+}

--- a/security/security-core/src/main/java/io/camunda/security/oidc/CachingOidcClaimsProvider.java
+++ b/security/security-core/src/main/java/io/camunda/security/oidc/CachingOidcClaimsProvider.java
@@ -35,7 +35,8 @@ import org.slf4j.LoggerFactory;
  * <p>Runtime fail-open on IdP errors: a {@code /userinfo} fetch failure (network, non-2xx, parse
  * failure, or UserInfo {@code sub} mismatch per OIDC Core §5.3.2) is logged at ERROR and the
  * provider returns the JWT claims unchanged. Degraded entries are negatively cached for a short TTL
- * ({@link OidcUserInfoAugmentationConfiguration#NEGATIVE_CACHE_TTL}) to avoid hammering a down IdP.
+ * ({@link OidcUserInfoAugmentationConfiguration#getNegativeCacheTtl()}) to avoid hammering a down
+ * IdP.
  */
 public class CachingOidcClaimsProvider implements OidcClaimsProvider {
 

--- a/security/security-core/src/main/java/io/camunda/security/oidc/NoopOidcClaimsProvider.java
+++ b/security/security-core/src/main/java/io/camunda/security/oidc/NoopOidcClaimsProvider.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.oidc;
+
+import java.util.Map;
+
+/**
+ * Pass-through {@link OidcClaimsProvider}. Returns the JWT claims unchanged without calling the
+ * UserInfo endpoint. Used when UserInfo augmentation is disabled or unavailable.
+ */
+public class NoopOidcClaimsProvider implements OidcClaimsProvider {
+
+  @Override
+  public Map<String, Object> claimsFor(
+      final Map<String, Object> jwtClaims, final String tokenValue) {
+    return jwtClaims;
+  }
+}

--- a/security/security-core/src/main/java/io/camunda/security/oidc/OidcClaimsProvider.java
+++ b/security/security-core/src/main/java/io/camunda/security/oidc/OidcClaimsProvider.java
@@ -12,15 +12,18 @@ import java.util.Map;
 /**
  * Resolves the final claims map used for authorization from a validated JWT's claims and the raw
  * token value. Implementations may augment the JWT claims with the OIDC UserInfo response, subject
- * to provider-specific configuration and caching.
+ * to provider-specific configuration, caching, and failure-handling behaviour. Specifically,
+ * implementations choose whether to fail open (return JWT-only claims on UserInfo failure) or fail
+ * closed (propagate an exception); see the concrete implementation's Javadoc for its policy.
  */
 public interface OidcClaimsProvider {
 
   /**
    * @param jwtClaims the claims as extracted from the validated JWT access token
    * @param tokenValue the raw bearer token string (needed if UserInfo must be called)
-   * @return the claims map to be used for principal and authorization resolution
-   * @throws OidcUserInfoException if UserInfo augmentation is required but the IdP call fails
+   * @return the claims map to be used for principal and authorization resolution. Fail-open
+   *     implementations may return the original JWT claims unchanged when UserInfo augmentation is
+   *     unavailable; fail-closed implementations may throw to reject the request.
    */
   Map<String, Object> claimsFor(Map<String, Object> jwtClaims, String tokenValue);
 }

--- a/security/security-core/src/main/java/io/camunda/security/oidc/OidcClaimsProvider.java
+++ b/security/security-core/src/main/java/io/camunda/security/oidc/OidcClaimsProvider.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.oidc;
+
+import java.util.Map;
+
+/**
+ * Resolves the final claims map used for authorization from a validated JWT's claims and the raw
+ * token value. Implementations may augment the JWT claims with the OIDC UserInfo response, subject
+ * to provider-specific configuration and caching.
+ */
+public interface OidcClaimsProvider {
+
+  /**
+   * @param jwtClaims the claims as extracted from the validated JWT access token
+   * @param tokenValue the raw bearer token string (needed if UserInfo must be called)
+   * @return the claims map to be used for principal and authorization resolution
+   * @throws OidcUserInfoException if UserInfo augmentation is required but the IdP call fails
+   */
+  Map<String, Object> claimsFor(Map<String, Object> jwtClaims, String tokenValue);
+}

--- a/security/security-core/src/main/java/io/camunda/security/oidc/OidcUserInfoClient.java
+++ b/security/security-core/src/main/java/io/camunda/security/oidc/OidcUserInfoClient.java
@@ -14,14 +14,32 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
 /**
  * Thin wrapper around {@link HttpClient} for calling an OIDC provider's UserInfo endpoint with a
  * bearer token and parsing the JSON response into a claim map.
+ *
+ * <p>Defences against common IdP misbehaviour:
+ *
+ * <ul>
+ *   <li>Response body size capped at {@value #MAX_BODY_BYTES} bytes. A misconfigured or hostile
+ *       endpoint streaming unbounded data is rejected rather than consuming heap.
+ *   <li>{@code Content-Type} is checked before JSON parsing. Signed UserInfo responses ({@code
+ *       application/jwt}, per OIDC Core §5.3.2) are not supported in this version and are rejected
+ *       with a clear error rather than producing a confusing JSON parse failure.
+ * </ul>
  */
 public class OidcUserInfoClient {
+
+  /**
+   * Maximum accepted UserInfo response body size (bytes). OIDC UserInfo responses are typically
+   * well under 10 KiB; 1 MiB is generous for well-behaved IdPs and caps memory exposure under
+   * adversarial or misconfigured ones.
+   */
+  public static final int MAX_BODY_BYTES = 1 << 20; // 1 MiB
 
   private static final TypeReference<Map<String, Object>> CLAIMS_TYPE = new TypeReference<>() {};
 
@@ -55,8 +73,24 @@ public class OidcUserInfoClient {
       throw new OidcUserInfoException("UserInfo request returned HTTP " + response.statusCode());
     }
 
+    final byte[] body = response.body();
+    if (body != null && body.length > MAX_BODY_BYTES) {
+      throw new OidcUserInfoException(
+          "UserInfo response exceeds maximum accepted size ("
+              + MAX_BODY_BYTES
+              + " bytes); refusing to parse");
+    }
+
+    final String contentType =
+        response.headers().firstValue("Content-Type").orElse("").toLowerCase(Locale.ROOT);
+    if (contentType.contains("application/jwt")) {
+      throw new OidcUserInfoException(
+          "Signed UserInfo responses (application/jwt) are not supported in this version; "
+              + "configure the IdP to return application/json or disable userInfoAugmentation");
+    }
+
     try {
-      return objectMapper.readValue(response.body(), CLAIMS_TYPE);
+      return objectMapper.readValue(body, CLAIMS_TYPE);
     } catch (final Exception e) {
       throw new OidcUserInfoException("Failed to parse UserInfo JSON: " + e.getMessage(), e);
     }

--- a/security/security-core/src/main/java/io/camunda/security/oidc/OidcUserInfoClient.java
+++ b/security/security-core/src/main/java/io/camunda/security/oidc/OidcUserInfoClient.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.oidc;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Thin wrapper around {@link HttpClient} for calling an OIDC provider's UserInfo endpoint with a
+ * bearer token and parsing the JSON response into a claim map.
+ */
+public class OidcUserInfoClient {
+
+  private static final TypeReference<Map<String, Object>> CLAIMS_TYPE = new TypeReference<>() {};
+
+  private final HttpClient httpClient;
+  private final ObjectMapper objectMapper;
+  private final Duration requestTimeout;
+
+  public OidcUserInfoClient(final HttpClient httpClient, final Duration requestTimeout) {
+    this.httpClient = Objects.requireNonNull(httpClient);
+    this.requestTimeout = Objects.requireNonNull(requestTimeout);
+    objectMapper = new ObjectMapper();
+  }
+
+  public Map<String, Object> fetch(final URI userInfoUri, final String bearerToken) {
+    final HttpRequest request =
+        HttpRequest.newBuilder(userInfoUri)
+            .timeout(requestTimeout)
+            .header("Authorization", "Bearer " + bearerToken)
+            .header("Accept", "application/json")
+            .GET()
+            .build();
+
+    final HttpResponse<byte[]> response;
+    try {
+      response = httpClient.send(request, HttpResponse.BodyHandlers.ofByteArray());
+    } catch (final Exception e) {
+      throw new OidcUserInfoException("UserInfo request failed: " + e.getMessage(), e);
+    }
+
+    if (response.statusCode() / 100 != 2) {
+      throw new OidcUserInfoException("UserInfo request returned HTTP " + response.statusCode());
+    }
+
+    try {
+      return objectMapper.readValue(response.body(), CLAIMS_TYPE);
+    } catch (final Exception e) {
+      throw new OidcUserInfoException("Failed to parse UserInfo JSON: " + e.getMessage(), e);
+    }
+  }
+}

--- a/security/security-core/src/main/java/io/camunda/security/oidc/OidcUserInfoClient.java
+++ b/security/security-core/src/main/java/io/camunda/security/oidc/OidcUserInfoClient.java
@@ -65,6 +65,9 @@ public class OidcUserInfoClient {
     final HttpResponse<byte[]> response;
     try {
       response = httpClient.send(request, HttpResponse.BodyHandlers.ofByteArray());
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new OidcUserInfoException("UserInfo request interrupted", e);
     } catch (final Exception e) {
       throw new OidcUserInfoException("UserInfo request failed: " + e.getMessage(), e);
     }

--- a/security/security-core/src/main/java/io/camunda/security/oidc/OidcUserInfoException.java
+++ b/security/security-core/src/main/java/io/camunda/security/oidc/OidcUserInfoException.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.oidc;
+
+public class OidcUserInfoException extends RuntimeException {
+
+  public OidcUserInfoException(final String message) {
+    super(message);
+  }
+
+  public OidcUserInfoException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/security/security-core/src/test/java/io/camunda/security/configuration/OidcUserInfoAugmentationConfigurationTest.java
+++ b/security/security-core/src/test/java/io/camunda/security/configuration/OidcUserInfoAugmentationConfigurationTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+class OidcUserInfoAugmentationConfigurationTest {
+
+  @Test
+  void defaultsAreDisabledWithFiveMinuteTtlAndTenThousandEntries() {
+    final var config = new OidcUserInfoAugmentationConfiguration();
+
+    assertThat(config.isEnabled()).isFalse();
+    assertThat(config.getCacheTtl()).isEqualTo(Duration.ofMinutes(5));
+    assertThat(config.getCacheMaxSize()).isEqualTo(10_000);
+  }
+
+  @Test
+  void oidcAuthenticationConfigurationExposesNonNullAugmentationByDefault() {
+    final var oidc = new OidcAuthenticationConfiguration();
+
+    assertThat(oidc.getUserInfoAugmentation()).isNotNull();
+    assertThat(oidc.getUserInfoAugmentation().isEnabled()).isFalse();
+  }
+}

--- a/security/security-core/src/test/java/io/camunda/security/oidc/CachingOidcClaimsProviderTest.java
+++ b/security/security-core/src/test/java/io/camunda/security/oidc/CachingOidcClaimsProviderTest.java
@@ -8,7 +8,6 @@
 package io.camunda.security.oidc;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -24,6 +23,10 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -46,37 +49,129 @@ class CachingOidcClaimsProviderTest {
     meterRegistry = new SimpleMeterRegistry();
   }
 
+  private CachingOidcClaimsProvider newProvider() {
+    return newProvider(
+        Map.of(
+            "https://idp.example",
+            URI.create("https://idp.example/userinfo"),
+            "https://idp-a.example",
+            URI.create("https://idp-a.example/userinfo"),
+            "https://idp-b.example",
+            URI.create("https://idp-b.example/userinfo")));
+  }
+
+  private CachingOidcClaimsProvider newProvider(final Map<String, URI> userInfoUriByIssuer) {
+    return new CachingOidcClaimsProvider(
+        oidcConfig, userInfoUriByIssuer, userInfoClient, meterRegistry);
+  }
+
   @Test
   void returnsJwtClaimsUnchangedWhenAugmentationDisabled() {
     oidcConfig.getUserInfoAugmentation().setEnabled(false);
-    final var provider =
-        new CachingOidcClaimsProvider(
-            oidcConfig, URI.create("https://idp.example/userinfo"), userInfoClient, meterRegistry);
+    final var provider = newProvider();
 
     final Map<String, Object> jwtClaims = Map.of("sub", "alice");
-    final var result = provider.claimsFor(jwtClaims, "token-abc");
-
-    assertThat(result).isSameAs(jwtClaims);
+    assertThat(provider.claimsFor(jwtClaims, "token-abc")).isSameAs(jwtClaims);
     verify(userInfoClient, times(0)).fetch(any(), any());
   }
 
   @Test
-  void callsUserInfoOnceAndMergesClaimsOverJwt() {
+  void mergeIsAdditiveOnlyJwtWinsOnConflict() {
+    // UserInfo tries to override claims that should be JWT-authoritative.
     when(userInfoClient.fetch(any(), eq("token-abc")))
-        .thenReturn(Map.of("groups", List.of("eng"), "sub", "alice-from-userinfo"));
+        .thenReturn(
+            Map.of(
+                "sub",
+                "alice", // matches JWT — legitimate
+                "groups",
+                List.of("eng"), // absent from JWT — should be added
+                "exp",
+                Instant.now().plusSeconds(99_999).getEpochSecond(), // UserInfo MUST NOT override
+                "email",
+                "alice@example.com")); // absent from JWT — added
 
-    final var provider =
-        new CachingOidcClaimsProvider(
-            oidcConfig, URI.create("https://idp.example/userinfo"), userInfoClient, meterRegistry);
-
+    final var provider = newProvider();
+    final long exp = Instant.now().getEpochSecond() + 3600;
     final Map<String, Object> jwtClaims =
-        Map.of("sub", "alice", "jti", "jti-1", "exp", Instant.now().getEpochSecond() + 3600);
+        Map.of(
+            "sub",
+            "alice",
+            "iss",
+            "https://idp.example",
+            "scope",
+            "openid",
+            "jti",
+            "jti-1",
+            "exp",
+            exp);
 
-    final var result = provider.claimsFor(jwtClaims, "token-abc");
+    final Map<String, Object> result = provider.claimsFor(jwtClaims, "token-abc");
+
+    assertThat(result)
+        .containsEntry("sub", "alice")
+        .containsEntry("iss", "https://idp.example")
+        .containsEntry("jti", "jti-1")
+        .containsEntry("exp", exp) // JWT's exp preserved; UserInfo's ignored
+        .containsEntry("groups", List.of("eng")) // additive
+        .containsEntry("email", "alice@example.com"); // additive
+  }
+
+  @Test
+  void fallsBackToJwtClaimsWhenUserInfoSubMismatchesJwtSub() {
+    // Spec §5.3.2 MUST — UserInfo sub must equal JWT sub. Mismatch means the IdP
+    // returned the wrong user's claims; treat as a degradation event, don't merge.
+    when(userInfoClient.fetch(any(), eq("token-abc")))
+        .thenReturn(Map.of("sub", "bob", "groups", List.of("admin")));
+
+    final var provider = newProvider();
+    final long exp = Instant.now().getEpochSecond() + 3600;
+    final Map<String, Object> jwtClaims =
+        Map.of(
+            "sub",
+            "alice",
+            "iss",
+            "https://idp.example",
+            "scope",
+            "openid",
+            "jti",
+            "jti-1",
+            "exp",
+            exp);
+
+    final Map<String, Object> result = provider.claimsFor(jwtClaims, "token-abc");
+
+    // groups from bob's response must NOT reach alice's authorization
+    assertThat(result).containsEntry("sub", "alice").doesNotContainKey("groups");
+    assertThat(
+            meterRegistry
+                .get("camunda.oidc.userinfo.fetch")
+                .tag("outcome", "failure")
+                .counter()
+                .count())
+        .isEqualTo(1.0);
+  }
+
+  @Test
+  void callsUserInfoOnceAndAddsMissingClaimsFromUserInfo() {
+    when(userInfoClient.fetch(any(), eq("token-abc"))).thenReturn(Map.of("groups", List.of("eng")));
+
+    final var provider = newProvider();
+    final Map<String, Object> jwtClaims =
+        Map.of(
+            "sub",
+            "alice",
+            "iss",
+            "https://idp.example",
+            "scope",
+            "openid",
+            "jti",
+            "jti-1",
+            "exp",
+            Instant.now().getEpochSecond() + 3600);
+
+    final Map<String, Object> result = provider.claimsFor(jwtClaims, "token-abc");
 
     assertThat(result).containsEntry("groups", List.of("eng"));
-    assertThat(result).containsEntry("sub", "alice-from-userinfo"); // userinfo overrides
-    assertThat(result).containsEntry("jti", "jti-1"); // jwt-only claim preserved
     verify(userInfoClient, times(1)).fetch(any(), any());
   }
 
@@ -84,12 +179,19 @@ class CachingOidcClaimsProviderTest {
   void cachesByJtiSoSecondCallDoesNotHitIdp() {
     when(userInfoClient.fetch(any(), any())).thenReturn(Map.of("groups", List.of("eng")));
 
-    final var provider =
-        new CachingOidcClaimsProvider(
-            oidcConfig, URI.create("https://idp.example/userinfo"), userInfoClient, meterRegistry);
-
+    final var provider = newProvider();
     final Map<String, Object> jwtClaims =
-        Map.of("sub", "alice", "jti", "jti-1", "exp", Instant.now().getEpochSecond() + 3600);
+        Map.of(
+            "sub",
+            "alice",
+            "iss",
+            "https://idp.example",
+            "scope",
+            "openid",
+            "jti",
+            "jti-1",
+            "exp",
+            Instant.now().getEpochSecond() + 3600);
 
     provider.claimsFor(jwtClaims, "token-abc");
     provider.claimsFor(jwtClaims, "token-abc");
@@ -101,70 +203,326 @@ class CachingOidcClaimsProviderTest {
   void distinctJtisResultInDistinctCacheEntries() {
     when(userInfoClient.fetch(any(), any())).thenReturn(Map.of("groups", List.of("eng")));
 
-    final var provider =
-        new CachingOidcClaimsProvider(
-            oidcConfig, URI.create("https://idp.example/userinfo"), userInfoClient, meterRegistry);
-
+    final var provider = newProvider();
     final long exp = Instant.now().getEpochSecond() + 3600;
-    provider.claimsFor(Map.of("sub", "alice", "jti", "jti-1", "exp", exp), "token-a");
-    provider.claimsFor(Map.of("sub", "alice", "jti", "jti-2", "exp", exp), "token-b");
+    provider.claimsFor(
+        Map.of(
+            "sub",
+            "alice",
+            "iss",
+            "https://idp.example",
+            "scope",
+            "openid",
+            "jti",
+            "jti-1",
+            "exp",
+            exp),
+        "token-a");
+    provider.claimsFor(
+        Map.of(
+            "sub",
+            "alice",
+            "iss",
+            "https://idp.example",
+            "scope",
+            "openid",
+            "jti",
+            "jti-2",
+            "exp",
+            exp),
+        "token-b");
 
     verify(userInfoClient, times(2)).fetch(any(), any());
   }
 
   @Test
-  void fallsBackToTokenHashWhenJtiAbsent() {
+  void cacheKeyIncludesIssSoSameJtiFromDifferentIssuersDoNotCollide() {
+    // Key invariant: jti is only unique per-issuer (RFC 7519); without the iss prefix,
+    // two providers could legitimately issue tokens with the same jti and collide in the
+    // cache, leaking one user's merged claims to the other.
     when(userInfoClient.fetch(any(), any())).thenReturn(Map.of("groups", List.of("eng")));
 
-    final var provider =
-        new CachingOidcClaimsProvider(
-            oidcConfig, URI.create("https://idp.example/userinfo"), userInfoClient, meterRegistry);
-
+    final var provider = newProvider();
     final long exp = Instant.now().getEpochSecond() + 3600;
-    final Map<String, Object> claimsNoJti = Map.of("sub", "alice", "exp", exp);
 
-    provider.claimsFor(claimsNoJti, "token-abc");
-    provider.claimsFor(claimsNoJti, "token-abc"); // same token -> same cache entry
-    provider.claimsFor(claimsNoJti, "token-xyz"); // different token -> new entry
+    final Map<String, Object> issA =
+        Map.of(
+            "sub",
+            "alice",
+            "iss",
+            "https://idp-a.example",
+            "scope",
+            "openid",
+            "jti",
+            "shared-jti",
+            "exp",
+            exp);
+    final Map<String, Object> issB =
+        Map.of(
+            "sub",
+            "alice",
+            "iss",
+            "https://idp-b.example",
+            "scope",
+            "openid",
+            "jti",
+            "shared-jti",
+            "exp",
+            exp);
+
+    provider.claimsFor(issA, "token-a");
+    provider.claimsFor(issB, "token-b");
 
     verify(userInfoClient, times(2)).fetch(any(), any());
   }
 
   @Test
-  void failsClosedWhenUserInfoThrows() {
-    when(userInfoClient.fetch(any(), any())).thenThrow(new OidcUserInfoException("boom"));
+  void fallsBackToSubIatExpKeyWhenJtiAbsent() {
+    when(userInfoClient.fetch(any(), any())).thenReturn(Map.of("groups", List.of("eng")));
 
-    final var provider =
-        new CachingOidcClaimsProvider(
-            oidcConfig, URI.create("https://idp.example/userinfo"), userInfoClient, meterRegistry);
+    final var provider = newProvider();
+    final long exp = Instant.now().getEpochSecond() + 3600;
+    final long iat = Instant.now().getEpochSecond();
+    final Map<String, Object> claimsNoJti =
+        Map.of(
+            "sub",
+            "alice",
+            "iss",
+            "https://idp.example",
+            "scope",
+            "openid",
+            "iat",
+            iat,
+            "exp",
+            exp);
 
-    final Map<String, Object> jwtClaims =
-        Map.of("sub", "alice", "jti", "jti-1", "exp", Instant.now().getEpochSecond() + 3600);
+    provider.claimsFor(claimsNoJti, "token-abc");
+    provider.claimsFor(claimsNoJti, "token-abc"); // same sub+iat+exp+iss -> cache hit
 
-    assertThatThrownBy(() -> provider.claimsFor(jwtClaims, "token-abc"))
-        .isInstanceOf(OidcUserInfoException.class);
+    verify(userInfoClient, times(1)).fetch(any(), any());
   }
 
   @Test
-  void negativeCachePreventsHammeringDuringOutage() {
+  void routesUserInfoFetchToUriMatchingJwtIssuer() {
+    // Multi-provider deployment: verify tokens go to their own issuer's userinfo URI.
+    when(userInfoClient.fetch(eq(URI.create("https://idp-a.example/userinfo")), eq("token-from-a")))
+        .thenReturn(Map.of("groups", List.of("team-a")));
+    when(userInfoClient.fetch(eq(URI.create("https://idp-b.example/userinfo")), eq("token-from-b")))
+        .thenReturn(Map.of("groups", List.of("team-b")));
+
+    final var provider = newProvider();
+    final long exp = Instant.now().getEpochSecond() + 3600;
+    final Map<String, Object> tokenA =
+        Map.of(
+            "sub",
+            "alice",
+            "iss",
+            "https://idp-a.example",
+            "scope",
+            "openid",
+            "jti",
+            "jti-a",
+            "exp",
+            exp);
+    final Map<String, Object> tokenB =
+        Map.of(
+            "sub",
+            "bob",
+            "iss",
+            "https://idp-b.example",
+            "scope",
+            "openid",
+            "jti",
+            "jti-b",
+            "exp",
+            exp);
+
+    final Map<String, Object> resultA = provider.claimsFor(tokenA, "token-from-a");
+    final Map<String, Object> resultB = provider.claimsFor(tokenB, "token-from-b");
+
+    assertThat(resultA).containsEntry("groups", List.of("team-a"));
+    assertThat(resultB).containsEntry("groups", List.of("team-b"));
+    verify(userInfoClient, times(1))
+        .fetch(eq(URI.create("https://idp-a.example/userinfo")), eq("token-from-a"));
+    verify(userInfoClient, times(1))
+        .fetch(eq(URI.create("https://idp-b.example/userinfo")), eq("token-from-b"));
+  }
+
+  @Test
+  void fallsBackToJwtClaimsWhenIssuerHasNoRegisteredUserInfoUri() {
+    // Token claims to be from an unknown issuer — no URL in the map. Degrade rather than
+    // send the bearer token to a wrong IdP or a guess.
+    final var provider = newProvider();
+    final long exp = Instant.now().getEpochSecond() + 3600;
+    final Map<String, Object> unknownIssToken =
+        Map.of(
+            "sub",
+            "alice",
+            "iss",
+            "https://rogue.example",
+            "scope",
+            "openid",
+            "jti",
+            "jti-1",
+            "exp",
+            exp);
+
+    final Map<String, Object> result = provider.claimsFor(unknownIssToken, "token-abc");
+
+    assertThat(result).containsEntry("sub", "alice").doesNotContainKey("groups");
+    verify(userInfoClient, times(0)).fetch(any(), any());
+  }
+
+  @Test
+  void skipsAugmentationForTokenWithoutOpenidScope() {
+    // M2M / client-credentials tokens typically lack 'openid' scope. Calling /userinfo with
+    // them is undefined per OIDC Core §5.3; skip silently and return JWT claims.
+    final var provider = newProvider();
+    final long exp = Instant.now().getEpochSecond() + 3600;
+    final Map<String, Object> m2mToken =
+        Map.of(
+            "sub",
+            "svc-account-1",
+            "iss",
+            "https://idp.example",
+            "jti",
+            "jti-m2m",
+            "exp",
+            exp,
+            "scope",
+            "write:jobs read:processes");
+
+    final Map<String, Object> result = provider.claimsFor(m2mToken, "token-abc");
+
+    assertThat(result).isSameAs(m2mToken);
+    verify(userInfoClient, times(0)).fetch(any(), any());
+  }
+
+  @Test
+  void acceptsOpenidScopeAsCollectionInAdditionToSpaceSeparatedString() {
+    when(userInfoClient.fetch(any(), any())).thenReturn(Map.of("groups", List.of("eng")));
+
+    final var provider = newProvider();
+    final long exp = Instant.now().getEpochSecond() + 3600;
+    final Map<String, Object> scopeAsList =
+        Map.of(
+            "sub",
+            "alice",
+            "iss",
+            "https://idp.example",
+            "jti",
+            "jti-coll",
+            "exp",
+            exp,
+            "scope",
+            List.of("openid", "profile"));
+
+    final Map<String, Object> result = provider.claimsFor(scopeAsList, "token-abc");
+
+    assertThat(result).containsEntry("groups", List.of("eng"));
+    verify(userInfoClient, times(1)).fetch(any(), any());
+  }
+
+  @Test
+  void bypassesCacheWhenNeitherJtiNorSubIatExpAvailable() {
+    // Malformed/unusual JWT with no jti, no iat, no exp. Can't key safely — skip cache
+    // entirely so we never store the bearer-token material and every request re-fetches.
+    when(userInfoClient.fetch(any(), any())).thenReturn(Map.of("groups", List.of("eng")));
+
+    final var provider = newProvider();
+    final Map<String, Object> sparseClaims =
+        Map.of("sub", "alice", "iss", "https://idp.example", "scope", "openid");
+
+    provider.claimsFor(sparseClaims, "token-abc");
+    provider.claimsFor(sparseClaims, "token-abc");
+
+    verify(userInfoClient, times(2)).fetch(any(), any());
+  }
+
+  @Test
+  void fallsBackToJwtClaimsWhenUserInfoFetchThrows() {
     when(userInfoClient.fetch(any(), any())).thenThrow(new OidcUserInfoException("IdP down"));
 
-    final var provider =
-        new CachingOidcClaimsProvider(
-            oidcConfig, URI.create("https://idp.example/userinfo"), userInfoClient, meterRegistry);
-
+    final var provider = newProvider();
     final Map<String, Object> jwtClaims =
-        Map.of("sub", "alice", "jti", "jti-1", "exp", Instant.now().getEpochSecond() + 3600);
+        Map.of(
+            "sub",
+            "alice",
+            "iss",
+            "https://idp.example",
+            "scope",
+            "openid",
+            "jti",
+            "jti-1",
+            "exp",
+            Instant.now().getEpochSecond() + 3600);
+
+    // Fail-open: returns JWT claims unchanged, increments failure counter, does not throw.
+    final Map<String, Object> result = provider.claimsFor(jwtClaims, "token-abc");
+    assertThat(result).containsEntry("sub", "alice").doesNotContainKey("groups");
+    assertThat(
+            meterRegistry
+                .get("camunda.oidc.userinfo.fetch")
+                .tag("outcome", "failure")
+                .counter()
+                .count())
+        .isEqualTo(1.0);
+  }
+
+  @Test
+  void degradedEntryPreventsRetrySpamDuringOutage() {
+    when(userInfoClient.fetch(any(), any())).thenThrow(new OidcUserInfoException("IdP down"));
+
+    final var provider = newProvider();
+    final Map<String, Object> jwtClaims =
+        Map.of(
+            "sub",
+            "alice",
+            "iss",
+            "https://idp.example",
+            "scope",
+            "openid",
+            "jti",
+            "jti-1",
+            "exp",
+            Instant.now().getEpochSecond() + 3600);
 
     for (int i = 0; i < 20; i++) {
-      try {
-        provider.claimsFor(jwtClaims, "token-abc");
-      } catch (final OidcUserInfoException ignored) {
-        // expected
-      }
+      provider.claimsFor(jwtClaims, "token-abc");
     }
 
     verify(userInfoClient, times(1)).fetch(any(), any());
+  }
+
+  @Test
+  void ttlCapRespectsExpWhenExpIsInstant() {
+    // Spring's NimbusJwtDecoder + MappedJwtClaimSetConverter surfaces 'exp' as a
+    // java.time.Instant, not a Number. Regression guard against the earlier
+    // `instanceof Number` check that silently fell through to the 5-minute fallback
+    // in production.
+    when(userInfoClient.fetch(any(), any())).thenReturn(Map.of("groups", List.of("eng")));
+
+    oidcConfig.getUserInfoAugmentation().setCacheTtl(Duration.ofHours(1));
+    final var provider = newProvider();
+
+    final Instant expPast = Instant.now().minusSeconds(120);
+    final Map<String, Object> expired =
+        Map.of(
+            "sub",
+            "alice",
+            "iss",
+            "https://idp.example",
+            "scope",
+            "openid",
+            "jti",
+            "jti-i",
+            "exp",
+            expPast);
+
+    provider.claimsFor(expired, "token-abc");
+    provider.claimsFor(expired, "token-abc");
+
+    verify(userInfoClient, times(2)).fetch(any(), any());
   }
 
   @Test
@@ -172,13 +530,22 @@ class CachingOidcClaimsProviderTest {
     when(userInfoClient.fetch(any(), any())).thenReturn(Map.of("groups", List.of("eng")));
 
     oidcConfig.getUserInfoAugmentation().setCacheTtl(Duration.ofHours(1));
-    final var provider =
-        new CachingOidcClaimsProvider(
-            oidcConfig, URI.create("https://idp.example/userinfo"), userInfoClient, meterRegistry);
+    final var provider = newProvider();
 
     // exp is far enough in the past that after clockSkew the effective TTL is <= 0
     final long expPast = Instant.now().minusSeconds(120).getEpochSecond();
-    final Map<String, Object> expired = Map.of("sub", "alice", "jti", "jti-1", "exp", expPast);
+    final Map<String, Object> expired =
+        Map.of(
+            "sub",
+            "alice",
+            "iss",
+            "https://idp.example",
+            "scope",
+            "openid",
+            "jti",
+            "jti-1",
+            "exp",
+            expPast);
 
     provider.claimsFor(expired, "token-abc");
     provider.claimsFor(expired, "token-abc");
@@ -191,12 +558,19 @@ class CachingOidcClaimsProviderTest {
   void exposesHitAndMissCounters() {
     when(userInfoClient.fetch(any(), any())).thenReturn(Map.of("groups", List.of("eng")));
 
-    final var provider =
-        new CachingOidcClaimsProvider(
-            oidcConfig, URI.create("https://idp.example/userinfo"), userInfoClient, meterRegistry);
-
+    final var provider = newProvider();
     final Map<String, Object> jwtClaims =
-        Map.of("sub", "alice", "jti", "jti-1", "exp", Instant.now().getEpochSecond() + 3600);
+        Map.of(
+            "sub",
+            "alice",
+            "iss",
+            "https://idp.example",
+            "scope",
+            "openid",
+            "jti",
+            "jti-1",
+            "exp",
+            Instant.now().getEpochSecond() + 3600);
 
     provider.claimsFor(jwtClaims, "token-abc"); // miss
     provider.claimsFor(jwtClaims, "token-abc"); // hit
@@ -211,5 +585,96 @@ class CachingOidcClaimsProviderTest {
     assertThat(
             meterRegistry.get("camunda.oidc.userinfo.cache").tag("result", "hit").counter().count())
         .isEqualTo(1.0);
+  }
+
+  @Test
+  void concurrentRequestsForSameJtiTriggerSingleFetch() throws Exception {
+    final CountDownLatch startGate = new CountDownLatch(1);
+    final CountDownLatch finishGate = new CountDownLatch(10);
+    when(userInfoClient.fetch(any(), any()))
+        .thenAnswer(
+            invocation -> {
+              // slow fetch — simulates IdP latency so all threads race on the miss
+              Thread.sleep(50);
+              return Map.of("groups", List.of("eng"));
+            });
+
+    final var provider = newProvider();
+    final Map<String, Object> jwtClaims =
+        Map.of(
+            "sub",
+            "alice",
+            "iss",
+            "https://idp.example",
+            "scope",
+            "openid",
+            "jti",
+            "jti-concurrent",
+            "exp",
+            Instant.now().getEpochSecond() + 3600);
+
+    final ExecutorService pool = Executors.newFixedThreadPool(10);
+    try {
+      for (int i = 0; i < 10; i++) {
+        pool.submit(
+            () -> {
+              try {
+                startGate.await();
+                provider.claimsFor(jwtClaims, "token-concurrent");
+              } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+              } finally {
+                finishGate.countDown();
+              }
+            });
+      }
+      startGate.countDown(); // release all threads
+      assertThat(finishGate.await(5, TimeUnit.SECONDS)).isTrue();
+    } finally {
+      pool.shutdownNow();
+    }
+
+    // Caffeine's atomic cache.get(key, loader) coalesces concurrent misses on the same key.
+    verify(userInfoClient, times(1)).fetch(any(), any());
+  }
+
+  @Test
+  void restoresInterruptFlagWhenFetchIsInterrupted() throws Exception {
+    when(userInfoClient.fetch(any(), any()))
+        .thenAnswer(
+            invocation -> {
+              throw new InterruptedException("simulated interrupt during fetch");
+            });
+
+    final var provider = newProvider();
+    final Map<String, Object> jwtClaims =
+        Map.of(
+            "sub",
+            "alice",
+            "iss",
+            "https://idp.example",
+            "scope",
+            "openid",
+            "jti",
+            "jti-int",
+            "exp",
+            Instant.now().getEpochSecond() + 3600);
+
+    // Run in a dedicated thread so we can inspect its interrupt state.
+    final boolean[] interruptedAfter = {false};
+    final Map<String, Object>[] result = new Map[1];
+    final Thread t =
+        new Thread(
+            () -> {
+              result[0] = provider.claimsFor(jwtClaims, "token-int");
+              interruptedAfter[0] = Thread.interrupted();
+            });
+    t.start();
+    t.join(2_000);
+
+    assertThat(interruptedAfter[0])
+        .as("interrupt flag must be restored after swallowed InterruptedException")
+        .isTrue();
+    assertThat(result[0]).as("fail-open returns JWT claims").containsEntry("sub", "alice");
   }
 }

--- a/security/security-core/src/test/java/io/camunda/security/oidc/CachingOidcClaimsProviderTest.java
+++ b/security/security-core/src/test/java/io/camunda/security/oidc/CachingOidcClaimsProviderTest.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.oidc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.security.configuration.OidcAuthenticationConfiguration;
+import io.camunda.security.configuration.OidcUserInfoAugmentationConfiguration;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class CachingOidcClaimsProviderTest {
+
+  private OidcAuthenticationConfiguration oidcConfig;
+  private OidcUserInfoClient userInfoClient;
+  private SimpleMeterRegistry meterRegistry;
+
+  @BeforeEach
+  void setUp() {
+    oidcConfig = new OidcAuthenticationConfiguration();
+    oidcConfig.setIssuerUri("https://idp.example");
+    final var aug = new OidcUserInfoAugmentationConfiguration();
+    aug.setEnabled(true);
+    aug.setCacheTtl(Duration.ofMinutes(5));
+    aug.setCacheMaxSize(100);
+    oidcConfig.setUserInfoAugmentation(aug);
+    userInfoClient = mock(OidcUserInfoClient.class);
+    meterRegistry = new SimpleMeterRegistry();
+  }
+
+  @Test
+  void returnsJwtClaimsUnchangedWhenAugmentationDisabled() {
+    oidcConfig.getUserInfoAugmentation().setEnabled(false);
+    final var provider =
+        new CachingOidcClaimsProvider(
+            oidcConfig, URI.create("https://idp.example/userinfo"), userInfoClient, meterRegistry);
+
+    final Map<String, Object> jwtClaims = Map.of("sub", "alice");
+    final var result = provider.claimsFor(jwtClaims, "token-abc");
+
+    assertThat(result).isSameAs(jwtClaims);
+    verify(userInfoClient, times(0)).fetch(any(), any());
+  }
+
+  @Test
+  void callsUserInfoOnceAndMergesClaimsOverJwt() {
+    when(userInfoClient.fetch(any(), eq("token-abc")))
+        .thenReturn(Map.of("groups", List.of("eng"), "sub", "alice-from-userinfo"));
+
+    final var provider =
+        new CachingOidcClaimsProvider(
+            oidcConfig, URI.create("https://idp.example/userinfo"), userInfoClient, meterRegistry);
+
+    final Map<String, Object> jwtClaims =
+        Map.of("sub", "alice", "jti", "jti-1", "exp", Instant.now().getEpochSecond() + 3600);
+
+    final var result = provider.claimsFor(jwtClaims, "token-abc");
+
+    assertThat(result).containsEntry("groups", List.of("eng"));
+    assertThat(result).containsEntry("sub", "alice-from-userinfo"); // userinfo overrides
+    assertThat(result).containsEntry("jti", "jti-1"); // jwt-only claim preserved
+    verify(userInfoClient, times(1)).fetch(any(), any());
+  }
+
+  @Test
+  void cachesByJtiSoSecondCallDoesNotHitIdp() {
+    when(userInfoClient.fetch(any(), any())).thenReturn(Map.of("groups", List.of("eng")));
+
+    final var provider =
+        new CachingOidcClaimsProvider(
+            oidcConfig, URI.create("https://idp.example/userinfo"), userInfoClient, meterRegistry);
+
+    final Map<String, Object> jwtClaims =
+        Map.of("sub", "alice", "jti", "jti-1", "exp", Instant.now().getEpochSecond() + 3600);
+
+    provider.claimsFor(jwtClaims, "token-abc");
+    provider.claimsFor(jwtClaims, "token-abc");
+
+    verify(userInfoClient, times(1)).fetch(any(), any());
+  }
+
+  @Test
+  void distinctJtisResultInDistinctCacheEntries() {
+    when(userInfoClient.fetch(any(), any())).thenReturn(Map.of("groups", List.of("eng")));
+
+    final var provider =
+        new CachingOidcClaimsProvider(
+            oidcConfig, URI.create("https://idp.example/userinfo"), userInfoClient, meterRegistry);
+
+    final long exp = Instant.now().getEpochSecond() + 3600;
+    provider.claimsFor(Map.of("sub", "alice", "jti", "jti-1", "exp", exp), "token-a");
+    provider.claimsFor(Map.of("sub", "alice", "jti", "jti-2", "exp", exp), "token-b");
+
+    verify(userInfoClient, times(2)).fetch(any(), any());
+  }
+
+  @Test
+  void fallsBackToTokenHashWhenJtiAbsent() {
+    when(userInfoClient.fetch(any(), any())).thenReturn(Map.of("groups", List.of("eng")));
+
+    final var provider =
+        new CachingOidcClaimsProvider(
+            oidcConfig, URI.create("https://idp.example/userinfo"), userInfoClient, meterRegistry);
+
+    final long exp = Instant.now().getEpochSecond() + 3600;
+    final Map<String, Object> claimsNoJti = Map.of("sub", "alice", "exp", exp);
+
+    provider.claimsFor(claimsNoJti, "token-abc");
+    provider.claimsFor(claimsNoJti, "token-abc"); // same token -> same cache entry
+    provider.claimsFor(claimsNoJti, "token-xyz"); // different token -> new entry
+
+    verify(userInfoClient, times(2)).fetch(any(), any());
+  }
+
+  @Test
+  void failsClosedWhenUserInfoThrows() {
+    when(userInfoClient.fetch(any(), any())).thenThrow(new OidcUserInfoException("boom"));
+
+    final var provider =
+        new CachingOidcClaimsProvider(
+            oidcConfig, URI.create("https://idp.example/userinfo"), userInfoClient, meterRegistry);
+
+    final Map<String, Object> jwtClaims =
+        Map.of("sub", "alice", "jti", "jti-1", "exp", Instant.now().getEpochSecond() + 3600);
+
+    assertThatThrownBy(() -> provider.claimsFor(jwtClaims, "token-abc"))
+        .isInstanceOf(OidcUserInfoException.class);
+  }
+
+  @Test
+  void negativeCachePreventsHammeringDuringOutage() {
+    when(userInfoClient.fetch(any(), any())).thenThrow(new OidcUserInfoException("IdP down"));
+
+    final var provider =
+        new CachingOidcClaimsProvider(
+            oidcConfig, URI.create("https://idp.example/userinfo"), userInfoClient, meterRegistry);
+
+    final Map<String, Object> jwtClaims =
+        Map.of("sub", "alice", "jti", "jti-1", "exp", Instant.now().getEpochSecond() + 3600);
+
+    for (int i = 0; i < 20; i++) {
+      try {
+        provider.claimsFor(jwtClaims, "token-abc");
+      } catch (final OidcUserInfoException ignored) {
+        // expected
+      }
+    }
+
+    verify(userInfoClient, times(1)).fetch(any(), any());
+  }
+
+  @Test
+  void ttlIsCappedByTokenExpiry() {
+    when(userInfoClient.fetch(any(), any())).thenReturn(Map.of("groups", List.of("eng")));
+
+    oidcConfig.getUserInfoAugmentation().setCacheTtl(Duration.ofHours(1));
+    final var provider =
+        new CachingOidcClaimsProvider(
+            oidcConfig, URI.create("https://idp.example/userinfo"), userInfoClient, meterRegistry);
+
+    // exp is far enough in the past that after clockSkew the effective TTL is <= 0
+    final long expPast = Instant.now().minusSeconds(120).getEpochSecond();
+    final Map<String, Object> expired = Map.of("sub", "alice", "jti", "jti-1", "exp", expPast);
+
+    provider.claimsFor(expired, "token-abc");
+    provider.claimsFor(expired, "token-abc");
+
+    // Entry expired immediately, both calls should hit the IdP
+    verify(userInfoClient, times(2)).fetch(any(), any());
+  }
+
+  @Test
+  void exposesHitAndMissCounters() {
+    when(userInfoClient.fetch(any(), any())).thenReturn(Map.of("groups", List.of("eng")));
+
+    final var provider =
+        new CachingOidcClaimsProvider(
+            oidcConfig, URI.create("https://idp.example/userinfo"), userInfoClient, meterRegistry);
+
+    final Map<String, Object> jwtClaims =
+        Map.of("sub", "alice", "jti", "jti-1", "exp", Instant.now().getEpochSecond() + 3600);
+
+    provider.claimsFor(jwtClaims, "token-abc"); // miss
+    provider.claimsFor(jwtClaims, "token-abc"); // hit
+
+    assertThat(
+            meterRegistry
+                .get("camunda.oidc.userinfo.cache")
+                .tag("result", "miss")
+                .counter()
+                .count())
+        .isEqualTo(1.0);
+    assertThat(
+            meterRegistry.get("camunda.oidc.userinfo.cache").tag("result", "hit").counter().count())
+        .isEqualTo(1.0);
+  }
+}

--- a/security/security-core/src/test/java/io/camunda/security/oidc/NoopOidcClaimsProviderTest.java
+++ b/security/security-core/src/test/java/io/camunda/security/oidc/NoopOidcClaimsProviderTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.oidc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class NoopOidcClaimsProviderTest {
+
+  @Test
+  void returnsJwtClaimsUnchanged() {
+    final var provider = new NoopOidcClaimsProvider();
+    final var input = Map.<String, Object>of("sub", "alice", "iss", "https://idp.example");
+
+    final var output = provider.claimsFor(input, "token-abc");
+
+    assertThat(output).isSameAs(input);
+  }
+}

--- a/security/security-core/src/test/java/io/camunda/security/oidc/OidcUserInfoClientTest.java
+++ b/security/security-core/src/test/java/io/camunda/security/oidc/OidcUserInfoClientTest.java
@@ -61,4 +61,37 @@ class OidcUserInfoClientTest {
     assertThatThrownBy(() -> client.fetch(URI.create(idp.baseUrl() + "/userinfo"), "token-abc"))
         .isInstanceOf(OidcUserInfoException.class);
   }
+
+  @Test
+  void rejectsResponseLargerThanMaxBodyBytes() {
+    // Produce a payload that's just over the cap. StringBuilder is cheap; we're not
+    // exercising JSON parsing, just the size-cap branch.
+    final var oversized = new StringBuilder("{\"sub\":\"alice\",\"filler\":\"");
+    while (oversized.length() <= OidcUserInfoClient.MAX_BODY_BYTES) {
+      oversized.append('a');
+    }
+    oversized.append("\"}");
+    idp.stubFor(get("/userinfo").willReturn(okJson(oversized.toString())));
+
+    assertThatThrownBy(() -> client.fetch(URI.create(idp.baseUrl() + "/userinfo"), "token-abc"))
+        .isInstanceOf(OidcUserInfoException.class)
+        .hasMessageContaining("exceeds maximum accepted size");
+  }
+
+  @Test
+  void rejectsSignedUserInfoResponse() {
+    // OIDC Core §5.3.2 allows signed UserInfo responses (application/jwt). Not supported
+    // in this version — reject with a clear error rather than a confusing JSON parse failure.
+    idp.stubFor(
+        get("/userinfo")
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/jwt")
+                    .withBody("eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJhbGljZSJ9.sig")));
+
+    assertThatThrownBy(() -> client.fetch(URI.create(idp.baseUrl() + "/userinfo"), "token-abc"))
+        .isInstanceOf(OidcUserInfoException.class)
+        .hasMessageContaining("application/jwt");
+  }
 }

--- a/security/security-core/src/test/java/io/camunda/security/oidc/OidcUserInfoClientTest.java
+++ b/security/security-core/src/test/java/io/camunda/security/oidc/OidcUserInfoClientTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.oidc;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class OidcUserInfoClientTest {
+
+  @RegisterExtension
+  static WireMockExtension idp =
+      WireMockExtension.newInstance().options(wireMockConfig().dynamicPort()).build();
+
+  private final OidcUserInfoClient client =
+      new OidcUserInfoClient(HttpClient.newHttpClient(), Duration.ofSeconds(2));
+
+  @Test
+  void returnsClaimsFromSuccessfulResponse() {
+    idp.stubFor(
+        get("/userinfo")
+            .withHeader("Authorization", equalTo("Bearer token-abc"))
+            .willReturn(okJson("{\"sub\":\"alice\",\"groups\":[\"engineering\",\"ops\"]}")));
+
+    final var claims = client.fetch(URI.create(idp.baseUrl() + "/userinfo"), "token-abc");
+
+    assertThat(claims).containsEntry("sub", "alice");
+    assertThat(claims).containsEntry("groups", List.of("engineering", "ops"));
+  }
+
+  @Test
+  void throwsOnNon2xx() {
+    idp.stubFor(get("/userinfo").willReturn(aResponse().withStatus(401)));
+
+    assertThatThrownBy(() -> client.fetch(URI.create(idp.baseUrl() + "/userinfo"), "bad-token"))
+        .isInstanceOf(OidcUserInfoException.class)
+        .hasMessageContaining("401");
+  }
+
+  @Test
+  void throwsOnTimeout() {
+    idp.stubFor(get("/userinfo").willReturn(aResponse().withFixedDelay(3_000).withBody("{}")));
+
+    assertThatThrownBy(() -> client.fetch(URI.create(idp.baseUrl() + "/userinfo"), "token-abc"))
+        .isInstanceOf(OidcUserInfoException.class);
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -90,6 +90,7 @@ public final class Broker implements AutoCloseable {
             systemContext.getUserServices(),
             systemContext.getPasswordEncoder(),
             systemContext.getJwtDecoder(),
+            systemContext.getOidcClaimsProvider(),
             systemContext.getSearchClientsProxy(),
             systemContext.getBrokerRequestAuthorizationConverter(),
             systemContext.getNodeIdProvider());

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
@@ -12,6 +12,7 @@ import io.camunda.identity.sdk.IdentityConfiguration;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.oidc.OidcClaimsProvider;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.PartitionRaftListener;
@@ -139,6 +140,8 @@ public interface BrokerStartupContext {
   PasswordEncoder getPasswordEncoder();
 
   JwtDecoder getJwtDecoder();
+
+  OidcClaimsProvider getOidcClaimsProvider();
 
   SnapshotApiRequestHandler getSnapshotApiRequestHandler();
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
@@ -15,6 +15,7 @@ import io.camunda.identity.sdk.IdentityConfiguration;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.oidc.OidcClaimsProvider;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.PartitionRaftListener;
@@ -67,6 +68,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   private final UserServices userServices;
   private final PasswordEncoder passwordEncoder;
   private final JwtDecoder jwtDecoder;
+  private final OidcClaimsProvider oidcClaimsProvider;
   private final SearchClientsProxy searchClientsProxy;
   private final NodeIdProvider nodeIdProvider;
   private final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter;
@@ -103,6 +105,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
       final UserServices userServices,
       final PasswordEncoder passwordEncoder,
       final JwtDecoder jwtDecoder,
+      final OidcClaimsProvider oidcClaimsProvider,
       final SearchClientsProxy searchClientsProxy,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter,
       final NodeIdProvider nodeIdProvider) {
@@ -122,6 +125,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
     this.userServices = userServices;
     this.passwordEncoder = passwordEncoder;
     this.jwtDecoder = jwtDecoder;
+    this.oidcClaimsProvider = oidcClaimsProvider;
     this.searchClientsProxy = searchClientsProxy;
     this.nodeIdProvider = requireNonNull(nodeIdProvider);
     partitionListeners.addAll(additionalPartitionListeners);
@@ -361,6 +365,11 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   @Override
   public JwtDecoder getJwtDecoder() {
     return jwtDecoder;
+  }
+
+  @Override
+  public OidcClaimsProvider getOidcClaimsProvider() {
+    return oidcClaimsProvider;
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/EmbeddedGatewayServiceStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/EmbeddedGatewayServiceStep.java
@@ -49,6 +49,7 @@ class EmbeddedGatewayServiceStep extends AbstractBrokerStartupStep {
             userService,
             passwordEncoder,
             brokerStartupContext.getJwtDecoder(),
+            brokerStartupContext.getOidcClaimsProvider(),
             brokerStartupContext.getMeterRegistry());
 
     final var embeddedGatewayServiceFuture = embeddedGatewayService.start();

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/EmbeddedGatewayService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/EmbeddedGatewayService.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.system;
 
 import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.oidc.OidcClaimsProvider;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
@@ -40,6 +41,7 @@ public final class EmbeddedGatewayService implements AutoCloseable {
       final UserServices userServices,
       final PasswordEncoder passwordEncoder,
       final JwtDecoder jwtDecoder,
+      final OidcClaimsProvider oidcClaimsProvider,
       final MeterRegistry meterRegistry) {
     this.concurrencyControl = concurrencyControl;
     this.brokerClient = brokerClient;
@@ -55,6 +57,7 @@ public final class EmbeddedGatewayService implements AutoCloseable {
             userServices,
             passwordEncoder,
             jwtDecoder,
+            oidcClaimsProvider,
             meterRegistry,
             configuration.getExperimental().getEngine().getValidators().getMaxNameFieldLength());
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -170,7 +170,8 @@ public final class SystemContext {
     this.userServices = userServices;
     this.passwordEncoder = passwordEncoder;
     this.jwtDecoder = jwtDecoder;
-    this.oidcClaimsProvider = oidcClaimsProvider;
+    this.oidcClaimsProvider =
+        Objects.requireNonNull(oidcClaimsProvider, "oidcClaimsProvider must not be null");
     this.searchClientsProxy = searchClientsProxy;
     this.brokerRequestAuthorizationConverter = brokerRequestAuthorizationConverter;
     this.nodeIdProvider = nodeIdProvider;

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -14,6 +14,7 @@ import io.camunda.identity.sdk.IdentityConfiguration;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.oidc.OidcClaimsProvider;
 import io.camunda.security.validation.AuthorizationValidator;
 import io.camunda.security.validation.GroupValidator;
 import io.camunda.security.validation.IdentifierValidator;
@@ -136,6 +137,7 @@ public final class SystemContext {
   private final UserServices userServices;
   private final PasswordEncoder passwordEncoder;
   private final JwtDecoder jwtDecoder;
+  private final OidcClaimsProvider oidcClaimsProvider;
   private final SearchClientsProxy searchClientsProxy;
   private final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter;
   private final NodeIdProvider nodeIdProvider;
@@ -153,6 +155,7 @@ public final class SystemContext {
       final UserServices userServices,
       final PasswordEncoder passwordEncoder,
       final JwtDecoder jwtDecoder,
+      final OidcClaimsProvider oidcClaimsProvider,
       final SearchClientsProxy searchClientsProxy,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter,
       final NodeIdProvider nodeIdProvider) {
@@ -167,6 +170,7 @@ public final class SystemContext {
     this.userServices = userServices;
     this.passwordEncoder = passwordEncoder;
     this.jwtDecoder = jwtDecoder;
+    this.oidcClaimsProvider = oidcClaimsProvider;
     this.searchClientsProxy = searchClientsProxy;
     this.brokerRequestAuthorizationConverter = brokerRequestAuthorizationConverter;
     this.nodeIdProvider = nodeIdProvider;
@@ -184,6 +188,7 @@ public final class SystemContext {
       final UserServices userServices,
       final PasswordEncoder passwordEncoder,
       final JwtDecoder jwtDecoder,
+      final OidcClaimsProvider oidcClaimsProvider,
       final SearchClientsProxy searchClientsProxy,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter,
       final NodeIdProvider nodeIdProvider) {
@@ -199,6 +204,7 @@ public final class SystemContext {
         userServices,
         passwordEncoder,
         jwtDecoder,
+        oidcClaimsProvider,
         searchClientsProxy,
         brokerRequestAuthorizationConverter,
         nodeIdProvider);
@@ -748,6 +754,10 @@ public final class SystemContext {
 
   public PasswordEncoder getPasswordEncoder() {
     return passwordEncoder;
+  }
+
+  public OidcClaimsProvider getOidcClaimsProvider() {
+    return oidcClaimsProvider;
   }
 
   public JwtDecoder getJwtDecoder() {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/SimpleBrokerStartTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/SimpleBrokerStartTest.java
@@ -16,6 +16,7 @@ import io.atomix.cluster.AtomixCluster;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.oidc.NoopOidcClaimsProvider;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.system.SystemContext;
@@ -77,6 +78,7 @@ public final class SimpleBrokerStartTest {
                       mock(UserServices.class),
                       mock(PasswordEncoder.class),
                       mock(JwtDecoder.class),
+                      new NoopOidcClaimsProvider(),
                       mock(SearchClientsProxy.class),
                       mock(BrokerRequestAuthorizationConverter.class),
                       mock(NodeIdProvider.class));
@@ -109,6 +111,7 @@ public final class SimpleBrokerStartTest {
             mock(UserServices.class),
             mock(PasswordEncoder.class),
             mock(JwtDecoder.class),
+            new NoopOidcClaimsProvider(),
             mock(SearchClientsProxy.class),
             mock(BrokerRequestAuthorizationConverter.class),
             mock(NodeIdProvider.class));

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/MockBrokerStartupContext.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/MockBrokerStartupContext.java
@@ -15,6 +15,8 @@ import io.camunda.identity.sdk.IdentityConfiguration;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.oidc.NoopOidcClaimsProvider;
+import io.camunda.security.oidc.OidcClaimsProvider;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.PartitionRaftListener;
@@ -80,6 +82,7 @@ public class MockBrokerStartupContext implements BrokerStartupContext {
   private UserServices userServices = mock(UserServices.class);
   private PasswordEncoder passwordEncoder = mock(PasswordEncoder.class);
   private JwtDecoder jwtDecoder = mock(JwtDecoder.class);
+  private OidcClaimsProvider oidcClaimsProvider = new NoopOidcClaimsProvider();
   private SnapshotApiRequestHandler snapshotApiRequestHandler =
       mock(SnapshotApiRequestHandler.class);
   private BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter =
@@ -380,6 +383,15 @@ public class MockBrokerStartupContext implements BrokerStartupContext {
 
   public void setJwtDecoder(final JwtDecoder jwtDecoder) {
     this.jwtDecoder = jwtDecoder;
+  }
+
+  @Override
+  public OidcClaimsProvider getOidcClaimsProvider() {
+    return oidcClaimsProvider;
+  }
+
+  public void setOidcClaimsProvider(final OidcClaimsProvider oidcClaimsProvider) {
+    this.oidcClaimsProvider = oidcClaimsProvider;
   }
 
   @Override

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionJoinTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionJoinTest.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.broker.test.EmbeddedBrokerRule.assignSocketAddres
 
 import io.atomix.cluster.MemberId;
 import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.oidc.NoopOidcClaimsProvider;
 import io.camunda.zeebe.broker.Broker;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
 import io.camunda.zeebe.broker.system.SystemContext;
@@ -119,7 +120,7 @@ final class PartitionJoinTest {
             null,
             null,
             null,
-            null,
+            new NoopOidcClaimsProvider(),
             null,
             null,
             NodeIdProvider.staticProvider(brokerCfg.getCluster().getNodeId()));

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionJoinTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionJoinTest.java
@@ -121,6 +121,7 @@ final class PartitionJoinTest {
             null,
             null,
             null,
+            null,
             NodeIdProvider.staticProvider(brokerCfg.getCluster().getNodeId()));
 
     return new Broker(systemContext, new SpringBrokerBridge(), List.of());

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionLeaveTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionLeaveTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.security.configuration.SecurityConfigurations;
+import io.camunda.security.oidc.NoopOidcClaimsProvider;
 import io.camunda.zeebe.broker.Broker;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
 import io.camunda.zeebe.broker.system.SystemContext;
@@ -235,7 +236,7 @@ final class PartitionLeaveTest {
             null,
             null,
             null,
-            null,
+            new NoopOidcClaimsProvider(),
             null,
             null,
             NodeIdProvider.staticProvider(brokerCfg.getCluster().getNodeId()));

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionLeaveTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionLeaveTest.java
@@ -237,6 +237,7 @@ final class PartitionLeaveTest {
             null,
             null,
             null,
+            null,
             NodeIdProvider.staticProvider(brokerCfg.getCluster().getNodeId()));
 
     return new Broker(systemContext, new SpringBrokerBridge(), List.of());

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -17,6 +17,7 @@ import io.atomix.cluster.AtomixCluster;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.oidc.NoopOidcClaimsProvider;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
@@ -383,6 +384,7 @@ final class SystemContextTest {
         mock(UserServices.class),
         mock(PasswordEncoder.class),
         mock(JwtDecoder.class),
+        new NoopOidcClaimsProvider(),
         mock(SearchClientsProxy.class),
         mock(BrokerRequestAuthorizationConverter.class),
         mock(NodeIdProvider.class));

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
@@ -18,6 +18,7 @@ import io.atomix.cluster.AtomixCluster;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.impl.util.AddressUtil;
 import io.camunda.security.configuration.SecurityConfigurations;
+import io.camunda.security.oidc.NoopOidcClaimsProvider;
 import io.camunda.zeebe.broker.Broker;
 import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
@@ -255,7 +256,7 @@ public final class EmbeddedBrokerRule extends ExternalResource {
             null,
             null,
             null,
-            null,
+            new NoopOidcClaimsProvider(),
             null,
             null,
             NodeIdProvider.staticProvider(brokerCfg.getCluster().getNodeId()));

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/test/EmbeddedBrokerRule.java
@@ -257,6 +257,7 @@ public final class EmbeddedBrokerRule extends ExternalResource {
             null,
             null,
             null,
+            null,
             NodeIdProvider.staticProvider(brokerCfg.getCluster().getNodeId()));
 
     final var additionalListeners = new ArrayList<>(Arrays.asList(listeners));

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/Gateway.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/Gateway.java
@@ -64,6 +64,7 @@ import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutorService;
@@ -125,7 +126,7 @@ public final class Gateway implements CloseableSilently {
         userServices,
         passwordEncoder,
         jwtDecoder,
-        null,
+        new NoopOidcClaimsProvider(),
         meterRegistry,
         VariableNameLengthValidator.DEFAULT_MAX_NAME_FIELD_LENGTH);
   }
@@ -151,7 +152,7 @@ public final class Gateway implements CloseableSilently {
         userServices,
         passwordEncoder,
         jwtDecoder,
-        null,
+        new NoopOidcClaimsProvider(),
         meterRegistry,
         VariableNameLengthValidator.DEFAULT_MAX_NAME_FIELD_LENGTH);
   }
@@ -178,7 +179,7 @@ public final class Gateway implements CloseableSilently {
     this.userServices = userServices;
     this.passwordEncoder = passwordEncoder;
     this.jwtDecoder = jwtDecoder;
-    this.oidcClaimsProvider = oidcClaimsProvider;
+    this.oidcClaimsProvider = Objects.requireNonNull(oidcClaimsProvider);
     this.meterRegistry = meterRegistry;
     this.maxVariableNameLength = maxVariableNameLength;
 
@@ -458,7 +459,7 @@ public final class Gateway implements CloseableSilently {
             case OIDC ->
                 new AuthenticationHandler.Oidc(
                     jwtDecoder,
-                    oidcClaimsProvider != null ? oidcClaimsProvider : new NoopOidcClaimsProvider(),
+                    oidcClaimsProvider,
                     securityConfiguration.getAuthentication().getOidc());
           };
       interceptors.add(

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/Gateway.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/Gateway.java
@@ -9,6 +9,8 @@ package io.camunda.zeebe.gateway;
 
 import com.google.rpc.Code;
 import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.oidc.NoopOidcClaimsProvider;
+import io.camunda.security.oidc.OidcClaimsProvider;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.gateway.health.GatewayHealthManager;
@@ -99,6 +101,7 @@ public final class Gateway implements CloseableSilently {
   private final UserServices userServices;
   private final PasswordEncoder passwordEncoder;
   private final JwtDecoder jwtDecoder;
+  private final OidcClaimsProvider oidcClaimsProvider;
   private final MeterRegistry meterRegistry;
   private final int maxVariableNameLength;
 
@@ -122,6 +125,7 @@ public final class Gateway implements CloseableSilently {
         userServices,
         passwordEncoder,
         jwtDecoder,
+        null,
         meterRegistry,
         VariableNameLengthValidator.DEFAULT_MAX_NAME_FIELD_LENGTH);
   }
@@ -147,6 +151,7 @@ public final class Gateway implements CloseableSilently {
         userServices,
         passwordEncoder,
         jwtDecoder,
+        null,
         meterRegistry,
         VariableNameLengthValidator.DEFAULT_MAX_NAME_FIELD_LENGTH);
   }
@@ -161,6 +166,7 @@ public final class Gateway implements CloseableSilently {
       final UserServices userServices,
       final PasswordEncoder passwordEncoder,
       final JwtDecoder jwtDecoder,
+      final OidcClaimsProvider oidcClaimsProvider,
       final MeterRegistry meterRegistry,
       final int maxVariableNameLength) {
     shutdownTimeout = shutdownDuration;
@@ -172,6 +178,7 @@ public final class Gateway implements CloseableSilently {
     this.userServices = userServices;
     this.passwordEncoder = passwordEncoder;
     this.jwtDecoder = jwtDecoder;
+    this.oidcClaimsProvider = oidcClaimsProvider;
     this.meterRegistry = meterRegistry;
     this.maxVariableNameLength = maxVariableNameLength;
 
@@ -450,7 +457,9 @@ public final class Gateway implements CloseableSilently {
             case BASIC -> basicAuth();
             case OIDC ->
                 new AuthenticationHandler.Oidc(
-                    jwtDecoder, securityConfiguration.getAuthentication().getOidc());
+                    jwtDecoder,
+                    oidcClaimsProvider != null ? oidcClaimsProvider : new NoopOidcClaimsProvider(),
+                    securityConfiguration.getAuthentication().getOidc());
           };
       interceptors.add(
           new AuthenticationInterceptor(

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationHandler.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationHandler.java
@@ -14,6 +14,7 @@ import io.camunda.security.auth.OidcGroupsLoader;
 import io.camunda.security.auth.OidcPrincipalLoader;
 import io.camunda.security.auth.OidcPrincipalLoader.OidcPrincipals;
 import io.camunda.security.configuration.OidcAuthenticationConfiguration;
+import io.camunda.security.oidc.OidcClaimsProvider;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.util.Either;
 import io.grpc.Context;
@@ -51,14 +52,17 @@ public sealed interface AuthenticationHandler {
 
     public static final String BEARER_PREFIX = "Bearer ";
     private final JwtDecoder jwtDecoder;
+    private final OidcClaimsProvider claimsProvider;
     private final OidcAuthenticationConfiguration oidcAuthenticationConfiguration;
     private final OidcPrincipalLoader oidcPrincipalLoader;
     private final OidcGroupsLoader oidcGroupsLoader;
 
     public Oidc(
         final JwtDecoder jwtDecoder,
+        final OidcClaimsProvider claimsProvider,
         final OidcAuthenticationConfiguration oidcAuthenticationConfiguration) {
       this.jwtDecoder = Objects.requireNonNull(jwtDecoder);
+      this.claimsProvider = Objects.requireNonNull(claimsProvider);
       this.oidcAuthenticationConfiguration =
           Objects.requireNonNull(oidcAuthenticationConfiguration);
       oidcPrincipalLoader =
@@ -76,13 +80,24 @@ public sealed interface AuthenticationHandler {
                 "Expected authentication information to start with '%s'".formatted(BEARER_PREFIX)));
       }
 
+      final String tokenValue = authorizationHeader.substring(BEARER_PREFIX.length());
       final Jwt token;
       try {
-        token = jwtDecoder.decode(authorizationHeader.substring(BEARER_PREFIX.length()));
+        token = jwtDecoder.decode(tokenValue);
       } catch (final JwtException e) {
         return Either.left(
             Status.UNAUTHENTICATED
                 .augmentDescription("Expected a valid token, see cause for details")
+                .withCause(e));
+      }
+
+      final Map<String, Object> claims;
+      try {
+        claims = claimsProvider.claimsFor(token.getClaims(), tokenValue);
+      } catch (final Exception e) {
+        return Either.left(
+            Status.UNAUTHENTICATED
+                .augmentDescription("Failed to resolve OIDC claims, see cause for details")
                 .withCause(e));
       }
 
@@ -94,7 +109,7 @@ public sealed interface AuthenticationHandler {
               !oidcAuthenticationConfiguration.isGroupsClaimConfigured());
       if (oidcAuthenticationConfiguration.isGroupsClaimConfigured()) {
         try {
-          context = context.withValue(GROUPS_CLAIMS, oidcGroupsLoader.load(token.getClaims()));
+          context = context.withValue(GROUPS_CLAIMS, oidcGroupsLoader.load(claims));
         } catch (final Exception e) {
           return Either.left(
               Status.UNAUTHENTICATED
@@ -105,7 +120,7 @@ public sealed interface AuthenticationHandler {
 
       final OidcPrincipals principals;
       try {
-        principals = oidcPrincipalLoader.load(token.getClaims());
+        principals = oidcPrincipalLoader.load(claims);
       } catch (final Exception e) {
         return Either.left(
             Status.UNAUTHENTICATED
@@ -125,14 +140,10 @@ public sealed interface AuthenticationHandler {
       final var preferUsernameClaim = oidcAuthenticationConfiguration.isPreferUsernameClaim();
       if ((preferUsernameClaim && principals.username() != null) || principals.clientId() == null) {
         return Either.right(
-            context
-                .withValue(USERNAME, principals.username())
-                .withValue(USER_CLAIMS, token.getClaims()));
+            context.withValue(USERNAME, principals.username()).withValue(USER_CLAIMS, claims));
       } else {
         return Either.right(
-            context
-                .withValue(CLIENT_ID, principals.clientId())
-                .withValue(USER_CLAIMS, token.getClaims()));
+            context.withValue(CLIENT_ID, principals.clientId()).withValue(USER_CLAIMS, claims));
       }
     }
   }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationHandler.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationHandler.java
@@ -24,6 +24,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
@@ -51,6 +53,7 @@ public sealed interface AuthenticationHandler {
         Context.key("io.camunda.zeebe:user_claim");
 
     public static final String BEARER_PREFIX = "Bearer ";
+    private static final Logger LOG = LoggerFactory.getLogger(Oidc.class);
     private final JwtDecoder jwtDecoder;
     private final OidcClaimsProvider claimsProvider;
     private final OidcAuthenticationConfiguration oidcAuthenticationConfiguration;
@@ -85,20 +88,19 @@ public sealed interface AuthenticationHandler {
       try {
         token = jwtDecoder.decode(tokenValue);
       } catch (final JwtException e) {
-        return Either.left(
-            Status.UNAUTHENTICATED
-                .augmentDescription("Expected a valid token, see cause for details")
-                .withCause(e));
+        // Exception details may include the IdP URL or issuer mismatch strings; log them
+        // server-side and return a generic status so API callers don't see them.
+        LOG.debug("Rejecting bearer token: JWT decode failed", e);
+        return Either.left(Status.UNAUTHENTICATED.augmentDescription("Invalid bearer token"));
       }
 
       final Map<String, Object> claims;
       try {
         claims = claimsProvider.claimsFor(token.getClaims(), tokenValue);
       } catch (final Exception e) {
+        LOG.warn("Rejecting bearer token: OIDC claims resolution failed", e);
         return Either.left(
-            Status.UNAUTHENTICATED
-                .augmentDescription("Failed to resolve OIDC claims, see cause for details")
-                .withCause(e));
+            Status.UNAUTHENTICATED.augmentDescription("Failed to resolve OIDC claims"));
       }
 
       var context = Context.current();
@@ -111,10 +113,9 @@ public sealed interface AuthenticationHandler {
         try {
           context = context.withValue(GROUPS_CLAIMS, oidcGroupsLoader.load(claims));
         } catch (final Exception e) {
+          LOG.warn("Rejecting bearer token: OIDC groups loader failed", e);
           return Either.left(
-              Status.UNAUTHENTICATED
-                  .augmentDescription("Failed to load OIDC groups, see cause for details")
-                  .withCause(e));
+              Status.UNAUTHENTICATED.augmentDescription("Failed to load OIDC groups"));
         }
       }
 
@@ -122,10 +123,9 @@ public sealed interface AuthenticationHandler {
       try {
         principals = oidcPrincipalLoader.load(claims);
       } catch (final Exception e) {
+        LOG.warn("Rejecting bearer token: OIDC principal loader failed", e);
         return Either.left(
-            Status.UNAUTHENTICATED
-                .augmentDescription("Failed to load OIDC principals, see cause for details")
-                .withCause(e));
+            Status.UNAUTHENTICATED.augmentDescription("Failed to load OIDC principals"));
       }
 
       if (principals.username() == null && principals.clientId() == null) {

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
@@ -12,6 +12,7 @@ import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.interfaces.Claim;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.security.entity.AuthenticationMethod;
+import io.camunda.security.oidc.NoopOidcClaimsProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.gateway.EndpointManager;
 import io.camunda.zeebe.gateway.Gateway;
@@ -110,6 +111,7 @@ public final class StubbedGateway {
                     new AuthenticationInterceptor(
                         new AuthenticationHandler.Oidc(
                             new FakeJwtDecoder(),
+                            new NoopOidcClaimsProvider(),
                             securityConfiguration.getAuthentication().getOidc()),
                         new AuthenticationMetrics(
                             new SimpleMeterRegistry(), AuthenticationMethod.OIDC))));

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationHandlerOidcUserInfoTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationHandlerOidcUserInfoTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.interceptors.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.security.configuration.OidcAuthenticationConfiguration;
+import io.camunda.security.oidc.OidcClaimsProvider;
+import io.camunda.zeebe.gateway.interceptors.impl.AuthenticationHandler.Oidc;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+
+class AuthenticationHandlerOidcUserInfoTest {
+
+  @Test
+  void usesClaimsProviderResultForGroupsAndPrincipal() throws Exception {
+    final var jwtDecoder = mock(JwtDecoder.class);
+    final var claimsProvider = mock(OidcClaimsProvider.class);
+    final var oidc = new OidcAuthenticationConfiguration();
+    oidc.setUsernameClaim("sub");
+    oidc.setGroupsClaim("groups");
+
+    final var jwt =
+        Jwt.withTokenValue("token-abc").header("alg", "RS256").claim("sub", "alice").build();
+    when(jwtDecoder.decode("token-abc")).thenReturn(jwt);
+    // provider adds groups from userinfo that the JWT does not have
+    when(claimsProvider.claimsFor(any(), eq("token-abc")))
+        .thenReturn(Map.of("sub", "alice", "groups", List.of("engineering")));
+
+    final var handler = new Oidc(jwtDecoder, claimsProvider, oidc);
+    final var result = handler.authenticate("Bearer token-abc");
+
+    assertThat(result.isRight()).isTrue();
+    final var ctx = result.get();
+    assertThat(ctx.call(() -> AuthenticationHandler.GROUPS_CLAIMS.get()))
+        .isEqualTo(List.of("engineering"));
+    assertThat(ctx.call(() -> AuthenticationHandler.USERNAME.get())).isEqualTo("alice");
+  }
+
+  @Test
+  void failsClosedWhenClaimsProviderThrows() {
+    final var jwtDecoder = mock(JwtDecoder.class);
+    final var claimsProvider = mock(OidcClaimsProvider.class);
+    final var oidc = new OidcAuthenticationConfiguration();
+    oidc.setUsernameClaim("sub");
+
+    final var jwt =
+        Jwt.withTokenValue("token-abc").header("alg", "RS256").claim("sub", "alice").build();
+    when(jwtDecoder.decode("token-abc")).thenReturn(jwt);
+    when(claimsProvider.claimsFor(any(), eq("token-abc")))
+        .thenThrow(new RuntimeException("userinfo down"));
+
+    final var handler = new Oidc(jwtDecoder, claimsProvider, oidc);
+    final var result = handler.authenticate("Bearer token-abc");
+
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft().getCode()).isEqualTo(io.grpc.Status.UNAUTHENTICATED.getCode());
+  }
+
+}

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationHandlerOidcUserInfoTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationHandlerOidcUserInfoTest.java
@@ -69,4 +69,45 @@ class AuthenticationHandlerOidcUserInfoTest {
     assertThat(result.getLeft().getCode()).isEqualTo(io.grpc.Status.UNAUTHENTICATED.getCode());
   }
 
+  @Test
+  void bearerAuthFailureStatusDoesNotLeakIdpDetails() {
+    // Cause exceptions whose messages embed IdP URLs and internal error codes. The gRPC
+    // Status description returned to the client must NOT carry these through (no
+    // .withCause(e), no upstream error strings).
+    final var jwtDecoder = mock(JwtDecoder.class);
+    final var claimsProvider = mock(OidcClaimsProvider.class);
+    final var oidc = new OidcAuthenticationConfiguration();
+    oidc.setUsernameClaim("sub");
+
+    // (1) claims-provider failure with a URL-bearing cause
+    final var jwt =
+        Jwt.withTokenValue("token-abc").header("alg", "RS256").claim("sub", "alice").build();
+    when(jwtDecoder.decode("token-abc")).thenReturn(jwt);
+    when(claimsProvider.claimsFor(any(), eq("token-abc")))
+        .thenThrow(
+            new RuntimeException(
+                "UserInfo request to https://internal.idp.example/userinfo returned 502"));
+
+    final var handler = new Oidc(jwtDecoder, claimsProvider, oidc);
+    final var claimsFail = handler.authenticate("Bearer token-abc");
+
+    assertThat(claimsFail.isLeft()).isTrue();
+    final String claimsDescription = claimsFail.getLeft().getDescription();
+    assertThat(claimsDescription)
+        .doesNotContain("internal.idp.example")
+        .doesNotContain("502")
+        .doesNotContain("userinfo");
+    assertThat(claimsFail.getLeft().getCause()).isNull();
+
+    // (2) JWT decode failure with a diagnostic message
+    when(jwtDecoder.decode("token-bad"))
+        .thenThrow(
+            new org.springframework.security.oauth2.jwt.JwtException(
+                "Jwt expired at 2024-01-01; iss mismatch: https://wrong.example"));
+
+    final var decodeFail = handler.authenticate("Bearer token-bad");
+    final String decodeDescription = decodeFail.getLeft().getDescription();
+    assertThat(decodeDescription).doesNotContain("wrong.example").doesNotContain("2024-01-01");
+    assertThat(decodeFail.getLeft().getCause()).isNull();
+  }
 }

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptorTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptorTest.java
@@ -270,12 +270,8 @@ public class AuthenticationInterceptorTest {
         .hasValueSatisfying(
             status -> {
               assertThat(status.getCode()).isEqualTo(Status.UNAUTHENTICATED.getCode());
-              assertThat(status.getDescription())
-                  .isEqualTo("Failed to load OIDC principals, see cause for details");
-              assertThat(status.getCause())
-                  .isInstanceOf(IllegalArgumentException.class)
-                  .hasMessageContaining(
-                      "Value for $['username'] is not a string. Please check your OIDC configuration.");
+              assertThat(status.getDescription()).isEqualTo("Failed to load OIDC principals");
+              assertThat(status.getCause()).isNull();
             });
   }
 
@@ -309,12 +305,8 @@ public class AuthenticationInterceptorTest {
         .hasValueSatisfying(
             status -> {
               assertThat(status.getCode()).isEqualTo(Status.UNAUTHENTICATED.getCode());
-              assertThat(status.getDescription())
-                  .isEqualTo("Failed to load OIDC principals, see cause for details");
-              assertThat(status.getCause())
-                  .isInstanceOf(IllegalArgumentException.class)
-                  .hasMessageContaining(
-                      "Value for $['client_id'] is not a string. Please check your OIDC configuration.");
+              assertThat(status.getDescription()).isEqualTo("Failed to load OIDC principals");
+              assertThat(status.getCause()).isNull();
             });
   }
 
@@ -600,12 +592,8 @@ public class AuthenticationInterceptorTest {
         .hasValueSatisfying(
             status -> {
               assertThat(status.getCode()).isEqualTo(Status.UNAUTHENTICATED.getCode());
-              assertThat(status.getDescription())
-                  .isEqualTo("Failed to load OIDC groups, see cause for details");
-              assertThat(status.getCause())
-                  .isInstanceOf(IllegalArgumentException.class)
-                  .hasMessageContaining(
-                      "Group's list derived from ($.groups[*]) is not a string array. Please check your OIDC configuration.");
+              assertThat(status.getDescription()).isEqualTo("Failed to load OIDC groups");
+              assertThat(status.getCause()).isNull();
             });
   }
 

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptorTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptorTest.java
@@ -22,6 +22,7 @@ import io.camunda.search.entities.UserEntity;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.configuration.OidcAuthenticationConfiguration;
 import io.camunda.security.entity.AuthenticationMethod;
+import io.camunda.security.oidc.NoopOidcClaimsProvider;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.gateway.interceptors.impl.AuthenticationHandler.BasicAuth;
 import io.camunda.zeebe.gateway.interceptors.impl.AuthenticationHandler.Oidc;
@@ -190,7 +191,7 @@ public class AuthenticationInterceptorTest {
     oidcAuthenticationConfiguration.setUsernameClaim("username");
     oidcAuthenticationConfiguration.setClientIdClaim("application_id");
 
-    new AuthenticationInterceptor(new Oidc(jwtDecoder, oidcAuthenticationConfiguration))
+    new AuthenticationInterceptor(new Oidc(jwtDecoder, new NoopOidcClaimsProvider(), oidcAuthenticationConfiguration))
         .interceptCall(
             closeStatusCapturingServerCall,
             createAuthHeader(),
@@ -220,7 +221,7 @@ public class AuthenticationInterceptorTest {
     oidcAuthenticationConfiguration.setUsernameClaim("sub");
     oidcAuthenticationConfiguration.setClientIdClaim("client_id");
 
-    new AuthenticationInterceptor(new Oidc(jwtDecoder, oidcAuthenticationConfiguration))
+    new AuthenticationInterceptor(new Oidc(jwtDecoder, new NoopOidcClaimsProvider(), oidcAuthenticationConfiguration))
         .interceptCall(
             closeStatusCapturingServerCall,
             createAuthHeader(),
@@ -256,7 +257,7 @@ public class AuthenticationInterceptorTest {
     oidcAuthenticationConfiguration.setUsernameClaim("username");
     oidcAuthenticationConfiguration.setClientIdClaim("application_id");
 
-    new AuthenticationInterceptor(new Oidc(jwtDecoder, oidcAuthenticationConfiguration))
+    new AuthenticationInterceptor(new Oidc(jwtDecoder, new NoopOidcClaimsProvider(), oidcAuthenticationConfiguration))
         .interceptCall(
             closeStatusCapturingServerCall,
             createAuthHeader(),
@@ -295,7 +296,7 @@ public class AuthenticationInterceptorTest {
     oidcAuthenticationConfiguration.setUsernameClaim("username");
     oidcAuthenticationConfiguration.setClientIdClaim("client_id");
 
-    new AuthenticationInterceptor(new Oidc(jwtDecoder, oidcAuthenticationConfiguration))
+    new AuthenticationInterceptor(new Oidc(jwtDecoder, new NoopOidcClaimsProvider(), oidcAuthenticationConfiguration))
         .interceptCall(
             closeStatusCapturingServerCall,
             createAuthHeader(),
@@ -343,7 +344,7 @@ public class AuthenticationInterceptorTest {
     oidcAuthenticationConfiguration.setClientIdClaim("application_id");
 
     // when
-    new AuthenticationInterceptor(new Oidc(jwtDecoder, oidcAuthenticationConfiguration))
+    new AuthenticationInterceptor(new Oidc(jwtDecoder, new NoopOidcClaimsProvider(), oidcAuthenticationConfiguration))
         .interceptCall(
             closeStatusCapturingServerCall,
             metadata,
@@ -377,7 +378,7 @@ public class AuthenticationInterceptorTest {
     oidcAuthenticationConfiguration.setClientIdClaim("application_id");
 
     // when
-    new AuthenticationInterceptor(new Oidc(jwtDecoder, oidcAuthenticationConfiguration))
+    new AuthenticationInterceptor(new Oidc(jwtDecoder, new NoopOidcClaimsProvider(), oidcAuthenticationConfiguration))
         .interceptCall(
             closeStatusCapturingServerCall,
             metadata,
@@ -410,7 +411,7 @@ public class AuthenticationInterceptorTest {
     oidcAuthenticationConfiguration.setClientIdClaim("application_id");
 
     // when
-    new AuthenticationInterceptor(new Oidc(jwtDecoder, oidcAuthenticationConfiguration))
+    new AuthenticationInterceptor(new Oidc(jwtDecoder, new NoopOidcClaimsProvider(), oidcAuthenticationConfiguration))
         .interceptCall(
             closeStatusCapturingServerCall,
             metadata,
@@ -446,7 +447,7 @@ public class AuthenticationInterceptorTest {
     oidcAuthenticationConfiguration.setPreferUsernameClaim(true);
 
     // when
-    new AuthenticationInterceptor(new Oidc(jwtDecoder, oidcAuthenticationConfiguration))
+    new AuthenticationInterceptor(new Oidc(jwtDecoder, new NoopOidcClaimsProvider(), oidcAuthenticationConfiguration))
         .interceptCall(
             closeStatusCapturingServerCall,
             metadata,
@@ -481,7 +482,7 @@ public class AuthenticationInterceptorTest {
     oidcAuthenticationConfiguration.setClientIdClaim("missing_claim");
 
     // when
-    new AuthenticationInterceptor(new Oidc(jwtDecoder, oidcAuthenticationConfiguration))
+    new AuthenticationInterceptor(new Oidc(jwtDecoder, new NoopOidcClaimsProvider(), oidcAuthenticationConfiguration))
         .interceptCall(
             closeStatusCapturingServerCall,
             metadata,
@@ -517,7 +518,7 @@ public class AuthenticationInterceptorTest {
     oidcAuthenticationConfiguration.setClientIdClaim("application_id");
 
     // when
-    new AuthenticationInterceptor(new Oidc(jwtDecoder, oidcAuthenticationConfiguration))
+    new AuthenticationInterceptor(new Oidc(jwtDecoder, new NoopOidcClaimsProvider(), oidcAuthenticationConfiguration))
         .interceptCall(
             closeStatusCapturingServerCall,
             metadata,
@@ -554,7 +555,7 @@ public class AuthenticationInterceptorTest {
     oidcAuthenticationConfiguration.setGroupsClaim("$.groups[*]");
 
     // when
-    new AuthenticationInterceptor(new Oidc(jwtDecoder, oidcAuthenticationConfiguration))
+    new AuthenticationInterceptor(new Oidc(jwtDecoder, new NoopOidcClaimsProvider(), oidcAuthenticationConfiguration))
         .interceptCall(
             closeStatusCapturingServerCall,
             metadata,
@@ -586,7 +587,7 @@ public class AuthenticationInterceptorTest {
     oidcAuthenticationConfiguration.setClientIdClaim("client_id");
     oidcAuthenticationConfiguration.setGroupsClaim("$.groups[*]");
 
-    new AuthenticationInterceptor(new Oidc(jwtDecoder, oidcAuthenticationConfiguration))
+    new AuthenticationInterceptor(new Oidc(jwtDecoder, new NoopOidcClaimsProvider(), oidcAuthenticationConfiguration))
         .interceptCall(
             closeStatusCapturingServerCall,
             createAuthHeader(),

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptorTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptorTest.java
@@ -191,7 +191,8 @@ public class AuthenticationInterceptorTest {
     oidcAuthenticationConfiguration.setUsernameClaim("username");
     oidcAuthenticationConfiguration.setClientIdClaim("application_id");
 
-    new AuthenticationInterceptor(new Oidc(jwtDecoder, new NoopOidcClaimsProvider(), oidcAuthenticationConfiguration))
+    new AuthenticationInterceptor(
+            new Oidc(jwtDecoder, new NoopOidcClaimsProvider(), oidcAuthenticationConfiguration))
         .interceptCall(
             closeStatusCapturingServerCall,
             createAuthHeader(),
@@ -221,7 +222,8 @@ public class AuthenticationInterceptorTest {
     oidcAuthenticationConfiguration.setUsernameClaim("sub");
     oidcAuthenticationConfiguration.setClientIdClaim("client_id");
 
-    new AuthenticationInterceptor(new Oidc(jwtDecoder, new NoopOidcClaimsProvider(), oidcAuthenticationConfiguration))
+    new AuthenticationInterceptor(
+            new Oidc(jwtDecoder, new NoopOidcClaimsProvider(), oidcAuthenticationConfiguration))
         .interceptCall(
             closeStatusCapturingServerCall,
             createAuthHeader(),
@@ -257,7 +259,8 @@ public class AuthenticationInterceptorTest {
     oidcAuthenticationConfiguration.setUsernameClaim("username");
     oidcAuthenticationConfiguration.setClientIdClaim("application_id");
 
-    new AuthenticationInterceptor(new Oidc(jwtDecoder, new NoopOidcClaimsProvider(), oidcAuthenticationConfiguration))
+    new AuthenticationInterceptor(
+            new Oidc(jwtDecoder, new NoopOidcClaimsProvider(), oidcAuthenticationConfiguration))
         .interceptCall(
             closeStatusCapturingServerCall,
             createAuthHeader(),
@@ -292,7 +295,8 @@ public class AuthenticationInterceptorTest {
     oidcAuthenticationConfiguration.setUsernameClaim("username");
     oidcAuthenticationConfiguration.setClientIdClaim("client_id");
 
-    new AuthenticationInterceptor(new Oidc(jwtDecoder, new NoopOidcClaimsProvider(), oidcAuthenticationConfiguration))
+    new AuthenticationInterceptor(
+            new Oidc(jwtDecoder, new NoopOidcClaimsProvider(), oidcAuthenticationConfiguration))
         .interceptCall(
             closeStatusCapturingServerCall,
             createAuthHeader(),
@@ -336,7 +340,8 @@ public class AuthenticationInterceptorTest {
     oidcAuthenticationConfiguration.setClientIdClaim("application_id");
 
     // when
-    new AuthenticationInterceptor(new Oidc(jwtDecoder, new NoopOidcClaimsProvider(), oidcAuthenticationConfiguration))
+    new AuthenticationInterceptor(
+            new Oidc(jwtDecoder, new NoopOidcClaimsProvider(), oidcAuthenticationConfiguration))
         .interceptCall(
             closeStatusCapturingServerCall,
             metadata,
@@ -370,7 +375,8 @@ public class AuthenticationInterceptorTest {
     oidcAuthenticationConfiguration.setClientIdClaim("application_id");
 
     // when
-    new AuthenticationInterceptor(new Oidc(jwtDecoder, new NoopOidcClaimsProvider(), oidcAuthenticationConfiguration))
+    new AuthenticationInterceptor(
+            new Oidc(jwtDecoder, new NoopOidcClaimsProvider(), oidcAuthenticationConfiguration))
         .interceptCall(
             closeStatusCapturingServerCall,
             metadata,
@@ -403,7 +409,8 @@ public class AuthenticationInterceptorTest {
     oidcAuthenticationConfiguration.setClientIdClaim("application_id");
 
     // when
-    new AuthenticationInterceptor(new Oidc(jwtDecoder, new NoopOidcClaimsProvider(), oidcAuthenticationConfiguration))
+    new AuthenticationInterceptor(
+            new Oidc(jwtDecoder, new NoopOidcClaimsProvider(), oidcAuthenticationConfiguration))
         .interceptCall(
             closeStatusCapturingServerCall,
             metadata,
@@ -439,7 +446,8 @@ public class AuthenticationInterceptorTest {
     oidcAuthenticationConfiguration.setPreferUsernameClaim(true);
 
     // when
-    new AuthenticationInterceptor(new Oidc(jwtDecoder, new NoopOidcClaimsProvider(), oidcAuthenticationConfiguration))
+    new AuthenticationInterceptor(
+            new Oidc(jwtDecoder, new NoopOidcClaimsProvider(), oidcAuthenticationConfiguration))
         .interceptCall(
             closeStatusCapturingServerCall,
             metadata,
@@ -474,7 +482,8 @@ public class AuthenticationInterceptorTest {
     oidcAuthenticationConfiguration.setClientIdClaim("missing_claim");
 
     // when
-    new AuthenticationInterceptor(new Oidc(jwtDecoder, new NoopOidcClaimsProvider(), oidcAuthenticationConfiguration))
+    new AuthenticationInterceptor(
+            new Oidc(jwtDecoder, new NoopOidcClaimsProvider(), oidcAuthenticationConfiguration))
         .interceptCall(
             closeStatusCapturingServerCall,
             metadata,
@@ -510,7 +519,8 @@ public class AuthenticationInterceptorTest {
     oidcAuthenticationConfiguration.setClientIdClaim("application_id");
 
     // when
-    new AuthenticationInterceptor(new Oidc(jwtDecoder, new NoopOidcClaimsProvider(), oidcAuthenticationConfiguration))
+    new AuthenticationInterceptor(
+            new Oidc(jwtDecoder, new NoopOidcClaimsProvider(), oidcAuthenticationConfiguration))
         .interceptCall(
             closeStatusCapturingServerCall,
             metadata,
@@ -547,7 +557,8 @@ public class AuthenticationInterceptorTest {
     oidcAuthenticationConfiguration.setGroupsClaim("$.groups[*]");
 
     // when
-    new AuthenticationInterceptor(new Oidc(jwtDecoder, new NoopOidcClaimsProvider(), oidcAuthenticationConfiguration))
+    new AuthenticationInterceptor(
+            new Oidc(jwtDecoder, new NoopOidcClaimsProvider(), oidcAuthenticationConfiguration))
         .interceptCall(
             closeStatusCapturingServerCall,
             metadata,
@@ -579,7 +590,8 @@ public class AuthenticationInterceptorTest {
     oidcAuthenticationConfiguration.setClientIdClaim("client_id");
     oidcAuthenticationConfiguration.setGroupsClaim("$.groups[*]");
 
-    new AuthenticationInterceptor(new Oidc(jwtDecoder, new NoopOidcClaimsProvider(), oidcAuthenticationConfiguration))
+    new AuthenticationInterceptor(
+            new Oidc(jwtDecoder, new NoopOidcClaimsProvider(), oidcAuthenticationConfiguration))
         .interceptCall(
             closeStatusCapturingServerCall,
             createAuthHeader(),

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusteringRule.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusteringRule.java
@@ -38,6 +38,7 @@ import io.camunda.client.impl.util.AddressUtil;
 import io.camunda.configuration.beans.BrokerBasedProperties;
 import io.camunda.configuration.beans.GatewayBasedProperties;
 import io.camunda.security.configuration.SecurityConfigurations;
+import io.camunda.security.oidc.NoopOidcClaimsProvider;
 import io.camunda.zeebe.broker.Broker;
 import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
@@ -382,7 +383,7 @@ public class ClusteringRule extends ExternalResource {
             null,
             null,
             null,
-            null,
+            new NoopOidcClaimsProvider(),
             null,
             null,
             NodeIdProvider.staticProvider(brokerCfg.getCluster().getNodeId()));

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusteringRule.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusteringRule.java
@@ -384,6 +384,7 @@ public class ClusteringRule extends ExternalResource {
             null,
             null,
             null,
+            null,
             NodeIdProvider.staticProvider(brokerCfg.getCluster().getNodeId()));
 
     final Broker broker =


### PR DESCRIPTION
## Summary

Adds an opt-in UserInfo-claim augmentation path for the OIDC bearer-token flow, so authorization claims (`groups`, roles, tenants) emitted only by an IdP's `/userinfo` response — not on the JWT access token — are picked up by the REST and gRPC APIs. Disabled by default; enabled via `camunda.security.authentication.oidc.userInfoAugmentation.enabled=true`.

Supersedes #51446 (rebased onto `main` and adapted for main's divergence — `MockBrokerStartupContext` facade, per-issuer userinfo URL map, additional fallback `MeterRegistry` bean). Will backport to `stable/8.8` once this merges.

## What's in this PR

- `OidcClaimsProvider` interface with `NoopOidcClaimsProvider` default and `CachingOidcClaimsProvider` (Caffeine-backed) implementation.
- `OidcUserInfoClient` using the JDK `HttpClient` with 1 MiB body cap, `application/jwt` rejection, 2s connect + 2s request timeouts, and `openid`-scope gate.
- JWT-wins additive merge of UserInfo claims with OIDC Core §5.3.2 `sub` integrity check; cache keyed by `jti:iss:jti` or `sie:iss:sub:iat:exp` (iss-namespaced).
- Per-issuer userinfo URL routing built from `ClientRegistrationRepository`.
- Spring wiring: `@ConditionalOnMissingBean` for `OidcClaimsProvider`, `MeterRegistry`, and the named `oidcUserInfoHttpClient` bean with `SslBundles` integration for the `oidc-userinfo` bundle.
- Configurable negative-cache TTL on the `OidcUserInfoAugmentationConfiguration`.
- REST path: `OidcTokenAuthenticationConverter` routes claims through the provider.
- gRPC path: `AuthenticationHandler.Oidc` routes claims through the provider; `.withCause(e)` stripped from bearer-auth failure statuses so IdP URLs and internal diagnostics don't leak to clients (logged server-side via SLF4J instead).
- ADR-0006 documenting the design, failure-mode asymmetry (startup fail-fast vs runtime fail-open), and the IdP-side workaround recommendation.
- New IT `OidcBearerUserInfoClaimGapIT` plus unit coverage across the new components.

## Test plan

- [ ] `mvn -pl security/security-core verify -Dtest='Oidc*Test,Caching*Test' -DskipITs` — 44 tests green locally.
- [ ] `mvn -pl zeebe/gateway-grpc verify -Dtest='Authentication*Test' -DskipITs` — 23 tests green locally (including new `AuthenticationHandlerOidcUserInfoTest`).
- [ ] `mvn -pl authentication verify -Dit.test='OidcBearerUserInfoClaimGapIT' -DskipUTs` — 3 tests green locally.
- [ ] CI run on this branch (spotless, checkstyle, dependency analysis, commit-lint, full Java checks).
- [ ] Manual smoke: enable augmentation against a test IdP that emits `groups` only on `/userinfo`, confirm group-based authorization triggers on both REST and gRPC bearer requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)