### PR TITLE
ci: unified urgency automation with org-level field and project sync

### DIFF
--- a/.github/workflows/assign-urgency-to-issue.yml
+++ b/.github/workflows/assign-urgency-to-issue.yml
@@ -55,9 +55,9 @@ on:
   workflow_call:
     inputs:
       issue_number:
-        description: 'Issue number to process'
+        description: 'Issue number to process (must be numeric)'
         required: true
-        type: string
+        type: string # workflow_call only supports string/boolean; GraphQL -F coerces to Int
       repo:
         description: 'Repository name (e.g. web-modeler)'
         required: true
@@ -114,6 +114,12 @@ jobs:
             echo "🔬 DRY RUN MODE - No changes will be made"
           fi
 
+          # Validate issue number is numeric
+          if ! [[ "$ISSUE_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "❌ Invalid issue number: '$ISSUE_NUMBER' (must be numeric)"
+            exit 1
+          fi
+
           echo "🔍 Fetching issue #${ISSUE_NUMBER} from ${OWNER}/${REPO}"
 
           # Fetch issue labels, type, current org-level urgency, and project memberships
@@ -157,6 +163,11 @@ jobs:
           }
 
           ISSUE_DATA=$(echo "$RESP" | jq -c '.data.repository.issue')
+
+          if [[ "$ISSUE_DATA" == "null" || -z "$ISSUE_DATA" ]]; then
+            echo "❌ Issue #${ISSUE_NUMBER} not found in ${OWNER}/${REPO}"
+            exit 1
+          fi
 
           echo "✅ Fetched issue data"
 

--- a/.github/workflows/assign-urgency-to-issue.yml
+++ b/.github/workflows/assign-urgency-to-issue.yml
@@ -3,13 +3,14 @@
 ---
 # Urgency Field Automation
 #
-# This workflow automatically calculates and updates the Urgency field for issues in GitHub Projects.
+# This workflow automatically calculates and updates the Urgency field for issues.
 #
 # How it works:
 # - Triggers when issues are opened, labeled, unlabeled, reopened, or transferred
 # - Calculates urgency based on severity/likelihood OR impact/when labels using risk matrices
-# - Updates the Urgency field in ProjectV2 with values: immediate, next, planned, someday
-# - Applies to any issue with a severity label OR impact label
+# - Updates the org-level Urgency issue field with values: immediate, next, planned, someday
+# - Syncs urgency to project-level Urgency fields for configured projects (e.g. #187)
+# - Can be called from other repos via workflow_call for cross-repo support
 #
 # Labels (Option 1 - Risk-based):
 # - severity/{low,mid,high,critical} - Required to trigger severity/likelihood calculation
@@ -22,10 +23,19 @@
 # Other labels:
 # - urgency-locked - Prevents automatic urgency updates while showing calculated value
 #
-# Note: If both severity and impact labels are present, impact/when takes precedence
+# Note: If both severity and impact labels are present, the higher urgency wins
 #
 # Manual usage:
-#   gh workflow run assign-urgency-to-issue.yml -f issue_number=123 -f project_id=173
+#   gh workflow run assign-urgency-to-issue.yml -f issue_number=123
+#
+# Cross-repo usage (add to other repos in the org):
+#   jobs:
+#     urgency:
+#       uses: camunda/camunda/.github/workflows/assign-urgency-to-issue.yml@main
+#       with:
+#         issue_number: ${{ github.event.issue.number }}
+#         repo: ${{ github.event.repository.name }}
+#       secrets: inherit
 #
 name: Assign urgency field when issue is updated
 
@@ -35,19 +45,26 @@ on:
   workflow_dispatch:
     inputs:
       issue_number:
-        description: 'Issue number to process (optional)'
-        required: false
-      project_id:
-        description: 'Target project ID (optional, defaults to job env)'
-        required: false
+        description: 'Issue number to process'
+        required: true
       dry_run:
         description: 'Dry run mode - calculate urgency but do not update field'
         required: false
         type: boolean
         default: false
+  workflow_call:
+    inputs:
+      issue_number:
+        description: 'Issue number to process'
+        required: true
+        type: string
+      repo:
+        description: 'Repository name (e.g. web-modeler)'
+        required: true
+        type: string
 
 concurrency:
-  group: update-urgency-${{ github.event.inputs.issue_number || github.event.issue.number }}
+  group: update-urgency-${{ inputs.issue_number || github.event.inputs.issue_number || github.event.issue.number }}-${{ inputs.repo || github.event.repository.name }}
   cancel-in-progress: true
 
 jobs:
@@ -57,10 +74,12 @@ jobs:
     timeout-minutes: 10
     env:
       OWNER: ${{ github.repository_owner }}
-      REPO: ${{ github.event.repository.name }}
-      ISSUE_NUMBER: ${{ github.event.inputs.issue_number || github.event.issue.number }}
-      PROJECT_NUMBER: ${{ github.event.inputs.project_id || '173' }}
-      URGENCY_FIELD_NAME: 'Urgency'
+      REPO: ${{ inputs.repo || github.event.repository.name }}
+      ISSUE_NUMBER: ${{ inputs.issue_number || github.event.inputs.issue_number || github.event.issue.number }}
+      URGENCY_FIELD_ID: 'IFSS_kgDNKAw'
+      # Projects whose project-level Urgency field should be kept in sync
+      # (for public projects where org-level fields are not visible)
+      SYNC_PROJECT_NUMBERS: '187'
       DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
     defaults:
       run:
@@ -84,7 +103,7 @@ jobs:
           cat << 'EOF'
           ${{ toJSON(github.event.issue) }}
           EOF
-      - name: Fetch issue and project data
+      - name: Fetch issue data
         id: fetch_data
         env:
           GH_TOKEN: ${{ steps.github-token.outputs.token }}
@@ -95,20 +114,24 @@ jobs:
             echo "🔬 DRY RUN MODE - No changes will be made"
           fi
 
-          echo "🔍 Fetching issue #${ISSUE_NUMBER} and project ${PROJECT_NUMBER} data"
+          echo "🔍 Fetching issue #${ISSUE_NUMBER} from ${OWNER}/${REPO}"
 
-          # Single GraphQL query fetches: project info, project item, labels, issue type, and current urgency value
-          # projectItems section is needed to:
-          #   - Get PROJECT_ITEM_ID (required for updating the urgency field)
-          #   - Verify the issue is in the target project (filter by project.number)
-          #   - Fetch current urgency value (from fieldValues to check if update is needed)
-          # Note: Limited to first 100 projects - if issue is in 100+ projects, target might be missed
-          QUERY="query(\$owner:String!,\$repo:String!,\$issueNumber:Int!,\$projectNumber:Int!){
+          # Fetch issue labels, type, current org-level urgency, and project memberships
+          QUERY="query(\$owner:String!,\$repo:String!,\$issueNumber:Int!){
             repository(owner:\$owner,name:\$repo){
               issue(number:\$issueNumber){
                 id
                 issueType { name }
                 labels(first:100){ nodes { name } }
+                issueFieldValues(first:50){
+                  nodes{
+                    ... on IssueFieldSingleSelectValue {
+                      field { ... on IssueFieldSingleSelect { id name } }
+                      name
+                      optionId
+                    }
+                  }
+                }
                 projectItems(first:100){
                   nodes{
                     id
@@ -125,75 +148,26 @@ jobs:
                 }
               }
             }
-            organization(login:\$owner){
-              projectV2(number:\$projectNumber){ id }
-            }
           }"
 
-          RESP=$(gh api graphql -f query="$QUERY" -F owner="$OWNER" -F repo="$REPO" -F issueNumber="$ISSUE_NUMBER" -F projectNumber="$PROJECT_NUMBER") || {
+          RESP=$(gh api graphql -f query="$QUERY" -F owner="$OWNER" -F repo="$REPO" -F issueNumber="$ISSUE_NUMBER") || {
             echo "❌ GraphQL query failed:"
             echo "$RESP"
             exit 1
           }
 
-          # Store raw response parts in outputs for extraction where needed
           ISSUE_DATA=$(echo "$RESP" | jq -c '.data.repository.issue')
-          PROJECT_DATA=$(echo "$RESP" | jq -c '.data.organization.projectV2')
 
-          echo "✅ Fetched issue and project data"
+          echo "✅ Fetched issue data"
 
-          # Store raw data in outputs for next steps
           {
             echo "issue_data<<EOF"
             echo "$ISSUE_DATA"
             echo "EOF"
-            echo "project_data<<EOF"
-            echo "$PROJECT_DATA"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Validate project membership
-        id: validate_project
-        run: |
-          set -euo pipefail
-
-          ISSUE_DATA='${{ steps.fetch_data.outputs.issue_data }}'
-          PROJECT_DATA='${{ steps.fetch_data.outputs.project_data }}'
-
-          # Extract project information
-          TARGET_PROJECT_NODE_ID=$(echo "$PROJECT_DATA" | jq -r '.id // empty')
-          PROJECT_ITEM_ID=$(echo "$ISSUE_DATA" | jq -r --argjson pn "$PROJECT_NUMBER" \
-            '.projectItems.nodes[] | select(.project.number==$pn) | .id // empty')
-
-          echo "📦 Project: #${PROJECT_NUMBER} (id: ${TARGET_PROJECT_NODE_ID:-not found})"
-          echo "🔗 Project item: ${PROJECT_ITEM_ID:-not found}"
-
-          # Check if project exists
-          if [[ -z "$TARGET_PROJECT_NODE_ID" ]]; then
-            echo "❌ Target project #${PROJECT_NUMBER} not found in organization ${OWNER}"
-            echo "💡 Check that the project exists and PROJECT_NUMBER is correct"
-            exit 1
-          fi
-
-          # Check if issue is in the project
-          if [[ -z "$PROJECT_ITEM_ID" ]]; then
-            echo "⏭️ Issue #${ISSUE_NUMBER} is not in target project #${PROJECT_NUMBER}; skipping"
-            echo "in_target_project=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "✅ Issue is in target project (item: $PROJECT_ITEM_ID)"
-
-          # Store extracted IDs for later use
-          {
-            echo "in_target_project=true"
-            echo "project_v2_id=$TARGET_PROJECT_NODE_ID"
-            echo "project_item_id=$PROJECT_ITEM_ID"
           } >> "$GITHUB_OUTPUT"
 
       - name: Check labels
         id: check_labels
-        if: steps.validate_project.outputs.in_target_project == 'true'
         run: |
           set -euo pipefail
 
@@ -375,28 +349,35 @@ jobs:
 
           echo "urgency=$URGENCY" >> "$GITHUB_OUTPUT"
 
-      - name: Update Urgency
-        if: steps.validate_project.outputs.in_target_project == 'true'
+      - name: Update org-level Urgency field
+        if: steps.validate_urgency.outputs.urgency != ''
         env:
           GH_TOKEN: ${{ steps.github-token.outputs.token }}
         run: |
           set -euo pipefail
 
           ISSUE_DATA='${{ steps.fetch_data.outputs.issue_data }}'
-          PROJECT_ITEM_ID='${{ steps.validate_project.outputs.project_item_id }}'
-          PROJECT_V2_ID='${{ steps.validate_project.outputs.project_v2_id }}'
+          ISSUE_ID=$(echo "$ISSUE_DATA" | jq -r '.id')
           NEW_URGENCY='${{ steps.validate_urgency.outputs.urgency }}'
           HAS_URGENCY_LOCKED='${{ steps.check_labels.outputs.has_urgency_locked }}'
 
-          # Extract current urgency value
-          CURRENT_URGENCY=$(echo "$ISSUE_DATA" | jq -r --argjson pn "$PROJECT_NUMBER" --arg fieldName "$URGENCY_FIELD_NAME" \
-            '.projectItems.nodes[] | select(.project.number==$pn) | .fieldValues.nodes[] | select(.field.name==$fieldName) | .name // empty')
+          # Org-level urgency field option IDs
+          declare -A OPTION_IDS=(
+            [immediate]="IFSSO_kgDNOUI"
+            [next]="IFSSO_kgDNOUM"
+            [planned]="IFSSO_kgDNOUQ"
+            [someday]="IFSSO_kgDNOUU"
+          )
 
-          echo "🔄 Update urgency: '${CURRENT_URGENCY:-(empty)}' → '${NEW_URGENCY:-(empty)}'"
+          # Extract current urgency value from org-level issue field
+          CURRENT_URGENCY=$(echo "$ISSUE_DATA" | jq -r --arg fieldId "$URGENCY_FIELD_ID" \
+            '.issueFieldValues.nodes[] | select(.field.id==$fieldId) | .name // empty')
+
+          echo "🔄 Org-level urgency: '${CURRENT_URGENCY:-(empty)}' → '${NEW_URGENCY}'"
 
           # Check if urgency would change
           if [[ "$CURRENT_URGENCY" == "$NEW_URGENCY" ]]; then
-            echo "⏭️ Urgency already set to '$NEW_URGENCY'"
+            echo "⏭️ Org-level urgency already set to '$NEW_URGENCY'"
             exit 0
           fi
 
@@ -412,60 +393,119 @@ jobs:
             exit 0
           fi
 
-          # Fetch project fields
-          FIELD_DATA=$(gh api graphql -f query="
-            query(\$projectId:ID!){
-              node(id:\$projectId){
-                ... on ProjectV2 {
-                  fields(first:100){
-                    nodes{
-                      ... on ProjectV2SingleSelectField { id name options { id name } }
-                    }
-                  }
-                }
-              }
-            }" -F projectId="$PROJECT_V2_ID") || {
-            echo "❌ Failed to fetch project fields"
-            exit 1
-          }
+          OPTION_ID="${OPTION_IDS[$NEW_URGENCY]:-}"
 
-          FIELD_ID=$(echo "$FIELD_DATA" | jq -r --arg name "$URGENCY_FIELD_NAME" \
-            '.data.node.fields.nodes[] | select(.name==$name) | .id // empty')
-
-          if [[ -z "$FIELD_ID" ]]; then
-            echo "❌ Field '$URGENCY_FIELD_NAME' does not exist in project '$PROJECT_V2_ID'"
-            echo "   Expected: A ProjectV2 single-select field named '$URGENCY_FIELD_NAME' with options: immediate, next, planned, someday"
-            echo "   Verify: The field exists in the target project and URGENCY_FIELD_NAME is configured correctly"
+          if [[ -z "$OPTION_ID" ]]; then
+            echo "❌ No option ID mapped for urgency value '$NEW_URGENCY'"
             exit 1
           fi
 
-          # Build mutation based on whether we're clearing or updating
-          if [[ -z "$NEW_URGENCY" ]]; then
-            JSON_PAYLOAD=$(jq -n \
-              --arg projectId "$PROJECT_V2_ID" \
-              --arg itemId "$PROJECT_ITEM_ID" \
-              --arg fieldId "$FIELD_ID" \
-              '{
-                "query": "mutation($input: ClearProjectV2ItemFieldValueInput!) { clearProjectV2ItemFieldValue(input: $input) { projectV2Item { id } } }",
-                "variables": {
-                  "input": {
-                    "projectId": $projectId,
-                    "itemId": $itemId,
-                    "fieldId": $fieldId
+          JSON_PAYLOAD=$(jq -n \
+            --arg issueId "$ISSUE_ID" \
+            --arg fieldId "$URGENCY_FIELD_ID" \
+            --arg optionId "$OPTION_ID" \
+            '{
+              "query": "mutation($input: SetIssueFieldValueInput!) { setIssueFieldValue(input: $input) { issue { id } } }",
+              "variables": {
+                "input": {
+                  "issueId": $issueId,
+                  "issueFields": [{
+                    "fieldId": $fieldId,
+                    "singleSelectOptionId": $optionId
+                  }]
+                }
+              }
+            }')
+
+          MUTATION_RESP=$(gh api graphql -H "Content-Type: application/json" --input - <<< "$JSON_PAYLOAD" 2>&1) || {
+            echo "❌ GraphQL mutation failed:"
+            echo "$MUTATION_RESP"
+            exit 1
+          }
+
+          if echo "$MUTATION_RESP" | jq -e '.errors' > /dev/null 2>&1; then
+            echo "❌ GraphQL mutation returned errors:"
+            echo "$MUTATION_RESP" | jq '.errors'
+            exit 1
+          fi
+
+          echo "✅ Updated org-level urgency: '${CURRENT_URGENCY:-(empty)}' → '${NEW_URGENCY}'"
+
+      - name: Sync urgency to project-level fields
+        if: steps.validate_urgency.outputs.urgency != '' && steps.check_labels.outputs.has_urgency_locked != 'true'
+        env:
+          GH_TOKEN: ${{ steps.github-token.outputs.token }}
+        run: |
+          set -euo pipefail
+
+          ISSUE_DATA='${{ steps.fetch_data.outputs.issue_data }}'
+          NEW_URGENCY='${{ steps.validate_urgency.outputs.urgency }}'
+          URGENCY_FIELD_NAME='Urgency'
+
+          if [[ "$DRY_RUN" == "true" ]]; then
+            echo "🔬 DRY RUN: Project sync skipped"
+            exit 0
+          fi
+
+          # Iterate over configured projects to sync
+          for PROJECT_NUM in $SYNC_PROJECT_NUMBERS; do
+            # Find the project item for this project
+            PROJECT_ITEM=$(echo "$ISSUE_DATA" | jq -c --argjson pn "$PROJECT_NUM" \
+              '.projectItems.nodes[] | select(.project.number==$pn)')
+
+            if [[ -z "$PROJECT_ITEM" || "$PROJECT_ITEM" == "null" ]]; then
+              echo "⏭️ Issue not in project #${PROJECT_NUM} — skipping sync"
+              continue
+            fi
+
+            PROJECT_ITEM_ID=$(echo "$PROJECT_ITEM" | jq -r '.id')
+            PROJECT_V2_ID=$(echo "$PROJECT_ITEM" | jq -r '.project.id')
+
+            # Check current project-level urgency
+            CURRENT_PROJECT_URGENCY=$(echo "$PROJECT_ITEM" | jq -r --arg fn "$URGENCY_FIELD_NAME" \
+              '.fieldValues.nodes[] | select(.field.name==$fn) | .name // empty')
+
+            if [[ "$CURRENT_PROJECT_URGENCY" == "$NEW_URGENCY" ]]; then
+              echo "⏭️ Project #${PROJECT_NUM}: already set to '$NEW_URGENCY'"
+              continue
+            fi
+
+            echo "🔄 Project #${PROJECT_NUM}: '${CURRENT_PROJECT_URGENCY:-(empty)}' → '${NEW_URGENCY}'"
+
+            # Fetch project field and option IDs
+            FIELD_DATA=$(gh api graphql -f query="
+              query(\$projectId:ID!){
+                node(id:\$projectId){
+                  ... on ProjectV2 {
+                    fields(first:100){
+                      nodes{
+                        ... on ProjectV2SingleSelectField { id name options { id name } }
+                      }
+                    }
                   }
                 }
-              }')
-          else
+              }" -F projectId="$PROJECT_V2_ID") || {
+              echo "⚠️ Project #${PROJECT_NUM}: failed to fetch fields — skipping"
+              continue
+            }
+
+            FIELD_ID=$(echo "$FIELD_DATA" | jq -r --arg name "$URGENCY_FIELD_NAME" \
+              '.data.node.fields.nodes[] | select(.name==$name) | .id // empty')
+
+            if [[ -z "$FIELD_ID" ]]; then
+              echo "⏭️ Project #${PROJECT_NUM}: no '$URGENCY_FIELD_NAME' field — skipping"
+              continue
+            fi
+
             OPTION_ID=$(echo "$FIELD_DATA" | jq -r --arg name "$URGENCY_FIELD_NAME" --arg value "$NEW_URGENCY" \
               '.data.node.fields.nodes[] | select(.name==$name) | .options[]? | select(.name==$value) | .id // empty')
 
             if [[ -z "$OPTION_ID" ]]; then
-              echo "❌ Option '$NEW_URGENCY' not found in field '$URGENCY_FIELD_NAME'"
-              echo "   Expected options: immediate, next, planned, someday"
-              echo "   Verify: The field has all required options configured in the project"
-              exit 1
+              echo "⚠️ Project #${PROJECT_NUM}: option '$NEW_URGENCY' not found — skipping"
+              continue
             fi
 
+            # Update project-level field
             JSON_PAYLOAD=$(jq -n \
               --arg projectId "$PROJECT_V2_ID" \
               --arg itemId "$PROJECT_ITEM_ID" \
@@ -482,19 +522,17 @@ jobs:
                   }
                 }
               }')
-          fi
 
-          # Execute mutation
-          MUTATION_RESP=$(gh api graphql -H "Content-Type: application/json" --input - <<< "$JSON_PAYLOAD" 2>&1) || {
-            echo "❌ GraphQL mutation failed:"
-            echo "$MUTATION_RESP"
-            exit 1
-          }
+            MUTATION_RESP=$(gh api graphql -H "Content-Type: application/json" --input - <<< "$JSON_PAYLOAD" 2>&1) || {
+              echo "⚠️ Project #${PROJECT_NUM}: mutation failed — skipping"
+              continue
+            }
 
-          if echo "$MUTATION_RESP" | jq -e '.errors' > /dev/null 2>&1; then
-            echo "❌ GraphQL mutation returned errors:"
-            echo "$MUTATION_RESP" | jq '.errors'
-            exit 1
-          fi
+            if echo "$MUTATION_RESP" | jq -e '.errors' > /dev/null 2>&1; then
+              echo "⚠️ Project #${PROJECT_NUM}: mutation errors:"
+              echo "$MUTATION_RESP" | jq '.errors'
+              continue
+            fi
 
-          echo "✅ Updated urgency: '${CURRENT_URGENCY:-(empty)}' → '${NEW_URGENCY:-(empty)}'"
+            echo "✅ Project #${PROJECT_NUM}: synced to '${NEW_URGENCY}'"
+          done

--- a/.github/workflows/assign-urgency-to-issues.sh
+++ b/.github/workflows/assign-urgency-to-issues.sh
@@ -46,20 +46,35 @@ EOF
   exit 0
 }
 
+require_arg() {
+  if [[ $# -lt 2 || -z "$2" || "$2" == --* ]]; then
+    echo "Error: $1 requires a value"; exit 1
+  fi
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --repo)       REPO_NAME="$2"; shift 2 ;;
-    --project)    PROJECT_ID="$2"; shift 2 ;;
-    --branch)     BRANCH="$2"; shift 2 ;;
-    --limit)      LIMIT="$2"; shift 2 ;;
-    --type)       ISSUE_TYPE="$2"; shift 2 ;;
-    --label)      LABEL="$2"; shift 2 ;;
+    --repo)       require_arg "$@"; REPO_NAME="$2"; shift 2 ;;
+    --project)    require_arg "$@"; PROJECT_ID="$2"; shift 2 ;;
+    --branch)     require_arg "$@"; BRANCH="$2"; shift 2 ;;
+    --limit)      require_arg "$@"; LIMIT="$2"; shift 2 ;;
+    --type)       require_arg "$@"; ISSUE_TYPE="$2"; shift 2 ;;
+    --label)      require_arg "$@"; LABEL="$2"; shift 2 ;;
     --skip-assigned) SKIP_ASSIGNED=true; shift ;;
