### PR TITLE
Update CI Spectral Linting

### DIFF
--- a/docs/rest-api-endpoint-guidelines.md
+++ b/docs/rest-api-endpoint-guidelines.md
@@ -85,6 +85,7 @@ All descriptive text (summaries, descriptions, property docs) should follow the 
 - `description` — full sentence(s) with period. First line must be a complete sentence (used as `meta description` in docs)
 - `tags` — exactly one tag matching the resource
 - `x-eventually-consistent` — explicitly `true` or `false` (see §2.5)
+- `x-added-in-version` — the Camunda version in which the operation was introduced, e.g., `"8.9"` (see §2.17)
 
 **Path patterns:**
 
@@ -789,6 +790,36 @@ If you add `@RequiresSecondaryStorage` to a method, verify the spec counterpart 
 
 > **Note:** There is currently no automated CI check that cross-references `@RequiresSecondaryStorage` against `x-eventually-consistent`. This is a manual review responsibility. [#36469](https://github.com/camunda/camunda/issues/36469) tracks the aspiration to add such static analysis.
 
+### 2.17 Operation versioning annotation (`x-added-in-version`)
+
+Every operation **must** declare the Camunda version in which it was introduced via the `x-added-in-version` extension. This enables generated docs and SDKs to surface endpoint version availability to consumers.
+
+```yaml
+/process-instances/{processInstanceKey}/sequence-flows:
+  get:
+    operationId: getProcessInstanceSequenceFlows
+    summary: Get sequence flows of a process instance
+    description: Returns the sequence flows traversed by the given process instance.
+    x-added-in-version: "8.9"
+    tags:
+      - Process instance
+```
+
+#### Rules
+
+- The value is a **string** containing the minor version (e.g., `"8.6"`, `"8.9"`). Patch versions are not used.
+- Set the value to the version in which the endpoint **first** ships. Do **not** update it on subsequent changes — that's what changelogs and the breaking-change rules in §2.7 are for.
+
+#### What the Spectral rule enforces
+
+The `require-added-in-version` rule (severity `error`) checks every operation under `paths` (`get`, `post`, `put`, `patch`, `delete`) and fails the build if `x-added-in-version` is missing. The rule does **not** validate the version string format — that's a reviewer responsibility.
+
+If you add a new endpoint without this annotation, CI will fail with a message such as:
+
+```
+Operation "createMyResource" (POST /my-resources) is missing x-added-in-version. Every endpoint must declare the Camunda version in which it was introduced.
+```
+
 ---
 
 ## 3. Spectral linting & custom rules
@@ -834,6 +865,7 @@ The ruleset lives in `zeebe/gateway-protocol/.spectral.yaml`. Custom functions a
 | `array-properties-must-be-required`        | error    | Response array properties must be `required` and not `nullable`                                   |
 | `no-eventually-consistent-on-commands`     | error    | Command operations must not have `x-eventually-consistent: true`                                  |
 | `valid-deprecated-enum-members`            | error    | `x-deprecated-enum-members` must be well-formed                                                   |
+| `require-added-in-version`                 | error    | Every operation must declare `x-added-in-version` (see §2.17)                                     |
 | `oas3-valid-schema-example`                | error    | Schemas must be valid per OpenAPI 3.0 JSON Schema rules                                           |
 
 ### 3.4 Adding new Spectral rules
@@ -1122,6 +1154,7 @@ Before opening a PR:
 - [ ] **All properties have descriptions**
 - [ ] **Key properties are `type: string`**
 - [ ] **`x-eventually-consistent`** set correctly (`true` for queries, `false` for commands)
+- [ ] **`x-added-in-version`** field present on every new operation (see §2.17)
 - [ ] **Response arrays** are `required` and not `nullable`
 - [ ] **`required` entries** all exist in `properties`
 - [ ] **Controller implemented** following conventions (§4)
@@ -1211,6 +1244,32 @@ properties:
 ```
 
 **Fix:** Change to `x-eventually-consistent: false`. Only search/statistics/GET endpoints use `true`.
+
+---
+
+### ❌ Missing `x-added-in-version` on a new operation
+
+```yaml
+# Wrong — Spectral error: require-added-in-version
+/my-resources:
+  post:
+    operationId: createMyResource
+    summary: Create a my-resource
+    tags: [My resource]
+```
+
+**Fix:** Add `x-added-in-version` set to the version in which the endpoint first ships:
+
+```yaml
+/my-resources:
+  post:
+    operationId: createMyResource
+    summary: Create a my-resource
+    x-added-in-version: "8.9"
+    tags: [My resource]
+```
+
+See §2.17 for full conventions.
 
 ---
 

--- a/zeebe/gateway-protocol/.spectral.yaml
+++ b/zeebe/gateway-protocol/.spectral.yaml
@@ -10,6 +10,7 @@ functions:
   - verifyArrayPropertiesRequired
   - verifyResponsePropertiesRequired
   - verifyDeprecatedEnumMembers
+  - verifyAddedInVersion
 functionsDir: ./spectral-functions
 rules:
   # Tag validation
@@ -149,3 +150,11 @@ rules:
     message: "{{error}}"
     then:
       function: verifyDeprecatedEnumMembers
+
+  require-added-in-version:
+    description: "Every operation must have `x-added-in-version` declaring the Camunda version in which it was introduced."
+    severity: error
+    given: $.paths[*][*]
+    message: "{{error}}"
+    then:
+      function: verifyAddedInVersion

--- a/zeebe/gateway-protocol/OPENAPI_VALIDATION.md
+++ b/zeebe/gateway-protocol/OPENAPI_VALIDATION.md
@@ -18,6 +18,7 @@ We use [Spectral CLI](https://docs.stoplight.io/docs/spectral/) to validate the 
   - Key property type validation (`...Key` properties must be strings)
   - Eventually-consistent annotation validation (command operations must not be marked as eventually consistent)
   - Required property existence validation (entries in required array must exist in properties)
+  - Operation versioning annotation validation (every operation must declare `x-added-in-version`)
 
 ## Running Validation Locally
 
@@ -123,6 +124,36 @@ schema:
 ```
 
 See [#46224](https://github.com/camunda/camunda/issues/46224) for details.
+
+### Missing `x-added-in-version` on an Operation
+
+Every operation must declare the Camunda version in which it was first introduced via the `x-added-in-version` extension. The `require-added-in-version` rule fails the build if this annotation is missing.
+
+**Wrong:**
+
+```yaml
+paths:
+  /my-resources:
+    post:
+      operationId: createMyResource
+      summary: Create a my-resource
+      tags: [My resource]
+      # ❌ Missing x-added-in-version
+```
+
+**Correct:**
+
+```yaml
+paths:
+  /my-resources:
+    post:
+      operationId: createMyResource
+      summary: Create a my-resource
+      x-added-in-version: "8.9"  # ✓ String containing the minor version (no patch)
+      tags: [My resource]
+```
+
+Set the value to the version in which the endpoint **first** ships and do not update it on later changes. See §2.17 of [`docs/rest-api-endpoint-guidelines.md`](../../docs/rest-api-endpoint-guidelines.md) for the full convention.
 
 ## Testing Custom Spectral Functions
 

--- a/zeebe/gateway-protocol/spectral-functions/verifyAddedInVersion.js
+++ b/zeebe/gateway-protocol/spectral-functions/verifyAddedInVersion.js
@@ -4,6 +4,10 @@
 //
 // Applied to each operation object under paths (get, post, put, patch, delete).
 
+// $.paths[*][*] matches all keys under a path item, including non-operation
+// entries like "parameters", "summary", "$ref", etc. Only check actual HTTP methods.
+const HTTP_METHODS = new Set(['get', 'post', 'put', 'patch', 'delete']);
+
 module.exports = (input, _opts, context) => {
   const errors = [];
 
@@ -14,10 +18,7 @@ module.exports = (input, _opts, context) => {
   const pathString = context.path[1];
   const method = context.path[2];
 
-  // $.paths[*][*] matches all keys under a path item, including non-operation
-  // entries like "parameters", "summary", "$ref", etc. Only check actual HTTP methods.
-  const httpMethods = new Set(['get', 'post', 'put', 'patch', 'delete']);
-  if (!httpMethods.has(method)) {
+  if (!HTTP_METHODS.has(method)) {
     return errors;
   }
 

--- a/zeebe/gateway-protocol/spectral-functions/verifyAddedInVersion.js
+++ b/zeebe/gateway-protocol/spectral-functions/verifyAddedInVersion.js
@@ -22,8 +22,9 @@ module.exports = (input, _opts, context) => {
   }
 
   const operationId = input.operationId || '?';
+  const addedInVersion = input['x-added-in-version'];
 
-  if (input['x-added-in-version'] == null) {
+  if (typeof addedInVersion !== 'string' || addedInVersion.trim().length === 0) {
     errors.push({
       message: `Operation "${operationId}" (${method.toUpperCase()} ${pathString}) is missing x-added-in-version. Every endpoint must declare the Camunda version in which it was introduced.`,
       path: [...context.path],

--- a/zeebe/gateway-protocol/spectral-functions/verifyAddedInVersion.js
+++ b/zeebe/gateway-protocol/spectral-functions/verifyAddedInVersion.js
@@ -1,0 +1,34 @@
+// Spectral custom function to verify that every operation has
+// x-added-in-version set. This ensures new endpoints always declare
+// the Camunda version in which they were introduced.
+//
+// Applied to each operation object under paths (get, post, put, patch, delete).
+
+module.exports = (input, _opts, context) => {
+  const errors = [];
+
+  if (!context.path || context.path.length < 3) {
+    return errors;
+  }
+
+  const pathString = context.path[1];
+  const method = context.path[2];
+
+  // $.paths[*][*] matches all keys under a path item, including non-operation
+  // entries like "parameters", "summary", "$ref", etc. Only check actual HTTP methods.
+  const httpMethods = new Set(['get', 'post', 'put', 'patch', 'delete']);
+  if (!httpMethods.has(method)) {
+    return errors;
+  }
+
+  const operationId = input.operationId || '?';
+
+  if (input['x-added-in-version'] == null) {
+    errors.push({
+      message: `Operation "${operationId}" (${method.toUpperCase()} ${pathString}) is missing x-added-in-version. Every endpoint must declare the Camunda version in which it was introduced.`,
+      path: [...context.path],
+    });
+  }
+
+  return errors;
+};

--- a/zeebe/gateway-protocol/spectral-tests/fixtures/added-in-version/rest-api.yaml
+++ b/zeebe/gateway-protocol/spectral-tests/fixtures/added-in-version/rest-api.yaml
@@ -1,0 +1,25 @@
+# Entry point for require-added-in-version rule tests.
+# Mirrors the real spec structure: paths $ref to domain files.
+openapi: "3.0.3"
+info:
+  title: Test Fixture — require-added-in-version
+  version: "1.0"
+tags:
+  - name: Test
+
+paths:
+  # ── Valid cases ──────────────────────────────────────────────
+  # Endpoint with x-added-in-version set
+  /valid/thing:
+    $ref: 'things.yaml#/paths/~1valid~1thing'
+
+  /valid/thing/{thingKey}:
+    $ref: 'things.yaml#/paths/~1valid~1thing~1{thingKey}'
+
+  # ── Invalid cases ───────────────────────────────────────────
+  # Endpoint missing x-added-in-version
+  /invalid/thing:
+    $ref: 'things.yaml#/paths/~1invalid~1thing'
+
+  /invalid/thing/{thingKey}:
+    $ref: 'things.yaml#/paths/~1invalid~1thing~1{thingKey}'

--- a/zeebe/gateway-protocol/spectral-tests/fixtures/added-in-version/things.yaml
+++ b/zeebe/gateway-protocol/spectral-tests/fixtures/added-in-version/things.yaml
@@ -1,0 +1,68 @@
+# Domain file for added-in-version rule test fixture.
+openapi: "3.0.3"
+info:
+  title: Things domain (test fixture)
+  version: "1.0"
+tags:
+  - name: Test
+
+paths:
+  # ── Valid: operation has x-added-in-version ──────────────────
+  /valid/thing:
+    post:
+      operationId: createThing
+      summary: Create a thing
+      description: Creates a new thing.
+      x-added-in-version: "8.6"
+      tags:
+        - Test
+      responses:
+        '200':
+          description: The thing was created.
+
+  /valid/thing/{thingKey}:
+    get:
+      operationId: getThing
+      summary: Get a thing
+      description: Gets a thing by key.
+      x-added-in-version: "8.7"
+      tags:
+        - Test
+      parameters:
+        - name: thingKey
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The thing.
+
+  # ── Invalid: operation missing x-added-in-version ────────────
+  /invalid/thing:
+    post:
+      operationId: createInvalidThing
+      summary: Create an invalid thing
+      description: Missing x-added-in-version.
+      tags:
+        - Test
+      responses:
+        '200':
+          description: The thing was created.
+
+  /invalid/thing/{thingKey}:
+    get:
+      operationId: getInvalidThing
+      summary: Get an invalid thing
+      description: Missing x-added-in-version.
+      tags:
+        - Test
+      parameters:
+        - name: thingKey
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The thing.

--- a/zeebe/gateway-protocol/spectral-tests/verifyAddedInVersion.test.js
+++ b/zeebe/gateway-protocol/spectral-tests/verifyAddedInVersion.test.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const { describe, it, before } = require('node:test');
+const assert = require('node:assert/strict');
+const { lintFixture, filterByRule } = require('./helpers');
+
+const RULE = 'require-added-in-version';
+const FIXTURE = 'added-in-version';
+
+describe('verifyAddedInVersion', () => {
+  let violations;
+
+  before(() => {
+    const allResults = lintFixture(FIXTURE);
+    violations = filterByRule(allResults, RULE);
+  });
+
+  // ── Valid cases (should produce zero violations) ─────────────────
+
+  describe('valid: operation with x-added-in-version', () => {
+    it('produces no violations for createThing', () => {
+      const v = violations.filter(
+        (e) => e.message.includes('createThing')
+      );
+      assert.equal(v.length, 0);
+    });
+
+    it('produces no violations for getThing', () => {
+      const v = violations.filter(
+        (e) => e.message.includes('getThing') && !e.message.includes('Invalid')
+      );
+      assert.equal(v.length, 0);
+    });
+  });
+
+  // ── Invalid cases ────────────────────────────────────────────────
+
+  describe('invalid: operation missing x-added-in-version', () => {
+    it('flags createInvalidThing', () => {
+      const v = violations.filter(
+        (e) => e.message.includes('createInvalidThing')
+      );
+      assert.equal(v.length, 1);
+    });
+
+    it('flags getInvalidThing', () => {
+      const v = violations.filter(
+        (e) => e.message.includes('getInvalidThing')
+      );
+      assert.equal(v.length, 1);
+    });
+
+    it('reports the correct message', () => {
+      const v = violations.filter(
+        (e) => e.message.includes('createInvalidThing')
+      );
+      assert.match(v[0].message, /missing x-added-in-version/);
+    });
+
+    it('produces exactly 2 violations total', () => {
+      assert.equal(violations.length, 2);
+    });
+  });
+});


### PR DESCRIPTION
## Description

Adding a new rule `require-added-in-version` to the Spectral Linting Ruleset so that the `x-added-in-version` field is checked for every operation during CI.

## Related issues
[46745](https://github.com/camunda/camunda/issues/46745)

## Related PR
[51427](https://github.com/camunda/camunda/pull/51427)