### PR TITLE
feat: display MCP process tool details in expandable rows

### DIFF
--- a/identity/client/src/components/entityList/EntityList.tsx
+++ b/identity/client/src/components/entityList/EntityList.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { FC, ReactNode, useMemo } from "react";
+import { FC, Fragment, ReactNode, useMemo } from "react";
 import {
   Button,
   DataTable,
@@ -18,6 +18,8 @@ import {
   TableBody,
   TableCell,
   TableExpandHeader,
+  TableExpandRow,
+  TableExpandedRow,
   TableHead,
   TableHeader,
   TableRow,
@@ -117,6 +119,7 @@ type EntityListProps<D extends EntityData> = {
     | undefined;
   setSort?: (sort: SortConfig[] | undefined) => void;
   setSearch?: (search: Record<string, string> | undefined) => void;
+  renderExpandedRow?: (entity: D) => ReactNode;
 };
 
 const MAX_ICON_ACTIONS = 2;
@@ -145,10 +148,12 @@ const EntityList = <D extends EntityData>({
   page: pageData,
   setSort = () => {},
   setSearch = () => {},
+  renderExpandedRow,
 }: EntityListProps<D>): ReturnType<FC> => {
   const { t } = useTranslate("components");
 
   const hasMenu = menuItems && menuItems.length > 0;
+  const isExpandable = !!renderExpandedRow;
 
   const [index, tableData] = useMemo(() => {
     const entityIndex: { [id: string]: D } = {};
@@ -201,6 +206,12 @@ const EntityList = <D extends EntityData>({
           ),
       };
 
+  const rowColSpan =
+    headers.length +
+    (isExpandable ? 1 : 0) +
+    (batchSelection ? 1 : 0) +
+    (hasMenu ? 1 : 0);
+
   return (
     <DataTable
       rows={tableData}
@@ -210,7 +221,14 @@ const EntityList = <D extends EntityData>({
         return 0;
       }}
     >
-      {({ rows, getHeaderProps, getToolbarProps, getTableProps }) => (
+      {({
+        rows,
+        getHeaderProps,
+        getRowProps,
+        getExpandedRowProps,
+        getToolbarProps,
+        getTableProps,
+      }) => (
         <StyledTableContainer {...tableContainerProps}>
           <>
             {(searchKey || addEntityLabel) && (
@@ -249,6 +267,7 @@ const EntityList = <D extends EntityData>({
               <Table {...getTableProps()}>
                 <TableHead>
                   <TableRow>
+                    {isExpandable && <TableExpandHeader />}
                     {batchSelection && (
                       <TableSelectAll
                         id="select-all"
@@ -300,7 +319,7 @@ const EntityList = <D extends EntityData>({
                 {areRowsEmpty && !loading && (
                   <TableBody>
                     <TableRow>
-                      <StyledTableCell colSpan={headers.length + 1}>
+                      <StyledTableCell colSpan={rowColSpan}>
                         {t("No results found")}
                       </StyledTableCell>
                     </TableRow>
@@ -308,123 +327,146 @@ const EntityList = <D extends EntityData>({
                 )}
                 {!areRowsEmpty && (
                   <TableBody>
-                    {rows.map(({ id: rowId, cells }) => (
-                      <TableRow key={rowId}>
-                        {batchSelection && (
-                          <TableSelectRow
-                            id={`select-${rowId}`}
-                            name={`select-${rowId}`}
-                            checked={batchSelection.isSelected(index[rowId])}
-                            onSelect={() => {
-                              const item = index[rowId];
+                    {rows.map((row) => {
+                      const { id: rowId, cells, isExpanded } = row;
 
-                              if (batchSelection.isSelected(item)) {
-                                batchSelection.onUnselect(item);
-                              } else {
-                                batchSelection.onSelect(item);
-                              }
-                            }}
-                          />
-                        )}
-                        {cells.map(({ id: cellId, value }, index) => {
-                          const displayValue = Array.isArray(value)
-                            ? value.join(", ")
-                            : value;
+                      const cellContent = (
+                        <>
+                          {batchSelection && (
+                            <TableSelectRow
+                              id={`select-${rowId}`}
+                              name={`select-${rowId}`}
+                              checked={batchSelection.isSelected(index[rowId])}
+                              onSelect={() => {
+                                const item = index[rowId];
 
-                          const truncatedValue =
-                            displayValue &&
-                            displayValue.toString().length >
-                              maxDisplayCellLength ? (
-                              <StyledToolTip
-                                label={displayValue}
-                                autoAlign
-                                align="bottom"
-                              >
-                                <TooltipTrigger>
-                                  {displayValue
-                                    .substring(0, maxDisplayCellLength)
-                                    .concat("…")}
-                                </TooltipTrigger>
-                              </StyledToolTip>
-                            ) : (
-                              displayValue
-                            );
+                                if (batchSelection.isSelected(item)) {
+                                  batchSelection.onUnselect(item);
+                                } else {
+                                  batchSelection.onSelect(item);
+                                }
+                              }}
+                            />
+                          )}
+                          {cells.map(({ id: cellId, value }, index) => {
+                            const displayValue = Array.isArray(value)
+                              ? value.join(", ")
+                              : value;
 
-                          return (
-                            <StyledTableCell
-                              key={cellId}
-                              onClick={handleEntityClick(rowId)}
-                              $isClickable={isEntityClickable}
-                            >
-                              {index === 0 && isEntityClickable ? (
-                                <Link>{displayValue}</Link>
+                            const truncatedValue =
+                              displayValue &&
+                              displayValue.toString().length >
+                                maxDisplayCellLength ? (
+                                <StyledToolTip
+                                  label={displayValue}
+                                  autoAlign
+                                  align="bottom"
+                                >
+                                  <TooltipTrigger>
+                                    {displayValue
+                                      .substring(0, maxDisplayCellLength)
+                                      .concat("…")}
+                                  </TooltipTrigger>
+                                </StyledToolTip>
                               ) : (
-                                truncatedValue
-                              )}
-                            </StyledTableCell>
-                          );
-                        })}
-                        {hasMenu && (
-                          <TableCell>
-                            {menuItems?.length > MAX_ICON_ACTIONS ? (
-                              <OverflowMenu flipped>
-                                {getVisibleMenuItems(menuItems).map(
-                                  ({ label, onClick, isDangerous }) => (
-                                    <OverflowMenuItem
-                                      key={`${label}-${rowId}`}
-                                      itemText={<p>{label}</p>}
-                                      isDelete={isDangerous}
-                                      onClick={handleMenuItemClick(
-                                        rowId,
-                                        onClick,
-                                      )}
-                                    />
-                                  ),
+                                displayValue
+                              );
+
+                            return (
+                              <StyledTableCell
+                                key={cellId}
+                                onClick={handleEntityClick(rowId)}
+                                $isClickable={isEntityClickable}
+                              >
+                                {index === 0 && isEntityClickable ? (
+                                  <Link>{displayValue}</Link>
+                                ) : (
+                                  truncatedValue
                                 )}
-                              </OverflowMenu>
-                            ) : (
-                              <Flex>
-                                {getVisibleMenuItems(menuItems).map(
-                                  (menuItem) => {
-                                    const {
-                                      label,
-                                      onClick,
-                                      icon,
-                                      isDangerous,
-                                      disabled,
-                                    } = menuItem as MenuItem<D>;
-
-                                    const kind: ButtonKind = isDangerous
-                                      ? "danger--ghost"
-                                      : "ghost";
-                                    const hasIconOnly = !!icon && !isDangerous;
-
-                                    return (
-                                      <Button
+                              </StyledTableCell>
+                            );
+                          })}
+                          {hasMenu && (
+                            <TableCell>
+                              {menuItems?.length > MAX_ICON_ACTIONS ? (
+                                <OverflowMenu flipped>
+                                  {getVisibleMenuItems(menuItems).map(
+                                    ({ label, onClick, isDangerous }) => (
+                                      <OverflowMenuItem
                                         key={`${label}-${rowId}`}
-                                        kind={kind}
-                                        size="md"
-                                        disabled={disabled}
-                                        hasIconOnly={hasIconOnly}
-                                        renderIcon={icon}
-                                        tooltipAlignment="end"
-                                        iconDescription={label}
+                                        itemText={<p>{label}</p>}
+                                        isDelete={isDangerous}
                                         onClick={handleMenuItemClick(
                                           rowId,
                                           onClick,
                                         )}
-                                      >
-                                        {hasIconOnly ? "" : label}
-                                      </Button>
-                                    );
-                                  },
-                                )}
-                              </Flex>
-                            )}
-                          </TableCell>
-                        )}
-                      </TableRow>
-                    ))}
+                                      />
+                                    ),
+                                  )}
+                                </OverflowMenu>
+                              ) : (
+                                <Flex>
+                                  {getVisibleMenuItems(menuItems).map(
+                                    (menuItem) => {
+                                      const {
+                                        label,
+                                        onClick,
+                                        icon,
+                                        isDangerous,
+                                        disabled,
+                                      } = menuItem as MenuItem<D>;
+
+                                      const kind: ButtonKind = isDangerous
+                                        ? "danger--ghost"
+                                        : "ghost";
+                                      const hasIconOnly =
+                                        !!icon && !isDangerous;
+
+                                      return (
+                                        <Button
+                                          key={`${label}-${rowId}`}
+                                          kind={kind}
+                                          size="md"
+                                          disabled={disabled}
+                                          hasIconOnly={hasIconOnly}
+                                          renderIcon={icon}
+                                          tooltipAlignment="end"
+                                          iconDescription={label}
+                                          onClick={handleMenuItemClick(
+                                            rowId,
+                                            onClick,
+                                          )}
+                                        >
+                                          {hasIconOnly ? "" : label}
+                                        </Button>
+                                      );
+                                    },
+                                  )}
+                                </Flex>
+                              )}
+                            </TableCell>
+                          )}
+                        </>
+                      );
+
+                      if (!isExpandable) {
+                        return <TableRow>{cellContent}</TableRow>;
+                      }
+
+                      return (
+                        <Fragment key={rowId}>
+                          <TableExpandRow {...getRowProps({ row })}>
+                            {cellContent}
+                          </TableExpandRow>
+                          <TableExpandedRow
+                            colSpan={rowColSpan}
+                            {...getExpandedRowProps({ row })}
+                          >
+                            {isExpanded && renderExpandedRow(index[rowId])}
+                          </TableExpandedRow>
+                        </Fragment>
+                      );
+                    })}
                   </TableBody>
                 )}
               </Table>

--- a/identity/client/src/components/entityList/EntityList.tsx
+++ b/identity/client/src/components/entityList/EntityList.tsx
@@ -450,12 +450,15 @@ const EntityList = <D extends EntityData>({
                       );
 
                       if (!isExpandable) {
-                        return <TableRow>{cellContent}</TableRow>;
+                        return <TableRow key={rowId}>{cellContent}</TableRow>;
                       }
 
                       return (
                         <Fragment key={rowId}>
                           <TableExpandRow
+                            // > Warning: A props object containing a "key" prop is being spread into JSX.
+                            // A key is already configured in the fragment. Overwriting the
+                            // key prevents the error from being reported.
                             {...getRowProps({ row })}
                             key={undefined}
                           >

--- a/identity/client/src/components/entityList/EntityList.tsx
+++ b/identity/client/src/components/entityList/EntityList.tsx
@@ -455,14 +455,19 @@ const EntityList = <D extends EntityData>({
 
                       return (
                         <Fragment key={rowId}>
-                          <TableExpandRow {...getRowProps({ row })}>
+                          <TableExpandRow
+                            {...getRowProps({ row })}
+                            key={undefined}
+                          >
                             {cellContent}
                           </TableExpandRow>
                           <TableExpandedRow
                             colSpan={rowColSpan}
                             {...getExpandedRowProps({ row })}
                           >
-                            {isExpanded && renderExpandedRow(index[rowId])}
+                            {isExpanded &&
+                              index[rowId] &&
+                              renderExpandedRow(index[rowId])}
                           </TableExpandedRow>
                         </Fragment>
                       );

--- a/identity/client/src/pages/mcp-processes/List.tsx
+++ b/identity/client/src/pages/mcp-processes/List.tsx
@@ -14,9 +14,8 @@ import EntityList, {
 } from "src/components/entityList/EntityList";
 import { TranslatedErrorInlineNotification } from "src/components/notifications/InlineNotification";
 import { isTenantsApiEnabled } from "src/configuration";
-import { useEntityModal } from "src/components/modal";
 import { useMcpProcessTools, type McpProcessTool } from "./useMcpProcessTools";
-import DetailsModal from "./modals/DetailsModal";
+import { ExpandedToolDetails } from "./components/ExpandedToolDetails";
 
 const List: FC = () => {
   const { t } = useTranslate("mcpProcesses");
@@ -24,8 +23,6 @@ const List: FC = () => {
 
   const { processTools, loading, success, reload, ...paginationProps } =
     useMcpProcessTools();
-
-  const [viewTool, viewToolModal] = useEntityModal(DetailsModal, () => {});
 
   const headers = useMemo<DataTableHeader<McpProcessTool>[]>(() => {
     const columns: DataTableHeader<McpProcessTool>[] = [
@@ -55,7 +52,7 @@ const List: FC = () => {
         loading={loading}
         searchKey="toolName"
         searchPlaceholder={t("searchByToolName")}
-        menuItems={[{ label: t("viewDetails"), onClick: viewTool }]}
+        renderExpandedRow={(entity) => <ExpandedToolDetails tool={entity} />}
         {...paginationProps}
       />
       {!loading && !success && (
@@ -64,7 +61,6 @@ const List: FC = () => {
           actionButton={{ label: tComponents("retry"), onClick: reload }}
         />
       )}
-      {viewToolModal}
     </Page>
   );
 };

--- a/identity/client/src/pages/mcp-processes/List.tsx
+++ b/identity/client/src/pages/mcp-processes/List.tsx
@@ -14,7 +14,9 @@ import EntityList, {
 } from "src/components/entityList/EntityList";
 import { TranslatedErrorInlineNotification } from "src/components/notifications/InlineNotification";
 import { isTenantsApiEnabled } from "src/configuration";
+import { useEntityModal } from "src/components/modal";
 import { useMcpProcessTools, type McpProcessTool } from "./useMcpProcessTools";
+import DetailsModal from "./modals/DetailsModal";
 
 const List: FC = () => {
   const { t } = useTranslate("mcpProcesses");
@@ -22,6 +24,8 @@ const List: FC = () => {
 
   const { processTools, loading, success, reload, ...paginationProps } =
     useMcpProcessTools();
+
+  const [viewTool, viewToolModal] = useEntityModal(DetailsModal, () => {});
 
   const headers = useMemo<DataTableHeader<McpProcessTool>[]>(() => {
     const columns: DataTableHeader<McpProcessTool>[] = [
@@ -51,6 +55,7 @@ const List: FC = () => {
         loading={loading}
         searchKey="toolName"
         searchPlaceholder={t("searchByToolName")}
+        menuItems={[{ label: t("viewDetails"), onClick: viewTool }]}
         {...paginationProps}
       />
       {!loading && !success && (
@@ -59,6 +64,7 @@ const List: FC = () => {
           actionButton={{ label: tComponents("retry"), onClick: reload }}
         />
       )}
+      {viewToolModal}
     </Page>
   );
 };

--- a/identity/client/src/pages/mcp-processes/List.tsx
+++ b/identity/client/src/pages/mcp-processes/List.tsx
@@ -47,7 +47,7 @@ const List: FC = () => {
       <PageHeader
         title={tComponents("mcpProcesses")}
         linkText={tComponents("mcpProcesses").toLowerCase()}
-        shouldShowDocumentationLink={false}
+        docsLinkPath="/components/admin/mcp-processes/"
       />
       <EntityList
         data={processTools}

--- a/identity/client/src/pages/mcp-processes/components/ExpandedToolDetails.tsx
+++ b/identity/client/src/pages/mcp-processes/components/ExpandedToolDetails.tsx
@@ -9,9 +9,8 @@
 import { FC } from "react";
 import { heading01, spacing06 } from "@carbon/elements";
 import styled from "styled-components";
-import Modal, { UseEntityModalProps } from "src/components/modal";
 import useTranslate from "src/utility/localization";
-import { type McpProcessTool } from "../useMcpProcessTools";
+import type { McpProcessTool } from "../useMcpProcessTools";
 
 const SectionHeading = styled.h3`
   font-size: ${heading01.fontSize};
@@ -23,44 +22,43 @@ const SectionHeading = styled.h3`
 const SectionBody = styled.p`
   white-space: pre-wrap;
   word-break: break-word;
+  max-inline-size: 80ch; // Keep descriptions at a readable line length
+
+  &[data-fallback="true"] {
+    font-style: italic;
+    color: var(--cds-text-secondary);
+  }
 
   &:not(:last-child) {
     margin-block-end: ${spacing06};
   }
 `;
 
-const DetailsModal: FC<UseEntityModalProps<McpProcessTool>> = ({
-  open,
-  onClose,
-  entity,
-}) => {
+export const ExpandedToolDetails: FC<{ tool: McpProcessTool }> = ({ tool }) => {
   const { t } = useTranslate("mcpProcesses");
-  const tool = entity.toolData;
+  const data = tool.toolData;
 
   return (
-    <Modal
-      passiveModal
-      preventCloseOnClickOutside
-      open={open}
-      onClose={onClose}
-      headline={t("detailsHeadline", { toolName: entity.toolName })}
-      size="md"
-    >
-      {/* Flat content to make use of Carbon's built-in modal content alignment:
-      https://carbondesignsystem.com/components/modal/usage/#alignment */}
+    <>
       <SectionHeading>{t("toolPurpose")}</SectionHeading>
-      <SectionBody>{tool.purpose ?? t("informationMissing")}</SectionBody>
+      <SectionBody data-fallback={!data.purpose}>
+        {data.purpose ?? t("informationMissing")}
+      </SectionBody>
 
       <SectionHeading>{t("toolResults")}</SectionHeading>
-      <SectionBody>{tool.results ?? t("informationMissing")}</SectionBody>
+      <SectionBody data-fallback={!data.results}>
+        {data.results ?? t("informationMissing")}
+      </SectionBody>
 
       <SectionHeading>{t("toolWhenToUse")}</SectionHeading>
-      <SectionBody>{tool.whenToUse ?? t("informationMissing")}</SectionBody>
+      <SectionBody data-fallback={!data.whenToUse}>
+        {data.whenToUse ?? t("informationMissing")}
+      </SectionBody>
 
       <SectionHeading>{t("toolWhenNotToUse")}</SectionHeading>
-      <SectionBody>{tool.whenNotToUse ?? t("informationMissing")}</SectionBody>
-    </Modal>
+      <SectionBody data-fallback={!data.whenNotToUse}>
+        {data.whenNotToUse ?? t("informationMissing")}
+      </SectionBody>
+    </>
   );
 };
-
-export default DetailsModal;

--- a/identity/client/src/pages/mcp-processes/modals/DetailsModal.tsx
+++ b/identity/client/src/pages/mcp-processes/modals/DetailsModal.tsx
@@ -7,25 +7,26 @@
  */
 
 import { FC } from "react";
-import { heading01 } from "@carbon/elements";
+import { heading01, spacing06 } from "@carbon/elements";
 import styled from "styled-components";
 import Modal, { UseEntityModalProps } from "src/components/modal";
 import useTranslate from "src/utility/localization";
 import { type McpProcessTool } from "../useMcpProcessTools";
-import { Stack } from "@carbon/react";
 
 const SectionHeading = styled.h3`
   font-size: ${heading01.fontSize};
   font-weight: ${heading01.fontWeight};
   line-height: ${heading01.lineHeight};
   letter-spacing: ${heading01.letterSpacing};
-  margin: 0;
 `;
 
 const SectionBody = styled.p`
-  margin: 0;
   white-space: pre-wrap;
   word-break: break-word;
+
+  &:not(:last-child) {
+    margin-block-end: ${spacing06};
+  }
 `;
 
 const DetailsModal: FC<UseEntityModalProps<McpProcessTool>> = ({
@@ -45,30 +46,19 @@ const DetailsModal: FC<UseEntityModalProps<McpProcessTool>> = ({
       headline={t("detailsHeadline", { toolName: entity.toolName })}
       size="md"
     >
-      <Stack gap={6}>
-        <section>
-          <SectionHeading>{t("toolPurpose")}</SectionHeading>
-          <SectionBody>{tool.purpose ?? t("informationMissing")}</SectionBody>
-        </section>
-        <section>
-          <SectionHeading>{t("toolResults")}</SectionHeading>
-          <SectionBody>{tool.results ?? t("informationMissing")}</SectionBody>
-        </section>
-        <Stack orientation="horizontal" gap={6}>
-          <section>
-            <SectionHeading>{t("toolWhenToUse")}</SectionHeading>
-            <SectionBody>
-              {tool.whenToUse ?? t("informationMissing")}
-            </SectionBody>
-          </section>
-          <section>
-            <SectionHeading>{t("toolWhenNotToUse")}</SectionHeading>
-            <SectionBody>
-              {tool.whenNotToUse ?? t("informationMissing")}
-            </SectionBody>
-          </section>
-        </Stack>
-      </Stack>
+      {/* Flat content to make use of Carbon's built-in modal content alignment:
+      https://carbondesignsystem.com/components/modal/usage/#alignment */}
+      <SectionHeading>{t("toolPurpose")}</SectionHeading>
+      <SectionBody>{tool.purpose ?? t("informationMissing")}</SectionBody>
+
+      <SectionHeading>{t("toolResults")}</SectionHeading>
+      <SectionBody>{tool.results ?? t("informationMissing")}</SectionBody>
+
+      <SectionHeading>{t("toolWhenToUse")}</SectionHeading>
+      <SectionBody>{tool.whenToUse ?? t("informationMissing")}</SectionBody>
+
+      <SectionHeading>{t("toolWhenNotToUse")}</SectionHeading>
+      <SectionBody>{tool.whenNotToUse ?? t("informationMissing")}</SectionBody>
     </Modal>
   );
 };

--- a/identity/client/src/pages/mcp-processes/modals/DetailsModal.tsx
+++ b/identity/client/src/pages/mcp-processes/modals/DetailsModal.tsx
@@ -1,0 +1,76 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+import { heading01 } from "@carbon/elements";
+import styled from "styled-components";
+import Modal, { UseEntityModalProps } from "src/components/modal";
+import useTranslate from "src/utility/localization";
+import { type McpProcessTool } from "../useMcpProcessTools";
+import { Stack } from "@carbon/react";
+
+const SectionHeading = styled.h3`
+  font-size: ${heading01.fontSize};
+  font-weight: ${heading01.fontWeight};
+  line-height: ${heading01.lineHeight};
+  letter-spacing: ${heading01.letterSpacing};
+  margin: 0;
+`;
+
+const SectionBody = styled.p`
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+`;
+
+const DetailsModal: FC<UseEntityModalProps<McpProcessTool>> = ({
+  open,
+  onClose,
+  entity,
+}) => {
+  const { t } = useTranslate("mcpProcesses");
+  const tool = entity.toolData;
+
+  return (
+    <Modal
+      passiveModal
+      preventCloseOnClickOutside
+      open={open}
+      onClose={onClose}
+      headline={t("detailsHeadline", { toolName: entity.toolName })}
+      size="md"
+    >
+      <Stack gap={6}>
+        <section>
+          <SectionHeading>{t("toolPurpose")}</SectionHeading>
+          <SectionBody>{tool.purpose ?? t("informationMissing")}</SectionBody>
+        </section>
+        <section>
+          <SectionHeading>{t("toolResults")}</SectionHeading>
+          <SectionBody>{tool.results ?? t("informationMissing")}</SectionBody>
+        </section>
+        <Stack orientation="horizontal" gap={6}>
+          <section>
+            <SectionHeading>{t("toolWhenToUse")}</SectionHeading>
+            <SectionBody>
+              {tool.whenToUse ?? t("informationMissing")}
+            </SectionBody>
+          </section>
+          <section>
+            <SectionHeading>{t("toolWhenNotToUse")}</SectionHeading>
+            <SectionBody>
+              {tool.whenNotToUse ?? t("informationMissing")}
+            </SectionBody>
+          </section>
+        </Stack>
+      </Stack>
+    </Modal>
+  );
+};
+
+export default DetailsModal;

--- a/identity/client/src/pages/mcp-processes/useMcpProcessTools.ts
+++ b/identity/client/src/pages/mcp-processes/useMcpProcessTools.ts
@@ -11,18 +11,33 @@ import {
   QueryMessageSubscriptionsRequestBody,
 } from "@camunda/camunda-api-zod-schemas/8.10";
 import { useMemo } from "react";
+import { z } from "zod";
 import { useApi, usePagination } from "src/utility/api";
 import { searchMessageSubscriptions } from "src/utility/api/message-subscriptions";
 
-const TOOL_PURPOSE_KEY = "io.camunda.tool:purpose";
-
 type Sort = NonNullable<QueryMessageSubscriptionsRequestBody["sort"]>;
 const DEFAULT_SORT: Sort = [{ field: "toolName", order: "asc" }];
+
+const toolString = z.string().trim().min(1).nullable().default(null);
+const toolDataSchema = z
+  .looseObject({
+    "io.camunda.tool:purpose": toolString,
+    "io.camunda.tool:results": toolString,
+    "io.camunda.tool:when_to_use": toolString,
+    "io.camunda.tool:when_not_to_use": toolString,
+  })
+  .transform((data) => ({
+    purpose: data["io.camunda.tool:purpose"],
+    results: data["io.camunda.tool:results"],
+    whenToUse: data["io.camunda.tool:when_to_use"],
+    whenNotToUse: data["io.camunda.tool:when_not_to_use"],
+  }));
 
 export type McpProcessTool = {
   id: string;
   toolName: string;
   toolDescription: string;
+  toolData: z.output<typeof toolDataSchema>;
   processDefinitionKey: string | null;
   processDefinitionId: string;
   processDefinitionName: string;
@@ -36,10 +51,12 @@ const mapSubscriptionToProcessTool = (
   // `toolName` is expected to exist based on the filter supplied to the backend.
   if (!sub.toolName) return null;
 
+  const toolData = toolDataSchema.parse(sub.extensionProperties ?? {});
   return {
     id: sub.messageSubscriptionKey,
     toolName: sub.toolName,
-    toolDescription: sub.extensionProperties?.[TOOL_PURPOSE_KEY] ?? "-",
+    toolDescription: toolData.purpose ?? "-",
+    toolData,
     processDefinitionKey: sub.processDefinitionKey,
     processDefinitionId: sub.processDefinitionId,
     processDefinitionName: sub.processDefinitionName ?? sub.processDefinitionId,

--- a/identity/client/src/utility/localization/en/mcpProcesses.json
+++ b/identity/client/src/utility/localization/en/mcpProcesses.json
@@ -6,8 +6,6 @@
   "tenant": "Tenant",
   "searchByToolName": "Search by tool name",
   "mcpProcessesCouldNotLoad": "MCP Processes could not be loaded.",
-  "viewDetails": "View details",
-  "detailsHeadline": "MCP Tool \"{{toolName}}\"",
   "informationMissing": "No information provided.",
   "toolPurpose": "Purpose",
   "toolResults": "Results",

--- a/identity/client/src/utility/localization/en/mcpProcesses.json
+++ b/identity/client/src/utility/localization/en/mcpProcesses.json
@@ -5,5 +5,12 @@
   "version": "Version",
   "tenant": "Tenant",
   "searchByToolName": "Search by tool name",
-  "mcpProcessesCouldNotLoad": "MCP Processes could not be loaded."
+  "mcpProcessesCouldNotLoad": "MCP Processes could not be loaded.",
+  "viewDetails": "View details",
+  "detailsHeadline": "MCP Tool \"{{toolName}}\"",
+  "informationMissing": "No information provided.",
+  "toolPurpose": "Purpose",
+  "toolResults": "Results",
+  "toolWhenToUse": "When to use",
+  "toolWhenNotToUse": "When not to use"
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityMcpProcessesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/IdentityMcpProcessesPage.ts
@@ -33,4 +33,24 @@ export class IdentityMcpProcessesPage {
   getRowByToolName(toolName: string): Locator {
     return this.mcpProcessesTable.getByRole('row').filter({hasText: toolName});
   }
+
+  async expandRowByToolName(toolName: string): Promise<void> {
+    await this.getRowByToolName(toolName)
+      .getByRole('button', {name: 'Expand current row'})
+      .click();
+  }
+
+  getRowToolDetails(toolName: string) {
+    const container = this.mcpProcessesTable.locator(
+      `tr[data-parent-row]:has-text("${toolName}") + tr[data-child-row]`,
+    );
+
+    return {
+      container,
+      purpose: container.locator('h3:has-text("Purpose") + p'),
+      results: container.locator('h3:has-text("Results") + p'),
+      whenToUse: container.locator('h3:has-text("When to use") + p'),
+      whenNotToUse: container.locator('h3:has-text("When not to use") + p'),
+    };
+  }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/mcpProcessAlpha.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/mcpProcessAlpha.bpmn
@@ -6,6 +6,9 @@
         <zeebe:properties>
           <zeebe:property name="io.camunda.tool:name" value="alpha-tool-name" />
           <zeebe:property name="io.camunda.tool:purpose" value="Tool for executing an alpha process triggered by MCP." />
+          <zeebe:property name="io.camunda.tool:results" value="Alpha tool returns the result of the alpha process execution." />
+          <zeebe:property name="io.camunda.tool:when_to_use" value="Use the alpha tool when an alpha process needs to be triggered." />
+          <zeebe:property name="io.camunda.tool:when_not_to_use" value="Do not use the alpha tool for bravo processes." />
         </zeebe:properties>
       </bpmn:extensionElements>
       <bpmn:outgoing>Flow_1</bpmn:outgoing>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/mcpProcessBravo.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/mcpProcessBravo.bpmn
@@ -6,6 +6,7 @@
         <zeebe:properties>
           <zeebe:property name="io.camunda.tool:name" value="bravo-tool-name" />
           <zeebe:property name="io.camunda.tool:purpose" value="Tool for executing a bravo process triggered by MCP." />
+          <zeebe:property name="io.camunda.tool:results" value="Bravo tool returns the result of the bravo process execution." />
         </zeebe:properties>
       </bpmn:extensionElements>
       <bpmn:outgoing>Flow_1</bpmn:outgoing>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/mcp-processes.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/mcp-processes.spec.ts
@@ -144,7 +144,7 @@ test.describe('Identity MCP Processes', () => {
 
     await test.step("Verify default sort is ascending by 'Tool Name'", async () => {
       await expect(rows.nth(1)).toContainText(ALPHA_TOOL_NAME);
-      await expect(rows.nth(2)).toContainText(BRAVO_TOOL_NAME);
+      await expect(rows.nth(3)).toContainText(BRAVO_TOOL_NAME);
     });
 
     await test.step("Sort ASC by 'Tool Name'", async () => {
@@ -152,7 +152,7 @@ test.describe('Identity MCP Processes', () => {
       await toolNameHeader.click();
 
       await expect(rows.nth(1)).toContainText(ALPHA_TOOL_NAME);
-      await expect(rows.nth(2)).toContainText(BRAVO_TOOL_NAME);
+      await expect(rows.nth(3)).toContainText(BRAVO_TOOL_NAME);
     });
 
     await test.step("Sort DESC by 'Tool Name'", async () => {
@@ -160,7 +160,58 @@ test.describe('Identity MCP Processes', () => {
       await toolNameHeader.click();
 
       await expect(rows.nth(1)).toContainText(BRAVO_TOOL_NAME);
-      await expect(rows.nth(2)).toContainText(ALPHA_TOOL_NAME);
+      await expect(rows.nth(3)).toContainText(ALPHA_TOOL_NAME);
+    });
+  });
+
+  test('MCP Processes rows can be expanded to show more tool information', async ({
+    identityMcpProcessesPage,
+  }) => {
+    await identityMcpProcessesPage.navigateToMcpProcesses();
+
+    await test.step('Verify tool with all information', async () => {
+      const details =
+        identityMcpProcessesPage.getRowToolDetails(ALPHA_TOOL_NAME);
+
+      await identityMcpProcessesPage.expandRowByToolName(ALPHA_TOOL_NAME);
+
+      await expect(details.container).toBeVisible();
+
+      await expect(details.purpose).toBeVisible();
+      await expect(details.purpose).toHaveText(
+        'Tool for executing an alpha process triggered by MCP.',
+      );
+      await expect(details.results).toBeVisible();
+      await expect(details.results).toHaveText(
+        'Alpha tool returns the result of the alpha process execution.',
+      );
+      await expect(details.whenToUse).toBeVisible();
+      await expect(details.whenToUse).toHaveText(
+        'Use the alpha tool when an alpha process needs to be triggered.',
+      );
+      await expect(details.whenNotToUse).toBeVisible();
+      await expect(details.whenNotToUse).toHaveText(
+        'Do not use the alpha tool for bravo processes.',
+      );
+    });
+
+    await test.step('Verify tool with partial information', async () => {
+      const details =
+        identityMcpProcessesPage.getRowToolDetails(BRAVO_TOOL_NAME);
+      await identityMcpProcessesPage.expandRowByToolName(BRAVO_TOOL_NAME);
+
+      await expect(details.purpose).toBeVisible();
+      await expect(details.purpose).toHaveText(
+        'Tool for executing a bravo process triggered by MCP.',
+      );
+      await expect(details.results).toBeVisible();
+      await expect(details.results).toHaveText(
+        'Bravo tool returns the result of the bravo process execution.',
+      );
+      await expect(details.whenToUse).toBeVisible();
+      await expect(details.whenToUse).toHaveText('No information provided.');
+      await expect(details.whenNotToUse).toBeVisible();
+      await expect(details.whenNotToUse).toHaveText('No information provided.');
     });
   });
 });


### PR DESCRIPTION
## Description

@tmetzke This PR experiments with expandable rows for MCP process tools, which display all configured tool data. It might be fitting to display [tool I/O specifications](https://github.com/camunda/camunda/issues/51404) here as well, or a separate modal if it gets too cluttered. Let me know what you think!

<img width="1756" height="1053" alt="Screenshot 2026-04-23 at 17 06 18" src="https://github.com/user-attachments/assets/a05fcdb0-7278-4342-a2c4-6943e6b71d7e" />

## Changes

- Adds expandable rows to the reusable `EntityList` component in Admin
- Extracts more tool data from message-subscription's extension properties
- Displays the extract data in an expanded row in the MCP Processes page (see image)
- Adds a documentation link for MCP Processes (does not exist yet) that follows the pattern of all other Admin pages.

## Todo

- [x] App crashes when row is expanded and item leaves current table page due to a search or sort change.

## Related issues

closes #51581
