### PR TITLE
49826 more process instance archiving ITs

### DIFF
--- a/search/search-test-utils/src/main/java/io/camunda/search/test/utils/SearchClientAdapter.java
+++ b/search/search-test-utils/src/main/java/io/camunda/search/test/utils/SearchClientAdapter.java
@@ -187,10 +187,22 @@ public class SearchClientAdapter {
 
   public String index(final String id, final String index, final Object document)
       throws IOException {
+    return index(id, null, index, document);
+  }
+
+  public String index(
+      final String id, final String routing, final String index, final Object document)
+      throws IOException {
     if (elsClient != null) {
-      return elsClient.index(i -> i.index(index).id(id).document(document)).result().jsonValue();
+      return elsClient
+          .index(i -> i.index(index).id(id).routing(routing).document(document))
+          .result()
+          .jsonValue();
     } else if (osClient != null) {
-      return osClient.index(i -> i.index(index).id(id).document(document)).result().jsonValue();
+      return osClient
+          .index(i -> i.index(index).id(id).routing(routing).document(document))
+          .result()
+          .jsonValue();
     }
     return "";
   }

--- a/search/search-test-utils/src/main/java/io/camunda/search/test/utils/SearchClientAdapter.java
+++ b/search/search-test-utils/src/main/java/io/camunda/search/test/utils/SearchClientAdapter.java
@@ -177,10 +177,16 @@ public class SearchClientAdapter {
 
   public <T> T get(final String id, final String index, final Class<T> classType)
       throws IOException {
+    return get(id, null, index, classType);
+  }
+
+  public <T> T get(
+      final String id, final String routing, final String index, final Class<T> classType)
+      throws IOException {
     if (elsClient != null) {
-      return elsClient.get(r -> r.id(id).index(index), classType).source();
+      return elsClient.get(r -> r.id(id).routing(routing).index(index), classType).source();
     } else if (osClient != null) {
-      return osClient.get(r -> r.id(id).index(index), classType).source();
+      return osClient.get(r -> r.id(id).routing(routing).index(index), classType).source();
     }
     return null;
   }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AbstractProcessInstanceArchiverJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AbstractProcessInstanceArchiverJobIT.java
@@ -101,11 +101,11 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
 
           final ProcessInstanceForListViewEntity finishedInstance =
               processInstanceForListViewEntity("2020-01-01T00:00:00+00:00");
-          final ProcessInstanceForListViewEntity unfinishedInstance =
+          final ProcessInstanceForListViewEntity notOldEnoughInstance =
               processInstanceForListViewEntity("2099-01-01T00:00:00+00:00");
 
           store(listViewTemplate, client, finishedInstance);
-          store(listViewTemplate, client, unfinishedInstance);
+          store(listViewTemplate, client, notOldEnoughInstance);
 
           client.refresh();
 
@@ -117,7 +117,7 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
 
           // check that the finished process is no longer in the main index
           verifyMoved(listViewTemplate, client, finishedInstance, "2020-01-01");
-          verifyNotMoved(listViewTemplate, client, unfinishedInstance);
+          verifyNotMoved(listViewTemplate, client, notOldEnoughInstance);
         });
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AbstractProcessInstanceArchiverJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AbstractProcessInstanceArchiverJobIT.java
@@ -12,15 +12,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.exporter.ExporterResourceProvider;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.search.test.utils.SearchClientAdapter;
+import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
+import io.camunda.webapps.schema.entities.ExporterEntity;
+import io.camunda.webapps.schema.entities.listview.FlowNodeInstanceForListViewEntity;
 import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.TestTemplate;
 
 public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInstanceArchiverJob>
     extends ArchiverJobIT<T> {
+  private static final AtomicLong ID_GENERATOR = new AtomicLong(1);
 
   @TestTemplate
   void shouldArchiveLoneProcessInstance(
@@ -30,9 +36,9 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
         (job, resourceProvider) -> {
           // given
           final ProcessInstanceForListViewEntity processInstance =
-              processInstanceForListViewEntity(1234L, "2020-01-01T00:00:00+00:00");
+              processInstanceForListViewEntity("2020-01-01T00:00:00+00:00");
 
-          store(resourceProvider, client, processInstance);
+          storeInListView(resourceProvider, client, processInstance);
 
           client.refresh();
 
@@ -45,14 +51,7 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
           // check that the process is no longer in the main index
           final var listViewTemplate =
               resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class);
-          final var oldIndexPI =
-              get(client, processInstance, listViewTemplate.getFullQualifiedName());
-          assertThat(oldIndexPI).isNull();
-
-          // process should now be in the dated index
-          final var dateIndex = listViewTemplate.getFullQualifiedName() + "2020-01-01";
-          final var newIndexPI = get(client, processInstance, dateIndex);
-          assertThat(newIndexPI).isEqualTo(processInstance);
+          verifyMoved(listViewTemplate, client, processInstance, "2020-01-01");
         });
   }
 
