### PR TITLE
refactor: optimize variable tenancy it test

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/VariableTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/VariableTenancyIT.java
@@ -7,22 +7,27 @@
  */
 package io.camunda.it.tenancy;
 
+import static io.camunda.it.util.TestHelper.deployResourceForTenant;
+import static io.camunda.it.util.TestHelper.startProcessInstanceForTenant;
+import static io.camunda.it.util.TestHelper.waitForVariablesBeingExported;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.client.api.search.response.Variable;
 import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TenantDefinition;
+import io.camunda.qa.util.auth.TestTenant;
 import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
-import java.time.Duration;
 import java.util.List;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
@@ -54,50 +59,44 @@ public class VariableTenancyIT {
   @UserDefinition
   private static final TestUser USER2_USER = new TestUser(USER2, "password", List.of());
 
+  @TenantDefinition
+  private static final TestTenant A_TENANT =
+      new TestTenant(TENANT_A).setName(TENANT_A).addUsers(ADMIN, USER1);
+
+  @TenantDefinition
+  private static final TestTenant B_TENANT =
+      new TestTenant(TENANT_B).setName(TENANT_B).addUsers(ADMIN);
+
   @BeforeAll
   static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
-    createTenant(adminClient, TENANT_A);
-    createTenant(adminClient, TENANT_B);
-    assignUserToTenant(adminClient, ADMIN, TENANT_A);
-    assignUserToTenant(adminClient, ADMIN, TENANT_B);
-    assignUserToTenant(adminClient, USER1, TENANT_A);
+    deployResourceForTenant(adminClient, "process/bpm_variable_test.bpmn", TENANT_A);
+    startProcessInstanceForTenant(adminClient, PROCESS_ID, TENANT_A);
 
-    deployResource(adminClient, "process/bpm_variable_test.bpmn", TENANT_A);
-    startProcessInstance(adminClient, PROCESS_ID, TENANT_A);
-
-    deployResource(adminClient, "process/bpm_variable_test.bpmn", TENANT_B);
-    startProcessInstance(adminClient, PROCESS_ID, TENANT_B);
-    waitForVariablesBeingExported(adminClient);
+    deployResourceForTenant(adminClient, "process/bpm_variable_test.bpmn", TENANT_B);
+    startProcessInstanceForTenant(adminClient, PROCESS_ID, TENANT_B);
+    waitForVariablesBeingExported(adminClient, 10);
   }
 
   @Test
   public void shouldReturnAllVariablesWithTenantAccess(
       @Authenticated(ADMIN) final CamundaClient camundaClient) {
-    // when
-    final var result = camundaClient.newVariableSearchRequest().send().join();
-    // then
-    assertThat(result.items()).hasSize(10);
-    assertThat(result.items().stream().map(Variable::getTenantId).collect(Collectors.toSet()))
-        .containsExactlyInAnyOrder(TENANT_A, TENANT_B);
+    // when / then
+    assertVariablesForCommand(
+        () -> camundaClient.newVariableSearchRequest().send().join(), 10, TENANT_A, TENANT_B);
   }
 
   @Test
   public void shouldReturnOnlyTenantAVariables(
       @Authenticated(USER1) final CamundaClient camundaClient) {
-    // when
-    final var result = camundaClient.newVariableSearchRequest().send().join();
-    // then
-    assertThat(result.items()).hasSize(5);
-    assertThat(result.items().stream().map(Variable::getTenantId).collect(Collectors.toSet()))
-        .containsExactlyInAnyOrder(TENANT_A);
+    // when / then
+    assertVariablesForCommand(
+        () -> camundaClient.newVariableSearchRequest().send().join(), 5, TENANT_A);
   }
 
   @Test
   public void shouldNotReturnAnyVariables(@Authenticated(USER2) final CamundaClient camundaClient) {
     // when
-    final var result = camundaClient.newVariableSearchRequest().send().join();
-    // then
-    assertThat(result.items()).hasSize(0);
+    assertVariablesForCommand(() -> camundaClient.newVariableSearchRequest().send().join(), 0);
   }
 
   @Test
@@ -136,45 +135,14 @@ public class VariableTenancyIT {
         .contains("Variable with key '%s' not found".formatted(variableKey));
   }
 
-  private static void createTenant(final CamundaClient camundaClient, final String tenant) {
-    camundaClient.newCreateTenantCommand().tenantId(tenant).name(tenant).send().join();
-  }
-
-  private static void assignUserToTenant(
-      final CamundaClient camundaClient, final String username, final String tenant) {
-    camundaClient.newAssignUserToTenantCommand().username(username).tenantId(tenant).send().join();
-  }
-
-  private static void deployResource(
-      final CamundaClient camundaClient, final String resourceName, final String tenant) {
-    camundaClient
-        .newDeployResourceCommand()
-        .addResourceFromClasspath(resourceName)
-        .tenantId(tenant)
-        .send()
-        .join();
-  }
-
-  private static void startProcessInstance(
-      final CamundaClient camundaClient, final String processId, final String tenant) {
-    camundaClient
-        .newCreateInstanceCommand()
-        .bpmnProcessId(processId)
-        .latestVersion()
-        .tenantId(tenant)
-        .send()
-        .join();
-  }
-
-  private static void waitForVariablesBeingExported(final CamundaClient camundaClient) {
-    Awaitility.await("should receive data from secondary storage")
-        .atMost(Duration.ofMinutes(1))
-        .ignoreExceptions() // Ignore exceptions and continue retrying
-        .untilAsserted(
-            () -> {
-              assertThat(camundaClient.newVariableSearchRequest().send().join().items())
-                  .hasSize(10);
-            });
+  private void assertVariablesForCommand(
+      final Supplier<SearchResponse<Variable>> command,
+      final int expectedSize,
+      final String... expectedTenants) {
+    final var result = command.get();
+    assertThat(result.items()).hasSize(expectedSize);
+    assertThat(result.items().stream().map(Variable::getTenantId).collect(Collectors.toSet()))
+        .containsExactlyInAnyOrder(expectedTenants);
   }
 
   private long getVariableInstanceKey(final CamundaClient camundaClient, final String tenantId) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
@@ -398,6 +398,18 @@ public final class TestHelper {
             camundaClient.newProcessInstanceSearchRequest().filter(filter).page(page).execute());
   }
 
+  public static void waitForVariablesBeingExported(
+      final CamundaClient camundaClient, final int expectedSize) {
+    Awaitility.await("should receive variables from secondary storage")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .untilAsserted(
+            () -> {
+              assertThat(camundaClient.newVariableSearchRequest().send().join().items())
+                  .hasSize(expectedSize);
+            });
+  }
+
   /**
    * Starts a process instance with a process variable {@link #VAR_TEST_SCOPE_ID} for scope.
    *


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
- Use TestHelper utility methods instead of local methods.
- Align Await call max wait times for `waitForVariablesBeingExported` - this may be a source of flakiness
- Deduplicate assertion code.

ℹ️ I couldn't reproduce the flakiness in these tests (even after 400+ executions). Furthermore, in the last 30 days, there haven't been any reports of flakiness from this test ([src](https://dashboard.int.camunda.com/d/ae2j69npxh3b4f/flaky-tests-camunda-camunda-monorepo?orgId=1&from=now-30d&to=now&timezone=browser&var-branch=main)). As a result, I optimized the code and addressed possible points of flakiness.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #50864 
