### PR TITLE
fix: backport of 50367

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/IncidentMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/IncidentMetrics.java
@@ -39,6 +39,10 @@ public final class IncidentMetrics {
     pendingIncidents.decrement();
   }
 
+  public void setPendingIncidents(final long count) {
+    pendingIncidents.set(count);
+  }
+
   private Counter registerCounter(final MeterRegistry meterRegistry, final IncidentAction action) {
     return Counter.builder(EngineMetricsDoc.INCIDENT_EVENTS.getName())
         .description(EngineMetricsDoc.INCIDENT_EVENTS.getDescription())

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.protocol.record.intent.DeploymentIntent.CREATE;
 
 import io.camunda.zeebe.dmn.DecisionEngineFactory;
 import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.metrics.IncidentMetrics;
 import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
 import io.camunda.zeebe.engine.metrics.ProcessEngineMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
@@ -98,6 +99,7 @@ public final class EngineProcessors {
             scheduledTaskStateFactory.get().getTimerState(), featureFlags, clock);
 
     final var jobMetrics = new JobProcessingMetrics(typedRecordProcessorContext.getMeterRegistry());
+    final var incidentMetrics = new IncidentMetrics(typedRecordProcessorContext.getMeterRegistry());
     final var processEngineMetrics =
         new ProcessEngineMetrics(typedRecordProcessorContext.getMeterRegistry());
 
@@ -120,7 +122,10 @@ public final class EngineProcessors {
             decisionBehavior,
             clock,
             transientProcessMessageSubscriptionState,
-            config);
+            config,
+            incidentMetrics);
+
+    typedRecordProcessors.withListener(bpmnBehaviors.incidentBehavior());
 
     final var commandDistributionBehavior =
         new CommandDistributionBehavior(
@@ -184,14 +189,16 @@ public final class EngineProcessors {
         writers,
         jobMetrics,
         config,
-        clock);
+        clock,
+        incidentMetrics);
 
     addIncidentProcessors(
         processingState,
         bpmnStreamProcessor,
         typedRecordProcessors,
         writers,
-        bpmnBehaviors.jobActivationBehavior());
+        bpmnBehaviors.jobActivationBehavior(),
+        incidentMetrics);
     addResourceDeletionProcessors(
         typedRecordProcessors,
         writers,
@@ -246,7 +253,8 @@ public final class EngineProcessors {
       final DecisionBehavior decisionBehavior,
       final InstantSource clock,
       final TransientPendingSubscriptionState transientProcessMessageSubscriptionState,
-      final EngineConfiguration config) {
+      final EngineConfiguration config,
+      final IncidentMetrics incidentMetrics) {
     return new BpmnBehaviorsImpl(
         processingState,
         writers,
@@ -258,7 +266,8 @@ public final class EngineProcessors {
         jobStreamer,
         clock,
         transientProcessMessageSubscriptionState,
-        config);
+        config,
+        incidentMetrics);
   }
 
   private static TypedRecordProcessor<ProcessInstanceRecord> addProcessProcessors(
@@ -348,13 +357,15 @@ public final class EngineProcessors {
       final TypedRecordProcessor<ProcessInstanceRecord> bpmnStreamProcessor,
       final TypedRecordProcessors typedRecordProcessors,
       final Writers writers,
-      final BpmnJobActivationBehavior jobActivationBehavior) {
+      final BpmnJobActivationBehavior jobActivationBehavior,
+      final IncidentMetrics incidentMetrics) {
     IncidentEventProcessors.addProcessors(
         typedRecordProcessors,
         processingState,
         bpmnStreamProcessor,
         writers,
-        jobActivationBehavior);
+        jobActivationBehavior,
+        incidentMetrics);
   }
 
   private static void addMessageProcessors(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.bpmn.behavior;
 
 import io.camunda.zeebe.el.ExpressionLanguageFactory;
 import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.metrics.IncidentMetrics;
 import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.ProcessInstanceStateTransitionGuard;
 import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
@@ -65,7 +66,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
       final JobStreamer jobStreamer,
       final InstantSource clock,
       final TransientPendingSubscriptionState transientProcessMessageSubscriptionState,
-      final EngineConfiguration config) {
+      final EngineConfiguration config,
+      final IncidentMetrics incidentMetrics) {
     expressionBehavior =
         new ExpressionProcessor(
             ExpressionLanguageFactory.createExpressionLanguage(new ZeebeFeelEngineClock(clock)),
@@ -117,7 +119,7 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
 
     incidentBehavior =
         new BpmnIncidentBehavior(
-            processingState, processingState.getKeyGenerator(), writers.state());
+            processingState, processingState.getKeyGenerator(), writers.state(), incidentMetrics);
 
     eventPublicationBehavior =
         new BpmnEventPublicationBehavior(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnIncidentBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnIncidentBehavior.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.bpmn.behavior;
 
+import io.camunda.zeebe.engine.metrics.IncidentMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.common.ElementTreePathBuilder;
 import io.camunda.zeebe.engine.processing.common.Failure;
@@ -17,10 +18,12 @@ import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
+import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.collection.Tuple;
 
-public final class BpmnIncidentBehavior {
+public final class BpmnIncidentBehavior implements StreamProcessorLifecycleAware {
 
   private final IncidentRecord incidentRecord = new IncidentRecord();
 
@@ -29,16 +32,24 @@ public final class BpmnIncidentBehavior {
   private final KeyGenerator keyGenerator;
   private final ElementInstanceState elementInstanceState;
   private final ProcessState processState;
+  private final IncidentMetrics incidentMetrics;
 
   public BpmnIncidentBehavior(
       final ProcessingState processingState,
       final KeyGenerator keyGenerator,
-      final StateWriter stateWriter) {
+      final StateWriter stateWriter,
+      final IncidentMetrics incidentMetrics) {
     incidentState = processingState.getIncidentState();
     elementInstanceState = processingState.getElementInstanceState();
     processState = processingState.getProcessState();
     this.keyGenerator = keyGenerator;
     this.stateWriter = stateWriter;
+    this.incidentMetrics = incidentMetrics;
+  }
+
+  @Override
+  public void onRecovered(final ReadonlyStreamProcessorContext context) {
+    incidentMetrics.setPendingIncidents(incidentState.getIncidentCount());
   }
 
   public void resolveJobIncident(final long jobKey) {
@@ -48,6 +59,7 @@ public final class BpmnIncidentBehavior {
     if (hasIncident) {
       final IncidentRecord incidentRecord = incidentState.getIncidentRecord(incidentKey);
       stateWriter.appendFollowUpEvent(incidentKey, IncidentIntent.RESOLVED, incidentRecord);
+      incidentMetrics.incidentResolved();
     }
   }
 
@@ -85,6 +97,7 @@ public final class BpmnIncidentBehavior {
 
     final var key = keyGenerator.nextKey();
     stateWriter.appendFollowUpEvent(key, IncidentIntent.CREATED, incidentRecord);
+    incidentMetrics.incidentCreated();
   }
 
   public void resolveIncidents(final BpmnElementContext context) {
@@ -94,6 +107,9 @@ public final class BpmnIncidentBehavior {
   public void resolveIncidents(final long elementInstanceKey) {
     incidentState.forExistingProcessIncident(
         elementInstanceKey,
-        (record, key) -> stateWriter.appendFollowUpEvent(key, IncidentIntent.RESOLVED, record));
+        (record, key) -> {
+          stateWriter.appendFollowUpEvent(key, IncidentIntent.RESOLVED, record);
+          incidentMetrics.incidentResolved();
+        });
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentEventProcessors.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.incident;
 
+import io.camunda.zeebe.engine.metrics.IncidentMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
@@ -23,11 +24,12 @@ public final class IncidentEventProcessors {
       final ProcessingState processingState,
       final TypedRecordProcessor<ProcessInstanceRecord> bpmnStreamProcessor,
       final Writers writers,
-      final BpmnJobActivationBehavior jobActivationBehavior) {
+      final BpmnJobActivationBehavior jobActivationBehavior,
+      final IncidentMetrics incidentMetrics) {
     typedRecordProcessors.onCommand(
         ValueType.INCIDENT,
         IncidentIntent.RESOLVE,
         new IncidentResolveProcessor(
-            processingState, bpmnStreamProcessor, writers, jobActivationBehavior));
+            processingState, bpmnStreamProcessor, writers, jobActivationBehavior, incidentMetrics));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.incident;
 
+import io.camunda.zeebe.engine.metrics.IncidentMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
@@ -47,12 +48,14 @@ public final class IncidentResolveProcessor implements TypedRecordProcessor<Inci
   private final TypedResponseWriter responseWriter;
   private final BpmnJobActivationBehavior jobActivationBehavior;
   private final JobState jobState;
+  private final IncidentMetrics incidentMetrics;
 
   public IncidentResolveProcessor(
       final ProcessingState processingState,
       final TypedRecordProcessor<ProcessInstanceRecord> bpmnStreamProcessor,
       final Writers writers,
-      final BpmnJobActivationBehavior jobActivationBehavior) {
+      final BpmnJobActivationBehavior jobActivationBehavior,
+      final IncidentMetrics incidentMetrics) {
     this.bpmnStreamProcessor = bpmnStreamProcessor;
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
@@ -61,6 +64,7 @@ public final class IncidentResolveProcessor implements TypedRecordProcessor<Inci
     elementInstanceState = processingState.getElementInstanceState();
     this.jobActivationBehavior = jobActivationBehavior;
     jobState = processingState.getJobState();
+    this.incidentMetrics = incidentMetrics;
   }
 
   @Override
@@ -83,6 +87,7 @@ public final class IncidentResolveProcessor implements TypedRecordProcessor<Inci
 
     stateWriter.appendFollowUpEvent(key, IncidentIntent.RESOLVED, incident);
     responseWriter.writeEventOnCommand(key, IncidentIntent.RESOLVED, incident, command);
+    incidentMetrics.incidentResolved();
 
     publishIncidentRelatedJob(jobKey);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.job;
 import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 
 import io.camunda.zeebe.engine.metrics.EngineMetricsDoc.JobAction;
+import io.camunda.zeebe.engine.metrics.IncidentMetrics;
 import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
 import io.camunda.zeebe.engine.processing.common.ElementTreePathBuilder;
 import io.camunda.zeebe.engine.processing.job.JobBatchCollector.TooLargeJob;
@@ -48,13 +49,15 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
   private final JobProcessingMetrics jobMetrics;
   private final ElementInstanceState elementInstanceState;
   private final ProcessState processState;
+  private final IncidentMetrics incidentMetrics;
 
   public JobBatchActivateProcessor(
       final Writers writers,
       final ProcessingState state,
       final KeyGenerator keyGenerator,
       final JobProcessingMetrics jobMetrics,
-      final InstantSource clock) {
+      final InstantSource clock,
+      final IncidentMetrics incidentMetrics) {
 
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
@@ -70,6 +73,7 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
     this.jobMetrics = jobMetrics;
     elementInstanceState = state.getElementInstanceState();
     processState = state.getProcessState();
+    this.incidentMetrics = incidentMetrics;
   }
 
   @Override
@@ -179,5 +183,6 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
             .setCallingElementPath(treePathProperties.callingElementPath());
 
     stateWriter.appendFollowUpEvent(keyGenerator.nextKey(), IncidentIntent.CREATED, incidentEvent);
+    incidentMetrics.incidentCreated();
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.job;
 
 import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.metrics.IncidentMetrics;
 import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
@@ -31,7 +32,8 @@ public final class JobEventProcessors {
       final Writers writers,
       final JobProcessingMetrics jobMetrics,
       final EngineConfiguration config,
-      final InstantSource clock) {
+      final InstantSource clock,
+      final IncidentMetrics incidentMetrics) {
 
     final var keyGenerator = processingState.getKeyGenerator();
 
@@ -60,7 +62,8 @@ public final class JobEventProcessors {
                 processingState.getKeyGenerator(),
                 jobMetrics,
                 jobBackoffChecker,
-                bpmnBehaviors))
+                bpmnBehaviors,
+                incidentMetrics))
         .onCommand(
             ValueType.JOB,
             JobIntent.YIELD,
@@ -73,7 +76,8 @@ public final class JobEventProcessors {
                 bpmnBehaviors.eventPublicationBehavior(),
                 keyGenerator,
                 jobMetrics,
-                writers))
+                writers,
+                incidentMetrics))
         .onCommand(
             ValueType.JOB,
             JobIntent.TIME_OUT,
@@ -104,7 +108,12 @@ public final class JobEventProcessors {
             ValueType.JOB_BATCH,
             JobBatchIntent.ACTIVATE,
             new JobBatchActivateProcessor(
-                writers, processingState, processingState.getKeyGenerator(), jobMetrics, clock))
+                writers,
+                processingState,
+                processingState.getKeyGenerator(),
+                jobMetrics,
+                clock,
+                incidentMetrics))
         .withListener(
             new JobTimeoutCheckerScheduler(
                 scheduledTaskStateFactory.get().getJobState(),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.util.StringUtil.limitString;
 import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 
 import io.camunda.zeebe.engine.metrics.EngineMetricsDoc.JobAction;
+import io.camunda.zeebe.engine.metrics.IncidentMetrics;
 import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavior;
@@ -60,6 +61,7 @@ public final class JobFailProcessor implements TypedRecordProcessor<JobRecord> {
   private final JobCommandPreconditionChecker preconditionChecker;
   private final ElementInstanceState elementInstanceState;
   private final ProcessState processState;
+  private final IncidentMetrics incidentMetrics;
 
   public JobFailProcessor(
       final ProcessingState state,
@@ -67,7 +69,8 @@ public final class JobFailProcessor implements TypedRecordProcessor<JobRecord> {
       final KeyGenerator keyGenerator,
       final JobProcessingMetrics jobMetrics,
       final JobBackoffChecker jobBackoffChecker,
-      final BpmnBehaviors bpmnBehaviors) {
+      final BpmnBehaviors bpmnBehaviors,
+      final IncidentMetrics incidentMetrics) {
     jobState = state.getJobState();
     elementInstanceState = state.getElementInstanceState();
     processState = state.getProcessState();
@@ -82,6 +85,7 @@ public final class JobFailProcessor implements TypedRecordProcessor<JobRecord> {
     this.keyGenerator = keyGenerator;
     this.jobBackoffChecker = jobBackoffChecker;
     this.jobMetrics = jobMetrics;
+    this.incidentMetrics = incidentMetrics;
   }
 
   @Override
@@ -195,5 +199,6 @@ public final class JobFailProcessor implements TypedRecordProcessor<JobRecord> {
         .setCallingElementPath(treePathProperties.callingElementPath());
 
     stateWriter.appendFollowUpEvent(keyGenerator.nextKey(), IncidentIntent.CREATED, incidentEvent);
+    incidentMetrics.incidentCreated();
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_MAX_ERROR_MESS
 import static io.camunda.zeebe.util.StringUtil.limitString;
 
 import io.camunda.zeebe.engine.metrics.EngineMetricsDoc.JobAction;
+import io.camunda.zeebe.engine.metrics.IncidentMetrics;
 import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnEventPublicationBehavior;
 import io.camunda.zeebe.engine.processing.common.ElementTreePathBuilder;
@@ -73,13 +74,15 @@ public class JobThrowErrorProcessor implements TypedRecordProcessor<JobRecord> {
   private final TypedResponseWriter responseWriter;
   private final TypedRejectionWriter rejectionWriter;
   private final StateWriter stateWriter;
+  private final IncidentMetrics incidentMetrics;
 
   public JobThrowErrorProcessor(
       final ProcessingState state,
       final BpmnEventPublicationBehavior eventPublicationBehavior,
       final KeyGenerator keyGenerator,
       final JobProcessingMetrics jobMetrics,
-      final Writers writers) {
+      final Writers writers,
+      final IncidentMetrics incidentMetrics) {
     this.keyGenerator = keyGenerator;
     jobState = state.getJobState();
     elementInstanceState = state.getElementInstanceState();
@@ -97,6 +100,7 @@ public class JobThrowErrorProcessor implements TypedRecordProcessor<JobRecord> {
 
     this.eventPublicationBehavior = eventPublicationBehavior;
     this.jobMetrics = jobMetrics;
+    this.incidentMetrics = incidentMetrics;
   }
 
   @Override
@@ -211,6 +215,7 @@ public class JobThrowErrorProcessor implements TypedRecordProcessor<JobRecord> {
         .setCallingElementPath(treePathProperties.callingElementPath());
 
     stateWriter.appendFollowUpEvent(keyGenerator.nextKey(), IncidentIntent.CREATED, incidentEvent);
+    incidentMetrics.incidentCreated();
   }
 
   private DirectBuffer getElementId(final JobRecord job) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
@@ -141,7 +141,7 @@ public class ProcessingDbState implements MutableProcessingState {
         new DbProcessMessageSubscriptionState(
             zeebeDb, transactionContext, transientProcessMessageSubscriptionState, clock);
     messageCorrelationState = new DbMessageCorrelationState(zeebeDb, transactionContext);
-    incidentState = new DbIncidentState(zeebeDb, transactionContext, partitionId);
+    incidentState = new DbIncidentState(zeebeDb, transactionContext);
     bannedInstanceState = new DbBannedInstanceState(zeebeDb, transactionContext);
     decisionState = new DbDecisionState(zeebeDb, transactionContext, config);
     formState = new DbFormState(zeebeDb, transactionContext, config);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/IncidentState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/IncidentState.java
@@ -27,4 +27,7 @@ public interface IncidentState {
 
   void forExistingProcessIncident(
       long elementInstanceKey, ObjLongConsumer<IncidentRecord> resolver);
+
+  /** Returns the total number of incidents currently stored in the state. */
+  long getIncidentCount();
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbIncidentState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbIncidentState.java
@@ -13,7 +13,6 @@ import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.impl.DbForeignKey;
 import io.camunda.zeebe.db.impl.DbLong;
-import io.camunda.zeebe.engine.metrics.IncidentMetrics;
 import io.camunda.zeebe.engine.state.immutable.IncidentState;
 import io.camunda.zeebe.engine.state.mutable.MutableIncidentState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
@@ -46,12 +45,8 @@ public final class DbIncidentState implements MutableIncidentState {
   private final ColumnFamily<DbForeignKey<DbLong>, IncidentKey> jobIncidentColumnFamily;
   private final IncidentKey incidentKeyValue = new IncidentKey();
 
-  private final IncidentMetrics metrics;
-
   public DbIncidentState(
-      final ZeebeDb<ZbColumnFamilies> zeebeDb,
-      final TransactionContext transactionContext,
-      final int partitionId) {
+      final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
     incidentKey = new DbLong();
     incidentColumnFamily =
         zeebeDb.createColumnFamily(
@@ -69,8 +64,6 @@ public final class DbIncidentState implements MutableIncidentState {
     jobIncidentColumnFamily =
         zeebeDb.createColumnFamily(
             ZbColumnFamilies.INCIDENT_JOBS, transactionContext, jobKey, incidentKeyValue);
-
-    metrics = new IncidentMetrics(zeebeDb.getMeterRegistry());
   }
 
   @Override
@@ -87,8 +80,6 @@ public final class DbIncidentState implements MutableIncidentState {
       elementInstanceKey.inner().wrapLong(incident.getElementInstanceKey());
       processInstanceIncidentColumnFamily.insert(elementInstanceKey, incidentKeyValue);
     }
-
-    metrics.incidentCreated();
   }
 
   @Override
@@ -105,8 +96,6 @@ public final class DbIncidentState implements MutableIncidentState {
         elementInstanceKey.inner().wrapLong(incidentRecord.getElementInstanceKey());
         processInstanceIncidentColumnFamily.deleteExisting(elementInstanceKey);
       }
-
-      metrics.incidentResolved();
     }
   }
 
@@ -178,6 +167,11 @@ public final class DbIncidentState implements MutableIncidentState {
       final IncidentRecord incidentRecord = getIncidentRecord(processIncidentKey);
       resolver.accept(incidentRecord, processIncidentKey);
     }
+  }
+
+  @Override
+  public long getIncidentCount() {
+    return incidentColumnFamily.count();
   }
 
   private List<String> getAuthorizedTenantIds(final Map<String, Object> authorizations) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/IncidentMetricsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/IncidentMetricsTest.java
@@ -84,6 +84,37 @@ public class IncidentMetricsTest {
     assertThat(resolvedIncidentsMetric()).describedAs("Resolved incidents metric").isOne();
   }
 
+  @Test
+  public void shouldRebuildPendingIncidentsMetricOnRecovery() {
+    // given - process with a call activity referencing a non-existing process
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .callActivity("call", a -> a.zeebeProcessId("non-existing"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+    assertThat(pendingIncidentsMetric()).describedAs("Pending incidents before restart").isOne();
+
+    // when - restart the engine (triggers recovery)
+    engine.snapshot();
+    engine.stop();
+    engine.start();
+
+    // then - pending incidents metric should be rebuilt from state, not double-counted
+    assertThat(pendingIncidentsMetric())
+        .describedAs("Pending incidents after restart should still be 1, not inflated")
+        .isOne();
+  }
+
   private Double createdIncidentsMetric() {
     return engine
         .getMeterRegistry()


### PR DESCRIPTION
## Description

⤵️ Backport of https://github.com/camunda/camunda/pull/50367 → stable/8.7

relates to https://github.com/camunda/camunda/issues/34328

Opened this so we can close https://github.com/camunda/camunda/pull/50972 as there were too many conflicts per commit and I did not want to deal with all of those.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).


