### PR TITLE
feat: sync new properties to message-subscription in camunda-api-zod-schemas

### DIFF
--- a/identity/client/package-lock.json
+++ b/identity/client/package-lock.json
@@ -8,7 +8,7 @@
       "name": "identity-frontend",
       "version": "8.10.0-SNAPSHOT",
       "dependencies": {
-        "@camunda/camunda-api-zod-schemas": "^0.0.58",
+        "@camunda/camunda-api-zod-schemas": "0.0.60",
         "@camunda/camunda-composite-components": "0.22.6",
         "@carbon/elements": "11.87.0",
         "@carbon/react": "1.105.0",
@@ -326,9 +326,9 @@
       }
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.58",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.58.tgz",
-      "integrity": "sha512-nPStQCSGrrFJDx+lo76uhkLXUTAiYodOfZlUk+w8cKb4XUYHqwt7CGBmE6k11oqQTiW4LsILa3ALuqhpfDVoAQ==",
+      "version": "0.0.60",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.60.tgz",
+      "integrity": "sha512-A1tAjBmTrs7CVBkZNQAFXPnC6NOCKqFJk7COtWnyjj1jMSgEk3CPsXaTYrN6UhNKKheWqTbLQGp5bxN5phbpsw==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/identity/client/package.json
+++ b/identity/client/package.json
@@ -18,7 +18,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@camunda/camunda-api-zod-schemas": "^0.0.58",
+    "@camunda/camunda-api-zod-schemas": "0.0.60",
     "@camunda/camunda-composite-components": "0.22.6",
     "@carbon/elements": "11.87.0",
     "@carbon/react": "1.105.0",

--- a/identity/client/src/pages/mcp-processes/useMcpProcessTools.ts
+++ b/identity/client/src/pages/mcp-processes/useMcpProcessTools.ts
@@ -6,13 +6,13 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import {
+  MessageSubscription,
+  QueryMessageSubscriptionsRequestBody,
+} from "@camunda/camunda-api-zod-schemas/8.10";
 import { useMemo } from "react";
 import { useApi, usePagination } from "src/utility/api";
-import {
-  searchMessageSubscriptions,
-  type MessageSubscription,
-  type QueryMessageSubscriptionsRequestBody,
-} from "src/utility/api/message-subscriptions";
+import { searchMessageSubscriptions } from "src/utility/api/message-subscriptions";
 
 const TOOL_PURPOSE_KEY = "io.camunda.tool:purpose";
 

