### PR TITLE
fix: scope variableSpinner locator to first matching element

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -166,7 +166,7 @@ class OperateProcessInstancePage {
     this.newVariableNameField = page.getByRole('textbox', {name: 'Name'});
     this.newVariableValueField = page.getByRole('group', {name: 'Value'});
     this.editVariableValueField = page.getByRole('group', {name: 'Value'});
-    this.variableSpinner = page.getByTestId('full-variable-loader');
+    this.variableSpinner = page.getByTestId('full-variable-loader').first();
     this.operationSpinner = page.getByTestId('operation-spinner');
     this.executionCountToggleOn = this.instanceHistory.getByLabel(
       'show execution count',


### PR DESCRIPTION
## Summary

In `OperateProcessInstancePage`, the `variableSpinner` locator used `getByTestId('full-variable-loader')` which can match multiple elements when more than one variable is loading simultaneously. Playwright's strict mode raises an error when a locator resolves to more than one element and an action (e.g. `toBeVisible`, `toBeHidden`) is performed on it.

## Change

```diff
- this.variableSpinner = page.getByTestId('full-variable-loader');
+ this.variableSpinner = page.getByTestId('full-variable-loader').first();
```

Scoping to `.first()` ensures a single element is targeted, resolving the strict-mode violation without changing the intent of the locator.

## Testing
https://github.com/camunda/camunda/actions/runs/24881869306
❗ Failing tests are fixed in https://github.com/camunda/camunda/pull/51751