@@ -64,12 +63,12 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
         (job, resourceProvider) -> {
           // given
           final ProcessInstanceForListViewEntity finishedInstance =
-              processInstanceForListViewEntity(1234L, "2020-01-01T00:00:00+00:00");
+              processInstanceForListViewEntity("2020-01-01T00:00:00+00:00");
           final ProcessInstanceForListViewEntity unfinishedInstance =
-              processInstanceForListViewEntity(1235L, null);
+              processInstanceForListViewEntity(null);
 
-          store(resourceProvider, client, finishedInstance);
-          store(resourceProvider, client, unfinishedInstance);
+          storeInListView(resourceProvider, client, finishedInstance);
+          storeInListView(resourceProvider, client, unfinishedInstance);
 
           client.refresh();
 
@@ -82,13 +81,8 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
           // check that the finished process is no longer in the main index
           final var listViewTemplate =
               resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class);
-          final var oldIndexFinishedPI =
-              get(client, finishedInstance, listViewTemplate.getFullQualifiedName());
-          assertThat(oldIndexFinishedPI).isNull();
-
-          final var oldIndexUnfinishedPI =
-              get(client, unfinishedInstance, listViewTemplate.getFullQualifiedName());
-          assertThat(oldIndexUnfinishedPI).isEqualTo(unfinishedInstance);
+          verifyMoved(listViewTemplate, client, finishedInstance, "2020-01-01");
+          verifyNotMoved(listViewTemplate, client, unfinishedInstance);
         });
   }
 
@@ -100,12 +94,12 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
         (job, resourceProvider) -> {
           // given
           final ProcessInstanceForListViewEntity finishedInstance =
-              processInstanceForListViewEntity(1234L, "2020-01-01T00:00:00+00:00");
+              processInstanceForListViewEntity("2020-01-01T00:00:00+00:00");
           final ProcessInstanceForListViewEntity unfinishedInstance =
-              processInstanceForListViewEntity(1235L, "2099-01-01T00:00:00+00:00");
+              processInstanceForListViewEntity("2099-01-01T00:00:00+00:00");
 
-          store(resourceProvider, client, finishedInstance);
-          store(resourceProvider, client, unfinishedInstance);
+          storeInListView(resourceProvider, client, finishedInstance);
+          storeInListView(resourceProvider, client, unfinishedInstance);
 
           client.refresh();
 
@@ -118,38 +112,77 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
           // check that the finished process is no longer in the main index
           final var listViewTemplate =
               resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class);
-          final var oldIndexFinishedPI =
-              get(client, finishedInstance, listViewTemplate.getFullQualifiedName());
-          assertThat(oldIndexFinishedPI).isNull();
-
-          final var oldIndexUnfinishedPI =
-              get(client, unfinishedInstance, listViewTemplate.getFullQualifiedName());
-          assertThat(oldIndexUnfinishedPI).isEqualTo(unfinishedInstance);
+          verifyMoved(listViewTemplate, client, finishedInstance, "2020-01-01");
+          verifyNotMoved(listViewTemplate, client, unfinishedInstance);
         });
   }
 
-  private void store(
+  @TestTemplate
+  void shouldArchiveProcessInstanceAndDependentFlowNodes(
+      final ExporterConfiguration config, final SearchClientAdapter client) throws Exception {
+    withArchiverJob(
+        config,
+        (job, resourceProvider) -> {
+          // given
+          final ProcessInstanceForListViewEntity processInstance =
+              processInstanceForListViewEntity("2020-01-01T00:00:00+00:00");
+
+          final List<FlowNodeInstanceForListViewEntity> flowNodes =
+              List.of(
+                  flowNodeInstanceForListViewEntity(processInstance),
+                  flowNodeInstanceForListViewEntity(processInstance),
+                  flowNodeInstanceForListViewEntity(processInstance));
+
+          storeInListView(resourceProvider, client, processInstance);
+          for (final var flowNode : flowNodes) {
+            storeInListView(resourceProvider, client, processInstance, flowNode);
+          }
+
+          client.refresh();
+
+          // when
+          final var archived = job.execute();
+
+          // then
+          assertThat(archived).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(1);
+
+          // check that the process is no longer in the main index
+          final var listViewTemplate =
+              resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class);
+          verifyMoved(listViewTemplate, client, processInstance, "2020-01-01");
+          for (final var flowNode : flowNodes) {
+            verifyMoved(listViewTemplate, client, flowNode, "2020-01-01");
+          }
+        });
+  }
+
+  private void storeInListView(
       final ExporterResourceProvider resourceProvider,
       final SearchClientAdapter client,
-      final ProcessInstanceForListViewEntity instance)
+      final ExporterEntity<?> entity)
       throws IOException {
     client.index(
-        instance.getId(),
+        entity.getId(),
         resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class).getFullQualifiedName(),
-        instance);
+        entity);
   }
 
