### PR TITLE
fix: downgrade DEADLINE_EXCEEDED log level to TRACE in job poller

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/worker/JobPollerImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/worker/JobPollerImpl.java
@@ -158,11 +158,14 @@ public final class JobPollerImpl implements JobPoller {
 
     if (throwable instanceof StatusRuntimeException) {
       final StatusRuntimeException statusRuntimeException = (StatusRuntimeException) throwable;
-      if (statusRuntimeException.getStatus().getCode() == Status.RESOURCE_EXHAUSTED.getCode()) {
-        // Log RESOURCE_EXHAUSTED status exceptions only as trace, otherwise it is just too
-        // noisy. Furthermore it is not worth to be a warning since it is expected on a fully
-        // loaded cluster. It should be handled by our backoff mechanism, but if there is an
-        // issue or a configuration mistake the user can turn on trace logging to see this.
+      if (statusRuntimeException.getStatus().getCode() == Status.RESOURCE_EXHAUSTED.getCode()
+          || statusRuntimeException.getStatus().getCode() == Status.DEADLINE_EXCEEDED.getCode()) {
+        // Log RESOURCE_EXHAUSTED and DEADLINE_EXCEEDED status exceptions only as trace,
+        // otherwise it is just too noisy. RESOURCE_EXHAUSTED is expected on a fully loaded
+        // cluster, and DEADLINE_EXCEEDED is expected during idle long-polling when the
+        // gateway's long-polling timeout exceeds the client's gRPC deadline. Both should be
+        // handled by the backoff mechanism, but if there is an issue or a configuration
+        // mistake the user can turn on trace logging to see this.
         LOG.trace(errorMsg, workerName, jobType, throwable);
         return;
       }

--- a/clients/java/src/test/java/io/camunda/client/impl/worker/JobPollerImplTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/worker/JobPollerImplTest.java
@@ -105,6 +105,25 @@ public final class JobPollerImplTest extends ClientTest {
   }
 
   @Test
+  public void shouldCallbackWhenPollFailedWithDeadlineExceeded() {
+    // given
+    gatewayService.onActivateJobsRequest(new StatusRuntimeException(Status.DEADLINE_EXCEEDED));
+
+    // when
+    getJobPoller().poll(123, jobConsumer, doneCallback, errorCallback, () -> true);
+
+    // then
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(
+            () -> {
+              verify(jobConsumer, never()).accept(any(ActivatedJob.class));
+              verify(doneCallback, never()).accept(any(Integer.class));
+              verify(errorCallback).accept(any(StatusRuntimeException.class));
+            });
+  }
+
+  @Test
   public void shouldUseProvidedTenantFilterWithTenantIds() {
     // given
     gatewayService.onActivateJobsRequest(TestData.job(), TestData.job());

--- a/clients/java/src/test/java/io/camunda/client/impl/worker/JobPollerImplTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/worker/JobPollerImplTest.java
@@ -86,28 +86,18 @@ public final class JobPollerImplTest extends ClientTest {
   }
 
   @Test
-  public void shouldCallbackWhenPollFailed() {
-    // given
-    gatewayService.onActivateJobsRequest(new StatusRuntimeException(Status.RESOURCE_EXHAUSTED));
-
-    // when
-    getJobPoller().poll(123, jobConsumer, doneCallback, errorCallback, () -> true);
-
-    // then
-    Awaitility.await()
-        .atMost(Duration.ofSeconds(5))
-        .untilAsserted(
-            () -> {
-              verify(jobConsumer, never()).accept(any(ActivatedJob.class));
-              verify(doneCallback, never()).accept(any(Integer.class));
-              verify(errorCallback).accept(any(StatusRuntimeException.class));
-            });
+  public void shouldCallbackWhenPollFailedWithResourceExhausted() {
+    shouldCallbackWhenPollFailedWithStatus(Status.RESOURCE_EXHAUSTED);
   }
 
   @Test
   public void shouldCallbackWhenPollFailedWithDeadlineExceeded() {
+    shouldCallbackWhenPollFailedWithStatus(Status.DEADLINE_EXCEEDED);
+  }
+
+  private void shouldCallbackWhenPollFailedWithStatus(final Status status) {
     // given
-    gatewayService.onActivateJobsRequest(new StatusRuntimeException(Status.DEADLINE_EXCEEDED));
+    gatewayService.onActivateJobsRequest(new StatusRuntimeException(status));
 
     // when
     getJobPoller().poll(123, jobConsumer, doneCallback, errorCallback, () -> true);

--- a/clients/java/src/test/java/io/camunda/client/impl/worker/JobPollerImplTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/worker/JobPollerImplTest.java
@@ -34,22 +34,52 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.IntConsumer;
+import java.util.stream.Collectors;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.appender.ListAppender;
 import org.awaitility.Awaitility;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
 public final class JobPollerImplTest extends ClientTest {
 
+  private static final String JOB_POLLER_LOGGER_NAME = "io.camunda.client.job.poller";
+
   private Consumer<ActivatedJob> jobConsumer;
   private IntConsumer doneCallback;
   private Consumer<Throwable> errorCallback;
+  private ListAppender logCapture;
 
   @Before
   public void setup() {
     jobConsumer = Mockito.spy(Consumer.class);
     doneCallback = Mockito.spy(IntConsumer.class);
     errorCallback = Mockito.spy(Consumer.class);
+
+    logCapture = new ListAppender("capture-" + JOB_POLLER_LOGGER_NAME);
+    logCapture.start();
+    final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+    final org.apache.logging.log4j.core.config.LoggerConfig loggerConfig =
+        new org.apache.logging.log4j.core.config.LoggerConfig(
+            JOB_POLLER_LOGGER_NAME, Level.ALL, true);
+    loggerConfig.addAppender(logCapture, null, null);
+    ctx.getConfiguration().addLogger(JOB_POLLER_LOGGER_NAME, loggerConfig);
+    ctx.updateLoggers();
+  }
+
+  @After
+  public void tearDown() {
+    if (logCapture != null) {
+      final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+      ctx.getConfiguration().removeLogger(JOB_POLLER_LOGGER_NAME);
+      ctx.updateLoggers();
+      logCapture.stop();
+    }
   }
 
   @Test
@@ -110,7 +140,26 @@ public final class JobPollerImplTest extends ClientTest {
               verify(jobConsumer, never()).accept(any(ActivatedJob.class));
               verify(doneCallback, never()).accept(any(Integer.class));
               verify(errorCallback).accept(any(StatusRuntimeException.class));
+
+              assertThat(eventsAt(Level.WARN))
+                  .as("%s should not produce a WARN", status.getCode())
+                  .isEmpty();
+              assertThat(eventsAt(Level.TRACE))
+                  .as("%s should be logged at TRACE", status.getCode())
+                  .anySatisfy(
+                      e -> {
+                        assertThat(e.getMessage().getFormattedMessage())
+                            .contains("Failed to activate jobs");
+                        assertThat(e.getThrown()).isInstanceOf(StatusRuntimeException.class);
+                      });
             });
+  }
+
+  private List<LogEvent> eventsAt(final Level level) {
+    return logCapture.getEvents().stream()
+        .filter(e -> JOB_POLLER_LOGGER_NAME.equals(e.getLoggerName()))
+        .filter(e -> level.equals(e.getLevel()))
+        .collect(Collectors.toList());
   }
 
   @Test


### PR DESCRIPTION
## Description

When a Job Worker is idle (no jobs available), the gRPC long-polling mechanism can produce repeated `DEADLINE_EXCEEDED` exceptions logged at **WARN** level with full stack traces. This pollutes application logs with noisy, non-actionable output.

Closes #40220

## Root Cause

`JobPollerImpl.logFailure()` only downgrades `RESOURCE_EXHAUSTED` to TRACE level. `DEADLINE_EXCEEDED` — which is equally expected and harmless during idle long-polling — falls through to `LOG.warn()` with a full stack trace.

### When does DEADLINE_EXCEEDED occur?

The client sets a gRPC deadline of `requestTimeout + DEADLINE_OFFSET` (where `DEADLINE_OFFSET` is hardcoded to **10 seconds** in `ActivateJobsCommandImpl`). The gateway decides how long to hold the long-poll:

- If `requestTimeout > 0` → gateway uses the client's value → the 10s buffer ensures the server always responds first → **no issue**
- If `requestTimeout == 0` → gateway falls back to its own `longPollingTimeout` (default 10s, configurable) → if that exceeds 10s → **DEADLINE_EXCEEDED fires**

This also affects environments with high network latency, GC pauses, or proxy timeouts that eat into the 10s buffer.

## Changes

- **`JobPollerImpl.java`**: Add `DEADLINE_EXCEEDED` to the same TRACE-level downgrade as `RESOURCE_EXHAUSTED`
- **`JobPollerImplTest.java`**: Add `shouldCallbackWhenPollFailedWithDeadlineExceeded` test

## Reproducer

A fully automated reproducer with a 10-combination matrix validating the exact conditions is available at: https://github.com/emilyoram/reproducer-40220

| requestTimeout | Server longPolling | gRPC Deadline | Result |
|---|---|---|---|
| 0s | 15s | 10s | DEADLINE_EXCEEDED (bug) |
| 0s | 8s | 10s | No warnings |
| 10s | 30s | 20s | No warnings |
