### PR TITLE
test: add qa tests for the new MCP processes Admin page

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/fixtures.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/fixtures.ts
@@ -35,6 +35,7 @@ import {IdentityTenantsPage} from '@pages/IdentityTenantsPage';
 import {IdentityRolesDetailsPage} from '@pages/IdentityRolesDetailsPage';
 import {IdentityAuditLogPage} from '@pages/IdentityAuditLogPage';
 import {IdentityGlobalTaskListenersPage} from '@pages/IdentityGlobalTaskListenersPage';
+import {IdentityMcpProcessesPage} from '@pages/IdentityMcpProcessesPage';
 import {OperateOperationsDetailsPage} from '@pages/OperateOperationsDetailsPage';
 import {OperateOperationsLogPage} from '@pages/OperateOperationsLogPage';
 import {SwaggerPage} from '@pages/SwaggerPage';
@@ -72,6 +73,7 @@ type PlaywrightFixtures = {
   identityTenantsPage: IdentityTenantsPage;
   identityRolesDetailsPage: IdentityRolesDetailsPage;
   identityAuditLogPage: IdentityAuditLogPage;
+  identityMcpProcessesPage: IdentityMcpProcessesPage;
   swaggerPage: SwaggerPage;
   identityGlobalTaskListenersPage: IdentityGlobalTaskListenersPage;
   suppressHelperModals: void;
@@ -204,6 +206,9 @@ const test = base.extend<PlaywrightFixtures>({
   },
   identityGlobalTaskListenersPage: async ({page}, use) => {
     await use(new IdentityGlobalTaskListenersPage(page));
+  },
+  identityMcpProcessesPage: async ({page}, use) => {
+    await use(new IdentityMcpProcessesPage(page));
   },
 });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityMcpProcessesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityMcpProcessesPage.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Page, Locator} from '@playwright/test';
