### PR TITLE
deps: update spring security to 6.5.10

### DIFF
--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -53,7 +53,7 @@
     <guava.version>33.3.1-jre</guava.version>
     <spring.boot.version>3.5.13</spring.boot.version>
     <spring.version>6.2.17</spring.version>
-    <spring.security.version>6.5.9</spring.security.version>
+    <spring.security.version>6.5.10</spring.security.version>
     <version.tomcat>10.1.44</version.tomcat>
     <httpclient.version>4.5.14</httpclient.version>
     <quartz.version>2.3.2</quartz.version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -99,7 +99,7 @@
     <version.dmn-scala>1.10.0</version.dmn-scala>
     <version.rest-assured>5.5.0</version.rest-assured>
     <version.spring>6.2.17</version.spring>
-    <version.spring-security>6.5.9</version.spring-security>
+    <version.spring-security>6.5.10</version.spring-security>
     <!--  Adding spring-security.version to ensure Spring Boot's BOM honors the override regardless of import order.  -->
     <spring-security.version>${version.spring-security}</spring-security.version>
     <version.spring-boot>3.5.13</version.spring-boot>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Update spring security to latest patch.

Fixes CVE (internal): https://camunda.slack.com/archives/C0AV5L6R6TT

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues
[#cve-2026-22746-medium-core-features](https://camunda.slack.com/archives/C0B0714B5T2)
