### PR TITLE
fix: transaction management in DefaultExecutionQueue

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterFactory.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterFactory.java
@@ -31,6 +31,7 @@ import io.camunda.db.rdbms.sql.UsageMetricTUMapper;
 import io.camunda.db.rdbms.sql.UserTaskMapper;
 import io.camunda.db.rdbms.sql.VariableMapper;
 import io.camunda.db.rdbms.write.queue.DefaultExecutionQueue;
+import io.camunda.db.rdbms.write.queue.TransactionRunner;
 import io.camunda.db.rdbms.write.service.ExporterPositionService;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.ibatis.session.SqlSessionFactory;
@@ -62,6 +63,7 @@ public class RdbmsWriterFactory {
   private final CorrelatedMessageSubscriptionMapper correlatedMessageSubscriptionMapper;
   private final ClusterVariableMapper clusterVariableMapper;
   private final HistoryDeletionMapper historyDeletionMapper;
+  private final TransactionRunner transactionRunner;
 
   public RdbmsWriterFactory(
       final SqlSessionFactory sqlSessionFactory,
@@ -88,7 +90,8 @@ public class RdbmsWriterFactory {
       final MessageSubscriptionMapper messageSubscriptionMapper,
       final CorrelatedMessageSubscriptionMapper correlatedMessageSubscriptionMapper,
       final ClusterVariableMapper clusterVariableMapper,
-      final HistoryDeletionMapper historyDeletionMapper) {
+      final HistoryDeletionMapper historyDeletionMapper,
+      final TransactionRunner transactionRunner) {
     this.sqlSessionFactory = sqlSessionFactory;
     this.exporterPositionMapper = exporterPositionMapper;
     this.vendorDatabaseProperties = vendorDatabaseProperties;
@@ -114,6 +117,7 @@ public class RdbmsWriterFactory {
     this.correlatedMessageSubscriptionMapper = correlatedMessageSubscriptionMapper;
     this.clusterVariableMapper = clusterVariableMapper;
     this.historyDeletionMapper = historyDeletionMapper;
+    this.transactionRunner = transactionRunner;
   }
 
   public RdbmsWriters createWriter(final RdbmsWriterConfig config) {
@@ -124,7 +128,8 @@ public class RdbmsWriterFactory {
             config.partitionId(),
             config.queueSize(),
             config.queueMemoryLimit(),
-            metrics);
+            metrics,
+            transactionRunner);
     return new RdbmsWriters(
         config,
         executionQueue,

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueue.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueue.java
@@ -255,7 +255,6 @@ public class DefaultExecutionQueue implements ExecutionQueue {
       for (final var entry : optimizedItems) {
         LOG.trace("[RDBMS ExecutionQueue, Partition {}] Executing entry: {}", partitionId, entry);
         session.update(entry.statementId(), entry.parameter());
-        queue.remove();
         flushedElements++;
       }
 
@@ -274,6 +273,7 @@ public class DefaultExecutionQueue implements ExecutionQueue {
       }
 
       session.commit();
+      queue.clear();
       if (!postFlushListeners.isEmpty()) {
         LOG.trace("[RDBMS ExecutionQueue, Partition {}] Call post flush listeners", partitionId);
         postFlushListeners.forEach(PostFlushListener::onPostFlush);

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueue.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueue.java
@@ -43,6 +43,7 @@ public class DefaultExecutionQueue implements ExecutionQueue {
           Pattern.compile("io.camunda.db.rdbms.sql.BatchOperationMapper.activate"));
 
   private final SqlSessionFactory sessionFactory;
+  private final TransactionRunner transactionRunner;
   private final List<PreFlushListener> preFlushListeners = new ArrayList<>();
   private final List<PostFlushListener> postFlushListeners = new ArrayList<>();
   private final List<InTransactionHook> inTransactionHooks = new ArrayList<>();
@@ -63,13 +64,15 @@ public class DefaultExecutionQueue implements ExecutionQueue {
       final long partitionId,
       final int queueFlushLimit,
       final int queueMemoryLimitMb,
-      final RdbmsWriterMetrics metrics) {
+      final RdbmsWriterMetrics metrics,
+      final TransactionRunner transactionRunner) {
     this.sessionFactory = sessionFactory;
     this.partitionId = partitionId;
     this.queueFlushLimit = queueFlushLimit;
     // Convert MB to bytes for internal comparison
     queueMemoryLimitBytes = (long) queueMemoryLimitMb * BYTES_PER_MB;
     this.metrics = metrics;
+    this.transactionRunner = transactionRunner;
   }
 
   @Override
@@ -136,7 +139,7 @@ public class DefaultExecutionQueue implements ExecutionQueue {
       try (final var ignored = metrics.measureFlushDuration()) {
         // Record memory usage before flush
         metrics.recordQueueMemoryUsage(currentQueueMemoryBytes);
-        final int numFlushedElements = doFLush();
+        final int numFlushedElements = transactionRunner.runInTransaction(this::doFLush);
         metrics.stopFlushLatencyMeasurement();
         metrics.recordBulkSize(numFlushedElements);
         // Reset memory tracking after flush
@@ -236,7 +239,7 @@ public class DefaultExecutionQueue implements ExecutionQueue {
     final var startMillis = System.currentTimeMillis();
 
     final var session =
-        sessionFactory.openSession(ExecutorType.BATCH, TransactionIsolationLevel.READ_UNCOMMITTED);
+        sessionFactory.openSession(ExecutorType.BATCH, TransactionIsolationLevel.READ_COMMITTED);
 
     var flushedElements = 0;
     final var optimizedItems = optimizeQueueOrder(queue);

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/TransactionRunner.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/TransactionRunner.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.queue;
+
+import java.util.function.Supplier;
+
+@FunctionalInterface
+public interface TransactionRunner {
+
+  <T> T runInTransaction(Supplier<T> callback);
+
+  static TransactionRunner noop() {
+    return Supplier::get;
+  }
+}

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueueTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueueTest.java
@@ -42,10 +42,11 @@ class DefaultExecutionQueueTest {
     sqlSessionFactory = mock(SqlSessionFactory.class);
     metrics = mock(RdbmsWriterMetrics.class);
     when(sqlSessionFactory.openSession(
-            ExecutorType.BATCH, TransactionIsolationLevel.READ_UNCOMMITTED))
+            ExecutorType.BATCH, TransactionIsolationLevel.READ_COMMITTED))
         .thenReturn(session);
 
-    executionQueue = new DefaultExecutionQueue(sqlSessionFactory, 1, 10, 0, metrics);
+    executionQueue =
+        new DefaultExecutionQueue(sqlSessionFactory, 1, 10, 0, metrics, TransactionRunner.noop());
   }
 
   @Test
@@ -57,7 +58,8 @@ class DefaultExecutionQueueTest {
 
   @Test
   public void whenElementIsAddedNoFlushHappens() {
-    executionQueue = new DefaultExecutionQueue(sqlSessionFactory, 1, 0, 0, metrics);
+    executionQueue =
+        new DefaultExecutionQueue(sqlSessionFactory, 1, 0, 0, metrics, TransactionRunner.noop());
 
     executionQueue.executeInQueue(mock(QueueItem.class));
 
@@ -66,7 +68,8 @@ class DefaultExecutionQueueTest {
 
   @Test
   public void whenFlushLimitIsZeroFlushShouldNotHappenAfterCheck() {
-    executionQueue = new DefaultExecutionQueue(sqlSessionFactory, 1, 0, 0, metrics);
+    executionQueue =
+        new DefaultExecutionQueue(sqlSessionFactory, 1, 0, 0, metrics, TransactionRunner.noop());
     final var item1 =
         new QueueItem(
             ContextType.PROCESS_INSTANCE,
@@ -86,7 +89,8 @@ class DefaultExecutionQueueTest {
 
   @Test
   public void whenFlushLimitIsNotActivatedFlushShouldNotHappenAfterCheck() {
-    executionQueue = new DefaultExecutionQueue(sqlSessionFactory, 1, 3, 0, metrics);
+    executionQueue =
+        new DefaultExecutionQueue(sqlSessionFactory, 1, 3, 0, metrics, TransactionRunner.noop());
     final var item1 =
         new QueueItem(
             ContextType.PROCESS_INSTANCE,
@@ -106,7 +110,8 @@ class DefaultExecutionQueueTest {
 
   @Test
   public void whenFlushLimitIsActivatedFlushShouldHappenAfterCheck() {
-    executionQueue = new DefaultExecutionQueue(sqlSessionFactory, 1, 3, 0, metrics);
+    executionQueue =
+        new DefaultExecutionQueue(sqlSessionFactory, 1, 3, 0, metrics, TransactionRunner.noop());
     final var item1 =
         new QueueItem(
             ContextType.PROCESS_INSTANCE,
@@ -138,7 +143,7 @@ class DefaultExecutionQueueTest {
     assertThat(result).isTrue();
 
     verify(sqlSessionFactory)
-        .openSession(ExecutorType.BATCH, TransactionIsolationLevel.READ_UNCOMMITTED);
+        .openSession(ExecutorType.BATCH, TransactionIsolationLevel.READ_COMMITTED);
     verify(session).update("statement1", "parameter1");
     verify(session).update("statement2", "parameter2");
     verify(session).flushStatements();
@@ -160,7 +165,7 @@ class DefaultExecutionQueueTest {
     executionQueue.flush();
 
     verify(sqlSessionFactory)
-        .openSession(ExecutorType.BATCH, TransactionIsolationLevel.READ_UNCOMMITTED);
+        .openSession(ExecutorType.BATCH, TransactionIsolationLevel.READ_COMMITTED);
     verify(session).update("statement1", "parameter1");
     verify(session).flushStatements();
     verify(session).commit();
@@ -559,7 +564,8 @@ class DefaultExecutionQueueTest {
   @Test
   public void whenMemoryLimitIsReachedFlushShouldHappen() {
     // Set a small memory limit (1 MB)
-    executionQueue = new DefaultExecutionQueue(sqlSessionFactory, 1, 1000, 1, metrics);
+    executionQueue =
+        new DefaultExecutionQueue(sqlSessionFactory, 1, 1000, 1, metrics, TransactionRunner.noop());
 
     // Create items with large parameters to exceed 1 MB memory limit
     // Each large param is ~600KB, so 2 items should exceed 1 MB
@@ -582,7 +588,7 @@ class DefaultExecutionQueueTest {
     assertThat(result).isTrue();
 
     verify(sqlSessionFactory)
-        .openSession(ExecutorType.BATCH, TransactionIsolationLevel.READ_UNCOMMITTED);
+        .openSession(ExecutorType.BATCH, TransactionIsolationLevel.READ_COMMITTED);
     verify(session).update("statement1", largeParam);
     verify(session).update("statement2", largeParam);
     verify(session).flushStatements();
@@ -592,7 +598,9 @@ class DefaultExecutionQueueTest {
   @Test
   public void whenMemoryLimitIsNotReachedNoFlushShouldHappen() {
     // Set a large memory limit (10 MB)
-    executionQueue = new DefaultExecutionQueue(sqlSessionFactory, 1, 1000, 10, metrics);
+    executionQueue =
+        new DefaultExecutionQueue(
+            sqlSessionFactory, 1, 1000, 10, metrics, TransactionRunner.noop());
 
     final var item1 =
         new QueueItem(
@@ -614,7 +622,8 @@ class DefaultExecutionQueueTest {
   @Test
   public void whenEitherCountOrMemoryLimitIsReachedFlushShouldHappen() {
     // Set both count and memory limits (2 items count, 10 MB memory)
-    executionQueue = new DefaultExecutionQueue(sqlSessionFactory, 1, 2, 10, metrics);
+    executionQueue =
+        new DefaultExecutionQueue(sqlSessionFactory, 1, 2, 10, metrics, TransactionRunner.noop());
 
     final var item1 =
         new QueueItem(
@@ -650,13 +659,14 @@ class DefaultExecutionQueueTest {
     assertThat(result).isTrue();
 
     verify(sqlSessionFactory)
-        .openSession(ExecutorType.BATCH, TransactionIsolationLevel.READ_UNCOMMITTED);
+        .openSession(ExecutorType.BATCH, TransactionIsolationLevel.READ_COMMITTED);
   }
 
   @Test
   public void whenOnlyMemoryLimitIsConfiguredItShouldWork() {
     // Set only memory limit (1 MB), no count limit
-    executionQueue = new DefaultExecutionQueue(sqlSessionFactory, 1, 0, 1, metrics);
+    executionQueue =
+        new DefaultExecutionQueue(sqlSessionFactory, 1, 0, 1, metrics, TransactionRunner.noop());
 
     // Create items with large parameters to exceed 1 MB memory limit
     final var largeParam = "x".repeat(600_000); // ~600 KB each
@@ -674,6 +684,6 @@ class DefaultExecutionQueueTest {
     assertThat(result).isTrue();
 
     verify(sqlSessionFactory)
-        .openSession(ExecutorType.BATCH, TransactionIsolationLevel.READ_UNCOMMITTED);
+        .openSession(ExecutorType.BATCH, TransactionIsolationLevel.READ_COMMITTED);
   }
 }

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -560,6 +560,11 @@
       </exclusions>
     </dependency>
 
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-tx</artifactId>
+    </dependency>
+
     <!-- Micrometer backend/implementations -->
     <dependency>
       <groupId>io.micrometer</groupId>

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
@@ -63,11 +63,12 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration;
+import org.springframework.boot.jdbc.autoconfigure.DataSourceTransactionManagerAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 
-@Import(DataSourceAutoConfiguration.class)
+@Import({DataSourceAutoConfiguration.class, DataSourceTransactionManagerAutoConfiguration.class})
 public class MyBatisConfiguration {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(MyBatisConfiguration.class);

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
@@ -89,6 +89,7 @@ import io.camunda.db.rdbms.sql.UserMapper;
 import io.camunda.db.rdbms.sql.UserTaskMapper;
 import io.camunda.db.rdbms.sql.VariableMapper;
 import io.camunda.db.rdbms.write.RdbmsWriterFactory;
+import io.camunda.db.rdbms.write.queue.TransactionRunner;
 import io.camunda.db.rdbms.write.service.PersistentWebSessionWriter;
 import io.camunda.search.clients.reader.ProcessDefinitionMessageSubscriptionStatisticsReader;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -99,11 +100,14 @@ import org.apache.ibatis.session.SqlSessionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.health.contributor.HealthContributor;
 import org.springframework.boot.jdbc.health.DataSourceHealthIndicator;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.transaction.PlatformTransactionManager;
 
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnSecondaryStorageType(SecondaryStorageType.rdbms)
@@ -397,6 +401,19 @@ public class RdbmsConfiguration {
   }
 
   @Bean
+  @ConditionalOnBean(PlatformTransactionManager.class)
+  public TransactionRunner springTransactionRunner(
+      final PlatformTransactionManager transactionManager) {
+    return new SpringTransactionRunner(transactionManager);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(TransactionRunner.class)
+  public TransactionRunner noOpTransactionRunner() {
+    return TransactionRunner.noop();
+  }
+
+  @Bean
   public RdbmsWriterFactory rdbmsWriterFactory(
       final SqlSessionFactory sqlSessionFactory,
       final ExporterPositionMapper exporterPositionMapper,
@@ -422,7 +439,8 @@ public class RdbmsConfiguration {
       final MessageSubscriptionMapper messageSubscriptionMapper,
       final CorrelatedMessageSubscriptionMapper correlatedMessageSubscriptionMapper,
       final ClusterVariableMapper clusterVariableMapper,
-      final HistoryDeletionMapper historyDeletionMapper) {
+      final HistoryDeletionMapper historyDeletionMapper,
+      final TransactionRunner transactionRunner) {
     return new RdbmsWriterFactory(
         sqlSessionFactory,
         exporterPositionMapper,
@@ -448,7 +466,8 @@ public class RdbmsConfiguration {
         messageSubscriptionMapper,
         correlatedMessageSubscriptionMapper,
         clusterVariableMapper,
-        historyDeletionMapper);
+        historyDeletionMapper,
+        transactionRunner);
   }
 
   @Bean

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/SpringTransactionRunner.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/SpringTransactionRunner.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.rdbms;
+
+import io.camunda.db.rdbms.write.queue.TransactionRunner;
+import java.util.function.Supplier;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
+
+public final class SpringTransactionRunner implements TransactionRunner {
+
+  private final TransactionTemplate transactionTemplate;
+
+  public SpringTransactionRunner(final PlatformTransactionManager transactionManager) {
+    transactionTemplate = new TransactionTemplate(transactionManager);
+    // Explicitly request READ_COMMITTED since SpringManagedTransactionFactory ignores
+    // the isolation level hint passed to SqlSessionFactory.openSession().
+    transactionTemplate.setIsolationLevel(TransactionDefinition.ISOLATION_READ_COMMITTED);
+  }
+
+  @Override
+  public <T> T runInTransaction(final Supplier<T> callback) {
+    return transactionTemplate.execute(ignored -> callback.get());
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/RdbmsFlushRollbackIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/RdbmsFlushRollbackIT.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db;
+
+import static io.camunda.it.rdbms.db.fixtures.AuditLogFixtures.createRandomized;
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.resourceAccessChecksFromTenantIds;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.read.service.FlowNodeInstanceDbReader;
+import io.camunda.db.rdbms.write.RdbmsWriters;
+import io.camunda.it.rdbms.db.fixtures.FlowNodeInstanceFixtures;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+/**
+ * Integration test to verify that DefaultExecutionQueue with JdbcTransactionFactory ensures atomic
+ * batch flush behavior. When statements are batched and flushed, they should either all commit or
+ * all rollback to maintain data integrity.
+ *
+ * <p>This test uses the actual RDBMS infrastructure (H2 by default) to verify that the
+ * JdbcTransactionFactory correctly provides transaction isolation for batch operations in the
+ * execution queue.
+ */
+@Tag("rdbms")
+public class RdbmsFlushRollbackIT {
+
+  @RegisterExtension
+  static final CamundaRdbmsInvocationContextProviderExtension TEST_APPLICATIONS =
+      new CamundaRdbmsInvocationContextProviderExtension("camundaWithH2");
+
+  private static final int PARTITION_ID = 0;
+
+  @TestTemplate
+  void shouldRollbackAllStatementsWhenSecondStatementFails(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final FlowNodeInstanceDbReader flowNodeInstanceReader =
+        rdbmsService.getFlowNodeInstanceReader();
+
+    final var duplicateAuditLogKey = "atomicity-duplicate-key";
+    final var firstAuditLog = createRandomized(b -> b.auditLogKey(duplicateAuditLogKey));
+    final var flowNodeInstance = FlowNodeInstanceFixtures.createRandomized(b -> b);
+
+    rdbmsWriters.getAuditLogWriter().create(firstAuditLog);
+    rdbmsWriters.flush();
+
+    rdbmsWriters.getAuditLogWriter().create(firstAuditLog);
+    rdbmsWriters.getFlowNodeInstanceWriter().create(flowNodeInstance);
+
+    // when
+    assertThatThrownBy(rdbmsWriters::flush).isInstanceOf(Exception.class);
+
+    // then
+    assertThat(
+            flowNodeInstanceReader.getByKey(
+                flowNodeInstance.flowNodeInstanceKey(), resourceAccessChecksFromTenantIds()))
+        .isNull();
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/RdbmsFlushRollbackIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/RdbmsFlushRollbackIT.java
@@ -23,12 +23,12 @@ import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
- * Integration test to verify that DefaultExecutionQueue with JdbcTransactionFactory ensures atomic
+ * Integration test to verify that DefaultExecutionQueue with a TransactionRunner ensures atomic
  * batch flush behavior. When statements are batched and flushed, they should either all commit or
  * all rollback to maintain data integrity.
  *
  * <p>This test uses the actual RDBMS infrastructure (H2 by default) to verify that the
- * JdbcTransactionFactory correctly provides transaction isolation for batch operations in the
+ * SpringTransactionRunner correctly provides transaction isolation for batch operations in the
  * execution queue.
  */
 @Tag("rdbms")
@@ -60,7 +60,7 @@ public class RdbmsFlushRollbackIT {
     rdbmsWriters.getFlowNodeInstanceWriter().create(flowNodeInstance);
 
     // when
-    assertThatThrownBy(rdbmsWriters::flush).isInstanceOf(Exception.class);
+    assertThatThrownBy(rdbmsWriters::flush).hasMessageContaining(duplicateAuditLogKey);
 
     // then
     assertThat(


### PR DESCRIPTION
This pull request introduces transactional support for batch flush operations in the `DefaultExecutionQueue` by integrating a new `TransactionRunner` abstraction. This ensures that all batched statements are executed atomically—either all succeed or all are rolled back on failure. Additionally, the transaction isolation level is raised from `READ_UNCOMMITTED` to `READ_COMMITTED` for improved data integrity. The changes are covered by a new integration test and corresponding updates to the test suite.

**Transactional batch execution and improved isolation:**

* Introduced the `TransactionRunner` interface to encapsulate transaction management, and updated `DefaultExecutionQueue` to use it for the `flush()` operation, ensuring atomicity of batch writes. (`DefaultExecutionQueue.java`, `TransactionRunner.java`, `RdbmsWriterFactory.java`) [[1]](diffhunk://#diff-478819beacfd753ea541e594ef13ac663d31dc002dfd3ab75dd1d0354cf8b1a5L138-R141) [[2]](diffhunk://#diff-1b1c3840f52fbbf10b022bfcabb5387d304eabcbe2d5c2219dfaca68d38dd57bR1-R20) [[3]](diffhunk://#diff-1e2289824087f4a8e7786a1984ea655d228b0650d349d6a558ce3592337b2abfL131-R136)
* Changed the transaction isolation level for batch operations from `READ_UNCOMMITTED` to `READ_COMMITTED` to prevent dirty reads and improve data consistency. (`DefaultExecutionQueue.java`, `DefaultExecutionQueueTest.java`) [[1]](diffhunk://#diff-478819beacfd753ea541e594ef13ac663d31dc002dfd3ab75dd1d0354cf8b1a5L238-R241) [[2]](diffhunk://#diff-fbb7602830667fb6180fcddf7bd6dec20b54c3369bf1f802060a0e01791f1157L45-R49) [[3]](diffhunk://#diff-fbb7602830667fb6180fcddf7bd6dec20b54c3369bf1f802060a0e01791f1157L141-R146) [[4]](diffhunk://#diff-fbb7602830667fb6180fcddf7bd6dec20b54c3369bf1f802060a0e01791f1157L163-R168) [[5]](diffhunk://#diff-fbb7602830667fb6180fcddf7bd6dec20b54c3369bf1f802060a0e01791f1157L585-R591) [[6]](diffhunk://#diff-fbb7602830667fb6180fcddf7bd6dec20b54c3369bf1f802060a0e01791f1157L677-R687)

**Factory and test updates:**

* Updated `RdbmsWriterFactory` and all related test cases to accept and propagate the new `TransactionRunner` dependency. (`RdbmsWriterFactory.java`, `DefaultExecutionQueueTest.java`) [[1]](diffhunk://#diff-1e2289824087f4a8e7786a1984ea655d228b0650d349d6a558ce3592337b2abfR35) [[2]](diffhunk://#diff-1e2289824087f4a8e7786a1984ea655d228b0650d349d6a558ce3592337b2abfR68) [[3]](diffhunk://#diff-1e2289824087f4a8e7786a1984ea655d228b0650d349d6a558ce3592337b2abfL94-R97) [[4]](diffhunk://#diff-1e2289824087f4a8e7786a1984ea655d228b0650d349d6a558ce3592337b2abfR124) [[5]](diffhunk://#diff-fbb7602830667fb6180fcddf7bd6dec20b54c3369bf1f802060a0e01791f1157L60-R62) [[6]](diffhunk://#diff-fbb7602830667fb6180fcddf7bd6dec20b54c3369bf1f802060a0e01791f1157L69-R72) [[7]](diffhunk://#diff-fbb7602830667fb6180fcddf7bd6dec20b54c3369bf1f802060a0e01791f1157L89-R93) [[8]](diffhunk://#diff-fbb7602830667fb6180fcddf7bd6dec20b54c3369bf1f802060a0e01791f1157L109-R114) [[9]](diffhunk://#diff-fbb7602830667fb6180fcddf7bd6dec20b54c3369bf1f802060a0e01791f1157L562-R568) [[10]](diffhunk://#diff-fbb7602830667fb6180fcddf7bd6dec20b54c3369bf1f802060a0e01791f1157L595-R603) [[11]](diffhunk://#diff-fbb7602830667fb6180fcddf7bd6dec20b54c3369bf1f802060a0e01791f1157L617-R626) [[12]](diffhunk://#diff-fbb7602830667fb6180fcddf7bd6dec20b54c3369bf1f802060a0e01791f1157L653-R669)

**Integration test for atomicity:**

* Added a new integration test `RdbmsFlushRollbackIT` to verify that the execution queue correctly rolls back all statements if any statement in a batch fails, ensuring transactional atomicity. (`RdbmsFlushRollbackIT.java`)