### PR TITLE
ci: add hourly cron for urgency sync on Quality Board

### DIFF
--- a/.github/workflows/assign-urgency-to-issues-cron.yml
+++ b/.github/workflows/assign-urgency-to-issues-cron.yml
@@ -1,0 +1,51 @@
+# type: Project Management
+# owner: @camunda/core-features-team
+---
+# Hourly urgency sync for Quality Board (#187)
+#
+# Picks up issues that were recently updated but don't have urgency set yet.
+# This covers cross-repo issues that can't trigger the main workflow directly.
+#
+name: Assign urgency to new issues in Quality Board
+
+on:
+  schedule:
+    - cron: '0 * * * *' # every hour
+  workflow_dispatch: {}
+
+jobs:
+  assign-urgency-batch:
+    runs-on: ubuntu-latest
+    permissions: {}
+    timeout-minutes: 15
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Generate GitHub token
+        id: github-token
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@fc4fa13813cbc1835129967f10a12f24aa7a393c # main
+        with:
+          github-app-id-vault-key: PROJECT_BOARD_AUTOMATION_APP_ID
+          github-app-id-vault-path: secret/data/products/camunda/ci/camunda
+          github-app-private-key-vault-key: PROJECT_BOARD_AUTOMATION_APP_PRIVATE_KEY
+          github-app-private-key-vault-path: secret/data/products/camunda/ci/camunda
+          vault-auth-method: approle
+          vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          vault-url: ${{ secrets.VAULT_ADDR }}
+
+      - name: Run urgency batch for Quality Board
+        env:
+          GH_TOKEN: ${{ steps.github-token.outputs.token }}
+        run: |
+          bash .github/workflows/assign-urgency-to-issues.sh \
+            --project 187 \
+            --updated-since 2h \
+            --skip-assigned \
+            --limit 100 \
+            --delay 1


### PR DESCRIPTION
## Summary

Add an hourly cron workflow that runs the urgency batch script against project #187 (Quality Board). This picks up cross-repo issues that can't trigger the main urgency workflow directly — no per-repo setup needed.

**Stacked on:** #51665 → #51657

## How it works

1. Runs every hour via `schedule`
2. Checks issues in project #187 updated in the last 2 hours (`--updated-since 2h`)
3. Skips issues that already have urgency set (`--skip-assigned`)
4. Triggers the urgency workflow for up to 100 matching issues

Uses a 2h window (not 1h) to catch issues missed by a failed or delayed previous run.

## Trade-offs

| Aspect | Value |
|---|---|
| Max delay for new issues | ~1 hour |
| Cross-repo setup needed | None |
| Actions minutes (steady state) | Minimal — typically 0-10 issues per run |
| Self-healing | Yes — missed issues caught by next run |

## Test plan
- [ ] Manual trigger via `workflow_dispatch`
- [ ] Verify it finds recently updated issues without urgency
- [ ] Verify it's a no-op when all issues already have urgency

## Related
- #51657 — unified urgency automation
- #51665 — `--updated-since` flag
- #51633 — multi-repo support (Option E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)