--- a/identity/client/src/pages/mcp-processes/useMcpProcessTools.ts
+++ b/identity/client/src/pages/mcp-processes/useMcpProcessTools.ts
@@ -23,7 +23,7 @@ export type McpProcessTool = {
   id: string;
   toolName: string;
   toolDescription: string;
-  processDefinitionKey: string;
+  processDefinitionKey: string | null;
   processDefinitionId: string;
   processDefinitionName: string;
   processDefinitionVersion: number | string;

--- a/identity/client/src/utility/api/message-subscriptions/index.ts
+++ b/identity/client/src/utility/api/message-subscriptions/index.ts
@@ -7,9 +7,8 @@
  */
 
 import type {
-  MessageSubscription as BaseMessageSubscription,
-  QueryMessageSubscriptionsRequestBody as BaseQueryMessageSubscriptionsRequestBody,
-  QueryMessageSubscriptionsResponseBody as BaseQueryMessageSubscriptionsResponseBody,
+  QueryMessageSubscriptionsRequestBody,
+  QueryMessageSubscriptionsResponseBody,
 } from "@camunda/camunda-api-zod-schemas/8.10";
 import { ApiDefinition, apiPost } from "src/utility/api/request";
 
@@ -19,63 +18,3 @@ export const searchMessageSubscriptions: ApiDefinition<
   QueryMessageSubscriptionsResponseBody,
   QueryMessageSubscriptionsRequestBody | undefined
 > = (params) => apiPost(`${MESSAGE_SUBSCRIPTIONS_ENDPOINT}/search`, params);
-
-// TODO: Remove extended types once API is stabilized and schema merged back into @camunda/camunda-api-zod-schemas.
-// https://github.com/camunda/camunda/issues/51241
-
-type MessageSubscriptionType = "START_EVENT" | "PROCESS_EVENT";
-
-export interface MessageSubscription extends BaseMessageSubscription {
-  messageSubscriptionType: MessageSubscriptionType;
-  extensionProperties: Record<string, string>;
-  processDefinitionName: string | null;
-  processDefinitionVersion: number | null;
-  toolName: string | null;
-  inboundConnectorType: string | null;
-}
-
-type AdvancedStringFilter =
-  | string
-  | {
-      $eq?: string;
-      $neq?: string;
-      $exists?: boolean;
-      $in?: string[];
-      $notIn?: string[];
-      $like?: string;
-    };
-
-type BaseMessageSubscriptionFilter = NonNullable<
-  BaseQueryMessageSubscriptionsRequestBody["filter"]
->;
-type BaseMessageSubscriptionSort = NonNullable<
-  BaseQueryMessageSubscriptionsRequestBody["sort"]
->[number];
-
-interface MessageSubscriptionFilter extends BaseMessageSubscriptionFilter {
-  messageSubscriptionType?: MessageSubscriptionType;
-  toolName?: AdvancedStringFilter;
-  inboundConnectorType?: AdvancedStringFilter;
-}
-
-interface MessageSubscriptionSort extends Omit<
-  BaseMessageSubscriptionSort,
-  "field"
-> {
-  field: BaseMessageSubscriptionSort["field"] | "toolName";
-}
-
-export interface QueryMessageSubscriptionsRequestBody extends Omit<
-  BaseQueryMessageSubscriptionsRequestBody,
-  "filter" | "sort"
-> {
-  filter?: MessageSubscriptionFilter;
-  sort?: MessageSubscriptionSort[];
-}
-
-export interface QueryMessageSubscriptionsResponseBody extends Omit<
-  BaseQueryMessageSubscriptionsResponseBody,
-  "items"
-> {
-  items: MessageSubscription[];
-}

--- a/operate/client/package-lock.json
+++ b/operate/client/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@axe-core/playwright": "4.11.1",
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
-        "@camunda/camunda-api-zod-schemas": "^0.0.58",
+        "@camunda/camunda-api-zod-schemas": "0.0.60",
         "@camunda/camunda-composite-components": "0.22.6",
         "@carbon/elements": "11.87.0",
         "@carbon/react": "1.105.0",
@@ -451,9 +451,9 @@
       "license": "LicenseRef-Camunda-1.0"
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.58",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.58.tgz",
-      "integrity": "sha512-nPStQCSGrrFJDx+lo76uhkLXUTAiYodOfZlUk+w8cKb4XUYHqwt7CGBmE6k11oqQTiW4LsILa3ALuqhpfDVoAQ==",
+      "version": "0.0.60",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.60.tgz",
+      "integrity": "sha512-A1tAjBmTrs7CVBkZNQAFXPnC6NOCKqFJk7COtWnyjj1jMSgEk3CPsXaTYrN6UhNKKheWqTbLQGp5bxN5phbpsw==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@axe-core/playwright": "4.11.1",
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
-    "@camunda/camunda-api-zod-schemas": "^0.0.58",
+    "@camunda/camunda-api-zod-schemas": "0.0.60",
     "@camunda/camunda-composite-components": "0.22.6",
     "@carbon/elements": "11.87.0",
     "@carbon/react": "1.105.0",

--- a/tasklist/client/package-lock.json
+++ b/tasklist/client/package-lock.json
@@ -11,7 +11,7 @@
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
         "@bpmn-io/form-js-carbon-styles": "1.21.2",
         "@bpmn-io/form-js-viewer": "1.21.2",
-        "@camunda/camunda-api-zod-schemas": "^0.0.58",
+        "@camunda/camunda-api-zod-schemas": "0.0.60",
         "@camunda/camunda-composite-components": "0.22.6",
         "@carbon/react": "1.105.0",
         "@monaco-editor/react": "4.7.0",
@@ -587,9 +587,9 @@
       "license": "LicenseRef-Camunda-1.0"
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.58",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.58.tgz",
-      "integrity": "sha512-nPStQCSGrrFJDx+lo76uhkLXUTAiYodOfZlUk+w8cKb4XUYHqwt7CGBmE6k11oqQTiW4LsILa3ALuqhpfDVoAQ==",
+      "version": "0.0.60",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.60.tgz",
+      "integrity": "sha512-A1tAjBmTrs7CVBkZNQAFXPnC6NOCKqFJk7COtWnyjj1jMSgEk3CPsXaTYrN6UhNKKheWqTbLQGp5bxN5phbpsw==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/tasklist/client/package.json
+++ b/tasklist/client/package.json
@@ -7,7 +7,7 @@
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
     "@bpmn-io/form-js-carbon-styles": "1.21.2",
     "@bpmn-io/form-js-viewer": "1.21.2",
-    "@camunda/camunda-api-zod-schemas": "^0.0.58",
+    "@camunda/camunda-api-zod-schemas": "0.0.60",
     "@camunda/camunda-composite-components": "0.22.6",
     "@carbon/react": "1.105.0",
     "@monaco-editor/react": "4.7.0",

--- a/webapp/client/package-lock.json
+++ b/webapp/client/package-lock.json
@@ -3779,13 +3779,13 @@
 			"version": "0.0.1",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
-				"@camunda/camunda-api-zod-schemas": "0.0.58",
+				"@camunda/camunda-api-zod-schemas": "0.0.59",
 				"typescript": "5.9.3"
 			}
 		},
 		"packages/camunda-api-zod-schemas": {
 			"name": "@camunda/camunda-api-zod-schemas",
-			"version": "0.0.58",
+			"version": "0.0.59",
 			"hasInstallScript": true,
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {

--- a/webapp/client/package-lock.json
+++ b/webapp/client/package-lock.json
@@ -3779,14 +3779,13 @@
 			"version": "0.0.1",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
-				"@camunda/camunda-api-zod-schemas": "0.0.59",
+				"@camunda/camunda-api-zod-schemas": "0.0.60",
 				"typescript": "5.9.3"
 			}
 		},
 		"packages/camunda-api-zod-schemas": {
 			"name": "@camunda/camunda-api-zod-schemas",
-			"version": "0.0.59",
-			"hasInstallScript": true,
+			"version": "0.0.60",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
 				"@types/node": "25.5.2",

--- a/webapp/client/packages/c8-mocks/package.json
+++ b/webapp/client/packages/c8-mocks/package.json
@@ -18,7 +18,7 @@
 		"typecheck": "tsc"
 	},
 	"devDependencies": {
-		"@camunda/camunda-api-zod-schemas": "0.0.59",
+		"@camunda/camunda-api-zod-schemas": "0.0.60",
 		"typescript": "5.9.3"
 	}
 }

