### PR TITLE
fix: include @Document parameter names in fetchVariables

### DIFF
--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/annotation/AnnotationUtil.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/annotation/AnnotationUtil.java
@@ -114,6 +114,12 @@ public class AnnotationUtil {
     return result;
   }
 
+  public static List<ParameterInfo> getDocumentParameters(final MethodInfo methodInfo) {
+    final List<ParameterInfo> result = new ArrayList<>();
+    result.addAll(methodInfo.getParametersFilteredByAnnotation(Document.class));
+    return result;
+  }
+
   public static List<ParameterInfo> getVariablesAsTypeParameters(final MethodInfo methodInfo) {
     final List<ParameterInfo> result = new ArrayList<>();
     result.addAll(methodInfo.getParametersFilteredByAnnotation(VariablesAsType.class));
@@ -278,6 +284,13 @@ public class AnnotationUtil {
             .filter(Optional::isPresent)
             .map(Optional::get)
             .map(VariableValue::getName)
+            .toList());
+    result.addAll(
+        getDocumentParameters(methodInfo).stream()
+            .map(AnnotationUtil::getDocumentValue)
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .map(DocumentValue::getName)
             .toList());
     return result;
   }

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/annotation/AnnotationUtil.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/annotation/AnnotationUtil.java
@@ -292,7 +292,7 @@ public class AnnotationUtil {
             .map(Optional::get)
             .map(DocumentValue::getName)
             .toList());
