### PR TITLE
ci: add project #187 to urgency automation with matrix strategy

### DIFF
--- a/.github/workflows/assign-urgency-to-issue.yml
+++ b/.github/workflows/assign-urgency-to-issue.yml
@@ -10,6 +10,7 @@
 # - Calculates urgency based on severity/likelihood OR impact/when labels using risk matrices
 # - Updates the Urgency field in ProjectV2 with values: immediate, next, planned, someday
 # - Applies to any issue with a severity label OR impact label
+# - Runs against projects #173 and #187 (or a single project when triggered manually)
 #
 # Labels (Option 1 - Risk-based):
 # - severity/{low,mid,high,critical} - Required to trigger severity/likelihood calculation
@@ -22,7 +23,7 @@
 # Other labels:
 # - urgency-locked - Prevents automatic urgency updates while showing calculated value
 #
-# Note: If both severity and impact labels are present, impact/when takes precedence
+# Note: If both severity and impact labels are present, the higher urgency wins
 #
 # Manual usage:
 #   gh workflow run assign-urgency-to-issue.yml -f issue_number=123 -f project_id=173
@@ -35,8 +36,8 @@ on:
   workflow_dispatch:
     inputs:
       issue_number:
-        description: 'Issue number to process (optional)'
-        required: false
+        description: 'Issue number to process'
+        required: true
       project_id:
         description: 'Target project ID (optional, defaults to job env)'
         required: false
@@ -55,11 +56,15 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        project_number: ${{ github.event.inputs.project_id && fromJSON(format('["{0}"]', github.event.inputs.project_id)) || fromJSON('["173", "187"]') }}
     env:
       OWNER: ${{ github.repository_owner }}
       REPO: ${{ github.event.repository.name }}
       ISSUE_NUMBER: ${{ github.event.inputs.issue_number || github.event.issue.number }}
-      PROJECT_NUMBER: ${{ github.event.inputs.project_id || '173' }}
+      PROJECT_NUMBER: ${{ matrix.project_number }}
       URGENCY_FIELD_NAME: 'Urgency'
       DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
     defaults:
@@ -376,7 +381,7 @@ jobs:
           echo "urgency=$URGENCY" >> "$GITHUB_OUTPUT"
 
       - name: Update Urgency
-        if: steps.validate_project.outputs.in_target_project == 'true'
+        if: steps.validate_project.outputs.in_target_project == 'true' && steps.validate_urgency.outputs.urgency != ''
         env:
           GH_TOKEN: ${{ steps.github-token.outputs.token }}
         run: |

--- a/.github/workflows/assign-urgency-to-issues.sh
+++ b/.github/workflows/assign-urgency-to-issues.sh
@@ -1,59 +1,98 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# --- Configuration with CLI arguments and fallbacks ---
-ORG_NAME="camunda"                                    # Hardcoded organization
-REPO_NAME="camunda"                                   # Hardcoded repository
-PROJECT_ID="${1:-173}"                                # Numeric Project V2 number
-BRANCH="${2:-main}"        # Branch to trigger workflow on
-LIMIT="${3:-20}"                                      # Number of issues to process
-SKIP_ASSIGNED="${4:-false}"                           # Skip issues that already have urgency assigned (true/false)
-DRY_RUN="${5:-false}"                                 # Dry run mode - don't trigger workflows (true/false)
+# --- Constants ---
+ORG_NAME="camunda"
+REPO_NAME="camunda"
 
