### PR TITLE
test: fix optimize IT setup

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/ZeebeExtension.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/ZeebeExtension.java
@@ -123,14 +123,8 @@ public class ZeebeExtension implements BeforeEachCallback, AfterEachCallback {
                       Map.of("prefix", zeebeRecordPrefix),
                       "bulk",
                       Map.of("size", 1),
-                      "connect",
-                      Map.of(
-                          "url",
-                          "http://localhost:9200",
-                          "indexPrefix",
-                          zeebeRecordPrefix,
-                          "type",
-                          dbType.toString())));
+                      "url",
+                      "http://localhost:9200"));
             })
         .withCreateSchema(true)
         .withAdditionalProperties(


### PR DESCRIPTION
Now the config is more strictly enforced this was breaking due to it providing properties that are not actually used.

https://github.com/camunda/camunda/pull/51401 was the change that added `@StrictConfiguration` and broke the tests.