### PR TITLE
[stable/8.9] fix: log proxy 504 job stream errors at DEBUG only (zeebe client)

### DIFF
--- a/clients/java-deprecated/pom.xml
+++ b/clients/java-deprecated/pom.xml
@@ -261,6 +261,19 @@
       <groupId>net.jcip</groupId>
       <artifactId>jcip-annotations</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/clients/java-deprecated/src/main/java/io/camunda/zeebe/client/impl/worker/JobStreamerImpl.java
+++ b/clients/java-deprecated/src/main/java/io/camunda/zeebe/client/impl/worker/JobStreamerImpl.java
@@ -288,9 +288,29 @@ final class JobStreamerImpl implements JobStreamer {
         LOGGER.trace(errorMsg, jobType, workerName, error);
         return;
       }
+      if (isProxyGatewayTimeout(statusRuntimeException)) {
+        // An intermediary proxy (e.g. nginx) closed the idle streaming connection with HTTP 504.
+        // The stream is transparently reopened, so only log at DEBUG.
+        LOGGER.debug(
+            "Job stream for type '{}' to worker '{}' was closed by an upstream proxy (HTTP 504 Gateway Timeout). "
+                + "The stream will be reopened. To avoid this, configure a shorter stream timeout "
+                + "(JobWorkerBuilder#streamTimeout) below your ingress/proxy idle timeout.",
+            jobType,
+            workerName,
+            error);
+        return;
+      }
     }
 
     LOGGER.warn(errorMsg, jobType, workerName, error);
+  }
+
+  private static boolean isProxyGatewayTimeout(final StatusRuntimeException error) {
+    if (error.getStatus().getCode() != Status.UNAVAILABLE.getCode()) {
+      return false;
+    }
+    final String description = error.getStatus().getDescription();
+    return description != null && description.contains("HTTP status code 504");
   }
 
   private static final class StreamingTimeoutException extends RuntimeException {}

--- a/clients/java-deprecated/src/test/java/io/camunda/zeebe/client/impl/worker/JobStreamImplTest.java
+++ b/clients/java-deprecated/src/test/java/io/camunda/zeebe/client/impl/worker/JobStreamImplTest.java
@@ -44,6 +44,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.appender.ListAppender;
 import org.jmock.lib.concurrent.DeterministicScheduler;
 import org.junit.Rule;
 import org.junit.jupiter.api.AfterEach;
