### PR TITLE
refactor: move builder from configuration api to CamundaClient

### DIFF
--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/SpringCamundaClientConfiguration.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/SpringCamundaClientConfiguration.java
@@ -15,8 +15,6 @@
  */
 package io.camunda.client.spring.configuration;
 
-import io.camunda.client.CamundaClient;
-import io.camunda.client.CamundaClientBuilder;
 import io.camunda.client.CamundaClientConfiguration;
 import io.camunda.client.CredentialsProvider;
 import io.camunda.client.api.JsonMapper;
@@ -26,12 +24,10 @@ import io.camunda.client.jobhandling.CamundaClientExecutorService;
 import io.camunda.client.jobhandling.JobExceptionHandlerSupplier;
 import io.camunda.client.jobhandling.JobExceptionHandlerSupplier.JobExceptionHandlerSupplierContext;
 import io.camunda.client.spring.properties.CamundaClientProperties;
-import io.camunda.client.spring.properties.CamundaClientProperties.ClientMode;
 import io.grpc.ClientInterceptor;
 import java.net.URI;
 import java.time.Duration;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import org.apache.hc.client5.http.async.AsyncExecChainHandler;
@@ -237,80 +233,6 @@ public class SpringCamundaClientConfiguration implements CamundaClientConfigurat
   @Override
   public boolean useClientSideLoadBalancing() {
     return camundaClientProperties.isUseClientSideLoadBalancing();
-  }
-
-  /**
-   * Creates a new {@link CamundaClientBuilder} configured with all settings from this
-   * configuration. Use this to apply all client properties (auth, addresses, etc.) to the builder.
-   *
-   * <p>If SaaS mode is detected (i.e. a cluster ID is set), a cloud client builder is used.
-   * Otherwise, a regular self-managed client builder is returned.
-   *
-   * @return a new {@link CamundaClientBuilder} with all settings applied
-   */
-  public CamundaClientBuilder toBuilder() {
-    final CamundaClientBuilder builder = createClientBuilder();
-
-    Optional.ofNullable(getRestAddress()).ifPresent(builder::restAddress);
-    Optional.ofNullable(getGrpcAddress()).ifPresent(builder::grpcAddress);
-    builder.preferRestOverGrpc(preferRestOverGrpc());
-    Optional.ofNullable(getDefaultTenantId()).ifPresent(builder::defaultTenantId);
-    Optional.ofNullable(getDefaultJobWorkerTenantIds())
-        .ifPresent(builder::defaultJobWorkerTenantIds);
-    Optional.ofNullable(getDefaultJobWorkerTenantFilter())
-        .ifPresent(builder::defaultJobWorkerTenantFilter);
-    builder.numJobWorkerExecutionThreads(getNumJobWorkerExecutionThreads());
-    builder.defaultJobWorkerMaxJobsActive(getDefaultJobWorkerMaxJobsActive());
-    Optional.ofNullable(getDefaultJobWorkerName()).ifPresent(builder::defaultJobWorkerName);
-    builder.defaultJobTimeout(getDefaultJobTimeout());
-    builder.defaultJobPollInterval(getDefaultJobPollInterval());
-    builder.defaultMessageTimeToLive(getDefaultMessageTimeToLive());
-    builder.defaultRequestTimeout(getDefaultRequestTimeout());
-    builder.defaultRequestTimeoutOffset(getDefaultRequestTimeoutOffset());
-    Optional.ofNullable(getCaCertificatePath()).ifPresent(builder::caCertificatePath);
-    Optional.ofNullable(getKeepAlive()).ifPresent(builder::keepAlive);
-    Optional.ofNullable(getOverrideAuthority()).ifPresent(builder::overrideAuthority);
-    builder.maxMessageSize(getMaxMessageSize());
-    builder.maxMetadataSize(getMaxMetadataSize());
-    builder.defaultJobWorkerStreamEnabled(getDefaultJobWorkerStreamEnabled());
-    builder.maxHttpConnections(getMaxHttpConnections());
-    Optional.ofNullable(credentialsProvider).ifPresent(builder::credentialsProvider);
-    Optional.ofNullable(jsonMapper).ifPresent(builder::withJsonMapper);
-    if (interceptors != null && !interceptors.isEmpty()) {
-      builder.withInterceptors(interceptors.toArray(new ClientInterceptor[0]));
-    }
-    if (chainHandlers != null && !chainHandlers.isEmpty()) {
-      builder.withChainHandlers(chainHandlers.toArray(new AsyncExecChainHandler[0]));
-    }
-    if (zeebeClientExecutorService != null) {
-      final ScheduledExecutorService scheduledExecutor =
-          zeebeClientExecutorService.getScheduledExecutor();
-      if (scheduledExecutor != null) {
-        builder.jobWorkerSchedulingExecutor(
-            scheduledExecutor,
-            zeebeClientExecutorService.isScheduledExecutorOwnedByCamundaClient());
-      }
-      final ExecutorService jobHandlingExecutor =
-          zeebeClientExecutorService.getJobHandlingExecutor();
-      if (jobHandlingExecutor != null) {
-        builder.jobHandlingExecutor(
-            jobHandlingExecutor,
-            zeebeClientExecutorService.isJobHandlingExecutorOwnedByCamundaClient());
-      }
-    }
-    return builder;
-  }
-
-  private CamundaClientBuilder createClientBuilder() {
-    if (camundaClientProperties.getMode() == ClientMode.saas
-        || camundaClientProperties.getCloud().getClusterId() != null) {
-      return CamundaClient.newCloudClientBuilder()
-          .withClusterId(camundaClientProperties.getCloud().getClusterId())
-          .withClientId(camundaClientProperties.getAuth().getClientId())
-          .withClientSecret(camundaClientProperties.getAuth().getClientSecret())
-          .withRegion(camundaClientProperties.getCloud().getRegion());
-    }
-    return CamundaClient.newClientBuilder();
   }
 
   @Override

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configuration/SpringCamundaClientConfigurationTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configuration/SpringCamundaClientConfigurationTest.java
@@ -17,29 +17,17 @@ package io.camunda.client.spring.configuration;
 
 import static org.assertj.core.api.Assertions.*;
 
-import io.camunda.client.CamundaClient;
-import io.camunda.client.CamundaClientBuilder;
-import io.camunda.client.CamundaClientConfiguration;
 import io.camunda.client.CredentialsProvider;
 import io.camunda.client.api.JsonMapper;
 import io.camunda.client.impl.CamundaObjectMapper;
 import io.camunda.client.impl.NoopCredentialsProvider;
-import io.camunda.client.impl.oauth.OAuthCredentialsProvider;
 import io.camunda.client.jobhandling.CamundaClientExecutorService;
 import io.camunda.client.jobhandling.JobExceptionHandlerSupplier;
-import io.camunda.client.spring.properties.CamundaClientAuthProperties;
-import io.camunda.client.spring.properties.CamundaClientCloudProperties;
 import io.camunda.client.spring.properties.CamundaClientProperties;
-import io.camunda.client.spring.properties.CamundaClientProperties.ClientMode;
 import io.grpc.ClientInterceptor;
-import java.net.URI;
-import java.time.Duration;
 import java.util.List;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import org.apache.hc.client5.http.async.AsyncExecChainHandler;
 import org.junit.jupiter.api.Test;
