### PR TITLE
fix: reduce GCS upload buffer allocation by capping at file size

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Gcs.java
+++ b/configuration/src/main/java/io/camunda/configuration/Gcs.java
@@ -64,6 +64,9 @@ public class Gcs {
   /** Maximum number of concurrent file transfers (uploads and downloads) using virtual threads. */
   private int maxConcurrentTransfers = 8;
 
+  /** Size of the buffer (in bytes) used when uploading files to GCS. */
+  private int bufferSize = 2 * 1024 * 1024;
+
   public String getBucketName() {
     return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
         PREFIX + ".bucket-name",
@@ -122,6 +125,14 @@ public class Gcs {
 
   public void setMaxConcurrentTransfers(final int maxConcurrentTransfers) {
     this.maxConcurrentTransfers = maxConcurrentTransfers;
+  }
+
+  public int getBufferSize() {
+    return bufferSize;
+  }
+
+  public void setBufferSize(final int bufferSize) {
+    this.bufferSize = bufferSize;
   }
 
   public enum GcsBackupStoreAuth {

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -737,6 +737,7 @@ public class BrokerBasedPropertiesOverride {
     gcsBackupStoreConfig.setHost(gcs.getHost());
     gcsBackupStoreConfig.setAuth(GcsBackupStoreAuth.valueOf(gcs.getAuth().name()));
     gcsBackupStoreConfig.setMaxConcurrentTransfers(gcs.getMaxConcurrentTransfers());
+    gcsBackupStoreConfig.setBufferSize(gcs.getBufferSize());
 
     override.getData().getBackup().setGcs(gcsBackupStoreConfig);
   }

--- a/configuration/src/test/java/io/camunda/configuration/DataBackupGcsTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/DataBackupGcsTest.java
@@ -359,4 +359,23 @@ public class DataBackupGcsTest {
           .isEqualTo(100);
     }
   }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.data.primary-storage.backup.gcs.bucket-name=test-bucket",
+        "camunda.data.primary-storage.backup.gcs.buffer-size=4194304",
+      })
+  class WithCustomBufferSize {
+    final BrokerBasedProperties brokerCfg;
+
+    WithCustomBufferSize(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetBufferSize() {
+      assertThat(brokerCfg.getData().getBackup().getGcs().getBufferSize()).isEqualTo(4194304);
+    }
+  }
 }

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/FileSetManager.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/FileSetManager.java
@@ -52,18 +52,21 @@ final class FileSetManager {
   private final String basePath;
   private final ExecutorService executor;
   private final Semaphore concurrencyLimit;
+  private final int bufferSize;
 
   FileSetManager(
       final Storage client,
       final BucketInfo bucketInfo,
       final String basePath,
       final ExecutorService executor,
-      final int maxConcurrentOperations) {
+      final int maxConcurrentOperations,
+      final int bufferSize) {
     this.client = client;
     this.bucketInfo = bucketInfo;
     this.basePath = basePath;
     this.executor = executor;
     concurrencyLimit = new Semaphore(maxConcurrentOperations);
+    this.bufferSize = bufferSize;
   }
 
   /**
@@ -120,8 +123,12 @@ final class FileSetManager {
       final String fileName,
       final Path filePath) {
     try (final var inputStream = Files.newInputStream(filePath)) {
+      final int effectiveBufferSize = Math.clamp(Files.size(filePath), 1, bufferSize);
       client.createFrom(
-          blobInfo(id, fileSetName, fileName), inputStream, BlobWriteOption.doesNotExist());
+          blobInfo(id, fileSetName, fileName),
+          inputStream,
+          effectiveBufferSize,
+          BlobWriteOption.doesNotExist());
     } catch (final IOException e) {
       throw new UncheckedIOException(e);
     }

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupConfig.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupConfig.java
@@ -17,16 +17,22 @@ public record GcsBackupConfig(
     String bucketName,
     String basePath,
     GcsConnectionConfig connection,
-    int maxConcurrentTransfers) {
+    int maxConcurrentTransfers,
+    int bufferSize) {
   public GcsBackupConfig(
       final String bucketName,
       final String basePath,
       final GcsConnectionConfig connection,
-      final int maxConcurrentTransfers) {
+      final int maxConcurrentTransfers,
+      final int bufferSize) {
     this.bucketName = requireBucketName(bucketName);
     this.basePath = sanitizeBasePath(basePath);
     this.connection = requireNonNull(connection);
     this.maxConcurrentTransfers = maxConcurrentTransfers;
+    if (bufferSize <= 0) {
+      throw new IllegalArgumentException("Expected bufferSize to be > 0, but got " + bufferSize);
+    }
+    this.bufferSize = bufferSize;
   }
 
   private static String requireBucketName(final String bucketName) {
@@ -67,6 +73,8 @@ public record GcsBackupConfig(
     private String basePath;
     private String host;
     private GcsConnectionConfig.Authentication auth;
+    // 2MiB matches the default used by the GCS library's Path-based upload
+    private int bufferSize = 2 * 1024 * 1024;
 
     /** Default parallelism for file transfers (uploads and downloads) using virtual threads */
     private int maxConcurrentTransfers = 50;
@@ -102,9 +110,18 @@ public record GcsBackupConfig(
       return this;
     }
 
+    public Builder withBufferSize(final int bufferSize) {
+      this.bufferSize = bufferSize;
+      return this;
+    }
+
     public GcsBackupConfig build() {
       return new GcsBackupConfig(
-          bucketName, basePath, new GcsConnectionConfig(host, auth), maxConcurrentTransfers);
+          bucketName,
+          basePath,
+          new GcsConnectionConfig(host, auth),
+          maxConcurrentTransfers,
+          bufferSize);
     }
   }
 }

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupConfig.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupConfig.java
@@ -30,7 +30,7 @@ public record GcsBackupConfig(
     this.connection = requireNonNull(connection);
     this.maxConcurrentTransfers = maxConcurrentTransfers;
     if (bufferSize <= 0) {
-      throw new IllegalArgumentException("Expected bufferSize to be > 0, but got " + bufferSize);
+      throw new ConfigurationException("Expected bufferSize to be > 0, but got " + bufferSize);
     }
     this.bufferSize = bufferSize;
   }

