### PR TITLE
test: deflake ProcessInstanceStartMeterTest    and ConnectionMonitorTest

### DIFF
--- a/load-tests/load-tester/src/test/java/io/camunda/zeebe/metrics/ConnectionMonitorTest.java
+++ b/load-tests/load-tester/src/test/java/io/camunda/zeebe/metrics/ConnectionMonitorTest.java
@@ -78,13 +78,16 @@ class ConnectionMonitorTest {
     final var registry = new SimpleMeterRegistry();
     final var client = mock(CamundaClient.class);
 
-    // when — just construct, do not call awaitAndPrintTopology
-    new ConnectionMonitor(client, registry);
+    // when — just construct, do not call awaitAndPrintTopology.
+    // The local reference is required: Micrometer's Gauge.builder(name, obj, fn) holds a
+    // weak reference to obj, so without this binding GC could clear it and value() → NaN.
+    final var monitor = new ConnectionMonitor(client, registry);
 
     // then
     assertThat(registry.find(AppMetricsDoc.CONNECTED.getName()).gauge().value())
         .describedAs("Gauge must be registered at 0 immediately on bean creation")
         .isEqualTo(0.0);
+    assertThat(monitor).isNotNull();
   }
 
   /** Returns a completed {@link CamundaFuture} whose {@link Topology} has no brokers. */

--- a/load-tests/load-tester/src/test/java/io/camunda/zeebe/metrics/ProcessInstanceStartMeterTest.java
+++ b/load-tests/load-tester/src/test/java/io/camunda/zeebe/metrics/ProcessInstanceStartMeterTest.java
@@ -116,7 +116,7 @@ class ProcessInstanceStartMeterTest {
     // then - over a sustained window, the availability metric must never be created
     await()
         .during(Duration.ofMillis(250))
-        .atMost(Duration.ofMillis(500))
+        .atMost(Duration.ofSeconds(2))
         .untilAsserted(
             () ->
                 assertThatThrownBy(
@@ -139,7 +139,7 @@ class ProcessInstanceStartMeterTest {
     // must stay at zero over a sustained window because the checker never runs
     await()
         .during(Duration.ofMillis(250))
-        .atMost(Duration.ofMillis(500))
+        .atMost(Duration.ofSeconds(2))
         .untilAsserted(
             () ->
                 assertThat(


### PR DESCRIPTION
## What this PR does

Fixes two flaky tests in `load-tests/load-tester`. Both fixes are in test code only — no production changes.

| Test | Symptom on CI |
|---|---|
| `ProcessInstanceStartMeterTest#shouldNotRecordQueryDurationWhenNoInstancesStarted` | `ConditionTimeoutException ... within 500 milliseconds` |
| `ConnectionMonitorTest#shouldInitializeConnectedGaugeAtZeroBeforeTopologyCompletes` | `expected: 0.0 but was: NaN` |

---

## Fix 1: `ProcessInstanceStartMeterTest` — flake from a too-tight Awaitility timeout

The test used:

```java
await()
    .during(Duration.ofMillis(250))    // condition must hold continuously for 250 ms
    .atMost(Duration.ofMillis(500))    // Awaitility has 500 ms total to find that window
    .untilAsserted(...)
```

**Why it flaked:** the gap between `during` and `atMost` (only 250 ms) is the budget Awaitility has to absorb GC pauses, class-loader warm-up, and scheduler jitter. On a loaded CI runner, that budget is too small — Awaitility runs out of time before it can prove the condition held continuously.

The assertion itself (count stays at 0) is *always* true here: `checkForProcessInstances()` early-returns when there are no instances, so the counter literally cannot increment. So this was purely a timing-budget issue, not a real test failure.

**Fix:** keep the `during(250 ms)` soak window — it's already plenty (the scheduler runs every 1 ms, so 250 ms is ~250 ticks of "no recording happened") — and only widen `atMost`:

```java
await()
    .during(Duration.ofMillis(250))
    .atMost(Duration.ofSeconds(2))
    .untilAsserted(...)
```

Slack is now `2000 - 250 = 1750 ms` (7× the during window), which comfortably absorbs CI jitter without lengthening the suite.

Applied to both `shouldNotRecordInstanceAvailability` and `shouldNotRecordQueryDurationWhenNoInstancesStarted` (the only two `during(...)` callers under `load-tests/`).

---

## Fix 2: `ConnectionMonitorTest` — gauge returns `NaN` because of GC

The test was:

```java
new ConnectionMonitor(client, registry);    // <-- not stored anywhere!
assertThat(registry.find(...).gauge().value()).isEqualTo(0.0);
```

**Why it flaked:** inside `ConnectionMonitor`'s constructor, the gauge is registered as:

```java
Gauge.builder(name, connected, AtomicInteger::get).register(registry);
```

Micrometer's `Gauge.builder(name, obj, fn)` holds `obj` by **weak reference** (this is intentional — so a leaked gauge doesn't keep app objects alive). The `AtomicInteger` is reachable only through the `ConnectionMonitor` instance, but the test never assigns that instance to a variable, so it's eligible for GC immediately after construction. If GC runs between construction and the assertion, the weak ref is cleared and `gauge.value()` returns `NaN` instead of `0.0`.

**Fix:** bind the instance to a local variable so it stays strongly reachable through the assertions:

```java
final var monitor = new ConnectionMonitor(client, registry);
// ...
assertThat(monitor).isNotNull();    // pins `monitor` until assertions complete
```

No production change. Micrometer's weak-ref behavior is by design.

---

## Verification

- 50× local rerun of `ProcessInstanceStartMeterTest`: 50/50 green.
- `ConnectionMonitorTest`: 3/3 green.
- No production code touched.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related

Failing-test signal: https://camunda.slack.com/archives/C071KP5BTHB/p1777013403110019