### PR TITLE
test: fix flaky e2e test for batch cancel operations

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
@@ -194,15 +194,11 @@ test.describe('Operations', () => {
         assertion: async () => {
           await expect(operateProcessesPage.dataList).toBeVisible();
           // Verify at least one canceled icon is visible
-          const canceledIconsVisibility = await Promise.all(
-            instances.map((instance) =>
-              operateProcessesPage
-                .getCanceledIcon(instance.processInstanceKey)
-                .isVisible(),
+          await expect(
+            operateProcessesPage.getCanceledIcon(
+              instances[0].processInstanceKey,
             ),
-          );
-
-          expect(canceledIconsVisibility.some(Boolean)).toBe(true);
+          ).toBeVisible({timeout: 5000});
         },
         onFailure: async () => {
           await page.reload();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
@@ -194,11 +194,15 @@ test.describe('Operations', () => {
         assertion: async () => {
           await expect(operateProcessesPage.dataList).toBeVisible();
           // Verify at least one canceled icon is visible
-          await expect(
-            operateProcessesPage.getCanceledIcon(
-              instances[0].processInstanceKey,
+          const canceledIconsVisibility = await Promise.all(
+            instances.map((instance) =>
+              operateProcessesPage
+                .getCanceledIcon(instance.processInstanceKey)
+                .isVisible(),
             ),
-          ).toBeVisible({timeout: 5000});
+          );
+
+          expect(canceledIconsVisibility.some(Boolean)).toBe(true);
         },
         onFailure: async () => {
           await page.reload();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
@@ -170,15 +170,42 @@ test.describe('Operations', () => {
       await operateProcessesPage.cancelButton.click();
       await operateProcessesPage.applyButton.click();
 
-      await operateFiltersPanelPage.clickIncidentsInstancesCheckbox();
-      await operateFiltersPanelPage.clickCanceledInstancesCheckbox();
-
       await expect(
         operateProcessesPage.batchOperationStartedMessage(
           'Cancel Process Instance',
         ),
       ).toBeVisible({timeout: 60000});
 
+      // Apply filters to show canceled instances with retries
+      await waitForAssertion({
+        assertion: async () => {
+          await operateFiltersPanelPage.clickCanceledInstancesCheckbox();
+          await expect(
+            operateFiltersPanelPage.canceledInstancesCheckbox,
+          ).toBeChecked();
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+
+      // Wait for canceled instances to load in the filtered view
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(operateProcessesPage.dataList).toBeVisible();
+          // Verify at least one canceled icon is visible
+          await expect(
+            operateProcessesPage.getCanceledIcon(
+              instances[0].processInstanceKey,
+            ),
+          ).toBeVisible({timeout: 5000});
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+
+      // Verify all instances have canceled icons
       await waitForAssertion({
         assertion: async () => {
           await Promise.all(


### PR DESCRIPTION
## Summary
Fixed a flaky E2E test that was passing locally but failing in CI. The "Retry and cancel multiple instances" test didn't properly wait for filter state changes to complete.

## Changes
- Added `waitForAssertion` with retries when clicking the "Canceled" checkbox to ensure it's actually checked
- Added wait for at least one canceled instance to be visible, confirming the filter is applied and instances are loaded
- Then verifies all instances have canceled icons visible

## Why This Fix
After canceling instances and applying filters, the test needed to wait for:
1. The "Canceled" checkbox to be checked
2. The UI to fetch and render canceled instances
3. The canceled icons to appear in the table

In CI environments, these operations take longer than the original 5-second timeout, causing the test to fail. The `waitForAssertion` utility provides up to 3 retries with page reloads between attempts, making the test resilient to timing variations.

## Testing
https://github.com/camunda/camunda/actions/runs/24822777281