### PR TITLE
fix: remove links for completed deletion operation items

### DIFF
--- a/operate/client/src/App/BatchOperation/BatchItemsTable.test.tsx
+++ b/operate/client/src/App/BatchOperation/BatchItemsTable.test.tsx
@@ -202,19 +202,11 @@ describe('<BatchItemsTable />', () => {
     expect(screen.getByText('Error processing item 1')).toBeInTheDocument();
   });
 
-  it('should show a Decision Instance Key column with a link', async () => {
-    const items: BatchOperationItem[] = [
-      {
-        batchOperationKey: BATCH_OPERATION_KEY,
-        itemKey: 'decision-key-1',
-        processInstanceKey: '2251799813685250',
-        rootProcessInstanceKey: null,
-        state: 'COMPLETED',
-        operationType: 'DELETE_DECISION_INSTANCE',
-        processedDate: '2023-11-22T09:03:29.564+0100',
-        errorMessage: null,
-      },
-    ];
+  it('should show a Decision Instance Key column with a link for non-completed items', async () => {
+    const items = createMockBatchOperationItems(1, {
+      state: 'FAILED',
+      operationType: 'DELETE_DECISION_INSTANCE',
+    });
     mockQueryBatchOperationItems().withSuccess({
       items,
       page: {
@@ -245,10 +237,116 @@ describe('<BatchItemsTable />', () => {
       screen.queryByRole('columnheader', {name: /process instance key/i}),
     ).not.toBeInTheDocument();
     expect(
+      screen.getByRole('link', {name: /view decision instance item-1/i}),
+    ).toHaveAttribute('href', '/decisions/item-1');
+  });
+
+  it('should not show a link for completed decision instances deletion operation', async () => {
+    const items = createMockBatchOperationItems(1, {
+      state: 'COMPLETED',
+      operationType: 'DELETE_DECISION_INSTANCE',
+    });
+    mockQueryBatchOperationItems().withSuccess({
+      items,
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    render(
+      <BatchItemsTable
+        batchOperationKey={BATCH_OPERATION_KEY}
+        batchOperationType="DELETE_DECISION_INSTANCE"
+        isLoading={false}
+      />,
+      {wrapper: Wrapper},
+    );
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryAllByTestId('data-table-skeleton'),
+    );
+
+    expect(screen.getByText('item-1')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', {name: /view decision instance item-1/i}),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should show a Process Instance Key column with a link for non-completed process instances deletion operation', async () => {
+    const items = createMockBatchOperationItems(1, {
+      state: 'FAILED',
+      operationType: 'DELETE_PROCESS_INSTANCE',
+    });
+    mockQueryBatchOperationItems().withSuccess({
+      items,
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    render(
+      <BatchItemsTable
+        batchOperationKey={BATCH_OPERATION_KEY}
+        batchOperationType="DELETE_PROCESS_INSTANCE"
+        isLoading={false}
+      />,
+      {wrapper: Wrapper},
+    );
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryAllByTestId('data-table-skeleton'),
+    );
+
+    expect(
+      screen.getByRole('columnheader', {name: /process instance key/i}),
+    ).toBeInTheDocument();
+    expect(
       screen.getByRole('link', {
-        name: /view decision instance decision-key-1/i,
+        name: /view process instance 2251799813685250/i,
       }),
-    ).toHaveAttribute('href', '/decisions/decision-key-1');
+    ).toHaveAttribute('href', '/processes/2251799813685250');
+  });
+
+  it('should not show a link for completed process instances deletion operation', async () => {
+    const items = createMockBatchOperationItems(1, {
+      state: 'COMPLETED',
+      operationType: 'DELETE_PROCESS_INSTANCE',
+    });
+    mockQueryBatchOperationItems().withSuccess({
+      items,
+      page: {
+        totalItems: 1,
+        startCursor: null,
+        endCursor: null,
+        hasMoreTotalItems: false,
+      },
+    });
+
+    render(
+      <BatchItemsTable
+        batchOperationKey={BATCH_OPERATION_KEY}
+        batchOperationType="DELETE_PROCESS_INSTANCE"
+        isLoading={false}
+      />,
+      {wrapper: Wrapper},
+    );
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryAllByTestId('data-table-skeleton'),
+    );
+
+    expect(screen.getByText('2251799813685250')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', {
+        name: /view process instance 2251799813685250/i,
+      }),
+    ).not.toBeInTheDocument();
   });
 
   it('should show "No decision instance" when there is no associated decision instance', async () => {

--- a/operate/client/src/App/BatchOperation/BatchItemsTable.tsx
+++ b/operate/client/src/App/BatchOperation/BatchItemsTable.tsx
@@ -104,8 +104,38 @@ export const BatchItemsTable: React.FC<Props> = ({
               <ItemKeyCell
                 itemKey={itemKey}
                 fallbackText="No decision instance"
-                to={Paths.decisionInstance(itemKey)}
-                label={`View decision instance ${itemKey}`}
+                to={
+                  state === 'COMPLETED'
+                    ? undefined
+                    : Paths.decisionInstance(itemKey)
+                }
+                label={
+                  state === 'COMPLETED'
+                    ? undefined
+                    : `View decision instance ${itemKey}`
+                }
+              />
+            ),
+          };
+        }
+
+        if (batchOperationType === 'DELETE_PROCESS_INSTANCE') {
+          return {
+            ...commonCells,
+            processInstanceKey: (
+              <ItemKeyCell
+                itemKey={processInstanceKey}
+                fallbackText="No process instance"
+                to={
+                  state === 'COMPLETED'
+                    ? undefined
+                    : Paths.processInstance(processInstanceKey)
+                }
+                label={
+                  state === 'COMPLETED'
+                    ? undefined
+                    : `View process instance ${processInstanceKey}`
+                }
               />
             ),
           };


### PR DESCRIPTION
## Description

This PR updates the batch items table (instance key columns):

No link will be shown if
- The batch item type is DELETE_PROCESS_INSTANCE or DELETE_DECISION_INSTANCE and
- The batch item state is COMPLETED

In this case the instance is deleted and not reachable anymore.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #51530 
