### PR TITLE
feat: add nullaway nullness checker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,7 +268,7 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
       # Not running Maven Spotless here since it is checked in a dedicated job
-      - run: ./mvnw -T1C -B -D skipTests -Dspotless.check.skip=true -P !autoFormat,checkFormat,spotbugs,nullaway,skipFrontendBuild verify
+      - run: ./mvnw -T1C -B -D skipTests -Dspotless.check.skip=true -P !autoFormat,checkFormat,spotbugs,skipFrontendBuild verify
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,7 +268,7 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
       # Not running Maven Spotless here since it is checked in a dedicated job
-      - run: ./mvnw -T1C -B -D skipTests -Dspotless.check.skip=true -P !autoFormat,checkFormat,spotbugs,skipFrontendBuild verify
+      - run: ./mvnw -T1C -B -D skipTests -Dspotless.check.skip=true -P !autoFormat,checkFormat,spotbugs,nullaway,skipFrontendBuild verify
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,9 +1,14 @@
 --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
 --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
 --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
 --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
 --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
---add-opens=java.base/java.util=ALL-UNNAMED
---add-opens=java.base/java.lang.reflect=ALL-UNNAMED
---add-opens=java.base/java.text=ALL-UNNAMED
---add-opens=java.desktop/java.awt.font=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED
+--add-opens java.base/java.util=ALL-UNNAMED
+--add-opens java.base/java.lang.reflect=ALL-UNNAMED
+--add-opens java.base/java.text=ALL-UNNAMED
+--add-opens java.desktop/java.awt.font=ALL-UNNAMED

--- a/gateways/gateway-mapping-http/pom.xml
+++ b/gateways/gateway-mapping-http/pom.xml
@@ -21,7 +21,6 @@
 
   <properties>
     <openapi.dir>${maven.multiModuleProjectDirectory}/zeebe/gateway-protocol/src/main/proto/v2</openapi.dir>
-    <version.nullaway>0.13.3</version.nullaway>
   </properties>
 
   <dependencies>
@@ -191,77 +190,5 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <fork>true</fork>
-          <showWarnings>true</showWarnings>
-          <compilerArgs combine.children="append">
-            <arg>-XDcompilePolicy=simple</arg>
-            <arg>-XDaddTypeAnnotationsToSymbol=true</arg>
-            <arg>--should-stop=ifError=FLOW</arg>
-            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
-            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
-            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
-            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
-            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
-            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
-            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
-            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
-            <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
-            <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
-            <arg>-Xplugin:ErrorProne -Xep:NullAway:ERROR -XepOpt:NullAway:AnnotatedPackages=io.camunda.gateway.protocol.model,io.camunda.gateway.mapping.http -XepOpt:NullAway:JSpecifyMode=true</arg>
-          </compilerArgs>
-          <annotationProcessorPaths>
-            <path>
-              <groupId>com.google.errorprone</groupId>
-              <artifactId>error_prone_core</artifactId>
-              <version>${version.error-prone}</version>
-            </path>
-            <path>
-              <groupId>com.uber.nullaway</groupId>
-              <artifactId>nullaway</artifactId>
-              <version>${version.nullaway}</version>
-            </path>
-          </annotationProcessorPaths>
-        </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-compiler-javac-errorprone</artifactId>
-            <version>2.15.0</version>
-          </dependency>
-          <dependency>
-            <groupId>com.google.errorprone</groupId>
-            <artifactId>error_prone_core</artifactId>
-            <version>${version.error-prone}</version>
-          </dependency>
-          <dependency>
-            <groupId>com.uber.nullaway</groupId>
-            <artifactId>nullaway</artifactId>
-            <version>${version.nullaway}</version>
-          </dependency>
-        </dependencies>
-        <executions>
-          <execution>
-            <!-- NullAway/ErrorProne are focused on production code; tests should be able
-                 to exercise nullable boundaries freely without per-call-site null guards. -->
-            <id>default-testCompile</id>
-            <goals>
-              <goal>testCompile</goal>
-            </goals>
-            <configuration>
-              <compilerArgs combine.self="override"/>
-              <annotationProcessorPaths combine.self="override"/>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 
 </project>

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/converters/package-info.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/converters/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+@NullMarked
+package io.camunda.gateway.mapping.http.converters;
+
+import org.jspecify.annotations.NullMarked;

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/package-info.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+@NullMarked
+package io.camunda.gateway.mapping.http.mapper;
+
+import org.jspecify.annotations.NullMarked;

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/package-info.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+@NullMarked
+package io.camunda.gateway.mapping.http.search;
+
+import org.jspecify.annotations.NullMarked;

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/util/package-info.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/util/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+@NullMarked
+package io.camunda.gateway.mapping.http.util;
+
+import org.jspecify.annotations.NullMarked;

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/package-info.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+@NullMarked
+package io.camunda.gateway.mapping.http.validator;
+
+import org.jspecify.annotations.NullMarked;

--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -763,7 +763,6 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${plugin.version.compiler}</version>
         <configuration>
-          <fork>false</fork>
           <meminitial>128m</meminitial>
           <maxmem>256m</maxmem>
         </configuration>
@@ -817,6 +816,30 @@
             <configuration>
               <outputDirectory>${project.build.directory}/lib</outputDirectory>
               <includeScope>runtime</includeScope>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-compile</id>
+            <configuration>
+              <!-- See https://logging.apache.org/log4j/2.x/manual/plugins.html#plugin-registry -->
+              <annotationProcessorPaths>
+                <!-- Include `log4j-core` providing `org.apache.logging.log4j.core.config.plugins.processor.PluginProcessor` that generates `Log4j2Plugins.dat`-->
+                <path>
+                  <groupId>org.apache.logging.log4j</groupId>
+                  <artifactId>log4j-core</artifactId>
+                  <version>${version.log4j}</version>
+                </path>
+              </annotationProcessorPaths>
+              <annotationProcessors>
+                <!-- Process sources using `PluginProcessor` to generate `Log4j2Plugins.dat` -->
+                <processor>org.apache.logging.log4j.core.config.plugins.processor.PluginProcessor</processor>
+              </annotationProcessors>
             </configuration>
           </execution>
         </executions>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -2284,6 +2284,11 @@
                   <arg>-XDcompilePolicy=simple</arg>
                   <arg>--should-stop=ifError=FLOW</arg>
                   <arg>-XDaddTypeAnnotationsToSymbol=true</arg>
+                  <!--
+                    - exclude generated-sources (e.g. openapi) from nullaway checks
+                    - exclude all other checks from error prone except for nullaway
+                    - enable nullaway only on classes/packages marked as @NullMarked
+                  -->
                   <arg>-Xplugin:ErrorProne -XepDisableAllChecks -Xep:NullAway:ERROR -XepExcludedPaths:.*/target/generated-sources/.* -XepOpt:NullAway:JSpecifyMode=true -XepOpt:NullAway:OnlyNullMarked=true -XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true</arg>
                 </compilerArgs>
               </configuration>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -2263,18 +2263,6 @@
             </compilerArgs>
             <useIncrementalCompilation>false</useIncrementalCompilation>
           </configuration>
-          <dependencies>
-            <dependency>
-              <groupId>com.google.errorprone</groupId>
-              <artifactId>error_prone_core</artifactId>
-              <version>${version.error-prone}</version>
-            </dependency>
-            <dependency>
-              <groupId>com.uber.nullaway</groupId>
-              <artifactId>nullaway</artifactId>
-              <version>${version.nullaway}</version>
-            </dependency>
-          </dependencies>
           <executions>
             <execution>
               <!-- Only run NullAway on main sources; tests can exercise nullable boundaries freely. -->

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -57,6 +57,7 @@
     <version.elasticsearch>8.19.14</version.elasticsearch>
     <version.elasticsearch-java-client>8.19.14</version.elasticsearch-java-client>
     <version.error-prone>2.49.0</version.error-prone>
+    <version.nullaway>0.13.4</version.nullaway>
     <version.grpc>1.80.0</version.grpc>
     <version.gson>2.13.2</version.gson>
     <version.guava>33.5.0-jre</version.guava>
@@ -3208,6 +3209,53 @@
                 <phase>post-integration-test</phase>
               </execution>
             </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <!--
