### PR TITLE
fix(zeebe/backup): lower log level for transient invalid snapshot backup case

### DIFF
--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackupImpl.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackupImpl.java
@@ -319,7 +319,7 @@ final class InProgressBackupImpl implements InProgressBackup {
       final var errorMessage =
           "No valid snapshots found for backup:\n"
               + snapshotValidationErrorMessage(validationResults);
-      LOG.atError().addKeyValue("backup", backupId).log(errorMessage);
+      LOG.atWarn().addKeyValue("backup", backupId).log(errorMessage);
       return Either.left(errorMessage);
     } else {
       final var validSnapshotCount = validSnapshots.size();


### PR DESCRIPTION
## Summary
- Downgrade the log level from `ERROR` to `WARN` when backup finds no valid snapshots due to transient snapshot/checkpoint timing.
- Keep snapshot validation and backup behavior unchanged.

## Why
- This condition is expected and transient in some cases, and logging it as `ERROR` creates avoidable alert noise.

## Testing
- ./mvnw verify -pl zeebe/backup -Dtest=InProgressBackupImplTest -DskipTests=false -DskipITs -Dquickly
- Result: pass

Closes #51682