-  private ProcessInstanceForListViewEntity get(
+  private void storeInListView(
+      final ExporterResourceProvider resourceProvider,
       final SearchClientAdapter client,
-      final ProcessInstanceForListViewEntity instance,
-      final String index)
+      final ExporterEntity<?> parent,
+      final ExporterEntity<?> child)
       throws IOException {
-    return client.get(instance.getId(), index, ProcessInstanceForListViewEntity.class);
+    client.index(
+        child.getId(),
+        parent.getId(),
+        resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class).getFullQualifiedName(),
+        child);
   }
 
-  private ProcessInstanceForListViewEntity processInstanceForListViewEntity(
-      final long id, final String endDate) {
+  private ProcessInstanceForListViewEntity processInstanceForListViewEntity(final String endDate) {
     final ProcessInstanceForListViewEntity processInstance = new ProcessInstanceForListViewEntity();
+    final long id = ID_GENERATOR.incrementAndGet();
     processInstance.setId(String.valueOf(id));
     processInstance.setKey(id);
     processInstance.setPartitionId(PARTITION_ID);
@@ -158,5 +191,46 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
     }
 
     return processInstance;
+  }
+
+  private FlowNodeInstanceForListViewEntity flowNodeInstanceForListViewEntity(
+      final ProcessInstanceForListViewEntity processInstance) {
+    final FlowNodeInstanceForListViewEntity flowNode = new FlowNodeInstanceForListViewEntity();
+    final long id = ID_GENERATOR.incrementAndGet();
+    flowNode.setId(String.valueOf(id));
+    flowNode.setKey(id);
+    flowNode.setPartitionId(PARTITION_ID);
+    flowNode.setProcessInstanceKey(processInstance.getKey());
+    flowNode.setRootProcessInstanceKey(processInstance.getKey());
+    flowNode.getJoinRelation().setParent(processInstance.getKey());
+
+    return flowNode;
+  }
+
+  private void verifyMoved(
+      final IndexTemplateDescriptor templateDescriptor,
+      final SearchClientAdapter client,
+      final ExporterEntity<?> entity,
+      final String datedIndexSuffix)
+      throws IOException {
+    // should no longer be in the original index
+    final var originalIndexEntity =
+        client.get(entity.getId(), templateDescriptor.getFullQualifiedName(), entity.getClass());
+    assertThat(originalIndexEntity).isNull();
+
+    // should now be in the dated index
+    final var dateIndex = templateDescriptor.getFullQualifiedName() + datedIndexSuffix;
+    final var newIndexEntity = client.get(entity.getId(), dateIndex, entity.getClass());
+    assertThat(newIndexEntity).isEqualTo(entity);
+  }
+
+  private void verifyNotMoved(
+      final IndexTemplateDescriptor templateDescriptor,
+      final SearchClientAdapter client,
+      final ExporterEntity<?> entity)
+      throws IOException {
+    final var originalIndexEntity =
+        client.get(entity.getId(), templateDescriptor.getFullQualifiedName(), entity.getClass());
+    assertThat(originalIndexEntity).isEqualTo(entity);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AbstractProcessInstanceArchiverJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AbstractProcessInstanceArchiverJobIT.java
@@ -9,10 +9,12 @@ package io.camunda.exporter.tasks.archiver;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.exporter.ExporterResourceProvider;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.search.test.utils.SearchClientAdapter;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
+import java.io.IOException;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import org.junit.jupiter.api.TestTemplate;
@@ -28,18 +30,9 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
         (job, resourceProvider) -> {
           // given
           final ProcessInstanceForListViewEntity processInstance =
-              new ProcessInstanceForListViewEntity();
-          processInstance.setId("1234");
-          processInstance.setKey(1234L);
-          processInstance.setPartitionId(PARTITION_ID);
-          processInstance.setEndDate(OffsetDateTime.parse("2020-01-01T00:00:00+00:00"));
+              processInstanceForListViewEntity(1234L, "2020-01-01T00:00:00+00:00");
 
-          client.index(
-              processInstance.getId(),
-              resourceProvider
-                  .getIndexTemplateDescriptor(ListViewTemplate.class)
-                  .getFullQualifiedName(),
-              processInstance);
+          store(resourceProvider, client, processInstance);
 
           client.refresh();
 
@@ -53,18 +46,79 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
           final var listViewTemplate =
               resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class);
           final var oldIndexPI =
-              client.get(
-                  processInstance.getId(),
-                  listViewTemplate.getFullQualifiedName(),
-                  ProcessInstanceForListViewEntity.class);
+              get(client, processInstance, listViewTemplate.getFullQualifiedName());
           assertThat(oldIndexPI).isNull();
 
           // process should now be in the dated index
           final var dateIndex = listViewTemplate.getFullQualifiedName() + "2020-01-01";
-          final var newIndexPI =
-              client.get(
-                  processInstance.getId(), dateIndex, ProcessInstanceForListViewEntity.class);
+          final var newIndexPI = get(client, processInstance, dateIndex);
           assertThat(newIndexPI).isEqualTo(processInstance);
         });
