### PR TITLE
chore: assign backup update-tests to zeebe-distributed-platform

### DIFF
--- a/.codeowners
+++ b/.codeowners
@@ -214,6 +214,7 @@ mwnw*                       @camunda/monorepo-devops-team
 # Zeebe QA
 /zeebe/qa/util/             @camunda/core-features
 /zeebe/qa/update-tests/     @camunda/core-features
+/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/backup/ @camunda/zeebe-distributed-platform
 /zeebe/qa/integration-tests/ @camunda/core-features
 /zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/ @camunda/core-features
 


### PR DESCRIPTION
## Summary

- Adds a `.codeowners` entry for `zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/backup/` owned by `@camunda/zeebe-distributed-platform`
- Overrides the broader `core-features` ownership of `zeebe/qa/update-tests/` for the backup subpackage only (last-match-wins semantics)
- Consistent with existing patterns for other distributed-platform subpackage overrides (integration tests, acceptance tests, broker packages)

## Test plan

- [ ] Verify `.codeowners` linting passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)