+      Profile to run NullAway (backed by Error Prone) at compile time.
+      Only checks code within @NullMarked scopes (jspecify mode), so it is safe
+      to enable on modules that are not yet annotated.
+    -->
+    <profile>
+      <id>nullaway</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <fork>true</fork>
+              <annotationProcessorPaths combine.children="append">
+                <path>
+                  <groupId>com.google.errorprone</groupId>
+                  <artifactId>error_prone_core</artifactId>
+                  <version>${version.error-prone}</version>
+                </path>
+                <path>
+                  <groupId>com.uber.nullaway</groupId>
+                  <artifactId>nullaway</artifactId>
+                  <version>${version.nullaway}</version>
+                </path>
+              </annotationProcessorPaths>
+              <compilerArgs combine.children="append">
+                <arg>-XDcompilePolicy=simple</arg>
+                <arg>--should-stop=ifError=FLOW</arg>
+                <arg>-XDaddTypeAnnotationsToSymbol=true</arg>
+                <arg>-Xplugin:ErrorProne -XepDisableAllChecks -Xep:NullAway:ERROR -XepOpt:NullAway:JSpecifyMode=true -XepOpt:NullAway:OnlyNullMarked=true -XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
+              </compilerArgs>
+            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1477,7 +1477,6 @@
         <groupId>com.google.errorprone</groupId>
         <artifactId>error_prone_annotations</artifactId>
         <version>${version.error-prone}</version>
-        <scope>provided</scope>
       </dependency>
 
       <dependency>
@@ -3214,9 +3213,10 @@
       </build>
     </profile>
     <!--
-      Profile to run NullAway (backed by Error Prone) at compile time.
-      Only checks code within @NullMarked scopes (jspecify mode), so it is safe
-      to enable on modules that are not yet annotated.
+      Runs NullAway (backed by Error Prone) at compile time for all modules.
+      Only checks code within @NullMarked scopes (OnlyNullMarked=true), so it is
+      safe to enable globally — unannotated modules are unaffected. Modules opt
+      into enforcement by adding @NullMarked to their packages or classes.
     -->
     <profile>
       <id>nullaway</id>
@@ -3225,37 +3225,43 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <fork>true</fork>
-              <annotationProcessorPaths combine.children="append">
-                <path>
-                  <groupId>com.google.errorprone</groupId>
-                  <artifactId>error_prone_core</artifactId>
-                  <version>${version.error-prone}</version>
-                </path>
-                <path>
-                  <groupId>com.uber.nullaway</groupId>
-                  <artifactId>nullaway</artifactId>
-                  <version>${version.nullaway}</version>
-                </path>
-              </annotationProcessorPaths>
-              <compilerArgs combine.children="append">
-                <arg>-XDcompilePolicy=simple</arg>
-                <arg>--should-stop=ifError=FLOW</arg>
-                <arg>-XDaddTypeAnnotationsToSymbol=true</arg>
-                <arg>-Xplugin:ErrorProne -XepDisableAllChecks -Xep:NullAway:ERROR -XepOpt:NullAway:JSpecifyMode=true -XepOpt:NullAway:OnlyNullMarked=true -XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true</arg>
-                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
-                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
-                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
-                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
-                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
-                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
-                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
-                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
-                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
-                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
-              </compilerArgs>
-            </configuration>
+            <executions>
+              <execution>
+                <!-- Only run NullAway on main sources; test sources are excluded -->
+                <id>default-compile</id>
+                <configuration>
+                  <fork>true</fork>
+                  <annotationProcessorPaths combine.children="append">
+                    <path>
+                      <groupId>com.google.errorprone</groupId>
+                      <artifactId>error_prone_core</artifactId>
+                      <version>${version.error-prone}</version>
+                    </path>
+                    <path>
+                      <groupId>com.uber.nullaway</groupId>
+                      <artifactId>nullaway</artifactId>
+                      <version>${version.nullaway}</version>
+                    </path>
+                  </annotationProcessorPaths>
+                  <compilerArgs combine.children="append">
+                    <arg>-XDcompilePolicy=simple</arg>
+                    <arg>--should-stop=ifError=FLOW</arg>
+                    <arg>-XDaddTypeAnnotationsToSymbol=true</arg>
+                    <arg>-Xplugin:ErrorProne -XepDisableAllChecks -Xep:NullAway:ERROR -XepOpt:NullAway:JSpecifyMode=true -XepOpt:NullAway:OnlyNullMarked=true -XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true</arg>
+                    <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
+                    <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+                    <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
+                    <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+                    <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+                    <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+                    <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+                    <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+                    <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
+                    <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
+                  </compilerArgs>
+                </configuration>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -2257,12 +2257,78 @@
           <configuration>
             <parameters>true</parameters>
             <release>${version.java}</release>
+            <fork>true</fork>
             <compilerArgs>
               <!-- ensure we generate a class file for package-info.java files to avoid recompiling every time -->
               <arg>-Xpkginfo:always</arg>
             </compilerArgs>
             <useIncrementalCompilation>false</useIncrementalCompilation>
           </configuration>
+          <dependencies>
+            <dependency>
+              <groupId>org.codehaus.plexus</groupId>
+              <artifactId>plexus-compiler-javac-errorprone</artifactId>
+              <version>2.15.0</version>
+            </dependency>
+            <dependency>
+              <groupId>com.google.errorprone</groupId>
+              <artifactId>error_prone_core</artifactId>
+              <version>${version.error-prone}</version>
+            </dependency>
+            <dependency>
+              <groupId>com.uber.nullaway</groupId>
+              <artifactId>nullaway</artifactId>
+              <version>${version.nullaway}</version>
+            </dependency>
+          </dependencies>
+          <executions>
+            <execution>
+              <!-- Only run NullAway on main sources; tests can exercise nullable boundaries freely. -->
+              <id>default-compile</id>
+              <configuration>
+                <annotationProcessorPaths combine.children="append">
+                  <path>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_core</artifactId>
+                    <version>${version.error-prone}</version>
+                  </path>
+                  <path>
+                    <groupId>com.uber.nullaway</groupId>
+                    <artifactId>nullaway</artifactId>
+                    <version>${version.nullaway}</version>
+                  </path>
+                </annotationProcessorPaths>
+                <compilerArgs combine.children="append">
+                  <arg>-XDcompilePolicy=simple</arg>
+                  <arg>--should-stop=ifError=FLOW</arg>
+                  <arg>-XDaddTypeAnnotationsToSymbol=true</arg>
+                  <arg>-Xplugin:ErrorProne -XepDisableAllChecks -Xep:NullAway:ERROR -XepExcludedPaths:.*/target/generated-sources/.* -XepOpt:NullAway:JSpecifyMode=true -XepOpt:NullAway:OnlyNullMarked=true -XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true</arg>
+                  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
+                  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+                  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
+                  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+                  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+                  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+                  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+                  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+                  <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
+                  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
+                </compilerArgs>
+              </configuration>
+            </execution>
+            <execution>
+              <!-- NullAway/ErrorProne are focused on production code; tests should be able
+                   to exercise nullable boundaries freely without per-call-site null guards. -->
+              <id>default-testCompile</id>
+              <goals>
+                <goal>testCompile</goal>
+              </goals>
+              <configuration>
+                <compilerArgs combine.self="override"/>
+                <annotationProcessorPaths combine.self="override"/>
+              </configuration>
+            </execution>
+          </executions>
         </plugin>
 
         <!-- compatibility checks/guard -->
@@ -3206,60 +3272,6 @@
                   <goal>extract-flaky-tests</goal>
                 </goals>
                 <phase>post-integration-test</phase>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <!--
-      Runs NullAway (backed by Error Prone) at compile time for all modules.
-      Only checks code within @NullMarked scopes (OnlyNullMarked=true), so it is
-      safe to enable globally — unannotated modules are unaffected. Modules opt
-      into enforcement by adding @NullMarked to their packages or classes.
-    -->
-    <profile>
-      <id>nullaway</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <executions>
-              <execution>
-                <!-- Only run NullAway on main sources; test sources are excluded -->
-                <id>default-compile</id>
-                <configuration>
-                  <fork>true</fork>
-                  <annotationProcessorPaths combine.children="append">
-                    <path>
-                      <groupId>com.google.errorprone</groupId>
-                      <artifactId>error_prone_core</artifactId>
-                      <version>${version.error-prone}</version>
-                    </path>
-                    <path>
-                      <groupId>com.uber.nullaway</groupId>
-                      <artifactId>nullaway</artifactId>
-                      <version>${version.nullaway}</version>
-                    </path>
-                  </annotationProcessorPaths>
-                  <compilerArgs combine.children="append">
-                    <arg>-XDcompilePolicy=simple</arg>
-                    <arg>--should-stop=ifError=FLOW</arg>
-                    <arg>-XDaddTypeAnnotationsToSymbol=true</arg>
-                    <arg>-Xplugin:ErrorProne -XepDisableAllChecks -Xep:NullAway:ERROR -XepOpt:NullAway:JSpecifyMode=true -XepOpt:NullAway:OnlyNullMarked=true -XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true</arg>
-                    <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
-                    <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
-                    <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
-                    <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
-                    <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
-                    <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
-                    <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
-                    <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
-                    <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
-                    <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
-                  </compilerArgs>
-                </configuration>
               </execution>
             </executions>
           </plugin>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -2257,7 +2257,6 @@
           <configuration>
             <parameters>true</parameters>
             <release>${version.java}</release>