+  }
+
+  @TestTemplate
+  void shouldOnlyArchiveFinishedProcessInstances(
+      final ExporterConfiguration config, final SearchClientAdapter client) throws Exception {
+    withArchiverJob(
+        config,
+        (job, resourceProvider) -> {
+          // given
+          final ProcessInstanceForListViewEntity finishedInstance =
+              processInstanceForListViewEntity(1234L, "2020-01-01T00:00:00+00:00");
+          final ProcessInstanceForListViewEntity unfinishedInstance =
+              processInstanceForListViewEntity(1235L, "2099-01-01T00:00:00+00:00");
+
+          store(resourceProvider, client, finishedInstance);
+          store(resourceProvider, client, unfinishedInstance);
+
+          client.refresh();
+
+          // when
+          final var archived = job.execute();
+
+          // then
+          assertThat(archived).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(1);
+
+          // check that the finished process is no longer in the main index
+          final var listViewTemplate =
+              resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class);
+          final var oldIndexFinishedPI =
+              get(client, finishedInstance, listViewTemplate.getFullQualifiedName());
+          assertThat(oldIndexFinishedPI).isNull();
+
+          final var oldIndexUnfinishedPI =
+              get(client, unfinishedInstance, listViewTemplate.getFullQualifiedName());
+          assertThat(oldIndexUnfinishedPI).isEqualTo(unfinishedInstance);
+        });
+  }
+
+  private void store(
+      final ExporterResourceProvider resourceProvider,
+      final SearchClientAdapter client,
+      final ProcessInstanceForListViewEntity instance)
+      throws IOException {
+    client.index(
+        instance.getId(),
+        resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class).getFullQualifiedName(),
+        instance);
+  }
+
+  private ProcessInstanceForListViewEntity get(
+      final SearchClientAdapter client,
+      final ProcessInstanceForListViewEntity instance,
+      final String index)
+      throws IOException {
+    return client.get(instance.getId(), index, ProcessInstanceForListViewEntity.class);
+  }
+
+  private ProcessInstanceForListViewEntity processInstanceForListViewEntity(
+      final long id, final String endDate) {
+    final ProcessInstanceForListViewEntity processInstance = new ProcessInstanceForListViewEntity();
+    processInstance.setId(String.valueOf(id));
+    processInstance.setKey(id);
+    processInstance.setPartitionId(PARTITION_ID);
+    processInstance.setEndDate(OffsetDateTime.parse(endDate));
+
+    return processInstance;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AbstractProcessInstanceArchiverJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AbstractProcessInstanceArchiverJobIT.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.archiver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.exporter.config.ExporterConfiguration;
+import io.camunda.search.test.utils.SearchClientAdapter;
+import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
+import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.TestTemplate;
+
+public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInstanceArchiverJob>
+    extends ArchiverJobIT<T> {
+
+  @TestTemplate
+  void shouldArchiveLoneProcessInstance(
+      final ExporterConfiguration config, final SearchClientAdapter client) throws Exception {
+    withArchiverJob(
+        config,
+        (job, resourceProvider) -> {
+          // given
+          final ProcessInstanceForListViewEntity processInstance =
+              new ProcessInstanceForListViewEntity();
+          processInstance.setId("1234");
+          processInstance.setKey(1234L);
+          processInstance.setPartitionId(PARTITION_ID);
+          processInstance.setEndDate(OffsetDateTime.parse("2020-01-01T00:00:00+00:00"));
+
+          client.index(
+              processInstance.getId(),
+              resourceProvider
+                  .getIndexTemplateDescriptor(ListViewTemplate.class)
+                  .getFullQualifiedName(),
+              processInstance);
+
+          client.refresh();
+
+          // when
+          final var archived = job.execute();
+
+          // then
+          assertThat(archived).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(1);
+
+          // check that the process is no longer in the main index
+          final var listViewTemplate =
+              resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class);
+          final var oldIndexPI =
+              client.get(
+                  processInstance.getId(),
+                  listViewTemplate.getFullQualifiedName(),
+                  ProcessInstanceForListViewEntity.class);
+          assertThat(oldIndexPI).isNull();
+
+          // process should now be in the dated index
+          final var dateIndex = listViewTemplate.getFullQualifiedName() + "2020-01-01";
+          final var newIndexPI =
+              client.get(
+                  processInstance.getId(), dateIndex, ProcessInstanceForListViewEntity.class);
+          assertThat(newIndexPI).isEqualTo(processInstance);
+        });
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AbstractProcessInstanceArchiverJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AbstractProcessInstanceArchiverJobIT.java
@@ -9,12 +9,13 @@ package io.camunda.exporter.tasks.archiver;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.exporter.ExporterResourceProvider;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.search.test.utils.SearchClientAdapter;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
+import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.entities.ExporterEntity;
+import io.camunda.webapps.schema.entities.flownode.FlowNodeInstanceEntity;
 import io.camunda.webapps.schema.entities.listview.FlowNodeInstanceForListViewEntity;
 import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
 import java.io.IOException;
@@ -35,10 +36,13 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
         config,
         (job, resourceProvider) -> {
           // given
+          final var listViewTemplate =
+              resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class);
+
           final ProcessInstanceForListViewEntity processInstance =
               processInstanceForListViewEntity("2020-01-01T00:00:00+00:00");
 
-          storeInListView(resourceProvider, client, processInstance);
+          store(listViewTemplate, client, processInstance);
 
           client.refresh();
 
@@ -49,8 +53,6 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
           assertThat(archived).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(1);
 
           // check that the process is no longer in the main index
-          final var listViewTemplate =
-              resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class);
           verifyMoved(listViewTemplate, client, processInstance, "2020-01-01");
         });
   }
