### PR TITLE
ci: fix unloaded openapi config in operate legacy e2e

### DIFF
--- a/.github/workflows/operate-e2e-tests.yml
+++ b/.github/workflows/operate-e2e-tests.yml
@@ -116,9 +116,11 @@ jobs:
         # we're excluding optimize from the build, not to impact this Operate workflow.
         run: ./mvnw clean install -T1C -DskipChecks -P -docker,skipFrontendBuild -DskipTests=true -B -DskipRemoteStaging=true -Dmaven.deploy.skip=true
       - name: Start Operate
-        run: >
-          ./mvnw -q -B spring-boot:start -pl dist -Dspring-boot.run.fork=true
-          -Dspring-boot.run.main-class=io.camunda.application.StandaloneCamunda
+        run: |
+          DIST_DIR="$(find dist/target -maxdepth 1 -type d -name 'camunda-zeebe*' | head -n 1)"
+
+          nohup "$DIST_DIR/bin/camunda" > "$RUNNER_TEMP/operate.log" 2>&1 &
+          echo $! > "$RUNNER_TEMP/operate.pid"
         env:
           SPRING_PROFILES_ACTIVE: operate,consolidated-auth,broker
           ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_CLASSNAME: io.camunda.exporter.CamundaExporter
@@ -134,6 +136,22 @@ jobs:
           CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_USERS_0: demo
           CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI: true
           CAMUNDA_SECURITY_AUTHORIZATIONS_ENABLED: false
+
+      - name: Wait for Operate to be ready
+        run: |
+          echo "Waiting for Operate to be ready..."
+          for i in $(seq 1 90); do
+            if curl -sf -u demo:demo http://localhost:8080/v2/topology >/dev/null 2>&1; then
+              echo "Operate is ready!"
+              exit 0
+            fi
+            echo "Waiting... ($i/90)"
+            sleep 5
+          done
+          echo "Operate failed to start in time."
+          echo "=== Last 100 lines of log ==="
+          tail -100 "$RUNNER_TEMP/operate.log"
+          exit 1
 
       - name: Python setup
         if: always()
@@ -173,6 +191,19 @@ jobs:
         with:
           name: logs.tgz
           path: ./logs.tgz
+
+      - name: Show Operate logs on failure
+        if: failure()
+        run: |
+          echo "=== Camunda logs ==="
+          cat "$RUNNER_TEMP/operate.log"
+
+      - name: Stop Operate
+        if: always()
+        run: |
+          if [[ -f "$RUNNER_TEMP/operate.pid" ]]; then
+            kill "$(cat "$RUNNER_TEMP/operate.pid")" || true
+          fi
 
       - name: Observe build status
         if: always()

--- a/qa/c8-orchestration-cluster-e2e-test-suite/fixtures.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/fixtures.ts
@@ -36,6 +36,7 @@ import {IdentityRolesDetailsPage} from '@pages/IdentityRolesDetailsPage';
 import {IdentityAuditLogPage} from '@pages/IdentityAuditLogPage';
 import {OperateOperationsDetailsPage} from '@pages/OperateOperationsDetailsPage';
 import {OperateOperationsLogPage} from '@pages/OperateOperationsLogPage';
