### PR TITLE
feat: move `beforeAll` listeners to MI body

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowNode;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableMultiInstanceBody;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutionListener;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -169,8 +170,7 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
         final var activatingContext = stateTransitionBehavior.transitionToActivating(context);
         stateTransitionBehavior
             .onElementActivating(element, activatingContext)
-            .flatMap(ok -> processor.onActivate(element, activatingContext))
-            .flatMap(ok -> afterActivating(element, processor, activatingContext))
+            .flatMap(ok -> beforeActivating(element, processor, activatingContext))
             .ifLeft(failure -> incidentBehavior.createIncident(failure, activatingContext));
         break;
       case COMPLETE_ELEMENT:
@@ -190,9 +190,12 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
       case COMPLETE_EXECUTION_LISTENER:
         final ProcessInstanceIntent elementState =
             stateBehavior.getElementInstance(context).getState();
+        final var node = (ExecutableFlowNode) element;
         switch (elementState) {
           case ELEMENT_ACTIVATING ->
-              onStartExecutionListenerComplete((ExecutableFlowNode) element, processor, context)
+              (node instanceof ExecutableMultiInstanceBody
+                      ? onBeforeAllExecutionListenerComplete(node, processor, context)
+                      : onStartExecutionListenerComplete(node, processor, context))
                   .ifLeft(failure -> incidentBehavior.createIncident(failure, context));
           case ELEMENT_COMPLETING ->
               onEndExecutionListenerComplete((ExecutableFlowNode) element, processor, context)
@@ -223,6 +226,37 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
         context,
         ExecutableFlowNode::getStartExecutionListeners,
         processor::finalizeActivation);