@@ -62,13 +64,16 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
         config,
         (job, resourceProvider) -> {
           // given
+          final var listViewTemplate =
+              resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class);
+
           final ProcessInstanceForListViewEntity finishedInstance =
               processInstanceForListViewEntity("2020-01-01T00:00:00+00:00");
           final ProcessInstanceForListViewEntity unfinishedInstance =
               processInstanceForListViewEntity(null);
 
-          storeInListView(resourceProvider, client, finishedInstance);
-          storeInListView(resourceProvider, client, unfinishedInstance);
+          store(listViewTemplate, client, finishedInstance);
+          store(listViewTemplate, client, unfinishedInstance);
 
           client.refresh();
 
@@ -79,8 +84,6 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
           assertThat(archived).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(1);
 
           // check that the finished process is no longer in the main index
-          final var listViewTemplate =
-              resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class);
           verifyMoved(listViewTemplate, client, finishedInstance, "2020-01-01");
           verifyNotMoved(listViewTemplate, client, unfinishedInstance);
         });
@@ -93,13 +96,16 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
         config,
         (job, resourceProvider) -> {
           // given
+          final var listViewTemplate =
+              resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class);
+
           final ProcessInstanceForListViewEntity finishedInstance =
               processInstanceForListViewEntity("2020-01-01T00:00:00+00:00");
           final ProcessInstanceForListViewEntity unfinishedInstance =
               processInstanceForListViewEntity("2099-01-01T00:00:00+00:00");
 
-          storeInListView(resourceProvider, client, finishedInstance);
-          storeInListView(resourceProvider, client, unfinishedInstance);
+          store(listViewTemplate, client, finishedInstance);
+          store(listViewTemplate, client, unfinishedInstance);
 
           client.refresh();
 
@@ -110,20 +116,21 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
           assertThat(archived).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(1);
 
           // check that the finished process is no longer in the main index
-          final var listViewTemplate =
-              resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class);
           verifyMoved(listViewTemplate, client, finishedInstance, "2020-01-01");
           verifyNotMoved(listViewTemplate, client, unfinishedInstance);
         });
   }
 
   @TestTemplate
-  void shouldArchiveProcessInstanceAndDependentFlowNodes(
+  void shouldArchiveProcessInstanceAndDependentListViewFlowNodes(
       final ExporterConfiguration config, final SearchClientAdapter client) throws Exception {
     withArchiverJob(
         config,
         (job, resourceProvider) -> {
           // given
+          final var listViewTemplate =
+              resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class);
+
           final ProcessInstanceForListViewEntity processInstance =
               processInstanceForListViewEntity("2020-01-01T00:00:00+00:00");
 
@@ -133,9 +140,9 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
                   flowNodeInstanceForListViewEntity(processInstance),
                   flowNodeInstanceForListViewEntity(processInstance));
 
-          storeInListView(resourceProvider, client, processInstance);
+          store(listViewTemplate, client, processInstance);
           for (final var flowNode : flowNodes) {
-            storeInListView(resourceProvider, client, processInstance, flowNode);
+            store(listViewTemplate, client, processInstance, flowNode);
           }
 
           client.refresh();
@@ -147,8 +154,6 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
           assertThat(archived).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(1);
 
           // check that the process is no longer in the main index
-          final var listViewTemplate =
-              resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class);
           verifyMoved(listViewTemplate, client, processInstance, "2020-01-01");
           for (final var flowNode : flowNodes) {
             verifyMoved(listViewTemplate, client, flowNode, "2020-01-01");
@@ -156,28 +161,63 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
         });
   }
 