+import {SwaggerPage} from '@pages/SwaggerPage';
 
 type PlaywrightFixtures = {
   makeAxeBuilder: () => AxeBuilder;
@@ -68,6 +69,7 @@ type PlaywrightFixtures = {
   identityTenantsPage: IdentityTenantsPage;
   identityRolesDetailsPage: IdentityRolesDetailsPage;
   identityAuditLogPage: IdentityAuditLogPage;
+  swaggerPage: SwaggerPage;
   suppressHelperModals: void;
 };
 
@@ -116,6 +118,9 @@ const test = base.extend<PlaywrightFixtures>({
   },
   loginPage: async ({page}, use) => {
     await use(new LoginPage(page));
+  },
+  swaggerPage: async ({page}, use) => {
+    await use(new SwaggerPage(page));
   },
   taskPanelPage: async ({page}, use) => {
     await use(new TaskPanelPage(page));

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/SwaggerPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/SwaggerPage.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Page, Locator, expect, type APIRequestContext} from '@playwright/test';
+
+import {credentials} from '../utils/http';
+
+export class SwaggerPage {
+  private readonly page: Page;
+  private readonly csrfCookieName = 'X-CSRF-TOKEN';
+  private readonly orchestrationClusterApiName = 'Orchestration Cluster API';
+  readonly swaggerUiPath = '/swagger-ui/index.html';
+  readonly apiDocsPath = '/v3/api-docs';
+  readonly swaggerConfigPath = '/v3/api-docs/swagger-config';
+  readonly processDefinitionSearchApiPath = '/v2/process-definitions/search';
+  readonly swaggerUiContainer: Locator;
+  readonly apiTags: Locator;
+  readonly firstApiTag: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.swaggerUiContainer = page.locator(
+      'section.swagger-ui.swagger-container',
+    );
+    this.apiTags = page.locator('.opblock-tag');
+    this.firstApiTag = this.apiTags.first();
+  }
+
+  async gotoSwaggerUI(options?: Parameters<Page['goto']>[1]): Promise<void> {
+    await this.page.goto(this.swaggerUiPath, options);
+  }
+
+  async expectLoaded(timeout: number = 30_000): Promise<void> {
+    await expect(this.swaggerUiContainer).toBeVisible({timeout});
+    await expect(this.firstApiTag).toBeVisible({timeout});
+  }
+
+  async getCsrfCookie() {
+    const cookies = await this.page.context().cookies();
+
+    return cookies.find((cookie) => cookie.name === this.csrfCookieName);
+  }
+
+  async getGroupedApiDocsUrl(request: APIRequestContext): Promise<string> {
+    const swaggerConfigResponse = await request.get(this.swaggerConfigPath, {
+      headers: {
+        Accept: 'application/json',
+        Authorization: `Basic ${credentials.accessToken}`,
+      },
+    });
+
+    await expect(swaggerConfigResponse).toBeOK();
+
+    const swaggerConfig = await swaggerConfigResponse.json();
+    const orchestrationClusterApi = swaggerConfig.urls?.find(
+      (entry: {name?: string; url?: string}) =>
+        entry.name === this.orchestrationClusterApiName,
+    );
+
+    expect(orchestrationClusterApi?.url).toBeTruthy();
+
+    return orchestrationClusterApi.url as string;
+  }
+
+  async openExecuteProcessDefinitionSearchDropdown(): Promise<void> {
+    const operation = await this.getOperation(
+      'post',
+      this.processDefinitionSearchApiPath,
+    );
+
+    // noWaitAfter prevents Playwright from hanging on Swagger UI's hash-navigation
+    // triggered by expanding the operation block.
+    await operation.click({noWaitAfter: true});
+
+    const tryItOutButton = operation.getByRole('button', {
+      name: /try it out/i,
+    });
+    await expect(tryItOutButton).toBeVisible({timeout: 10_000});
+    await tryItOutButton.click({noWaitAfter: true});
+
+    const executeButton = operation.getByRole('button', {
+      name: /execute/i,
+    });
+    await expect(executeButton).toBeVisible({timeout: 10_000});
+    await executeButton.click();
+  }
+
+  async getProcessDefinitionSearchCurlCommandText(): Promise<string> {
+    const curlCommand = (
+      await this.getOperation('post', this.processDefinitionSearchApiPath)
+    ).locator('.responses-wrapper .curl-command pre.curl code.language-bash');
+
+    await expect(curlCommand).toBeVisible({timeout: 10_000});
+
+    return curlCommand.innerText();
+  }
+
+  private async getOperation(
+    method: string,
+    apiPath: string,
+  ): Promise<Locator> {
+    const operation = this.page
+      .locator(`.opblock.opblock-${method.toLowerCase()}`)
+      .filter({hasText: apiPath})
+      .first();
+
+    await expect(operation).toBeVisible({timeout: 10_000});
+
+    return operation;
+  }
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/swagger.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/swagger.spec.ts
@@ -6,19 +6,10 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {expect, type APIRequestContext, Page} from '@playwright/test';
+import {expect} from '@playwright/test';
 import {test} from 'fixtures';
-import {LoginPage} from '@pages/LoginPage';
 import {credentials} from '../../utils/http';
 import {LOGIN_CREDENTIALS} from '../../utils/constants';
-
-const SWAGGER_UI_URL = '/swagger-ui/index.html';
-const SWAGGER_CONFIG_URL = '/v3/api-docs/swagger-config';
-const ORCHESTRATION_CLUSTER_API_NAME = 'Orchestration Cluster API';
-const CSRF_COOKIE_NAME = 'X-CSRF-TOKEN';
-const PROCESS_DEFINITION_API_PATH = '/v2/process-definitions/search';
-const SWAGGER_UI_CONTAINER_SELECTOR = 'section.swagger-ui.swagger-container';
-const PROCESS_DEFINITION_OPERATION_SELECTOR = '.opblock.opblock-post';
 
 const collectRefs = (value: unknown): string[] => {
   if (Array.isArray(value)) {
@@ -36,96 +27,32 @@ const collectRefs = (value: unknown): string[] => {
   return [];
 };
 
-const getGroupedApiDocsUrl = async (request: APIRequestContext) => {
-  const swaggerConfigResponse = await request.get(
-    `${credentials.baseUrl}${SWAGGER_CONFIG_URL}`,
-    {
-      headers: {
-        Accept: 'application/json',
-        Authorization: `Basic ${credentials.accessToken}`,
-      },
-    },
-  );
-
-  expect(swaggerConfigResponse.status()).toBe(200);
-
-  const swaggerConfig = await swaggerConfigResponse.json();
-  const orchestrationClusterApi = swaggerConfig.urls?.find(
-    (entry: {name?: string; url?: string}) =>
-      entry.name === ORCHESTRATION_CLUSTER_API_NAME,
-  );
-
-  expect(orchestrationClusterApi?.url).toBeTruthy();
-
-  return orchestrationClusterApi.url as string;
-};
-
-const getCurlCommandTextForProcessDefinition = async (page: Page) => {
-  await expect(page.locator(SWAGGER_UI_CONTAINER_SELECTOR)).toBeVisible({
-    timeout: 10_000,
-  });
-  await expect(page.locator('.opblock-tag').first()).toBeVisible({
-    timeout: 10_000,
-  });
-
-  // Find the POST /v2/process-definitions/search operation block and expand it
-  const processDefinitionOperation = page
-    .locator(PROCESS_DEFINITION_OPERATION_SELECTOR)
-    .filter({hasText: PROCESS_DEFINITION_API_PATH})
-    .first();
-  await expect(processDefinitionOperation).toBeVisible({timeout: 10_000});
-  // noWaitAfter prevents Playwright from hanging on Swagger UI's hash-navigation
-  // triggered by expanding the operation block.
-  await processDefinitionOperation.click({noWaitAfter: true});
-
-  // Click "Try it out" so Swagger generates the request command preview
-  const tryItOutButton = processDefinitionOperation.getByRole('button', {
-    name: /try it out/i,
-  });
-  await expect(tryItOutButton).toBeVisible({timeout: 10_000});
-  await tryItOutButton.click({noWaitAfter: true});
-
-  // Trigger generation of the curl/response section without inspecting network requests.
-  const executeButton = processDefinitionOperation.getByRole('button', {
-    name: /execute/i,
-  });
-  await expect(executeButton).toBeVisible({timeout: 10_000});
-  await executeButton.click();
-
-  const curlCommand = processDefinitionOperation.locator(
-    '.responses-wrapper .curl-command pre.curl code.language-bash',
-  );
-  await expect(curlCommand).toBeVisible({timeout: 10_000});
-  const curlCommandText = await curlCommand.innerText();
-
-  console.log(curlCommandText);
-  return curlCommandText;
-};
-
 test.beforeEach(async ({context}) => {
   // Ensure this scenario is fully unauthenticated even if prior tests logged in.
   await context.clearCookies();
 });
 
 test.describe('Swagger UI Tests', () => {
-  test('Swagger UI is accessible and presents the API list', async ({page}) => {
-    await page.goto(SWAGGER_UI_URL);
+  test('Swagger UI is accessible and presents the API list', async ({
+    swaggerPage,
+  }) => {
+    await swaggerPage.gotoSwaggerUI();
 
     // Verify the main Swagger UI container is rendered
-    await expect(page.locator(SWAGGER_UI_CONTAINER_SELECTOR)).toBeVisible({
+    await expect(swaggerPage.swaggerUiContainer).toBeVisible({
       timeout: 30_000,
     });
 
     // Verify that at least one API section/tag is listed
-    const firstTag = page.locator('.opblock-tag').first();
-    await expect(firstTag).toBeVisible({timeout: 30_000});
+    await expect(swaggerPage.firstApiTag).toBeVisible({timeout: 30_000});
   });
 
   test('Grouped OpenAPI spec returns valid JSON without external file refs', async ({
     request,
+    swaggerPage,
   }) => {
     // given
-    const groupedApiDocsUrl = await getGroupedApiDocsUrl(request);
+    const groupedApiDocsUrl = await swaggerPage.getGroupedApiDocsUrl(request);
 
     // when
     const response = await request.get(
@@ -150,6 +77,7 @@ test.describe('Swagger UI Tests', () => {
     expect(body).toHaveProperty('openapi');
     expect(body).toHaveProperty('info');
     expect(body).toHaveProperty('paths');
+    expect(groupedApiDocsUrl).not.toBe(swaggerPage.apiDocsPath);
 
     const refs = collectRefs(body);
     const externalFileRefs = refs.filter((ref) => ref.includes('.yaml#'));
@@ -158,12 +86,13 @@ test.describe('Swagger UI Tests', () => {
   });
 
   test('CSRF token is filled in and Swagger UI is accessible with CSRF token', async ({
+    loginPage,
     operateHomePage,
     page,
+    swaggerPage,
   }) => {
     // setup login CSRF token
     await page.goto('/operate/login');
-    const loginPage = new LoginPage(page);
     await loginPage.login(
       LOGIN_CREDENTIALS.username,
       LOGIN_CREDENTIALS.password,
@@ -171,13 +100,10 @@ test.describe('Swagger UI Tests', () => {
     await expect(operateHomePage.operateBanner).toBeVisible();
 
     // go to swagger UI
-    await page.goto(SWAGGER_UI_URL);
+    await swaggerPage.gotoSwaggerUI();
 
     // Read browser cookies and find the CSRF cookie by name.
-    const cookies = await page.context().cookies();
-    const csrfCookie = cookies.find(
-      (cookie) => cookie.name === CSRF_COOKIE_NAME,
-    );
+    const csrfCookie = await swaggerPage.getCsrfCookie();
 
     // The CSRF cookie must be present and must not be the string "null"
     expect(csrfCookie).toBeDefined();
@@ -185,29 +111,31 @@ test.describe('Swagger UI Tests', () => {
     expect(csrfCookie!.value.length).toBeGreaterThan(0);
 
     // Wait for Swagger UI to fully initialize
-    const curlCommandText = await getCurlCommandTextForProcessDefinition(page);
+    await swaggerPage.expectLoaded(10_000);
+    await swaggerPage.openExecuteProcessDefinitionSearchDropdown();
+    const curlCommandText =
+      await swaggerPage.getProcessDefinitionSearchCurlCommandText();
     expect(curlCommandText).toMatch(/x-csrf-token\s*:\s*/i);
     expect(curlCommandText).toMatch(/x-csrf-token\s*:\s*(?!null\b)\S+/i);
   });
 
   test('CSRF token is NOT filled in and Swagger UI is accessible', async ({
-    page,
+    swaggerPage,
   }) => {
     // go to swagger UI
-    await page.goto(SWAGGER_UI_URL);
+    await swaggerPage.gotoSwaggerUI();
 
     // Read browser cookies and find the CSRF cookie by name.
-    const cookies = await page.context().cookies();
-    console.log(cookies);
-    const csrfCookie = cookies.find(
-      (cookie) => cookie.name === CSRF_COOKIE_NAME,
-    );
+    const csrfCookie = await swaggerPage.getCsrfCookie();
 
     // The CSRF cookie must NOT be present
     expect(csrfCookie).toBeUndefined();
 
     // Wait for Swagger UI to fully initialize
-    const curlCommandText = await getCurlCommandTextForProcessDefinition(page);
+    await swaggerPage.expectLoaded(10_000);
+    await swaggerPage.openExecuteProcessDefinitionSearchDropdown();
+    const curlCommandText =
+      await swaggerPage.getProcessDefinitionSearchCurlCommandText();
     expect(curlCommandText).not.toMatch(/x-csrf-token\s*:\s*/i);
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/swagger.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/swagger.spec.ts
@@ -92,7 +92,6 @@ const getCurlCommandTextForProcessDefinition = async (page: Page) => {
   await expect(executeButton).toBeVisible({timeout: 10_000});
   await executeButton.click();
 
-  // Validate the generated curl command does not include a CSRF header.
   const curlCommand = processDefinitionOperation.locator(
     '.responses-wrapper .curl-command pre.curl code.language-bash',
   );

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/swagger.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/swagger.spec.ts
@@ -6,18 +6,102 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {expect} from '@playwright/test';
+import {expect, type APIRequestContext, Page} from '@playwright/test';
 import {test} from 'fixtures';
 import {LoginPage} from '@pages/LoginPage';
 import {credentials} from '../../utils/http';
 import {LOGIN_CREDENTIALS} from '../../utils/constants';
 
 const SWAGGER_UI_URL = '/swagger-ui/index.html';
-const API_DOCS_URL = '/v3/api-docs';
+const SWAGGER_CONFIG_URL = '/v3/api-docs/swagger-config';
+const ORCHESTRATION_CLUSTER_API_NAME = 'Orchestration Cluster API';
 const CSRF_COOKIE_NAME = 'X-CSRF-TOKEN';
 const PROCESS_DEFINITION_API_PATH = '/v2/process-definitions/search';
 const SWAGGER_UI_CONTAINER_SELECTOR = 'section.swagger-ui.swagger-container';
 const PROCESS_DEFINITION_OPERATION_SELECTOR = '.opblock.opblock-post';
+
+const collectRefs = (value: unknown): string[] => {
+  if (Array.isArray(value)) {
+    return value.flatMap(collectRefs);
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.entries(value).flatMap(([key, nestedValue]) =>
+      key === '$ref' && typeof nestedValue === 'string'
+        ? [nestedValue, ...collectRefs(nestedValue)]
+        : collectRefs(nestedValue),
+    );
+  }
+
+  return [];
+};
+
+const getGroupedApiDocsUrl = async (request: APIRequestContext) => {
+  const swaggerConfigResponse = await request.get(
+    `${credentials.baseUrl}${SWAGGER_CONFIG_URL}`,
+    {
+      headers: {
+        Accept: 'application/json',
+        Authorization: `Basic ${credentials.accessToken}`,
+      },
+    },
+  );
+
+  expect(swaggerConfigResponse.status()).toBe(200);
+
+  const swaggerConfig = await swaggerConfigResponse.json();
+  const orchestrationClusterApi = swaggerConfig.urls?.find(
+    (entry: {name?: string; url?: string}) =>
+      entry.name === ORCHESTRATION_CLUSTER_API_NAME,
+  );
+
+  expect(orchestrationClusterApi?.url).toBeTruthy();
+
+  return orchestrationClusterApi.url as string;
+};
+
+const getCurlCommandTextForProcessDefinition = async (page: Page) => {
+  await expect(page.locator(SWAGGER_UI_CONTAINER_SELECTOR)).toBeVisible({
+    timeout: 10_000,
+  });
+  await expect(page.locator('.opblock-tag').first()).toBeVisible({
+    timeout: 10_000,
+  });
+
+  // Find the POST /v2/process-definitions/search operation block and expand it
+  const processDefinitionOperation = page
+    .locator(PROCESS_DEFINITION_OPERATION_SELECTOR)
+    .filter({hasText: PROCESS_DEFINITION_API_PATH})
+    .first();
+  await expect(processDefinitionOperation).toBeVisible({timeout: 10_000});
+  // noWaitAfter prevents Playwright from hanging on Swagger UI's hash-navigation
+  // triggered by expanding the operation block.
+  await processDefinitionOperation.click({noWaitAfter: true});
+
+  // Click "Try it out" so Swagger generates the request command preview
+  const tryItOutButton = processDefinitionOperation.getByRole('button', {
+    name: /try it out/i,
+  });
+  await expect(tryItOutButton).toBeVisible({timeout: 10_000});
+  await tryItOutButton.click({noWaitAfter: true});
+
+  // Trigger generation of the curl/response section without inspecting network requests.
+  const executeButton = processDefinitionOperation.getByRole('button', {
+    name: /execute/i,
+  });
+  await expect(executeButton).toBeVisible({timeout: 10_000});
+  await executeButton.click();
+
+  // Validate the generated curl command does not include a CSRF header.
+  const curlCommand = processDefinitionOperation.locator(
+    '.responses-wrapper .curl-command pre.curl code.language-bash',
+  );
+  await expect(curlCommand).toBeVisible({timeout: 10_000});
+  const curlCommandText = await curlCommand.innerText();
+
+  console.log(curlCommandText);
+  return curlCommandText;
+};
 
 test.beforeEach(async ({context}) => {
   // Ensure this scenario is fully unauthenticated even if prior tests logged in.
@@ -38,11 +122,15 @@ test.describe('Swagger UI Tests', () => {
     await expect(firstTag).toBeVisible({timeout: 30_000});
   });
 
-  test('OpenAPI spec endpoint returns valid JSON (not Base64-encoded)', async ({
+  test('Grouped OpenAPI spec returns valid JSON without external file refs', async ({
     request,
   }) => {
+    // given
+    const groupedApiDocsUrl = await getGroupedApiDocsUrl(request);
+
+    // when
     const response = await request.get(
-      `${credentials.baseUrl}${API_DOCS_URL}`,
+      `${credentials.baseUrl}${groupedApiDocsUrl}`,
       {
         headers: {
           Accept: 'application/json',
@@ -51,6 +139,7 @@ test.describe('Swagger UI Tests', () => {
       },
     );
 
+    // then
     expect(response.status()).toBe(200);
 
     const contentType = response.headers()['content-type'];
@@ -58,11 +147,15 @@ test.describe('Swagger UI Tests', () => {
 
     const body = await response.json();
 
-    // Verify the spec has the expected OpenAPI structure (not a Base64 string)
     expect(typeof body).toBe('object');
     expect(body).toHaveProperty('openapi');
     expect(body).toHaveProperty('info');
     expect(body).toHaveProperty('paths');
+
+    const refs = collectRefs(body);
+    const externalFileRefs = refs.filter((ref) => ref.includes('.yaml#'));
+
+    expect(externalFileRefs).toEqual([]);
   });
 
   test('CSRF token is filled in and Swagger UI is accessible with CSRF token', async ({
@@ -93,45 +186,7 @@ test.describe('Swagger UI Tests', () => {
     expect(csrfCookie!.value.length).toBeGreaterThan(0);
 
     // Wait for Swagger UI to fully initialize
-    await expect(page.locator(SWAGGER_UI_CONTAINER_SELECTOR)).toBeVisible({
-      timeout: 10_000,
-    });
-    await expect(page.locator('.opblock-tag').first()).toBeVisible({
-      timeout: 10_000,
-    });
-
-    // Find the POST /v2/process-definitions/search operation block and expand it
-    const processDefinitionOperation = page
-      .locator(PROCESS_DEFINITION_OPERATION_SELECTOR)
-      .filter({hasText: PROCESS_DEFINITION_API_PATH})
-      .first();
-    await expect(processDefinitionOperation).toBeVisible({timeout: 10_000});
-    // noWaitAfter prevents Playwright from hanging on Swagger UI's hash-navigation
-    // triggered by expanding the operation block.
-    await processDefinitionOperation.click({noWaitAfter: true});
-
-    // Click "Try it out" so Swagger generates the request command preview
-    const tryItOutButton = processDefinitionOperation.getByRole('button', {
-      name: /try it out/i,
-    });
-    await expect(tryItOutButton).toBeVisible({timeout: 10_000});
-    await tryItOutButton.click({noWaitAfter: true});
-
-    // Trigger generation of the curl/response section without inspecting network requests.
-    const executeButton = processDefinitionOperation.getByRole('button', {
-      name: /execute/i,
-    });
-    await expect(executeButton).toBeVisible({timeout: 10_000});
-    await executeButton.click();
-
-    // Validate the generated curl command does not include a CSRF header.
-    const curlCommand = processDefinitionOperation.locator(
-      '.responses-wrapper .curl-command pre.curl code.language-bash',
-    );
-    await expect(curlCommand).toBeVisible({timeout: 10_000});
-    const curlCommandText = await curlCommand.innerText();
-
-    console.log(curlCommandText);
+    const curlCommandText = await getCurlCommandTextForProcessDefinition(page);
     expect(curlCommandText).toMatch(/x-csrf-token\s*:\s*/i);
     expect(curlCommandText).toMatch(/x-csrf-token\s*:\s*(?!null\b)\S+/i);
   });
@@ -153,45 +208,7 @@ test.describe('Swagger UI Tests', () => {
     expect(csrfCookie).toBeUndefined();
 
     // Wait for Swagger UI to fully initialize
-    await expect(page.locator(SWAGGER_UI_CONTAINER_SELECTOR)).toBeVisible({
-      timeout: 10_000,
-    });
-    await expect(page.locator('.opblock-tag').first()).toBeVisible({
-      timeout: 10_000,
-    });
-
-    // Find the POST /v2/process-definitions/search operation block and expand it
-    const processDefinitionOperation = page
-      .locator(PROCESS_DEFINITION_OPERATION_SELECTOR)
-      .filter({hasText: PROCESS_DEFINITION_API_PATH})
-      .first();
-    await expect(processDefinitionOperation).toBeVisible({timeout: 10_000});
-    // noWaitAfter prevents Playwright from hanging on Swagger UI's hash-navigation
-    // triggered by expanding the operation block.
-    await processDefinitionOperation.click({noWaitAfter: true});
-
-    // Click "Try it out" so Swagger generates the request command preview
-    const tryItOutButton = processDefinitionOperation.getByRole('button', {
-      name: /try it out/i,
-    });
-    await expect(tryItOutButton).toBeVisible({timeout: 10_000});
-    await tryItOutButton.click({noWaitAfter: true});
-
-    // Trigger generation of the curl/response section without inspecting network requests.
-    const executeButton = processDefinitionOperation.getByRole('button', {
-      name: /execute/i,
-    });
-    await expect(executeButton).toBeVisible({timeout: 10_000});
-    await executeButton.click();
-
-    // Validate the generated curl command includes a non-null CSRF header.
-    const curlCommand = processDefinitionOperation.locator(
-      '.responses-wrapper .curl-command pre.curl code.language-bash',
-    );
-    await expect(curlCommand).toBeVisible({timeout: 10_000});
-    const curlCommandText = await curlCommand.innerText();
-
-    console.log(curlCommandText);
+    const curlCommandText = await getCurlCommandTextForProcessDefinition(page);
     expect(curlCommandText).not.toMatch(/x-csrf-token\s*:\s*/i);
   });
 });


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Fixes the Swagger tests for the legacy E2E Operate CI.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #51702