+import {relativizePath, Paths} from 'utils/relativizePath';
+
+export class IdentityMcpProcessesPage {
+  private page: Page;
+  readonly mcpProcessesTable: Locator;
+  readonly mcpProcessesHeading: Locator;
+  readonly searchInput: Locator;
+  readonly allMcpProcessRows: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.mcpProcessesTable = page.getByRole('table');
+    this.mcpProcessesHeading = page.getByRole('heading', {
+      name: 'MCP Processes',
+    });
+    this.searchInput = page.getByPlaceholder('Search by tool name');
+    this.allMcpProcessRows = this.mcpProcessesTable.getByRole('row');
+  }
+
+  async navigateToMcpProcesses(): Promise<void> {
+    await this.page.goto(relativizePath(Paths.mcpProcesses()));
+  }
+
+  getRowByToolName(toolName: string): Locator {
+    return this.mcpProcessesTable.getByRole('row').filter({hasText: toolName});
+  }
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/mcpProcessAlpha.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/mcpProcessAlpha.bpmn
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="e2e-test" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="mcpProcessAlpha" name="MCP Process Alpha" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Alpha tool triggered">
+      <bpmn:extensionElements>
+        <zeebe:properties>
+          <zeebe:property name="io.camunda.tool:name" value="alpha-tool-name" />
+          <zeebe:property name="io.camunda.tool:purpose" value="Tool for executing an alpha process triggered by MCP." />
+        </zeebe:properties>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1" messageRef="Message_alpha" />
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="EndEvent_1" />
+  </bpmn:process>
+  <bpmn:message id="Message_alpha" name="alpha-tool-name" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="mcpProcessAlpha">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_1" bpmnElement="StartEvent_1">
+        <dc:Bounds x="150" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="242" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+        <di:waypoint x="186" y="118" />
+        <di:waypoint x="242" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/mcpProcessBravo.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/mcpProcessBravo.bpmn
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="e2e-test" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="mcpProcessBravo" name="MCP Process Bravo" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Bravo tool triggered">
+      <bpmn:extensionElements>
+        <zeebe:properties>
+          <zeebe:property name="io.camunda.tool:name" value="bravo-tool-name" />
+          <zeebe:property name="io.camunda.tool:purpose" value="Tool for executing a bravo process triggered by MCP." />
+        </zeebe:properties>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1" messageRef="Message_bravo" />
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="EndEvent_1" />
+  </bpmn:process>
+  <bpmn:message id="Message_bravo" name="bravo-tool-name" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="mcpProcessBravo">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_1" bpmnElement="StartEvent_1">
+        <dc:Bounds x="150" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="242" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+        <di:waypoint x="186" y="118" />
+        <di:waypoint x="242" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/mcp-processes.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/mcp-processes.spec.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect} from '@playwright/test';
+import {test} from 'fixtures';
+import {deploy} from 'utils/zeebeClient';
+import {relativizePath, Paths} from 'utils/relativizePath';
+import {navigateToApp} from '@pages/UtilitiesPage';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {LOGIN_CREDENTIALS} from 'utils/constants';
+import {cleanupResources} from 'utils/resourceCleanup';
+
+const ALPHA_TOOL_NAME = 'alpha-tool-name';
+const BRAVO_TOOL_NAME = 'bravo-tool-name';
+
+test.describe('Identity MCP Processes', () => {
+  const deployedResourceKeys: string[] = [];
+
+  test.beforeAll(async () => {
+    const alphaResult = await deploy(['./resources/mcpProcessAlpha.bpmn']);
+    deployedResourceKeys.push(alphaResult.processes[0].processDefinitionKey);
+
+    const bravoResult = await deploy(['./resources/mcpProcessBravo.bpmn']);
+    deployedResourceKeys.push(bravoResult.processes[0].processDefinitionKey);
+  });
+
+  test.beforeEach(async ({page, loginPage}) => {
+    await navigateToApp(page, 'admin');
+    await loginPage.login(
+      LOGIN_CREDENTIALS.username,
+      LOGIN_CREDENTIALS.password,
+    );
+    await expect(page).toHaveURL(relativizePath(Paths.users()));
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test.afterAll(async ({request}) => {
+    await cleanupResources(request, deployedResourceKeys);
+  });
+
+  test('MCP Processes page shows table headers and entries', async ({
+    page,
+    identityMcpProcessesPage,
+  }) => {
+    await identityMcpProcessesPage.navigateToMcpProcesses();
+
+    await test.step('Verify table headers are visible', async () => {
+      await expect(identityMcpProcessesPage.mcpProcessesHeading).toBeVisible();
+
+      await expect(
+        page.getByRole('columnheader', {name: 'Tool Name'}),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('columnheader', {name: 'Tool Description'}),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('columnheader', {name: 'Process Name'}),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('columnheader', {name: 'Version'}),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('columnheader', {name: 'Tenant'}),
+      ).toBeVisible();
+    });
+
+    await test.step('Verify MCP Process entries are visible', async () => {
+      await expect(
+        identityMcpProcessesPage.getRowByToolName(ALPHA_TOOL_NAME),
+      ).toBeVisible();
+      await expect(
+        identityMcpProcessesPage.getRowByToolName(BRAVO_TOOL_NAME),
+      ).toBeVisible();
+    });
+  });
+
+  test('MCP Processes can be filtered by tool name', async ({
+    identityMcpProcessesPage,
+  }) => {
+    await identityMcpProcessesPage.navigateToMcpProcesses();
+
+    await test.step("Filter by tool name 'alpha'", async () => {
+      await identityMcpProcessesPage.searchInput.fill('alpha');
+
+      await expect(
+        identityMcpProcessesPage.getRowByToolName(ALPHA_TOOL_NAME),
+      ).toBeVisible();
+      await expect(
+        identityMcpProcessesPage.getRowByToolName(BRAVO_TOOL_NAME),
+      ).toBeHidden();
+    });
+
+    await test.step('Clear search input', async () => {
+      await identityMcpProcessesPage.searchInput.clear();
+
+      await expect(
+        identityMcpProcessesPage.getRowByToolName(ALPHA_TOOL_NAME),
+      ).toBeVisible();
+      await expect(
+        identityMcpProcessesPage.getRowByToolName(BRAVO_TOOL_NAME),
+      ).toBeVisible();
+    });
+  });
+
+  test('MCP Processes can be sorted by tool name', async ({
+    page,
+    identityMcpProcessesPage,
+  }) => {
+    const rows = identityMcpProcessesPage.allMcpProcessRows;
+    const toolNameHeader = page.getByRole('columnheader', {
+      name: 'Tool Name',
+    });
+    await identityMcpProcessesPage.navigateToMcpProcesses();
+
+    await test.step("Verify default sort is ascending by 'Tool Name'", async () => {
+      await expect(rows.nth(1)).toContainText(ALPHA_TOOL_NAME);
+      await expect(rows.nth(2)).toContainText(BRAVO_TOOL_NAME);
+    });
+
+    await test.step("Sort ASC by 'Tool Name'", async () => {
+      // First click results in ASC order
+      await toolNameHeader.click();
+
+      await expect(rows.nth(1)).toContainText(ALPHA_TOOL_NAME);
+      await expect(rows.nth(2)).toContainText(BRAVO_TOOL_NAME);
+    });
+
+    await test.step("Sort DESC by 'Tool Name'", async () => {
+      // Second click results in DESC order
+      await toolNameHeader.click();
+
+      await expect(rows.nth(1)).toContainText(BRAVO_TOOL_NAME);
+      await expect(rows.nth(2)).toContainText(ALPHA_TOOL_NAME);
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/mcp-processes.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/mcp-processes.spec.ts
@@ -14,6 +14,7 @@ import {navigateToApp} from '@pages/UtilitiesPage';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {LOGIN_CREDENTIALS} from 'utils/constants';
 import {cleanupResources} from 'utils/resourceCleanup';
+import {jsonHeaders, buildUrl} from 'utils/http';
 
 const ALPHA_TOOL_NAME = 'alpha-tool-name';
 const BRAVO_TOOL_NAME = 'bravo-tool-name';
@@ -21,12 +22,32 @@ const BRAVO_TOOL_NAME = 'bravo-tool-name';
 test.describe('Identity MCP Processes', () => {
   const deployedResourceKeys: string[] = [];
 
-  test.beforeAll(async () => {
+  test.beforeAll(async ({request}) => {
     const alphaResult = await deploy(['./resources/mcpProcessAlpha.bpmn']);
     deployedResourceKeys.push(alphaResult.processes[0].processDefinitionKey);
 
     const bravoResult = await deploy(['./resources/mcpProcessBravo.bpmn']);
     deployedResourceKeys.push(bravoResult.processes[0].processDefinitionKey);
+
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/message-subscriptions/search'),
+        {
+          headers: jsonHeaders(),
+          data: {filter: {toolName: {$exists: true}}},
+        },
+      );
+      expect(res.status()).toBe(200);
+      const json = await res.json();
+      const toolNames = json.items.map(
+        (item: {toolName: string}) => item.toolName,
+      );
+      expect(toolNames).toContain(ALPHA_TOOL_NAME);
+      expect(toolNames).toContain(BRAVO_TOOL_NAME);
+    }).toPass({
+      intervals: [5_000, 10_000, 15_000],
+      timeout: 30_000,
+    });
   });
 
   test.beforeEach(async ({page, loginPage}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/relativizePath.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/relativizePath.ts
@@ -37,6 +37,9 @@ export const Paths = {
   globalTaskListeners() {
     return '/admin/global-task-listeners';
   },
+  mcpProcesses() {
+    return '/admin/mcp-processes';
+  },
   operateDashboard() {
     return '/operate';
   },

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/resourceCleanup.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/resourceCleanup.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {APIRequestContext} from '@playwright/test';
+import {defaultHeaders, buildUrl} from './http';
+
+export async function cleanupResources(
+  request: APIRequestContext,
+  resourceKeys: string[],
+): Promise<void> {
+  if (resourceKeys.length === 0) return;
+
+  console.log(`Cleaning up ${resourceKeys.length} resources via API...`);
+
+  const results = await Promise.allSettled(
+    resourceKeys.map(async (resourceKey) => {
+      try {
+        const response = await request.post(
+          buildUrl('/resources/{resourceKey}/deletion', {resourceKey}),
+          {headers: defaultHeaders()},
+        );
+        if (response.status() === 200) {
+          console.log(`Successfully deleted resource: ${resourceKey}`);
+          return {resourceKey, status: 'deleted'};
+        } else if (response.status() === 404) {
+          console.log(
+            `Resource already deleted or doesn't exist: ${resourceKey}`,
+          );
+          return {resourceKey, status: 'not_found'};
+        } else {
+          console.warn(
+            `Unexpected response status ${response.status()} for resource ${resourceKey}`,
+          );
+          return {
+            resourceKey,
+            status: 'error',
+            statusCode: response.status(),
+          };
+        }
+      } catch (error) {
+        console.error(`Failed to delete resource ${resourceKey}:`, error);
+        return {resourceKey, status: 'failed', error};
+      }
+    }),
+  );
+
+  const failed = results.filter(
+    (result) =>
+      result.status === 'rejected' ||
+      (result.status === 'fulfilled' && result.value.status === 'failed'),
+  );
+
+  if (failed.length > 0) {
+    console.warn(`Failed to clean up ${failed.length} resources`);
+  }
+}


### PR DESCRIPTION
## Description

This PR adds tests to the QA E2E suite for the new "MCP Processes" page added in https://github.com/camunda/camunda/pull/51389. This appears to be the only test suite for the Admin webapp, so tests are added there.

## Checklist

- [X] This branch is stacked on https://github.com/camunda/camunda/pull/51389.
- [X] This branch requires changes that will be introduced https://github.com/camunda/camunda/pull/51449.


## Related issues

related #51241
