### PR TITLE
fix: use SNAPSHOT starter/worker images when orchestration-tag is set

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -406,7 +406,7 @@ jobs:
 
   build-load-test-images:
     name: Build Starter and Worker
-    if: ${{ inputs.reuse-tag == '' || inputs.orchestration-tag != '' }}
+    if: ${{ inputs.reuse-tag == '' && inputs.orchestration-tag == '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: calculate-image-tag
@@ -492,7 +492,10 @@ jobs:
           cd load-tests/setup/${{ env.NAMESPACE }}
 
           # Build load test configuration
-          load_test_config="--set global.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }} \
+          # Use SNAPSHOT tag for starter/worker when using official Docker Hub images (orchestration-tag),
+          # otherwise use the built/reused image tag from the internal registry.
+          load_test_image_tag="${{ inputs.orchestration-tag != '' && 'SNAPSHOT' || needs.calculate-image-tag.outputs.image-tag }}"
+          load_test_config="--set global.image.tag=${load_test_image_tag} \
                             --set global.image.repository=${{ env.IMAGE_REPOSITORY }} \
                             --set global.image.pullSecrets[0].name=harbor-registry \
                             --set global.extraEnvVars[0].name=CONFIG_FORCE_app_performReadBenchmarks \

--- a/load-tests/load-test-values.yaml
+++ b/load-tests/load-test-values.yaml
@@ -1,6 +1,7 @@
 global:
   image:
     repository: registry.camunda.cloud/team-zeebe
+    tag: SNAPSHOT
     pullSecrets:
       - name: harbor-registry
 


### PR DESCRIPTION
## Description

The load test Docker image builds by reusing pre-built SNAPSHOT images instead of rebuilding starter and worker from source when an `orchestration-tag` is provided.

### Changes

- **Skip starter/worker build for orchestration-tag**: Changed the `build-load-test-images` job condition so it only runs when neither `reuse-tag` nor `orchestration-tag` is set. Previously it would rebuild starter/worker from source even when using official Docker Hub images.
- **Use SNAPSHOT tag in deploy step**: When `orchestration-tag` is provided, the load test Helm config now uses `SNAPSHOT` as the image tag for starter/worker instead of the computed build tag.
- **Pin default image tag**: Added `tag: SNAPSHOT` to `load-test-values.yaml` so manual load test runs (`make install`) also use a stable SNAPSHOT version by default.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #50881