### PR TITLE
ci: gate SHR jobs behind ci:run label for on-demand CI (PoC)

### DIFF
--- a/.github/actions/ci-gate/action.yml
+++ b/.github/actions/ci-gate/action.yml
@@ -1,0 +1,69 @@
+---
+name: CI Gate
+# owner: @camunda/monorepo-devops-team
+description: |
+  On-demand CI gate that controls whether expensive self-hosted runner (SHR) jobs
+  should run. The gate opens automatically for non-PR events, bot PRs, and PRs
+  with the `ci:run` label. The label is auto-removed after consumption (one-shot).
+
+  See docs/monorepo-docs/ci.md § "On-Demand CI" for full documentation.
+
+inputs:
+  github-token:
+    description: "GitHub token with pull-requests:write permission (for label removal)"
+    required: true
+
+outputs:
+  should-run:
+    description: "'true' if SHR jobs should run, 'false' if they should be skipped"
+    value: ${{ steps.gate.outputs.run }}
+
+runs:
+  using: composite
+  steps:
+    - name: Evaluate CI gate
+      id: gate
+      shell: bash
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        HAS_LABEL: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:run') }}
+        PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+      run: |
+        # Always run SHR jobs for non-PR events (merge queue, push, schedule, dispatch)
+        if [[ "${EVENT_NAME}" != "pull_request" ]]; then
+          echo "run=true" >> "$GITHUB_OUTPUT"
+          echo "::notice::CI gate: OPEN (event=${EVENT_NAME}, not a pull_request)"
+          exit 0
+        fi
+
+        # Run if PR has the ci:run label
+        if [[ "${HAS_LABEL}" == "true" ]]; then
+          echo "run=true" >> "$GITHUB_OUTPUT"
+          echo "::notice::CI gate: OPEN (ci:run label present)"
+          exit 0
+        fi
+
+        # Auto-run for bot PRs (Renovate, release bot) to preserve existing behavior
+        if [[ "${PR_AUTHOR}" == "renovate[bot]" || "${PR_AUTHOR}" == "camunda-platform-release[bot]" ]]; then
+          echo "run=true" >> "$GITHUB_OUTPUT"
+          echo "::notice::CI gate: OPEN (bot PR, author=${PR_AUTHOR})"
+          exit 0
+        fi
+
+        # Gate is closed: skip SHR jobs
+        echo "run=false" >> "$GITHUB_OUTPUT"
+        echo "::notice::CI gate: CLOSED — add the 'ci:run' label to trigger the CI"
+
+    # Remove the ci:run label after consuming it so the next push doesn't
+    # automatically re-trigger the full CI matrix. This makes the label a
+    # one-shot trigger: add it → CI runs → label removed → next push is cheap.
+    - name: Remove ci:run label (one-shot trigger)
+      if: steps.gate.outputs.run == 'true' && github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:run')
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+      run: |
+        gh pr edit "${{ github.event.pull_request.number }}" \
+          --repo "${{ github.repository }}" \
+          --remove-label "ci:run"
+        echo "::notice::Removed ci:run label (one-shot consumed)"

