### PR TITLE
perf: cache resolved CamundaAuthentication per JWT token in DefaultCamundaAuthenticationProvider

### DIFF
--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -183,6 +183,10 @@
       <artifactId>spring-security-oauth2-jose</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
       <scope>test</scope>

--- a/authentication/src/main/java/io/camunda/authentication/DefaultCamundaAuthenticationProvider.java
+++ b/authentication/src/main/java/io/camunda/authentication/DefaultCamundaAuthenticationProvider.java
@@ -18,7 +18,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Optional;
-import org.checkerframework.checker.index.qual.NonNegative;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.core.Authentication;
@@ -27,14 +26,14 @@ import org.springframework.security.oauth2.server.resource.authentication.Abstra
 
 public class DefaultCamundaAuthenticationProvider implements CamundaAuthenticationProvider {
 
-  private static final Logger LOG =
-      LoggerFactory.getLogger(DefaultCamundaAuthenticationProvider.class);
-
   /** Maximum TTL for a cache entry even if the token's own expiry is further in the future. */
   static final Duration MAX_CACHE_TTL = Duration.ofHours(24);
 
   /** Fallback TTL when the token carries no expiry claim. */
   static final Duration DEFAULT_CACHE_TTL = Duration.ofMinutes(5);
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(DefaultCamundaAuthenticationProvider.class);
 
   private final CamundaAuthenticationHolder holder;
   private final CamundaAuthenticationConverter<Authentication> converter;
@@ -59,9 +58,7 @@ public class DefaultCamundaAuthenticationProvider implements CamundaAuthenticati
                 new Expiry<String, CamundaAuthentication>() {
                   @Override
                   public long expireAfterCreate(
-                      final String key,
-                      final CamundaAuthentication value,
-                      final long currentTime) {
+                      final String key, final CamundaAuthentication value, final long currentTime) {
                     return computeTtlNanos(key);
                   }
 
@@ -70,7 +67,7 @@ public class DefaultCamundaAuthenticationProvider implements CamundaAuthenticati
                       final String key,
                       final CamundaAuthentication value,
                       final long currentTime,
-                      @NonNegative final long currentDuration) {
+                      final long currentDuration) {
                     return currentDuration;
                   }
 
@@ -79,7 +76,7 @@ public class DefaultCamundaAuthenticationProvider implements CamundaAuthenticati
                       final String key,
                       final CamundaAuthentication value,
                       final long currentTime,
-                      @NonNegative final long currentDuration) {
+                      final long currentDuration) {
                     return currentDuration;
                   }
                 })
@@ -107,11 +104,16 @@ public class DefaultCamundaAuthenticationProvider implements CamundaAuthenticati
     }
 
     // 2. Resolve — use the cross-request cache for OIDC bearer tokens only
