### PR TITLE
fix: flaky UserTaskIT

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/UserTaskFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/UserTaskFixtures.java
@@ -35,7 +35,7 @@ public final class UserTaskFixtures extends CommonFixtures {
             .rootProcessInstanceKey(nextKey())
             .creationDate(NOW)
             .completionDate(NOW.plusDays(1))
-            .assignee(generateRandomString(5, "user"))
+            .assignee(generateRandomString("user"))
             .state(UserTaskState.CREATED)
             .formKey(nextKey())
             .processDefinitionKey(nextKey())


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Increase assignee random string size (aligned with other random strings used for tests) to significantly decrease collision risk that leads to test failures (with occasionally one too many items found in assertions).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/50861