-    --delay)      DELAY="$2"; shift 2 ;;
+    --delay)      require_arg "$@"; DELAY="$2"; shift 2 ;;
     --dry-run)    DRY_RUN=true; shift ;;
     -h|--help)    usage ;;
     *) echo "Unknown option: $1"; exit 1 ;;
   esac
+done
+
+# Validate numeric arguments
+for var_name in LIMIT DELAY PROJECT_ID; do
+  eval "val=\$$var_name"
+  if ! [[ "$val" =~ ^[0-9]+$ ]]; then
+    echo "Error: --${var_name,,} must be a positive integer, got '$val'"
+    exit 1
+  fi
 done
 
 # --- Build search query ---

--- a/.github/workflows/assign-urgency-to-issues.sh
+++ b/.github/workflows/assign-urgency-to-issues.sh
@@ -1,59 +1,103 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# --- Configuration with CLI arguments and fallbacks ---
-ORG_NAME="camunda"                                    # Hardcoded organization
-REPO_NAME="camunda"                                   # Hardcoded repository
-PROJECT_ID="${1:-173}"                                # Numeric Project V2 number
-BRANCH="${2:-main}"        # Branch to trigger workflow on
-LIMIT="${3:-20}"                                      # Number of issues to process
-SKIP_ASSIGNED="${4:-false}"                           # Skip issues that already have urgency assigned (true/false)
-DRY_RUN="${5:-false}"                                 # Dry run mode - don't trigger workflows (true/false)
+# --- Constants ---
+ORG_NAME="camunda"
 
