### PR TITLE
refactor: remove RocksDB override

### DIFF
--- a/load-tests/camunda-platform-no-secondary-storage.yaml
+++ b/load-tests/camunda-platform-no-secondary-storage.yaml
@@ -83,9 +83,6 @@ orchestration:
         zeebe.broker.flowControl.write.enabled: "true"
         zeebe.broker.flowControl.write.limit: 10000
         zeebe.broker.flowControl.write.throttling.enabled: "true"
-        # RocksDB memory limit setting, limits the overall RocksDB memory usage
-        # ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_MEMORYLIMIT
-        zeebe.broker.experimental.rocksdb.memoryLimit: "64MB"
     # This file is loaded after application.yml (higher priority). It is empty by default,
     # but can be overridden via --set-file for specific scenarios (e.g. max) to change settings
     # like disabling consistency checks without duplicating the full application.yml content.

--- a/load-tests/camunda-platform-values-rdbms.yaml
+++ b/load-tests/camunda-platform-values-rdbms.yaml
@@ -34,9 +34,6 @@ orchestration:
         zeebe.broker.flowControl.write.enabled: "true"
         zeebe.broker.flowControl.write.limit: 10000
         zeebe.broker.flowControl.write.throttling.enabled: "true"
-        # RocksDB memory limit setting, limits the overall RocksDB memory usage
-        # ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_MEMORYLIMIT
-        zeebe.broker.experimental.rocksdb.memoryLimit: "64MB"
         # History cleanup adjust batch sizes
         camunda.data.secondary-storage.rdbms.history.history-cleanup-batch-size: 100000
         camunda.data.secondary-storage.rdbms.history.history-cleanup-process-instance-batch-size: 2000

--- a/load-tests/camunda-platform-values.yaml
+++ b/load-tests/camunda-platform-values.yaml
@@ -275,9 +275,6 @@ orchestration:
         zeebe.broker.flowControl.write.enabled: "true"
         zeebe.broker.flowControl.write.limit: 10000
         zeebe.broker.flowControl.write.throttling.enabled: "true"
-        # RocksDB memory limit setting, limits the overall RocksDB memory usage
-        # ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_MEMORYLIMIT
-        zeebe.broker.experimental.rocksdb.memoryLimit: "64MB"
     # This file is loaded after application.yml (higher priority). It is empty by default,
     # but can be overridden via --set-file for specific scenarios (e.g. max) to change settings
     # like disabling consistency checks without duplicating the full application.yml content.


### PR DESCRIPTION
## Description

* We should avoid to set custom configurations like the memory setting in our load test to be as realistic as possible

See related incident https://app.slack.com/client/T0PM0P1SA/C0AUF7LSLDC and related issue https://github.com/camunda/camunda/issues/50958 - which is likely to happen because we were not running with actual defaults

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

related https://github.com/camunda/camunda/issues/50958
