### PR TITLE
test: Navigate to the called decision instance in case of an incident

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceIncidents.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceIncidents.spec.ts
@@ -457,6 +457,10 @@ test.describe('Process Instance Incident', () => {
 
     await test.step('Open incidents tab', async () => {
       await operateProcessInstancePage.clickIncidentsTab();
+      await expect(operateProcessInstancePage.incidentsTab).toHaveAttribute(
+        'aria-selected',
+        'true',
+      );
     });
 
     await test.step('Click on the Business Rule Task in the diagram that triggered the decision', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceIncidents.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceIncidents.spec.ts
@@ -479,9 +479,9 @@ test.describe('Process Instance Incident', () => {
         name: /Decision C \(Root Cause\)/i,
       });
       await expect(decisionLink).toBeVisible();
-      const linkText = await decisionLink.textContent();
-      expect(linkText).toMatch(/Decision C \(Root Cause\)/i);
-      expect(linkText).toMatch(/\d+/);
+      await expect(decisionLink).toHaveAccessibleName(
+        /Decision C \(Root Cause\).*?\d+/i,
+      );
     });
 
     await test.step('Click the link to navigate to the decision that caused the incident', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceIncidents.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceIncidents.spec.ts
@@ -458,8 +458,8 @@ test.describe('Process Instance Incident', () => {
     await test.step('Open incidents tab', async () => {
       await operateProcessInstancePage.clickIncidentsTab();
       await expect(operateProcessInstancePage.incidentsTab).toHaveAttribute(
-        'aria-selected',
-        'true',
+        'aria-current',
+        'page',
       );
     });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceIncidents.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceIncidents.spec.ts
@@ -432,4 +432,67 @@ test.describe('Process Instance Incident', () => {
       ).toBeVisible();
     });
   });
+
+  test('Navigate to called decision instance from DMN incident', async ({
+    operateProcessInstancePage,
+    operateDecisionInstancePage,
+    operateHomePage,
+    operateProcessesPage,
+  }) => {
+    test.slow();
+
+    await test.step('Navigate to Processes tab and open the process instance', async () => {
+      await operateHomePage.clickProcessesTab();
+      await operateProcessesPage.filterByProcessName('Process-Incident');
+      await operateProcessesPage.clickProcessInstanceLink();
+    });
+
+    await test.step('Verify process diagram is visible and incidents tab is present', async () => {
+      await expect(operateProcessInstancePage.diagram).toBeVisible();
+      await expect(operateProcessInstancePage.diagramSpinner).toBeHidden({
+        timeout: 30000,
+      });
+      await expect(operateProcessInstancePage.incidentsTab).toBeVisible();
+    });
+
+    await test.step('Open incidents tab', async () => {
+      await operateProcessInstancePage.clickIncidentsTab();
+    });
+
+    await test.step('Click on the Business Rule Task in the diagram that triggered the decision', async () => {
+      await operateProcessInstancePage.clickOnElementInDiagram('Task_Decision');
+    });
+
+    await test.step('Verify the incident tab displays the failed downstream decision', async () => {
+      await expect(
+        operateProcessInstancePage.getSelectedIncidentRow(
+          /Decision evaluation error\./i,
+        ),
+      ).toBeVisible();
+    });
+
+    await test.step('Verify the incident includes a link whose label contains the decision name and instance ID', async () => {
+      const incidentRow = operateProcessInstancePage.getSelectedIncidentRow(
+        /Decision evaluation error\./i,
+      );
+      const decisionLink = incidentRow.getByRole('link', {
+        name: /Decision C \(Root Cause\)/i,
+      });
+      await expect(decisionLink).toBeVisible();
+      const linkText = await decisionLink.textContent();
+      expect(linkText).toMatch(/Decision C \(Root Cause\)/i);
+      expect(linkText).toMatch(/\d+/);
+    });
+
+    await test.step('Click the link to navigate to the decision that caused the incident', async () => {
+      await operateProcessInstancePage.navigateToFailingElementForIncident(
+        /Decision evaluation error\./i,
+        'Decision C (Root Cause)',
+      );
+    });
+
+    await test.step('Verify navigation to the decision instance page', async () => {
+      await expect(operateDecisionInstancePage.decisionPanel).toBeVisible();
+    });
+  });
 });


### PR DESCRIPTION
## Description


Adds a new end-to-end test in processInstanceIncidents.spec.ts covering the following scenario:

> As an Operate user, I can navigate to the called decision instance when a Business Rule Task triggers a DMN incident.

## What the test verifies

1. Navigate to a `Process-Incident` instance that has active incidents
2. Open the incidents tab and click the **Business Rule Task** (`Task_Decision`) in the diagram
3. The incidents tab highlights the row with `Decision evaluation error.`
4. The highlighted row contains a link whose label includes both the decision name (`Decision C (Root Cause)`) and a numeric instance ID
5. Clicking the link navigates to the decision instance page (`decisionPanel` becomes visible)

## Notes

- All page-object methods used (`clickOnElementInDiagram`, `getSelectedIncidentRow`, `navigateToFailingElementForIncident`, `decisionPanel`, etc.) already exist — no new page object code was added.
- The test is marked `test.slow()` consistent with other multi-step incident tests in the same describe block.
- No new resources or fixtures were introduced; the test reuses the existing `beforeAll` setup.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

[E2E - [Operate] - Navigate to the called decision instance in case of an incident](https://github.com/camunda/camunda/issues/42659)

[Link to the test run ](https://github.com/camunda/camunda/actions/runs/24821522961/job/72647313024)
