### PR TITLE
fix: remove empty header space above Admin tables

### DIFF
--- a/identity/client/src/components/entityList/EntityList.tsx
+++ b/identity/client/src/components/entityList/EntityList.tsx
@@ -188,16 +188,17 @@ const EntityList = <D extends EntityData>({
     ? { $compact: true }
     : {
         title,
-        description: (
-          <>
-            {description && <p>{description}</p>}
-            {documentationPath && (
-              <DocumentationLink path={documentationPath}>
-                {t("Learn more")}
-              </DocumentationLink>
-            )}
-          </>
-        ),
+        description:
+          !description && !documentationPath ? undefined : (
+            <>
+              {description && <p>{description}</p>}
+              {documentationPath && (
+                <DocumentationLink path={documentationPath}>
+                  {t("Learn more")}
+                </DocumentationLink>
+              )}
+            </>
+          ),
       };
 
   return (


### PR DESCRIPTION
## Description

DataTables in Admin have this weird visual white-space above tables. This is caused by `EntityList` rendering a table description fragment even when no description exists. This fix ensures that Carbon's `TableContainer` receive no description if none is provided to `EntityList`, which removes the white-space.

### Before
<img width="878" height="244" alt="Screenshot 2026-04-23 at 15 28 46" src="https://github.com/user-attachments/assets/d8fb3deb-de54-40ec-b1a5-c6ec3a939e56" />

### After
<img width="878" height="244" alt="Screenshot 2026-04-23 at 15 28 53" src="https://github.com/user-attachments/assets/df33d268-d27d-493b-abe2-3fb7aab667ec" />
