### PR TITLE
ci: enable CPU and memory utilization measurement in ci.yml

### DIFF
--- a/.github/actions/observe-build-status/action.yml
+++ b/.github/actions/observe-build-status/action.yml
@@ -76,14 +76,14 @@ runs:
         else
           echo "result=" >> $GITHUB_OUTPUT
         fi
-    ######################## Report test result #############################  
+    ######################## Report test result #############################
     - name: Get detailed info on JUnit tests
       id: get-detailed-junit-tests
       if: ${{ inputs.detailed_junit_tests == 'true' && steps.secrets.outputs.gcloud_sa_key != '' }}
       shell: bash
       run: |
         TEST_RESULTS_FILE=$(mktemp --suffix=.jsonl)
-        echo "test_results_file=${TEST_RESULTS_FILE}" >> $GITHUB_OUTPUT        
+        echo "test_results_file=${TEST_RESULTS_FILE}" >> $GITHUB_OUTPUT
         find . -iname 'TEST-*.xml' | python3 .ci/scripts/ci/observe-build-status/junit-test-results-to-jsonl.py > "${TEST_RESULTS_FILE}"
         echo "Generated $(wc -l < "${TEST_RESULTS_FILE}") test results"
 
@@ -93,7 +93,7 @@ runs:
       with:
         test_results_file_path: "${{ steps.get-detailed-junit-tests.outputs.test_results_file }}"
         job_name_override: "${{ inputs.job_name }}"
-        gcp_credentials_json: "${{ steps.secrets.outputs.gcloud_sa_key }}"   
+        gcp_credentials_json: "${{ steps.secrets.outputs.gcloud_sa_key }}"
    ######################## Report build result #############################
     - uses: camunda/infra-global-github-actions/submit-build-status@main
       if: ${{ always() && steps.secrets.outputs.gcloud_sa_key != '' }}

--- a/.github/conftest-unified-ci-rules.rego
+++ b/.github/conftest-unified-ci-rules.rego
@@ -127,6 +127,16 @@ warn[msg] {
         [concat(", ", get_jobs_without_printmetadata(input.jobs))])
 }
 
+warn[msg] {
+    # only enforced on Unified CI
+    input.name == "CI"
+
+    count(get_jobs_without_monitor_as_first_step(input.jobs)) > 0
+
+    msg := sprintf("There are GitHub Actions jobs in Unified CI without start-build-monitor as first step! Affected job IDs: %s",
+        [concat(", ", get_jobs_without_monitor_as_first_step(input.jobs))])
+}
+
 ###########################   RULE HELPERS   ##################################
 
 get_jobs_without_timeoutminutes(jobInput) = jobs_without_timeoutminutes {
@@ -248,6 +258,37 @@ get_jobs_with_flaky_outputs(jobInput) = jobs_with_flaky_outputs {
         # check if job has flakyTests output
         job.outputs.flakyTests
     }
+}
+
+get_jobs_without_monitor_as_first_step(jobInput) = result {
+    result := { job_id |
+        job := jobInput[job_id]
+
+        # not enforced on special control-flow jobs
+        job_id != "detect-changes"
+        job_id != "check-results"
+        job_id != "test-summary"
+        job_id != "get-concurrency-group-dynamically"
+        job_id != "get-snapshot-docker-version-tag"
+        job_id != "observe-aborted-jobs"
+        job_id != "setup-tests"
+        job_id != "utils-flaky-tests-summary"
+        job_id != "fe-unit-tests-merge"
+        job_id != "operate-fe-visual-regression-merge"
+        job_id != "generate-db-versions"
+        job_id != "generate-matrix"
+
+        # not enforced on jobs that invoke other reusable workflows (instead enforced there)
+        not job.uses
+
+        # check that the first step uses start-build-monitor
+        not job_has_monitor_as_first_step(job)
+    }
+}
+
+job_has_monitor_as_first_step(job) {
+    step := job.steps[0]
+    startswith(step.uses, "camunda/infra-global-github-actions/start-build-monitor@")
 }
 
 get_jobs_without_printmetadata(jobInput) = jobs_without_printmetadata {

--- a/.github/conftest-unified-ci-rules.rego
+++ b/.github/conftest-unified-ci-rules.rego
@@ -127,7 +127,7 @@ warn[msg] {
         [concat(", ", get_jobs_without_printmetadata(input.jobs))])
 }
 