-  private void storeInListView(
-      final ExporterResourceProvider resourceProvider,
+  @TestTemplate
+  void shouldArchiveProcessInstanceAndDependentFlowNodeInstances(
+      final ExporterConfiguration config, final SearchClientAdapter client) throws Exception {
+    withArchiverJob(
+        config,
+        (job, resourceProvider) -> {
+          // given
+          final var listViewTemplate =
+              resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class);
+          final var flowNodeInstanceTemplate =
+              resourceProvider.getIndexTemplateDescriptor(FlowNodeInstanceTemplate.class);
+
+          final ProcessInstanceForListViewEntity processInstance =
+              processInstanceForListViewEntity("2020-01-01T00:00:00+00:00");
+
+          final List<FlowNodeInstanceEntity> flowNodes =
+              List.of(
+                  flowNodeInstanceEntity(processInstance),
+                  flowNodeInstanceEntity(processInstance),
+                  flowNodeInstanceEntity(processInstance));
+
+          store(listViewTemplate, client, processInstance);
+          for (final var flowNode : flowNodes) {
+            store(flowNodeInstanceTemplate, client, processInstance, flowNode);
+          }
+
+          client.refresh();
+
+          // when
+          final var archived = job.execute();
+
+          // then
+          assertThat(archived).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(1);
+
+          // check that the process is no longer in the main index
+          verifyMoved(listViewTemplate, client, processInstance, "2020-01-01");
+          for (final var flowNode : flowNodes) {
+            verifyMoved(flowNodeInstanceTemplate, client, flowNode, "2020-01-01");
+          }
+        });
+  }
+
+  private void store(
+      final IndexTemplateDescriptor template,
       final SearchClientAdapter client,
       final ExporterEntity<?> entity)
       throws IOException {
-    client.index(
-        entity.getId(),
-        resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class).getFullQualifiedName(),
-        entity);
+    client.index(entity.getId(), template.getFullQualifiedName(), entity);
   }
 
-  private void storeInListView(
-      final ExporterResourceProvider resourceProvider,
+  private void store(
+      final IndexTemplateDescriptor template,
       final SearchClientAdapter client,
       final ExporterEntity<?> parent,
       final ExporterEntity<?> child)
       throws IOException {
-    client.index(
-        child.getId(),
-        parent.getId(),
-        resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class).getFullQualifiedName(),
-        child);
+    client.index(child.getId(), parent.getId(), template.getFullQualifiedName(), child);
   }
 
   private ProcessInstanceForListViewEntity processInstanceForListViewEntity(final String endDate) {
@@ -203,6 +243,19 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
     flowNode.setProcessInstanceKey(processInstance.getKey());
     flowNode.setRootProcessInstanceKey(processInstance.getKey());
     flowNode.getJoinRelation().setParent(processInstance.getKey());
+
+    return flowNode;
+  }
+
+  private FlowNodeInstanceEntity flowNodeInstanceEntity(
+      final ProcessInstanceForListViewEntity processInstance) {
+    final FlowNodeInstanceEntity flowNode = new FlowNodeInstanceEntity();
+    final long id = ID_GENERATOR.incrementAndGet();
+    flowNode.setId(String.valueOf(id));
+    flowNode.setKey(id);
+    flowNode.setPartitionId(PARTITION_ID);
+    flowNode.setProcessInstanceKey(processInstance.getKey());
+    flowNode.setRootProcessInstanceKey(processInstance.getKey());
 
     return flowNode;
   }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AbstractProcessInstanceArchiverJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AbstractProcessInstanceArchiverJobIT.java
@@ -156,7 +156,7 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
           // check that the process is no longer in the main index
           verifyMoved(listViewTemplate, client, processInstance, "2020-01-01");
           for (final var flowNode : flowNodes) {
-            verifyMoved(listViewTemplate, client, flowNode, "2020-01-01");
+            verifyMoved(listViewTemplate, client, flowNode, processInstance, "2020-01-01");
           }
         });
   }
