### PR TITLE
test: add E2E API tests for Execution Listener custom headers 

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/el-header-basic-end.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/el-header-basic-end.bpmn
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions
+  xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+  xmlns:modeler="http://camunda.org/schema/modeler/1.0"
+  id="Definitions_2"
+  targetNamespace="http://bpmn.io/schema/bpmn"
+  modeler:executionPlatform="Camunda Cloud"
+  modeler:executionPlatformVersion="8.10.0">
+  <bpmn:process id="el-header-basic-end" name="EL Header Basic End" isExecutable="true">
+    <bpmn:startEvent id="start" name="Start">
+      <bpmn:outgoing>sf1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="sf1" sourceRef="start" targetRef="task"/>
+    <bpmn:serviceTask id="task" name="Process Order">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="process-order-end" retries="3"/>
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="end" type="el-end-listener" retries="3">
+            <zeebe:taskHeaders>
+              <zeebe:header key="phase" value="post-processing"/>
+              <zeebe:header key="audited" value="true"/>
+            </zeebe:taskHeaders>
+          </zeebe:executionListener>
+        </zeebe:executionListeners>
+      </bpmn:extensionElements>
+      <bpmn:incoming>sf1</bpmn:incoming>
+      <bpmn:outgoing>sf2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="sf2" sourceRef="task" targetRef="end"/>
+    <bpmn:endEvent id="end" name="End">
+      <bpmn:incoming>sf2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="el-header-basic-end">
+      <bpmndi:BPMNShape id="start_di" bpmnElement="start"><dc:Bounds x="150" y="100" width="36" height="36"/></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="task_di" bpmnElement="task"><dc:Bounds x="240" y="78" width="100" height="80"/></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_di" bpmnElement="end"><dc:Bounds x="402" y="100" width="36" height="36"/></bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="sf1_di" bpmnElement="sf1"><di:waypoint x="186" y="118"/><di:waypoint x="240" y="118"/></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="sf2_di" bpmnElement="sf2"><di:waypoint x="340" y="118"/><di:waypoint x="402" y="118"/></bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/el-header-basic-start.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/el-header-basic-start.bpmn
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions
+  xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+  xmlns:modeler="http://camunda.org/schema/modeler/1.0"
+  id="Definitions_1"
+  targetNamespace="http://bpmn.io/schema/bpmn"
+  modeler:executionPlatform="Camunda Cloud"
+  modeler:executionPlatformVersion="8.10.0">
+  <bpmn:process id="el-header-basic-start" name="EL Header Basic Start" isExecutable="true">
+    <bpmn:startEvent id="start" name="Start">
+      <bpmn:outgoing>sf1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="sf1" sourceRef="start" targetRef="task"/>
+    <bpmn:serviceTask id="task" name="Process Order">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="process-order" retries="3"/>
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="start" type="el-start-listener" retries="3">
+            <zeebe:taskHeaders>
+              <zeebe:header key="env" value="production"/>
+              <zeebe:header key="retryPolicy" value="fast"/>
+            </zeebe:taskHeaders>
+          </zeebe:executionListener>
+        </zeebe:executionListeners>
+      </bpmn:extensionElements>
+      <bpmn:incoming>sf1</bpmn:incoming>
+      <bpmn:outgoing>sf2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="sf2" sourceRef="task" targetRef="end"/>
+    <bpmn:endEvent id="end" name="End">
+      <bpmn:incoming>sf2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="el-header-basic-start">
+      <bpmndi:BPMNShape id="start_di" bpmnElement="start"><dc:Bounds x="150" y="100" width="36" height="36"/></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="task_di" bpmnElement="task"><dc:Bounds x="240" y="78" width="100" height="80"/></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_di" bpmnElement="end"><dc:Bounds x="402" y="100" width="36" height="36"/></bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="sf1_di" bpmnElement="sf1"><di:waypoint x="186" y="118"/><di:waypoint x="240" y="118"/></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="sf2_di" bpmnElement="sf2"><di:waypoint x="340" y="118"/><di:waypoint x="402" y="118"/></bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/el-header-call-activity-child.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/el-header-call-activity-child.bpmn
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions
+  xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+  xmlns:modeler="http://camunda.org/schema/modeler/1.0"
+  id="Definitions_child"
+  targetNamespace="http://bpmn.io/schema/bpmn"
+  modeler:executionPlatform="Camunda Cloud"
+  modeler:executionPlatformVersion="8.10.0">
+  <bpmn:process id="el-header-call-activity-child" name="Child Process" isExecutable="true">
+    <bpmn:startEvent id="start" name="Start">
+      <bpmn:outgoing>sf1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="sf1" sourceRef="start" targetRef="childTask"/>
+    <bpmn:serviceTask id="childTask" name="Child Service Task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="child-service-job" retries="3"/>
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="start" type="el-child-start" retries="3">
+            <zeebe:taskHeaders>
+              <zeebe:header key="scope" value="child"/>
+              <zeebe:header key="env" value="sandbox"/>
+            </zeebe:taskHeaders>
+          </zeebe:executionListener>
+        </zeebe:executionListeners>
+      </bpmn:extensionElements>
+      <bpmn:incoming>sf1</bpmn:incoming>
+      <bpmn:outgoing>sf2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="sf2" sourceRef="childTask" targetRef="end"/>
+    <bpmn:endEvent id="end" name="End">
+      <bpmn:incoming>sf2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="el-header-call-activity-child">
+      <bpmndi:BPMNShape id="start_di" bpmnElement="start"><dc:Bounds x="150" y="100" width="36" height="36"/></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="childTask_di" bpmnElement="childTask"><dc:Bounds x="240" y="78" width="100" height="80"/></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_di" bpmnElement="end"><dc:Bounds x="402" y="100" width="36" height="36"/></bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="sf1_di" bpmnElement="sf1"><di:waypoint x="186" y="118"/><di:waypoint x="240" y="118"/></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="sf2_di" bpmnElement="sf2"><di:waypoint x="340" y="118"/><di:waypoint x="402" y="118"/></bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/el-header-call-activity-parent.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/el-header-call-activity-parent.bpmn
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions
+  xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+  xmlns:modeler="http://camunda.org/schema/modeler/1.0"
+  id="Definitions_parent"
+  targetNamespace="http://bpmn.io/schema/bpmn"
+  modeler:executionPlatform="Camunda Cloud"
+  modeler:executionPlatformVersion="8.10.0">
+  <bpmn:process id="el-header-call-activity-parent" name="Parent Process" isExecutable="true">
+    <bpmn:startEvent id="start" name="Start">
+      <bpmn:outgoing>sf1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="sf1" sourceRef="start" targetRef="callActivity"/>
+    <bpmn:callActivity id="callActivity" name="Call Child Process">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="el-header-call-activity-child" propagateAllChildVariables="false"/>
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="start" type="el-call-activity-start" retries="3">
+            <zeebe:taskHeaders>
+              <zeebe:header key="scope" value="parent"/>
+              <zeebe:header key="env" value="production"/>
+            </zeebe:taskHeaders>
+          </zeebe:executionListener>
+        </zeebe:executionListeners>
+      </bpmn:extensionElements>
+      <bpmn:incoming>sf1</bpmn:incoming>
+      <bpmn:outgoing>sf2</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="sf2" sourceRef="callActivity" targetRef="end"/>
+    <bpmn:endEvent id="end" name="End">
+      <bpmn:incoming>sf2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="el-header-call-activity-parent">
+      <bpmndi:BPMNShape id="start_di" bpmnElement="start"><dc:Bounds x="150" y="100" width="36" height="36"/></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="callActivity_di" bpmnElement="callActivity"><dc:Bounds x="240" y="78" width="100" height="80"/></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_di" bpmnElement="end"><dc:Bounds x="402" y="100" width="36" height="36"/></bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="sf1_di" bpmnElement="sf1"><di:waypoint x="186" y="118"/><di:waypoint x="240" y="118"/></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="sf2_di" bpmnElement="sf2"><di:waypoint x="340" y="118"/><di:waypoint x="402" y="118"/></bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/el-header-conflict.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/el-header-conflict.bpmn
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions
+  xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+  xmlns:modeler="http://camunda.org/schema/modeler/1.0"
+  id="Definitions_5"
+  targetNamespace="http://bpmn.io/schema/bpmn"
+  modeler:executionPlatform="Camunda Cloud"
+  modeler:executionPlatformVersion="8.10.0">
+  <bpmn:process id="el-header-conflict" name="EL Header Conflict" isExecutable="true">
+    <bpmn:startEvent id="start" name="Start">
+      <bpmn:outgoing>sf1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="sf1" sourceRef="start" targetRef="task"/>
+    <bpmn:serviceTask id="task" name="Conflict Test Task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="conflict-main-task" retries="3"/>
+        <zeebe:taskHeaders>
+          <zeebe:header key="config" value="defaultValue"/>
+          <zeebe:header key="onlyBase" value="fromBase"/>
+        </zeebe:taskHeaders>
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="start" type="el-conflict-listener" retries="3">
+            <zeebe:taskHeaders>
+              <zeebe:header key="config" value="overriddenValue"/>
+              <zeebe:header key="onlyEl" value="fromEL"/>
+            </zeebe:taskHeaders>
+          </zeebe:executionListener>
+        </zeebe:executionListeners>
+      </bpmn:extensionElements>
+      <bpmn:incoming>sf1</bpmn:incoming>
+      <bpmn:outgoing>sf2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="sf2" sourceRef="task" targetRef="end"/>
+    <bpmn:endEvent id="end" name="End">
+      <bpmn:incoming>sf2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="el-header-conflict">
+      <bpmndi:BPMNShape id="start_di" bpmnElement="start"><dc:Bounds x="150" y="100" width="36" height="36"/></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="task_di" bpmnElement="task"><dc:Bounds x="240" y="78" width="100" height="80"/></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_di" bpmnElement="end"><dc:Bounds x="402" y="100" width="36" height="36"/></bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="sf1_di" bpmnElement="sf1"><di:waypoint x="186" y="118"/><di:waypoint x="240" y="118"/></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="sf2_di" bpmnElement="sf2"><di:waypoint x="340" y="118"/><di:waypoint x="402" y="118"/></bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/el-header-gateway.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/el-header-gateway.bpmn
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions
+  xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+  xmlns:modeler="http://camunda.org/schema/modeler/1.0"
+  id="Definitions_9"
+  targetNamespace="http://bpmn.io/schema/bpmn"
+  modeler:executionPlatform="Camunda Cloud"
+  modeler:executionPlatformVersion="8.10.0">
+  <bpmn:process id="el-header-gateway" name="EL Header Gateway" isExecutable="true">
+    <bpmn:startEvent id="start" name="Start">
+      <bpmn:outgoing>sf1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="sf1" sourceRef="start" targetRef="gw"/>
+    <bpmn:exclusiveGateway id="gw" name="Route?" default="sfDefault">
+      <bpmn:extensionElements>
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="start" type="el-gw-listener" retries="3">
+            <zeebe:taskHeaders>
+              <zeebe:header key="gatewayCtx" value="routing-phase"/>
+            </zeebe:taskHeaders>
+          </zeebe:executionListener>
+        </zeebe:executionListeners>
+      </bpmn:extensionElements>
+      <bpmn:incoming>sf1</bpmn:incoming>
+      <bpmn:outgoing>sfDefault</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="sfDefault" sourceRef="gw" targetRef="taskA"/>
+    <bpmn:serviceTask id="taskA" name="Task A">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="task-a" retries="3"/>
+      </bpmn:extensionElements>
+      <bpmn:incoming>sfDefault</bpmn:incoming>
+      <bpmn:outgoing>sf3</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="sf3" sourceRef="taskA" targetRef="end"/>
+    <bpmn:endEvent id="end" name="End">
+      <bpmn:incoming>sf3</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="el-header-gateway">
+      <bpmndi:BPMNShape id="start_di" bpmnElement="start"><dc:Bounds x="150" y="100" width="36" height="36"/></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="gw_di" bpmnElement="gw" isMarkerVisible="true"><dc:Bounds x="240" y="93" width="50" height="50"/></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="taskA_di" bpmnElement="taskA"><dc:Bounds x="350" y="78" width="100" height="80"/></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_di" bpmnElement="end"><dc:Bounds x="512" y="100" width="36" height="36"/></bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="sf1_di" bpmnElement="sf1"><di:waypoint x="186" y="118"/><di:waypoint x="240" y="118"/></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="sfDefault_di" bpmnElement="sfDefault"><di:waypoint x="290" y="118"/><di:waypoint x="350" y="118"/></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="sf3_di" bpmnElement="sf3"><di:waypoint x="450" y="118"/><di:waypoint x="512" y="118"/></bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/el-header-subprocess.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/el-header-subprocess.bpmn
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions
+  xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+  xmlns:modeler="http://camunda.org/schema/modeler/1.0"
+  id="Definitions_10"
+  targetNamespace="http://bpmn.io/schema/bpmn"
+  modeler:executionPlatform="Camunda Cloud"
+  modeler:executionPlatformVersion="8.10.0">
+  <bpmn:process id="el-header-subprocess" name="EL Header Subprocess" isExecutable="true">
+    <bpmn:startEvent id="start" name="Start">
+      <bpmn:outgoing>sf1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="sf1" sourceRef="start" targetRef="subprocess"/>
+    <bpmn:subProcess id="subprocess" name="Sub Process">
+      <bpmn:extensionElements>
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="start" type="el-subprocess-start" retries="3">
+            <zeebe:taskHeaders>
+              <zeebe:header key="scope" value="subprocess-init"/>
+            </zeebe:taskHeaders>
+          </zeebe:executionListener>
+          <zeebe:executionListener eventType="end" type="el-subprocess-end" retries="3">
+            <zeebe:taskHeaders>
+              <zeebe:header key="scope" value="subprocess-cleanup"/>
+            </zeebe:taskHeaders>
+          </zeebe:executionListener>
+        </zeebe:executionListeners>
+      </bpmn:extensionElements>
+      <bpmn:incoming>sf1</bpmn:incoming>
+      <bpmn:outgoing>sf2</bpmn:outgoing>
+      <bpmn:startEvent id="subStart">
+        <bpmn:outgoing>sfsub1</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="sfsub1" sourceRef="subStart" targetRef="subTask"/>
+      <bpmn:serviceTask id="subTask" name="Inner Task">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="inner-task" retries="3"/>
+        </bpmn:extensionElements>
+        <bpmn:incoming>sfsub1</bpmn:incoming>
+        <bpmn:outgoing>sfsub2</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:sequenceFlow id="sfsub2" sourceRef="subTask" targetRef="subEnd"/>
+      <bpmn:endEvent id="subEnd">
+        <bpmn:incoming>sfsub2</bpmn:incoming>
+      </bpmn:endEvent>
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="sf2" sourceRef="subprocess" targetRef="end"/>
+    <bpmn:endEvent id="end" name="End">
+      <bpmn:incoming>sf2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="el-header-subprocess">
+      <bpmndi:BPMNShape id="start_di" bpmnElement="start"><dc:Bounds x="150" y="118" width="36" height="36"/></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="subprocess_di" bpmnElement="subprocess" isExpanded="true"><dc:Bounds x="240" y="60" width="350" height="150"/></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="subStart_di" bpmnElement="subStart"><dc:Bounds x="272" y="118" width="36" height="36"/></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="subTask_di" bpmnElement="subTask"><dc:Bounds x="360" y="96" width="100" height="80"/></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="subEnd_di" bpmnElement="subEnd"><dc:Bounds x="512" y="118" width="36" height="36"/></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="end_di" bpmnElement="end"><dc:Bounds x="652" y="118" width="36" height="36"/></bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="sf1_di" bpmnElement="sf1"><di:waypoint x="186" y="136"/><di:waypoint x="240" y="136"/></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="sfsub1_di" bpmnElement="sfsub1"><di:waypoint x="308" y="136"/><di:waypoint x="360" y="136"/></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="sfsub2_di" bpmnElement="sfsub2"><di:waypoint x="460" y="136"/><di:waypoint x="512" y="136"/></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="sf2_di" bpmnElement="sf2"><di:waypoint x="590" y="136"/><di:waypoint x="652" y="136"/></bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/el-header-basic-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/el-header-basic-tests.spec.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect, test} from '@playwright/test';
+import {randomUUID} from 'crypto';
+import {
+  cancelProcessInstance,
+  createInstances,
+  deployWithSubstitutions,
+} from '../../../../utils/zeebeClient';
+import {assertStatusCode, buildUrl, jsonHeaders} from '../../../../utils/http';
+import {
+  activateJobAndGetHeaders,
+  completeJob,
+} from '../../../../utils/requestHelpers/job-requestHelpers';
+
+test.describe.parallel('EL Header Basic Tests', () => {
+  const suffix = randomUUID().slice(0, 8);
+
+  // E2E-01
+  const basicStartProcessId = `el-header-basic-start-${suffix}`;
+  const elStartListenerType = `el-start-listener-${suffix}`;
+  const processOrderType = `process-order-${suffix}`;
+
+  // E2E-02
+  const basicEndProcessId = `el-header-basic-end-${suffix}`;
+  const elEndListenerType = `el-end-listener-${suffix}`;
+  const processOrderEndType = `process-order-end-${suffix}`;
+
+  test.beforeAll(async () => {
+    await deployWithSubstitutions('./resources/el-header-basic-start.bpmn', {
+      'el-header-basic-start': basicStartProcessId,
+      'el-start-listener': elStartListenerType,
+      'process-order': processOrderType,
+    });
+    await deployWithSubstitutions('./resources/el-header-basic-end.bpmn', {
+      'el-header-basic-end': basicEndProcessId,
+      'el-end-listener': elEndListenerType,
+      'process-order-end': processOrderEndType,
+    });
+  });
+
+  test('As a developer, I can define headers on a start EL and verify the job worker receives them', async ({
+    request,
+  }) => {
+    const instances = await createInstances(basicStartProcessId, 1, 1);
+    const piKey = String(instances[0].processInstanceKey);
+
+    try {
+      // Activate start EL job and assert its headers
+      const elJob = await activateJobAndGetHeaders(
+        request,
+        elStartListenerType,
+      );
+      expect(elJob.customHeaders).toMatchObject({
+        env: 'production',
+        retryPolicy: 'fast',
+      });
+
+      // Main task must be blocked while start EL is still active (use search, not long-poll)
+      const blockingRes = await request.post(buildUrl('/jobs/search'), {
+        headers: jsonHeaders(),
+        data: {filter: {processInstanceKey: piKey, type: processOrderType}},
+      });
+      await assertStatusCode(blockingRes, 200);
+      expect((await blockingRes.json()).items).toHaveLength(0);
+
+      // Complete EL job — main task should now be available
+      await completeJob(request, elJob.jobKey);
+
+      // Main task must have no EL headers (no leakage)
+      const mainJob = await activateJobAndGetHeaders(request, processOrderType);
+      expect(mainJob.customHeaders['env']).toBeUndefined();
+      expect(mainJob.customHeaders['retryPolicy']).toBeUndefined();
+      await completeJob(request, mainJob.jobKey);
+    } finally {
+      await cancelProcessInstance(piKey);
+    }
+  });
+
+  test('As a developer, I can define headers on an end EL and verify they are delivered after the main task completes', async ({
+    request,
+  }) => {
+    const instances = await createInstances(basicEndProcessId, 1, 1);
+    const piKey = String(instances[0].processInstanceKey);
+
+    try {
+      // Complete the main task first
+      const mainJob = await activateJobAndGetHeaders(
+        request,
+        processOrderEndType,
+      );
+      await completeJob(request, mainJob.jobKey);
+
+      // End EL fires after main task — assert headers
+      const elJob = await activateJobAndGetHeaders(request, elEndListenerType);
+      expect(elJob.customHeaders).toMatchObject({
+        phase: 'post-processing',
+        audited: 'true',
+      });
+      await completeJob(request, elJob.jobKey);
+    } finally {
+      await cancelProcessInstance(piKey);
+    }
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/el-header-basic-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/el-header-basic-tests.spec.ts
@@ -14,10 +14,7 @@ import {
   deployWithSubstitutions,
 } from '../../../../utils/zeebeClient';
 import {assertStatusCode, buildUrl, jsonHeaders} from '../../../../utils/http';
-import {
-  activateJobAndGetHeaders,
-  completeJob,
-} from '../../../../utils/requestHelpers/job-requestHelpers';
+import {activateJobAndGetHeaders, completeJob} from '@requestHelpers';
 
 test.describe.parallel('EL Header Basic Tests', () => {
   const suffix = randomUUID().slice(0, 8);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/el-header-cross-task-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/el-header-cross-task-tests.spec.ts
@@ -13,10 +13,7 @@ import {
   createInstances,
   deployWithSubstitutions,
 } from '../../../../utils/zeebeClient';
-import {
-  activateJobAndGetHeaders,
-  completeJob,
-} from '../../../../utils/requestHelpers/job-requestHelpers';
+import {activateJobAndGetHeaders, completeJob} from '@requestHelpers';
 
 test.describe.parallel('EL Header Cross-Task Isolation Tests', () => {
   const suffix = randomUUID().slice(0, 8);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/el-header-cross-task-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/el-header-cross-task-tests.spec.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect, test} from '@playwright/test';
+import {randomUUID} from 'crypto';
+import {
+  cancelProcessInstance,
+  createInstances,
+  deployWithSubstitutions,
+} from '../../../../utils/zeebeClient';
+import {
+  activateJobAndGetHeaders,
+  completeJob,
+} from '../../../../utils/requestHelpers/job-requestHelpers';
+
+test.describe.parallel('EL Header Cross-Task Isolation Tests', () => {
+  const suffix = randomUUID().slice(0, 8);
+
+  const callActivityParentProcessId = `el-header-call-activity-parent-${suffix}`;
+  const callActivityChildProcessId = `el-header-call-activity-child-${suffix}`;
+  const elCallActivityStartType = `el-call-activity-start-${suffix}`;
+  const elChildStartType = `el-child-start-${suffix}`;
+  const childServiceJobType = `child-service-job-${suffix}`;
+
+  test.beforeAll(async () => {
+    // Child must be deployed before parent so the calledElement reference resolves
+    await deployWithSubstitutions(
+      './resources/el-header-call-activity-child.bpmn',
+      {
+        'el-header-call-activity-child': callActivityChildProcessId,
+        'el-child-start': elChildStartType,
+        'child-service-job': childServiceJobType,
+      },
+    );
+    await deployWithSubstitutions(
+      './resources/el-header-call-activity-parent.bpmn',
+      {
+        'el-header-call-activity-parent': callActivityParentProcessId,
+        'el-header-call-activity-child': callActivityChildProcessId,
+        'el-call-activity-start': elCallActivityStartType,
+      },
+    );
+  });
+
+  test('As a developer, I can verify that EL headers defined on a Call Activity do not appear in the EL jobs of the called process', async ({
+    request,
+  }) => {
+    const instances = await createInstances(callActivityParentProcessId, 1, 1);
+    const piKey = String(instances[0].processInstanceKey);
+
+    try {
+      // Parent Call Activity start EL: parent-scoped headers
+      const caJob = await activateJobAndGetHeaders(
+        request,
+        elCallActivityStartType,
+      );
+      expect(caJob.customHeaders).toMatchObject({
+        scope: 'parent',
+        env: 'production',
+      });
+      await completeJob(request, caJob.jobKey);
+
+      // Child process service task start EL: child-scoped headers only — no bleed from parent
+      const childJob = await activateJobAndGetHeaders(
+        request,
+        elChildStartType,
+      );
+      expect(childJob.customHeaders).toMatchObject({
+        scope: 'child',
+        env: 'sandbox',
+      });
+      expect(childJob.customHeaders['scope']).not.toBe('parent');
+      expect(childJob.customHeaders['env']).not.toBe('production');
+      await completeJob(request, childJob.jobKey);
+
+      // Complete the child service task to let the child process finish
+      const childServiceJob = await activateJobAndGetHeaders(
+        request,
+        childServiceJobType,
+      );
+      await completeJob(request, childServiceJob.jobKey);
+    } finally {
+      await cancelProcessInstance(piKey);
+    }
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/el-header-element-types-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/el-header-element-types-tests.spec.ts
@@ -13,10 +13,7 @@ import {
   createInstances,
   deployWithSubstitutions,
 } from '../../../../utils/zeebeClient';
-import {
-  activateJobAndGetHeaders,
-  completeJob,
-} from '../../../../utils/requestHelpers/job-requestHelpers';
+import {activateJobAndGetHeaders, completeJob} from '@requestHelpers';
 
 test.describe.parallel('EL Header Element Types Tests', () => {
   const suffix = randomUUID().slice(0, 8);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/el-header-element-types-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/el-header-element-types-tests.spec.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect, test} from '@playwright/test';
+import {randomUUID} from 'crypto';
+import {
+  cancelProcessInstance,
+  createInstances,
+  deployWithSubstitutions,
+} from '../../../../utils/zeebeClient';
+import {
+  activateJobAndGetHeaders,
+  completeJob,
+} from '../../../../utils/requestHelpers/job-requestHelpers';
+
+test.describe.parallel('EL Header Element Types Tests', () => {
+  const suffix = randomUUID().slice(0, 8);
+
+  // E2E-09
+  const gatewayProcessId = `el-header-gateway-${suffix}`;
+  const elGwListenerType = `el-gw-listener-${suffix}`;
+  const taskAType = `task-a-${suffix}`;
+
+  // E2E-10
+  const subprocessProcessId = `el-header-subprocess-${suffix}`;
+  const elSubprocessStartType = `el-subprocess-start-${suffix}`;
+  const elSubprocessEndType = `el-subprocess-end-${suffix}`;
+  const innerTaskType = `inner-task-${suffix}`;
+
+  test.beforeAll(async () => {
+    await deployWithSubstitutions('./resources/el-header-gateway.bpmn', {
+      'el-header-gateway': gatewayProcessId,
+      'el-gw-listener': elGwListenerType,
+      'task-a': taskAType,
+    });
+    await deployWithSubstitutions('./resources/el-header-subprocess.bpmn', {
+      'el-header-subprocess': subprocessProcessId,
+      'el-subprocess-start': elSubprocessStartType,
+      'el-subprocess-end': elSubprocessEndType,
+      'inner-task': innerTaskType,
+    });
+  });
+
+  test('As a developer, I can define a start EL with headers on an Exclusive Gateway and verify the job worker receives them', async ({
+    request,
+  }) => {
+    const instances = await createInstances(gatewayProcessId, 1, 1);
+    const piKey = String(instances[0].processInstanceKey);
+
+    try {
+      const elJob = await activateJobAndGetHeaders(request, elGwListenerType);
+      expect(elJob.customHeaders).toMatchObject({gatewayCtx: 'routing-phase'});
+      await completeJob(request, elJob.jobKey);
+
+      const downstreamJob = await activateJobAndGetHeaders(request, taskAType);
+      await completeJob(request, downstreamJob.jobKey);
+    } finally {
+      await cancelProcessInstance(piKey);
+    }
+  });
+
+  test('As a developer, I can define start and end EL headers on an Embedded Subprocess and verify both are delivered correctly', async ({
+    request,
+  }) => {
+    const instances = await createInstances(subprocessProcessId, 1, 1);
+    const piKey = String(instances[0].processInstanceKey);
+
+    try {
+      // Subprocess start EL
+      const startJob = await activateJobAndGetHeaders(
+        request,
+        elSubprocessStartType,
+      );
+      expect(startJob.customHeaders).toMatchObject({scope: 'subprocess-init'});
+      await completeJob(request, startJob.jobKey);
+
+      // Inner task inside the subprocess
+      const innerJob = await activateJobAndGetHeaders(request, innerTaskType);
+      await completeJob(request, innerJob.jobKey);
+
+      // Subprocess end EL
+      const endJob = await activateJobAndGetHeaders(
+        request,
+        elSubprocessEndType,
+      );
+      expect(endJob.customHeaders).toMatchObject({scope: 'subprocess-cleanup'});
+      await completeJob(request, endJob.jobKey);
+    } finally {
+      await cancelProcessInstance(piKey);
+    }
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/el-header-merge-conflict-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/el-header-merge-conflict-tests.spec.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect, test} from '@playwright/test';
+import {randomUUID} from 'crypto';
+import {
+  cancelProcessInstance,
+  createInstances,
+  deployWithSubstitutions,
+} from '../../../../utils/zeebeClient';
+import {
+  activateJobAndGetHeaders,
+  completeJob,
+} from '../../../../utils/requestHelpers/job-requestHelpers';
+
+test.describe.parallel('EL Header Merge and Conflict Tests', () => {
+  const suffix = randomUUID().slice(0, 8);
+
+  const conflictProcessId = `el-header-conflict-${suffix}`;
+  const elConflictListenerType = `el-conflict-listener-${suffix}`;
+  const conflictMainTaskType = `conflict-main-task-${suffix}`;
+
+  test.beforeAll(async () => {
+    await deployWithSubstitutions('./resources/el-header-conflict.bpmn', {
+      'el-header-conflict': conflictProcessId,
+      'el-conflict-listener': elConflictListenerType,
+      'conflict-main-task': conflictMainTaskType,
+    });
+  });
+
+  test('As a developer, I can verify that when a header key is defined on both the base element and the EL, the EL value takes precedence', async ({
+    request,
+  }) => {
+    const instances = await createInstances(conflictProcessId, 1, 1);
+    const piKey = String(instances[0].processInstanceKey);
+
+    try {
+      const elJob = await activateJobAndGetHeaders(
+        request,
+        elConflictListenerType,
+      );
+      // EL overrides base "config"; base-only and EL-only headers are preserved
+      expect(elJob.customHeaders).toMatchObject({
+        config: 'overriddenValue',
+        onlyBase: 'fromBase',
+        onlyEl: 'fromEL',
+      });
+      // Original base value must not appear anywhere in the headers
+      expect(Object.values(elJob.customHeaders)).not.toContain('defaultValue');
+      await completeJob(request, elJob.jobKey);
+
+      const mainJob = await activateJobAndGetHeaders(
+        request,
+        conflictMainTaskType,
+      );
+      await completeJob(request, mainJob.jobKey);
+    } finally {
+      await cancelProcessInstance(piKey);
+    }
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/el-header-merge-conflict-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/el-header-merge-conflict-tests.spec.ts
@@ -13,10 +13,7 @@ import {
   createInstances,
   deployWithSubstitutions,
 } from '../../../../utils/zeebeClient';
-import {
-  activateJobAndGetHeaders,
-  completeJob,
-} from '../../../../utils/requestHelpers/job-requestHelpers';
+import {activateJobAndGetHeaders, completeJob} from '@requestHelpers';
 
 test.describe.parallel('EL Header Merge and Conflict Tests', () => {
   const suffix = randomUUID().slice(0, 8);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
@@ -57,8 +57,11 @@ export {assertClientsInResponse} from './clients-requestHelpers';
 export {
   setupProcessInstanceForTests,
   activateJobToObtainAValidJobKey,
+  activateJobAndGetHeaders,
+  completeJob,
   getLast24HoursRange,
   type StatisticsJobItem,
+  type ActivatedJob,
 } from './job-requestHelpers';
 export {
   createGlobalClusterVariable,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/job-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/job-requestHelpers.ts
@@ -75,6 +75,30 @@ export async function searchJobKey(
   return result.jobKey;
 }
 
+export interface ActivatedJob {
+  jobKey: number;
+  customHeaders: Record<string, string>;
+}
+
+export async function activateJobAndGetHeaders(
+  request: APIRequestContext,
+  jobType: string,
+): Promise<ActivatedJob> {
+  const result: ActivatedJob = {jobKey: 0, customHeaders: {}};
+  await expect(async () => {
+    const res = await request.post(buildUrl('/jobs/activation'), {
+      headers: jsonHeaders(),
+      data: {type: jobType, timeout: 5000, maxJobsToActivate: 1},
+    });
+    await assertStatusCode(res, 200);
+    const json = await res.json();
+    expect(json.jobs).toHaveLength(1);
+    result.jobKey = json.jobs[0].jobKey;
+    result.customHeaders = json.jobs[0].customHeaders;
+  }).toPass(defaultAssertionOptions);
+  return result;
+}
+
 export async function completeJob(
   request: APIRequestContext,
   jobKey: number,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/job-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/job-requestHelpers.ts
@@ -77,7 +77,7 @@ export async function searchJobKey(
 
 export interface ActivatedJob {
   jobKey: number;
-  customHeaders: Record<string, string>;
+  customHeaders: JSONDoc;
 }
 
 export async function activateJobAndGetHeaders(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/job-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/job-requestHelpers.ts
@@ -91,6 +91,14 @@ export async function activateJobAndGetHeaders(
       data: {type: jobType, timeout: 5000, maxJobsToActivate: 1},
     });
     await assertStatusCode(res, 200);
+    await validateResponse(
+      {
+        path: '/jobs/activation',
+        method: 'POST',
+        status: '200',
+      },
+      res,
+    );
     const json = await res.json();
     expect(json.jobs).toHaveLength(1);
     result.jobKey = json.jobs[0].jobKey;


### PR DESCRIPTION
## Description

Adds 6 focused Playwright API tests for the Execution Listener (EL) configuration headers feature (Epic #3450). Tests are placed in `tests/api/v2/job/` alongside existing job worker tests.

**Tests added:**
- **start EL headers** — verifies headers are delivered to the job worker and the main task is blocked until the EL completes
- **end EL headers** — verifies headers are delivered after the main task completes
- **EL overrides element header on conflict** — verifies merge behaviour: both unique keys preserved, EL value wins on a shared key
- **exclusive gateway EL** — verifies header delivery on a gateway element type
- **embedded subprocess EL** — verifies start + end EL headers on a subprocess scope
- **call activity cross-process isolation** — verifies parent EL headers do not bleed into child process EL jobs (cross-process boundary; this scenario has no coverage at unit/integration level)


**Helper changes (`utils/requestHelpers/job-requestHelpers.ts`):**
- Added `ActivatedJob` interface and `activateJobAndGetHeaders()` polling helper
- Uses `timeout: 5000` in the Zeebe body to stay safely under Playwright's global `actionTimeout: 10000`
- The blocking check in the start-EL test uses `POST /jobs/search` instead of a long-poll activation — Zeebe holds long-polls indefinitely when the main task is genuinely blocked, which would hit Playwright's action timeout

## Test plan

- [x] All 6 new tests pass against a local Camunda 8 Self-Managed instance (Docker Compose / Elasticsearch mode)
- [x] No regressions in the existing `api-tests` suite (82 passed, 1 pre-existing failure in `job-statistics-by-worker` unrelated to this change)
- [x] ESLint/Prettier formatting verified clean

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

https://github.com/camunda/product-hub/issues/3587
https://github.com/camunda/camunda/issues/51419