-warn[msg] {
+deny[msg] {
     # only enforced on Unified CI
     input.name == "CI"
 
@@ -175,7 +175,7 @@ get_jobs_without_cihealth(jobInput) = jobs_without_cihealth {
         job_id != "get-snapshot-docker-version-tag"
         job_id != "observe-aborted-jobs"
         job_id != "setup-tests"
-        job_id != "utils-flaky-tests-summary"
+        job_id != "detect-new-flaky-tests"
         job_id != "fe-unit-tests-merge"
         job_id != "operate-fe-visual-regression-merge"
         job_id != "generate-db-versions"
@@ -272,7 +272,7 @@ get_jobs_without_monitor_as_first_step(jobInput) = result {
         job_id != "get-snapshot-docker-version-tag"
         job_id != "observe-aborted-jobs"
         job_id != "setup-tests"
-        job_id != "utils-flaky-tests-summary"
+        job_id != "detect-new-flaky-tests"
         job_id != "fe-unit-tests-merge"
         job_id != "operate-fe-visual-regression-merge"
         job_id != "generate-db-versions"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,7 @@ jobs:
       # renovate: datasource=github-tags depName=open-policy-agent/conftest
       CONFTEST_VERSION: '0.68.2'
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: camunda/infra-global-github-actions/actionlint@main
         with:
@@ -132,6 +133,7 @@ jobs:
     timeout-minutes: 5
     permissions: { }  # GITHUB_TOKEN unused in this job
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - name: Determine fetch depth for checkout
         id: depth
         run: |
@@ -165,6 +167,7 @@ jobs:
     timeout-minutes: 10
     permissions: { }  # GITHUB_TOKEN unused in this job
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-build
         with:
@@ -191,6 +194,7 @@ jobs:
     timeout-minutes: 5
     permissions: { }  # GITHUB_TOKEN unused in this job
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Check for missing junit-vintage-engine
         run: .ci/scripts/ci/check-junit-vintage-engine.sh .
@@ -212,6 +216,7 @@ jobs:
     timeout-minutes: 10
     permissions: { }  # GITHUB_TOKEN unused in this job
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
@@ -245,6 +250,7 @@ jobs:
     timeout-minutes: 5
     permissions: { }  # GITHUB_TOKEN unused in this job
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/codeowners-setup-cli
       - name: Check for unowned files
@@ -275,6 +281,7 @@ jobs:
     permissions: { }  # GITHUB_TOKEN unused in this job
     runs-on: gcp-perf-core-8-default
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-build
         with:
@@ -321,6 +328,7 @@ jobs:
             -Dquickly=true
             -DskipQaBuild=true
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-build
         with:
@@ -371,6 +379,7 @@ jobs:
     timeout-minutes: 20
     permissions: { }  # GITHUB_TOKEN unused in this job
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/build-frontend
         id: build-operate-fe
@@ -433,6 +442,7 @@ jobs:
     timeout-minutes: 5
     permissions: { }
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - name: Set all test constants
         id: set-constants
         run: |
@@ -687,6 +697,7 @@ jobs:
     outputs:
       flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-build
         with:
@@ -781,6 +792,7 @@ jobs:
             suite: CamundaEx
             maven-modules: ${{ needs.setup-tests.outputs.ZEEBE_CLIENT_MODULES }}
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Print metadata
         uses: ./.github/actions/print-metadata
@@ -938,6 +950,7 @@ jobs:
       flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
     permissions: { }  # no GITHUB_TOKEN is needed
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-build
         with:
@@ -1018,6 +1031,7 @@ jobs:
         ports:
           - 5000:5000
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Generate cache key with current hour
         if: matrix.group == 'qa-update'
@@ -1145,6 +1159,7 @@ jobs:
     outputs:
       flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Print metadata
         uses: ./.github/actions/print-metadata
@@ -1219,6 +1234,7 @@ jobs:
       TEST_ELASTICSEARCH_IMAGE: docker.elastic.co/elasticsearch/elasticsearch:${{ needs.generate-db-versions.outputs.elasticsearch-8 }}
       DOCKER_PLATFORMS: "linux/arm64,linux/amd64" # build AMD64 last so it gets picked up by the test
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
         with:
@@ -1519,6 +1535,7 @@ jobs:
       run:
         working-directory: identity/client
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -1563,6 +1580,7 @@ jobs:
       run:
         working-directory: identity/client
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Print metadata
         uses: ./.github/actions/print-metadata
@@ -1655,6 +1673,7 @@ jobs:
       run:
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -1689,6 +1708,7 @@ jobs:
       BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
     if: needs.detect-changes.outputs.protobuf-changes == 'true'
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - id: pr-body
         name: Fetch latest PR body
@@ -1737,6 +1757,7 @@ jobs:
       # renovate: datasource=npm depName=@stoplight/spectral-cli
       SPECTRAL_VERSION: '6.16.0'
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node.js for Spectral
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -1783,6 +1804,7 @@ jobs:
     timeout-minutes: 10
     permissions: {}  # GITHUB_TOKEN unused in this job
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -1806,6 +1828,7 @@ jobs:
     timeout-minutes: 5
     permissions: {}
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install bats
         run: sudo apt-get install -y bats
@@ -1913,6 +1936,7 @@ jobs:
       group: ${{ needs.utils-get-concurrency-group-for-maven-snapshot.outputs.concurrency_group_name }}
       cancel-in-progress: false
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-build
         with:
@@ -1981,6 +2005,7 @@ jobs:
       group: ${{ needs.utils-get-concurrency-group-for-docker-snapshot.outputs.concurrency_group_name }}
       cancel-in-progress: false
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-build
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1514,15 +1514,6 @@ jobs:
           name: |
             zeebe-unit-tests-*
             integration-tests-*
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
   identity-frontend-tests:
     if: needs.detect-changes.outputs.identity-frontend-tests == 'true'


### PR DESCRIPTION
## Description

Based on the work of https://github.com/camunda/infra-global-github-actions/pull/670, this PR proposes to enable resource usage tracking and reporting to CI Analytics for all relevant ci.yml jobs as a first stage.

I don't expect any impact onto the ci.yml workloads at scale but want to be certain before enabling the new feature also for other jobs in the Unified CI (mostly called workflows).

Adds a `conftest` rule to ensure all ci.yml jobs use it.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

Related to https://github.com/camunda/team-infrastructure/issues/1051