@@ -184,7 +184,7 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
 
           store(listViewTemplate, client, processInstance);
           for (final var flowNode : flowNodes) {
-            store(flowNodeInstanceTemplate, client, processInstance, flowNode);
+            store(flowNodeInstanceTemplate, client, flowNode);
           }
 
           client.refresh();
@@ -266,14 +266,35 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
       final ExporterEntity<?> entity,
       final String datedIndexSuffix)
       throws IOException {
+    verifyMoved(templateDescriptor, client, entity, (String) null, datedIndexSuffix);
+  }
+
+  private void verifyMoved(
+      final IndexTemplateDescriptor templateDescriptor,
+      final SearchClientAdapter client,
+      final ExporterEntity<?> parent,
+      final ExporterEntity<?> entity,
+      final String datedIndexSuffix)
+      throws IOException {
+    verifyMoved(templateDescriptor, client, entity, parent.getId(), datedIndexSuffix);
+  }
+
+  private void verifyMoved(
+      final IndexTemplateDescriptor templateDescriptor,
+      final SearchClientAdapter client,
+      final ExporterEntity<?> entity,
+      final String routing,
+      final String datedIndexSuffix)
+      throws IOException {
     // should no longer be in the original index
     final var originalIndexEntity =
-        client.get(entity.getId(), templateDescriptor.getFullQualifiedName(), entity.getClass());
+        client.get(
+            entity.getId(), routing, templateDescriptor.getFullQualifiedName(), entity.getClass());
     assertThat(originalIndexEntity).isNull();
 
     // should now be in the dated index
     final var dateIndex = templateDescriptor.getFullQualifiedName() + datedIndexSuffix;
-    final var newIndexEntity = client.get(entity.getId(), dateIndex, entity.getClass());
+    final var newIndexEntity = client.get(entity.getId(), routing, dateIndex, entity.getClass());
     assertThat(newIndexEntity).isEqualTo(entity);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AbstractProcessInstanceArchiverJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AbstractProcessInstanceArchiverJobIT.java
@@ -66,6 +66,42 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
           final ProcessInstanceForListViewEntity finishedInstance =
               processInstanceForListViewEntity(1234L, "2020-01-01T00:00:00+00:00");
           final ProcessInstanceForListViewEntity unfinishedInstance =
+              processInstanceForListViewEntity(1235L, null);
+
+          store(resourceProvider, client, finishedInstance);
+          store(resourceProvider, client, unfinishedInstance);
+
+          client.refresh();
+
+          // when
+          final var archived = job.execute();
+
+          // then
+          assertThat(archived).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(1);
+
+          // check that the finished process is no longer in the main index
+          final var listViewTemplate =
+              resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class);
+          final var oldIndexFinishedPI =
+              get(client, finishedInstance, listViewTemplate.getFullQualifiedName());
+          assertThat(oldIndexFinishedPI).isNull();
+
+          final var oldIndexUnfinishedPI =
+              get(client, unfinishedInstance, listViewTemplate.getFullQualifiedName());
+          assertThat(oldIndexUnfinishedPI).isEqualTo(unfinishedInstance);
+        });
+  }
+
+  @TestTemplate
+  void shouldOnlyArchiveProcessInstancesCompletedAfterAWhile(
+      final ExporterConfiguration config, final SearchClientAdapter client) throws Exception {
+    withArchiverJob(
+        config,
+        (job, resourceProvider) -> {
+          // given
+          final ProcessInstanceForListViewEntity finishedInstance =
+              processInstanceForListViewEntity(1234L, "2020-01-01T00:00:00+00:00");
+          final ProcessInstanceForListViewEntity unfinishedInstance =
               processInstanceForListViewEntity(1235L, "2099-01-01T00:00:00+00:00");
 
           store(resourceProvider, client, finishedInstance);
@@ -117,7 +153,9 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
     processInstance.setId(String.valueOf(id));
     processInstance.setKey(id);
     processInstance.setPartitionId(PARTITION_ID);
-    processInstance.setEndDate(OffsetDateTime.parse(endDate));
+    if (endDate != null) {
+      processInstance.setEndDate(OffsetDateTime.parse(endDate));
+    }
 
     return processInstance;
   }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ProcessInstanceArchiverJobIT.java
@@ -7,70 +7,16 @@
  */
 package io.camunda.exporter.tasks.archiver;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import io.camunda.exporter.ExporterResourceProvider;
 import io.camunda.exporter.config.ExporterConfiguration;
-import io.camunda.search.test.utils.SearchClientAdapter;
 import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
-import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
-import java.time.Duration;
-import java.time.OffsetDateTime;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.junit.jupiter.api.TestTemplate;
 
 @TestInstance(Lifecycle.PER_CLASS)
-public class ProcessInstanceArchiverJobIT extends ArchiverJobIT<ProcessInstanceArchiverJob> {
-
-  @TestTemplate
-  void shouldArchiveLoneProcessInstance(
-      final ExporterConfiguration config, final SearchClientAdapter client) throws Exception {
-    withArchiverJob(
-        config,
-        (job, resourceProvider) -> {
-          // given
-          final ProcessInstanceForListViewEntity processInstance =
-              new ProcessInstanceForListViewEntity();
-          processInstance.setId("1234");
-          processInstance.setKey(1234L);
-          processInstance.setPartitionId(PARTITION_ID);
-          processInstance.setEndDate(OffsetDateTime.parse("2020-01-01T00:00:00+00:00"));
-
-          client.index(
-              processInstance.getId(),
-              resourceProvider
-                  .getIndexTemplateDescriptor(ListViewTemplate.class)
-                  .getFullQualifiedName(),
-              processInstance);
-
-          client.refresh();
-
-          // when
-          final var archived = job.execute();
-
-          // then
-          assertThat(archived).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(1);
-
-          // check that the process is no longer in the main index
-          final var listViewTemplate =
-              resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class);
-          final var oldIndexPI =
-              client.get(
-                  processInstance.getId(),
-                  listViewTemplate.getFullQualifiedName(),
-                  ProcessInstanceForListViewEntity.class);
-          assertThat(oldIndexPI).isNull();
-
-          // process should now be in the dated index
-          final var dateIndex = listViewTemplate.getFullQualifiedName() + "2020-01-01";
-          final var newIndexPI =
-              client.get(
-                  processInstance.getId(), dateIndex, ProcessInstanceForListViewEntity.class);
-          assertThat(newIndexPI).isEqualTo(processInstance);
-        });
-  }
+public class ProcessInstanceArchiverJobIT
+    extends AbstractProcessInstanceArchiverJobIT<ProcessInstanceArchiverJob> {
 
   @Override
   ProcessInstanceArchiverJob createArchiveJob(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ProcessInstanceByIdArchiverJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ProcessInstanceByIdArchiverJobIT.java
@@ -7,71 +7,16 @@
  */
 package io.camunda.exporter.tasks.archiver;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import io.camunda.exporter.ExporterResourceProvider;
 import io.camunda.exporter.config.ExporterConfiguration;
-import io.camunda.search.test.utils.SearchClientAdapter;
 import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
-import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
-import java.time.Duration;
-import java.time.OffsetDateTime;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.junit.jupiter.api.TestTemplate;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class ProcessInstanceByIdArchiverJobIT
-    extends ArchiverJobIT<ProcessInstanceByIdArchiverJob> {
-
-  @TestTemplate
-  void shouldArchiveLoneProcessInstance(
-      final ExporterConfiguration config, final SearchClientAdapter client) throws Exception {
-    withArchiverJob(
-        config,
-        (job, resourceProvider) -> {
-          // given
-          final ProcessInstanceForListViewEntity processInstance =
-              new ProcessInstanceForListViewEntity();
-          processInstance.setId("1234");
-          processInstance.setKey(1234L);
-          processInstance.setPartitionId(PARTITION_ID);
-          processInstance.setEndDate(OffsetDateTime.parse("2020-01-01T00:00:00+00:00"));
-
-          client.index(
-              processInstance.getId(),
-              resourceProvider
-                  .getIndexTemplateDescriptor(ListViewTemplate.class)
-                  .getFullQualifiedName(),
-              processInstance);
-
-          client.refresh();
-
-          // when
-          final var archived = job.execute();
-
-          // then
-          assertThat(archived).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(1);
-
-          // check that the process is no longer in the main index
-          final var listViewTemplate =
-              resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class);
-          final var oldIndexPI =
-              client.get(
-                  processInstance.getId(),
-                  listViewTemplate.getFullQualifiedName(),
-                  ProcessInstanceForListViewEntity.class);
-          assertThat(oldIndexPI).isNull();
-
-          // process should now be in the dated index
-          final var dateIndex = listViewTemplate.getFullQualifiedName() + "2020-01-01";
-          final var newIndexPI =
-              client.get(
-                  processInstance.getId(), dateIndex, ProcessInstanceForListViewEntity.class);
-          assertThat(newIndexPI).isEqualTo(processInstance);
-        });
-  }
+    extends AbstractProcessInstanceArchiverJobIT<ProcessInstanceByIdArchiverJob> {
 
   @Override
   ProcessInstanceByIdArchiverJob createArchiveJob(


### PR DESCRIPTION
This expands the Process Instance archiver ITs a bit.

* unifies the tests for the two jobs (so we always maintain parity)
* checks that we only archive finished processes with old enough end dates
* checks that we archive dependent docs that are in the list view index too
* checks that we archive dependent docs in other indexes

Refs: #49826