-# Display usage if help is requested
-if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+# --- Defaults ---
+PROJECT_ID="173"
+BRANCH="main"
+LIMIT=20
+SKIP_ASSIGNED=false
+DRY_RUN=false
+ISSUE_TYPE=""
+LABEL=""
+DELAY=0
+
+# --- Parse flags ---
+usage() {
   cat <<EOF
-Usage: $0 [PROJECT_ID] [BRANCH] [LIMIT] [SKIP_ASSIGNED] [DRY_RUN]
+Usage: $0 [OPTIONS]
 
-Arguments (all optional, with defaults):
-  PROJECT_ID       Numeric Project V2 number (default: 173)
-  BRANCH           Branch to trigger workflow on (default: eppdot-urgency-field-automation)
-  LIMIT            Number of issues to process (default: 20)
-  SKIP_ASSIGNED    Skip issues that already have urgency assigned (default: false)
-  DRY_RUN          Don't trigger workflows, just show what would be done (default: false)
+Batch-trigger the urgency automation workflow for issues in a project.
+
+Options:
+  --project <id>       Project number to scope issue search (default: 173)
+  --branch <ref>       Branch to trigger workflow on (default: main)
+  --limit <n>          Max issues to process (default: 20)
+  --type <type>        Filter by issue type: Bug, Task, Feature, Epic, etc.
+  --label <name>       Filter by label (e.g. "severity/high", "component/tasklist")
+  --skip-assigned      Skip issues that already have urgency assigned in the project
+  --delay <seconds>    Delay between workflow dispatches (default: 0)
+  --dry-run            Show what would be triggered without running anything
+  -h, --help           Show this help
 
 Examples:
-  $0                        # Use all defaults - process all issues in project 173
-  $0 173                    # Specify project
-  $0 173 main 50            # All parameters except skip filter and dry run
-  $0 173 main 50 true       # Only process issues without urgency
-  $0 173 main 50 true true  # Dry run - show what would be processed
+  $0                                    # Defaults: project 173, limit 20
+  $0 --type Bug --skip-assigned         # Only bugs without urgency
+  $0 --project 187 --type Bug --limit 50 --dry-run
+  $0 --label "severity/high" --limit 10
+  $0 --type Task --delay 2 --branch my-feature-branch
 EOF
   exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --project)    PROJECT_ID="$2"; shift 2 ;;
+    --branch)     BRANCH="$2"; shift 2 ;;
+    --limit)      LIMIT="$2"; shift 2 ;;
+    --type)       ISSUE_TYPE="$2"; shift 2 ;;
+    --label)      LABEL="$2"; shift 2 ;;
+    --skip-assigned) SKIP_ASSIGNED=true; shift ;;
+    --delay)      DELAY="$2"; shift 2 ;;
+    --dry-run)    DRY_RUN=true; shift ;;
+    -h|--help)    usage ;;
+    *) echo "Unknown option: $1"; exit 1 ;;
+  esac
+done
+
+# --- Build search query ---
+SEARCH_QUERY="repo:${ORG_NAME}/${REPO_NAME} is:issue is:open project:${ORG_NAME}/${PROJECT_ID}"
+
+if [[ -n "$LABEL" ]]; then
+  SEARCH_QUERY="$SEARCH_QUERY label:\"$LABEL\""
 fi
 
-# --- Fetch first N issues from the project ---
-echo "Fetching up to $LIMIT issues from project (with pagination)..."
+# --- Summary ---
+echo "Configuration:"
+echo "  Project:       #$PROJECT_ID"
+echo "  Branch:        $BRANCH"
+echo "  Limit:         $LIMIT"
+[[ -n "$ISSUE_TYPE" ]] && echo "  Type filter:   $ISSUE_TYPE"
+[[ -n "$LABEL" ]]      && echo "  Label filter:  $LABEL"
+[[ "$SKIP_ASSIGNED" == "true" ]] && echo "  Skip assigned: yes"
+[[ "$DRY_RUN" == "true" ]] && echo "  Mode:          DRY RUN"
+[[ "$DELAY" -gt 0 ]] && echo "  Delay:         ${DELAY}s between dispatches"
+echo ""
 
-# Initialize variables for pagination
+# --- Fetch issues with pagination ---
+echo "Fetching up to $LIMIT issues from project $PROJECT_ID..."
+
 ISSUE_NUMBERS=""
 ISSUE_COUNT=0
 CURSOR="null"
 PAGE_SIZE=50
