### PR TITLE
ci: add cross-repo support for urgency automation

### DIFF
--- a/.github/workflows/assign-urgency-to-issue.yml
+++ b/.github/workflows/assign-urgency-to-issue.yml
@@ -11,6 +11,7 @@
 # - Updates the Urgency field in ProjectV2 with values: immediate, next, planned, someday
 # - Applies to any issue with a severity label OR impact label
 # - Runs against projects #173 and #187 (or a single project when triggered manually)
+# - Can be called from other repos via workflow_call (only targets project #187)
 #
 # Labels (Option 1 - Risk-based):
 # - severity/{low,mid,high,critical} - Required to trigger severity/likelihood calculation
@@ -27,6 +28,15 @@
 #
 # Manual usage:
 #   gh workflow run assign-urgency-to-issue.yml -f issue_number=123 -f project_id=173
+#
+# Cross-repo usage (add to other repos in the org):
+#   jobs:
+#     urgency:
+#       uses: camunda/camunda/.github/workflows/assign-urgency-to-issue.yml@main
+#       with:
+#         issue_number: ${{ github.event.issue.number }}
+#         repo: ${{ github.event.repository.name }}
+#       secrets: inherit
 #
 name: Assign urgency field when issue is updated
 
@@ -46,9 +56,19 @@ on:
         required: false
         type: boolean
         default: false
+  workflow_call:
+    inputs:
+      issue_number:
+        description: 'Issue number to process'
+        required: true
+        type: string
+      repo:
+        description: 'Repository name (e.g. web-modeler)'
+        required: true
+        type: string
 
 concurrency:
-  group: update-urgency-${{ github.event.inputs.issue_number || github.event.issue.number }}
+  group: update-urgency-${{ inputs.issue_number || github.event.inputs.issue_number || github.event.issue.number }}-${{ inputs.repo || github.event.repository.name }}
   cancel-in-progress: true
 
 jobs:
@@ -59,11 +79,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        project_number: ${{ github.event.inputs.project_id && fromJSON(format('["{0}"]', github.event.inputs.project_id)) || fromJSON('["173", "187"]') }}
+        # Cross-repo calls (workflow_call) only target project 187 (Quality Board)
+        # Direct triggers (issues/workflow_dispatch) target both 173 and 187
+        project_number: ${{ inputs.repo && fromJSON('["187"]') || github.event.inputs.project_id && fromJSON(format('["{0}"]', github.event.inputs.project_id)) || fromJSON('["173", "187"]') }}
     env:
       OWNER: ${{ github.repository_owner }}
-      REPO: ${{ github.event.repository.name }}
-      ISSUE_NUMBER: ${{ github.event.inputs.issue_number || github.event.issue.number }}
+      REPO: ${{ inputs.repo || github.event.repository.name }}
+      ISSUE_NUMBER: ${{ inputs.issue_number || github.event.inputs.issue_number || github.event.issue.number }}
       PROJECT_NUMBER: ${{ matrix.project_number }}
       URGENCY_FIELD_NAME: 'Urgency'
       DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}

--- a/.github/workflows/assign-urgency-to-issues.sh
+++ b/.github/workflows/assign-urgency-to-issues.sh
@@ -3,9 +3,9 @@ set -euo pipefail
 
 # --- Constants ---
 ORG_NAME="camunda"
-REPO_NAME="camunda"
 
 # --- Defaults ---
+REPO_NAME="camunda"
 PROJECT_ID="173"
 BRANCH="main"
 LIMIT=20
@@ -23,6 +23,7 @@ Usage: $0 [OPTIONS]
 Batch-trigger the urgency automation workflow for issues in a project.
 
 Options:
+  --repo <name>        Repository name (default: camunda)
   --project <id>       Project number to scope issue search (default: 173)
   --branch <ref>       Branch to trigger workflow on (default: main)
   --limit <n>          Max issues to process (default: 20)
@@ -38,13 +39,14 @@ Examples:
   $0 --type Bug --skip-assigned         # Only bugs without urgency
   $0 --project 187 --type Bug --limit 50 --dry-run
   $0 --label "severity/high" --limit 10
-  $0 --type Task --delay 2 --branch my-feature-branch
+  $0 --repo web-modeler --project 187 --skip-assigned
 EOF
   exit 0
 }
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --repo)       REPO_NAME="$2"; shift 2 ;;
     --project)    PROJECT_ID="$2"; shift 2 ;;
     --branch)     BRANCH="$2"; shift 2 ;;
     --limit)      LIMIT="$2"; shift 2 ;;
@@ -67,6 +69,7 @@ fi
 
 # --- Summary ---
 echo "Configuration:"
+echo "  Repository:    ${ORG_NAME}/${REPO_NAME}"
 echo "  Project:       #$PROJECT_ID"
 echo "  Branch:        $BRANCH"
 echo "  Limit:         $LIMIT"


### PR DESCRIPTION
## Summary

Enable the urgency automation to be called from other repositories in the org via `workflow_call`. This allows issues in repos like `web-modeler`, `connectors`, etc. that are tracked in project #187 (Quality Board) to get automatic urgency assignment.

**Stacked on:** #51655

## Changes

### Workflow (`assign-urgency-to-issue.yml`)
- Add `workflow_call` trigger with `issue_number` and `repo` inputs
- Cross-repo calls automatically target only project #187 (other repos' issues aren't in #173)
- `REPO` env var resolves from `inputs.repo` (workflow_call), `github.event.repository.name` (issues trigger), or `github.event.inputs` (workflow_dispatch)
- Concurrency group includes repo name to prevent cross-repo cancellation

### Batch script (`assign-urgency-to-issues.sh`)
- Add `--repo` flag to target issues in other repositories
- Search query and summary output use the specified repo

### Caller workflow (for other repos)

Add this to any repo in the `camunda` org:

```yaml
# .github/workflows/assign-urgency-to-issue.yml
name: Assign urgency
on:
  issues:
    types: [opened, labeled, unlabeled, reopened, transferred]
jobs:
  urgency:
    uses: camunda/camunda/.github/workflows/assign-urgency-to-issue.yml@main
    with:
      issue_number: ${{ github.event.issue.number }}
      repo: ${{ github.event.repository.name }}
    secrets: inherit
```

**Note:** The calling repo needs `VAULT_ROLE_ID` and `VAULT_SECRET_ID` secrets configured for the GitHub App token generation.

## Test plan
- [ ] Trigger workflow_call from a test repo and verify urgency set in project #187
- [ ] Verify direct issue events in `camunda/camunda` still target both projects
- [ ] Verify `--repo web-modeler --project 187` works in batch script
- [ ] Verify concurrency doesn't cancel across repos

## Related
- #51655 — base PR (matrix strategy for projects 173 + 187)
- #51633 — multi-repo support tracking issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)