### PR TITLE
feat: warn in the camunda java client when the REST address uses plaintext HTTP

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -467,6 +467,7 @@ public final class CamundaClientImpl implements CamundaClient {
     asyncStub = gatewayStub;
     this.executorResource = executorResource;
     this.httpClient = httpClient;
+    warnIfInsecureRestAddress(config);
 
     if (config.getCredentialsProvider() != null) {
       credentialsProvider = config.getCredentialsProvider();
@@ -479,6 +480,15 @@ public final class CamundaClientImpl implements CamundaClient {
 
   private static HttpClient buildHttpClient(final CamundaClientConfiguration config) {
     return new HttpClientFactory(config).createClient();
+  }
+
+  private static void warnIfInsecureRestAddress(final CamundaClientConfiguration config) {
+    final URI restAddress = config.getRestAddress();
+    if (restAddress != null && "http".equalsIgnoreCase(restAddress.getScheme())) {
+      Loggers.LOGGER.warn(
+          "Using the Camunda Client with an insecure REST address [{}]; traffic, including authentication credentials, will not be encrypted. Configure an HTTPS REST address for production use.",
+          restAddress);
+    }
   }
 
   public static ManagedChannel buildChannel(final CamundaClientConfiguration config) {

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -397,6 +397,7 @@ import java.io.Closeable;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.time.OffsetDateTime;
 import java.util.HashMap;
@@ -467,7 +468,7 @@ public final class CamundaClientImpl implements CamundaClient {
     asyncStub = gatewayStub;
     this.executorResource = executorResource;
     this.httpClient = httpClient;
-    warnIfInsecureRestAddress(config);
+    warnIfInsecureRestAddress(config.getRestAddress());
 
     if (config.getCredentialsProvider() != null) {
       credentialsProvider = config.getCredentialsProvider();
@@ -482,12 +483,31 @@ public final class CamundaClientImpl implements CamundaClient {
     return new HttpClientFactory(config).createClient();
   }
 
-  private static void warnIfInsecureRestAddress(final CamundaClientConfiguration config) {
-    final URI restAddress = config.getRestAddress();
+  static void warnIfInsecureRestAddress(final URI restAddress) {
     if (restAddress != null && "http".equalsIgnoreCase(restAddress.getScheme())) {
       Loggers.LOGGER.warn(
           "Using the Camunda Client with an insecure REST address [{}]; traffic, including authentication credentials, will not be encrypted. Configure an HTTPS REST address for production use.",
-          restAddress);
+          sanitizeRestAddressForLogging(restAddress));
+    }
+  }
+
+  private static String sanitizeRestAddressForLogging(final URI restAddress) {
+    if (restAddress.getHost() == null) {
+      return restAddress.getScheme() + ":<redacted>";
+    }
+
+    try {
+      return new URI(
+              restAddress.getScheme(),
+              null,
+              restAddress.getHost(),
+              restAddress.getPort(),
+              restAddress.getPath(),
+              null,
+              null)
+          .toString();
+    } catch (final URISyntaxException e) {
+      return restAddress.getScheme() + "://<redacted>";
     }
   }
 

--- a/clients/java/src/test/java/io/camunda/client/impl/CamundaClientImplTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/CamundaClientImplTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
+import org.junit.jupiter.api.Test;
+
+final class CamundaClientImplTest {
+
+  @Test
+  void shouldWarnIfRestAddressUsesPlaintextHttp() {
+    // given
+    final URI restAddress =
+        URI.create("http://user:secret@example.com:8080/v1?access_token=secret#section");
+
+    try (final ClientLogCapture logs = ClientLogCapture.start()) {
+      // when
+      CamundaClientImpl.warnIfInsecureRestAddress(restAddress);
+
+      // then
+      final List<String> warningMessages = logs.warningMessages();
+      assertThat(warningMessages).hasSize(1);
+      assertThat(warningMessages.get(0))
+          .contains("http://example.com:8080/v1")
+          .doesNotContain("user", "secret", "access_token", "section");
+    }
+  }
+
+  @Test
+  void shouldNotWarnIfRestAddressUsesHttps() {
+    // given
+    final URI restAddress =
+        URI.create("https://user:secret@example.com:443/v1?access_token=secret#section");
+
+    try (final ClientLogCapture logs = ClientLogCapture.start()) {
+      // when
+      CamundaClientImpl.warnIfInsecureRestAddress(restAddress);
+
+      // then
+      assertThat(logs.warningMessages()).isEmpty();
+    }
+  }
+
+  @Test
+  void shouldNotWarnIfRestAddressIsNull() {
+    try (final ClientLogCapture logs = ClientLogCapture.start()) {
+      // when
+      CamundaClientImpl.warnIfInsecureRestAddress(null);
+
+      // then
+      assertThat(logs.warningMessages()).isEmpty();
+    }
+  }
+
+  private static final class ClientLogCapture implements AutoCloseable {
+
+    private final Logger logger;
+    private final RecordingAppender appender;
+
+    private ClientLogCapture() {
+      logger = (Logger) LogManager.getLogger("io.camunda.client");
+      appender = new RecordingAppender();
+      appender.start();
+      logger.addAppender(appender);
+    }
+
+    private static ClientLogCapture start() {
+      return new ClientLogCapture();
+    }
+
+    private List<String> warningMessages() {
+      final List<String> messages = new ArrayList<>();
+      for (final LogEvent event : appender.events()) {
+        if (Level.WARN.equals(event.getLevel())) {
+          messages.add(event.getMessage().getFormattedMessage());
+        }
+      }
+      return messages;
+    }
+
+    @Override
+    public void close() {
+      logger.removeAppender(appender);
+      appender.stop();
+    }
+  }
+
+  private static final class RecordingAppender extends AbstractAppender {
+
+    private final List<LogEvent> events = new ArrayList<>();
+
+    private RecordingAppender() {
+      super("CamundaClientImplTestAppender", null, null, true, Property.EMPTY_ARRAY);
+    }
+
+    @Override
+    public void append(final LogEvent event) {
+      events.add(event.toImmutable());
+    }
+
+    private List<LogEvent> events() {
+      return events;
+    }
+  }
+}


### PR DESCRIPTION
### Summary

`CamundaClient` currently accepts an `http://` REST address without any feedback, so operators can deploy a client that transmits authentication credentials and payloads over the wire in cleartext without ever being told. This change logs a single `io.camunda.client` WARN at client construction time when the configured REST URI uses the `http` scheme.

Closes #36658.

### Behaviour

- Logged once, during `CamundaClientImpl` construction (not per request).
- Fires for any `restAddress` whose scheme is `http` (case-insensitive). `https` and `null` stay silent.
- Uses the existing `Loggers.LOGGER` (`io.camunda.client`), so it can be suppressed by lowering that logger if the user consciously wants plaintext (e.g. an internal test cluster).
- No change to gRPC behaviour -- the ticket is scoped to the REST surface, happy to extend to gRPC in a follow-up if maintainers want symmetry.

### Sample output

```
WARN  io.camunda.client - Using the Camunda Client with an insecure REST address [http://localhost:8080]; traffic, including authentication credentials, will not be encrypted. Configure an HTTPS REST address for production use.
```

### Checklist

- [x] Change is scoped to `clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java`
- [x] No new dependencies
- [x] Warning fires once per client, not per request (acceptance criterion from the issue)
- [ ] Happy to add a logger-capture unit test in `CamundaClientTest` if reviewers prefer -- left out of this PR to keep the diff minimal and easy to revert.