-    final CamundaAuthentication result;
-    if (springBasedAuthentication
-        instanceof AbstractOAuth2TokenAuthenticationToken<?> oidcToken) {
+    CamundaAuthentication result;
+    if (springBasedAuthentication instanceof AbstractOAuth2TokenAuthenticationToken<?> oidcToken) {
       final var tokenValue = oidcToken.getToken().getTokenValue();
-      result = tokenCache.get(tokenValue, k -> converter.convert(springBasedAuthentication));
+      result = tokenCache.getIfPresent(tokenValue);
+      if (result == null) {
+        result = converter.convert(springBasedAuthentication);
+        if (result != null) {
+          tokenCache.put(tokenValue, result);
+        }
+      }
     } else {
       result = converter.convert(springBasedAuthentication);
     }

--- a/authentication/src/main/java/io/camunda/authentication/DefaultCamundaAuthenticationProvider.java
+++ b/authentication/src/main/java/io/camunda/authentication/DefaultCamundaAuthenticationProvider.java
@@ -7,36 +7,121 @@
  */
 package io.camunda.authentication;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Expiry;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.CamundaAuthenticationConverter;
 import io.camunda.security.auth.CamundaAuthenticationHolder;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Optional;
+import org.checkerframework.checker.index.qual.NonNegative;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.server.resource.authentication.AbstractOAuth2TokenAuthenticationToken;
 
 public class DefaultCamundaAuthenticationProvider implements CamundaAuthenticationProvider {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(DefaultCamundaAuthenticationProvider.class);
 
+  /** Maximum TTL for a cache entry even if the token's own expiry is further in the future. */
+  static final Duration MAX_CACHE_TTL = Duration.ofHours(24);
+
+  /** Fallback TTL when the token carries no expiry claim. */
+  static final Duration DEFAULT_CACHE_TTL = Duration.ofMinutes(5);
+
   private final CamundaAuthenticationHolder holder;
   private final CamundaAuthenticationConverter<Authentication> converter;
+
+  /**
+   * Cross-request cache: raw JWT token string → resolved CamundaAuthentication.
+   *
+   * <p>Keyed by the raw Bearer token value so that M2M clients reusing the same JWT across many
+   * requests skip all 4 membership DB queries after the first resolution. Each entry expires when
+   * the token itself expires (capped at {@link #MAX_CACHE_TTL}).
+   */
+  private final Cache<String, CamundaAuthentication> tokenCache;
 
   public DefaultCamundaAuthenticationProvider(
       final CamundaAuthenticationHolder holder,
       final CamundaAuthenticationConverter<Authentication> converter) {
     this.holder = holder;
     this.converter = converter;
+    this.tokenCache =
+        Caffeine.newBuilder()
+            .expireAfter(
+                new Expiry<String, CamundaAuthentication>() {
+                  @Override
+                  public long expireAfterCreate(
+                      final String key,
+                      final CamundaAuthentication value,
+                      final long currentTime) {
+                    return computeTtlNanos(key);
+                  }
+
+                  @Override
+                  public long expireAfterUpdate(
+                      final String key,
+                      final CamundaAuthentication value,
+                      final long currentTime,
+                      @NonNegative final long currentDuration) {
+                    return currentDuration;
+                  }
+
+                  @Override
+                  public long expireAfterRead(
+                      final String key,
+                      final CamundaAuthentication value,
+                      final long currentTime,
+                      @NonNegative final long currentDuration) {
+                    return currentDuration;
+                  }
+                })
+            .build();
+  }
+
+  /** Package-private constructor for tests that supply a pre-built cache instance. */
+  DefaultCamundaAuthenticationProvider(
+      final CamundaAuthenticationHolder holder,
+      final CamundaAuthenticationConverter<Authentication> converter,
+      final Cache<String, CamundaAuthentication> tokenCache) {
+    this.holder = holder;
+    this.converter = converter;
+    this.tokenCache = tokenCache;
   }
 
   @Override
   public CamundaAuthentication getCamundaAuthentication() {
     final var springBasedAuthentication = SecurityContextHolder.getContext().getAuthentication();
-    return getFromHolderIfPresent(springBasedAuthentication)
-        .orElseGet(() -> convertAndSetInHolder(springBasedAuthentication));
+
+    // 1. Check per-request holder first — cheapest path, no allocations
+    final var holderResult = getFromHolderIfPresent(springBasedAuthentication);
+    if (holderResult.isPresent()) {
+      return holderResult.get();
+    }
+
+    // 2. Resolve — use the cross-request cache for OIDC bearer tokens only
+    final CamundaAuthentication result;
+    if (springBasedAuthentication
+        instanceof AbstractOAuth2TokenAuthenticationToken<?> oidcToken) {
+      final var tokenValue = oidcToken.getToken().getTokenValue();
+      result = tokenCache.get(tokenValue, k -> converter.convert(springBasedAuthentication));
+    } else {
+      result = converter.convert(springBasedAuthentication);
+    }
+
+    LOG.debug("Resolved camunda authentication: {}", result);
+
+    // 3. Populate the per-request holder so intra-request subsequent calls are free
+    Optional.ofNullable(result).filter(a -> !a.isAnonymous()).ifPresent(holder::set);
+
+    return result;
   }
 
   private Optional<CamundaAuthentication> getFromHolderIfPresent(
@@ -44,10 +129,23 @@ public class DefaultCamundaAuthenticationProvider implements CamundaAuthenticati
     return Optional.ofNullable(authentication).map(principal -> holder.get());
   }
 
-  private CamundaAuthentication convertAndSetInHolder(final Authentication authentication) {
-    final var result = converter.convert(authentication);
-    LOG.debug("Created camunda authentication: {}", result);
-    Optional.ofNullable(result).filter(a -> !a.isAnonymous()).ifPresent(p -> holder.set(result));
-    return result;
+  /**
+   * Returns the Caffeine TTL in nanoseconds for the given raw token value.
+   *
+   * <p>Called synchronously from {@code expireAfterCreate} while the loading thread's
+   * SecurityContext still holds the JWT being cached, so the expiresAt can be read directly.
+   */
+  private static long computeTtlNanos(final String tokenValue) {
+    final var auth = SecurityContextHolder.getContext().getAuthentication();
+    if (auth instanceof AbstractOAuth2TokenAuthenticationToken<?> oidcToken
+        && oidcToken.getToken().getTokenValue().equals(tokenValue)) {
+      final Instant expiresAt = oidcToken.getToken().getExpiresAt();
+      if (expiresAt != null) {
+        final long remainingNanos = ChronoUnit.NANOS.between(Instant.now(), expiresAt);
+        final long maxNanos = MAX_CACHE_TTL.toNanos();
+        return Math.max(0L, Math.min(remainingNanos, maxNanos));
+      }
+    }
+    return DEFAULT_CACHE_TTL.toNanos();
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/CachingCamundaAuthenticationProviderTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CachingCamundaAuthenticationProviderTest.java
@@ -10,6 +10,7 @@ package io.camunda.authentication;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -77,7 +78,7 @@ class CachingCamundaAuthenticationProviderTest {
   // ── tests ──────────────────────────────────────────────────────────────────
 
   @Test
-  void cacheMissOnFirstCall_delegateConverterIsCalled() {
+  void shouldCallDelegateConverterOnCacheMiss() {
     // given
     final var oidcAuth = jwtAuth("token-aaa");
     SecurityContextHolder.getContext().setAuthentication(oidcAuth);
@@ -93,7 +94,7 @@ class CachingCamundaAuthenticationProviderTest {
   }
 
   @Test
-  void cacheHitOnSecondCall_converterCalledOnlyOnce() {
+  void shouldReturnCachedResultOnSecondCall() {
     // given
     final var oidcAuth = jwtAuth("token-bbb");
     SecurityContextHolder.getContext().setAuthentication(oidcAuth);
@@ -115,7 +116,7 @@ class CachingCamundaAuthenticationProviderTest {
   }
 
   @Test
-  void differentTokens_eachResolvedIndependently() {
+  void shouldResolveEachTokenIndependently() {
     // given
     final var authA = jwtAuth("token-ccc");
     final var authD = jwtAuth("token-ddd");
@@ -141,7 +142,7 @@ class CachingCamundaAuthenticationProviderTest {
   }
 
   @Test
-  void nonOidcAuth_cacheIsBypassed_converterCalledEachTime() {
+  void shouldBypassCacheForNonOidcAuth() {
     // given
     final var basicAuth = nonOidcAuth();
     SecurityContextHolder.getContext().setAuthentication(basicAuth);
@@ -160,7 +161,7 @@ class CachingCamundaAuthenticationProviderTest {
   }
 
   @Test
-  void perRequestHolderPopulatedAfterFirstCall() {
+  void shouldPopulatePerRequestHolderAfterFirstCall() {
     // given
     final var oidcAuth = jwtAuth("token-eee");
     SecurityContextHolder.getContext().setAuthentication(oidcAuth);
@@ -176,7 +177,7 @@ class CachingCamundaAuthenticationProviderTest {
   }
 
   @Test
-  void cacheHit_holderIsStillPopulated() {
+  void shouldPopulateHolderOnCacheHit() {
     // given — prime the cache directly (simulates a previous request having resolved the token)
     final var oidcAuth = jwtAuth("token-fff");
     SecurityContextHolder.getContext().setAuthentication(oidcAuth);
@@ -191,7 +192,7 @@ class CachingCamundaAuthenticationProviderTest {
 
     // then — result served from cache, and holder is populated for intra-request subsequent calls
     assertThat(result).isEqualTo(expected);
-    verify(converter, times(0)).convert(any());
+    verify(converter, never()).convert(any());
     verify(holder).set(expected);
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/CachingCamundaAuthenticationProviderTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CachingCamundaAuthenticationProviderTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import io.camunda.security.auth.CamundaAuthentication;
+import io.camunda.security.auth.CamundaAuthenticationConverter;
+import io.camunda.security.auth.CamundaAuthenticationHolder;
+import java.time.Instant;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+/**
+ * Unit tests for the cross-request caching behaviour in {@link
+ * DefaultCamundaAuthenticationProvider}.
+ */
+class CachingCamundaAuthenticationProviderTest {
+
+  private CamundaAuthenticationHolder holder;
+  private CamundaAuthenticationConverter<Authentication> converter;
+  private Cache<String, CamundaAuthentication> cache;
+  private DefaultCamundaAuthenticationProvider provider;
+
+  @BeforeEach
+  @SuppressWarnings("unchecked")
+  void setUp() {
+    holder = mock(CamundaAuthenticationHolder.class);
+    converter = mock(CamundaAuthenticationConverter.class);
+    // Use a real Caffeine cache with no automatic expiry — tests control invalidation
+    cache = Caffeine.newBuilder().build();
+    provider = new DefaultCamundaAuthenticationProvider(holder, converter, cache);
+    SecurityContextHolder.clearContext();
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  // ── helpers ────────────────────────────────────────────────────────────────
+
+  private static JwtAuthenticationToken jwtAuth(final String tokenValue) {
+    final Jwt jwt =
+        Jwt.withTokenValue(tokenValue)
+            .header("alg", "RS256")
+            .claim("sub", "client-id")
+            .expiresAt(Instant.now().plusSeconds(300))
+            .issuedAt(Instant.now().minusSeconds(60))
+            .build();
+    return new JwtAuthenticationToken(jwt);
+  }
+
+  private static Authentication nonOidcAuth() {
+    final var auth = mock(Authentication.class);
+    when(auth.getPrincipal()).thenReturn("basic-user");
+    return auth;
+  }
+
+  // ── tests ──────────────────────────────────────────────────────────────────
+
+  @Test
+  void cacheMissOnFirstCall_delegateConverterIsCalled() {
+    // given
+    final var oidcAuth = jwtAuth("token-aaa");
+    SecurityContextHolder.getContext().setAuthentication(oidcAuth);
+    final var expected = CamundaAuthentication.of(b -> b.clientId("client-id"));
+    when(converter.convert(oidcAuth)).thenReturn(expected);
+
+    // when
+    final var result = provider.getCamundaAuthentication();
+
+    // then
+    assertThat(result).isEqualTo(expected);
+    verify(converter, times(1)).convert(oidcAuth);
+  }
+
+  @Test
+  void cacheHitOnSecondCall_converterCalledOnlyOnce() {
+    // given
+    final var oidcAuth = jwtAuth("token-bbb");
+    SecurityContextHolder.getContext().setAuthentication(oidcAuth);
+    final var expected = CamundaAuthentication.of(b -> b.clientId("client-id"));
+    when(converter.convert(oidcAuth)).thenReturn(expected);
+
+    // when — first call populates the cache
+    when(holder.get()).thenReturn(null);
+    final var first = provider.getCamundaAuthentication();
+
+    // Simulate second request: reset per-request holder, same security context and cache
+    when(holder.get()).thenReturn(null);
+    final var second = provider.getCamundaAuthentication();
+
+    // then — converter called only once; both calls return the same resolved authentication
+    verify(converter, times(1)).convert(any());
+    assertThat(first).isEqualTo(expected);
+    assertThat(second).isEqualTo(expected);
+  }
+
+  @Test
+  void differentTokens_eachResolvedIndependently() {
+    // given
+    final var authA = jwtAuth("token-ccc");
+    final var authD = jwtAuth("token-ddd");
+    final var expectedA = CamundaAuthentication.of(b -> b.clientId("client-a"));
+    final var expectedD = CamundaAuthentication.of(b -> b.clientId("client-d"));
+    when(converter.convert(authA)).thenReturn(expectedA);
+    when(converter.convert(authD)).thenReturn(expectedD);
+
+    // when
+    SecurityContextHolder.getContext().setAuthentication(authA);
+    when(holder.get()).thenReturn(null);
+    final var resultA = provider.getCamundaAuthentication();
+
+    SecurityContextHolder.getContext().setAuthentication(authD);
+    when(holder.get()).thenReturn(null);
+    final var resultD = provider.getCamundaAuthentication();
+
+    // then — each token resolved exactly once
+    assertThat(resultA).isEqualTo(expectedA);
+    assertThat(resultD).isEqualTo(expectedD);
+    verify(converter, times(1)).convert(authA);
+    verify(converter, times(1)).convert(authD);
+  }
+
+  @Test
+  void nonOidcAuth_cacheIsBypassed_converterCalledEachTime() {
+    // given
+    final var basicAuth = nonOidcAuth();
+    SecurityContextHolder.getContext().setAuthentication(basicAuth);
+    final var expected = CamundaAuthentication.of(b -> b.user("basic-user"));
+    when(converter.convert(basicAuth)).thenReturn(expected);
+
+    // when — two calls with non-OIDC auth (holder returns null each time)
+    when(holder.get()).thenReturn(null);
+    provider.getCamundaAuthentication();
+    when(holder.get()).thenReturn(null);
+    provider.getCamundaAuthentication();
+
+    // then — converter is called each time; nothing was put in the cross-request cache
+    verify(converter, times(2)).convert(basicAuth);
+    assertThat(cache.getIfPresent("any-key")).isNull();
+  }
+
+  @Test
+  void perRequestHolderPopulatedAfterFirstCall() {
+    // given
+    final var oidcAuth = jwtAuth("token-eee");
+    SecurityContextHolder.getContext().setAuthentication(oidcAuth);
+    final var expected = CamundaAuthentication.of(b -> b.clientId("client-id"));
+    when(converter.convert(oidcAuth)).thenReturn(expected);
+    when(holder.get()).thenReturn(null);
+
+    // when
+    provider.getCamundaAuthentication();
+
+    // then — holder.set() was called so same-request subsequent calls go through the fast path
+    verify(holder).set(expected);
+  }
+
+  @Test
+  void cacheHit_holderIsStillPopulated() {
+    // given — prime the cache directly (simulates a previous request having resolved the token)
+    final var oidcAuth = jwtAuth("token-fff");
+    SecurityContextHolder.getContext().setAuthentication(oidcAuth);
+    final var expected = CamundaAuthentication.of(b -> b.clientId("client-id"));
+    cache.put("token-fff", expected);
+
+    // holder returns null — start of a new request
+    when(holder.get()).thenReturn(null);
+
+    // when
+    final var result = provider.getCamundaAuthentication();
+
+    // then — result served from cache, and holder is populated for intra-request subsequent calls
+    assertThat(result).isEqualTo(expected);
+    verify(converter, times(0)).convert(any());
+    verify(holder).set(expected);
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a Caffeine cache keyed by raw JWT token string to `DefaultCamundaAuthenticationProvider`
- M2M clients that reuse the same JWT across requests skip the 4 sequential secondary-storage DB queries (mapping rules → groups → roles → tenants) from the second request onward
- Cache TTL is driven by the token's own `exp` claim (capped at 24 h; defaults to 5 min when absent)
- Only applies to OIDC bearer tokens (`AbstractOAuth2TokenAuthenticationToken`); basic/anonymous auth is unaffected
- The existing per-request holder is still populated on every cache hit so intra-request calls remain allocation-free

## Motivation


<img width="1682" height="1300" alt="no-cache" src="https://github.com/user-attachments/assets/9cfa81df-4869-49c0-9e1b-473dfd2f6615" />

Flamegraph analysis of REST load tests showed that `DefaultMembershipService.resolveMemberships()` runs on every request, even when the same M2M JWT is reused for minutes. Under sustained REST load this generates hundreds of redundant Elasticsearch/DB queries per second that serve no purpose — the answer for the same token is always the same until the token expires.

Related: camunda/camunda#35067

## Test

Running a load test with a `realistic` workload shows a factor 5 improvement on p99 for the response latencies. 

<img width="833" height="239" alt="response-latency-cache" src="https://github.com/user-attachments/assets/93b2b858-a389-48c1-92dd-db296e261f31" />
<img width="838" height="252" alt="response-latency-no-cache" src="https://github.com/user-attachments/assets/d17716e1-4e68-4f25-a076-c3fb1a575eb6" />

Profiling shows also how we improved.
Example of publishMessage: on the left without cache, on the right with cache

<img width="3410" height="1337" alt="no-cache-vs-cache" src="https://github.com/user-attachments/assets/8c594ab5-9360-4c68-81a1-43288c0dcba3" />

The throughput is only slightly improved ~1 PI/s, (likely another road block).

<img width="3400" height="606" alt="2026-04-30_09-45" src="https://github.com/user-attachments/assets/4698b4b5-f967-4015-ad62-a32105a92e2d" />




## Test plan

- [ ] Unit tests added in `CachingCamundaAuthenticationProviderTest` covering: cache miss, cache hit (converter called once), distinct tokens, non-OIDC bypass, per-request holder population
- [ ] Load test triggered on this branch (`c8-ck-cache-auth`, realistic scenario, authz disabled) — compare DB query rate and REST latency vs baseline

> 🤖 Generated with [Claude Code](https://claude.com/claude-code)