-# Display usage if help is requested
-if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+# --- Defaults ---
+REPO_NAME="camunda"
+PROJECT_ID="173"
+BRANCH="main"
+LIMIT=20
+SKIP_ASSIGNED=false
+DRY_RUN=false
+ISSUE_TYPE=""
+LABEL=""
+DELAY=0
+
+URGENCY_FIELD_ID="IFSS_kgDNKAw"
+
+# --- Parse flags ---
+usage() {
   cat <<EOF
-Usage: $0 [PROJECT_ID] [BRANCH] [LIMIT] [SKIP_ASSIGNED] [DRY_RUN]
+Usage: $0 [OPTIONS]
 
-Arguments (all optional, with defaults):
-  PROJECT_ID       Numeric Project V2 number (default: 173)
-  BRANCH           Branch to trigger workflow on (default: eppdot-urgency-field-automation)
-  LIMIT            Number of issues to process (default: 20)
-  SKIP_ASSIGNED    Skip issues that already have urgency assigned (default: false)
-  DRY_RUN          Don't trigger workflows, just show what would be done (default: false)
+Batch-trigger the urgency automation workflow for issues in a project.
+
+Options:
+  --repo <name>        Repository name (default: camunda)
+  --project <id>       Project number to scope issue search (default: 173)
+  --branch <ref>       Branch to trigger workflow on (default: main)
+  --limit <n>          Max issues to process (default: 20)
+  --type <type>        Filter by issue type: Bug, Task, Feature, Epic, etc.
+  --label <name>       Filter by label (e.g. "severity/high", "component/tasklist")
+  --skip-assigned      Skip issues that already have org-level urgency set
+  --delay <seconds>    Delay between workflow dispatches (default: 0)
+  --dry-run            Show what would be triggered without running anything
+  -h, --help           Show this help
 
 Examples:
-  $0                        # Use all defaults - process all issues in project 173
-  $0 173                    # Specify project
-  $0 173 main 50            # All parameters except skip filter and dry run
-  $0 173 main 50 true       # Only process issues without urgency
-  $0 173 main 50 true true  # Dry run - show what would be processed
+  $0                                    # Defaults: project 173, limit 20
+  $0 --type Bug --skip-assigned         # Only bugs without urgency
+  $0 --project 187 --type Bug --limit 50 --dry-run
+  $0 --label "severity/high" --limit 10
+  $0 --repo web-modeler --project 187 --skip-assigned
 EOF
   exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)       REPO_NAME="$2"; shift 2 ;;