--- a/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
+++ b/zeebe/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
@@ -65,7 +65,13 @@ public final class GcsBackupStore implements BackupStore {
     executor = Executors.newVirtualThreadPerTaskExecutor();
     manifestManager = new ManifestManager(client, bucketInfo, basePath, executor);
     fileSetManager =
-        new FileSetManager(client, bucketInfo, basePath, executor, config.maxConcurrentTransfers());
+        new FileSetManager(
+            client,
+            bucketInfo,
+            basePath,
+            executor,
+            config.maxConcurrentTransfers(),
+            config.bufferSize());
   }
 
   public static BackupStore of(final GcsBackupConfig config) {

--- a/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/FileSetManagerTest.java
+++ b/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/FileSetManagerTest.java
@@ -84,7 +84,7 @@ final class FileSetManagerTest {
     // when
     manager.save(backupIdentifier, FileSetManager.SNAPSHOT_FILESET_NAME, namedFileSet);
 
-    // then - snapshots are uploaded in parallel using the executor
+    // then - the file size is used as the upload buffer size
     verify(storage, times(2)).createFrom(any(), any(InputStream.class), eq(1024), any());
   }
 

--- a/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/FileSetManagerTest.java
+++ b/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/FileSetManagerTest.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executors;
@@ -37,16 +38,20 @@ import org.mockito.junit.jupiter.MockitoExtension;
 final class FileSetManagerTest {
   private final Storage storage;
   private final FileSetManager manager;
+  private final byte[] fileContent;
 
   FileSetManagerTest(@Mock final Storage storage) {
     this.storage = storage;
+    fileContent = new byte[1024];
+    Arrays.fill(fileContent, 0, 1024, (byte) 1);
     manager =
         new FileSetManager(
             storage,
             BucketInfo.of("bucket"),
             "basePath",
             Executors.newVirtualThreadPerTaskExecutor(),
-            50);
+            50,
+            1024 * 1024);
   }
 
   @Test
@@ -62,7 +67,25 @@ final class FileSetManagerTest {
     manager.save(backupIdentifier, FileSetManager.SNAPSHOT_FILESET_NAME, namedFileSet);
 
     // then - snapshots are uploaded in parallel using the executor
-    verify(storage, times(2)).createFrom(any(), any(InputStream.class), any());
+    verify(storage, times(2)).createFrom(any(), any(InputStream.class), anyInt(), any());
+  }
+
+  @Test
+  void shouldUseFileSizeAsBufferSize(@TempDir final Path tempDir) throws IOException {
+    // given
+    final var backupIdentifier = new BackupIdentifierImpl(1, 2, 3);
+    final var file1 = Files.createFile(tempDir.resolve("file1"));
+    final var file2 = Files.createFile(tempDir.resolve("file2"));
+    final var namedFileSet =
+        new NamedFileSetImpl(Map.of("snapshotFile1", file1, "snapshotFile2", file2));
+    Files.write(file1, fileContent);
+    Files.write(file2, fileContent);
+
+    // when
+    manager.save(backupIdentifier, FileSetManager.SNAPSHOT_FILESET_NAME, namedFileSet);
+
+    // then - snapshots are uploaded in parallel using the executor
+    verify(storage, times(2)).createFrom(any(), any(InputStream.class), eq(1024), any());
   }
 
   @Test
@@ -74,7 +97,7 @@ final class FileSetManagerTest {
     final var file2 = Files.createFile(tempDir.resolve("file2"));
     final var namedFileSet =
         new NamedFileSetImpl(Map.of("snapshotFile1", file1, "snapshotFile2", file2));
-    when(storage.createFrom(any(), any(InputStream.class), any()))
+    when(storage.createFrom(any(), any(InputStream.class), anyInt(), any()))
         .thenThrow(new StorageException(412, "expected"));
 
     // when throw
@@ -98,7 +121,7 @@ final class FileSetManagerTest {
     manager.save(backupIdentifier, FileSetManager.SEGMENTS_FILESET_NAME, namedFileSet);
 
     // then - segments are uploaded in parallel using the executor
-    verify(storage, times(2)).createFrom(any(), any(InputStream.class), any());
+    verify(storage, times(2)).createFrom(any(), any(InputStream.class), anyInt(), any());
   }
 
   @Test
@@ -109,7 +132,7 @@ final class FileSetManagerTest {
     final var file2 = Files.createFile(tempDir.resolve("file2"));
     final var namedFileSet =
         new NamedFileSetImpl(Map.of("segmentFile1", file1, "segmentFile2", file2));
-    when(storage.createFrom(any(), any(InputStream.class), any()))
+    when(storage.createFrom(any(), any(InputStream.class), anyInt(), any()))
         .thenThrow(new StorageException(412, "expected"));
 
     // when throw

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/GcsBackupStoreConfig.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backup/GcsBackupStoreConfig.java
@@ -20,6 +20,9 @@ public class GcsBackupStoreConfig implements ConfigurationEntry {
   /** Default maximum concurrent transfers (uploads and downloads) */
   private int maxConcurrentTransfers = 8;
 
+  /** Size of the buffer (in bytes) used when uploading files to GCS. */
+  private int bufferSize = 2 * 1024 * 1024;
+
   public String getBucketName() {
     return bucketName;
   }
@@ -60,13 +63,22 @@ public class GcsBackupStoreConfig implements ConfigurationEntry {
     this.maxConcurrentTransfers = maxConcurrentTransfers;
   }
 
+  public int getBufferSize() {
+    return bufferSize;
+  }
+
+  public void setBufferSize(final int bufferSize) {
+    this.bufferSize = bufferSize;
+  }
+
   public static GcsBackupConfig toStoreConfig(final GcsBackupStoreConfig config) {
     final var storeConfig =
         new GcsBackupConfig.Builder()
             .withBucketName(config.getBucketName())
             .withBasePath(config.getBasePath())
             .withHost(config.getHost())
-            .withMaxConcurrentTransfers(config.getMaxConcurrentTransfers());
+            .withMaxConcurrentTransfers(config.getMaxConcurrentTransfers())
+            .withBufferSize(config.getBufferSize());
     final var authenticated =
         switch (config.getAuth()) {
           case NONE -> storeConfig.withoutAuthentication();
@@ -77,7 +89,7 @@ public class GcsBackupStoreConfig implements ConfigurationEntry {
 
   @Override
   public int hashCode() {
-    return Objects.hash(bucketName, basePath, host, auth, maxConcurrentTransfers);
+    return Objects.hash(bucketName, basePath, host, auth, maxConcurrentTransfers, bufferSize);
   }
 
   @Override
@@ -93,7 +105,8 @@ public class GcsBackupStoreConfig implements ConfigurationEntry {
         && Objects.equals(basePath, that.basePath)
         && Objects.equals(host, that.host)
         && auth == that.auth
-        && maxConcurrentTransfers == that.maxConcurrentTransfers;
+        && maxConcurrentTransfers == that.maxConcurrentTransfers
+        && bufferSize == that.bufferSize;
   }
 
   @Override
@@ -112,6 +125,8 @@ public class GcsBackupStoreConfig implements ConfigurationEntry {
         + auth
         + ", maxConcurrentTransfers="
         + maxConcurrentTransfers
+        + ", bufferSize="
+        + bufferSize
         + '}';
   }
 


### PR DESCRIPTION
## Description
The InputStream-based upload path was unconditionally allocating a large buffer (16MB) per file regardless of file size. Now the effective buffer is Math.min(fileSize, configuredBufferSize), avoiding oversized allocations for small snapshot and segment files.

The default buffer is set to 2MiB to match what the previous Path-based createFrom used, rather than the 16MiB write-channel default.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues
Introduced when fixing issue #45636 w/ PR #45646