-    return result;
+    return result.stream().distinct().toList();
   }
 
   private static String extractFieldName(final Field field) {

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/annotation/AnnotationUtil.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/annotation/AnnotationUtil.java
@@ -109,9 +109,7 @@ public class AnnotationUtil {
   }
 
   public static List<ParameterInfo> getVariableParameters(final MethodInfo methodInfo) {
-    final List<ParameterInfo> result = new ArrayList<>();
-    result.addAll(methodInfo.getParametersFilteredByAnnotation(Variable.class));
-    return result;
+    return methodInfo.getParametersFilteredByAnnotation(Variable.class);
   }
 
   public static List<ParameterInfo> getDocumentParameters(final MethodInfo methodInfo) {
@@ -119,9 +117,7 @@ public class AnnotationUtil {
   }
 
   public static List<ParameterInfo> getVariablesAsTypeParameters(final MethodInfo methodInfo) {
-    final List<ParameterInfo> result = new ArrayList<>();
-    result.addAll(methodInfo.getParametersFilteredByAnnotation(VariablesAsType.class));
-    return result;
+    return methodInfo.getParametersFilteredByAnnotation(VariablesAsType.class);
   }
 
   public static boolean isVariablesAsType(final ParameterInfo parameterInfo) {

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/annotation/AnnotationUtil.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/annotation/AnnotationUtil.java
@@ -115,9 +115,7 @@ public class AnnotationUtil {
   }
 
   public static List<ParameterInfo> getDocumentParameters(final MethodInfo methodInfo) {
-    final List<ParameterInfo> result = new ArrayList<>();
-    result.addAll(methodInfo.getParametersFilteredByAnnotation(Document.class));
-    return result;
+    return methodInfo.getParametersFilteredByAnnotation(Document.class);
   }
 
   public static List<ParameterInfo> getVariablesAsTypeParameters(final MethodInfo methodInfo) {

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/annotation/AnnotationUtil.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/annotation/AnnotationUtil.java
@@ -118,9 +118,7 @@ public class AnnotationUtil {
   }
 
   public static List<ParameterInfo> getDocumentParameters(final MethodInfo methodInfo) {
-    final List<ParameterInfo> result = new ArrayList<>();
-    result.addAll(methodInfo.getParametersFilteredByAnnotation(Document.class));
-    return result;
+    return methodInfo.getParametersFilteredByAnnotation(Document.class);
   }
 
   public static List<ParameterInfo> getVariablesAsTypeParameters(final MethodInfo methodInfo) {

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/annotation/AnnotationUtil.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/annotation/AnnotationUtil.java
@@ -112,9 +112,7 @@ public class AnnotationUtil {
   }
 
   public static List<ParameterInfo> getVariableParameters(final MethodInfo methodInfo) {
-    final List<ParameterInfo> result = new ArrayList<>();
-    result.addAll(methodInfo.getParametersFilteredByAnnotation(Variable.class));
-    return result;
+    return methodInfo.getParametersFilteredByAnnotation(Variable.class);
   }
 
   public static List<ParameterInfo> getDocumentParameters(final MethodInfo methodInfo) {
@@ -122,9 +120,7 @@ public class AnnotationUtil {
   }
 
   public static List<ParameterInfo> getVariablesAsTypeParameters(final MethodInfo methodInfo) {
-    final List<ParameterInfo> result = new ArrayList<>();
-    result.addAll(methodInfo.getParametersFilteredByAnnotation(VariablesAsType.class));
-    return result;
+    return methodInfo.getParametersFilteredByAnnotation(VariablesAsType.class);
   }
 
   public static boolean isVariablesAsType(final ParameterInfo parameterInfo) {

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/annotation/AnnotationUtil.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/annotation/AnnotationUtil.java
@@ -117,6 +117,12 @@ public class AnnotationUtil {
     return result;
   }
 
+  public static List<ParameterInfo> getDocumentParameters(final MethodInfo methodInfo) {
+    final List<ParameterInfo> result = new ArrayList<>();
+    result.addAll(methodInfo.getParametersFilteredByAnnotation(Document.class));
+    return result;
+  }
+
   public static List<ParameterInfo> getVariablesAsTypeParameters(final MethodInfo methodInfo) {
     final List<ParameterInfo> result = new ArrayList<>();
     result.addAll(methodInfo.getParametersFilteredByAnnotation(VariablesAsType.class));
@@ -351,6 +357,13 @@ public class AnnotationUtil {
             .filter(Optional::isPresent)
             .map(Optional::get)
             .map(VariableValue::getName)
+            .toList());
+    result.addAll(
+        getDocumentParameters(methodInfo).stream()
+            .map(AnnotationUtil::getDocumentValue)
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .map(DocumentValue::getName)
             .toList());
     return result;
   }

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/annotation/AnnotationUtil.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/annotation/AnnotationUtil.java
@@ -365,7 +365,7 @@ public class AnnotationUtil {
             .map(Optional::get)
             .map(DocumentValue::getName)
             .toList());
-    return result;
+    return result.stream().distinct().toList();
   }
 
   private static String extractFieldName(final Field field) {

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/annotation/AnnotationUtilTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/annotation/AnnotationUtilTest.java
@@ -158,9 +158,27 @@ public class AnnotationUtilTest {
     public void sampleWorkerWithDocumentReferenceList(
         @io.camunda.client.annotation.Document final List<DocumentReferenceResponse> documents) {}
 
+    @Test
+    void shouldDeduplicateVariableAndDocumentWithSameName() {
+      // given
+      final MethodInfo methodInfo =
+          methodInfo(this, "test", "sampleWorkerWithDuplicateVariableAndDocument");
+      // when
+      final Optional<JobWorkerValue> jobWorkerValue = AnnotationUtil.getJobWorkerValue(methodInfo);
+      // then
+      assertThat(jobWorkerValue).isPresent();
+      final JobWorkerValue value = jobWorkerValue.get();
+      assertThat(value.getFetchVariables()).containsExactly(new GeneratedFromMethodInfo<>("myVar"));
+    }
+
     @io.camunda.client.annotation.JobWorker
     public void sampleWorkerWithNamedDocument(
         @io.camunda.client.annotation.Document("myDoc") final DocumentContext context) {}
+
+    @io.camunda.client.annotation.JobWorker
+    public void sampleWorkerWithDuplicateVariableAndDocument(
+        @io.camunda.client.annotation.Variable("myVar") final String var1,
+        @io.camunda.client.annotation.Document("myVar") final DocumentContext context) {}
 
     private static final class PropertyAnnotatedClass {
       @JsonProperty("some_name")

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/annotation/AnnotationUtilTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/annotation/AnnotationUtilTest.java
@@ -41,6 +41,7 @@ import io.camunda.client.api.response.DocumentReferenceResponse;
 import io.camunda.client.bean.BeanInfo;
 import io.camunda.client.bean.MethodInfo;
 import io.camunda.client.bean.ParameterInfo;
+import io.camunda.client.jobhandling.DocumentContext;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
@@ -95,6 +96,45 @@ public class AnnotationUtilTest {
       assertThat(value.getFetchVariables()).containsExactly(new GeneratedFromMethodInfo<>("value"));
     }
 
+    @Test
+    void shouldExtractDocumentContextVariableName() {
+      // given
+      final MethodInfo methodInfo = methodInfo(this, "test", "sampleWorkerWithDocumentContext");
+      // when
+      final Optional<JobWorkerValue> jobWorkerValue = AnnotationUtil.getJobWorkerValue(methodInfo);
+      // then
+      assertThat(jobWorkerValue).isPresent();
+      final JobWorkerValue value = jobWorkerValue.get();
+      assertThat(value.getFetchVariables())
+          .containsExactly(new GeneratedFromMethodInfo<>("context"));
+    }
+
+    @Test
+    void shouldExtractDocumentReferenceListVariableName() {
+      // given
+      final MethodInfo methodInfo =
+          methodInfo(this, "test", "sampleWorkerWithDocumentReferenceList");
+      // when
+      final Optional<JobWorkerValue> jobWorkerValue = AnnotationUtil.getJobWorkerValue(methodInfo);
+      // then
+      assertThat(jobWorkerValue).isPresent();
+      final JobWorkerValue value = jobWorkerValue.get();
+      assertThat(value.getFetchVariables())
+          .containsExactly(new GeneratedFromMethodInfo<>("documents"));
+    }
+
+    @Test
+    void shouldExtractDocumentNamedVariableName() {
+      // given
+      final MethodInfo methodInfo = methodInfo(this, "test", "sampleWorkerWithNamedDocument");
+      // when
+      final Optional<JobWorkerValue> jobWorkerValue = AnnotationUtil.getJobWorkerValue(methodInfo);
+      // then
+      assertThat(jobWorkerValue).isPresent();
+      final JobWorkerValue value = jobWorkerValue.get();
+      assertThat(value.getFetchVariables()).containsExactly(new GeneratedFromMethodInfo<>("myDoc"));
+    }
+
     @io.camunda.client.annotation.JobWorker
     public void sampleWorkerWithEmptyJsonProperty(
         @VariablesAsType final PropertyAnnotatedClassEmptyValue annotatedClass) {}
@@ -109,6 +149,18 @@ public class AnnotationUtilTest {
     @io.camunda.client.annotation.JobWorker
     public void sampleWorkerWithJsonProperty(
         @VariablesAsType final PropertyAnnotatedClass annotatedClass) {}
+
+    @io.camunda.client.annotation.JobWorker
+    public void sampleWorkerWithDocumentContext(
+        @io.camunda.client.annotation.Document final DocumentContext context) {}
+
+    @io.camunda.client.annotation.JobWorker
+    public void sampleWorkerWithDocumentReferenceList(
+        @io.camunda.client.annotation.Document final List<DocumentReferenceResponse> documents) {}
+
+    @io.camunda.client.annotation.JobWorker
+    public void sampleWorkerWithNamedDocument(
+        @io.camunda.client.annotation.Document("myDoc") final DocumentContext context) {}
 
     private static final class PropertyAnnotatedClass {
       @JsonProperty("some_name")

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/annotation/AnnotationUtilTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/annotation/AnnotationUtilTest.java
@@ -162,9 +162,27 @@ public class AnnotationUtilTest {
     public void sampleWorkerWithDocumentReferenceList(
         @io.camunda.client.annotation.Document final List<DocumentReferenceResponse> documents) {}
 
+    @Test
+    void shouldDeduplicateVariableAndDocumentWithSameName() {
+      // given
+      final MethodInfo methodInfo =
+          methodInfo(this, "test", "sampleWorkerWithDuplicateVariableAndDocument");
+      // when
+      final Optional<JobWorkerValue> jobWorkerValue = AnnotationUtil.getJobWorkerValue(methodInfo);
+      // then
+      assertThat(jobWorkerValue).isPresent();
+      final JobWorkerValue value = jobWorkerValue.get();
+      assertThat(value.getFetchVariables()).containsExactly(new GeneratedFromMethodInfo<>("myVar"));
+    }
+
     @io.camunda.client.annotation.JobWorker
     public void sampleWorkerWithNamedDocument(
         @io.camunda.client.annotation.Document("myDoc") final DocumentContext context) {}
+
+    @io.camunda.client.annotation.JobWorker
+    public void sampleWorkerWithDuplicateVariableAndDocument(
+        @io.camunda.client.annotation.Variable("myVar") final String var1,
+        @io.camunda.client.annotation.Document("myVar") final DocumentContext context) {}
 
     private static final class PropertyAnnotatedClass {
       @JsonProperty("some_name")

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/annotation/AnnotationUtilTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/annotation/AnnotationUtilTest.java
@@ -44,6 +44,7 @@ import io.camunda.client.api.response.DocumentReferenceResponse;
 import io.camunda.client.bean.BeanInfo;
 import io.camunda.client.bean.MethodInfo;
 import io.camunda.client.bean.ParameterInfo;
+import io.camunda.client.jobhandling.DocumentContext;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -99,6 +100,45 @@ public class AnnotationUtilTest {
       assertThat(value.getFetchVariables()).containsExactly(new GeneratedFromMethodInfo<>("value"));
     }
 
+    @Test
+    void shouldExtractDocumentContextVariableName() {
+      // given
+      final MethodInfo methodInfo = methodInfo(this, "test", "sampleWorkerWithDocumentContext");
+      // when
+      final Optional<JobWorkerValue> jobWorkerValue = AnnotationUtil.getJobWorkerValue(methodInfo);
+      // then
+      assertThat(jobWorkerValue).isPresent();
+      final JobWorkerValue value = jobWorkerValue.get();
+      assertThat(value.getFetchVariables())
+          .containsExactly(new GeneratedFromMethodInfo<>("context"));
+    }
+
+    @Test
+    void shouldExtractDocumentReferenceListVariableName() {
+      // given
+      final MethodInfo methodInfo =
+          methodInfo(this, "test", "sampleWorkerWithDocumentReferenceList");
+      // when
+      final Optional<JobWorkerValue> jobWorkerValue = AnnotationUtil.getJobWorkerValue(methodInfo);
+      // then
+      assertThat(jobWorkerValue).isPresent();
+      final JobWorkerValue value = jobWorkerValue.get();
+      assertThat(value.getFetchVariables())
+          .containsExactly(new GeneratedFromMethodInfo<>("documents"));
+    }
+
+    @Test
+    void shouldExtractDocumentNamedVariableName() {
+      // given
+      final MethodInfo methodInfo = methodInfo(this, "test", "sampleWorkerWithNamedDocument");
+      // when
+      final Optional<JobWorkerValue> jobWorkerValue = AnnotationUtil.getJobWorkerValue(methodInfo);
+      // then
+      assertThat(jobWorkerValue).isPresent();
+      final JobWorkerValue value = jobWorkerValue.get();
+      assertThat(value.getFetchVariables()).containsExactly(new GeneratedFromMethodInfo<>("myDoc"));
+    }
+
     @io.camunda.client.annotation.JobWorker
     public void sampleWorkerWithEmptyJsonProperty(
         @VariablesAsType final PropertyAnnotatedClassEmptyValue annotatedClass) {}
@@ -113,6 +153,18 @@ public class AnnotationUtilTest {
     @io.camunda.client.annotation.JobWorker
     public void sampleWorkerWithJsonProperty(
         @VariablesAsType final PropertyAnnotatedClass annotatedClass) {}
+
+    @io.camunda.client.annotation.JobWorker
+    public void sampleWorkerWithDocumentContext(
+        @io.camunda.client.annotation.Document final DocumentContext context) {}
+
+    @io.camunda.client.annotation.JobWorker
+    public void sampleWorkerWithDocumentReferenceList(
+        @io.camunda.client.annotation.Document final List<DocumentReferenceResponse> documents) {}
+
+    @io.camunda.client.annotation.JobWorker
+    public void sampleWorkerWithNamedDocument(
+        @io.camunda.client.annotation.Document("myDoc") final DocumentContext context) {}
 
     private static final class PropertyAnnotatedClass {
       @JsonProperty("some_name")


### PR DESCRIPTION
## Summary

- `AnnotationUtil.usedVariableNames()` now includes variable names from `@Document` parameters (`DocumentContext`, `List<DocumentReferenceResponse>`, `DocumentReferenceResponse`) in the auto-generated `fetchVariables` list
- Previously, only `@Variable` and `@VariablesAsType` parameters contributed to `fetchVariables`, so `@Document`-annotated parameters were silently not fetched from the process engine
- `usedVariableNames()` now deduplicates results so that overlapping names across `@Variable`, `@VariablesAsType`, and `@Document` don't produce redundant `fetchVariables` entries

Closes #51540

## Test plan

- [x] `AnnotationUtilTest.shouldExtractDocumentContextVariableName` — `@Document DocumentContext context` produces fetchVariable "context"
- [x] `AnnotationUtilTest.shouldExtractDocumentReferenceListVariableName` — `@Document List<DocumentReferenceResponse> documents` produces fetchVariable "documents"
- [x] `AnnotationUtilTest.shouldExtractDocumentNamedVariableName` — `@Document("myDoc") DocumentContext context` produces fetchVariable "myDoc"
- [x] `AnnotationUtilTest.shouldDeduplicateVariableAndDocumentWithSameName` — `@Variable("myVar")` + `@Document("myVar")` produces a single fetchVariable "myVar"
- [x] All 25 `AnnotationUtilTest` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)