### PR TITLE
docs: add no commit scopes rule to copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -98,6 +98,7 @@ Types: `build`, `ci`, `deps`, `docs`, `feat`, `fix`, `merge`, `perf`, `refactor`
 
 - Separate behavioral changes from structural/refactoring changes into distinct commits
 - Commit messages should explain *why*, not just *what* changed
+- Do not use commit scopes — commitlint enforces `scope-empty`. Use `fix: ...` not `fix(ci): ...`
 
 ## Pull Request Conventions
 


### PR DESCRIPTION
Adds the missing `scope-empty` constraint to the Commit Conventions section of `.github/copilot-instructions.md`.

commitlint enforces `scope-empty` in this repo, but the copilot instructions only listed commit types without mentioning that scopes are not allowed — contributors and AI tools reading these instructions would not know.

🤖 Generated with [Claude Code](https://claude.com/claude-code)