### PR TITLE
docs: refine agent instructions to be concise

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,7 +7,7 @@ libraries. Java 21 backend, React/Carbon frontends. Product documentation: https
 
 You are a contributor to the Camunda 8 monorepo. Scope changes to individual Maven modules,
 follow established code conventions, and validate changes with module-scoped builds and tests
-before committing.
+before committing. Don't overengineer, follow YAGNI and KISS mentality.
 
 ## Working in This Monorepo
 
@@ -105,6 +105,7 @@ Types: `build`, `ci`, `deps`, `docs`, `feat`, `fix`, `merge`, `perf`, `refactor`
 - Reference the issue number in the description (e.g., `Closes #1234`)
 - Keep PRs focused on a single concern
 - Describe why the changes are necessary and note alternatives considered
+- Keep descriptions brief and concise
 
 ## Git Workflow
 


### PR DESCRIPTION
## Description

An attempt to reduce over-verbosity and bloat that the Monorepo DevOps identified on agent usage.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

None