--- a/webapp/client/packages/c8-mocks/package.json
+++ b/webapp/client/packages/c8-mocks/package.json
@@ -18,7 +18,7 @@
 		"typecheck": "tsc"
 	},
 	"devDependencies": {
-		"@camunda/camunda-api-zod-schemas": "0.0.58",
+		"@camunda/camunda-api-zod-schemas": "0.0.59",
 		"typescript": "5.9.3"
 	}
 }

--- a/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
+++ b/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.0.60
+
+### 🩹 Fixes
+
+- Replace `postinstall` script with `prepare`. Makes it possible to install the package again.
+
+### ❤️ Contributors
+
+- Christoph Fricke ([@christoph-fricke](https://github.com/christoph-fricke))
+
 ## v0.0.59
 
 ### 🚀 Enhancements

--- a/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
+++ b/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## v0.0.59
+
+### 🚀 Enhancements
+
+- Sync new properties to `MessageSubscription` that result in support for MCP Tools ([#51241](https://github.com/camunda/camunda/issues/51241))
+  - `messageSubscriptionType` enum
+  - `extensionProperties` (is a new loosely typed record)
+  - `processDefinitionName`
+  - `processDefinitionVersion`
+  - `toolName`
+  - `inboundConnectorType`
+
+### 🩹 Fixes
+
+- Mark `elementInstanceKey` and `correlationKey` as `nullable` in `CorrelatedMessageSubscription`
+- Mark `elementInstanceKey`, `correlationKey`, `processDefinitionKey`, and `processInstanceKey` as `nullable` in `MessageSubscription`
+
+### ❤️ Contributors
+
+- Christoph Fricke ([@christoph-fricke](https://github.com/christoph-fricke))
+
 ## v0.0.58
 
 ### 🚀 Enhancements

--- a/webapp/client/packages/camunda-api-zod-schemas/README.md
+++ b/webapp/client/packages/camunda-api-zod-schemas/README.md
@@ -29,7 +29,7 @@ Refer to the exported members from `lib/8.8/index.ts` and other files in the `li
 
 ## Publishing a new version
 
-1. Increment the version in `package.json` and push changes to `main`.
+1. Increment the version in `package.json`, dependency-version in `../c8-mocks/package.json`, and push changes to `main`.
 2. Run the [Publish Zod Schemas to npm](https://github.com/camunda/camunda/actions/workflows/publish-zod-schemas.yml) GitHub action.
    - By default, the dry-run option is enabled. Uncheck it to publish the new version.
 3. Update the `@camunda/camunda-api-zod-schemas` package versions in Operate, Admin and Tasklist.

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/index.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/index.ts
@@ -666,6 +666,7 @@ export {
 	queryCorrelatedMessageSubscriptionRequestBodySchema,
 	queryCorrelatedMessageSubscriptionsResponseBodySchema,
 	type MessageSubscriptionState,
+	type MessageSubscriptionType,
 	type MessageSubscription,
 	type QueryMessageSubscriptionsRequestBody,
 	type QueryMessageSubscriptionsResponseBody,

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/message-subscriptions.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/message-subscriptions.ts
@@ -21,19 +21,28 @@ import {
 const messageSubscriptionStateSchema = z.enum(['CORRELATED', 'CREATED', 'DELETED', 'MIGRATED']);
 type MessageSubscriptionState = z.infer<typeof messageSubscriptionStateSchema>;
 
+const messageSubscriptionTypeSchema = z.enum(['START_EVENT', 'PROCESS_EVENT']);
+type MessageSubscriptionType = z.infer<typeof messageSubscriptionTypeSchema>;
+
 const messageSubscriptionSchema = z.object({
 	messageSubscriptionKey: z.string(),
 	processDefinitionId: z.string(),
-	processDefinitionKey: z.string(),
-	processInstanceKey: z.string(),
+	processDefinitionKey: z.string().nullable(),
+	processInstanceKey: z.string().nullable(),
 	elementId: z.string(),
-	elementInstanceKey: z.string(),
+	elementInstanceKey: z.string().nullable(),
 	messageSubscriptionState: messageSubscriptionStateSchema,
+	messageSubscriptionType: messageSubscriptionTypeSchema,
 	lastUpdatedDate: z.string(),
 	messageName: z.string(),
-	correlationKey: z.string(),
+	correlationKey: z.string().nullable(),
 	tenantId: z.string(),
 	rootProcessInstanceKey: z.string().nullable(),
+	extensionProperties: z.record(z.string(), z.string()),
+	processDefinitionName: z.string().nullable(),
+	processDefinitionVersion: z.number().int().nullable(),
+	toolName: z.string().nullable(),
+	inboundConnectorType: z.string().nullable(),
 });
 type MessageSubscription = z.infer<typeof messageSubscriptionSchema>;
 
@@ -41,20 +50,29 @@ const queryMessageSubscriptionRequestBodySchema = getQueryRequestBodySchema({
 	sortFields: [
 		'messageSubscriptionKey',
 		'processDefinitionId',
+		'processDefinitionName',
+		'processDefinitionVersion',
 		'processInstanceKey',
 		'elementId',
 		'elementInstanceKey',
 		'messageSubscriptionState',
+		'messageSubscriptionType',
 		'lastUpdatedDate',
 		'messageName',
 		'correlationKey',
 		'tenantId',
+		'toolName',
+		'inboundConnectorType',
 	] as const,
 	filter: z
 		.object({
 			messageSubscriptionState: getEnumFilterSchema(messageSubscriptionStateSchema),
+			messageSubscriptionType: getEnumFilterSchema(messageSubscriptionTypeSchema),
 			messageSubscriptionKey: advancedStringFilterSchema,
 			processDefinitionId: advancedStringFilterSchema,
+			processDefinitionKey: advancedStringFilterSchema,
+			processDefinitionName: advancedStringFilterSchema,
+			processDefinitionVersion: advancedIntegerFilterSchema,
 			lastUpdatedDate: advancedDateTimeFilterSchema,
 			processInstanceKey: advancedStringFilterSchema,
 			elementId: advancedStringFilterSchema,
@@ -62,6 +80,8 @@ const queryMessageSubscriptionRequestBodySchema = getQueryRequestBodySchema({
 			messageName: advancedStringFilterSchema,
 			correlationKey: advancedStringFilterSchema,
 			tenantId: advancedStringFilterSchema,
+			toolName: advancedStringFilterSchema,
+			inboundConnectorType: advancedStringFilterSchema,
 		})
 		.partial(),
 });
@@ -84,10 +104,10 @@ const correlatedMessageSubscriptionSchema = z.object({
 	processDefinitionKey: z.string(),
 	processInstanceKey: z.string(),
 	elementId: z.string(),
-	elementInstanceKey: z.string(),
+	elementInstanceKey: z.string().nullable(),
 	correlationTime: z.string(),
 	messageName: z.string(),
-	correlationKey: z.string(),
+	correlationKey: z.string().nullable(),
 	messageKey: z.string(),
 	partitionId: z.number().int(),
 	tenantId: z.string(),
@@ -159,6 +179,7 @@ export {
 
 export type {
 	MessageSubscriptionState,
+	MessageSubscriptionType,
 	MessageSubscription,
 	QueryMessageSubscriptionsRequestBody,
 	QueryMessageSubscriptionsResponseBody,

--- a/webapp/client/packages/camunda-api-zod-schemas/package.json
+++ b/webapp/client/packages/camunda-api-zod-schemas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda/camunda-api-zod-schemas",
-	"version": "0.0.58",
+	"version": "0.0.59",
 	"license": "LicenseRef-Camunda-1.0",
 	"description": "Zod schemas and TypeScript types for Camunda 8 unified API",
 	"author": "Vinicius Goulart <vinicius.goulart@camunda.com>",

--- a/webapp/client/packages/camunda-api-zod-schemas/package.json
+++ b/webapp/client/packages/camunda-api-zod-schemas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda/camunda-api-zod-schemas",
-	"version": "0.0.59",
+	"version": "0.0.60",
 	"license": "LicenseRef-Camunda-1.0",
 	"description": "Zod schemas and TypeScript types for Camunda 8 unified API",
 	"author": "Vinicius Goulart <vinicius.goulart@camunda.com>",

--- a/webapp/client/packages/camunda-api-zod-schemas/package.json
+++ b/webapp/client/packages/camunda-api-zod-schemas/package.json
@@ -22,9 +22,8 @@
 		"dev": "vite",
 		"build": "vite build",
 		"format": "prettier --write .",
-		"prepublish": "npm run build",
 		"typecheck": "tsc",
-		"postinstall": "npm run build"
+    "prepare": "npm run build"
 	},
 	"sideEffects": false,
 	"files": [


### PR DESCRIPTION
## Description

This PR synchronizes upcoming changes to the `messages.yaml` OpenAPI spec with the `camunda-api-zod-schemas` message subscription types. The changes are prepared based on https://github.com/camunda/camunda/pull/51449, so we should hold with the release flow until the API changes are merged.

## Checklist

- [x] This PR is stacked on https://github.com/camunda/camunda/pull/51389
- [x] Trigger release workflow to release package
- [x] After release:
  - [x] Update version in Operate, Tasklist, and Admin
  - [X] Remove [temporary `MessageSubscription` overrides](https://github.com/camunda/camunda/blob/e3592f3226972a4852c96d2c87487b7c6919a186/identity/client/src/utility/api/message-subscriptions/index.ts) in Admin

## Related issues

relates #51241