+    --project)    PROJECT_ID="$2"; shift 2 ;;
+    --branch)     BRANCH="$2"; shift 2 ;;
+    --limit)      LIMIT="$2"; shift 2 ;;
+    --type)       ISSUE_TYPE="$2"; shift 2 ;;
+    --label)      LABEL="$2"; shift 2 ;;
+    --skip-assigned) SKIP_ASSIGNED=true; shift ;;
+    --delay)      DELAY="$2"; shift 2 ;;
+    --dry-run)    DRY_RUN=true; shift ;;
+    -h|--help)    usage ;;
+    *) echo "Unknown option: $1"; exit 1 ;;
+  esac
+done
+
+# --- Build search query ---
+SEARCH_QUERY="repo:${ORG_NAME}/${REPO_NAME} is:issue is:open project:${ORG_NAME}/${PROJECT_ID}"
+
+if [[ -n "$LABEL" ]]; then
+  SEARCH_QUERY="$SEARCH_QUERY label:\"$LABEL\""
 fi
 
-# --- Fetch first N issues from the project ---
-echo "Fetching up to $LIMIT issues from project (with pagination)..."
+# --- Summary ---
+echo "Configuration:"
+echo "  Repository:    ${ORG_NAME}/${REPO_NAME}"
+echo "  Project:       #$PROJECT_ID"
+echo "  Branch:        $BRANCH"
+echo "  Limit:         $LIMIT"
+[[ -n "$ISSUE_TYPE" ]] && echo "  Type filter:   $ISSUE_TYPE"
+[[ -n "$LABEL" ]]      && echo "  Label filter:  $LABEL"
+[[ "$SKIP_ASSIGNED" == "true" ]] && echo "  Skip assigned: yes"
+[[ "$DRY_RUN" == "true" ]] && echo "  Mode:          DRY RUN"
+[[ "$DELAY" -gt 0 ]] && echo "  Delay:         ${DELAY}s between dispatches"
+echo ""
 