-            <fork>true</fork>
             <compilerArgs>
               <!-- ensure we generate a class file for package-info.java files to avoid recompiling every time -->
               <arg>-Xpkginfo:always</arg>
@@ -2265,11 +2264,6 @@
             <useIncrementalCompilation>false</useIncrementalCompilation>
           </configuration>
           <dependencies>
-            <dependency>
-              <groupId>org.codehaus.plexus</groupId>
-              <artifactId>plexus-compiler-javac-errorprone</artifactId>
-              <version>2.15.0</version>
-            </dependency>
             <dependency>
               <groupId>com.google.errorprone</groupId>
               <artifactId>error_prone_core</artifactId>
@@ -2303,16 +2297,6 @@
                   <arg>--should-stop=ifError=FLOW</arg>
                   <arg>-XDaddTypeAnnotationsToSymbol=true</arg>
                   <arg>-Xplugin:ErrorProne -XepDisableAllChecks -Xep:NullAway:ERROR -XepExcludedPaths:.*/target/generated-sources/.* -XepOpt:NullAway:JSpecifyMode=true -XepOpt:NullAway:OnlyNullMarked=true -XepOpt:NullAway:AcknowledgeRestrictiveAnnotations=true</arg>
-                  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
-                  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
-                  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
-                  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
-                  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
-                  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
-                  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
-                  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
-                  <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
-                  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
                 </compilerArgs>
               </configuration>
             </execution>

