### PR TITLE
refactor: remove AZ backward compatibility when creating load tests

### DIFF
--- a/load-tests/setup/newLoadTest.sh
+++ b/load-tests/setup/newLoadTest.sh
@@ -113,22 +113,10 @@ if ! kubectl get namespace $namespace >/dev/null 2>&1; then
   fi
 else
   echo "Namespace '$namespace' already exists"
-  existing_zone="$(kubectl get ns "$namespace" -o json | jq --raw-output ".metadata.annotations[\"$single_zone_annotation_name\"]")"
 
-  if [[ "$existing_zone" == "null" ]]
-  then
-    # Existing namespace, but not labelled. Don't change scheduling there.
-    # This is for backward compatibility reasons and prevent already running
-    # tests, scheduled over multiple zones, from being forcefully rescheduled
-    # on a new single zone.
-    # Once all the namespaces have the annotation, this backward compatibility
-    # step can be removed.
-    availability_zone="~"
-    echo "Namespace ${namespace} is NOT configured to run on a single availability zone ; scheduling will not be changed."
-  else
-    availability_zone="$existing_zone"
-    echo "Namespace ${namespace} has previously been configured to run on the single availability zone: $availability_zone"
-  fi
+  existing_zone="$(kubectl get ns "$namespace" -o json | jq --raw-output ".metadata.annotations[\"$single_zone_annotation_name\"]")"
+  availability_zone="$existing_zone"
+  echo "Namespace ${namespace} has previously been configured to run on the single availability zone: $availability_zone"
 fi
 
 # Sanitize a string to be a valid Kubernetes label value
@@ -185,8 +173,7 @@ sed_inplace "s/__NAMESPACE__/$namespace/" Makefile
 sed_inplace "s/__NAMESPACE__/$namespace/" load-test-values.yaml
 sed_inplace "s/__STORAGE_TYPE__/$secondaryStorage/" Makefile
 sed_inplace "s/__ENABLE_OPTIMIZE__/$enable_optimize/" Makefile
-sed_inplace "s/__AVAILABILITY_ZONE__/$availability_zone/" *.yaml
-sed_inplace "s/__AVAILABILITY_ZONE__/$availability_zone/" databases/*.yaml
+sed_inplace "s/__AVAILABILITY_ZONE__/$availability_zone/" *.yaml databases/*.yaml
 
 # Add/update helm repositories
 helm repo add camunda https://helm.camunda.io/ --force-update


### PR DESCRIPTION
## Description

The code was added to prevent moving away already existing deployment from multi-availability zones to single-availability zones deployments.
Now that all the existing tests have been reconfigured, this should not be needed anymore.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

Fix: #50568