### PR TITLE
fix(cpt): Do not wait for condition reset if conditional behavior action is throwing

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/ConditionalBehaviorEngine.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/ConditionalBehaviorEngine.java
@@ -215,8 +215,12 @@ public class ConditionalBehaviorEngine {
     void evaluate() {
       if (isConditionMet()) {
         LOGGER.trace("Condition met for '{}', firing action at index {}", name, actionIndex.get());
-        fireAction();
-        waitForConditionReset();
+        if (fireAction()) {
+          waitForConditionReset();
+        }
+        // A failed action left the system unchanged, so there is nothing to
+        // reset. Skipping the reset-wait lets the scheduler retry at the poll
+        // interval instead of burning the full reset timeout.
       }
     }
 
@@ -252,9 +256,9 @@ public class ConditionalBehaviorEngine {
       }
     }
 
-    private void fireAction() {
+    private boolean fireAction() {
       if (actions.isEmpty()) {
-        return;
+        return false;
       }
       fireCount.incrementAndGet();
       final Runnable action = actions.get(clampToLastAction(actionIndex.get()));
@@ -263,9 +267,10 @@ public class ConditionalBehaviorEngine {
       } catch (final Throwable t) {
         failureCount.incrementAndGet();
         LOGGER.warn("Behavior '{}' action threw an exception, will retry", name, t);
-        return;
+        return false;
       }
       actionIndex.set(clampToLastAction(actionIndex.get() + 1));
+      return true;
     }
 
     private int clampToLastAction(final int index) {

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/ConditionalBehaviorEngine.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/ConditionalBehaviorEngine.java
@@ -218,9 +218,6 @@ public class ConditionalBehaviorEngine {
         if (fireAction()) {
           waitForConditionReset();
         }
-        // A failed action left the system unchanged, so there is nothing to
-        // reset. Skipping the reset-wait lets the scheduler retry at the poll
-        // interval instead of burning the full reset timeout.
       }
     }
 

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extension/ConditionalBehaviorEngineTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extension/ConditionalBehaviorEngineTest.java
@@ -452,9 +452,6 @@ class ConditionalBehaviorEngineTest {
 
   @Test
   void shouldRetryFailedActionAtPollIntervalWhenConditionStaysTrue() {
-    // If an action throws while the condition remains continuously true,
-    // the engine must retry at the poll interval rather than burning the
-    // full reset timeout — nothing changed, so there is nothing to reset.
     final AtomicInteger actionCount = new AtomicInteger(0);
 
     engine
@@ -465,9 +462,6 @@ class ConditionalBehaviorEngineTest {
               throw new RuntimeException("action always fails");
             });
 
-    // With the default 5s reset timeout, a pre-fix engine would fire ~once per
-    // 5s and never reach 3 fires within 1.5s. A fix that bypasses the reset
-    // wait on failure fires every pollInterval (~100ms) → well over 3 fires.
     await()
         .atMost(1500, TimeUnit.MILLISECONDS)
         .untilAsserted(() -> assertThat(actionCount.get()).isGreaterThanOrEqualTo(3));

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extension/ConditionalBehaviorEngineTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extension/ConditionalBehaviorEngineTest.java
@@ -449,4 +449,27 @@ class ConditionalBehaviorEngineTest {
         .atMost(5, TimeUnit.SECONDS)
         .untilAsserted(() -> assertThat(actionCount.get()).isGreaterThanOrEqualTo(2));
   }
+
+  @Test
+  void shouldRetryFailedActionAtPollIntervalWhenConditionStaysTrue() {
+    // If an action throws while the condition remains continuously true,
+    // the engine must retry at the poll interval rather than burning the
+    // full reset timeout — nothing changed, so there is nothing to reset.
+    final AtomicInteger actionCount = new AtomicInteger(0);
+
+    engine
+        .when(() -> {})
+        .then(
+            () -> {
+              actionCount.incrementAndGet();
+              throw new RuntimeException("action always fails");
+            });
+
+    // With the default 5s reset timeout, a pre-fix engine would fire ~once per
+    // 5s and never reach 3 fires within 1.5s. A fix that bypasses the reset
+    // wait on failure fires every pollInterval (~100ms) → well over 3 fires.
+    await()
+        .atMost(1500, TimeUnit.MILLISECONDS)
+        .untilAsserted(() -> assertThat(actionCount.get()).isGreaterThanOrEqualTo(3));
+  }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extension/ConditionalBehaviorEngineTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extension/ConditionalBehaviorEngineTest.java
@@ -24,6 +24,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -451,19 +452,24 @@ class ConditionalBehaviorEngineTest {
   }
 
   @Test
-  void shouldRetryFailedActionAtPollIntervalWhenConditionStaysTrue() {
-    final AtomicInteger actionCount = new AtomicInteger(0);
+  void shouldNotWaitForResetAfterFailedAction() {
+    final List<Long> fireTimestampsNanos = new CopyOnWriteArrayList<>();
 
     engine
         .when(() -> {})
         .then(
             () -> {
-              actionCount.incrementAndGet();
-              throw new RuntimeException("action always fails");
+              fireTimestampsNanos.add(System.nanoTime());
+              throw new RuntimeException("always fails");
             });
 
     await()
-        .atMost(1500, TimeUnit.MILLISECONDS)
-        .untilAsserted(() -> assertThat(actionCount.get()).isGreaterThanOrEqualTo(3));
+        .atMost(3, TimeUnit.SECONDS)
+        .untilAsserted(() -> assertThat(fireTimestampsNanos).hasSizeGreaterThanOrEqualTo(2));
+
+    final long gapMillis =
+        TimeUnit.NANOSECONDS.toMillis(fireTimestampsNanos.get(1) - fireTimestampsNanos.get(0));
+    // resetTimeout=5s, pollInterval=100ms — any gap < 1s proves reset-wait was skipped.
+    assertThat(gapMillis).isLessThan(1000);
   }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extension/ConditionalBehaviorEngineTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extension/ConditionalBehaviorEngineTest.java
@@ -469,7 +469,7 @@ class ConditionalBehaviorEngineTest {
 
     final long gapMillis =
         TimeUnit.NANOSECONDS.toMillis(fireTimestampsNanos.get(1) - fireTimestampsNanos.get(0));
-    // resetTimeout=5s, pollInterval=100ms — any gap < 1s proves reset-wait was skipped.
-    assertThat(gapMillis).isLessThan(1000);
+    // resetTimeout=5s, pollInterval=100ms — any gap < 5s proves reset-wait was skipped.
+    assertThat(gapMillis).isLessThan(5000);
   }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/ConditionalBehaviorApiIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/ConditionalBehaviorApiIT.java
@@ -15,14 +15,17 @@
  */
 package io.camunda.process.test.impl.extensions;
 
+import static io.camunda.process.test.api.CamundaAssert.assertThat;
 import static io.camunda.process.test.api.CamundaAssert.assertThatProcessInstance;
 import static io.camunda.process.test.impl.extensions.ConditionalBehaviorTestProcess.*;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.ProcessInstanceEvent;
+import io.camunda.process.test.api.CamundaAssert;
 import io.camunda.process.test.api.CamundaProcessTest;
 import io.camunda.process.test.api.CamundaProcessTestContext;
 import io.camunda.process.test.api.assertions.ProcessInstanceSelectors;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 import org.junit.jupiter.api.RepeatedTest;
@@ -30,36 +33,35 @@ import org.junit.jupiter.api.RepeatedTest;
 @CamundaProcessTest
 public class ConditionalBehaviorApiIT {
 
-  // injected by the extension
+  private static final Map<String, Object> UNHAPPY = Collections.singletonMap("happy", false);
+  private static final Map<String, Object> HAPPY = Collections.singletonMap("happy", true);
+  private static final Map<String, Object> EXPORT_VARS =
+      Collections.singletonMap("exportSuccess", true);
+
+  @SuppressWarnings("unused")
   private CamundaProcessTestContext processTestContext;
+
+  @SuppressWarnings("unused")
   private CamundaClient client;
 
   // ensure repeated tests get fresh behaviors
   @RepeatedTest(value = 2)
   void shouldCompleteProcessWithConditionalBehaviors() {
+    // increase assertion timeout because the immediate loop-back occasionally activates the reset
+    // gate timeout of 5 seconds
+    CamundaAssert.setAssertionTimeout(Duration.ofSeconds(30));
+
     // Deploy the process model
     client.newDeployResourceCommand().addProcessModel(MODEL, PROCESS_ID + ".bpmn").send().join();
-
-    final Map<String, Object> unhappy = Collections.singletonMap("happy", false);
-    final Map<String, Object> happy = Collections.singletonMap("happy", true);
-    final Map<String, Object> exportVars = Collections.singletonMap("exportSuccess", true);
 
     // Setup conditional behaviors before starting the process
     processTestContext
         .when(
             () ->
-                assertThatProcessInstance(ProcessInstanceSelectors.byProcessId(PROCESS_ID))
-                    .hasActiveElement(USER_TASK_ID, 1)
-                    .hasCompletedElement(USER_TASK_ID, 0))
-        .then(() -> processTestContext.completeUserTask(USER_TASK_ID, unhappy));
-
-    processTestContext
-        .when(
-            () ->
-                assertThatProcessInstance(ProcessInstanceSelectors.byProcessId(PROCESS_ID))
-                    .hasActiveElement(USER_TASK_ID, 1)
-                    .hasCompletedElement(USER_TASK_ID, 1))
-        .then(() -> processTestContext.completeUserTask(USER_TASK_ID, happy));
+                assertThat(ProcessInstanceSelectors.byProcessId(PROCESS_ID))
+                    .hasActiveElement(USER_TASK_ID, 1))
+        .then(() -> processTestContext.completeUserTask(USER_TASK_ID, UNHAPPY))
+        .then(() -> processTestContext.completeUserTask(USER_TASK_ID, HAPPY));
 
     // When Export_Happiness is active, complete the job
     processTestContext
@@ -67,7 +69,7 @@ public class ConditionalBehaviorApiIT {
             () ->
                 assertThatProcessInstance(ProcessInstanceSelectors.byProcessId(PROCESS_ID))
                     .hasActiveElements(SERVICE_TASK_ID))
-        .then(() -> processTestContext.completeJob(JOB_TYPE, exportVars));
+        .then(() -> processTestContext.completeJob(JOB_TYPE, EXPORT_VARS));
 
     // Start the process
     final ProcessInstanceEvent processInstanceEvent =

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/ConditionalBehaviorApiIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/ConditionalBehaviorApiIT.java
@@ -15,7 +15,6 @@
  */
 package io.camunda.process.test.impl.extensions;
 
-import static io.camunda.process.test.api.CamundaAssert.assertThat;
 import static io.camunda.process.test.api.CamundaAssert.assertThatProcessInstance;
 import static io.camunda.process.test.impl.extensions.ConditionalBehaviorTestProcess.*;
 
@@ -46,16 +45,20 @@ public class ConditionalBehaviorApiIT {
     final Map<String, Object> exportVars = Collections.singletonMap("exportSuccess", true);
 
     // Setup conditional behaviors before starting the process
-
-    // When user task "State_Happiness" is created, complete it:
-    //   1st time with happy=false (loops back)
-    //   2nd time with happy=true (proceeds to Export_Happiness)
     processTestContext
         .when(
             () ->
-                assertThat(ProcessInstanceSelectors.byProcessId(PROCESS_ID))
-                    .hasActiveElement(USER_TASK_ID, 1))
-        .then(() -> processTestContext.completeUserTask(USER_TASK_ID, unhappy))
+                assertThatProcessInstance(ProcessInstanceSelectors.byProcessId(PROCESS_ID))
+                    .hasActiveElement(USER_TASK_ID, 1)
+                    .hasCompletedElement(USER_TASK_ID, 0))
+        .then(() -> processTestContext.completeUserTask(USER_TASK_ID, unhappy));
+
+    processTestContext
+        .when(
+            () ->
+                assertThatProcessInstance(ProcessInstanceSelectors.byProcessId(PROCESS_ID))
+                    .hasActiveElement(USER_TASK_ID, 1)
+                    .hasCompletedElement(USER_TASK_ID, 1))
         .then(() -> processTestContext.completeUserTask(USER_TASK_ID, happy));
 
     // When Export_Happiness is active, complete the job

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/ConditionalBehaviorBeforeEachIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/ConditionalBehaviorBeforeEachIT.java
@@ -15,7 +15,6 @@
  */
 package io.camunda.process.test.impl.extensions;
 
-import static io.camunda.process.test.api.CamundaAssert.assertThat;
 import static io.camunda.process.test.api.CamundaAssert.assertThatProcessInstance;
 import static io.camunda.process.test.impl.extensions.ConditionalBehaviorTestProcess.*;
 
@@ -52,9 +51,17 @@ public class ConditionalBehaviorBeforeEachIT {
     processTestContext
         .when(
             () ->
-                assertThat(ProcessInstanceSelectors.byProcessId(PROCESS_ID))
-                    .hasActiveElement(USER_TASK_ID, 1))
-        .then(() -> processTestContext.completeUserTask(USER_TASK_ID, UNHAPPY))
+                assertThatProcessInstance(ProcessInstanceSelectors.byProcessId(PROCESS_ID))
+                    .hasActiveElement(USER_TASK_ID, 1)
+                    .hasCompletedElement(USER_TASK_ID, 0))
+        .then(() -> processTestContext.completeUserTask(USER_TASK_ID, UNHAPPY));
+
+    processTestContext
+        .when(
+            () ->
+                assertThatProcessInstance(ProcessInstanceSelectors.byProcessId(PROCESS_ID))
+                    .hasActiveElement(USER_TASK_ID, 1)
+                    .hasCompletedElement(USER_TASK_ID, 1))
         .then(() -> processTestContext.completeUserTask(USER_TASK_ID, HAPPY));
 
     processTestContext

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/ConditionalBehaviorBeforeEachIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/ConditionalBehaviorBeforeEachIT.java
@@ -15,14 +15,17 @@
  */
 package io.camunda.process.test.impl.extensions;
 
+import static io.camunda.process.test.api.CamundaAssert.assertThat;
 import static io.camunda.process.test.api.CamundaAssert.assertThatProcessInstance;
 import static io.camunda.process.test.impl.extensions.ConditionalBehaviorTestProcess.*;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.ProcessInstanceEvent;
+import io.camunda.process.test.api.CamundaAssert;
 import io.camunda.process.test.api.CamundaProcessTest;
 import io.camunda.process.test.api.CamundaProcessTestContext;
 import io.camunda.process.test.api.assertions.ProcessInstanceSelectors;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,28 +43,27 @@ public class ConditionalBehaviorBeforeEachIT {
   private static final Map<String, Object> EXPORT_VARS =
       Collections.singletonMap("exportSuccess", true);
 
+  @SuppressWarnings("unused")
   private CamundaProcessTestContext processTestContext;
+
+  @SuppressWarnings("unused")
   private CamundaClient client;
 
   @BeforeEach
   void setupBehaviors() {
+    // increase assertion timeout because the immediate loop-back occasionally activates the reset
+    // gate timeout of 5 seconds
+    CamundaAssert.setAssertionTimeout(Duration.ofSeconds(30));
+
     // Deploy the process model
     client.newDeployResourceCommand().addProcessModel(MODEL, PROCESS_ID + ".bpmn").send().join();
 
     processTestContext
         .when(
             () ->
-                assertThatProcessInstance(ProcessInstanceSelectors.byProcessId(PROCESS_ID))
-                    .hasActiveElement(USER_TASK_ID, 1)
-                    .hasCompletedElement(USER_TASK_ID, 0))
-        .then(() -> processTestContext.completeUserTask(USER_TASK_ID, UNHAPPY));
-
-    processTestContext
-        .when(
-            () ->
-                assertThatProcessInstance(ProcessInstanceSelectors.byProcessId(PROCESS_ID))
-                    .hasActiveElement(USER_TASK_ID, 1)
-                    .hasCompletedElement(USER_TASK_ID, 1))
+                assertThat(ProcessInstanceSelectors.byProcessId(PROCESS_ID))
+                    .hasActiveElement(USER_TASK_ID, 1))
+        .then(() -> processTestContext.completeUserTask(USER_TASK_ID, UNHAPPY))
         .then(() -> processTestContext.completeUserTask(USER_TASK_ID, HAPPY));
 
     processTestContext

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/SpringConditionalBehaviorApiIT.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/SpringConditionalBehaviorApiIT.java
@@ -15,12 +15,14 @@
  */
 package io.camunda.process.test.api;
 
+import static io.camunda.process.test.api.CamundaAssert.assertThat;
 import static io.camunda.process.test.api.CamundaAssert.assertThatProcessInstance;
 import static io.camunda.process.test.api.ConditionalBehaviorTestProcess.*;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.process.test.api.assertions.ProcessInstanceSelectors;
+import java.time.Duration;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,23 +37,19 @@ public class SpringConditionalBehaviorApiIT {
 
   @Test
   void shouldCompleteProcessWithConditionalBehaviors() {
+    // increase assertion timeout because the immediate loop-back occasionally activates the reset
+    // gate timeout of 5 seconds
+    CamundaAssert.setAssertionTimeout(Duration.ofSeconds(30));
+
     // Deploy
     client.newDeployResourceCommand().addProcessModel(MODEL, PROCESS_ID + ".bpmn").send().join();
 
     processTestContext
         .when(
             () ->
-                assertThatProcessInstance(ProcessInstanceSelectors.byProcessId(PROCESS_ID))
-                    .hasActiveElement(USER_TASK_ID, 1)
-                    .hasCompletedElement(USER_TASK_ID, 0))
-        .then(() -> processTestContext.completeUserTask(USER_TASK_ID, Map.of("happy", false)));
-
-    processTestContext
-        .when(
-            () ->
-                assertThatProcessInstance(ProcessInstanceSelectors.byProcessId(PROCESS_ID))
-                    .hasActiveElement(USER_TASK_ID, 1)
-                    .hasCompletedElement(USER_TASK_ID, 1))
+                assertThat(ProcessInstanceSelectors.byProcessId(PROCESS_ID))
+                    .hasActiveElement(USER_TASK_ID, 1))
+        .then(() -> processTestContext.completeUserTask(USER_TASK_ID, Map.of("happy", false)))
         .then(() -> processTestContext.completeUserTask(USER_TASK_ID, Map.of("happy", true)));
 
     processTestContext

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/SpringConditionalBehaviorApiIT.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/SpringConditionalBehaviorApiIT.java
@@ -15,7 +15,6 @@
  */
 package io.camunda.process.test.api;
 
-import static io.camunda.process.test.api.CamundaAssert.assertThat;
 import static io.camunda.process.test.api.CamundaAssert.assertThatProcessInstance;
 import static io.camunda.process.test.api.ConditionalBehaviorTestProcess.*;
 
@@ -39,13 +38,20 @@ public class SpringConditionalBehaviorApiIT {
     // Deploy
     client.newDeployResourceCommand().addProcessModel(MODEL, PROCESS_ID + ".bpmn").send().join();
 
-    // Setup conditional behaviors
     processTestContext
         .when(
             () ->
-                assertThat(ProcessInstanceSelectors.byProcessId(PROCESS_ID))
-                    .hasActiveElement(USER_TASK_ID, 1))
-        .then(() -> processTestContext.completeUserTask(USER_TASK_ID, Map.of("happy", false)))
+                assertThatProcessInstance(ProcessInstanceSelectors.byProcessId(PROCESS_ID))
+                    .hasActiveElement(USER_TASK_ID, 1)
+                    .hasCompletedElement(USER_TASK_ID, 0))
+        .then(() -> processTestContext.completeUserTask(USER_TASK_ID, Map.of("happy", false)));
+
+    processTestContext
+        .when(
+            () ->
+                assertThatProcessInstance(ProcessInstanceSelectors.byProcessId(PROCESS_ID))
+                    .hasActiveElement(USER_TASK_ID, 1)
+                    .hasCompletedElement(USER_TASK_ID, 1))
         .then(() -> processTestContext.completeUserTask(USER_TASK_ID, Map.of("happy", true)));
 
     processTestContext

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/SpringConditionalBehaviorBeforeEachIT.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/SpringConditionalBehaviorBeforeEachIT.java
@@ -15,7 +15,6 @@
  */
 package io.camunda.process.test.api;
 
-import static io.camunda.process.test.api.CamundaAssert.assertThat;
 import static io.camunda.process.test.api.CamundaAssert.assertThatProcessInstance;
 import static io.camunda.process.test.api.ConditionalBehaviorTestProcess.*;
 
@@ -50,9 +49,17 @@ public class SpringConditionalBehaviorBeforeEachIT {
     processTestContext
         .when(
             () ->
-                assertThat(ProcessInstanceSelectors.byProcessId(PROCESS_ID))
-                    .hasActiveElement(USER_TASK_ID, 1))
-        .then(() -> processTestContext.completeUserTask(USER_TASK_ID, Map.of("happy", false)))
+                assertThatProcessInstance(ProcessInstanceSelectors.byProcessId(PROCESS_ID))
+                    .hasActiveElement(USER_TASK_ID, 1)
+                    .hasCompletedElement(USER_TASK_ID, 0))
+        .then(() -> processTestContext.completeUserTask(USER_TASK_ID, Map.of("happy", false)));
+
+    processTestContext
+        .when(
+            () ->
+                assertThatProcessInstance(ProcessInstanceSelectors.byProcessId(PROCESS_ID))
+                    .hasActiveElement(USER_TASK_ID, 1)
+                    .hasCompletedElement(USER_TASK_ID, 1))
         .then(() -> processTestContext.completeUserTask(USER_TASK_ID, Map.of("happy", true)));
 
     processTestContext

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/SpringConditionalBehaviorBeforeEachIT.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/SpringConditionalBehaviorBeforeEachIT.java
@@ -15,12 +15,14 @@
  */
 package io.camunda.process.test.api;
 
+import static io.camunda.process.test.api.CamundaAssert.assertThat;
 import static io.camunda.process.test.api.CamundaAssert.assertThatProcessInstance;
 import static io.camunda.process.test.api.ConditionalBehaviorTestProcess.*;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.process.test.api.assertions.ProcessInstanceSelectors;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -44,22 +46,18 @@ public class SpringConditionalBehaviorBeforeEachIT {
 
   @BeforeEach
   void setupBehaviors() {
+    // increase assertion timeout because the immediate loop-back occasionally activates the reset
+    // gate timeout of 5 seconds
+    CamundaAssert.setAssertionTimeout(Duration.ofSeconds(30));
+
     client.newDeployResourceCommand().addProcessModel(MODEL, PROCESS_ID + ".bpmn").send().join();
 
     processTestContext
         .when(
             () ->
-                assertThatProcessInstance(ProcessInstanceSelectors.byProcessId(PROCESS_ID))
-                    .hasActiveElement(USER_TASK_ID, 1)
-                    .hasCompletedElement(USER_TASK_ID, 0))
-        .then(() -> processTestContext.completeUserTask(USER_TASK_ID, Map.of("happy", false)));
-
-    processTestContext
-        .when(
-            () ->
-                assertThatProcessInstance(ProcessInstanceSelectors.byProcessId(PROCESS_ID))
-                    .hasActiveElement(USER_TASK_ID, 1)
-                    .hasCompletedElement(USER_TASK_ID, 1))
+                assertThat(ProcessInstanceSelectors.byProcessId(PROCESS_ID))
+                    .hasActiveElement(USER_TASK_ID, 1))
+        .then(() -> processTestContext.completeUserTask(USER_TASK_ID, Map.of("happy", false)))
         .then(() -> processTestContext.completeUserTask(USER_TASK_ID, Map.of("happy", true)));
 
     processTestContext


### PR DESCRIPTION
## Description

* Do not wait for condition reset if conditional behavior action is throwing in `ConditionalBehaviorEngine`
* Refine integration test conditional behaviors such that the immediate loop-back to the same user task is properly asserted

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
