### PR TITLE
test: clear all process instances before task-panel tests

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-panel.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-panel.spec.ts
@@ -12,8 +12,11 @@ import {deploy, createInstances} from 'utils/zeebeClient';
 import {sleep} from 'utils/sleep';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {navigateToApp} from '@pages/UtilitiesPage';
+import {clearAllProcessInstances} from '@requestHelpers';
 
-test.beforeAll(async () => {
+test.beforeAll(async ({request}) => {
+  await clearAllProcessInstances(request);
+
   await deploy([
     './resources/usertask_to_be_assigned.bpmn',
     './resources/usertask_for_scrolling_1.bpmn',

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/process-instance-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/process-instance-requestHelpers.ts
@@ -237,7 +237,7 @@ async function countProcessInstances(
 
 async function runBatchAndWaitForCompletion(
   request: APIRequestContext,
-  endpoint: string,
+  endpoint: '/process-instances/cancellation' | '/process-instances/deletion',
   filter: Record<string, unknown>,
 ): Promise<void> {
   const res = await request.post(buildUrl(endpoint), {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/process-instance-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/process-instance-requestHelpers.ts
@@ -222,6 +222,19 @@ export async function expectProcessInstanceCanBeFound(
   });
 }
 
+async function countProcessInstances(
+  request: APIRequestContext,
+  state: string,
+): Promise<number> {
+  const res = await request.post(buildUrl('/process-instances/search'), {
+    headers: jsonHeaders(),
+    data: {filter: {state}, page: {limit: 1}},
+  });
+  await assertStatusCode(res, 200);
+  const json = await res.json();
+  return json.page.totalItems as number;
+}
+
 async function runBatchAndWaitForCompletion(
   request: APIRequestContext,
   endpoint: string,
@@ -231,9 +244,6 @@ async function runBatchAndWaitForCompletion(
     headers: jsonHeaders(),
     data: {filter},
   });
-
-  // 400 means no matching instances — nothing to do
-  if (res.status() === 400) return;
 
   await assertStatusCode(res, 200);
   await validateResponse(
@@ -253,15 +263,23 @@ async function runBatchAndWaitForCompletion(
 export async function clearAllProcessInstances(
   request: APIRequestContext,
 ): Promise<void> {
-  // Cancel all active instances first; the API overrides the state filter
-  // internally but requires a non-empty filter to be valid.
-  await runBatchAndWaitForCompletion(
-    request,
-    '/process-instances/cancellation',
-    {state: 'ACTIVE'},
-  );
-  // Cancellation moves instances to TERMINATED; delete both terminal states.
-  await runBatchAndWaitForCompletion(request, '/process-instances/deletion', {
-    $or: [{state: 'COMPLETED'}, {state: 'TERMINATED'}],
-  });
+  // Cancel all active instances first.
+  if ((await countProcessInstances(request, 'ACTIVE')) > 0) {
+    await runBatchAndWaitForCompletion(
+      request,
+      '/process-instances/cancellation',
+      {state: 'ACTIVE'},
+    );
+  }
+  // Cancellation moves instances to TERMINATED; delete each terminal state
+  // individually to avoid relying on $or in the search pre-check.
+  for (const state of ['COMPLETED', 'TERMINATED']) {
+    if ((await countProcessInstances(request, state)) > 0) {
+      await runBatchAndWaitForCompletion(
+        request,
+        '/process-instances/deletion',
+        {state},
+      );
+    }
+  }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/process-instance-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/process-instance-requestHelpers.ts
@@ -220,3 +220,50 @@ export async function expectProcessInstanceCanBeFound(
     timeout: 180_000,
   });
 }
+
+async function runBatchAndWaitForCompletion(
+  request: APIRequestContext,
+  endpoint: string,
+  filter: Record<string, unknown>,
+): Promise<void> {
+  const res = await request.post(buildUrl(endpoint), {
+    headers: jsonHeaders(),
+    data: {filter},
+  });
+
+  // 400 means no matching instances — nothing to do
+  if (res.status() === 400) return;
+
+  await assertStatusCode(res, 200);
+  const json = await res.json();
+  const batchKey = json.batchOperationKey;
+
+  await expect(async () => {
+    const statusRes = await request.get(
+      buildUrl(`/batch-operations/${batchKey}`),
+      {headers: jsonHeaders()},
+    );
+    await assertStatusCode(statusRes, 200);
+    const body = await statusRes.json();
+    expect(body.state).toBe('COMPLETED');
+  }).toPass({
+    intervals: [5_000, 10_000, 15_000, 25_000, 35_000],
+    timeout: 120_000,
+  });
+}
+
+export async function clearAllProcessInstances(
+  request: APIRequestContext,
+): Promise<void> {
+  // Cancel all active instances first; the API overrides the state filter
+  // internally but requires a non-empty filter to be valid.
+  await runBatchAndWaitForCompletion(
+    request,
+    '/process-instances/cancellation',
+    {state: 'ACTIVE'},
+  );
+  // Cancellation moves instances to TERMINATED; delete both terminal states.
+  await runBatchAndWaitForCompletion(request, '/process-instances/deletion', {
+    $or: [{state: 'COMPLETED'}, {state: 'TERMINATED'}],
+  });
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/process-instance-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/process-instance-requestHelpers.ts
@@ -13,6 +13,7 @@ import {defaultAssertionOptions} from '../constants';
 import {cancelProcessInstance} from '../zeebeClient';
 import {sleep} from '../sleep';
 import {validateResponse} from 'json-body-assertions';
+import {expectBatchState} from './batch-operation-requestHelpers';
 
 export async function getProcessDefinitionKey(
   request: APIRequestContext,
@@ -235,21 +236,18 @@ async function runBatchAndWaitForCompletion(
   if (res.status() === 400) return;
 
   await assertStatusCode(res, 200);
+  await validateResponse(
+    {
+      path: endpoint,
+      method: 'POST',
+      status: '200',
+    },
+    res,
+  );
   const json = await res.json();
   const batchKey = json.batchOperationKey;
 
-  await expect(async () => {
-    const statusRes = await request.get(
-      buildUrl(`/batch-operations/${batchKey}`),
-      {headers: jsonHeaders()},
-    );
-    await assertStatusCode(statusRes, 200);
-    const body = await statusRes.json();
-    expect(body.state).toBe('COMPLETED');
-  }).toPass({
-    intervals: [5_000, 10_000, 15_000, 25_000, 35_000],
-    timeout: 120_000,
-  });
+  await expectBatchState(request, batchKey, 'COMPLETED');
 }
 
 export async function clearAllProcessInstances(


### PR DESCRIPTION
## Summary

This is a follow-up impact of #50702 (_Remove Tasklist V1 API and related tests_), which removed the `resetData` helper that previously cleared process instances via the Tasklist V1 API. With that API gone, the `task-panel` tests had no environment cleanup before execution, causing them to fail due to leftover process instances from prior runs.

The `task-panel` tests rely on exact task counts (e.g. exactly 50 `Some user activity` tasks visible, and "No tasks found" under the "Assigned to me" filter). These assertions fail when leftover instances pollute the environment.

## Changes

### New utility: `clearAllProcessInstances`

Added to `utils/requestHelpers/process-instance-requestHelpers.ts`:

- **Step 1 – Cancel**: `POST /process-instances/cancellation` with `filter: {state: 'ACTIVE'}` — cancels all running instances (moves them to `TERMINATED`).
- **Step 2 – Delete**: `POST /process-instances/deletion` with `filter: {$or: [{state: 'COMPLETED'}, {state: 'TERMINATED'}]}` — deletes all historic data from secondary storage.
- Each step polls `GET /batch-operations/{key}` until the batch reaches `COMPLETED` before proceeding.
- A 400 response is treated as a no-op (no matching instances), so the cleanup is safe to run against a fresh environment.

### Updated `task-panel.spec.ts`

- `beforeAll` now accepts `{request}` from fixtures and calls `clearAllProcessInstances(request)` before deploying and creating instances.

## Testing
https://github.com/camunda/camunda/actions/runs/24880605132
✅ All task panel tests passed, remaining tests will be investigated in separate PRs