### PR TITLE
feat: introduce `TenantDefinition` and `TestTenant` for multi-tenant …

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ResourceAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ResourceAuthorizationIT.java
@@ -20,6 +20,8 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.Permissions;
+import io.camunda.qa.util.auth.TenantDefinition;
+import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.multidb.MultiDbTest;
@@ -51,8 +53,6 @@ class ResourceAuthorizationIT {
   private static final String UNAUTHORIZED = "unauthorizedUser";
   private static final AtomicLong RESOURCE_KEY_TENANT_A = new AtomicLong();
   private static final AtomicLong RESOURCE_KEY_TENANT_B = new AtomicLong();
-  private static final String TENANT_A = "tenantA";
-  private static final String TENANT_B = "tenantB";
 
   @UserDefinition
   private static final TestUser ADMIN_USER =
@@ -76,20 +76,21 @@ class ResourceAuthorizationIT {
   private static final TestUser UNAUTHORIZED_USER =
       new TestUser(UNAUTHORIZED, DEFAULT_PASSWORD, List.of());
 
+  @TenantDefinition
+  private static final TestTenant TENANT_A =
+      new TestTenant("tenantA").addUsers(ADMIN, RESTRICTED, UNAUTHORIZED);
+
+  @TenantDefinition
+  private static final TestTenant TENANT_B = new TestTenant("tenantB").addUsers(ADMIN);
+
   @BeforeAll
   static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
-    createTenant(adminClient, TENANT_A);
-    createTenant(adminClient, TENANT_B);
-    assignUserToTenant(adminClient, ADMIN, TENANT_A);
-    assignUserToTenant(adminClient, ADMIN, TENANT_B);
-    assignUserToTenant(adminClient, RESTRICTED, TENANT_A);
-    assignUserToTenant(adminClient, UNAUTHORIZED, TENANT_A);
 
     final var deploymentTenantA =
         adminClient
             .newDeployResourceCommand()
             .addResourceFromClasspath("rpa/test-rpa.rpa")
-            .tenantId(TENANT_A)
+            .tenantId(TENANT_A.getId())
             .send()
             .join();
     RESOURCE_KEY_TENANT_A.set(deploymentTenantA.getResource().getFirst().getResourceKey());
@@ -98,7 +99,7 @@ class ResourceAuthorizationIT {
         adminClient
             .newDeployResourceCommand()
             .addResourceFromClasspath("rpa/test-rpa.rpa")
-            .tenantId(TENANT_B)
+            .tenantId(TENANT_B.getId())
             .send()
             .join();
     RESOURCE_KEY_TENANT_B.set(deploymentTenantB.getResource().getFirst().getResourceKey());
@@ -198,14 +199,5 @@ class ResourceAuthorizationIT {
     assertThat(problemException.code()).isEqualTo(403);
     assertThat(problemException.details().getDetail())
         .isEqualTo("Unauthorized to perform operation 'READ' on resource 'RESOURCE'");
-  }
-
-  private static void createTenant(final CamundaClient camundaClient, final String tenant) {
-    camundaClient.newCreateTenantCommand().tenantId(tenant).name(tenant).send().join();
-  }
-
-  private static void assignUserToTenant(
-      final CamundaClient camundaClient, final String username, final String tenant) {
-    camundaClient.newAssignUserToTenantCommand().username(username).tenantId(tenant).send().join();
   }
 }

--- a/qa/util/src/main/java/io/camunda/qa/util/auth/TenantDefinition.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/auth/TenantDefinition.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.qa.util.auth;
+
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marker annotation for a tenant definition, that is picked up by the {@link
+ * CamundaMultiDBExtension}. This is to clearly communicate that this tenant definition will be
+ * consumed and created (with related members) by the {@link CamundaMultiDBExtension}.
+ *
+ * <pre>{@code
+ * @Tag("multi-db-test")
+ * final class MyAuthMultiDbTest {
+ *
+ *   static final TestStandaloneBroker BROKER =
+ *       new TestStandaloneBroker().withBasicAuth().withAuthorizationsEnabled();
+ *
+ *   @RegisterExtension
+ *   static final CamundaMultiDBExtension EXTENSION = new CamundaMultiDBExtension(BROKER);
+ *
+ *   @TenantDefinition
+ *   private static final TestTenant MY_TENANT =
+ *       new TestTenant("my-tenant")
+ *           .setName("My Tenant")
+ *           .addUsers("admin");
+ *
+ *    @Test
+ *    void shouldHaveCreatedTenant(@Authenticated(ADMIN) final CamundaClient adminClient) {
+ *      // The tenant and its memberships are created before this test runs
+ *    }
+ * }</pre>
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface TenantDefinition {}

--- a/qa/util/src/main/java/io/camunda/qa/util/auth/TestTenant.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/auth/TestTenant.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.qa.util.auth;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public final class TestTenant {
+  private final String id;
+  private String name;
+  private String description = "";
+  private final Set<String> users = new HashSet<>();
+  private final Set<String> groups = new HashSet<>();
+  private final Set<String> clients = new HashSet<>();
+  private final Set<String> roles = new HashSet<>();
+  private final Set<String> mappingRules = new HashSet<>();
+
+  public TestTenant(final String id) {
+    this.id = id;
+    name = id;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public TestTenant setName(final String name) {
+    this.name = name;
+    return this;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public TestTenant setDescription(final String description) {
+    this.description = description;
+    return this;
+  }
+
+  public Set<String> getUsers() {
+    return users;
+  }
+
+  public Set<String> getGroups() {
+    return groups;
+  }
+
+  public Set<String> getClients() {
+    return clients;
+  }
+
+  public Set<String> getRoles() {
+    return roles;
+  }
+
+  public Set<String> getMappingRules() {
+    return mappingRules;
+  }
+
+  public TestTenant addUsers(final String... users) {
+    this.users.addAll(Set.of(users));
+    return this;
+  }
+
+  public TestTenant addGroups(final String... groups) {
+    this.groups.addAll(Set.of(groups));
+    return this;
+  }
+
+  public TestTenant addClients(final String... clients) {
+    this.clients.addAll(Set.of(clients));
+    return this;
+  }
+
+  public TestTenant addRoles(final String... roles) {
+    this.roles.addAll(Set.of(roles));
+    return this;
+  }
+
+  public TestTenant addMappingRules(final String... mappingRules) {
+    this.mappingRules.addAll(Set.of(mappingRules));
+    return this;
+  }
+}

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
@@ -16,10 +16,12 @@ import io.camunda.qa.util.auth.ClientDefinition;
 import io.camunda.qa.util.auth.GroupDefinition;
 import io.camunda.qa.util.auth.MappingRuleDefinition;
 import io.camunda.qa.util.auth.RoleDefinition;
+import io.camunda.qa.util.auth.TenantDefinition;
 import io.camunda.qa.util.auth.TestClient;
 import io.camunda.qa.util.auth.TestGroup;
 import io.camunda.qa.util.auth.TestMappingRule;
 import io.camunda.qa.util.auth.TestRole;
+import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
@@ -517,6 +519,7 @@ public class CamundaMultiDBExtension
 
   private void createEntities(final Class<?> testClass, final Boolean shouldSetupKeycloak) {
     final var users = findUsers(testClass, null, ModifierSupport::isStatic);
+    final var tenants = findTenants(testClass, null, ModifierSupport::isStatic);
     final var mappingRules = findMappingRules(testClass, null, ModifierSupport::isStatic);
     final var clients = findClients(testClass, null, ModifierSupport::isStatic);
     final var groups = findGroups(testClass, null, ModifierSupport::isStatic);
@@ -527,6 +530,7 @@ public class CamundaMultiDBExtension
         .withMappingRules(mappingRules)
         .withGroups(groups)
         .withRoles(roles)
+        .withTenants(tenants)
         .await();
     users.forEach(
         user -> {
@@ -669,6 +673,11 @@ public class CamundaMultiDBExtension
   private List<TestUser> findUsers(
       final Class<?> testClass, final Object testInstance, final Predicate<Field> predicate) {
     return findFields(testClass, testInstance, predicate, TestUser.class, UserDefinition.class);
+  }
+
+  private List<TestTenant> findTenants(
+      final Class<?> testClass, final Object testInstance, final Predicate<Field> predicate) {
+    return findFields(testClass, testInstance, predicate, TestTenant.class, TenantDefinition.class);
   }
 
   private List<TestGroup> findGroups(

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/EntityManager.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/EntityManager.java
@@ -32,6 +32,7 @@ import io.camunda.qa.util.auth.TestClient;
 import io.camunda.qa.util.auth.TestGroup;
 import io.camunda.qa.util.auth.TestMappingRule;
 import io.camunda.qa.util.auth.TestRole;
+import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.List;
@@ -462,6 +463,75 @@ public final class EntityManager {
       final var response = request.page(p -> p.limit(expected)).send().join();
       return response.items();
     };
+  }
+
+  public EntityManager withTenants(final List<TestTenant> tenants) {
+    tenants.forEach(
+        tenant -> {
+          defaultClient
+              .newCreateTenantCommand()
+              .tenantId(tenant.getId())
+              .name(tenant.getName())
+              .description(tenant.getDescription())
+              .send()
+              .join();
+
+          tenant
+              .getUsers()
+              .forEach(
+                  user ->
+                      defaultClient
+                          .newAssignUserToTenantCommand()
+                          .username(user)
+                          .tenantId(tenant.getId())
+                          .send()
+                          .join());
+
+          tenant
+              .getGroups()
+              .forEach(
+                  groupId ->
+                      defaultClient
+                          .newAssignGroupToTenantCommand()
+                          .groupId(groupId)
+                          .tenantId(tenant.getId())
+                          .send()
+                          .join());
+
+          tenant
+              .getRoles()
+              .forEach(
+                  roleId ->
+                      defaultClient
+                          .newAssignRoleToTenantCommand()
+                          .roleId(roleId)
+                          .tenantId(tenant.getId())
+                          .send()
+                          .join());
+
+          tenant
+              .getClients()
+              .forEach(
+                  clientId ->
+                      defaultClient
+                          .newAssignClientToTenantCommand()
+                          .clientId(clientId)
+                          .tenantId(tenant.getId())
+                          .send()
+                          .join());
+
+          tenant
+              .getMappingRules()
+              .forEach(
+                  mappingRuleId ->
+                      defaultClient
+                          .newAssignMappingRuleToTenantCommand()
+                          .mappingRuleId(mappingRuleId)
+                          .tenantId(tenant.getId())
+                          .send()
+                          .join());
+        });
+    return this;
   }
 
   record MembershipSearch<T>(

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/EntityManager.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/EntityManager.java
@@ -25,6 +25,9 @@ import io.camunda.client.api.search.response.MappingRule;
 import io.camunda.client.api.search.response.Role;
 import io.camunda.client.api.search.response.RoleGroup;
 import io.camunda.client.api.search.response.RoleUser;
+import io.camunda.client.api.search.response.Tenant;
+import io.camunda.client.api.search.response.TenantGroup;
+import io.camunda.client.api.search.response.TenantUser;
 import io.camunda.client.api.search.response.User;
 import io.camunda.qa.util.auth.Membership;
 import io.camunda.qa.util.auth.Permissions;
@@ -39,6 +42,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -57,6 +61,7 @@ public final class EntityManager {
   final Map<String, TestGroup> groups = new ConcurrentHashMap<>();
   final Map<String, TestRole> roles = new ConcurrentHashMap<>();
   final Map<String, TestMappingRule> mappingRules = new ConcurrentHashMap<>();
+  final Map<String, TestTenant> tenants = new ConcurrentHashMap<>();
 
   private final Set<String> createdPermissionIdentifiers = ConcurrentHashMap.newKeySet();
 
@@ -356,6 +361,15 @@ public final class EntityManager {
             new MembershipSearch<>(
                 roleId -> wrap(defaultClient.newMappingRulesByRoleSearchRequest(roleId)),
                 MappingRule::getMappingRuleId)));
+
+    awaitSearchVisibility(
+        "tenants",
+        () -> wrap(defaultClient.newTenantsSearchRequest()),
+        extractField(Tenant::getTenantId),
+        tenants.keySet());
+
+    awaitTenantMembershipsVisibility();
+
     LOGGER.debug("Finished waiting for visibility of all entities and permissions.");
   }
 
@@ -466,72 +480,122 @@ public final class EntityManager {
   }
 
   public EntityManager withTenants(final List<TestTenant> tenants) {
-    tenants.forEach(
-        tenant -> {
-          defaultClient
-              .newCreateTenantCommand()
-              .tenantId(tenant.getId())
-              .name(tenant.getName())
-              .description(tenant.getDescription())
-              .send()
-              .join();
+    final var newTenants =
+        tenants.stream().filter(tenant -> !this.tenants.containsKey(tenant.getId())).toList();
 
-          tenant
-              .getUsers()
-              .forEach(
-                  user ->
-                      defaultClient
-                          .newAssignUserToTenantCommand()
-                          .username(user)
-                          .tenantId(tenant.getId())
-                          .send()
-                          .join());
+    // Create all tenants in parallel
+    final var creationFutures =
+        newTenants.stream()
+            .map(
+                tenant ->
+                    (CompletableFuture<?>)
+                        defaultClient
+                            .newCreateTenantCommand()
+                            .tenantId(tenant.getId())
+                            .name(tenant.getName())
+                            .description(tenant.getDescription())
+                            .send()
+                            .thenRun(() -> this.tenants.put(tenant.getId(), tenant)))
+            .toList();
+    CompletableFuture.allOf(creationFutures.toArray(CompletableFuture[]::new)).join();
 
-          tenant
-              .getGroups()
-              .forEach(
-                  groupId ->
-                      defaultClient
-                          .newAssignGroupToTenantCommand()
-                          .groupId(groupId)
-                          .tenantId(tenant.getId())
-                          .send()
-                          .join());
+    // Then assign memberships
+    newTenants.forEach(this::addTenantMemberships);
 
-          tenant
-              .getRoles()
-              .forEach(
-                  roleId ->
-                      defaultClient
-                          .newAssignRoleToTenantCommand()
-                          .roleId(roleId)
-                          .tenantId(tenant.getId())
-                          .send()
-                          .join());
-
-          tenant
-              .getClients()
-              .forEach(
-                  clientId ->
-                      defaultClient
-                          .newAssignClientToTenantCommand()
-                          .clientId(clientId)
-                          .tenantId(tenant.getId())
-                          .send()
-                          .join());
-
-          tenant
-              .getMappingRules()
-              .forEach(
-                  mappingRuleId ->
-                      defaultClient
-                          .newAssignMappingRuleToTenantCommand()
-                          .mappingRuleId(mappingRuleId)
-                          .tenantId(tenant.getId())
-                          .send()
-                          .join());
-        });
     return this;
+  }
+
+  private void addTenantMemberships(final TestTenant tenant) {
+    final var tenantId = tenant.getId();
+
+    tenant
+        .getUsers()
+        .forEach(
+            username ->
+                defaultClient
+                    .newAssignUserToTenantCommand()
+                    .username(username)
+                    .tenantId(tenantId)
+                    .send()
+                    .join());
+
+    tenant
+        .getGroups()
+        .forEach(
+            groupId ->
+                defaultClient
+                    .newAssignGroupToTenantCommand()
+                    .groupId(groupId)
+                    .tenantId(tenantId)
+                    .send()
+                    .join());
+
+    tenant
+        .getRoles()
+        .forEach(
+            roleId ->
+                defaultClient
+                    .newAssignRoleToTenantCommand()
+                    .roleId(roleId)
+                    .tenantId(tenantId)
+                    .send()
+                    .join());
+
+    tenant
+        .getClients()
+        .forEach(
+            clientId ->
+                defaultClient
+                    .newAssignClientToTenantCommand()
+                    .clientId(clientId)
+                    .tenantId(tenantId)
+                    .send()
+                    .join());
+
+    tenant
+        .getMappingRules()
+        .forEach(
+            mappingRuleId ->
+                defaultClient
+                    .newAssignMappingRuleToTenantCommand()
+                    .mappingRuleId(mappingRuleId)
+                    .tenantId(tenantId)
+                    .send()
+                    .join());
+  }
+
+  private void awaitTenantMembershipsVisibility() {
+    tenants
+        .values()
+        .forEach(
+            tenant -> {
+              final var tenantId = tenant.getId();
+              awaitSearchVisibility(
+                  "tenant users (tenantId=" + tenantId + ")",
+                  () -> wrap(defaultClient.newUsersByTenantSearchRequest(tenantId)),
+                  extractField(TenantUser::getUsername),
+                  tenant.getUsers());
+              awaitSearchVisibility(
+                  "tenant groups (tenantId=" + tenantId + ")",
+                  () -> wrap(defaultClient.newGroupsByTenantSearchRequest(tenantId)),
+                  extractField(TenantGroup::getGroupId),
+                  tenant.getGroups());
+              awaitSearchVisibility(
+                  "tenant roles (tenantId=" + tenantId + ")",
+                  () -> wrap(defaultClient.newRolesByTenantSearchRequest(tenantId)),
+                  extractField(Role::getRoleId),
+                  tenant.getRoles());
+              awaitSearchVisibility(
+                  "tenant clients (tenantId=" + tenantId + ")",
+                  () -> wrap(defaultClient.newClientsByTenantSearchRequest(tenantId)),
+                  extractField(Client::getClientId),
+                  tenant.getClients());
+              awaitSearchVisibility(
+                  "tenant mapping rules (tenantId=" + tenantId + ")",
+                  () -> wrap(defaultClient.newMappingRulesByTenantSearchRequest(tenantId)),
+                  extractField(MappingRule::getMappingRuleId),
+                  tenant.getMappingRules());
+            });
   }
 
   record MembershipSearch<T>(


### PR DESCRIPTION
## Description

- Added `TenantDefinition` annotation to mark and manage tenant definitions in tests.
- Introduced `TestTenant` class to handle tenant configurations such as users, groups, roles, and clients.
- Enhanced `CamundaMultiDBExtension` and `EntityManager` to create and manage tenants dynamically during multi-DB tests.
- Updated `ResourceAuthorizationIT` to utilize the new tenant setup mechanism.

## Related issues

closes https://github.com/camunda/camunda/issues/51569
