### PR TITLE
fix: exclude dotted paths from SPA catch-all forwarding

### DIFF
--- a/dist/src/main/java/io/camunda/identity/webapp/controllers/AdminIndexController.java
+++ b/dist/src/main/java/io/camunda/identity/webapp/controllers/AdminIndexController.java
@@ -44,7 +44,7 @@ public class AdminIndexController {
    *
    * <ul>
    *   <li>{@code (?!assets)} - excludes the "assets" directory
-   *   <li>{@code (?!.*\\.)} - excludes paths containing a dot (e.g., favicon.ico)
+   *   <li>{@code (?!.*\\.ico$)} - excludes paths ending with {@code .ico} (e.g., favicon.ico)
    *   <li>{@code .*} - matches any other path segment (SPA routes)
    * </ul>
    *
@@ -54,7 +54,10 @@ public class AdminIndexController {
    * instead of being served as static files.
    */
   @RequestMapping(
-      value = {"/admin/{path:^(?!assets)(?!.*\\.).*}", "/admin/{path:^(?!assets)(?!.*\\.).*}/**"})
+      value = {
+        "/admin/{path:^(?!assets)(?!.*\\.ico$).*}",
+        "/admin/{path:^(?!assets)(?!.*\\.ico$).*}/**"
+      })
   public String forwardToAdmin(final HttpServletRequest request) {
     return webappsRequestForwardManager.forward(request, "admin");
   }

--- a/dist/src/main/java/io/camunda/identity/webapp/controllers/AdminIndexController.java
+++ b/dist/src/main/java/io/camunda/identity/webapp/controllers/AdminIndexController.java
@@ -40,19 +40,21 @@ public class AdminIndexController {
   /**
    * Forwards SPA routes to index.html, excluding static assets.
    *
-   * <p>The regex pattern uses negative lookahead to prevent matching paths starting with "assets":
+   * <p>The regex pattern uses negative lookahead to prevent matching:
    *
    * <ul>
-   *   <li>{@code (?!assets)} - excludes "assets"
-   *   <li>{@code .*} - matches any other path segment
+   *   <li>{@code (?!assets)} - excludes the "assets" directory
+   *   <li>{@code (?!.*\\.)} - excludes paths containing a dot (e.g., favicon.ico)
+   *   <li>{@code .*} - matches any other path segment (SPA routes)
    * </ul>
    *
    * <p>This exclusion is necessary because PathPatternParser (Spring Framework 6+) gives controller
    * mappings higher precedence than static resource handlers. Without this pattern, requests like
-   * {@code /admin/assets/index.css} would be forwarded to index.html instead of being served as
-   * static files.
+   * {@code /admin/assets/index.css} or {@code /admin/favicon.ico} would be forwarded to index.html
+   * instead of being served as static files.
    */
-  @RequestMapping(value = {"/admin/{path:^(?!assets).*}", "/admin/{path:^(?!assets).*}/**"})
+  @RequestMapping(
+      value = {"/admin/{path:^(?!assets)(?!.*\\.).*}", "/admin/{path:^(?!assets)(?!.*\\.).*}/**"})
   public String forwardToAdmin(final HttpServletRequest request) {
     return webappsRequestForwardManager.forward(request, "admin");
   }

--- a/dist/src/main/java/io/camunda/operate/webapp/controllers/OperateIndexController.java
+++ b/dist/src/main/java/io/camunda/operate/webapp/controllers/OperateIndexController.java
@@ -36,19 +36,24 @@ public class OperateIndexController {
   /**
    * Forwards SPA routes to index.html, excluding static assets.
    *
-   * <p>The regex pattern uses negative lookahead to prevent matching paths starting with "assets":
+   * <p>The regex pattern uses negative lookahead to prevent matching:
    *
    * <ul>
-   *   <li>{@code (?!assets)} - excludes "assets"
-   *   <li>{@code .*} - matches any other path segment
+   *   <li>{@code (?!assets)} - excludes the "assets" directory
+   *   <li>{@code (?!.*\\.)} - excludes paths containing a dot (e.g., favicon.ico)
+   *   <li>{@code .*} - matches any other path segment (SPA routes)
    * </ul>
    *
    * <p>This exclusion is necessary because PathPatternParser (Spring Framework 6+) gives controller
    * mappings higher precedence than static resource handlers. Without this pattern, requests like
-   * {@code /operate/assets/index.css} would be forwarded to index.html instead of being served as
-   * static files.
+   * {@code /operate/assets/index.css} or {@code /operate/favicon.ico} would be forwarded to
+   * index.html instead of being served as static files.
    */
-  @RequestMapping(value = {"/operate/{path:^(?!assets).*}", "/operate/{path:^(?!assets).*}/**"})
+  @RequestMapping(
+      value = {
+        "/operate/{path:^(?!assets)(?!.*\\.).*}",
+        "/operate/{path:^(?!assets)(?!.*\\.).*}/**"
+      })
   public String forwardToOperate(final HttpServletRequest request) {
     return webappsRequestForwardManager.forward(request, "operate");
   }

--- a/dist/src/main/java/io/camunda/operate/webapp/controllers/OperateIndexController.java
+++ b/dist/src/main/java/io/camunda/operate/webapp/controllers/OperateIndexController.java
@@ -40,7 +40,7 @@ public class OperateIndexController {
    *
    * <ul>
    *   <li>{@code (?!assets)} - excludes the "assets" directory
-   *   <li>{@code (?!.*\\.)} - excludes paths containing a dot (e.g., favicon.ico)
+   *   <li>{@code (?!.*\\.ico$)} - excludes paths ending with {@code .ico} (e.g., favicon.ico)
    *   <li>{@code .*} - matches any other path segment (SPA routes)
    * </ul>
    *
@@ -51,8 +51,8 @@ public class OperateIndexController {
    */
   @RequestMapping(
       value = {
-        "/operate/{path:^(?!assets)(?!.*\\.).*}",
-        "/operate/{path:^(?!assets)(?!.*\\.).*}/**"
+        "/operate/{path:^(?!assets)(?!.*\\.ico$).*}",
+        "/operate/{path:^(?!assets)(?!.*\\.ico$).*}/**"
       })
   public String forwardToOperate(final HttpServletRequest request) {
     return webappsRequestForwardManager.forward(request, "operate");

--- a/dist/src/main/java/io/camunda/tasklist/webapp/controllers/TasklistIndexController.java
+++ b/dist/src/main/java/io/camunda/tasklist/webapp/controllers/TasklistIndexController.java
@@ -36,19 +36,24 @@ public class TasklistIndexController {
   /**
    * Forwards SPA routes to index.html, excluding static assets.
    *
-   * <p>The regex pattern uses negative lookahead to prevent matching paths starting with "assets":
+   * <p>The regex pattern uses negative lookahead to prevent matching:
    *
    * <ul>
-   *   <li>{@code (?!assets)} - excludes "assets"
-   *   <li>{@code .*} - matches any other path segment
+   *   <li>{@code (?!assets)} - excludes the "assets" directory
+   *   <li>{@code (?!.*\\.)} - excludes paths containing a dot (e.g., favicon.ico)
+   *   <li>{@code .*} - matches any other path segment (SPA routes)
    * </ul>
    *
    * <p>This exclusion is necessary because PathPatternParser (Spring Framework 6+) gives controller
    * mappings higher precedence than static resource handlers. Without this pattern, requests like
-   * {@code /operate/assets/index.css} would be forwarded to index.html instead of being served as
-   * static files.
+   * {@code /tasklist/assets/index.css} or {@code /tasklist/favicon.ico} would be forwarded to
+   * index.html instead of being served as static files.
    */
-  @RequestMapping(value = {"/tasklist/{path:^(?!assets).*}", "/tasklist/{path:^(?!assets).*}/**"})
+  @RequestMapping(
+      value = {
+        "/tasklist/{path:^(?!assets)(?!.*\\.).*}",
+        "/tasklist/{path:^(?!assets)(?!.*\\.).*}/**"
+      })
   public String forwardToTasklist(final HttpServletRequest request) {
     return webappsRequestForwardManager.forward(request, "tasklist");
   }

--- a/dist/src/main/java/io/camunda/tasklist/webapp/controllers/TasklistIndexController.java
+++ b/dist/src/main/java/io/camunda/tasklist/webapp/controllers/TasklistIndexController.java
@@ -40,7 +40,7 @@ public class TasklistIndexController {
    *
    * <ul>
    *   <li>{@code (?!assets)} - excludes the "assets" directory
-   *   <li>{@code (?!.*\\.)} - excludes paths containing a dot (e.g., favicon.ico)
+   *   <li>{@code (?!.*\\.ico$)} - excludes paths ending with {@code .ico} (e.g., favicon.ico)
    *   <li>{@code .*} - matches any other path segment (SPA routes)
    * </ul>
    *
@@ -51,8 +51,8 @@ public class TasklistIndexController {
    */
   @RequestMapping(
       value = {
-        "/tasklist/{path:^(?!assets)(?!.*\\.).*}",
-        "/tasklist/{path:^(?!assets)(?!.*\\.).*}/**"
+        "/tasklist/{path:^(?!assets)(?!.*\\.ico$).*}",
+        "/tasklist/{path:^(?!assets)(?!.*\\.ico$).*}/**"
       })
   public String forwardToTasklist(final HttpServletRequest request) {
     return webappsRequestForwardManager.forward(request, "tasklist");


### PR DESCRIPTION
## Description
<!-- Describe the goal and purpose of this PR. -->
See parent issue

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #51722
