### PR TITLE
doc: explain expectations for weekly load tests when an issue is known

### DIFF
--- a/docs/testing/reliability-testing.md
+++ b/docs/testing/reliability-testing.md
@@ -318,6 +318,10 @@ As an example, we have the following tests running:
 * medic-y-2025-cw-25-59a095c4-test-realistic
 * medic-y-2025-cw-25-59a095c4-test-rdbms-realistic
 
+**Expectations:**
+
+* In case an issue prevents a test from working properly, **and** no workaround is currently available, the test can be deleted to save resources.
+
 #### Daily load tests
 
 In addition to our weekly load tests, we ran daily stress tests based on the state of the **main** branch (from the [Camunda mono repository](https://github.com/camunda/camunda)) with our [Camunda load test GitHub workflow](https://github.com/camunda/camunda/actions/workflows/camunda-load-test.yml).


### PR DESCRIPTION
## Description

Context: we [had a known issue that was incurring high costs](https://camunda.slack.com/archives/C0807665N8G/p1776675503317789) and it was not clear whether we should update the tests or delete the test completely.

Although in this case we updated the tests (as a fix was available), we could also next time just delete the tests instead.

* Cf. [Slack discussion](https://camunda.slack.com/archives/C0807665N8G/p1776844222298189?thread_ts=1776675503.317789&cid=C0807665N8G)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

-