-# Initialize variables for pagination
+# --- Fetch issues with pagination ---
+echo "Fetching up to $LIMIT issues from project $PROJECT_ID..."
+
 ISSUE_NUMBERS=""
 ISSUE_COUNT=0
 CURSOR="null"
 PAGE_SIZE=50
-MAX_PAGES=20  # Safety limit to avoid infinite loops
-
-# Build search query - search for open issues in the repo and project
-SEARCH_QUERY="repo:${ORG_NAME}/${REPO_NAME} is:issue is:open project:${ORG_NAME}/${PROJECT_ID}"
+MAX_PAGES=20
 
 for ((page=1; page<=MAX_PAGES; page++)); do
-  # Build query with pagination cursor
   if [[ "$CURSOR" == "null" ]]; then
     CURSOR_ARG=""
   else
     CURSOR_ARG=", after: \"$CURSOR\""
   fi
 
-  # Search for issues - project filtering is done server-side via search query
   RESPONSE=$(gh api graphql -f query="
     query(\$searchQuery: String!) {
       search(query: \$searchQuery, type: ISSUE, first: $PAGE_SIZE$CURSOR_ARG) {
@@ -64,18 +108,12 @@ for ((page=1; page<=MAX_PAGES; page++)); do
         nodes {
           ... on Issue {
             number
-            projectItems(first: 5) {
+            issueType { name }
+            issueFieldValues(first: 50) {
               nodes {
-                fieldValues(first: 20) {
-                  nodes {
-                    ... on ProjectV2ItemFieldSingleSelectValue {
-                      field {
-                        ... on ProjectV2SingleSelectField {
-                          name
-                        }
-                      }
-                    }
-                  }
+                ... on IssueFieldSingleSelectValue {
+                  field { ... on IssueFieldSingleSelect { id } }
+                  name
                 }
               }
             }
@@ -84,17 +122,16 @@ for ((page=1; page<=MAX_PAGES; page++)); do
       }
     }" -F searchQuery="$SEARCH_QUERY")
 
-  # Optionally filter out issues that already have urgency assigned
-  if [[ "$SKIP_ASSIGNED" == "true" ]]; then
-    PAGE_ISSUES=$(echo "$RESPONSE" | jq -r '
-      .data.search.nodes[]
-      | select(.projectItems.nodes[0].fieldValues.nodes | map(select(.field.name == "Urgency")) | length == 0)
-      | .number')
-  else
-    PAGE_ISSUES=$(echo "$RESPONSE" | jq -r '.data.search.nodes[].number')
-  fi
+  # Apply client-side filters via jq (values passed safely via --arg)
+  PAGE_ISSUES=$(echo "$RESPONSE" | jq -r \
+    --arg issueType "$ISSUE_TYPE" \
+    --arg skipAssigned "$SKIP_ASSIGNED" \
+    --arg fieldId "$URGENCY_FIELD_ID" \
+    '.data.search.nodes[]
+     | if $issueType != "" then select(.issueType.name == $issueType) else . end
+     | if $skipAssigned == "true" then select(.issueFieldValues.nodes | map(select(.field.id == $fieldId)) | length == 0) else . end
+     | .number')
 
-  # Add issues from this page
   if [[ -n "$PAGE_ISSUES" ]]; then
     if [[ -z "$ISSUE_NUMBERS" ]]; then
       ISSUE_NUMBERS="$PAGE_ISSUES"
@@ -106,47 +143,49 @@ for ((page=1; page<=MAX_PAGES; page++)); do
 
   echo "  Page $page: Found $ISSUE_COUNT issue(s) so far..."
 
-  # Check if we have enough issues
   if [[ $ISSUE_COUNT -ge $LIMIT ]]; then
     echo "  Reached target of $LIMIT issues"
     ISSUE_NUMBERS=$(echo "$ISSUE_NUMBERS" | head -n "$LIMIT")
     break
   fi
 
-  # Check if there are more pages
   HAS_NEXT=$(echo "$RESPONSE" | jq -r '.data.search.pageInfo.hasNextPage')
   if [[ "$HAS_NEXT" != "true" ]]; then
     echo "  No more pages available"
     break
   fi
 
-  # Get cursor for next page
   CURSOR=$(echo "$RESPONSE" | jq -r '.data.search.pageInfo.endCursor')
 done
 
 if [[ -z "$ISSUE_NUMBERS" ]]; then
-  echo "⚠️  No issues found in the project (or missing permissions)."
+  echo "⚠️  No issues found matching the filters."
   exit 1
 fi
 
 ISSUE_COUNT=$(echo "$ISSUE_NUMBERS" | wc -l | tr -d ' ')
 echo "✅ Found $ISSUE_COUNT issue(s) to process"
+echo ""
 
-# --- Run the workflow for each issue ---
+# --- Dispatch workflows ---
 if [[ "$DRY_RUN" == "true" ]]; then
-  echo "🔍 DRY RUN MODE - Would trigger workflow for these issues:"
+  echo "🔍 DRY RUN — would trigger workflow for:"
   for ISSUE_NUMBER in $ISSUE_NUMBERS; do
-    echo "  → Would run for issue #$ISSUE_NUMBER"
+    echo "  → #$ISSUE_NUMBER"
   done
-  echo "ℹ️  Dry run complete. Would have triggered workflow for $ISSUE_COUNT issue(s)."
+  echo "ℹ️  Dry run complete. Would have triggered $ISSUE_COUNT workflow(s)."
 else
-  echo "Running workflow 'assign-urgency-to-issue.yml' for issues:"
+  echo "Triggering 'assign-urgency-to-issue.yml' for $ISSUE_COUNT issue(s):"
+  DISPATCHED=0
   for ISSUE_NUMBER in $ISSUE_NUMBERS; do
-    echo "→ Running for issue #$ISSUE_NUMBER"
+    echo "→ #$ISSUE_NUMBER"
     gh workflow run assign-urgency-to-issue.yml \
       --ref "$BRANCH" \
-      -f issue_number="$ISSUE_NUMBER" \
-      -f project_id="$PROJECT_ID"
+      -f issue_number="$ISSUE_NUMBER"
+    ((DISPATCHED++))
+    if [[ "$DELAY" -gt 0 && $DISPATCHED -lt $ISSUE_COUNT ]]; then
+      sleep "$DELAY"
+    fi
   done
-  echo "✅ Done! Triggered workflow for $ISSUE_COUNT issue(s)."
+  echo "✅ Done! Triggered $ISSUE_COUNT workflow(s)."
 fi


### PR DESCRIPTION
## Summary

Rewrite the urgency automation with a **dual-write approach** that sets urgency in two places:
1. **Org-level Urgency issue field** — visible in private project views (e.g. #173 Core Features)
2. **Project-level Urgency field** — synced for configured public projects (e.g. #187 Quality Board) where org-level fields are not yet visible

This supersedes #51626, #51655, and #51656.

## Why dual-write?

GitHub org-level issue fields are [not visible in public project views](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/managing-issue-fields-in-your-organization). Project #187 (Quality Board) is public, so we sync the urgency to its project-level field as well. When GitHub lifts this restriction, the project sync step can be removed.

## Changes

### Workflow (`assign-urgency-to-issue.yml`)
- **Org-level update**: `setIssueFieldValue` sets the org-level Urgency field directly on the issue
- **Project sync**: new step iterates over `SYNC_PROJECT_NUMBERS` (currently `187`), finds matching project items, and updates their project-level Urgency field via `updateProjectV2ItemFieldValue`
- **Cross-repo**: `workflow_call` trigger with `issue_number` and `repo` inputs — other repos add a 10-line caller workflow
- **Removed**: matrix strategy, project membership validation as a gate, `project_id` input
- **Fixes**: `issue_number` required for dispatch, Update guarded on urgency calculated, correct precedence comment

### Batch script (`assign-urgency-to-issues.sh`)
- Named flags: `--repo`, `--project`, `--type`, `--label`, `--skip-assigned`, `--delay`, `--dry-run`
- `--skip-assigned` checks org-level `issueFieldValues`
- Safe jq value passing via `--arg`
- Exit non-zero on unknown options

### Cross-repo caller (for other repos)
```yaml
name: Assign urgency
on:
  issues:
    types: [opened, labeled, unlabeled, reopened, transferred]
jobs:
  urgency:
    uses: camunda/camunda/.github/workflows/assign-urgency-to-issue.yml@main
    with:
      issue_number: ${{ github.event.issue.number }}
      repo: ${{ github.event.repository.name }}
    secrets: inherit
```

## Test plan
- [ ] Trigger for an issue in both projects — verify org-level field AND project #187 field set
- [ ] Trigger for an issue only in #173 — verify org-level field set, project sync skipped
- [ ] Trigger for an issue with `urgency-locked` — verify no updates
- [ ] Trigger for an issue without severity/impact labels — verify no updates
- [ ] Batch dry-run with `--type Bug --skip-assigned`
- [ ] Cross-repo: trigger via `workflow_call` from another repo

## Related
- #51633 — multi-repo support tracking issue
- Closes #51626, #51655, #51656 (superseded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)