@@ -55,6 +61,9 @@ import org.mockito.Mockito;
 
 @ExtendWith(ExternalResourceSupport.class)
 final class JobStreamImplTest {
+
+  private static final String JOB_WORKER_LOGGER_NAME = "io.camunda.client.job.worker";
+
   @Rule
   public final GrpcCleanupRule grpcRule =
       new GrpcCleanupRule().setTimeout(1, TimeUnit.MILLISECONDS);
@@ -63,6 +72,7 @@ final class JobStreamImplTest {
   private final DeterministicScheduler scheduler = new DeterministicScheduler();
   private JobClient client;
   private JobStreamerImpl jobStreamer;
+  private ListAppender logCapture;
 
   @BeforeEach
   void beforeEach() throws IOException {
@@ -81,12 +91,28 @@ final class JobStreamImplTest {
             new ZeebeObjectMapper(),
             ignored -> false);
     jobStreamer = createStreamer(Duration.ofHours(8));
+
+    logCapture = new ListAppender("capture-" + JOB_WORKER_LOGGER_NAME);
+    logCapture.start();
+    final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+    ctx.getConfiguration()
+        .getLoggerConfig(JOB_WORKER_LOGGER_NAME)
+        .addAppender(logCapture, null, null);
+    ctx.updateLoggers();
   }
 
   @AfterEach
   void afterEach() {
     if (jobStreamer != null) {
       jobStreamer.close();
+    }
+    if (logCapture != null) {
+      final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+      ctx.getConfiguration()
+          .getLoggerConfig(JOB_WORKER_LOGGER_NAME)
+          .removeAppender(logCapture.getName());
+      ctx.updateLoggers();
+      logCapture.stop();
     }
   }
 
@@ -196,6 +222,69 @@ final class JobStreamImplTest {
     assertThat(recreatedStream).isNotNull().isNotEqualTo(initialStream);
     assertThat(initialStream.isCancelled()).isTrue();
     assertThat(recreatedStream.isCancelled()).isFalse();
+  }
+
+  @Test
+  void shouldLogProxy504AtDebugOnlyWithException() {
+    // given - a realistic UNAVAILABLE status produced when an intermediary proxy (e.g. nginx)
+    // terminates the idle streaming connection with HTTP 504.
+    jobStreamer.openStreamer(ignored -> {});
+    final ServerCallStreamObserver<GatewayOuterClass.ActivatedJob> lastStream =
+        service.lastStream();
+
+    // when
+    lastStream.onError(
+        new StatusRuntimeException(
+            Status.UNAVAILABLE.withDescription(
+                "HTTP status code 504\n"
+                    + "invalid content-type: text/html\n"
+                    + "headers: Metadata(:status=504,content-type=text/html)\n"
+                    + "DATA-----------------------------\n"
+                    + "<html><body>504 Gateway Time-out</body></html>")));
+    scheduler.runUntilIdle();
+
+    // then
+    assertThat(eventsAt(Level.WARN)).as("proxy 504 should not produce a WARN").isEmpty();
+
+    assertThat(eventsAt(Level.DEBUG))
+        .as("DEBUG should carry the hint message and the full gRPC exception")
+        .anySatisfy(
+            e -> {
+              assertThat(e.getMessage().getFormattedMessage())
+                  .contains("upstream proxy")
+                  .contains("504")
+                  .contains("streamTimeout");
+              assertThat(e.getThrown()).isInstanceOf(StatusRuntimeException.class);
+            });
+  }
+
+  @Test
+  void shouldLogNonProxyUnavailableAsWarnWithException() {
+    // given - UNAVAILABLE for reasons other than an HTTP 504 from a proxy should continue to
+    // surface the full stack trace at WARN.
+    jobStreamer.openStreamer(ignored -> {});
+    final ServerCallStreamObserver<GatewayOuterClass.ActivatedJob> lastStream =
+        service.lastStream();
+
+    // when
+    lastStream.onError(
+        new StatusRuntimeException(Status.UNAVAILABLE.withDescription("io exception")));
+    scheduler.runUntilIdle();
+
+    // then
+    final List<LogEvent> warns = eventsAt(Level.WARN);
+    assertThat(warns).hasSize(1);
+    assertThat(warns.get(0).getThrown()).isInstanceOf(StatusRuntimeException.class);
+    assertThat(warns.get(0).getMessage().getFormattedMessage()).contains("Failed to stream jobs");
+  }
+
+  private List<LogEvent> eventsAt(final Level level) {
+    // ListAppender is attached to the nearest parent LoggerConfig (io.camunda.client), so filter
+    // by exact logger name to avoid cross-contamination from sibling loggers.
+    return logCapture.getEvents().stream()
+        .filter(e -> JOB_WORKER_LOGGER_NAME.equals(e.getLoggerName()))
+        .filter(e -> level.equals(e.getLevel()))
+        .collect(Collectors.toList());
   }
 
   private JobStreamerImpl createStreamer(final Duration streamingTimeout) {

--- a/clients/java-deprecated/src/test/resources/log4j2-test.xml
+++ b/clients/java-deprecated/src/test/resources/log4j2-test.xml
@@ -9,6 +9,7 @@
 
   <Loggers>
     <Logger name="io.camunda.zeebe" level="debug"/>
+    <Logger name="io.camunda.client" level="debug"/>
 
     <Root level="info">
       <AppenderRef ref="Console"/>


### PR DESCRIPTION
## Summary

Mirrors the proxy-504 job stream log adjustment from #51476 / backport #51754 into the deprecated zeebe client (`clients/java-deprecated`) on `stable/8.9`. The backport #51754 only touched the new camunda client (`clients/java`); this PR closes that gap so both clients behave identically.

- Detects `UNAVAILABLE: HTTP status code 504` (nginx/ingress idle-timeout on the stream) in `logStreamError` and emits a single actionable DEBUG line with the `StreamTimeout` hint instead of a noisy WARN.
- Other `UNAVAILABLE` reasons continue to surface at WARN with the full stack trace.
- Enables the `io.camunda.client` logger at `debug` in the module's `log4j2-test.xml` so the DEBUG-level assertions against `ListAppender` surface events — same adaptation as PR #51752.

Relates to #25535.