### PR TITLE
fix: report repository to release process

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -181,7 +181,7 @@ jobs:
           #   Additional arguments to pass to the Maven executions, separated by spaces.
           #   Per default it is not required, but the release plugin is configured in the camunda release plugin (and this property is used)
           #   This is the reason why we have to set it at least as empty string.
-          
+
           # Conditionally set profile flags based on includeOptimize input
           if [[ "${{ inputs.includeOptimize }}" == "true" ]]; then
             PROFILE_FLAGS=""
@@ -190,7 +190,7 @@ jobs:
             PROFILE_FLAGS="-P\!include-optimize"
             ARGUMENTS_PROFILE="-P!include-optimize"
           fi
-          
+
           ./mvnw release:prepare -B \
             -Dresume=false \
             -Dtag="${RELEASE_TAG}" \
@@ -225,7 +225,7 @@ jobs:
           #   In order to disable QA/IT and the auto formatting during the release.
           #   It is unnecessary to release integration tests, and we don't want to run the auto-formatting unnecessarily.
 
-          
+
 
           # Conditionally set profile flags based on includeOptimize input
           if [[ "${{ inputs.includeOptimize }}" == "true" ]]; then
@@ -283,12 +283,12 @@ jobs:
           cp target/checkout/dist/target/camunda-zeebe-"${RELEASE_VERSION}".tar.gz "${ARTIFACT_DIR}/"
           cp target/checkout/dist/target/camunda-zeebe-"${RELEASE_VERSION}".zip "${ARTIFACT_DIR}/"
           cp target/checkout/db/rdbms-schema/target/camunda-db-rdbms-schema-"${RELEASE_VERSION}".zip "${ARTIFACT_DIR}/"
-          
+
           # Include Optimize artifacts if Optimize is included in the release
           if [[ "${{ inputs.includeOptimize }}" == "true" ]]; then
             cp target/checkout/optimize-distro/target/camunda-optimize-"${RELEASE_VERSION}"-production.tar.gz "${ARTIFACT_DIR}/"
           fi
-          
+
           echo "dir=${ARTIFACT_DIR}" >> "$GITHUB_OUTPUT"
       - name: Upload Release Artifacts
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
@@ -961,7 +961,7 @@ jobs:
       releaseBodyUpdateOutcome: ${{ steps.update-github-release-body.outcome }}
     # Minor releases take more time since a lot of issues are included in the changelog
     timeout-minutes: 30
-    if: ${{ always() && !cancelled() && 
+    if: ${{ always() && !cancelled() &&
       needs.release.result == 'success' &&
       needs.zeebe-docker.result == 'success' &&
       needs.operate-docker.result == 'success' &&
@@ -1116,7 +1116,7 @@ jobs:
     name: Create FOSSA releases and generate attribution/SBOM reports
     runs-on: ubuntu-latest
     needs: [release, github, zeebe-docker, operate-docker, tasklist-docker, optimize-docker, camunda-docker]
-    if: ${{ always() && !cancelled() && 
+    if: ${{ always() && !cancelled() &&
       needs.release.result == 'success' &&
       needs.github.result == 'success' &&
       needs.zeebe-docker.result == 'success' &&
@@ -1223,8 +1223,9 @@ jobs:
           variables: |
             {
               "is_camunda_release_successful": "true",
-              "camunda_workflow_run_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-            }      
+              "camunda_workflow_run_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+              "camunda_repository": "${{ github.repository }}"
+            }
       - name: Send success Slack notification
         if: ${{ !inputs.dryRun && !inputs.releaseProcessDryRun && needs.github.outputs.releaseBodyUpdateOutcome != 'failure' }}
         uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
@@ -1316,8 +1317,9 @@ jobs:
           variables: |
             {
               "is_camunda_release_successful": "false",
-              "camunda_workflow_run_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-            }            
+              "camunda_workflow_run_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+              "camunda_repository": "${{ github.repository }}"
+            }
       - name: Send failure Slack notification
         if: ${{ !inputs.dryRun && !inputs.releaseProcessDryRun }}
         uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1


### PR DESCRIPTION
## Description

Our C8 process expects a key `camunda_repository` in the notification message, that will later on be displayed in a user task. Without that information the MRM cannot tell easily whether this is about monorepo or ZPT.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

None