--- a/.github/conftest-unified-ci-rules.rego
+++ b/.github/conftest-unified-ci-rules.rego
@@ -160,6 +160,7 @@ get_jobs_without_cihealth(jobInput) = jobs_without_cihealth {
         # not enforced on "special" jobs needed for control flow in Unified CI
         job_id != "detect-changes"
         job_id != "check-results"
+        job_id != "ci-gate"
         job_id != "test-summary"
         job_id != "get-concurrency-group-dynamically"
         job_id != "get-snapshot-docker-version-tag"
@@ -203,6 +204,7 @@ get_jobs_not_needing_detectchanges(jobInput) = jobs_not_needing_detectchanges {
         # not enforced on Unified CI jobs that are part of change detection control flow structure
         job_id != "detect-changes"
         job_id != "check-results"
+        job_id != "ci-gate"
 
         # not enforced on Unified CI jobs running after "check-results" job
         not startswith(job_id, "deploy-")
@@ -256,6 +258,7 @@ get_jobs_without_printmetadata(jobInput) = jobs_without_printmetadata {
         job_id != "detect-changes"
         job_id != "setup-tests"
         job_id != "check-results"
+        job_id != "ci-gate"
 
         # not enforced on Unified CI jobs running after "check-results" job
         not startswith(job_id, "deploy-")

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -18,20 +18,39 @@ on:
     types:
     - opened
     - synchronize
+    - labeled
 
 env:
   GHA_BEST_PRACTICES_LINTER: enabled
 
 jobs:
+  ci-gate:
+    name: "CI Gate"
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    permissions:
+      pull-requests: write
+    outputs:
+      should-run: ${{ steps.gate.outputs.should-run }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/actions/ci-gate
+      - name: Evaluate CI gate
+        id: gate
+        uses: ./.github/actions/ci-gate
+        with:
+          github-token: ${{ github.token }}
+
   analyze:
+    needs: [ ci-gate ]
+    if: needs.ci-gate.outputs.should-run == 'true' && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork)
     name: "Analyze ${{ matrix.project.name }} dependencies"
     permissions:
       # Needed for camunda/infra-global-github-actions/fossa/info
       actions: read
       contents: read
     runs-on: gcp-core-16-longrunning
-    # Skip analysis on fork PRs as they cannot access FOSSA due to lack of credentials
-    if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
     # If you change the job timeout, update the timeout in camunda/infra-global-github-actions/fossa/pr-check accordingly.
     timeout-minutes: 31
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,8 @@ on:
       - main
       - stable/*
       - release-*
-  pull_request: {}
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
   merge_group: {}
   workflow_dispatch: {}
   schedule:
@@ -72,6 +73,40 @@ jobs:
       - name: Detect changes
         uses: ./.github/actions/paths-filter
         id: filter
+
+  # ──────────────────────────────────────────────────────────────────────────────
+  # On-demand CI gate (PoC): gate expensive SHR jobs behind the `ci:run` label
+  # on pull_request events. All other trigger types (merge_group, push, schedule,
+  # workflow_dispatch) bypass the gate and always run.
+  #
+  # How it works for developers:
+  #   1. Open/push to PR → lightweight linters run automatically (GH-hosted)
+  #   2. Add the `ci:run` label when ready → full CI matrix runs on SHR
+  #   3. The label is automatically removed after consumption (one-shot trigger)
+  #   4. Next push only runs linters again; re-add `ci:run` for another full run
+  #   5. merge_group trigger remains unaffected (always runs full CI)
+  #
+  # Bot PRs (renovate[bot], camunda-platform-release[bot]) bypass the gate.
+  #
+  # See docs/monorepo-docs/ci.md § "On-Demand CI" for full documentation.
+  # ──────────────────────────────────────────────────────────────────────────────
+  ci-gate:
+    name: "CI Gate"
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    permissions:
+      pull-requests: write  # needed to remove the ci:run label after consuming it
+    outputs:
+      should-run-shr: ${{ steps.gate.outputs.should-run }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/actions/ci-gate
+      - name: Evaluate CI gate
+        id: gate
+        uses: ./.github/actions/ci-gate
+        with:
+          github-token: ${{ github.token }}
 
   actionlint:
     if: needs.detect-changes.outputs.actionlint == 'true'
@@ -253,9 +288,9 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
   java-checks:
-    if: needs.detect-changes.outputs.java-code-changes == 'true'
+    if: needs.detect-changes.outputs.java-code-changes == 'true' && needs.ci-gate.outputs.should-run-shr == 'true'
     name: "Java Checks"
-    needs: [ detect-changes ]
+    needs: [ detect-changes, ci-gate ]
     timeout-minutes: 20
     permissions: { }  # GITHUB_TOKEN unused in this job
     runs-on: gcp-perf-core-8-default
@@ -283,7 +318,7 @@ jobs:
     # Temporarily disabling the dependency-cycle-check as too brittle
     if: ${{ false }}
     name: "Dependency Cycle Check"
-    needs: [ detect-changes ]
+    needs: [ detect-changes, ci-gate ]
     runs-on: gcp-core-16-default
     timeout-minutes: 30
     permissions: { }  # GITHUB_TOKEN unused in this job
@@ -663,9 +698,9 @@ jobs:
 
   # Runs unit tests for all modules that are not Operate, Optimize, Tasklist, or Zeebe. This test will run any new modules that are added and are not included in setup-tests
   general-unit-tests:
-    if: needs.detect-changes.outputs.java-code-changes == 'true'
+    if: needs.detect-changes.outputs.java-code-changes == 'true' && needs.ci-gate.outputs.should-run-shr == 'true'
     name: "General / Unit - Back End"
-    needs: [ detect-changes, setup-tests ]
+    needs: [ detect-changes, setup-tests, ci-gate ]
     timeout-minutes: 20
     permissions: { }  # GITHUB_TOKEN unused in this job
     runs-on: gcp-perf-core-16-default
@@ -729,9 +764,9 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
   zeebe-unit-tests:
-    if: needs.detect-changes.outputs.java-code-changes == 'true'
+    if: needs.detect-changes.outputs.java-code-changes == 'true' && needs.ci-gate.outputs.should-run-shr == 'true'
     name: "Zeebe / Unit - ${{matrix.component}}"
-    needs: [ detect-changes, setup-tests ]
+    needs: [ detect-changes, setup-tests, ci-gate ]
     timeout-minutes: 20
     permissions: { }  # GITHUB_TOKEN unused in this job
     runs-on: gcp-perf-core-16-default
@@ -838,8 +873,8 @@ jobs:
 
   database-integration-tests:
     name: "Database Integration Tests / ${{ matrix.name }}"
-    if: needs.detect-changes.outputs.java-code-changes == 'true'
-    needs: [ detect-changes ]
+    if: needs.detect-changes.outputs.java-code-changes == 'true' && needs.ci-gate.outputs.should-run-shr == 'true'
+    needs: [ detect-changes, ci-gate ]
     strategy:
       fail-fast: false
       matrix: &database-matrix
@@ -882,8 +917,8 @@ jobs:
 
   history-tests:
     name: "History Integration Tests / ${{ matrix.name }}"
-    if: needs.detect-changes.outputs.java-code-changes == 'true'
-    needs: [ detect-changes ]
+    if: needs.detect-changes.outputs.java-code-changes == 'true' && needs.ci-gate.outputs.should-run-shr == 'true'
+    needs: [ detect-changes, ci-gate ]
     strategy:
       fail-fast: false
       matrix: *database-matrix
@@ -902,8 +937,8 @@ jobs:
 
   identity-tests:
     name: "Identity Integration Tests / ${{ matrix.name }}"
-    if: needs.detect-changes.outputs.java-code-changes == 'true'
-    needs: [ detect-changes ]
+    if: needs.detect-changes.outputs.java-code-changes == 'true' && needs.ci-gate.outputs.should-run-shr == 'true'
+    needs: [ detect-changes, ci-gate ]
     strategy:
       fail-fast: false
       matrix: *database-matrix
@@ -920,8 +955,8 @@ jobs:
       test-type-label: "Identity"
 
   rdbms-integration-tests:
-    if: needs.detect-changes.outputs.rdbms-integration-tests == 'true'
-    needs: [ detect-changes ]
+    if: needs.detect-changes.outputs.rdbms-integration-tests == 'true' && needs.ci-gate.outputs.should-run-shr == 'true'
+    needs: [ detect-changes, ci-gate ]
     name: "General / Integration / RDBMS ITs"
     timeout-minutes: 30
     runs-on: gcp-perf-core-8-default
@@ -987,9 +1022,9 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
   integration-tests:
-    if: needs.detect-changes.outputs.java-code-changes == 'true'
+    if: needs.detect-changes.outputs.java-code-changes == 'true' && needs.ci-gate.outputs.should-run-shr == 'true'
     name: "${{ matrix.module }} / Integration / ${{ matrix.name }} ITs (${{ matrix.stressRun }})"
-    needs: [ detect-changes, setup-tests ]
+    needs: [ detect-changes, setup-tests, ci-gate ]
     timeout-minutes: 30
     permissions: { }  # GITHUB_TOKEN unused in this job
     runs-on: ${{ matrix.runs-on }}
@@ -1129,9 +1164,9 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
   archunit-tests:
-    if: needs.detect-changes.outputs.java-code-changes == 'true'
+    if: needs.detect-changes.outputs.java-code-changes == 'true' && needs.ci-gate.outputs.should-run-shr == 'true'
     name: "General / Unit - ArchUnit"
-    needs: [ detect-changes ]
+    needs: [ detect-changes, ci-gate ]
     timeout-minutes: 20
     permissions: { }  # GITHUB_TOKEN unused in this job
     runs-on: gcp-perf-core-16-default
@@ -1435,9 +1470,9 @@ jobs:
           user_description: "Identity"
 
   tasklist-ci:
-    if: needs.detect-changes.outputs.java-code-changes == 'true' || needs.detect-changes.outputs.frontend-changes == 'true'
+    if: (needs.detect-changes.outputs.java-code-changes == 'true' || needs.detect-changes.outputs.frontend-changes == 'true') && needs.ci-gate.outputs.should-run-shr == 'true'
     name: "Tasklist"
-    needs: [ detect-changes ]
+    needs: [ detect-changes, ci-gate ]
     uses: ./.github/workflows/ci-tasklist.yml
     secrets: inherit
     permissions: { }
@@ -1446,9 +1481,9 @@ jobs:
       runBeTests: ${{ needs.detect-changes.outputs.tasklist-backend-changes == 'true' || needs.detect-changes.outputs.zeebe-changes == 'true' }}
 
   operate-ci:
-    if: needs.detect-changes.outputs.java-code-changes == 'true' || needs.detect-changes.outputs.frontend-changes == 'true'
+    if: (needs.detect-changes.outputs.java-code-changes == 'true' || needs.detect-changes.outputs.frontend-changes == 'true') && needs.ci-gate.outputs.should-run-shr == 'true'
     name: "Operate"
-    needs: [ detect-changes ]
+    needs: [ detect-changes, ci-gate ]
     uses: ./.github/workflows/ci-operate.yml
     secrets: inherit
     permissions: { }
@@ -1457,9 +1492,9 @@ jobs:
       runBeTests: ${{ needs.detect-changes.outputs.operate-backend-changes == 'true' || needs.detect-changes.outputs.zeebe-changes == 'true'}}
 
   optimize-ci:
-    if: ${{ needs.detect-changes.outputs.java-code-changes == 'true' || needs.detect-changes.outputs.frontend-changes == 'true' }}
+    if: ${{ (needs.detect-changes.outputs.java-code-changes == 'true' || needs.detect-changes.outputs.frontend-changes == 'true') && needs.ci-gate.outputs.should-run-shr == 'true' }}
     name: "Optimize"
-    needs: [ detect-changes ]
+    needs: [ detect-changes, ci-gate ]
     uses: ./.github/workflows/ci-optimize.yml
     secrets: inherit
     permissions: { }
@@ -1468,9 +1503,9 @@ jobs:
       runBeTests: ${{ needs.detect-changes.outputs.optimize-backend-changes == 'true' || needs.detect-changes.outputs.zeebe-changes == 'true' }}
 
   zeebe-ci:
-    if: needs.detect-changes.outputs.zeebe-changes == 'true'
+    if: needs.detect-changes.outputs.zeebe-changes == 'true' && needs.ci-gate.outputs.should-run-shr == 'true'
     name: "Zeebe"
-    needs: [ detect-changes ]
+    needs: [ detect-changes, ci-gate ]
     uses: ./.github/workflows/ci-zeebe.yml
     secrets: inherit
     with:
@@ -1675,6 +1710,7 @@ jobs:
     needs: # BELOW LIST IS IN ALPHABETICAL ORDER
       - actionlint
       - archunit-tests
+      - ci-gate
       - build-platform-frontend
       - c8-e2e-test-suite
       - codeowners-check

--- a/.github/workflows/operate-ci.yml
+++ b/.github/workflows/operate-ci.yml
@@ -23,6 +23,7 @@ on:
       - 'zeebe/**'
       - 'clients/**'
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     paths:
       - '.ci/**'
       - '.github/actions/**'
@@ -45,9 +46,28 @@ concurrency:
   group: ${{ format('{0}-{1}', github.workflow, github.ref == 'refs/heads/main' && github.sha || github.ref) }}
 
 jobs:
+  ci-gate:
+    name: "CI Gate"
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      pull-requests: write
+    outputs:
+      should-run: ${{ steps.gate.outputs.should-run }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/actions/ci-gate
+      - uses: ./.github/actions/ci-gate
+        id: gate
+        with:
+          github-token: ${{ github.token }}
+
   # builds image and pushes to Dockerhub if branch is `main`
   run-operate-build:
     name: "Build / Operate and Image"
+    needs: [ci-gate]
+    if: needs.ci-gate.outputs.should-run == 'true'
     uses: ./.github/workflows/operate-ci-build-reusable.yml
     secrets: inherit
     with:
@@ -55,6 +75,8 @@ jobs:
   # over 10min run time
   run-core-features-integration-tests:
     name: "Integration"
+    needs: [ci-gate]
+    if: needs.ci-gate.outputs.should-run == 'true'
     uses: ./.github/workflows/operate-ci-test-reusable.yml
     secrets: inherit
     with:

--- a/.github/workflows/operate-docker-tests.yml
+++ b/.github/workflows/operate-docker-tests.yml
@@ -20,6 +20,7 @@ on:
       - 'pom.xml'
       - 'webapps-common/**'
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     paths:
       - '.ci/**'
       - '.github/actions/**'
@@ -38,9 +39,28 @@ concurrency:
   group: ${{ format('{0}-{1}', github.workflow, github.ref == 'refs/heads/main' && github.sha || github.ref) }}
 
 jobs:
+  ci-gate:
+    name: "CI Gate"
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      pull-requests: write
+    outputs:
+      should-run: ${{ steps.gate.outputs.should-run }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/actions/ci-gate
+      - uses: ./.github/actions/ci-gate
+        id: gate
+        with:
+          github-token: ${{ github.token }}
+
   # does not meet the 10 minute runtime as required by the unified CI
   integration-tests:
     name: "Container Tests"
+    needs: [ci-gate]
+    if: needs.ci-gate.outputs.should-run == 'true'
     runs-on: gcp-core-4-default
     timeout-minutes: 40
     permissions: { }

--- a/.github/workflows/operate-e2e-tests.yml
+++ b/.github/workflows/operate-e2e-tests.yml
@@ -22,6 +22,7 @@ on:
       - "pom.xml"
 
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     paths:
       - ".ci/**"
       - ".github/actions/**"
@@ -41,7 +42,26 @@ concurrency:
   group: ${{ format('{0}-{1}', github.workflow, github.ref == 'refs/heads/main' && github.sha || github.ref) }}
 
 jobs:
+  ci-gate:
+    name: "CI Gate"
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      pull-requests: write
+    outputs:
+      should-run: ${{ steps.gate.outputs.should-run }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/actions/ci-gate
+      - uses: ./.github/actions/ci-gate
+        id: gate
+        with:
+          github-token: ${{ github.token }}
+
   test:
+    needs: [ci-gate]
+    if: needs.ci-gate.outputs.should-run == 'true'
     runs-on: gcp-core-4-default
     services:
       elasticsearch:

--- a/.github/workflows/optimize-ci-core-features.yml
+++ b/.github/workflows/optimize-ci-core-features.yml
@@ -1,6 +1,7 @@
 name: "[Legacy] Optimize / Core Features"
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     paths:
       - ".github/actions/**"
       - ".github/workflows/optimize-*"
@@ -38,6 +39,23 @@ permissions:
   pull-requests: write
 
 jobs:
+  ci-gate:
+    name: "CI Gate"
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      pull-requests: write
+    outputs:
+      should-run: ${{ steps.gate.outputs.should-run }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/actions/ci-gate
+      - uses: ./.github/actions/ci-gate
+        id: gate
+        with:
+          github-token: ${{ github.token }}
+
   detect-changes:
     name: "Get changed directories"
     runs-on: ubuntu-latest
@@ -52,7 +70,8 @@ jobs:
 
   docker:
     name: "Docker Build"
-    if: github.event_name == 'pull_request'
+    needs: [ci-gate]
+    if: needs.ci-gate.outputs.should-run == 'true' && github.event_name == 'pull_request'
     uses: ./.github/workflows/optimize-ci-build-reusable.yml
     secrets: inherit
     with:
@@ -62,8 +81,8 @@ jobs:
     name: "[IT] Run on Elasticsearch"
     runs-on: gcp-core-32-longrunning
     timeout-minutes: 120
-    needs: detect-changes
-    if: ${{ needs.detect-changes.outputs.backend-changes == 'true' }}
+    needs: [ci-gate, detect-changes]
+    if: needs.ci-gate.outputs.should-run == 'true' && needs.detect-changes.outputs.backend-changes == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -146,8 +165,8 @@ jobs:
     name: "[IT] Run on OpenSearch"
     runs-on: gcp-core-32-longrunning
     timeout-minutes: 120
-    needs: detect-changes
-    if: ${{ needs.detect-changes.outputs.backend-changes == 'true' }}
+    needs: [ci-gate, detect-changes]
+    if: needs.ci-gate.outputs.should-run == 'true' && needs.detect-changes.outputs.backend-changes == 'true'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/optimize-ci-data-layer.yml
+++ b/.github/workflows/optimize-ci-data-layer.yml
@@ -5,6 +5,7 @@
 name: "[Legacy] Optimize / Data Layer"
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     paths:
       - ".github/actions/**"
       - ".github/workflows/optimize-*"
@@ -42,6 +43,23 @@ permissions:
   pull-requests: write
 
 jobs:
+  ci-gate:
+    name: "CI Gate"
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      pull-requests: write
+    outputs:
+      should-run: ${{ steps.gate.outputs.should-run }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/actions/ci-gate
+      - uses: ./.github/actions/ci-gate
+        id: gate
+        with:
+          github-token: ${{ github.token }}
+
   detect-changes:
     name: Get changed directories
     runs-on: ubuntu-latest
@@ -61,8 +79,8 @@ jobs:
     strategy:
       matrix:
         database: [ elasticsearch, opensearch ]
-    needs: detect-changes
-    if: ${{ needs.detect-changes.outputs.backend-changes == 'true' }}
+    needs: [ci-gate, detect-changes]
+    if: needs.ci-gate.outputs.should-run == 'true' && needs.detect-changes.outputs.backend-changes == 'true'
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/tasklist-ci.yml
+++ b/.github/workflows/tasklist-ci.yml
@@ -12,6 +12,7 @@ on:
       - "stable/**"
       - "release**"
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
 
 # Limit workflow to 1 concurrent run per ref (branch): new commit -> old runs are canceled to save costs
 # Exception for main branch: complete builds for every commit needed for confidenence
@@ -20,6 +21,23 @@ concurrency:
   group: ${{ format('{0}-{1}', github.workflow, github.ref == 'refs/heads/main' && github.sha || github.ref) }}
 
 jobs:
+  ci-gate:
+    name: "CI Gate"
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      pull-requests: write
+    outputs:
+      should-run: ${{ steps.gate.outputs.should-run }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/actions/ci-gate
+      - uses: ./.github/actions/ci-gate
+        id: gate
+        with:
+          github-token: ${{ github.token }}
+
   detect-changes:
     outputs:
       tasklist-backend-changes: ${{ steps.filter.outputs.tasklist-backend-changes }}
@@ -37,20 +55,20 @@ jobs:
 
   run-build:
     name: run-build
-    needs: [detect-changes]
+    needs: [ci-gate, detect-changes]
     uses: ./.github/workflows/tasklist-ci-build-reusable.yml
     secrets: inherit
     with:
       branch: ${{ github.head_ref || github.ref_name }} # head_ref = branch name on PR, ref_name = `main` or `stable/**`
-    if: ${{ github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.tasklist-backend-changes == 'true' || needs.detect-changes.outputs.tasklist-frontend-changes == 'true' }}
+    if: needs.ci-gate.outputs.should-run == 'true' && (github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.tasklist-backend-changes == 'true' || needs.detect-changes.outputs.tasklist-frontend-changes == 'true')
 
   # Does not meet run time requirements for Unified CI
   run-integration-tests:
     name: "Integration"
-    needs: [detect-changes]
+    needs: [ci-gate, detect-changes]
     uses: ./.github/workflows/tasklist-ci-test-reusable.yml
     secrets: inherit
     permissions: { }
     with:
       branch: ${{ github.head_ref || github.ref_name }}
-    if: ${{ github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.tasklist-backend-changes == 'true' }}
+    if: needs.ci-gate.outputs.should-run == 'true' && (github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.tasklist-backend-changes == 'true')

--- a/docs/monorepo-docs/ci.md
+++ b/docs/monorepo-docs/ci.md
@@ -654,6 +654,7 @@ job-with-notification:
                 text: "Hello World"
 ```
 
+
 ## On-Demand CI
 
 By default, Pull Requests only run lightweight linters on GitHub-hosted runners. The expensive test jobs that run on self-hosted runners (SHR) are gated behind the **`ci:run`** label. This applies to both the [Unified CI](#unified-ci) (`ci.yml`) and the [License Checks](#license-checks) (`check-licenses.yml`) workflows.

--- a/docs/monorepo-docs/ci.md
+++ b/docs/monorepo-docs/ci.md
@@ -654,6 +654,43 @@ job-with-notification:
                 text: "Hello World"
 ```
 
+## On-Demand CI
+
+By default, Pull Requests only run lightweight linters on GitHub-hosted runners. The expensive test jobs that run on self-hosted runners (SHR) are gated behind the **`ci:run`** label. This applies to both the [Unified CI](#unified-ci) (`ci.yml`) and the [License Checks](#license-checks) (`check-licenses.yml`) workflows.
+
+### How it works
+
+1. **Open or push to a PR** — only cheap linter/check jobs run automatically (GitHub-hosted runners).
+2. **Add the `ci:run` label** — the full CI test matrix runs on self-hosted runners.
+3. **Label is auto-removed** — after the gate evaluates the label it is automatically removed, making it a *one-shot trigger*.
+4. **Push again** — only linters run (no label present). Add `ci:run` again when you are ready for another full CI run.
+
+### Exceptions (always run full CI)
+
+The gate is bypassed and the full CI matrix always runs for:
+
+* **Non-PR events:** merge queue (`merge_group`), pushes to `main`/`stable/*`, scheduled builds, manual `workflow_dispatch`.
+* **Bot PRs:** PRs authored by `renovate[bot]` or `camunda-platform-release[bot]`.
+
+### Interaction with other labels
+
+* **`ci:stress-test`** — stress testing is independent; add it alongside `ci:run` when needed (see [Stress Testing](#stress-testing)).
+* **`ci:no-cache`** — cache control is orthogonal to the CI gate and works as before.
+
+### FAQ
+
+**Q: Do I need to add `ci:run` every time I push?**
+
+> A: Only when you want the full test suite to run. Linters always run on every push.
+
+**Q: What happens in the merge queue?**
+
+> A: The merge queue triggers the `merge_group` event which bypasses the gate entirely. Full CI always runs in the merge queue.
+
+**Q: Do bot (Renovate) PRs need the label?**
+
+> A: No. Bot PRs are automatically exempted and always run the full CI matrix.
+
 ## ChatOps
 
 In the [camunda/camunda monorepo](https://github.com/camunda/camunda) certain automated workflows can be triggered by posting comments with commands on GitHub Issues and/or Pull Requests. Those commands are then processed by a [GitHub Actions workflow](https://github.com/camunda/camunda/blob/main/.github/workflows/chatops-command-dispatch.yml).

--- a/docs/monorepo-docs/ci.md
+++ b/docs/monorepo-docs/ci.md
@@ -654,7 +654,6 @@ job-with-notification:
                 text: "Hello World"
 ```
 
-
 ## On-Demand CI
 
 By default, Pull Requests only run lightweight linters on GitHub-hosted runners. The expensive test jobs that run on self-hosted runners (SHR) are gated behind the **`ci:run`** label. This applies to both the [Unified CI](#unified-ci) (`ci.yml`) and the [License Checks](#license-checks) (`check-licenses.yml`) workflows.


### PR DESCRIPTION
## What

Proof-of-concept for on-demand CI: gate expensive self-hosted runner (SHR) jobs behind the `ci:run` PR label.

## Why

CI and Check Licenses together account for ~90% of SHR compute cost in this repo. Most PR pushes are iterative (formatting fixes, review feedback) and don't need the full test matrix. By making the full CI opt-in per push, we avoid burning SHR minutes on work-in-progress commits.

**Estimated savings: ~$1,530/mo on CI + ~$730/mo on Check Licenses ≈ $2,260/mo total** (based on Feb–Apr 2026 actuals from the [CI cost analysis](https://github.com/camunda/infra-core/pull/12414)).

## How it works

1. **Open/push to PR** → only lightweight linters run (GitHub-hosted runners, free)
2. **Add the `ci:run` label** → full CI test matrix + FOSSA license checks run on SHR
3. **Label is auto-removed** after the gate evaluates it (one-shot trigger)
4. **Next push** → only linters again. Re-add `ci:run` when ready for another full run
5. **Merge queue / push to main / schedule** → always runs full CI (gate bypassed)
6. **Bot PRs** (Renovate, release bot) → always run full CI (gate bypassed)

## Changes

- **New: `.github/actions/ci-gate/action.yml`** — reusable composite action with gate logic + one-shot label removal
- **Modified: `.github/workflows/ci.yml`** — `ci-gate` job added, 14 SHR jobs gated, `check-results` depends on `ci-gate`
- **Modified: `.github/workflows/check-licenses.yml`** — `ci-gate` job added, `analyze` matrix gated
- **Modified: `docs/monorepo-docs/ci.md`** — new "On-Demand CI" documentation section

## Testing plan

1. Push to this PR without `ci:run` label → verify only linters run, SHR jobs show as skipped
2. Add `ci:run` label → verify full CI matrix triggers and label is auto-removed
3. Push again → verify gate is closed again (linters only)
4. Verify merge queue behavior is unaffected (always runs full CI)

## Risk assessment

- **Low risk**: `check-results` aggregation handles skipped jobs correctly (skipped ≠ failure)
- **No merge queue impact**: `merge_group` event bypasses the gate entirely
- **Reversible**: remove the `ci-gate` job and revert the `if` conditions to restore current behavior

---

Related: camunda/team-infrastructure#1039 (FinOps CI cost optimization tracker)