### PR TITLE
fix(operate-client): add tsconfig paths alias to enforce modules/* imports in autocompletion

### DIFF
--- a/operate/client/tsconfig.app.json
+++ b/operate/client/tsconfig.app.json
@@ -19,6 +19,9 @@
   ],
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
-    "baseUrl": "src"
+    "baseUrl": "src",
+    "paths": {
+      "modules/*": ["./modules/*"]
+    }
   }
 }


### PR DESCRIPTION
## Problem

The `modules/*` path alias was not defined anywhere in the tsconfig setup. Without it, TypeScript and IntelliJ's language service have no signal to prefer the alias-based form, causing editors and AI agents to suggest relative imports (e.g. `../modules/stores/notifications`) instead of the intended `modules/stores/notifications` pattern.

## Solution

Added the `paths` mapping to `tsconfig.app.json`, alongside the existing `"baseUrl": "src"`:

```jsonc
"modules/*": ["modules/*"]
```

The value is relative to `baseUrl` (`src`), so no path prefix is needed.

## Effect

- IntelliJ's **"Use path mappings from tsconfig.json: Always"** setting can now resolve the alias correctly
- Autocompletion and AI agent import suggestions will prefer `modules/*` over relative paths
- Combined with the `no-restricted-imports` ESLint rule, this enforces the pattern at both the editor and CI level

## No runtime impact

`baseUrl: "src"` already handled module resolution at build time — this change only affects how the TypeScript language service and editors interpret import suggestions.

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

relates to #51580
