### PR TITLE
fix: AsyncHttpRequestRetryExec as WARN logs

### DIFF
--- a/load-tests/load-tester/src/main/resources/application.yaml
+++ b/load-tests/load-tester/src/main/resources/application.yaml
@@ -10,6 +10,11 @@ server:
 logging:
   level:
     root: ${LOG_LEVEL:WARN}
+    # Apache HC5 (used by CamundaClient's REST transport) logs every 503 retry
+    # at INFO, flooding starter/worker pod logs under benchmark load when
+    # LOG_LEVEL=INFO. Pin this package to WARN; override with
+    # LOGGING_LEVEL_ORG_APACHE_HC_CLIENT5_HTTP_IMPL_ASYNC=INFO to debug retries.
+    org.apache.hc.client5.http.impl.async: WARN
 
 management:
   server:


### PR DESCRIPTION
Enabling INFO logs on starter and workers for max and other scenarios caused logs to be generated extensively

## Description

This pull request makes a configuration change to reduce log noise during benchmark load testing. Specifically, it adjusts the logging level of the verbose Apache HTTP client package to prevent excessive log output at higher log levels.

**Earlier, we didn't have INFO logs in max and other load tests (only enabled on the realistic workflow), so we didn't observe this.**

Logging configuration improvements:

* Set the logging level for `org.apache.hc.client5.http.impl.async` to `WARN` in `application.yaml` to suppress excessive INFO-level logs from the HTTP client during retries, helping keep logs manageable during load tests.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

**Earlier:**
<img width="1920" height="771" alt="Screenshot 2026-04-23 at 8 38 12 PM" src="https://github.com/user-attachments/assets/a3d8ef8b-59c2-4a40-995f-9e6d97a569c5" />


**Now:**
<img width="1919" height="858" alt="Screenshot 2026-04-23 at 8 54 35 PM" src="https://github.com/user-attachments/assets/a5a94706-8a62-40cc-a639-bd9ce4471d16" />



closes #https://camunda.slack.com/archives/C0807665N8G/p1776954305796809?thread_ts=1751291927.538359&cid=C0807665N8G