-MAX_PAGES=20  # Safety limit to avoid infinite loops
-
-# Build search query - search for open issues in the repo and project
-SEARCH_QUERY="repo:${ORG_NAME}/${REPO_NAME} is:issue is:open project:${ORG_NAME}/${PROJECT_ID}"
+MAX_PAGES=20
 
 for ((page=1; page<=MAX_PAGES; page++)); do
-  # Build query with pagination cursor
   if [[ "$CURSOR" == "null" ]]; then
     CURSOR_ARG=""
   else
     CURSOR_ARG=", after: \"$CURSOR\""
   fi
 
-  # Search for issues - project filtering is done server-side via search query
   RESPONSE=$(gh api graphql -f query="
     query(\$searchQuery: String!) {
       search(query: \$searchQuery, type: ISSUE, first: $PAGE_SIZE$CURSOR_ARG) {
@@ -64,6 +103,7 @@ for ((page=1; page<=MAX_PAGES; page++)); do
         nodes {
           ... on Issue {
             number
+            issueType { name }
             projectItems(first: 5) {
               nodes {
                 fieldValues(first: 20) {
@@ -84,17 +124,15 @@ for ((page=1; page<=MAX_PAGES; page++)); do
       }
     }" -F searchQuery="$SEARCH_QUERY")
 
-  # Optionally filter out issues that already have urgency assigned
-  if [[ "$SKIP_ASSIGNED" == "true" ]]; then
-    PAGE_ISSUES=$(echo "$RESPONSE" | jq -r '
-      .data.search.nodes[]
-      | select(.projectItems.nodes[0].fieldValues.nodes | map(select(.field.name == "Urgency")) | length == 0)
-      | .number')
-  else
-    PAGE_ISSUES=$(echo "$RESPONSE" | jq -r '.data.search.nodes[].number')
-  fi
+  # Apply client-side filters via jq (values passed safely via --arg)
+  PAGE_ISSUES=$(echo "$RESPONSE" | jq -r \
+    --arg issueType "$ISSUE_TYPE" \
+    --arg skipAssigned "$SKIP_ASSIGNED" \
+    '.data.search.nodes[]
+     | if $issueType != "" then select(.issueType.name == $issueType) else . end
+     | if $skipAssigned == "true" then select(.projectItems.nodes[0].fieldValues.nodes | map(select(.field.name == "Urgency")) | length == 0) else . end
+     | .number')
 
-  # Add issues from this page
   if [[ -n "$PAGE_ISSUES" ]]; then
     if [[ -z "$ISSUE_NUMBERS" ]]; then
       ISSUE_NUMBERS="$PAGE_ISSUES"
@@ -106,47 +144,50 @@ for ((page=1; page<=MAX_PAGES; page++)); do
 
   echo "  Page $page: Found $ISSUE_COUNT issue(s) so far..."
 
-  # Check if we have enough issues
   if [[ $ISSUE_COUNT -ge $LIMIT ]]; then
     echo "  Reached target of $LIMIT issues"
     ISSUE_NUMBERS=$(echo "$ISSUE_NUMBERS" | head -n "$LIMIT")
     break
   fi
 
-  # Check if there are more pages
   HAS_NEXT=$(echo "$RESPONSE" | jq -r '.data.search.pageInfo.hasNextPage')
   if [[ "$HAS_NEXT" != "true" ]]; then
     echo "  No more pages available"
     break
   fi
 
-  # Get cursor for next page
   CURSOR=$(echo "$RESPONSE" | jq -r '.data.search.pageInfo.endCursor')
 done
 
 if [[ -z "$ISSUE_NUMBERS" ]]; then
-  echo "⚠️  No issues found in the project (or missing permissions)."
+  echo "⚠️  No issues found matching the filters."
   exit 1
 fi
 
 ISSUE_COUNT=$(echo "$ISSUE_NUMBERS" | wc -l | tr -d ' ')
 echo "✅ Found $ISSUE_COUNT issue(s) to process"
+echo ""
 
-# --- Run the workflow for each issue ---
+# --- Dispatch workflows ---
 if [[ "$DRY_RUN" == "true" ]]; then
-  echo "🔍 DRY RUN MODE - Would trigger workflow for these issues:"
+  echo "🔍 DRY RUN — would trigger workflow for:"
   for ISSUE_NUMBER in $ISSUE_NUMBERS; do
-    echo "  → Would run for issue #$ISSUE_NUMBER"
+    echo "  → #$ISSUE_NUMBER"
   done
-  echo "ℹ️  Dry run complete. Would have triggered workflow for $ISSUE_COUNT issue(s)."
+  echo "ℹ️  Dry run complete. Would have triggered $ISSUE_COUNT workflow(s)."
 else
-  echo "Running workflow 'assign-urgency-to-issue.yml' for issues:"
+  echo "Triggering 'assign-urgency-to-issue.yml' for $ISSUE_COUNT issue(s):"
+  DISPATCHED=0
   for ISSUE_NUMBER in $ISSUE_NUMBERS; do
-    echo "→ Running for issue #$ISSUE_NUMBER"
+    echo "→ #$ISSUE_NUMBER"
     gh workflow run assign-urgency-to-issue.yml \
       --ref "$BRANCH" \
       -f issue_number="$ISSUE_NUMBER" \
       -f project_id="$PROJECT_ID"
+    ((DISPATCHED++))
+    if [[ "$DELAY" -gt 0 && $DISPATCHED -lt $ISSUE_COUNT ]]; then
+      sleep "$DELAY"
+    fi
   done
-  echo "✅ Done! Triggered workflow for $ISSUE_COUNT issue(s)."
+  echo "✅ Done! Triggered $ISSUE_COUNT workflow(s)."
 fi


### PR DESCRIPTION
## Summary

Add project #187 (Quality Board) to the urgency automation using a matrix strategy. Each issue event triggers parallel workflow runs — one per project — using **project-scoped ProjectV2 custom fields**.

This is an alternative to #51626 (org-level issue fields), which doesn't work in public projects.

## Why not org-level issue fields?

Org-level issue fields [are not available in public project views](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/managing-issue-fields-in-your-organization). Project #187 (Quality Board) is public, so the Urgency column cannot be displayed there with org-level fields. Project-scoped fields work in both public and private projects.

## Changes

### Workflow (`assign-urgency-to-issue.yml`)
- Add matrix strategy for projects `["173", "187"]` with `fail-fast: false`
- Manual dispatch with `project_id` targets a single project
- Make `issue_number` required for `workflow_dispatch`
- Guard Update step to skip when no urgency was calculated (prevents accidental clearing)
- Fix header comment (higher urgency wins, not "impact takes precedence")

### Batch script (`assign-urgency-to-issues.sh`)
- Replace positional args with named flags (`--project`, `--type`, `--label`, `--delay`, `--dry-run`)
- Add `--type` filter for incremental rollout by issue type
- Add `--label` filter for targeting specific labels
- Use `jq --arg` for safe value passing (no injection risk)
- Exit non-zero on unknown options
- Pass `project_id` to workflow dispatch

### Usage
```bash
# Bugs without urgency in project 187
./assign-urgency-to-issues.sh --project 187 --type Bug --skip-assigned --dry-run

# All open issues in project 173 with throttling
./assign-urgency-to-issues.sh --project 173 --skip-assigned --delay 2

# High-severity issues only
./assign-urgency-to-issues.sh --label "severity/high" --limit 50
```

## Test plan
- [ ] Trigger workflow for a single issue — verify Urgency set in both projects
- [ ] Verify issue only in one project skips the other cleanly
- [ ] Verify `urgency-locked` label prevents override
- [ ] Batch dry-run for project 187

## Related
- #51626 — org-level issue field approach (works for private projects only)
- #51633 — multi-repo support tracking issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)