+  }
+
+  /**
+   * In {@code MultiInstanceActivityTransformer#moveBeforeAllExecutionListenersToMultiInstanceBody}
+   * we move {@code beforeAll} execution listeners to multi instance body. That means we shouldn't
+   * have a flow node with both {@code beforeAll} and {@code start} event types.
+   */
+  private Either<Failure, ?> beforeActivating(
+      final ExecutableFlowElement element,
+      final BpmnElementProcessor<ExecutableFlowElement> processor,
+      final BpmnElementContext context) {
+
+    if (element instanceof final ExecutableMultiInstanceBody multiInstanceBody) {
+      final List<ExecutionListener> beforeAllListeners =
+          multiInstanceBody.getBeforeAllExecutionListeners();
+      if (!beforeAllListeners.isEmpty()) {
+        return createExecutionListenerJob(context, beforeAllListeners.getFirst());
+      }
+    }
+
+    // No beforeAll listeners — proceed with normal activation.
+    return runActivationChain(element, processor, context);
+  }
+
+  private Either<Failure, ?> runActivationChain(
+      final ExecutableFlowElement element,
+      final BpmnElementProcessor<ExecutableFlowElement> processor,
+      final BpmnElementContext context) {
+    return processor
+        .onActivate(element, context)
+        .flatMap(ok -> afterActivating(element, processor, context));
   }
 
   private Either<Failure, ?> afterCompleting(
@@ -263,6 +297,25 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
         .thenDo(
             elJobProperties ->
                 jobBehavior.createNewExecutionListenerJob(context, elJobProperties, listener));
+  }
+
+  /**
+   * Continues the {@code beforeAll} listener chain after one job completes. Variables produced by
+   * the listener are merged into the multi-instance body's local scope so the {@code
+   * inputCollection} expression can read them. When all {@code beforeAll} listeners have completed,
+   * the activation chain runs (see {@link #runActivationChain}), which evaluates the input
+   * collection and activates the inner instances.
+   */
+  public Either<Failure, ?> onBeforeAllExecutionListenerComplete(
+      final ExecutableFlowNode element,
+      final BpmnElementProcessor<ExecutableFlowElement> processor,
+      final BpmnElementContext context) {
+    mergeVariablesOfExecutionListener(context, true);
+    return onExecutionListenerComplete(
+        element,
+        context,
+        ExecutableFlowNode::getBeforeAllExecutionListeners,
+        (el, ctx) -> runActivationChain(el, processor, ctx));
   }
 
   public Either<Failure, ?> onStartExecutionListenerComplete(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableFlowNode.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableFlowNode.java
@@ -76,6 +76,12 @@ public class ExecutableFlowNode extends AbstractFlowElement {
     executionListeners.add(listener);
   }
 
+  public List<ExecutionListener> getBeforeAllExecutionListeners() {
+    return executionListeners.stream()
+        .filter(el -> el.getEventType() == ZeebeExecutionListenerEventType.beforeAll)
+        .toList();
+  }
+
   public List<ExecutionListener> getStartExecutionListeners() {
     return executionListeners.stream()
         .filter(el -> el.getEventType() == ZeebeExecutionListenerEventType.start)
@@ -90,5 +96,24 @@ public class ExecutableFlowNode extends AbstractFlowElement {
 
   public boolean hasExecutionListeners() {
     return !executionListeners.isEmpty();
+  }
+
+  /**
+   * Adds an already-constructed {@link ExecutionListener} to this flow node. Used when re-attaching
+   * listeners between flow nodes (e.g., moving {@code beforeAll} listeners from the inner activity
+   * to the multi-instance body during transformation).
+   */
+  public void addExecutionListener(final ExecutionListener listener) {
+    executionListeners.add(listener);
+  }
+
+  /**
+   * Removes all {@code beforeAll} execution listeners from this flow node and returns them. Used
+   * during multi-instance body transformation to re-attach them to the body.
+   */
+  public List<ExecutionListener> removeBeforeAllExecutionListeners() {
+    final List<ExecutionListener> removed = getBeforeAllExecutionListeners();
+    executionListeners.removeAll(removed);
+    return removed;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableFlowNode.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableFlowNode.java
@@ -60,22 +60,6 @@ public class ExecutableFlowNode extends AbstractFlowElement {
     this.outputMappings = Optional.of(outputMappings);
   }
 
-  public void addListener(
-      final ZeebeExecutionListenerEventType eventType,
-      final Expression type,
-      final Expression retries,
-      final Map<String, String> taskHeaders) {
-    final ExecutionListener listener = new ExecutionListener();
-    listener.setEventType(eventType);
-
-    final JobWorkerProperties jobWorkerProperties = new JobWorkerProperties();
-    jobWorkerProperties.setType(type);
-    jobWorkerProperties.setRetries(retries);
-    jobWorkerProperties.setTaskHeaders(taskHeaders);
-    listener.setJobWorkerProperties(jobWorkerProperties);
-    executionListeners.add(listener);
-  }
-
   public List<ExecutionListener> getBeforeAllExecutionListeners() {
     return executionListeners.stream()
         .filter(el -> el.getEventType() == ZeebeExecutionListenerEventType.beforeAll)
@@ -98,11 +82,22 @@ public class ExecutableFlowNode extends AbstractFlowElement {
     return !executionListeners.isEmpty();
   }
 
-  /**
-   * Adds an already-constructed {@link ExecutionListener} to this flow node. Used when re-attaching
-   * listeners between flow nodes (e.g., moving {@code beforeAll} listeners from the inner activity
-   * to the multi-instance body during transformation).
-   */
+  public void addExecutionListener(
+      final ZeebeExecutionListenerEventType eventType,
+      final Expression type,
+      final Expression retries,
+      final Map<String, String> taskHeaders) {
+    final ExecutionListener listener = new ExecutionListener();
+    listener.setEventType(eventType);
+
+    final JobWorkerProperties jobWorkerProperties = new JobWorkerProperties();
+    jobWorkerProperties.setType(type);
+    jobWorkerProperties.setRetries(retries);
+    jobWorkerProperties.setTaskHeaders(taskHeaders);
+    listener.setJobWorkerProperties(jobWorkerProperties);
+    executionListeners.add(listener);
+  }
+
   public void addExecutionListener(final ExecutionListener listener) {
     executionListeners.add(listener);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/MultiInstanceActivityTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/MultiInstanceActivityTransformer.java
@@ -108,6 +108,7 @@ public final class MultiInstanceActivityTransformer implements ModelElementTrans
     innerActivity.setFlowScope(multiInstanceBody);
 
     attachEventsToMultiInstanceBody(innerActivity, multiInstanceBody);
+    moveBeforeAllExecutionListenersToMultiInstanceBody(innerActivity, multiInstanceBody);
     connectSequenceFlowsToMultiInstanceBody(innerActivity, multiInstanceBody);
     replaceCompensationHandlerWithMultiInstanceBody(process, innerActivity, multiInstanceBody);
     replaceAdHocActivityWithMultiInstanceBody(process, innerActivity, multiInstanceBody);
@@ -128,6 +129,18 @@ public final class MultiInstanceActivityTransformer implements ModelElementTrans
 
     innerActivity.getInterruptingElementIds().clear();
     innerActivity.getBoundaryEvents().clear();
+  }
+
+  /**
+   * Moves {@code beforeAll} execution listeners from the inner activity to the multi-instance body.
+   * {@code beforeAll} listeners are scoped to the body so they fire once before the input
+   * collection is evaluated and before any inner instance is activated.
+   */
+  private static void moveBeforeAllExecutionListenersToMultiInstanceBody(
+      final ExecutableActivity innerActivity, final ExecutableMultiInstanceBody multiInstanceBody) {
+    innerActivity
+        .removeBeforeAllExecutionListeners()
+        .forEach(multiInstanceBody::addExecutionListener);
   }
 
   private static void connectSequenceFlowsToMultiInstanceBody(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/zeebe/ExecutionListenerTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/zeebe/ExecutionListenerTransformer.java
@@ -83,7 +83,7 @@ public final class ExecutionListenerTransformer {
         .flatMap(l -> requireNotNull(l, l::getRetries, "retries"))
         .ifRightOrLeft(
             ok -> {
-              flowNode.addListener(
+              flowNode.addExecutionListener(
                   ok.getEventType(),
                   expressionLanguage.parseExpression(ok.getType()),
                   expressionLanguage.parseExpression(ok.getRetries()),

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/execution/ExecutionListenerMultiInstanceActivitiesTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/execution/ExecutionListenerMultiInstanceActivitiesTest.java
@@ -8,10 +8,7 @@
 package io.camunda.zeebe.engine.processing.bpmn.activity.listeners.execution;
 
 import static io.camunda.zeebe.engine.processing.bpmn.activity.listeners.execution.ExecutionListenerTest.END_EL_TYPE;
-import static io.camunda.zeebe.engine.processing.bpmn.activity.listeners.execution.ExecutionListenerTest.PROCESS_ID;
-import static io.camunda.zeebe.engine.processing.bpmn.activity.listeners.execution.ExecutionListenerTest.SERVICE_TASK_TYPE;
 import static io.camunda.zeebe.engine.processing.bpmn.activity.listeners.execution.ExecutionListenerTest.START_EL_TYPE;
-import static io.camunda.zeebe.engine.processing.bpmn.activity.listeners.execution.ExecutionListenerTest.SUB_PROCESS_ID;
 import static io.camunda.zeebe.engine.processing.bpmn.activity.listeners.execution.ExecutionListenerTest.createProcessInstance;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.tuple;
@@ -19,25 +16,42 @@ import static org.assertj.core.api.AssertionsForClassTypes.tuple;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.MultiInstanceLoopCharacteristicsBuilder;
+import io.camunda.zeebe.model.bpmn.builder.ServiceTaskBuilder;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.JobKind;
+import io.camunda.zeebe.protocol.record.value.JobListenerEventType;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
 import org.assertj.core.groups.Tuple;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
 public class ExecutionListenerMultiInstanceActivitiesTest {
+
   @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final String PROCESS_ID = "process";
+  private static final String ELEMENT_ID = "task";
+  private static final String SERVICE_TASK_TYPE = "service-task";
+  private static final String BEFORE_ALL_1 = "before-all-1";
+  private static final String BEFORE_ALL_2 = "before-all-2";
+  private static final String BEFORE_ALL_3 = "before-all-3";
+  private static final String START_1 = "start-1";
+  private static final String START_2 = "start-2";
+  private static final String START_3 = "start-3";
+  private static final List<Integer> ITEMS = List.of(1, 2, 3);
   private static final Collection<Integer> INPUT_COLLECTION = List.of(1, 2, 3, 4);
 
   @Rule
@@ -68,35 +82,365 @@ public class ExecutionListenerMultiInstanceActivitiesTest {
     assertExecutionListenerEvents(processInstanceKey);
   }
 
-  private static void createChildProcess() {
-    final var childProcess =
-        Bpmn.createExecutableProcess(SUB_PROCESS_ID).startEvent().manualTask().endEvent().done();
-    ENGINE.deployment().withXmlResource("child.xml", childProcess).deploy();
+  @Test
+  public void shouldRunSingleStartListenerOnEachInnerInstance() {
+    // given
+    final BpmnModelInstance process = process(t -> t.zeebeStartExecutionListener(START_1));
+    ENGINE.deployment().withXmlResource(process).deploy();
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withVariable("items", ITEMS).create();
+
+    // when — drive each inner instance: start EL → service task
+    for (int i = 0; i < ITEMS.size(); i++) {
+      completeJobByType(processInstanceKey, START_1, i);
+      completeJobByType(processInstanceKey, SERVICE_TASK_TYPE, i);
+    }
+
+    // then — exactly one start EL job per inner instance, all marked as START
+    assertProcessCompleted(processInstanceKey);
+
+    assertThat(
+            RecordingExporter.jobRecords(JobIntent.COMPLETED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withType(START_1)
+                .limit(ITEMS.size())
+                .map(Record::getValue))
+        .extracting(JobRecordValue::getJobKind, JobRecordValue::getJobListenerEventType)
+        .containsOnly(tuple(JobKind.EXECUTION_LISTENER, JobListenerEventType.START))
+        .hasSize(ITEMS.size());
   }
 
-  private BpmnModelInstance buildMainProcessModel(boolean sequential) {
+  @Test
+  public void shouldRunMultipleStartListenersInDeclarationOrderOnEachInstance() {
+    // given
+    final BpmnModelInstance process =
+        process(
+            t ->
+                t.zeebeStartExecutionListener(START_1)
+                    .zeebeStartExecutionListener(START_2)
+                    .zeebeStartExecutionListener(START_3));
+    ENGINE.deployment().withXmlResource(process).deploy();
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withVariable("items", ITEMS).create();
+
+    // when — for each inner instance: start_1 → start_2 → start_3 → service task
+    for (int i = 0; i < ITEMS.size(); i++) {
+      completeJobByType(processInstanceKey, START_1, i);
+      completeJobByType(processInstanceKey, START_2, i);
+      completeJobByType(processInstanceKey, START_3, i);
+      completeJobByType(processInstanceKey, SERVICE_TASK_TYPE, i);
+    }
+
+    // then — start listeners executed in declared order, repeated per inner instance
+    assertProcessCompleted(processInstanceKey);
+    final List<Tuple> expected = new ArrayList<>();
+    for (int i = 0; i < ITEMS.size(); i++) {
+      expected.add(tuple(START_1, JobListenerEventType.START));
+      expected.add(tuple(START_2, JobListenerEventType.START));
+      expected.add(tuple(START_3, JobListenerEventType.START));
+    }
+    assertThat(
+            RecordingExporter.jobRecords(JobIntent.COMPLETED)
+                .withProcessInstanceKey(processInstanceKey)
+                .filter(r -> r.getValue().getJobKind() == JobKind.EXECUTION_LISTENER)
+                .limit(expected.size())
+                .map(Record::getValue))
+        .extracting(JobRecordValue::getType, JobRecordValue::getJobListenerEventType)
+        .containsExactlyElementsOf(expected);
+  }
+
+  @Test
+  public void shouldRunSingleBeforeAllListenerBeforeChildInstancesActivate() {
+    // given
+    final BpmnModelInstance process = process(t -> t.zeebeBeforeAllExecutionListener(BEFORE_ALL_1));
+    ENGINE.deployment().withXmlResource(process).deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when — beforeAll listener job is created
+    final Record<JobRecordValue> beforeAllJob =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(BEFORE_ALL_1)
+            .getFirst();
+
+    // then — it is the right kind of job
+    assertThat(beforeAllJob.getValue().getJobKind()).isEqualTo(JobKind.EXECUTION_LISTENER);
+    assertThat(beforeAllJob.getValue().getJobListenerEventType())
+        .isEqualTo(JobListenerEventType.BEFORE_ALL);
+
+    // when — listener completes with the input collection and all service-task jobs complete
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(BEFORE_ALL_1)
+        .withVariables(Map.of("items", ITEMS))
+        .complete();
+    completeAllServiceTasks(processInstanceKey, ITEMS.size());
+
+    // then — process completes
+    assertProcessCompleted(processInstanceKey);
+
+    // contains only BEFORE_ALL_1
+    final Tuple expected = tuple(BEFORE_ALL_1, JobListenerEventType.BEFORE_ALL);
+    assertThat(
+            RecordingExporter.jobRecords(JobIntent.COMPLETED)
+                .withProcessInstanceKey(processInstanceKey)
+                .filter(r -> r.getValue().getJobKind() == JobKind.EXECUTION_LISTENER)
+                .limit(1)
+                .map(Record::getValue))
+        .extracting(JobRecordValue::getType, JobRecordValue::getJobListenerEventType)
+        .containsOnlyOnce(expected);
+
+    // and — the first child instance only activated AFTER the beforeAll listener completed
+    final long miBodyKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.MULTI_INSTANCE_BODY)
+            .getFirst()
+            .getKey();
+
+    final long beforeAllCompletedPosition =
+        RecordingExporter.jobRecords(JobIntent.COMPLETED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(BEFORE_ALL_1)
+            .getFirst()
+            .getPosition();
+
+    final long firstChildActivatingPosition =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withProcessInstanceKey(processInstanceKey)
+            .withFlowScopeKey(miBodyKey)
+            .getFirst()
+            .getPosition();
+
+    assertThat(firstChildActivatingPosition)
+        .as("first child instance should only activate after the beforeAll listener completes")
+        .isGreaterThan(beforeAllCompletedPosition);
+  }
+
+  @Test
+  public void shouldRunMultipleBeforeAllListenersInDeclarationOrder() {
+    // given
+    final BpmnModelInstance process =
+        process(
+            t ->
+                t.zeebeBeforeAllExecutionListener(BEFORE_ALL_1)
+                    .zeebeBeforeAllExecutionListener(BEFORE_ALL_2)
+                    .zeebeBeforeAllExecutionListener(BEFORE_ALL_3));
+    ENGINE.deployment().withXmlResource(process).deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when — complete the listeners one by one (the first sets the collection)
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(BEFORE_ALL_1)
+        .withVariables(Map.of("items", ITEMS))
+        .complete();
+    ENGINE.job().ofInstance(processInstanceKey).withType(BEFORE_ALL_2).complete();
+    ENGINE.job().ofInstance(processInstanceKey).withType(BEFORE_ALL_3).complete();
+    completeAllServiceTasks(processInstanceKey, ITEMS.size());
+
+    // then — process completes and beforeAll jobs were created/completed in declared order
+    assertProcessCompleted(processInstanceKey);
+
+    // contains only BEFORE_ALL_1 → BEFORE_ALL_2 → BEFORE_ALL_3
+    final List<Tuple> expected = new ArrayList<>();
+    expected.add(tuple(BEFORE_ALL_1, JobListenerEventType.BEFORE_ALL));
+    expected.add(tuple(BEFORE_ALL_2, JobListenerEventType.BEFORE_ALL));
+    expected.add(tuple(BEFORE_ALL_3, JobListenerEventType.BEFORE_ALL));
+    assertThat(
+            RecordingExporter.jobRecords(JobIntent.COMPLETED)
+                .withProcessInstanceKey(processInstanceKey)
+                .filter(r -> r.getValue().getJobKind() == JobKind.EXECUTION_LISTENER)
+                .limit(expected.size())
+                .map(Record::getValue))
+        .extracting(JobRecordValue::getType, JobRecordValue::getJobListenerEventType)
+        .containsExactlyElementsOf(expected);
+
+    // and — the first child instance only activated AFTER all the beforeAll listener completed
+    final long miBodyKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.MULTI_INSTANCE_BODY)
+            .getFirst()
+            .getKey();
+
+    final long beforeAllCompletedPosition =
+        RecordingExporter.jobRecords(JobIntent.COMPLETED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(BEFORE_ALL_3)
+            .getFirst()
+            .getPosition();
+
+    final long firstChildActivatingPosition =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withProcessInstanceKey(processInstanceKey)
+            .withFlowScopeKey(miBodyKey)
+            .getFirst()
+            .getPosition();
+
+    assertThat(firstChildActivatingPosition)
+        .as("first child instance should only activate after the beforeAll listener completes")
+        .isGreaterThan(beforeAllCompletedPosition);
+  }
+
+  @Test
+  public void shouldRunMultipleBeforeAllThenMultipleStartListenersInOrder() {
+    // given
+    final BpmnModelInstance process =
+        process(
+            t ->
+                t.zeebeBeforeAllExecutionListener(BEFORE_ALL_1)
+                    .zeebeBeforeAllExecutionListener(BEFORE_ALL_2)
+                    .zeebeStartExecutionListener(START_1)
+                    .zeebeStartExecutionListener(START_2));
+    ENGINE.deployment().withXmlResource(process).deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(BEFORE_ALL_1)
+        .withVariables(Map.of("items", ITEMS))
+        .complete();
+    ENGINE.job().ofInstance(processInstanceKey).withType(BEFORE_ALL_2).complete();
+
+    for (int i = 0; i < ITEMS.size(); i++) {
+      completeJobByType(processInstanceKey, START_1, i);
+      completeJobByType(processInstanceKey, START_2, i);
+      completeJobByType(processInstanceKey, SERVICE_TASK_TYPE, i);
+    }
+
+    // then — beforeAlls fire once in order, then each instance runs its starts in order
+    assertProcessCompleted(processInstanceKey);
+
+    final List<Tuple> expected = new ArrayList<>();
+    expected.add(tuple(BEFORE_ALL_1, JobListenerEventType.BEFORE_ALL));
+    expected.add(tuple(BEFORE_ALL_2, JobListenerEventType.BEFORE_ALL));
+    for (int i = 0; i < ITEMS.size(); i++) {
+      expected.add(tuple(START_1, JobListenerEventType.START));
+      expected.add(tuple(START_2, JobListenerEventType.START));
+    }
+    assertThat(
+            RecordingExporter.jobRecords(JobIntent.COMPLETED)
+                .withProcessInstanceKey(processInstanceKey)
+                .filter(r -> r.getValue().getJobKind() == JobKind.EXECUTION_LISTENER)
+                .limit(expected.size())
+                .map(Record::getValue))
+        .extracting(JobRecordValue::getType, JobRecordValue::getJobListenerEventType)
+        .containsExactlyElementsOf(expected);
+  }
+
+  @Test
+  public void shouldOverwriteVariableWhenMultipleBeforeAllListenersSetTheSameVariable() {
+    // given — two beforeAll listeners that will both write to the same variable ("items")
+    final BpmnModelInstance process =
+        process(
+            t ->
+                t.zeebeBeforeAllExecutionListener(BEFORE_ALL_1)
+                    .zeebeBeforeAllExecutionListener(BEFORE_ALL_2));
+    ENGINE.deployment().withXmlResource(process).deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when — first listener sets items to a 2-element list, second overwrites with a 3-element one
+    final List<Integer> firstItems = List.of(1, 2);
+    final List<Integer> secondItems = List.of(10, 20, 30);
+
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(BEFORE_ALL_1)
+        .withVariables(Map.of("items", firstItems))
+        .complete();
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(BEFORE_ALL_2)
+        .withVariables(Map.of("items", secondItems))
+        .complete();
+
+    // and — drive the inner service-task jobs to completion using the overwritten collection size
+    completeAllServiceTasks(processInstanceKey, secondItems.size());
+
+    // then — process completes
+    assertProcessCompleted(processInstanceKey);
+
+    // and — exactly `secondItems.size()` inner instances were activated (i.e. the second write
+    // fully overwrote the first one; values were not merged)
+    final long innerInstancesCount =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId(ELEMENT_ID)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .limit(secondItems.size())
+            .count();
+
+    assertThat(innerInstancesCount)
+        .as(
+            "second beforeAll listener should overwrite the first; collection has %d elements",
+            secondItems.size())
+        .isEqualTo(secondItems.size());
+
+    final List<String> seenItemValues =
+        RecordingExporter.variableRecords()
+            .withProcessInstanceKey(processInstanceKey)
+            .withName("item")
+            .limit(secondItems.size())
+            .map(r -> r.getValue().getValue())
+            .toList();
+
+    assertThat(seenItemValues)
+        .as("inner instances should iterate over the collection set by the LAST beforeAll listener")
+        .containsExactly("10", "20", "30");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  /** Builds a process with a multi-instance service task; lets a customizer attach listeners. */
+  private static BpmnModelInstance process(final Consumer<ServiceTaskBuilder> listenerCustomizer) {
+    return multiInstanceProcess(
+        ELEMENT_ID,
+        listenerCustomizer,
+        m -> m.sequential().zeebeInputCollectionExpression("items").zeebeInputElement("item"));
+  }
+
+  /** Used by the legacy "around" tests; collection is hard-coded as a literal in the model. */
+  private static BpmnModelInstance buildMainProcessModel(final boolean sequential) {
+    return multiInstanceProcess(
+        "service_task",
+        t -> t.zeebeStartExecutionListener(START_EL_TYPE).zeebeEndExecutionListener(END_EL_TYPE),
+        m -> {
+          if (sequential) {
+            m.sequential();
+          } else {
+            m.parallel();
+          }
+          m.zeebeInputCollectionExpression(INPUT_COLLECTION.toString());
+        });
+  }
+
+  private static BpmnModelInstance multiInstanceProcess(
+      final String elementId,
+      final Consumer<ServiceTaskBuilder> serviceTaskCustomizer,
+      final Consumer<MultiInstanceLoopCharacteristicsBuilder> miCustomizer) {
     return Bpmn.createExecutableProcess(PROCESS_ID)
         .startEvent()
         .serviceTask(
-            "service_task",
-            t ->
-                t.zeebeJobType(SERVICE_TASK_TYPE)
-                    .zeebeStartExecutionListener(START_EL_TYPE)
-                    .zeebeEndExecutionListener(END_EL_TYPE))
-        .multiInstance(
-            m -> {
-              if (sequential) {
-                m.sequential();
-              } else {
-                m.parallel();
-              }
-              m.zeebeInputCollectionExpression(INPUT_COLLECTION.toString());
+            elementId,
+            t -> {
+              t.zeebeJobType(SERVICE_TASK_TYPE);
+              serviceTaskCustomizer.accept(t);
+              t.multiInstance(miCustomizer);
             })
         .endEvent()
         .done();
   }
 
-  private void executeMultiInstanceActivity(final long processInstanceKey) {
+  private static void executeMultiInstanceActivity(final long processInstanceKey) {
     for (int i = 0; i < INPUT_COLLECTION.size(); i++) {
       completeJobByType(processInstanceKey, START_EL_TYPE, i);
       completeJobByType(processInstanceKey, SERVICE_TASK_TYPE, i);
@@ -104,7 +448,7 @@ public class ExecutionListenerMultiInstanceActivitiesTest {
     }
   }
 
-  private void assertExecutionListenerEvents(final long processInstanceKey) {
+  private static void assertExecutionListenerEvents(final long processInstanceKey) {
     final var elementInstanceKeys =
         RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
             .withProcessInstanceKey(processInstanceKey)
@@ -146,5 +490,20 @@ public class ExecutionListenerMultiInstanceActivitiesTest {
             .getFirst()
             .getKey();
     ENGINE.job().ofInstance(processInstanceKey).withKey(jobKey).complete();
+  }
+
+  private static void completeAllServiceTasks(final long processInstanceKey, final int count) {
+    for (int i = 0; i < count; i++) {
+      completeJobByType(processInstanceKey, SERVICE_TASK_TYPE, i);
+    }
+  }
+
+  private static void assertProcessCompleted(final long processInstanceKey) {
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.PROCESS)
+                .exists())
+        .isTrue();
   }
 }


### PR DESCRIPTION
## Description

Adds a new execution-listener event type, `beforeAll`, that fires once on a multi-instance body before any inner instance is activated. Typical use case: a `beforeAll` listener computes or fetches the multi-instance `inputCollection` and writes it as a variable, so the body can iterate over a value that isn't known at process start.

---

### What changed
**deployment / transformer**: `MultiInstanceActivityTransformer` moves any `beforeAll` listeners from the inner activity onto the multi-instance body during transformation. After this pass, `beforeAll` only ever lives on `ExecutableMultiInstanceBody` -- `start/end` listeners stay on the inner activity.
**engine**: 
- `BpmnStreamProcessor.beforeActivating` runs the `beforeAll` chain on activation if the element is a multi-instance body with `beforeAll` listeners; otherwise it runs the activation chain immediately. Behavior for every other element type is unchanged.
- `COMPLETE_EXECUTION_LISTENER` while `ELEMENT_ACTIVATING` routes by element type: `ExecutableMultiInstanceBody` → `onBeforeAllExecutionListenerComplete`, else → `onStartExecutionListenerComplete`. The original start/end paths are untouched.`

---

### Decisions
1. Why we did not introduce a new `ProcessInstanceIntent` before `ACTIVATE_ELEMENT` ❓ →  big overhead
   1. A new intent means new appliers, version handling, golden-file updates, exporter mappings, downstream consumer updates (Operate, Tasklist, Optimize), migration considerations, and potentially client-protocol changes. The feature only applies to multi-instance bodies, so this overhead would buy us very little. 
   2. The existing `ELEMENT_ACTIVATING` transition already gives us an event-sourced anchor for the listener phase: once the element is activating, we either create the next `beforeAll` listener job or proceed with `onActivate`. The shared `executionListenerIndex` (already incremented by `JobCreated` and reset by `ElementActivated` appliers) is enough to walk the chain without any new state.
   3. Replay safety is preserved. Because no new processor-side state mutation is introduced — the only persisted change is the existing listener-job lifecycle — log replay and broker recovery work without any migration story.
2. Why a single `ExecutableFlowNode` cannot host both `beforeAll` and start listeners today ❓→ a lot of refactoring around `executionListenerIndex` 
   1. The single `executionListenerIndex` is shared across `beforeAll/start/end` on one element instance, so a start-listener lookup after `beforeAll` would skip listeners unless the offset is subtracted.
   2. The cursor is reset by the `ELEMENT_ACTIVATED` applier — but only some processors (MI body, user task, receive task, undefined task) write `ELEMENT_ACTIVATED` from `onActivate`; for the rest the reset never happens between phases, so the bug is per-processor.
   3. The dispatcher uses the cursor to infer the phase of a `COMPLETE_EXECUTION_LISTENER`; once the cursor is reset between phases, a start completion becomes indistinguishable from a mid-beforeAll completion and gets misrouted.

---

### Outcome

For the current feature, **moving `beforeAll` listeners onto the multi-instance body during transformation sidesteps the problem entirely**:
- The MI body holds only `beforeAll` listeners; the inner activity holds only `start/end` listeners. They live on different `ExecutableFlowNodes` with separate element-instance state and separate `ACTIVATE_ELEMENT` lifecycles.
- The dispatcher therefore routes by element type (`ExecutableMultiInstanceBody` → `beforeAll`, else → `start`) without any cursor arithmetic. No phase confusion is possible.
- Existing models without `beforeAll` are completely unaffected — the dispatch falls through to the original activation chain.

## Related issues

closes #51349