--- a/search/search-domain/src/main/java/io/camunda/search/entities/AuditLogEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/AuditLogEntity.java
@@ -66,39 +66,39 @@ public record AuditLogEntity(
   }
 
   public static class Builder implements ObjectBuilder<AuditLogEntity> {
-    private String auditLogKey;
-    private String entityKey;
-    private AuditLogEntityType entityType;
-    private AuditLogOperationType operationType;
-    private Long batchOperationKey;
-    private BatchOperationType batchOperationType;
-    private OffsetDateTime timestamp;
-    private String actorId;
-    private AuditLogActorType actorType;
-    private String agentElementId;
-    private String tenantId;
-    private AuditLogTenantScope tenantScope;
-    private AuditLogOperationResult result;
-    private AuditLogOperationCategory category;
-    private String processDefinitionId;
-    private Long processDefinitionKey;
-    private Long processInstanceKey;
-    private Long rootProcessInstanceKey;
-    private Long elementInstanceKey;
-    private Long jobKey;
-    private Long userTaskKey;
-    private String decisionRequirementsId;
-    private Long decisionRequirementsKey;
-    private String decisionDefinitionId;
-    private Long decisionDefinitionKey;
-    private Long decisionEvaluationKey;
-    private Long deploymentKey;
-    private Long formKey;
-    private Long resourceKey;
-    private AuditLogEntityType relatedEntityType;
-    private String relatedEntityKey;
-    private String entityDescription;
-    private OffsetDateTime historyCleanupDate;
+    private @Nullable String auditLogKey;
+    private @Nullable String entityKey;
+    private @Nullable AuditLogEntityType entityType;
+    private @Nullable AuditLogOperationType operationType;
+    private @Nullable Long batchOperationKey;
+    private @Nullable BatchOperationType batchOperationType;
+    private @Nullable OffsetDateTime timestamp;
+    private @Nullable String actorId;
+    private @Nullable AuditLogActorType actorType;
+    private @Nullable String agentElementId;
+    private @Nullable String tenantId;
+    private @Nullable AuditLogTenantScope tenantScope;
+    private @Nullable AuditLogOperationResult result;
+    private @Nullable AuditLogOperationCategory category;
+    private @Nullable String processDefinitionId;
+    private @Nullable Long processDefinitionKey;
+    private @Nullable Long processInstanceKey;
+    private @Nullable Long rootProcessInstanceKey;
+    private @Nullable Long elementInstanceKey;
+    private @Nullable Long jobKey;
+    private @Nullable Long userTaskKey;
+    private @Nullable String decisionRequirementsId;
+    private @Nullable Long decisionRequirementsKey;
+    private @Nullable String decisionDefinitionId;
+    private @Nullable Long decisionDefinitionKey;
+    private @Nullable Long decisionEvaluationKey;
+    private @Nullable Long deploymentKey;
+    private @Nullable Long formKey;
+    private @Nullable Long resourceKey;
+    private @Nullable AuditLogEntityType relatedEntityType;
+    private @Nullable String relatedEntityKey;
+    private @Nullable String entityDescription;
+    private @Nullable OffsetDateTime historyCleanupDate;
 
     public Builder auditLogKey(final String auditLogKey) {
       this.auditLogKey = auditLogKey;
@@ -265,6 +265,7 @@ public record AuditLogEntity(
       return this;
     }
 
+    @SuppressWarnings("NullAway")
     @Override
     public AuditLogEntity build() {
       return new AuditLogEntity(

--- a/search/search-domain/src/main/java/io/camunda/search/entities/CorrelatedMessageSubscriptionEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/CorrelatedMessageSubscriptionEntity.java
@@ -48,20 +48,20 @@ public record CorrelatedMessageSubscriptionEntity(
   }
 
   public static class Builder {
-    private String correlationKey;
-    private OffsetDateTime correlationTime;
-    private String flowNodeId;
-    private Long flowNodeInstanceKey;
-    private Long messageKey;
-    private String messageName;
-    private Integer partitionId;
-    private String processDefinitionId;
-    private Long processDefinitionKey;
-    private Long processInstanceKey;
-    private Long rootProcessInstanceKey;
-    private Long subscriptionKey;
-    private MessageSubscriptionType subscriptionType;
-    private String tenantId;
+    private @Nullable String correlationKey;
+    private @Nullable OffsetDateTime correlationTime;
+    private @Nullable String flowNodeId;
+    private @Nullable Long flowNodeInstanceKey;
+    private @Nullable Long messageKey;
+    private @Nullable String messageName;
+    private @Nullable Integer partitionId;
+    private @Nullable String processDefinitionId;
+    private @Nullable Long processDefinitionKey;
+    private @Nullable Long processInstanceKey;
+    private @Nullable Long rootProcessInstanceKey;
+    private @Nullable Long subscriptionKey;
+    private @Nullable MessageSubscriptionType subscriptionType;
+    private @Nullable String tenantId;
 
     public Builder correlationKey(final String correlationKey) {
       this.correlationKey = correlationKey;
@@ -133,6 +133,7 @@ public record CorrelatedMessageSubscriptionEntity(
       return this;
     }
 
+    @SuppressWarnings("NullAway")
     public CorrelatedMessageSubscriptionEntity build() {
       return new CorrelatedMessageSubscriptionEntity(
           correlationKey,

--- a/search/search-domain/src/main/java/io/camunda/search/entities/DecisionInstanceEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/DecisionInstanceEntity.java
@@ -82,26 +82,26 @@ public record DecisionInstanceEntity(
 
   public static class Builder implements ObjectBuilder<DecisionInstanceEntity> {
 
-    private String decisionInstanceId;
-    private Long decisionInstanceKey;
-    private DecisionInstanceState state;
-    private OffsetDateTime evaluationDate;
-    private String evaluationFailure;
-    private String evaluationFailureMessage;
-    private Long processDefinitionKey;
-    private Long processInstanceKey;
-    private Long rootProcessInstanceKey;
-    private Long flowNodeInstanceKey;
-    private String tenantId;
-    private String decisionDefinitionId;
-    private Long decisionDefinitionKey;
-    private String decisionDefinitionName;
-    private Integer decisionDefinitionVersion;
-    private DecisionDefinitionType decisionDefinitionType;
-    private Long rootDecisionDefinitionKey;
-    private String result;
-    private List<DecisionInstanceInputEntity> evaluatedInputs;
-    private List<DecisionInstanceOutputEntity> evaluatedOutputs;
+    private @Nullable String decisionInstanceId;
+    private @Nullable Long decisionInstanceKey;
+    private @Nullable DecisionInstanceState state;
+    private @Nullable OffsetDateTime evaluationDate;
+    private @Nullable String evaluationFailure;
+    private @Nullable String evaluationFailureMessage;
+    private @Nullable Long processDefinitionKey;
+    private @Nullable Long processInstanceKey;
+    private @Nullable Long rootProcessInstanceKey;
+    private @Nullable Long flowNodeInstanceKey;
+    private @Nullable String tenantId;
+    private @Nullable String decisionDefinitionId;
+    private @Nullable Long decisionDefinitionKey;
+    private @Nullable String decisionDefinitionName;
+    private @Nullable Integer decisionDefinitionVersion;
+    private @Nullable DecisionDefinitionType decisionDefinitionType;
+    private @Nullable Long rootDecisionDefinitionKey;
+    private @Nullable String result;
+    private @Nullable List<DecisionInstanceInputEntity> evaluatedInputs;
+    private @Nullable List<DecisionInstanceOutputEntity> evaluatedOutputs;
 
     public Builder decisionInstanceId(final String decisionInstanceId) {
       this.decisionInstanceId = decisionInstanceId;
@@ -123,32 +123,32 @@ public record DecisionInstanceEntity(
       return this;
     }
 
-    public Builder evaluationFailure(final String evaluationFailure) {
+    public Builder evaluationFailure(final @Nullable String evaluationFailure) {
       this.evaluationFailure = evaluationFailure;
       return this;
     }
 
-    public Builder evaluationFailureMessage(final String evaluationFailureMessage) {
+    public Builder evaluationFailureMessage(final @Nullable String evaluationFailureMessage) {
       this.evaluationFailureMessage = evaluationFailureMessage;
       return this;
     }
 
-    public Builder processDefinitionKey(final Long processDefinitionKey) {
+    public Builder processDefinitionKey(final @Nullable Long processDefinitionKey) {
       this.processDefinitionKey = processDefinitionKey;
       return this;
     }
 
-    public Builder processInstanceKey(final Long processInstanceKey) {
+    public Builder processInstanceKey(final @Nullable Long processInstanceKey) {
       this.processInstanceKey = processInstanceKey;
       return this;
     }
 
-    public Builder rootProcessInstanceKey(final Long rootProcessInstanceKey) {
+    public Builder rootProcessInstanceKey(final @Nullable Long rootProcessInstanceKey) {
       this.rootProcessInstanceKey = rootProcessInstanceKey;
       return this;
     }
 
-    public Builder flowNodeInstanceKey(final Long flowNodeInstanceKey) {
+    public Builder flowNodeInstanceKey(final @Nullable Long flowNodeInstanceKey) {
       this.flowNodeInstanceKey = flowNodeInstanceKey;
       return this;
     }
@@ -173,7 +173,7 @@ public record DecisionInstanceEntity(
       return this;
     }
 
-    public Builder decisionDefinitionVersion(final Integer decisionDefinitionVersion) {
+    public Builder decisionDefinitionVersion(final @Nullable Integer decisionDefinitionVersion) {
       this.decisionDefinitionVersion = decisionDefinitionVersion;
       return this;
     }
@@ -183,7 +183,7 @@ public record DecisionInstanceEntity(
       return this;
     }
 
-    public Builder rootDecisionDefinitionKey(final Long rootDecisionDefinitionKey) {
+    public Builder rootDecisionDefinitionKey(final @Nullable Long rootDecisionDefinitionKey) {
       this.rootDecisionDefinitionKey = rootDecisionDefinitionKey;
       return this;
     }
@@ -203,6 +203,7 @@ public record DecisionInstanceEntity(
       return this;
     }
 
+    @SuppressWarnings("NullAway")
     @Override
     public DecisionInstanceEntity build() {
       return new DecisionInstanceEntity(

--- a/search/search-domain/src/main/java/io/camunda/search/entities/DeployedResourceEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/DeployedResourceEntity.java
@@ -38,15 +38,15 @@ public record DeployedResourceEntity(
   }
 
   public static class Builder implements ObjectBuilder<DeployedResourceEntity> {
-    private Long resourceKey;
-    private String resourceId;
-    private String resourceName;
-    private String resourceType;
-    private Integer version;
-    private String versionTag;
-    private Long deploymentKey;
-    private String tenantId;
-    private String resourceContent;
+    private @Nullable Long resourceKey;
+    private @Nullable String resourceId;
+    private @Nullable String resourceName;
+    private @Nullable String resourceType;
+    private @Nullable Integer version;
+    private @Nullable String versionTag;
+    private @Nullable Long deploymentKey;
+    private @Nullable String tenantId;
+    private @Nullable String resourceContent;
 
     public Builder resourceKey(final Long resourceKey) {
       this.resourceKey = resourceKey;
@@ -93,6 +93,7 @@ public record DeployedResourceEntity(
       return this;
     }
 
+    @SuppressWarnings("NullAway")
     @Override
     public DeployedResourceEntity build() {
       return new DeployedResourceEntity(

--- a/search/search-domain/src/main/java/io/camunda/search/entities/IncidentProcessInstanceStatisticsByDefinitionEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/IncidentProcessInstanceStatisticsByDefinitionEntity.java
@@ -32,12 +32,12 @@ public record IncidentProcessInstanceStatisticsByDefinitionEntity(
 
   public static final class Builder
       implements ObjectBuilder<IncidentProcessInstanceStatisticsByDefinitionEntity> {
-    private String processDefinitionId;
-    private Long processDefinitionKey;
-    private String processDefinitionName;
-    private Integer processDefinitionVersion;
-    private String tenantId;
-    private Long activeInstancesWithErrorCount;
+    private @Nullable String processDefinitionId;
+    private @Nullable Long processDefinitionKey;
+    private @Nullable String processDefinitionName;
+    private @Nullable Integer processDefinitionVersion;
+    private @Nullable String tenantId;
+    private @Nullable Long activeInstancesWithErrorCount;
 
     public Builder processDefinitionId(final String value) {
       processDefinitionId = value;
@@ -69,6 +69,7 @@ public record IncidentProcessInstanceStatisticsByDefinitionEntity(
       return this;
     }
 
+    @SuppressWarnings("NullAway")
     @Override
     public IncidentProcessInstanceStatisticsByDefinitionEntity build() {
       return new IncidentProcessInstanceStatisticsByDefinitionEntity(

--- a/search/search-domain/src/main/java/io/camunda/search/entities/IncidentProcessInstanceStatisticsByErrorEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/IncidentProcessInstanceStatisticsByErrorEntity.java
@@ -26,9 +26,9 @@ public record IncidentProcessInstanceStatisticsByErrorEntity(
 
   public static final class Builder
       implements ObjectBuilder<IncidentProcessInstanceStatisticsByErrorEntity> {
-    private Integer errorHashCode;
-    private String errorMessage;
-    private Long activeInstancesWithErrorCount;
+    private @Nullable Integer errorHashCode;
+    private @Nullable String errorMessage;
+    private @Nullable Long activeInstancesWithErrorCount;
 
     public Builder errorHashCode(final Integer value) {
       errorHashCode = value;
@@ -45,6 +45,7 @@ public record IncidentProcessInstanceStatisticsByErrorEntity(
       return this;
     }
 
+    @SuppressWarnings("NullAway")
     @Override
     public IncidentProcessInstanceStatisticsByErrorEntity build() {
       return new IncidentProcessInstanceStatisticsByErrorEntity(

--- a/search/search-domain/src/main/java/io/camunda/search/entities/JobEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/JobEntity.java
@@ -68,30 +68,30 @@ public record JobEntity(
   }
 
   public static class Builder implements ObjectBuilder<JobEntity> {
-    private Long jobKey;
-    private String type;
-    private String worker;
-    private JobState state;
-    private JobKind kind;
-    private ListenerEventType listenerEventType;
-    private Integer retries;
-    private Boolean isDenied;
-    private String deniedReason;
-    private Boolean hasFailedWithRetriesLeft;
-    private String errorCode;
-    private String errorMessage;
-    private Map<String, String> customHeaders;
-    private OffsetDateTime deadline;
-    private OffsetDateTime endTime;
-    private String processDefinitionId;
-    private Long processDefinitionKey;
-    private Long processInstanceKey;
-    private Long rootProcessInstanceKey;
-    private String elementId;
-    private Long elementInstanceKey;
-    private String tenantId;
-    private OffsetDateTime creationTime;
-    private OffsetDateTime lastUpdateTime;
+    private @Nullable Long jobKey;
+    private @Nullable String type;
+    private @Nullable String worker;
+    private @Nullable JobState state;
+    private @Nullable JobKind kind;
+    private @Nullable ListenerEventType listenerEventType;
+    private @Nullable Integer retries;
+    private @Nullable Boolean isDenied;
+    private @Nullable String deniedReason;
+    private @Nullable Boolean hasFailedWithRetriesLeft;
+    private @Nullable String errorCode;
+    private @Nullable String errorMessage;
+    private @Nullable Map<String, String> customHeaders;
+    private @Nullable OffsetDateTime deadline;
+    private @Nullable OffsetDateTime endTime;
+    private @Nullable String processDefinitionId;
+    private @Nullable Long processDefinitionKey;
+    private @Nullable Long processInstanceKey;
+    private @Nullable Long rootProcessInstanceKey;
+    private @Nullable String elementId;
+    private @Nullable Long elementInstanceKey;
+    private @Nullable String tenantId;
+    private @Nullable OffsetDateTime creationTime;
+    private @Nullable OffsetDateTime lastUpdateTime;
 
     public Builder jobKey(final Long jobKey) {
       this.jobKey = jobKey;
@@ -213,6 +213,7 @@ public record JobEntity(
       return this;
     }
 
+    @SuppressWarnings("NullAway")
     @Override
     public JobEntity build() {
       return new JobEntity(

--- a/search/search-domain/src/main/java/io/camunda/search/entities/JobMetricsBatchEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/JobMetricsBatchEntity.java
@@ -66,20 +66,20 @@ public record JobMetricsBatchEntity(
 
   public static class Builder implements ObjectBuilder<JobMetricsBatchEntity> {
 
-    private String key;
-    private Integer partitionId;
-    private OffsetDateTime startTime;
-    private OffsetDateTime endTime;
-    private Boolean incompleteBatch;
-    private String tenantId;
-    private Integer failedCount;
-    private OffsetDateTime lastFailedAt;
-    private Integer completedCount;
-    private OffsetDateTime lastCompletedAt;
-    private Integer createdCount;
-    private OffsetDateTime lastCreatedAt;
-    private String jobType;
-    private String worker;
+    private @Nullable String key;
+    private @Nullable Integer partitionId;
+    private @Nullable OffsetDateTime startTime;
+    private @Nullable OffsetDateTime endTime;
+    private @Nullable Boolean incompleteBatch;
+    private @Nullable String tenantId;
+    private @Nullable Integer failedCount;
+    private @Nullable OffsetDateTime lastFailedAt;
+    private @Nullable Integer completedCount;
+    private @Nullable OffsetDateTime lastCompletedAt;
+    private @Nullable Integer createdCount;
+    private @Nullable OffsetDateTime lastCreatedAt;
+    private @Nullable String jobType;
+    private @Nullable String worker;
 
     public Builder key(final String key) {
       this.key = key;
@@ -151,6 +151,7 @@ public record JobMetricsBatchEntity(
       return this;
     }
 
+    @SuppressWarnings("NullAway")
     @Override
     public JobMetricsBatchEntity build() {
       return new JobMetricsBatchEntity(

--- a/search/search-domain/src/main/java/io/camunda/search/entities/MessageSubscriptionEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/MessageSubscriptionEntity.java
@@ -60,24 +60,24 @@ public record MessageSubscriptionEntity(
   }
 
   public static class Builder {
-    private Long messageSubscriptionKey;
-    private String processDefinitionId;
-    private Long processDefinitionKey;
-    private Long processInstanceKey;
-    private Long rootProcessInstanceKey;
-    private String flowNodeId;
-    private Long flowNodeInstanceKey;
-    private MessageSubscriptionState messageSubscriptionState;
-    private MessageSubscriptionType messageSubscriptionType;
-    private OffsetDateTime dateTime;
-    private String messageName;
-    private String correlationKey;
-    private String tenantId;
-    private String processDefinitionName;
-    private Integer processDefinitionVersion;
-    private Map<String, String> extensionProperties;
-    private String toolName;
-    private String inboundConnectorType;
+    private @Nullable Long messageSubscriptionKey;
+    private @Nullable String processDefinitionId;
+    private @Nullable Long processDefinitionKey;
+    private @Nullable Long processInstanceKey;
+    private @Nullable Long rootProcessInstanceKey;
+    private @Nullable String flowNodeId;
+    private @Nullable Long flowNodeInstanceKey;
+    private @Nullable MessageSubscriptionState messageSubscriptionState;
+    private @Nullable MessageSubscriptionType messageSubscriptionType;
+    private @Nullable OffsetDateTime dateTime;
+    private @Nullable String messageName;
+    private @Nullable String correlationKey;
+    private @Nullable String tenantId;
+    private @Nullable String processDefinitionName;
+    private @Nullable Integer processDefinitionVersion;
+    private @Nullable Map<String, String> extensionProperties;
+    private @Nullable String toolName;
+    private @Nullable String inboundConnectorType;
 
     public Builder messageSubscriptionKey(final Long messageSubscriptionKey) {
       this.messageSubscriptionKey = messageSubscriptionKey;
@@ -170,6 +170,7 @@ public record MessageSubscriptionEntity(
       return this;
     }
 
+    @SuppressWarnings("NullAway")
     public MessageSubscriptionEntity build() {
       return new MessageSubscriptionEntity(
           messageSubscriptionKey,

--- a/search/search-domain/src/main/java/io/camunda/search/entities/ProcessDefinitionInstanceStatisticsEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/ProcessDefinitionInstanceStatisticsEntity.java
@@ -32,12 +32,12 @@ public record ProcessDefinitionInstanceStatisticsEntity(
   }
 
   public static class Builder implements ObjectBuilder<ProcessDefinitionInstanceStatisticsEntity> {
-    private String processDefinitionId;
-    private String tenantId;
-    private String latestProcessDefinitionName;
-    private Boolean hasMultipleVersions;
-    private Long activeInstancesWithoutIncidentCount;
-    private Long activeInstancesWithIncidentCount;
+    private @Nullable String processDefinitionId;
+    private @Nullable String tenantId;
+    private @Nullable String latestProcessDefinitionName;
+    private @Nullable Boolean hasMultipleVersions;
+    private @Nullable Long activeInstancesWithoutIncidentCount;
+    private @Nullable Long activeInstancesWithIncidentCount;
 
     public Builder processDefinitionId(final String processDefinitionId) {
       this.processDefinitionId = processDefinitionId;
@@ -69,6 +69,7 @@ public record ProcessDefinitionInstanceStatisticsEntity(
       return this;
     }
 
+    @SuppressWarnings("NullAway")
     @Override
     public ProcessDefinitionInstanceStatisticsEntity build() {
       return new ProcessDefinitionInstanceStatisticsEntity(

--- a/search/search-domain/src/main/java/io/camunda/search/entities/ProcessDefinitionInstanceVersionStatisticsEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/ProcessDefinitionInstanceVersionStatisticsEntity.java
@@ -35,13 +35,13 @@ public record ProcessDefinitionInstanceVersionStatisticsEntity(
 
   public static class Builder
       implements ObjectBuilder<ProcessDefinitionInstanceVersionStatisticsEntity> {
-    private String processDefinitionId;
-    private Long processDefinitionKey;
-    private Integer processDefinitionVersion;
-    private String processDefinitionName;
-    private String tenantId;
-    private Long activeInstancesWithoutIncidentCount;
-    private Long activeInstancesWithIncidentCount;
+    private @Nullable String processDefinitionId;
+    private @Nullable Long processDefinitionKey;
+    private @Nullable Integer processDefinitionVersion;
+    private @Nullable String processDefinitionName;
+    private @Nullable String tenantId;
+    private @Nullable Long activeInstancesWithoutIncidentCount;
+    private @Nullable Long activeInstancesWithIncidentCount;
 
     public Builder processDefinitionId(final String processDefinitionId) {
       this.processDefinitionId = processDefinitionId;
@@ -78,6 +78,7 @@ public record ProcessDefinitionInstanceVersionStatisticsEntity(
       return this;
     }
 
+    @SuppressWarnings("NullAway")
     @Override
     public ProcessDefinitionInstanceVersionStatisticsEntity build() {
       return new ProcessDefinitionInstanceVersionStatisticsEntity(

--- a/search/search-domain/src/main/java/io/camunda/search/entities/ProcessDefinitionMessageSubscriptionStatisticsEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/ProcessDefinitionMessageSubscriptionStatisticsEntity.java
@@ -10,6 +10,7 @@ package io.camunda.search.entities;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.camunda.util.ObjectBuilder;
 import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record ProcessDefinitionMessageSubscriptionStatisticsEntity(
@@ -31,11 +32,11 @@ public record ProcessDefinitionMessageSubscriptionStatisticsEntity(
   public static class Builder
       implements ObjectBuilder<ProcessDefinitionMessageSubscriptionStatisticsEntity> {
 
-    private String processDefinitionId;
-    private String tenantId;
-    private Long processDefinitionKey;
-    private Long processInstancesWithActiveSubscriptions;
-    private Long activeSubscriptions;
+    private @Nullable String processDefinitionId;
+    private @Nullable String tenantId;
+    private @Nullable Long processDefinitionKey;
+    private @Nullable Long processInstancesWithActiveSubscriptions;
+    private @Nullable Long activeSubscriptions;
 
     public Builder processDefinitionId(final String processDefinitionId) {
       this.processDefinitionId = processDefinitionId;
@@ -63,6 +64,7 @@ public record ProcessDefinitionMessageSubscriptionStatisticsEntity(
       return this;
     }
 
+    @SuppressWarnings("NullAway")
     @Override
     public ProcessDefinitionMessageSubscriptionStatisticsEntity build() {
       return new ProcessDefinitionMessageSubscriptionStatisticsEntity(

--- a/search/search-domain/src/main/java/io/camunda/search/entities/ProcessFlowNodeStatisticsEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/ProcessFlowNodeStatisticsEntity.java
@@ -10,6 +10,7 @@ package io.camunda.search.entities;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.camunda.util.ObjectBuilder;
 import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record ProcessFlowNodeStatisticsEntity(
@@ -25,7 +26,7 @@ public record ProcessFlowNodeStatisticsEntity(
 
   public static class Builder implements ObjectBuilder<ProcessFlowNodeStatisticsEntity> {
 
-    private String flowNodeId;
+    private @Nullable String flowNodeId;
     private long active;
     private long canceled;
     private long incidents;
@@ -56,6 +57,7 @@ public record ProcessFlowNodeStatisticsEntity(
       return this;
     }
 
+    @SuppressWarnings("NullAway")
     @Override
     public ProcessFlowNodeStatisticsEntity build() {
       return new ProcessFlowNodeStatisticsEntity(

--- a/search/search-domain/src/main/java/io/camunda/search/entities/ProcessInstanceEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/ProcessInstanceEntity.java
@@ -89,7 +89,7 @@ public record ProcessInstanceEntity(
         hasIncident,
         tenantId,
         treePath,
-        null,
+        new HashSet<>(),
         businessId);
   }
 

--- a/search/search-domain/src/main/java/io/camunda/search/entities/SequenceFlowEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/SequenceFlowEntity.java
@@ -35,13 +35,13 @@ public record SequenceFlowEntity(
 
   public static class Builder implements ObjectBuilder<SequenceFlowEntity> {
 
-    private String sequenceFlowId;
-    private String flowNodeId;
-    private Long processInstanceKey;
-    private Long rootProcessInstanceKey;
-    private Long processDefinitionKey;
-    private String processDefinitionId;
-    private String tenantId;
+    private @Nullable String sequenceFlowId;
+    private @Nullable String flowNodeId;
+    private @Nullable Long processInstanceKey;
+    private @Nullable Long rootProcessInstanceKey;
+    private @Nullable Long processDefinitionKey;
+    private @Nullable String processDefinitionId;
+    private @Nullable String tenantId;
 
     public Builder sequenceFlowId(final String sequenceFlowId) {
       this.sequenceFlowId = sequenceFlowId;
@@ -78,6 +78,7 @@ public record SequenceFlowEntity(
       return this;
     }
 
+    @SuppressWarnings("NullAway")
     @Override
     public SequenceFlowEntity build() {
       return new SequenceFlowEntity(

--- a/testing/camunda-process-test-json-test-cases/pom.xml
+++ b/testing/camunda-process-test-json-test-cases/pom.xml
@@ -114,13 +114,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <compilerArgs combine.children="append">
-            <!-- required by javac detection logic in immutables -->
-            <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
-          </compilerArgs>
-          <fork>true</fork>
-        </configuration>
         <executions>
           <execution>
             <id>default-compile</id>

--- a/zeebe/logstreams/pom.xml
+++ b/zeebe/logstreams/pom.xml
@@ -178,4 +178,14 @@
     </plugins>
   </build>
 
+  <profiles>
+    <profile>
+      <!-- Always enable NullAway for this module; configuration is inherited from parent pom -->
+      <id>nullaway</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+    </profile>
+  </profiles>
+
 </project>

--- a/zeebe/logstreams/pom.xml
+++ b/zeebe/logstreams/pom.xml
@@ -177,15 +177,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <!-- Always enable NullAway for this module; configuration is inherited from parent pom -->
-      <id>nullaway</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-    </profile>
-  </profiles>
-
 </project>

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/LogStreamMetrics.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/LogStreamMetrics.java
@@ -13,9 +13,7 @@ import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.util.CloseableSilently;
-import org.jspecify.annotations.NullMarked;
 
-@NullMarked
 public interface LogStreamMetrics {
 
   void increaseInflightAppends();

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/LogStreamMetricsDoc.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/LogStreamMetricsDoc.java
@@ -17,11 +17,9 @@ import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
 import io.camunda.zeebe.util.micrometer.MicrometerUtil.PartitionKeyNames;
 import io.micrometer.common.docs.KeyName;
 import io.micrometer.core.instrument.Meter.Type;
-import org.jspecify.annotations.NullMarked;
 
 /** Flow control metrics for the log storage appender. */
 @SuppressWarnings("NullableProblems")
-@NullMarked
 public enum LogStreamMetricsDoc implements ExtendedMeterDocumentation {
   /** The count of records passing through the flow control, organized by context and outcome */
   FLOW_CONTROL_OUTCOME {

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/LogStreamMetricsImpl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/LogStreamMetricsImpl.java
@@ -45,9 +45,7 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import java.util.concurrent.atomic.AtomicLong;
-import org.jspecify.annotations.NullMarked;
 
-@NullMarked
 public final class LogStreamMetricsImpl implements LogStreamMetrics {
   private final AtomicLong inflightAppends = new AtomicLong();
   private final AtomicLong inflightRequests = new AtomicLong();

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/Loggers.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/Loggers.java
@@ -7,11 +7,9 @@
  */
 package io.camunda.zeebe.logstreams.impl;
 
-import org.jspecify.annotations.NullMarked;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@NullMarked
 public final class Loggers {
 
   public static final Logger LOGSTREAMS_LOGGER =

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
@@ -26,7 +26,6 @@ import io.camunda.zeebe.util.Either;
 import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -80,7 +79,6 @@ import org.jspecify.annotations.Nullable;
  * RateMeasurements to update the cluster load and the exporting rate metrics.
  */
 @SuppressWarnings("UnstableApiUsage")
-@NullMarked
 public final class FlowControl {
 
   private final LogStreamMetrics metrics;

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControlLimits.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControlLimits.java
@@ -8,9 +8,7 @@
 package io.camunda.zeebe.logstreams.impl.flowcontrol;
 
 import com.netflix.concurrency.limits.Limit;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
-@NullMarked
 public record FlowControlLimits(
     @Nullable Limit requestLimiter, @Nullable RateLimit writeRateLimit) {}

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/InFlightEntry.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/InFlightEntry.java
@@ -14,10 +14,8 @@ import io.camunda.zeebe.util.CloseableSilently;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import net.jcip.annotations.ThreadSafe;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
-@NullMarked
 @ThreadSafe
 public final class InFlightEntry {
   final LogStreamMetrics metrics;

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RateLimit.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RateLimit.java
@@ -10,11 +10,9 @@ package io.camunda.zeebe.logstreams.impl.flowcontrol;
 import com.google.common.util.concurrent.RateLimiter;
 import java.time.Duration;
 import java.util.Objects;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 @SuppressWarnings("UnstableApiUsage")
-@NullMarked
 public record RateLimit(boolean enabled, int limit, Duration rampUp, Throttling throttling) {
   public RateLimit {
     Objects.requireNonNull(throttling, "throttling must not be null");
@@ -45,7 +43,6 @@ public record RateLimit(boolean enabled, int limit, Duration rampUp, Throttling 
     return RateLimiter.create(limit, rampUp);
   }
 
-  @NullMarked
   public record Throttling(
       boolean enabled, long acceptableBacklog, long minRate, Duration resolution) {
     public Throttling {

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RateLimitThrottle.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RateLimitThrottle.java
@@ -12,6 +12,7 @@ import static java.lang.Math.clamp;
 import com.google.common.util.concurrent.RateLimiter;
 import io.camunda.zeebe.logstreams.impl.LogStreamMetrics;
 import java.util.concurrent.atomic.AtomicLong;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,8 +24,8 @@ final class RateLimitThrottle {
   private final AtomicLong lastUpdate = new AtomicLong(-1);
 
   private final LogStreamMetrics metrics;
-  private final RateLimit limit;
-  private final RateLimiter limiter;
+  private final @Nullable RateLimit limit;
+  private final @Nullable RateLimiter limiter;
   private final RateMeasurement measurement;
   private final long resolution;
   private final boolean enabled;
@@ -32,8 +33,8 @@ final class RateLimitThrottle {
 
   RateLimitThrottle(
       final LogStreamMetrics metrics,
-      final RateLimit limit,
-      final RateLimiter limiter,
+      final @Nullable RateLimit limit,
+      final @Nullable RateLimiter limiter,
       final RateMeasurement measurement) {
     this.metrics = metrics;
     this.limit = limit;
@@ -50,6 +51,10 @@ final class RateLimitThrottle {
     }
 
     if (canSkipUpdate(timestamp)) {
+      return;
+    }
+
+    if (limit == null || limiter == null) {
       return;
     }
 

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RateMeasurement.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RateMeasurement.java
@@ -11,11 +11,9 @@ import java.time.Duration;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.function.LongSupplier;
 import net.jcip.annotations.ThreadSafe;
-import org.jspecify.annotations.NullMarked;
 
 /** Measures the rate of change for monotonically increasing values. */
 @ThreadSafe
-@NullMarked
 public final class RateMeasurement {
   private final LongSupplier clock;
   private final LinkedBlockingDeque<Observation> observations;

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBuffer.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RingBuffer.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.logstreams.impl.flowcontrol;
 import io.camunda.zeebe.util.VisibleForTesting;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 import org.agrona.BitUtil;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,7 +49,6 @@ import org.slf4j.LoggerFactory;
  * #put(InFlightEntry)} stamps the entry with the sequential index before the volatile write, and
  * {@link #get(long, long)} verifies both the sequential index and the log position match.
  */
-@NullMarked
 final class RingBuffer {
   private static final int DEFAULT_CAPACITY = 8 * 1024; // 8K slots
   private static final Logger LOGGER = LoggerFactory.getLogger(RingBuffer.class);

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/WhiteListedCommands.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/WhiteListedCommands.java
@@ -15,10 +15,8 @@ import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
 import java.util.Set;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
-@NullMarked
 public class WhiteListedCommands {
 
   private static final Set<? extends Intent> WHITE_LISTED_COMMANDS =

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/package-info.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/package-info.java
@@ -5,19 +5,8 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
+
+@NullMarked
 package io.camunda.zeebe.logstreams.impl.flowcontrol;
 
-import com.netflix.concurrency.limits.Limiter.Listener;
-
-class NoopListener implements Listener {
-  public static final NoopListener INSTANCE = new NoopListener();
-
-  @Override
-  public void onSuccess() {}
-
-  @Override
-  public void onIgnore() {}
-
-  @Override
-  public void onDropped() {}
-}
+import org.jspecify.annotations.NullMarked;

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogAppendEntryMetadata.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogAppendEntryMetadata.java
@@ -12,9 +12,7 @@ import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import java.util.List;
-import org.jspecify.annotations.NullMarked;
 
-@NullMarked
 public final class LogAppendEntryMetadata {
   private final short[] recordTypes;
   private final short[] valueTypes;

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamBatchReaderImpl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamBatchReaderImpl.java
@@ -92,7 +92,11 @@ public class LogStreamBatchReaderImpl implements LogStreamBatchReader {
 
     private final LoggedEventImpl event = new LoggedEventImpl();
 
+    // wrap() must be called before any use; fields start null but are never null after wrapping
+    @SuppressWarnings("NullAway")
     private DirectBuffer buffer;
+
+    @SuppressWarnings("NullAway")
     private IntArrayList offsets;
 
     private int currentIndex = 0;

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamBatchReaderImpl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamBatchReaderImpl.java
@@ -93,10 +93,10 @@ public class LogStreamBatchReaderImpl implements LogStreamBatchReader {
     private final LoggedEventImpl event = new LoggedEventImpl();
 
     // wrap() must be called before any use; fields start null but are never null after wrapping
-    @SuppressWarnings("NullAway")
+    @SuppressWarnings("NullAway.Init")
     private DirectBuffer buffer;
 
-    @SuppressWarnings("NullAway")
+    @SuppressWarnings("NullAway.Init")
     private IntArrayList offsets;
 
     private int currentIndex = 0;

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamBuilderImpl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamBuilderImpl.java
@@ -16,10 +16,8 @@ import io.camunda.zeebe.logstreams.log.LogStreamBuilder;
 import io.camunda.zeebe.logstreams.storage.LogStorage;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.InstantSource;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
-@NullMarked
 public final class LogStreamBuilderImpl implements LogStreamBuilder {
   private static final int MINIMUM_FRAGMENT_SIZE = 4 * 1024;
   private int maxFragmentSize = 1024 * 1024 * 4;

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
@@ -22,11 +22,9 @@ import io.micrometer.core.instrument.MeterRegistry;
 import java.time.InstantSource;
 import java.util.Collection;
 import java.util.concurrent.CopyOnWriteArrayList;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 
-@NullMarked
 public final class LogStreamImpl implements LogStream, CommitListener {
 
   private static final Logger LOG = Loggers.LOGSTREAMS_LOGGER;

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LoggedEventImpl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LoggedEventImpl.java
@@ -16,7 +16,10 @@ import org.agrona.MutableDirectBuffer;
 
 /** Represents the implementation of the logged event. */
 public final class LoggedEventImpl implements LoggedEvent {
+  // wrap() must be called before any use; field starts null but is never null after wrapping
+  @SuppressWarnings("NullAway")
   private DirectBuffer buffer;
+
   private int fragmentOffset = -1;
   private int messageOffset = -1;
 

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LoggedEventImpl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LoggedEventImpl.java
@@ -17,7 +17,7 @@ import org.agrona.MutableDirectBuffer;
 /** Represents the implementation of the logged event. */
 public final class LoggedEventImpl implements LoggedEvent {
   // wrap() must be called before any use; field starts null but is never null after wrapping
-  @SuppressWarnings("NullAway")
+  @SuppressWarnings("NullAway.Init")
   private DirectBuffer buffer;
 
   private int fragmentOffset = -1;

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/SequencedBatch.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/SequencedBatch.java
@@ -13,9 +13,7 @@ import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.List;
 import java.util.Objects;
 import org.agrona.MutableDirectBuffer;
-import org.jspecify.annotations.NullMarked;
 
-@NullMarked
 public record SequencedBatch(
     long timestamp,
     long firstPosition,

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/Sequencer.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/Sequencer.java
@@ -24,7 +24,6 @@ import java.time.InstantSource;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.locks.ReentrantLock;
-import org.jspecify.annotations.NullMarked;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,7 +32,6 @@ import org.slf4j.LoggerFactory;
  * serializes them, assigning positions to all entries. Writes that are accepted are written
  * directly to the {@link LogStorage}.
  */
-@NullMarked
 final class Sequencer implements LogStreamWriter, Closeable {
   private static final Logger LOG = LoggerFactory.getLogger(Sequencer.class);
   private final int maxFragmentSize;

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/SequencerMetrics.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/SequencerMetrics.java
@@ -23,9 +23,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
-import org.jspecify.annotations.NullMarked;
 
-@NullMarked
 final class SequencerMetrics {
   private final MeterRegistry meterRegistry;
   private final DistributionSummary batchSize;

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/package-info.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/package-info.java
@@ -5,19 +5,8 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.zeebe.logstreams.impl.flowcontrol;
 
-import com.netflix.concurrency.limits.Limiter.Listener;
+@NullMarked
+package io.camunda.zeebe.logstreams.impl.log;
 
-class NoopListener implements Listener {
-  public static final NoopListener INSTANCE = new NoopListener();
-
-  @Override
-  public void onSuccess() {}
-
-  @Override
-  public void onIgnore() {}
-
-  @Override
-  public void onDropped() {}
-}
+import org.jspecify.annotations.NullMarked;

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/package-info.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/package-info.java
@@ -5,19 +5,8 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.zeebe.logstreams.impl.flowcontrol;
 
-import com.netflix.concurrency.limits.Limiter.Listener;
+@NullMarked
+package io.camunda.zeebe.logstreams.impl;
 
-class NoopListener implements Listener {
-  public static final NoopListener INSTANCE = new NoopListener();
-
-  @Override
-  public void onSuccess() {}
-
-  @Override
-  public void onIgnore() {}
-
-  @Override
-  public void onDropped() {}
-}
+import org.jspecify.annotations.NullMarked;

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/serializer/package-info.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/serializer/package-info.java
@@ -5,19 +5,8 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.zeebe.logstreams.impl.flowcontrol;
 
-import com.netflix.concurrency.limits.Limiter.Listener;
+@NullMarked
+package io.camunda.zeebe.logstreams.impl.serializer;
 
-class NoopListener implements Listener {
-  public static final NoopListener INSTANCE = new NoopListener();
-
-  @Override
-  public void onSuccess() {}
-
-  @Override
-  public void onIgnore() {}
-
-  @Override
-  public void onDropped() {}
-}
+import org.jspecify.annotations.NullMarked;

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStream.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStream.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.logstreams.log;
 
 import io.camunda.zeebe.logstreams.impl.flowcontrol.FlowControl;
 import io.camunda.zeebe.logstreams.impl.log.LogStreamBuilderImpl;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -19,7 +18,6 @@ import org.jspecify.annotations.Nullable;
  *
  * <p>To read events, the {@link LogStream#newLogStreamReader()} ()} can be used.
  */
-@NullMarked
 public interface LogStream extends AutoCloseable {
 
   @Override

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/package-info.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/package-info.java
@@ -5,19 +5,8 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.zeebe.logstreams.impl.flowcontrol;
 
-import com.netflix.concurrency.limits.Limiter.Listener;
+@NullMarked
+package io.camunda.zeebe.logstreams.log;
 
-class NoopListener implements Listener {
-  public static final NoopListener INSTANCE = new NoopListener();
-
-  @Override
-  public void onSuccess() {}
-
-  @Override
-  public void onIgnore() {}
-
-  @Override
-  public void onDropped() {}
-}
+import org.jspecify.annotations.NullMarked;

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/storage/package-info.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/storage/package-info.java
@@ -5,19 +5,8 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.zeebe.logstreams.impl.flowcontrol;
 
-import com.netflix.concurrency.limits.Limiter.Listener;
+@NullMarked
+package io.camunda.zeebe.logstreams.storage;
 
-class NoopListener implements Listener {
-  public static final NoopListener INSTANCE = new NoopListener();
-
-  @Override
-  public void onSuccess() {}
-
-  @Override
-  public void onIgnore() {}
-
-  @Override
-  public void onDropped() {}
-}
+import org.jspecify.annotations.NullMarked;

--- a/zeebe/protocol/pom.xml
+++ b/zeebe/protocol/pom.xml
@@ -115,13 +115,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <compilerArgs combine.children="append">
-            <!-- required by javac detection logic in immutables -->
-            <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
-          </compilerArgs>
-          <fork>true</fork>
-        </configuration>
         <executions>
           <execution>
             <id>default-compile</id>

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
@@ -112,11 +112,12 @@ public class RestoreManager implements CloseableSilently {
       }
       restoreTimeRange(from, to, validateConfig, ignoreFilesInTarget);
     } else {
-      restoreRdbms(from, to, validateConfig, ignoreFilesInTarget);
+      restoreRdbms(exporterPositionMapper, from, to, validateConfig, ignoreFilesInTarget);
     }
   }
 
   private void restoreRdbms(
+      final ExporterPositionMapper positionMapper,
       @Nullable final Instant from,
       @Nullable final Instant to,
       final boolean validateConfig,
@@ -124,7 +125,7 @@ public class RestoreManager implements CloseableSilently {
       throws IOException, ExecutionException, InterruptedException {
     final var partitionCount = configuration.getCluster().getPartitionsCount();
 
-    final var exportedPositions = exportedPositions(partitionCount).join();
+    final var exportedPositions = exportedPositions(positionMapper, partitionCount).join();
     LOG.info("Exported positions for all partitions: {}", exportedPositions);
 
     // Load backup metadata for each partition in parallel
@@ -376,13 +377,14 @@ public class RestoreManager implements CloseableSilently {
     }
   }
 
-  private CompletableFuture<Map<Integer, Long>> exportedPositions(final int partitionCount) {
+  private CompletableFuture<Map<Integer, Long>> exportedPositions(
+      final ExporterPositionMapper positionMapper, final int partitionCount) {
     return FuturesUtil.parTraverse(
             IntStream.rangeClosed(1, partitionCount).boxed().toList(),
             partition ->
                 CompletableFuture.supplyAsync(
                     () -> {
-                      final var positionModel = exporterPositionMapper.findOne(partition);
+                      final var positionModel = positionMapper.findOne(partition);
                       if (positionModel == null || positionModel.lastExportedPosition() == null) {
                         throw new IllegalArgumentException(
                             "No exported position found for partition " + partition + " in RDBMS");


### PR DESCRIPTION
## Description

Introduces NullAway (https://github.com/uber/NullAway) backed by Error Prone as a compile-time null-safety checker, enforcing JSpecify \`@NullMarked\`/\`@Nullable\` annotations across the codebase.

NullAway was chosen because we already use Error Prone and it integrates cheaply — only \`@NullMarked\` scopes are checked (\`OnlyNullMarked=true\`), so unannotated modules are unaffected.

### Build configuration

- **Global activation**: NullAway is configured in \`pluginManagement\` for \`maven-compiler-plugin\`, running on every compile. Only annotated scopes are checked so build overhead is minimal (~30s on the full repo).
- **No forking**: JVM flags required by Error Prone are in \`.mvn/jvm.config\` (\`--add-exports\`/\`--add-opens\` for \`jdk.compiler\`), avoiding per-module JVM fork overhead.
  - forking was slowing down the compilation
  - forking was removed from modules that were using it to add a jvm flag for immutable: that flag is now global
- **Test sources excluded**: the \`default-testCompile\` execution resets processor paths, so NullAway does not run on tests.
- **Generated sources excluded**: \`-XepExcludedPaths:.*/target/generated-sources/.*\` skips OpenAPI, SBE, and Immutables output.

### Modules annotated with \`@NullMarked\`

- **\`zeebe/logstreams\`**: all source packages covered via \`package-info.java\`. Flyweight-pattern fields in \`LoggedEventImpl\` and \`LogStreamBatchReaderImpl\` use \`@SuppressWarnings("NullAway")\` with a comment explaining the wrap-before-use contract. Optional fields in \`RateLimitThrottle\` are marked \`@Nullable\` with guarded access.
- **\`gateways/gateway-mapping-http\`**: \`package-info.java\` added to all subpackages (\`converters\`, \`mapper\`, \`search\`, \`util\`, \`validator\`). The module's own NullAway compiler configuration is removed — it now inherits from the parent.
- **\`search/search-domain\` entities**: the \`io.camunda.search.entities\` package was already \`@NullMarked\` (added by another team). Builder fields are annotated \`@Nullable\` to reflect their unset state, and \`build()\` methods carry \`@SuppressWarnings("NullAway")\` since null-safety is enforced at construction time via \`Objects.requireNonNull\` in the compact record constructor.