-import org.springframework.util.unit.DataSize;
 
 public class SpringCamundaClientConfigurationTest {
   private static SpringCamundaClientConfiguration configuration(
@@ -102,130 +90,5 @@ public class SpringCamundaClientConfigurationTest {
         new SpringCamundaClientConfiguration(properties(), null, null, null, null, null, null);
     final String toStringOutput = camundaClientConfiguration.toString();
     assertThat(toStringOutput).matches("SpringCamundaClientConfiguration\\{.*}");
-  }
-
-  @Test
-  void shouldCreateBuilderWithAllSelfManagedProperties() {
-    // given
-    final CamundaClientProperties props = properties();
-    props.setRestAddress(URI.create("http://0.0.0.0:8090"));
-    props.setGrpcAddress(URI.create("http://0.0.0.0:8091"));
-    props.setTenantId("my-tenant");
-    props.setRequestTimeout(Duration.ofSeconds(60));
-    props.setRequestTimeoutOffset(Duration.ofSeconds(10));
-    props.setKeepAlive(Duration.ofSeconds(30));
-    props.setMaxMessageSize(DataSize.ofMegabytes(100));
-    props.setMaxMetadataSize(DataSize.ofMegabytes(10));
-    props.setExecutionThreads(4);
-    props.setCaCertificatePath("/path/to/cert");
-    props.setOverrideAuthority("my-authority");
-    props.setPreferRestOverGrpc(true);
-    props.getWorker().getDefaults().setPollInterval(Duration.ofSeconds(5));
-    props.getWorker().getDefaults().setTimeout(Duration.ofSeconds(120));
-    props.getWorker().getDefaults().setMaxJobsActive(20);
-    props.getWorker().getDefaults().setName("my-worker");
-    props.getWorker().getDefaults().setStreamEnabled(true);
-
-    final CredentialsProvider creds = credentialsProvider();
-
-    final ScheduledExecutorService scheduledExecutor = Executors.newScheduledThreadPool(1);
-    final CamundaClientExecutorService executor =
-        new CamundaClientExecutorService(scheduledExecutor, false);
-
-    final SpringCamundaClientConfiguration configuration =
-        configuration(props, jsonMapper(), List.of(), List.of(), executor, creds, null);
-
-    // when
-    final CamundaClientBuilder builder = configuration.toBuilder();
-    final CamundaClientConfiguration config = buildConfiguration(builder);
-
-    try {
-      // then
-      assertThat(config.getRestAddress()).isEqualTo(URI.create("http://0.0.0.0:8090"));
-      assertThat(config.getGrpcAddress()).isEqualTo(URI.create("http://0.0.0.0:8091"));
-      assertThat(config.getDefaultTenantId()).isEqualTo("my-tenant");
-      assertThat(config.getDefaultRequestTimeout()).isEqualTo(Duration.ofSeconds(60));
-      assertThat(config.getDefaultRequestTimeoutOffset()).isEqualTo(Duration.ofSeconds(10));
-      assertThat(config.getKeepAlive()).isEqualTo(Duration.ofSeconds(30));
-      assertThat(config.getMaxMessageSize()).isEqualTo(DataSize.ofMegabytes(100).toBytes());
-      assertThat(config.getMaxMetadataSize()).isEqualTo(DataSize.ofMegabytes(10).toBytes());
-      assertThat(config.getNumJobWorkerExecutionThreads()).isEqualTo(4);
-      assertThat(config.getCaCertificatePath()).isEqualTo("/path/to/cert");
-      assertThat(config.getOverrideAuthority()).isEqualTo("my-authority");
-      assertThat(config.preferRestOverGrpc()).isTrue();
-      assertThat(config.getDefaultJobPollInterval()).isEqualTo(Duration.ofSeconds(5));
-      assertThat(config.getDefaultJobTimeout()).isEqualTo(Duration.ofSeconds(120));
-      assertThat(config.getDefaultJobWorkerMaxJobsActive()).isEqualTo(20);
-      assertThat(config.getDefaultJobWorkerName()).isEqualTo("my-worker");
-      assertThat(config.getDefaultJobWorkerStreamEnabled()).isTrue();
-      assertThat(config.getCredentialsProvider()).isSameAs(creds);
-      assertThat(config.ownsJobHandlingExecutor()).isFalse();
-      assertThat(config.ownsJobWorkerSchedulingExecutor()).isFalse();
-    } finally {
-      scheduledExecutor.shutdown();
-    }
-  }
-
-  @Test
-  void shouldCreateCloudBuilderForSaaSMode() {
-    // given
-    final CamundaClientProperties props = properties();
-    props.setMode(ClientMode.saas);
-
-    final CamundaClientCloudProperties cloud = props.getCloud();
-    cloud.setClusterId("my-cluster");
-    cloud.setRegion("my-region");
-
-    final CamundaClientAuthProperties auth = props.getAuth();
-    auth.setClientId("my-client-id");
-    auth.setClientSecret("my-client-secret");
-
-    final SpringCamundaClientConfiguration configuration =
-        configuration(props, jsonMapper(), List.of(), List.of(), executorService(), null, null);
-
-    // when
-    final CamundaClientBuilder builder = configuration.toBuilder();
-    final CamundaClientConfiguration config = buildConfiguration(builder);
-
-    // then
-    assertThat(config.getRestAddress())
-        .isEqualTo(URI.create("https://my-region.zeebe.camunda.io:443/my-cluster"));
-    assertThat(config.getGrpcAddress())
-        .isEqualTo(URI.create("https://my-cluster.my-region.zeebe.camunda.io:443"));
-    assertThat(config.getCredentialsProvider()).isInstanceOf(OAuthCredentialsProvider.class);
-  }
-
-  @Test
-  void shouldCreateCloudBuilderWhenClusterIdIsSet() {
-    // given
-    final CamundaClientProperties props = properties();
-    // No explicit mode - auto-detect based on clusterId
-
-    final CamundaClientCloudProperties cloud = props.getCloud();
-    cloud.setClusterId("auto-detected-cluster");
-    cloud.setRegion("us-east");
-
-    final CamundaClientAuthProperties auth = props.getAuth();
-    auth.setClientId("client-id");
-    auth.setClientSecret("client-secret");
-
-    final SpringCamundaClientConfiguration configuration =
-        configuration(props, jsonMapper(), List.of(), List.of(), executorService(), null, null);
-
-    // when
-    final CamundaClientBuilder builder = configuration.toBuilder();
-    final CamundaClientConfiguration config = buildConfiguration(builder);
-
-    // then
-    assertThat(config.getRestAddress())
-        .isEqualTo(URI.create("https://us-east.zeebe.camunda.io:443/auto-detected-cluster"));
-    assertThat(config.getGrpcAddress())
-        .isEqualTo(URI.create("https://auto-detected-cluster.us-east.zeebe.camunda.io:443"));
-  }
-
-  private static CamundaClientConfiguration buildConfiguration(final CamundaClientBuilder builder) {
-    try (final CamundaClient client = builder.build()) {
-      return client.getConfiguration();
-    }
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -227,6 +227,14 @@ public interface CamundaClient extends AutoCloseable, JobClient {
   }
 
   /**
+   * @return a builder to configure and create a new {@link CamundaClient} based on an existing
+   *     configuration.
+   */
+  static CamundaClientBuilder newClientBuilder(final CamundaClientConfiguration configuration) {
+    return new CamundaClientBuilderImpl().withConfiguration(configuration);
+  }
+
+  /**
    * @return a builder with convenient methods to connect to the Camunda Cloud cluster.
    */
   static CamundaClientCloudBuilderStep1 newCloudClientBuilder() {

--- a/clients/java/src/main/java/io/camunda/client/CamundaClientBuilder.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClientBuilder.java
@@ -42,6 +42,12 @@ public interface CamundaClientBuilder {
   CamundaClientBuilder withProperties(Properties properties);
 
   /**
+   * Sets the configuration from a {@link CamundaClientConfiguration} object. Can be used to
+   * configure a client from a base configuration.
+   */
+  CamundaClientBuilder withConfiguration(CamundaClientConfiguration configuration);
+
+  /**
    * Allows to disable the mechanism to override some properties by ENVIRONMENT VARIABLES. This is
    * useful if a client shall be constructed for test cases or in an environment that wants to fully
    * control properties (like Spring Boot).

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientBuilderImpl.java
@@ -692,7 +692,11 @@ public final class CamundaClientBuilderImpl
         value -> maxHttpConnections(Integer.parseInt(value)), MAX_HTTP_CONNECTIONS);
     applyEnvironmentValueIfNotNull(this::defaultTenantId, DEFAULT_TENANT_ID_VAR);
     applyEnvironmentValueIfNotNull(
-        value -> defaultJobWorkerTenantIds(Arrays.asList(value.split(TENANT_ID_LIST_SEPARATOR))),
+        value ->
+            defaultJobWorkerTenantIds(
+                value.isEmpty()
+                    ? Collections.emptyList()
+                    : Arrays.asList(value.split(TENANT_ID_LIST_SEPARATOR))),
         DEFAULT_JOB_WORKER_TENANT_IDS_VAR);
     applyEnvironmentValueIfNotNull(
         value -> defaultJobWorkerTenantFilter(TenantFilter.from(value)),

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientBuilderImpl.java
@@ -340,7 +340,11 @@ public final class CamundaClientBuilderImpl
 
     BuilderUtils.applyPropertyValueIfNotNull(
         properties,
-        value -> defaultJobWorkerTenantIds(Arrays.asList(value.split(TENANT_ID_LIST_SEPARATOR))),
+        value ->
+            defaultJobWorkerTenantIds(
+                value.isEmpty()
+                    ? Collections.emptyList()
+                    : Arrays.asList(value.split(TENANT_ID_LIST_SEPARATOR))),
         io.camunda.client.ClientProperties.DEFAULT_JOB_WORKER_TENANT_IDS);
 
     BuilderUtils.applyPropertyValueIfNotNull(
@@ -761,8 +765,7 @@ public final class CamundaClientBuilderImpl
     setIfNotNull(properties, GRPC_ADDRESS, configuration.getGrpcAddress());
     setIfNotNull(properties, REST_ADDRESS, configuration.getRestAddress());
     setIfNotNull(properties, DEFAULT_TENANT_ID, configuration.getDefaultTenantId());
-    if (configuration.getDefaultJobWorkerTenantIds() != null
-        && !configuration.getDefaultJobWorkerTenantIds().isEmpty()) {
+    if (configuration.getDefaultJobWorkerTenantIds() != null) {
       properties.setProperty(
           ClientProperties.DEFAULT_JOB_WORKER_TENANT_IDS,
           String.join(TENANT_ID_LIST_SEPARATOR, configuration.getDefaultJobWorkerTenantIds()));

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientBuilderImpl.java
@@ -740,6 +740,18 @@ public final class CamundaClientBuilderImpl
     if (configuration.getChainHandlers() != null) {
       configuration.getChainHandlers().forEach(this::withChainHandlers);
     }
+    if (configuration.jobWorkerSchedulingExecutor() != null) {
+      jobWorkerSchedulingExecutor(
+          configuration.jobWorkerSchedulingExecutor(),
+          configuration.ownsJobWorkerSchedulingExecutor());
+    }
+    if (configuration.jobHandlingExecutor() != null) {
+      jobHandlingExecutor(
+          configuration.jobHandlingExecutor(), configuration.ownsJobHandlingExecutor());
+    }
+    if (configuration.getDefaultJobWorkerExceptionHandler() != null) {
+      defaultJobWorkerExceptionHandler(configuration.getDefaultJobWorkerExceptionHandler());
+    }
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientBuilderImpl.java
@@ -722,6 +722,96 @@ public final class CamundaClientBuilderImpl
     return builder.build();
   }
 
+  public CamundaClientBuilderImpl withConfiguration(
+      final CamundaClientConfiguration configuration) {
+    final Properties properties = toProperties(configuration);
+    withProperties(properties);
+
+    // Properties not representable as string key-value pairs
+    if (configuration.getCredentialsProvider() != null) {
+      credentialsProvider(configuration.getCredentialsProvider());
+    }
+    if (configuration.getJsonMapper() != null) {
+      withJsonMapper(configuration.getJsonMapper());
+    }
+    if (configuration.getInterceptors() != null) {
+      configuration.getInterceptors().forEach(this::withInterceptors);
+    }
+    if (configuration.getChainHandlers() != null) {
+      configuration.getChainHandlers().forEach(this::withChainHandlers);
+    }
+    return this;
+  }
+
+  private static Properties toProperties(final CamundaClientConfiguration configuration) {
+    final Properties properties = new Properties();
+    setIfNotNull(properties, GRPC_ADDRESS, configuration.getGrpcAddress());
+    setIfNotNull(properties, REST_ADDRESS, configuration.getRestAddress());
+    setIfNotNull(properties, DEFAULT_TENANT_ID, configuration.getDefaultTenantId());
+    if (configuration.getDefaultJobWorkerTenantIds() != null
+        && !configuration.getDefaultJobWorkerTenantIds().isEmpty()) {
+      properties.setProperty(
+          ClientProperties.DEFAULT_JOB_WORKER_TENANT_IDS,
+          String.join(TENANT_ID_LIST_SEPARATOR, configuration.getDefaultJobWorkerTenantIds()));
+    }
+    if (configuration.getDefaultJobWorkerTenantFilter() != null) {
+      properties.setProperty(
+          ClientProperties.DEFAULT_JOB_WORKER_TENANT_FILTER_MODE,
+          configuration.getDefaultJobWorkerTenantFilter().name());
+    }
+    setIfNotNull(
+        properties, JOB_WORKER_EXECUTION_THREADS, configuration.getNumJobWorkerExecutionThreads());
+    setIfNotNull(
+        properties, JOB_WORKER_MAX_JOBS_ACTIVE, configuration.getDefaultJobWorkerMaxJobsActive());
+    setIfNotNull(properties, DEFAULT_JOB_WORKER_NAME, configuration.getDefaultJobWorkerName());
+    setDurationMillis(
+        properties, ClientProperties.DEFAULT_JOB_TIMEOUT, configuration.getDefaultJobTimeout());
+    setDurationMillis(
+        properties,
+        ClientProperties.DEFAULT_JOB_POLL_INTERVAL,
+        configuration.getDefaultJobPollInterval());
+    setDurationMillis(
+        properties, DEFAULT_MESSAGE_TIME_TO_LIVE, configuration.getDefaultMessageTimeToLive());
+    setDurationMillis(
+        properties,
+        ClientProperties.DEFAULT_REQUEST_TIMEOUT,
+        configuration.getDefaultRequestTimeout());
+    setDurationMillis(
+        properties,
+        ClientProperties.DEFAULT_REQUEST_TIMEOUT_OFFSET,
+        configuration.getDefaultRequestTimeoutOffset());
+    setIfNotNull(properties, CA_CERTIFICATE_PATH, configuration.getCaCertificatePath());
+    setDurationMillis(properties, KEEP_ALIVE, configuration.getKeepAlive());
+    setIfNotNull(properties, OVERRIDE_AUTHORITY, configuration.getOverrideAuthority());
+    setIfNotNull(properties, MAX_MESSAGE_SIZE, configuration.getMaxMessageSize());
+    setIfNotNull(properties, MAX_METADATA_SIZE, configuration.getMaxMetadataSize());
+    setIfNotNull(
+        properties, ClientProperties.MAX_HTTP_CONNECTIONS, configuration.getMaxHttpConnections());
+    properties.setProperty(
+        PREFER_REST_OVER_GRPC, String.valueOf(configuration.preferRestOverGrpc()));
+    properties.setProperty(
+        STREAM_ENABLED, String.valueOf(configuration.getDefaultJobWorkerStreamEnabled()));
+    properties.setProperty(
+        USE_DEFAULT_RETRY_POLICY, String.valueOf(configuration.useDefaultRetryPolicy()));
+    properties.setProperty(
+        USE_CLIENT_SIDE_LOAD_BALANCING, String.valueOf(configuration.useClientSideLoadBalancing()));
+    return properties;
+  }
+
+  private static void setIfNotNull(
+      final Properties properties, final String key, final Object value) {
+    if (value != null) {
+      properties.setProperty(key, String.valueOf(value));
+    }
+  }
+
+  private static void setDurationMillis(
+      final Properties properties, final String key, final Duration value) {
+    if (value != null) {
+      properties.setProperty(key, String.valueOf(value.toMillis()));
+    }
+  }
+
   private static URI getURIFromString(final String uri) {
     try {
       return new URI(uri);

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientBuilderImpl.java
@@ -419,6 +419,40 @@ public final class CamundaClientBuilderImpl
   }
 
   @Override
+  public CamundaClientBuilderImpl withConfiguration(
+      final CamundaClientConfiguration configuration) {
+    final Properties properties = toProperties(configuration);
+    withProperties(properties);
+
+    // Properties not representable as string key-value pairs
+    if (configuration.getCredentialsProvider() != null) {
+      credentialsProvider(configuration.getCredentialsProvider());
+    }
+    if (configuration.getJsonMapper() != null) {
+      withJsonMapper(configuration.getJsonMapper());
+    }
+    if (configuration.getInterceptors() != null) {
+      configuration.getInterceptors().forEach(this::withInterceptors);
+    }
+    if (configuration.getChainHandlers() != null) {
+      configuration.getChainHandlers().forEach(this::withChainHandlers);
+    }
+    if (configuration.jobWorkerSchedulingExecutor() != null) {
+      jobWorkerSchedulingExecutor(
+          configuration.jobWorkerSchedulingExecutor(),
+          configuration.ownsJobWorkerSchedulingExecutor());
+    }
+    if (configuration.jobHandlingExecutor() != null) {
+      jobHandlingExecutor(
+          configuration.jobHandlingExecutor(), configuration.ownsJobHandlingExecutor());
+    }
+    if (configuration.getDefaultJobWorkerExceptionHandler() != null) {
+      defaultJobWorkerExceptionHandler(configuration.getDefaultJobWorkerExceptionHandler());
+    }
+    return this;
+  }
+
+  @Override
   public CamundaClientBuilder applyEnvironmentVariableOverrides(
       final boolean applyEnvironmentVariableOverrides) {
     this.applyEnvironmentVariableOverrides = applyEnvironmentVariableOverrides;
@@ -720,39 +754,6 @@ public final class CamundaClientBuilderImpl
     final BasicAuthCredentialsProviderBuilder builder =
         CredentialsProvider.newBasicAuthCredentialsProviderBuilder();
     return builder.build();
-  }
-
-  public CamundaClientBuilderImpl withConfiguration(
-      final CamundaClientConfiguration configuration) {
-    final Properties properties = toProperties(configuration);
-    withProperties(properties);
-
-    // Properties not representable as string key-value pairs
-    if (configuration.getCredentialsProvider() != null) {
-      credentialsProvider(configuration.getCredentialsProvider());
-    }
-    if (configuration.getJsonMapper() != null) {
-      withJsonMapper(configuration.getJsonMapper());
-    }
-    if (configuration.getInterceptors() != null) {
-      configuration.getInterceptors().forEach(this::withInterceptors);
-    }
-    if (configuration.getChainHandlers() != null) {
-      configuration.getChainHandlers().forEach(this::withChainHandlers);
-    }
-    if (configuration.jobWorkerSchedulingExecutor() != null) {
-      jobWorkerSchedulingExecutor(
-          configuration.jobWorkerSchedulingExecutor(),
-          configuration.ownsJobWorkerSchedulingExecutor());
-    }
-    if (configuration.jobHandlingExecutor() != null) {
-      jobHandlingExecutor(
-          configuration.jobHandlingExecutor(), configuration.ownsJobHandlingExecutor());
-    }
-    if (configuration.getDefaultJobWorkerExceptionHandler() != null) {
-      defaultJobWorkerExceptionHandler(configuration.getDefaultJobWorkerExceptionHandler());
-    }
-    return this;
   }
 
   private static Properties toProperties(final CamundaClientConfiguration configuration) {

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientCloudBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientCloudBuilderImpl.java
@@ -29,6 +29,7 @@ import io.camunda.client.CamundaClientCloudBuilderStep1.CamundaClientCloudBuilde
 import io.camunda.client.CamundaClientCloudBuilderStep1.CamundaClientCloudBuilderStep2.CamundaClientCloudBuilderStep3;
 import io.camunda.client.CamundaClientCloudBuilderStep1.CamundaClientCloudBuilderStep2.CamundaClientCloudBuilderStep3.CamundaClientCloudBuilderStep4;
 import io.camunda.client.CamundaClientCloudBuilderStep1.CamundaClientCloudBuilderStep2.CamundaClientCloudBuilderStep3.CamundaClientCloudBuilderStep4.CamundaClientCloudBuilderStep5;
+import io.camunda.client.CamundaClientConfiguration;
 import io.camunda.client.ClientProperties;
 import io.camunda.client.CredentialsProvider;
 import io.camunda.client.api.ExperimentalApi;
@@ -119,11 +120,16 @@ public class CamundaClientCloudBuilderImpl
         ClientProperties.STREAM_ENABLED);
 
     innerBuilder.withProperties(properties);
+    resetMultiTenancy();
+    return this;
+  }
 
-    // todo(#14106): allow default tenant id setting for cloud client
-    innerBuilder.defaultTenantId("");
-    innerBuilder.defaultJobWorkerTenantIds(Collections.emptyList());
-
+  @Override
+  public CamundaClientBuilder withConfiguration(final CamundaClientConfiguration configuration) {
+    // no need to invoke the cloud builders withProperties here as the applied properties cannot be
+    // derived from the configuration anyway
+    innerBuilder.withConfiguration(configuration);
+    resetMultiTenancy();
     return this;
   }
 
@@ -334,6 +340,12 @@ public class CamundaClientCloudBuilderImpl
     innerBuilder.restAddress(determineRestAddress());
     innerBuilder.credentialsProvider(determineCredentialsProvider());
     return innerBuilder.build();
+  }
+
+  private void resetMultiTenancy() {
+    // todo(#14106): allow default tenant id setting for cloud client
+    innerBuilder.defaultTenantId("");
+    innerBuilder.defaultJobWorkerTenantIds(Collections.emptyList());
   }
 
   private URI determineRestAddress() {

--- a/clients/java/src/test/java/io/camunda/client/CamundaClientTest.java
+++ b/clients/java/src/test/java/io/camunda/client/CamundaClientTest.java
@@ -72,6 +72,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.ExecutorService;
@@ -1399,5 +1400,220 @@ public final class CamundaClientTest {
 
     // then
     assertThat(builder.useClientSideLoadBalancing()).isTrue();
+  }
+
+  @Test
+  void shouldPreserveConfigurationViaWithConfiguration() {
+    // given — a configuration with every property set to a non-default value
+    final CamundaClientConfiguration source =
+        new CamundaClientConfiguration() {
+          @Override
+          public URI getGrpcAddress() {
+            return URI.create("https://custom-grpc:12345");
+          }
+
+          @Override
+          public URI getRestAddress() {
+            return URI.create("https://custom-rest:54321");
+          }
+
+          @Override
+          public String getDefaultTenantId() {
+            return "custom-tenant";
+          }
+
+          @Override
+          public List<String> getDefaultJobWorkerTenantIds() {
+            return Arrays.asList("tenant-a", "tenant-b");
+          }
+
+          @Override
+          public TenantFilter getDefaultJobWorkerTenantFilter() {
+            return TenantFilter.ASSIGNED;
+          }
+
+          @Override
+          public int getNumJobWorkerExecutionThreads() {
+            return 7;
+          }
+
+          @Override
+          public int getDefaultJobWorkerMaxJobsActive() {
+            return 99;
+          }
+
+          @Override
+          public String getDefaultJobWorkerName() {
+            return "custom-worker";
+          }
+
+          @Override
+          public Duration getDefaultJobTimeout() {
+            return Duration.ofMinutes(42);
+          }
+
+          @Override
+          public Duration getDefaultJobPollInterval() {
+            return Duration.ofSeconds(3);
+          }
+
+          @Override
+          public Duration getDefaultMessageTimeToLive() {
+            return Duration.ofMinutes(30);
+          }
+
+          @Override
+          public Duration getDefaultRequestTimeout() {
+            return Duration.ofSeconds(77);
+          }
+
+          @Override
+          public Duration getDefaultRequestTimeoutOffset() {
+            return Duration.ofSeconds(5);
+          }
+
+          @Override
+          public String getCaCertificatePath() {
+            return "/custom/ca.pem";
+          }
+
+          @Override
+          public CredentialsProvider getCredentialsProvider() {
+            return null;
+          }
+
+          @Override
+          public Duration getKeepAlive() {
+            return Duration.ofSeconds(90);
+          }
+
+          @Override
+          public List<io.grpc.ClientInterceptor> getInterceptors() {
+            return Collections.emptyList();
+          }
+
+          @Override
+          public List<org.apache.hc.client5.http.async.AsyncExecChainHandler> getChainHandlers() {
+            return Collections.emptyList();
+          }
+
+          @Override
+          public io.camunda.client.api.JsonMapper getJsonMapper() {
+            return null;
+          }
+
+          @Override
+          public String getOverrideAuthority() {
+            return "custom-authority";
+          }
+
+          @Override
+          public int getMaxMessageSize() {
+            return 10 * ONE_MB;
+          }
+
+          @Override
+          public int getMaxMetadataSize() {
+            return 32 * ONE_KB;
+          }
+
+          @Override
+          public ScheduledExecutorService jobWorkerExecutor() {
+            return null;
+          }
+
+          @Override
+          public boolean ownsJobWorkerExecutor() {
+            return false;
+          }
+
+          @Override
+          public ScheduledExecutorService jobWorkerSchedulingExecutor() {
+            return null;
+          }
+
+          @Override
+          public boolean ownsJobWorkerSchedulingExecutor() {
+            return false;
+          }
+
+          @Override
+          public ExecutorService jobHandlingExecutor() {
+            return null;
+          }
+
+          @Override
+          public boolean ownsJobHandlingExecutor() {
+            return false;
+          }
+
+          @Override
+          public boolean getDefaultJobWorkerStreamEnabled() {
+            return true;
+          }
+
+          @Override
+          public boolean useDefaultRetryPolicy() {
+            return true;
+          }
+
+          @Override
+          public io.camunda.client.api.worker.JobExceptionHandler
+              getDefaultJobWorkerExceptionHandler() {
+            return null;
+          }
+
+          @Override
+          public boolean preferRestOverGrpc() {
+            return false;
+          }
+
+          @Override
+          public int getMaxHttpConnections() {
+            return 42;
+          }
+
+          @Override
+          public boolean useClientSideLoadBalancing() {
+            return true;
+          }
+        };
+
+    // when
+    final CamundaClientBuilderImpl builder = new CamundaClientBuilderImpl();
+    builder.applyEnvironmentVariableOverrides(false);
+    builder.withConfiguration(source);
+
+    // then — every property should match the source
+    assertThat(builder.getGrpcAddress()).isEqualTo(source.getGrpcAddress());
+    assertThat(builder.getRestAddress()).isEqualTo(source.getRestAddress());
+    assertThat(builder.getDefaultTenantId()).isEqualTo(source.getDefaultTenantId());
+    assertThat(builder.getDefaultJobWorkerTenantIds())
+        .isEqualTo(source.getDefaultJobWorkerTenantIds());
+    assertThat(builder.getDefaultJobWorkerTenantFilter())
+        .isEqualTo(source.getDefaultJobWorkerTenantFilter());
+    assertThat(builder.getNumJobWorkerExecutionThreads())
+        .isEqualTo(source.getNumJobWorkerExecutionThreads());
+    assertThat(builder.getDefaultJobWorkerMaxJobsActive())
+        .isEqualTo(source.getDefaultJobWorkerMaxJobsActive());
+    assertThat(builder.getDefaultJobWorkerName()).isEqualTo(source.getDefaultJobWorkerName());
+    assertThat(builder.getDefaultJobTimeout()).isEqualTo(source.getDefaultJobTimeout());
+    assertThat(builder.getDefaultJobPollInterval()).isEqualTo(source.getDefaultJobPollInterval());
+    assertThat(builder.getDefaultMessageTimeToLive())
+        .isEqualTo(source.getDefaultMessageTimeToLive());
+    assertThat(builder.getDefaultRequestTimeout()).isEqualTo(source.getDefaultRequestTimeout());
+    assertThat(builder.getDefaultRequestTimeoutOffset())
+        .isEqualTo(source.getDefaultRequestTimeoutOffset());
+    assertThat(builder.getCaCertificatePath()).isEqualTo(source.getCaCertificatePath());
+    assertThat(builder.getKeepAlive()).isEqualTo(source.getKeepAlive());
+    assertThat(builder.getOverrideAuthority()).isEqualTo(source.getOverrideAuthority());
+    assertThat(builder.getMaxMessageSize()).isEqualTo(source.getMaxMessageSize());
+    assertThat(builder.getMaxMetadataSize()).isEqualTo(source.getMaxMetadataSize());
+    assertThat(builder.getMaxHttpConnections()).isEqualTo(source.getMaxHttpConnections());
+    assertThat(builder.preferRestOverGrpc()).isEqualTo(source.preferRestOverGrpc());
+    assertThat(builder.getDefaultJobWorkerStreamEnabled())
+        .isEqualTo(source.getDefaultJobWorkerStreamEnabled());
+    assertThat(builder.useDefaultRetryPolicy()).isEqualTo(source.useDefaultRetryPolicy());
+    assertThat(builder.useClientSideLoadBalancing()).isEqualTo(source.useClientSideLoadBalancing());
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/CamundaClientTest.java
+++ b/clients/java/src/test/java/io/camunda/client/CamundaClientTest.java
@@ -53,20 +53,25 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
+import io.camunda.client.api.JsonMapper;
 import io.camunda.client.api.command.CommandWithTenantStep;
 import io.camunda.client.api.command.enums.TenantFilter;
+import io.camunda.client.api.worker.JobExceptionHandler;
 import io.camunda.client.api.worker.JobWorker;
 import io.camunda.client.impl.CamundaClientBuilderImpl;
 import io.camunda.client.impl.CamundaClientCloudBuilderImpl;
 import io.camunda.client.impl.CamundaClientEnvironmentVariables;
+import io.camunda.client.impl.CamundaObjectMapper;
 import io.camunda.client.impl.NoopCredentialsProvider;
 import io.camunda.client.impl.oauth.OAuthCredentialsProvider;
 import io.camunda.client.impl.util.AddressUtil;
 import io.camunda.client.impl.util.Environment;
 import io.camunda.client.impl.util.EnvironmentExtension;
+import io.grpc.ClientInterceptor;
 import java.io.FileNotFoundException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -80,6 +85,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.async.AsyncExecChainHandler;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -1405,215 +1411,239 @@ public final class CamundaClientTest {
   @Test
   void shouldPreserveConfigurationViaWithConfiguration() {
     // given — a configuration with every property set to a non-default value
-    final CamundaClientConfiguration source =
-        new CamundaClientConfiguration() {
-          @Override
-          public URI getGrpcAddress() {
-            return URI.create("https://custom-grpc:12345");
-          }
+    final CredentialsProvider credentialsProvider = new NoopCredentialsProvider();
+    final JsonMapper jsonMapper = new CamundaObjectMapper();
+    final ClientInterceptor interceptor = mock(ClientInterceptor.class);
+    final AsyncExecChainHandler chainHandler = mock(AsyncExecChainHandler.class);
+    final ScheduledExecutorService schedulingExecutor =
+        Executors.newSingleThreadScheduledExecutor();
+    final ExecutorService handlingExecutor = Executors.newSingleThreadExecutor();
+    final JobExceptionHandler exceptionHandler = mock(JobExceptionHandler.class);
 
-          @Override
-          public URI getRestAddress() {
-            return URI.create("https://custom-rest:54321");
-          }
+    try {
+      final CamundaClientConfiguration source =
+          new CamundaClientConfiguration() {
+            @Override
+            public URI getGrpcAddress() {
+              return URI.create("https://custom-grpc:12345");
+            }
 
-          @Override
-          public String getDefaultTenantId() {
-            return "custom-tenant";
-          }
+            @Override
+            public URI getRestAddress() {
+              return URI.create("https://custom-rest:54321");
+            }
 
-          @Override
-          public List<String> getDefaultJobWorkerTenantIds() {
-            return Arrays.asList("tenant-a", "tenant-b");
-          }
+            @Override
+            public String getDefaultTenantId() {
+              return "custom-tenant";
+            }
 
-          @Override
-          public TenantFilter getDefaultJobWorkerTenantFilter() {
-            return TenantFilter.ASSIGNED;
-          }
+            @Override
+            public List<String> getDefaultJobWorkerTenantIds() {
+              return Arrays.asList("tenant-a", "tenant-b");
+            }
 
-          @Override
-          public int getNumJobWorkerExecutionThreads() {
-            return 7;
-          }
+            @Override
+            public TenantFilter getDefaultJobWorkerTenantFilter() {
+              return TenantFilter.ASSIGNED;
+            }
 
-          @Override
-          public int getDefaultJobWorkerMaxJobsActive() {
-            return 99;
-          }
+            @Override
+            public int getNumJobWorkerExecutionThreads() {
+              return 7;
+            }
 
-          @Override
-          public String getDefaultJobWorkerName() {
-            return "custom-worker";
-          }
+            @Override
+            public int getDefaultJobWorkerMaxJobsActive() {
+              return 99;
+            }
 
-          @Override
-          public Duration getDefaultJobTimeout() {
-            return Duration.ofMinutes(42);
-          }
+            @Override
+            public String getDefaultJobWorkerName() {
+              return "custom-worker";
+            }
 
-          @Override
-          public Duration getDefaultJobPollInterval() {
-            return Duration.ofSeconds(3);
-          }
+            @Override
+            public Duration getDefaultJobTimeout() {
+              return Duration.ofMinutes(42);
+            }
 
-          @Override
-          public Duration getDefaultMessageTimeToLive() {
-            return Duration.ofMinutes(30);
-          }
+            @Override
+            public Duration getDefaultJobPollInterval() {
+              return Duration.ofSeconds(3);
+            }
 
-          @Override
-          public Duration getDefaultRequestTimeout() {
-            return Duration.ofSeconds(77);
-          }
+            @Override
+            public Duration getDefaultMessageTimeToLive() {
+              return Duration.ofMinutes(30);
+            }
 
-          @Override
-          public Duration getDefaultRequestTimeoutOffset() {
-            return Duration.ofSeconds(5);
-          }
+            @Override
+            public Duration getDefaultRequestTimeout() {
+              return Duration.ofSeconds(77);
+            }
 
-          @Override
-          public String getCaCertificatePath() {
-            return "/custom/ca.pem";
-          }
+            @Override
+            public Duration getDefaultRequestTimeoutOffset() {
+              return Duration.ofSeconds(5);
+            }
 
-          @Override
-          public CredentialsProvider getCredentialsProvider() {
-            return null;
-          }
+            @Override
+            public String getCaCertificatePath() {
+              return "/custom/ca.pem";
+            }
 
-          @Override
-          public Duration getKeepAlive() {
-            return Duration.ofSeconds(90);
-          }
+            @Override
+            public CredentialsProvider getCredentialsProvider() {
+              return credentialsProvider;
+            }
 
-          @Override
-          public List<io.grpc.ClientInterceptor> getInterceptors() {
-            return Collections.emptyList();
-          }
+            @Override
+            public Duration getKeepAlive() {
+              return Duration.ofSeconds(90);
+            }
 
-          @Override
-          public List<org.apache.hc.client5.http.async.AsyncExecChainHandler> getChainHandlers() {
-            return Collections.emptyList();
-          }
+            @Override
+            public List<ClientInterceptor> getInterceptors() {
+              return Collections.singletonList(interceptor);
+            }
 
-          @Override
-          public io.camunda.client.api.JsonMapper getJsonMapper() {
-            return null;
-          }
+            @Override
+            public List<AsyncExecChainHandler> getChainHandlers() {
+              return Collections.singletonList(chainHandler);
+            }
 
-          @Override
-          public String getOverrideAuthority() {
-            return "custom-authority";
-          }
+            @Override
+            public JsonMapper getJsonMapper() {
+              return jsonMapper;
+            }
 
-          @Override
-          public int getMaxMessageSize() {
-            return 10 * ONE_MB;
-          }
+            @Override
+            public String getOverrideAuthority() {
+              return "custom-authority";
+            }
 
-          @Override
-          public int getMaxMetadataSize() {
-            return 32 * ONE_KB;
-          }
+            @Override
+            public int getMaxMessageSize() {
+              return 10 * ONE_MB;
+            }
 
-          @Override
-          public ScheduledExecutorService jobWorkerExecutor() {
-            return null;
-          }
+            @Override
+            public int getMaxMetadataSize() {
+              return 32 * ONE_KB;
+            }
 
-          @Override
-          public boolean ownsJobWorkerExecutor() {
-            return false;
-          }
+            @Override
+            public ScheduledExecutorService jobWorkerExecutor() {
+              return schedulingExecutor;
+            }
 
-          @Override
-          public ScheduledExecutorService jobWorkerSchedulingExecutor() {
-            return null;
-          }
+            @Override
+            public boolean ownsJobWorkerExecutor() {
+              return true;
+            }
 
-          @Override
-          public boolean ownsJobWorkerSchedulingExecutor() {
-            return false;
-          }
+            @Override
+            public ScheduledExecutorService jobWorkerSchedulingExecutor() {
+              return schedulingExecutor;
+            }
 
-          @Override
-          public ExecutorService jobHandlingExecutor() {
-            return null;
-          }
+            @Override
+            public boolean ownsJobWorkerSchedulingExecutor() {
+              return true;
+            }
 
-          @Override
-          public boolean ownsJobHandlingExecutor() {
-            return false;
-          }
+            @Override
+            public ExecutorService jobHandlingExecutor() {
+              return handlingExecutor;
+            }
 
-          @Override
-          public boolean getDefaultJobWorkerStreamEnabled() {
-            return true;
-          }
+            @Override
+            public boolean ownsJobHandlingExecutor() {
+              return true;
+            }
 
-          @Override
-          public boolean useDefaultRetryPolicy() {
-            return true;
-          }
+            @Override
+            public boolean getDefaultJobWorkerStreamEnabled() {
+              return true;
+            }
 
-          @Override
-          public io.camunda.client.api.worker.JobExceptionHandler
-              getDefaultJobWorkerExceptionHandler() {
-            return null;
-          }
+            @Override
+            public boolean useDefaultRetryPolicy() {
+              return true;
+            }
 
-          @Override
-          public boolean preferRestOverGrpc() {
-            return false;
-          }
+            @Override
+            public JobExceptionHandler getDefaultJobWorkerExceptionHandler() {
+              return exceptionHandler;
+            }
 
-          @Override
-          public int getMaxHttpConnections() {
-            return 42;
-          }
+            @Override
+            public boolean preferRestOverGrpc() {
+              return false;
+            }
 
-          @Override
-          public boolean useClientSideLoadBalancing() {
-            return true;
-          }
-        };
+            @Override
+            public int getMaxHttpConnections() {
+              return 42;
+            }
 
-    // when
-    final CamundaClientBuilderImpl builder = new CamundaClientBuilderImpl();
-    builder.applyEnvironmentVariableOverrides(false);
-    builder.withConfiguration(source);
+            @Override
+            public boolean useClientSideLoadBalancing() {
+              return true;
+            }
+          };
 
-    // then — every property should match the source
-    assertThat(builder.getGrpcAddress()).isEqualTo(source.getGrpcAddress());
-    assertThat(builder.getRestAddress()).isEqualTo(source.getRestAddress());
-    assertThat(builder.getDefaultTenantId()).isEqualTo(source.getDefaultTenantId());
-    assertThat(builder.getDefaultJobWorkerTenantIds())
-        .isEqualTo(source.getDefaultJobWorkerTenantIds());
-    assertThat(builder.getDefaultJobWorkerTenantFilter())
-        .isEqualTo(source.getDefaultJobWorkerTenantFilter());
-    assertThat(builder.getNumJobWorkerExecutionThreads())
-        .isEqualTo(source.getNumJobWorkerExecutionThreads());
-    assertThat(builder.getDefaultJobWorkerMaxJobsActive())
-        .isEqualTo(source.getDefaultJobWorkerMaxJobsActive());
-    assertThat(builder.getDefaultJobWorkerName()).isEqualTo(source.getDefaultJobWorkerName());
-    assertThat(builder.getDefaultJobTimeout()).isEqualTo(source.getDefaultJobTimeout());
-    assertThat(builder.getDefaultJobPollInterval()).isEqualTo(source.getDefaultJobPollInterval());
-    assertThat(builder.getDefaultMessageTimeToLive())
-        .isEqualTo(source.getDefaultMessageTimeToLive());
-    assertThat(builder.getDefaultRequestTimeout()).isEqualTo(source.getDefaultRequestTimeout());
-    assertThat(builder.getDefaultRequestTimeoutOffset())
-        .isEqualTo(source.getDefaultRequestTimeoutOffset());
-    assertThat(builder.getCaCertificatePath()).isEqualTo(source.getCaCertificatePath());
-    assertThat(builder.getKeepAlive()).isEqualTo(source.getKeepAlive());
-    assertThat(builder.getOverrideAuthority()).isEqualTo(source.getOverrideAuthority());
-    assertThat(builder.getMaxMessageSize()).isEqualTo(source.getMaxMessageSize());
-    assertThat(builder.getMaxMetadataSize()).isEqualTo(source.getMaxMetadataSize());
-    assertThat(builder.getMaxHttpConnections()).isEqualTo(source.getMaxHttpConnections());
-    assertThat(builder.preferRestOverGrpc()).isEqualTo(source.preferRestOverGrpc());
-    assertThat(builder.getDefaultJobWorkerStreamEnabled())
-        .isEqualTo(source.getDefaultJobWorkerStreamEnabled());
-    assertThat(builder.useDefaultRetryPolicy()).isEqualTo(source.useDefaultRetryPolicy());
-    assertThat(builder.useClientSideLoadBalancing()).isEqualTo(source.useClientSideLoadBalancing());
+      // when
+      final CamundaClientBuilderImpl builder = new CamundaClientBuilderImpl();
+      builder.applyEnvironmentVariableOverrides(false);
+      builder.withConfiguration(source);
+
+      // then — every property should match the source
+      assertThat(builder.getGrpcAddress()).isEqualTo(source.getGrpcAddress());
+      assertThat(builder.getRestAddress()).isEqualTo(source.getRestAddress());
+      assertThat(builder.getDefaultTenantId()).isEqualTo(source.getDefaultTenantId());
+      assertThat(builder.getDefaultJobWorkerTenantIds())
+          .isEqualTo(source.getDefaultJobWorkerTenantIds());
+      assertThat(builder.getDefaultJobWorkerTenantFilter())
+          .isEqualTo(source.getDefaultJobWorkerTenantFilter());
+      assertThat(builder.getNumJobWorkerExecutionThreads())
+          .isEqualTo(source.getNumJobWorkerExecutionThreads());
+      assertThat(builder.getDefaultJobWorkerMaxJobsActive())
+          .isEqualTo(source.getDefaultJobWorkerMaxJobsActive());
+      assertThat(builder.getDefaultJobWorkerName()).isEqualTo(source.getDefaultJobWorkerName());
+      assertThat(builder.getDefaultJobTimeout()).isEqualTo(source.getDefaultJobTimeout());
+      assertThat(builder.getDefaultJobPollInterval()).isEqualTo(source.getDefaultJobPollInterval());
+      assertThat(builder.getDefaultMessageTimeToLive())
+          .isEqualTo(source.getDefaultMessageTimeToLive());
+      assertThat(builder.getDefaultRequestTimeout()).isEqualTo(source.getDefaultRequestTimeout());
+      assertThat(builder.getDefaultRequestTimeoutOffset())
+          .isEqualTo(source.getDefaultRequestTimeoutOffset());
+      assertThat(builder.getCaCertificatePath()).isEqualTo(source.getCaCertificatePath());
+      assertThat(builder.getKeepAlive()).isEqualTo(source.getKeepAlive());
+      assertThat(builder.getOverrideAuthority()).isEqualTo(source.getOverrideAuthority());
+      assertThat(builder.getMaxMessageSize()).isEqualTo(source.getMaxMessageSize());
+      assertThat(builder.getMaxMetadataSize()).isEqualTo(source.getMaxMetadataSize());
+      assertThat(builder.getMaxHttpConnections()).isEqualTo(source.getMaxHttpConnections());
+      assertThat(builder.preferRestOverGrpc()).isEqualTo(source.preferRestOverGrpc());
+      assertThat(builder.getDefaultJobWorkerStreamEnabled())
+          .isEqualTo(source.getDefaultJobWorkerStreamEnabled());
+      assertThat(builder.useDefaultRetryPolicy()).isEqualTo(source.useDefaultRetryPolicy());
+      assertThat(builder.useClientSideLoadBalancing())
+          .isEqualTo(source.useClientSideLoadBalancing());
+      // non-property fields
+      assertThat(builder.getCredentialsProvider()).isSameAs(credentialsProvider);
+      assertThat(builder.getJsonMapper()).isSameAs(jsonMapper);
+      assertThat(builder.getInterceptors()).containsExactly(interceptor);
+      assertThat(builder.getChainHandlers()).containsExactly(chainHandler);
+      assertThat(builder.jobWorkerSchedulingExecutor()).isSameAs(schedulingExecutor);
+      assertThat(builder.ownsJobWorkerSchedulingExecutor()).isTrue();
+      assertThat(builder.jobHandlingExecutor()).isSameAs(handlingExecutor);
+      assertThat(builder.ownsJobHandlingExecutor()).isTrue();
+      assertThat(builder.getDefaultJobWorkerExceptionHandler()).isSameAs(exceptionHandler);
+    } finally {
+      schedulingExecutor.shutdown();
+      handlingExecutor.shutdown();
+    }
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/CamundaClientTest.java
+++ b/clients/java/src/test/java/io/camunda/client/CamundaClientTest.java
@@ -1061,6 +1061,35 @@ public final class CamundaClientTest {
   }
 
   @ParameterizedTest
+  @CsvSource({
+    DEFAULT_JOB_WORKER_TENANT_IDS_VAR + "," + DEFAULT_JOB_WORKER_TENANT_IDS,
+  })
+  public void shouldSetEmptyDefaultJobWorkerTenantIdsFromEmptyStringInEnvVarAndProperty(
+      final String envName, final String propertyName) {
+    // given — empty string in environment variable
+    Environment.system().put(envName, "");
+    final CamundaClientBuilderImpl builderEnv = new CamundaClientBuilderImpl();
+
+    // when
+    builderEnv.build();
+
+    // then — environment variable path should return empty list
+    assertThat(builderEnv.getDefaultJobWorkerTenantIds()).isEmpty();
+
+    // given — empty string in property
+    final Properties properties = new Properties();
+    properties.setProperty(propertyName, "");
+    final CamundaClientBuilderImpl builderProp = new CamundaClientBuilderImpl();
+    builderProp.withProperties(properties);
+
+    // when
+    builderProp.build();
+
+    // then — property path should also return empty list
+    assertThat(builderProp.getDefaultJobWorkerTenantIds()).isEmpty();
+  }
+
+  @ParameterizedTest
   @ValueSource(strings = {DEFAULT_JOB_WORKER_TENANT_IDS})
   public void shouldNotSetDefaultJobWorkerTenantIdsFromPropertyWithCloudClientBuilder(
       final String propertyName) {

--- a/clients/java/src/test/java/io/camunda/client/CamundaClientTest.java
+++ b/clients/java/src/test/java/io/camunda/client/CamundaClientTest.java
@@ -1071,10 +1071,10 @@ public final class CamundaClientTest {
     final CamundaClientBuilderImpl builderEnv = new CamundaClientBuilderImpl();
 
     // when
-    builderEnv.build();
-
-    // then — environment variable path should return empty list
-    assertThat(builderEnv.getDefaultJobWorkerTenantIds()).isEmpty();
+    try (final CamundaClient clientEnv = builderEnv.build()) {
+      // then — environment variable path should return empty list
+      assertThat(builderEnv.getDefaultJobWorkerTenantIds()).isEmpty();
+    }
 
     // given — empty string in property
     final Properties properties = new Properties();
@@ -1083,10 +1083,10 @@ public final class CamundaClientTest {
     builderProp.withProperties(properties);
 
     // when
-    builderProp.build();
-
-    // then — property path should also return empty list
-    assertThat(builderProp.getDefaultJobWorkerTenantIds()).isEmpty();
+    try (final CamundaClient clientProp = builderProp.build()) {
+      // then — property path should also return empty list
+      assertThat(builderProp.getDefaultJobWorkerTenantIds()).isEmpty();
+    }
   }
 
   @ParameterizedTest

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestDefaultConfiguration.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestDefaultConfiguration.java
@@ -19,6 +19,7 @@ import static com.fasterxml.jackson.databind.DeserializationFeature.ACCEPT_EMPTY
 import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.client.CamundaClient;
 import io.camunda.client.CamundaClientBuilder;
 import io.camunda.client.CredentialsProvider;
 import io.camunda.client.api.JsonMapper;
@@ -112,7 +113,7 @@ public class CamundaProcessTestDefaultConfiguration {
 
     return new DefaultCamundaClientBuilderFactory(
         () -> {
-          final CamundaClientBuilder builder = configuration.toBuilder();
+          final CamundaClientBuilder builder = CamundaClient.newClientBuilder(configuration);
           // Backwards compatibility: apply remote client addresses only when explicitly configured
           // (i.e. different from the default addresses of CamundaClientProperties).
           // This matches the previously supported camunda.process-test.remote.client.* properties.


### PR DESCRIPTION
## Description
This pull request introduces a new way to create a `CamundaClientBuilder` from an existing `CamundaClientConfiguration`, simplifying the process of cloning or modifying client configurations. The main changes involve removing the custom builder logic from the Spring Boot starter and centralizing it in the core client library, enhancing maintainability and consistency. Corresponding tests and imports have been updated or removed to reflect this refactoring.

### Core client improvements

* Added a new static method `CamundaClient.newClientBuilder(CamundaClientConfiguration configuration)` to create a builder pre-populated with an existing configuration, and implemented the corresponding logic in `CamundaClientBuilderImpl` (`clients/java/src/main/java/io/camunda/client/CamundaClient.java`, `clients/java/src/main/java/io/camunda/client/impl/CamundaClientBuilderImpl.java`). [[1]](diffhunk://#diff-a4b4b289dc5bdd52e26201f8b6b15e8f7a7975166d5bd0e5c75ec305d4a3170cR228-R235) [[2]](diffhunk://#diff-e71b7942681f6de64e2e521b1a95a172ce6612ac649d8cdc70df73c0be475551R725-R814)
* The new builder method copies all relevant properties, including those not representable as string key-value pairs (such as interceptors and credentials providers), ensuring a comprehensive configuration transfer (`clients/java/src/main/java/io/camunda/client/impl/CamundaClientBuilderImpl.java`).

### Spring Boot starter refactoring

* Removed the `toBuilder()` and `createClientBuilder()` methods from `SpringCamundaClientConfiguration`, delegating builder creation to the new core client method (`clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/SpringCamundaClientConfiguration.java`).
* Cleaned up unused imports in both the main configuration and test files in the Spring Boot starter (`clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/SpringCamundaClientConfiguration.java`, `clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configuration/SpringCamundaClientConfigurationTest.java`). [[1]](diffhunk://#diff-56223bbd4adc083abd348a60793a5e04077f274ef238093b703a01f44a25704aL18-L19) [[2]](diffhunk://#diff-56223bbd4adc083abd348a60793a5e04077f274ef238093b703a01f44a25704aL29-L34) [[3]](diffhunk://#diff-fe25a7181c930f9e69b0dce1b6ac70404ebb147eead273d9cba2f7b14b4fb83bL20-L42)

### Test updates

* Removed Spring-specific tests that validated the old custom builder logic, as this is now handled by the core client (`clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configuration/SpringCamundaClientConfigurationTest.java`).
* Minor import update in a core client test file to support new test scenarios (`clients/java/src/test/java/io/camunda/client/CamundaClientTest.java`).
<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
