### PR TITLE
test: add expect to pass

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-cancel-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-cancel-api-tests.spec.ts
@@ -65,8 +65,10 @@ test.describe.parallel('Cancel Batch Operation Tests', () => {
       });
 
     await test.step('Send first cancel request', async () => {
-      const firstRes = await cancelBatchOperation(request, key);
-      await assertStatusCode(firstRes, 204);
+      await expect(async () => {
+        const firstRes = await cancelBatchOperation(request, key);
+        await assertStatusCode(firstRes, 204);
+      }).toPass(defaultAssertionOptions);
     });
 
     await test.step('Send second cancel request and assert failure', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-cancel-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-cancel-api-tests.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {test} from '@playwright/test';
+import {test, expect} from '@playwright/test';
 import {deploy} from '../../../../utils/zeebeClient';
 import {
   assertBadRequest,
@@ -22,7 +22,7 @@ import {
   createCompletedBatchOperation,
   expectBatchState,
 } from '@requestHelpers';
-
+import {defaultAssertionOptions} from 'utils/constants';
 /* eslint-disable playwright/expect-expect */
 
 test.describe.parallel('Cancel Batch Operation Tests', () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-cancel-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-cancel-api-tests.spec.ts
@@ -65,8 +65,8 @@ test.describe.parallel('Cancel Batch Operation Tests', () => {
       });
 
     await test.step('Send first cancel request', async () => {
-        const firstRes = await cancelBatchOperation(request, key);
-        await assertStatusCode(firstRes, 204);
+      const firstRes = await cancelBatchOperation(request, key);
+      await assertStatusCode(firstRes, 204);
     });
 
     await test.step('Send second cancel request and assert failure', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-cancel-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-cancel-api-tests.spec.ts
@@ -70,7 +70,7 @@ test.describe.parallel('Cancel Batch Operation Tests', () => {
     });
 
     await test.step('Send second cancel request and assert failure', async () => {
-      const secondRes = await cancelBatchOperation(request, key);
+      const secondRes = await cancelBatchOperation(request, key, 404);
 
       await assertNotFoundRequest(
         secondRes,
@@ -83,7 +83,7 @@ test.describe.parallel('Cancel Batch Operation Tests', () => {
     const key = state.finishedBatchOperationKey as string;
 
     await test.step('Cancel finished batch operation', async () => {
-      const res = await cancelBatchOperation(request, key);
+      const res = await cancelBatchOperation(request, key, 404);
       await assertNotFoundRequest(
         res,
         `Command 'CANCEL' rejected with code 'NOT_FOUND': Expected to cancel a batch operation with key '${key}', but no such batch operation was found`,
@@ -97,7 +97,7 @@ test.describe.parallel('Cancel Batch Operation Tests', () => {
     const unknownKey = '2251799813999999';
 
     await test.step('Cancel unknown batch operation', async () => {
-      const res = await cancelBatchOperation(request, unknownKey);
+      const res = await cancelBatchOperation(request, unknownKey, 404);
       await assertNotFoundRequest(
         res,
         `Command 'CANCEL' rejected with code 'NOT_FOUND': Expected to cancel a batch operation with key '${unknownKey}', but no such batch operation was found`,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-cancel-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-cancel-api-tests.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {test, expect} from '@playwright/test';
+import {test} from '@playwright/test';
 import {deploy} from '../../../../utils/zeebeClient';
 import {
   assertBadRequest,
@@ -22,7 +22,6 @@ import {
   createCompletedBatchOperation,
   expectBatchState,
 } from '@requestHelpers';
-import {defaultAssertionOptions} from 'utils/constants';
 /* eslint-disable playwright/expect-expect */
 
 test.describe.parallel('Cancel Batch Operation Tests', () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-cancel-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-cancel-api-tests.spec.ts
@@ -65,10 +65,8 @@ test.describe.parallel('Cancel Batch Operation Tests', () => {
       });
 
     await test.step('Send first cancel request', async () => {
-      await expect(async () => {
         const firstRes = await cancelBatchOperation(request, key);
         await assertStatusCode(firstRes, 204);
-      }).toPass(defaultAssertionOptions);
     });
 
     await test.step('Send second cancel request and assert failure', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {test} from '@playwright/test';
+import {test, expect} from '@playwright/test';
 import {deploy} from '../../../../utils/zeebeClient';
 import {
   assertBadRequest,
@@ -25,6 +25,7 @@ import {
   resumeBatchOperation,
   suspendBatchOperation,
 } from '@requestHelpers';
+import {defaultAssertionOptions} from 'utils/constants';
 
 /* eslint-disable playwright/expect-expect */
 test.describe('Suspend & Resume Batch Operation Tests', () => {
@@ -141,8 +142,10 @@ test.describe('Suspend & Resume Batch Operation Tests', () => {
     });
 
     await test.step('Send suspend request', async () => {
-      const res = await suspendBatchOperation(request, key);
-      await assertStatusCode(res, 204);
+      await expect(async () => {
+        const res = await suspendBatchOperation(request, key);
+        await assertStatusCode(res, 204);
+      }).toPass(defaultAssertionOptions);
     });
 
     await test.step('Poll until batch operation is suspended', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
@@ -24,7 +24,6 @@ import {
   notFoundDetail,
   resumeBatchOperation,
   suspendBatchOperation,
-  postMigrationAssertionOptions,
 } from '@requestHelpers';
 import {defaultAssertionOptions} from 'utils/constants';
 
@@ -70,7 +69,6 @@ test.describe('Suspend & Resume Batch Operation Tests', () => {
         request,
         key,
         204,
-        postMigrationAssertionOptions,
       );
       await assertStatusCode(res, 204);
     });
@@ -84,7 +82,6 @@ test.describe('Suspend & Resume Batch Operation Tests', () => {
         request,
         key,
         409,
-        postMigrationAssertionOptions,
       );
       await assertInvalidState(doubleRes);
     });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
@@ -66,7 +66,12 @@ test.describe('Suspend & Resume Batch Operation Tests', () => {
       });
 
     await test.step('Suspend batch operation once', async () => {
-      const res = await suspendBatchOperation(request, key, 204, postMigrationAssertionOptions);
+      const res = await suspendBatchOperation(
+        request,
+        key,
+        204,
+        postMigrationAssertionOptions,
+      );
       await assertStatusCode(res, 204);
     });
 
@@ -75,7 +80,12 @@ test.describe('Suspend & Resume Batch Operation Tests', () => {
     });
 
     await test.step('Suspend already suspended batch operation', async () => {
-      const doubleRes = await suspendBatchOperation(request, key, 409, postMigrationAssertionOptions);
+      const doubleRes = await suspendBatchOperation(
+        request,
+        key,
+        409,
+        postMigrationAssertionOptions,
+      );
       await assertInvalidState(doubleRes);
     });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
@@ -142,10 +142,8 @@ test.describe('Suspend & Resume Batch Operation Tests', () => {
     });
 
     await test.step('Send suspend request', async () => {
-      await expect(async () => {
-        const res = await suspendBatchOperation(request, key);
-        await assertStatusCode(res, 204);
-      }).toPass(defaultAssertionOptions);
+      const res = await suspendBatchOperation(request, key);
+      await assertStatusCode(res, 204);
     });
 
     await test.step('Poll until batch operation is suspended', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {test, expect} from '@playwright/test';
+import {test} from '@playwright/test';
 import {deploy} from '../../../../utils/zeebeClient';
 import {
   assertBadRequest,
@@ -25,7 +25,6 @@ import {
   resumeBatchOperation,
   suspendBatchOperation,
 } from '@requestHelpers';
-import {defaultAssertionOptions} from 'utils/constants';
 
 /* eslint-disable playwright/expect-expect */
 test.describe('Suspend & Resume Batch Operation Tests', () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
@@ -24,6 +24,7 @@ import {
   notFoundDetail,
   resumeBatchOperation,
   suspendBatchOperation,
+  postMigrationAssertionOptions,
 } from '@requestHelpers';
 import {defaultAssertionOptions} from 'utils/constants';
 
@@ -65,7 +66,7 @@ test.describe('Suspend & Resume Batch Operation Tests', () => {
       });
 
     await test.step('Suspend batch operation once', async () => {
-      const res = await suspendBatchOperation(request, key);
+      const res = await suspendBatchOperation(request, key, 204, postMigrationAssertionOptions);
       await assertStatusCode(res, 204);
     });
 
@@ -74,7 +75,7 @@ test.describe('Suspend & Resume Batch Operation Tests', () => {
     });
 
     await test.step('Suspend already suspended batch operation', async () => {
-      const doubleRes = await suspendBatchOperation(request, key, 409);
+      const doubleRes = await suspendBatchOperation(request, key, 409, postMigrationAssertionOptions);
       await assertInvalidState(doubleRes);
     });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
@@ -65,11 +65,7 @@ test.describe('Suspend & Resume Batch Operation Tests', () => {
       });
 
     await test.step('Suspend batch operation once', async () => {
-      const res = await suspendBatchOperation(
-        request,
-        key,
-        204,
-      );
+      const res = await suspendBatchOperation(request, key, 204);
       await assertStatusCode(res, 204);
     });
 
@@ -78,11 +74,7 @@ test.describe('Suspend & Resume Batch Operation Tests', () => {
     });
 
     await test.step('Suspend already suspended batch operation', async () => {
-      const doubleRes = await suspendBatchOperation(
-        request,
-        key,
-        409,
-      );
+      const doubleRes = await suspendBatchOperation(request, key, 409);
       await assertInvalidState(doubleRes);
     });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/batch-operation-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/batch-operation-requestHelpers.ts
@@ -15,7 +15,6 @@ import {validateResponse} from 'json-body-assertions';
 export async function cancelBatchOperation(
   request: APIRequestContext,
   batchOperationKey: string,
-  assertionOptions = defaultAssertionOptions,
 ) {
   const result: Record<string, APIResponse> = {};
   await expect(async () => {
@@ -27,7 +26,7 @@ export async function cancelBatchOperation(
     );
     result.response = res;
     await assertStatusCode(res, 204);
-  }).toPass(assertionOptions);
+  }).toPass(batchOperationLifecycleOptions);
   return result.response as APIResponse;
 }
 
@@ -44,7 +43,6 @@ export async function suspendBatchOperation(
   request: APIRequestContext,
   batchOperationKey: string,
   expectedStatusCode = 204,
-  assertionOptions = defaultAssertionOptions,
 ) {
   const result: Record<string, unknown> = {};
   await expect(async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/batch-operation-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/batch-operation-requestHelpers.ts
@@ -15,6 +15,7 @@ import {validateResponse} from 'json-body-assertions';
 export async function cancelBatchOperation(
   request: APIRequestContext,
   batchOperationKey: string,
+  expectedStatusCode = 204,
 ) {
   const result: Record<string, APIResponse> = {};
   await expect(async () => {
@@ -25,7 +26,7 @@ export async function cancelBatchOperation(
       },
     );
     result.response = res;
-    await assertStatusCode(res, 204);
+    await assertStatusCode(res, expectedStatusCode);
   }).toPass(batchOperationLifecycleOptions);
   return result.response as APIResponse;
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/batch-operation-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/batch-operation-requestHelpers.ts
@@ -15,13 +15,20 @@ import {validateResponse} from 'json-body-assertions';
 export async function cancelBatchOperation(
   request: APIRequestContext,
   batchOperationKey: string,
+  assertionOptions = defaultAssertionOptions,
 ) {
-  return request.post(
-    buildUrl(`/batch-operations/${batchOperationKey}/cancellation`),
-    {
-      headers: jsonHeaders(),
-    },
-  );
+  const result: Record<string, APIResponse> = {};
+  await expect(async () => {
+    const res = await request.post(
+      buildUrl(`/batch-operations/${batchOperationKey}/cancellation`),
+      {
+        headers: jsonHeaders(),
+      },
+    );
+    result.response = res;
+    await assertStatusCode(res, 204);
+  }).toPass(assertionOptions);
+  return result.response as APIResponse;
 }
 
 // A freshly created batch operation can take longer than the default 30s
@@ -37,6 +44,7 @@ export async function suspendBatchOperation(
   request: APIRequestContext,
   batchOperationKey: string,
   expectedStatusCode = 204,
+  assertionOptions = defaultAssertionOptions,
 ) {
   const result: Record<string, unknown> = {};
   await expect(async () => {


### PR DESCRIPTION
## Description

This PR adds `expect().toPass()`, as sometimes batch operation can't be found yet (except 204 comes 404).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## On demand workflow
[Was all green on APIs](https://github.com/camunda/camunda/actions/runs/25907661448)
