### PR TITLE
Optimize it tests faster

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/AbstractCCSMIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/AbstractCCSMIT.java
@@ -22,6 +22,7 @@ import io.camunda.optimize.dto.zeebe.process.ZeebeProcessInstanceDataDto;
 import io.camunda.optimize.dto.zeebe.process.ZeebeProcessInstanceRecordDto;
 import io.camunda.optimize.dto.zeebe.usertask.ZeebeUserTaskDataDto;
 import io.camunda.optimize.dto.zeebe.usertask.ZeebeUserTaskRecordDto;
+import io.camunda.optimize.dto.zeebe.variable.ZeebeVariableRecordDto;
 import io.camunda.optimize.exception.OptimizeIntegrationTestException;
 import io.camunda.optimize.service.db.DatabaseConstants;
 import io.camunda.optimize.service.importing.engine.service.zeebe.ZeebeProcessInstanceImportService;
@@ -31,10 +32,12 @@ import io.camunda.optimize.test.it.extension.ZeebeExtension;
 import io.camunda.optimize.test.it.extension.db.TermsQueryContainer;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import java.io.InputStream;
 import java.time.Instant;
@@ -44,12 +47,14 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
@@ -115,9 +120,17 @@ public abstract class AbstractCCSMIT extends AbstractIT {
   }
 
   @BeforeEach
-  public void setupZeebeImportAndReloadConfiguration() {
+  @Order(1)
+  public void ensureCleanZeebeState() {
+    // Safety net: records from the previous test may still be in the Zeebe exporter's write queue
+    // when after() ran; they can arrive in the window between after() and this @BeforeEach.
+    deleteZeebeRecordsAndAssertClean(zeebeExtension.getZeebeRecordPrefix());
+  }
+
+  @BeforeEach
+  @Order(2)
+  public void configureZeebeImport() {
     final String embeddedZeebePrefix = zeebeExtension.getZeebeRecordPrefix();
-    // set the new record prefix for the next test
     embeddedOptimizeExtension
         .getConfigurationService()
         .getConfiguredZeebe()
@@ -127,8 +140,114 @@ public abstract class AbstractCCSMIT extends AbstractIT {
 
   @AfterEach
   public void after() {
-    // Clear all potential existing Zeebe records in Optimize
-    databaseIntegrationTestExtension.deleteAllZeebeRecordsForPrefix(
+    final Set<Long> cancelledKeys = zeebeExtension.cancelAllStartedInstances();
+    waitForCancelledInstancesToExport(cancelledKeys);
+    deleteZeebeRecordsAndAssertClean(zeebeExtension.getZeebeRecordPrefix());
+  }
+
+  /**
+   * Waits until every cancelled instance has exported its PROCESS-level terminal record
+   * (ELEMENT_COMPLETED or ELEMENT_TERMINATED) before cleanup runs. That record is the last one the
+   * broker generates; once it appears in ES every earlier record for the instance — including
+   * asynchronously-exported variable records — is guaranteed to be there too.
+   *
+   * <p>Already-completed instances are excluded from {@code cancelledKeys} by {@link
+   * ZeebeExtension#cancelAllStartedInstances()}, so this wait never blocks on instances whose
+   * terminal record was deleted by a mid-test cleanup.
+   */
+  private void waitForCancelledInstancesToExport(final Set<Long> cancelledKeys) {
+    if (cancelledKeys.isEmpty()) {
+      return;
+    }
+    final TermsQueryContainer terminalQuery = new TermsQueryContainer();
+    terminalQuery.addTermQuery(
+        ZeebeRecordDto.Fields.intent,
+        List.of(
+            ProcessInstanceIntent.ELEMENT_COMPLETED.name(),
+            ProcessInstanceIntent.ELEMENT_TERMINATED.name()));
+    terminalQuery.addTermQuery(
+        ZeebeProcessInstanceRecordDto.Fields.value
+            + "."
+            + ZeebeProcessInstanceDataDto.Fields.bpmnElementType,
+        BpmnElementType.PROCESS.name());
+    waitUntilMinimumDataExportedCount(
+        cancelledKeys.size(), DatabaseConstants.ZEEBE_PROCESS_INSTANCE_INDEX_NAME, terminalQuery);
+  }
+
+  private void deleteZeebeRecordsAndAssertClean(final String zeebePrefix) {
+    final String processInstanceIndex =
+        zeebePrefix + "-" + DatabaseConstants.ZEEBE_PROCESS_INSTANCE_INDEX_NAME;
+    final String variableIndex = zeebePrefix + "-" + DatabaseConstants.ZEEBE_VARIABLE_INDEX_NAME;
+    final String userTaskIndex = zeebePrefix + "-" + DatabaseConstants.ZEEBE_USER_TASK_INDEX_NAME;
+    final String incidentIndex = zeebePrefix + "-" + DatabaseConstants.ZEEBE_INCIDENT_INDEX_NAME;
+    final String processDefinitionIndex =
+        zeebePrefix + "-" + DatabaseConstants.ZEEBE_PROCESS_DEFINITION_INDEX_NAME;
+    Awaitility.given()
+        .ignoreExceptions()
+        .timeout(30, TimeUnit.SECONDS)
+        .untilAsserted(
+            () -> {
+              databaseIntegrationTestExtension.deleteAllZeebeRecordsForPrefix(zeebePrefix);
+              if (databaseIntegrationTestExtension.zeebeIndexExists(processInstanceIndex)) {
+                assertThat(
+                        databaseIntegrationTestExtension.countRecordsByQuery(
+                            getQueryForProcessableProcessInstanceEvents(), processInstanceIndex))
+                    .isZero();
+              }
+              if (databaseIntegrationTestExtension.zeebeIndexExists(variableIndex)) {
+                assertThat(
+                        databaseIntegrationTestExtension.countRecordsByQuery(
+                            getQueryForProcessableVariableEvents(), variableIndex))
+                    .isZero();
+              }
+              if (databaseIntegrationTestExtension.zeebeIndexExists(userTaskIndex)) {
+                // Use match-all (empty container) to catch ALL user-task intents, including
+                // non-processable ones (CREATED, ASSIGNING, COMPLETING, CANCELING) that Zeebe
+                // generates but Optimize does not import. A filtered check would miss these and
+                // allow them to accumulate across tests.
+                assertThat(
+                        databaseIntegrationTestExtension.countRecordsByQuery(
+                            new TermsQueryContainer(), userTaskIndex))
+                    .isZero();
+              }
+              if (databaseIntegrationTestExtension.zeebeIndexExists(incidentIndex)) {
+                assertThat(
+                        databaseIntegrationTestExtension.countRecordsByQuery(
+                            getQueryForProcessableIncidentEvents(), incidentIndex))
+                    .isZero();
+              }
+              if (databaseIntegrationTestExtension.zeebeIndexExists(processDefinitionIndex)) {
+                assertThat(
+                        databaseIntegrationTestExtension.countRecordsByQuery(
+                            getQueryForProcessableProcessDefinitionEvents(),
+                            processDefinitionIndex))
+                    .isZero();
+              }
+            });
+  }
+
+  private TermsQueryContainer getQueryForProcessableIncidentEvents() {
+    final TermsQueryContainer container = new TermsQueryContainer();
+    container.addTermQuery(
+        ZeebeRecordDto.Fields.intent,
+        List.of(IncidentIntent.CREATED.name(), IncidentIntent.RESOLVED.name()));
+    return container;
+  }
+
+  private TermsQueryContainer getQueryForProcessableProcessDefinitionEvents() {
+    final TermsQueryContainer container = new TermsQueryContainer();
+    container.addTermQuery(
+        ZeebeProcessDefinitionRecordDto.Fields.intent, List.of(ProcessIntent.CREATED.name()));
+    return container;
+  }
+
+  @AfterAll
+  static void deleteZeebeIndices() {
+    // Physically delete all Zeebe indices after the class finishes so they don't accumulate.
+    // This runs after all tests in the class are complete; the broker is still alive at this
+    // point but shutting down in ZeebeExtension.afterAll(), which is fine — any stray writes
+    // are inconsequential since no further tests will read these indices.
+    databaseIntegrationTestExtension.deleteAllZeebeIndicesForPrefix(
         zeebeExtension.getZeebeRecordPrefix());
   }
 
@@ -159,6 +278,14 @@ public abstract class AbstractCCSMIT extends AbstractIT {
         ZeebeProcessInstanceImportService.INTENTS_TO_IMPORT.stream()
             .map(ProcessInstanceIntent::name)
             .toList());
+    return termsQueryContainer;
+  }
+
+  private TermsQueryContainer getQueryForProcessableVariableEvents() {
+    final TermsQueryContainer termsQueryContainer = new TermsQueryContainer();
+    termsQueryContainer.addTermQuery(
+        ZeebeVariableRecordDto.Fields.intent,
+        List.of(VariableIntent.CREATED.name(), VariableIntent.UPDATED.name()));
     return termsQueryContainer;
   }
 
@@ -392,6 +519,52 @@ public abstract class AbstractCCSMIT extends AbstractIT {
         ZeebeUserTaskRecordDto.Fields.intent,
         ZeebeUserTaskImportService.INTENTS_TO_IMPORT.stream().map(UserTaskIntent::name).toList());
     return query;
+  }
+
+  protected void waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(
+      final int minExportedEventCount, final long processInstanceKey) {
+    final TermsQueryContainer query = getQueryForProcessableProcessInstanceEvents();
+    query.addTermQuery(
+        ZeebeProcessInstanceRecordDto.Fields.value
+            + "."
+            + ZeebeProcessInstanceDataDto.Fields.processInstanceKey,
+        String.valueOf(processInstanceKey));
+    waitUntilMinimumDataExportedCount(
+        minExportedEventCount, DatabaseConstants.ZEEBE_PROCESS_INSTANCE_INDEX_NAME, query);
+  }
+
+  protected void waitUntilMinimumVariableDocumentsForInstanceExportedCount(
+      final int minExportedEventCount, final long processInstanceKey) {
+    waitUntilMinimumVariableDocumentsWithIntentForInstanceExportedCount(
+        minExportedEventCount, VariableIntent.CREATED, processInstanceKey);
+  }
+
+  protected void waitUntilMinimumVariableDocumentsWithIntentForInstanceExportedCount(
+      final int minExportedEventCount, final VariableIntent intent, final long processInstanceKey) {
+    final TermsQueryContainer query = new TermsQueryContainer();
+    query.addTermQuery(ZeebeVariableRecordDto.Fields.intent, intent.name());
+    query.addTermQuery(
+        ZeebeVariableRecordDto.Fields.value + ".processInstanceKey",
+        String.valueOf(processInstanceKey));
+    waitUntilMinimumDataExportedCount(
+        minExportedEventCount, DatabaseConstants.ZEEBE_VARIABLE_INDEX_NAME, query);
+  }
+
+  protected void waitUntilInstanceRecordWithElementIdForInstanceExported(
+      final String elementId, final long processInstanceKey) {
+    final TermsQueryContainer query = new TermsQueryContainer();
+    query.addTermQuery(
+        ZeebeProcessInstanceRecordDto.Fields.value
+            + "."
+            + ZeebeProcessInstanceDataDto.Fields.processInstanceKey,
+        String.valueOf(processInstanceKey));
+    query.addTermQuery(
+        ZeebeProcessInstanceRecordDto.Fields.value
+            + "."
+            + ZeebeProcessInstanceDataDto.Fields.elementId,
+        elementId);
+    waitUntilRecordMatchingQueryExported(
+        DatabaseConstants.ZEEBE_PROCESS_INSTANCE_INDEX_NAME, query);
   }
 
   protected void waitUntilInstanceRecordWithElementTypeAndIntentExported(

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeIncidentImportIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeIncidentImportIT.java
@@ -28,6 +28,7 @@ import io.camunda.optimize.dto.optimize.query.process.FlowNodeInstanceDto;
 import io.camunda.optimize.dto.zeebe.ZeebeRecordDto;
 import io.camunda.optimize.dto.zeebe.incident.ZeebeIncidentDataDto;
 import io.camunda.optimize.dto.zeebe.incident.ZeebeIncidentRecordDto;
+import io.camunda.optimize.dto.zeebe.process.ZeebeProcessInstanceDataDto;
 import io.camunda.optimize.dto.zeebe.process.ZeebeProcessInstanceRecordDto;
 import io.camunda.optimize.exception.OptimizeIntegrationTestException;
 import io.camunda.optimize.service.db.DatabaseConstants;
@@ -56,7 +57,7 @@ public class ZeebeIncidentImportIT extends AbstractCCSMIT {
     zeebeExtension.failTask(SERVICE_TASK);
 
     // when
-    waitUntilIncidentRecordWithProcessIdExported("someProcess");
+    waitUntilIncidentRecordForInstanceExported(deployedInstance.getProcessInstanceKey());
     importAllZeebeEntitiesFromScratch();
 
     // then
@@ -97,7 +98,7 @@ public class ZeebeIncidentImportIT extends AbstractCCSMIT {
     zeebeExtension.throwErrorIncident(SERVICE_TASK);
 
     // when
-    waitUntilIncidentRecordWithProcessIdExported("someProcess");
+    waitUntilIncidentRecordForInstanceExported(deployedInstance.getProcessInstanceKey());
     importAllZeebeEntitiesFromScratch();
 
     // then
@@ -118,12 +119,19 @@ public class ZeebeIncidentImportIT extends AbstractCCSMIT {
     final ProcessInstanceEvent deployedInstance =
         deployAndStartInstanceForProcess(createIncidentProcess("someProcess"));
 
-    // when
-    waitUntilIncidentRecordWithProcessIdExported("someProcess");
+    // when — wait for CATCH_EVENT in the process-instance index first, then wait for the
+    // incident. Both are pinned to this instance's key so stale records don't satisfy the waits.
+    // The two waits are necessary because the exporter flushes the process-instance and incident
+    // indices in separate bulk batches with no cross-index ordering guarantee.
+    waitUntilProcessInstanceElementRecordForInstanceExported(
+        deployedInstance.getProcessInstanceKey(), CATCH_EVENT);
+    waitUntilIncidentRecordForInstanceExported(deployedInstance.getProcessInstanceKey());
     importAllZeebeEntitiesFromScratch();
 
-    // then
+    // then — filter by instance key so ghost instances from prior tests don't interfere
+    final String instanceId = String.valueOf(deployedInstance.getProcessInstanceKey());
     assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+        .filteredOn(pi -> instanceId.equals(pi.getProcessInstanceId()))
         .singleElement()
         .satisfies(
             savedInstance ->
@@ -140,9 +148,9 @@ public class ZeebeIncidentImportIT extends AbstractCCSMIT {
     final ProcessInstanceEvent deployedInstance =
         deployAndStartInstanceForProcess(createSimpleServiceTaskProcess("someProcess"));
     zeebeExtension.throwErrorIncident(SERVICE_TASK);
-    waitUntilIncidentRecordWithProcessIdExported("someProcess");
+    waitUntilIncidentRecordForInstanceExported(deployedInstance.getProcessInstanceKey());
     resolveIncident();
-    waitUntilIncidentRecordsWithProcessIdExported(2, "someProcess");
+    waitUntilIncidentRecordsForInstanceExported(2, deployedInstance.getProcessInstanceKey());
 
     // when
     importAllZeebeEntitiesFromScratch();
@@ -164,7 +172,7 @@ public class ZeebeIncidentImportIT extends AbstractCCSMIT {
     final ProcessInstanceEvent deployedInstance =
         deployAndStartInstanceForProcess(createSimpleServiceTaskProcess("someProcess"));
     zeebeExtension.throwErrorIncident(SERVICE_TASK);
-    waitUntilIncidentRecordWithProcessIdExported("someProcess");
+    waitUntilIncidentRecordForInstanceExported(deployedInstance.getProcessInstanceKey());
 
     // when
     importAllZeebeEntitiesFromScratch();
@@ -181,7 +189,7 @@ public class ZeebeIncidentImportIT extends AbstractCCSMIT {
 
     // when
     resolveIncident();
-    waitUntilIncidentRecordsWithProcessIdExported(2, "someProcess");
+    waitUntilIncidentRecordsForInstanceExported(2, deployedInstance.getProcessInstanceKey());
     importAllZeebeEntitiesFromLastIndex();
 
     // then
@@ -201,9 +209,10 @@ public class ZeebeIncidentImportIT extends AbstractCCSMIT {
   @Test
   public void importZeebeIncidentData_defaultTenantIdForRecordsWithoutTenantId() {
     // given a process deployed before zeebe implemented multi tenancy
-    deployAndStartInstanceForProcess(createSimpleServiceTaskProcess("someProcess"));
+    final ProcessInstanceEvent deployedInstance =
+        deployAndStartInstanceForProcess(createSimpleServiceTaskProcess("someProcess"));
     zeebeExtension.failTask(SERVICE_TASK);
-    waitUntilIncidentRecordWithProcessIdExported("someProcess");
+    waitUntilIncidentRecordForInstanceExported(deployedInstance.getProcessInstanceKey());
 
     // when
     importAllZeebeEntitiesFromScratch();
@@ -220,9 +229,10 @@ public class ZeebeIncidentImportIT extends AbstractCCSMIT {
   @Test
   public void importZeebeIncidentData_tenantIdImported() {
     // given
-    deployAndStartInstanceForProcess(createSimpleServiceTaskProcess("aProcess"));
+    final ProcessInstanceEvent deployedInstance =
+        deployAndStartInstanceForProcess(createSimpleServiceTaskProcess("aProcess"));
     zeebeExtension.failTask(SERVICE_TASK);
-    waitUntilIncidentRecordsWithProcessIdExported(1, "aProcess");
+    waitUntilIncidentRecordForInstanceExported(deployedInstance.getProcessInstanceKey());
     final String expectedTenantId = "testTenant";
     setTenantIdForExportedZeebeRecords(ZEEBE_INCIDENT_INDEX_NAME, expectedTenantId);
 
@@ -237,8 +247,39 @@ public class ZeebeIncidentImportIT extends AbstractCCSMIT {
         .isEqualTo(expectedTenantId);
   }
 
-  private void waitUntilIncidentRecordWithProcessIdExported(final String processId) {
-    waitUntilIncidentRecordsWithProcessIdExported(1, processId);
+  private void waitUntilIncidentRecordsForInstanceExported(
+      final long minCount, final long processInstanceKey) {
+    final TermsQueryContainer query = new TermsQueryContainer();
+    query.addTermQuery(
+        ZeebeIncidentRecordDto.Fields.value + "." + ZeebeIncidentDataDto.Fields.processInstanceKey,
+        String.valueOf(processInstanceKey));
+    waitUntilRecordMatchingQueryExported(
+        minCount, DatabaseConstants.ZEEBE_INCIDENT_INDEX_NAME, query);
+  }
+
+  private void waitUntilProcessInstanceElementRecordForInstanceExported(
+      final long processInstanceKey, final String elementId) {
+    final TermsQueryContainer query = new TermsQueryContainer();
+    query.addTermQuery(
+        ZeebeProcessInstanceRecordDto.Fields.value
+            + "."
+            + ZeebeProcessInstanceDataDto.Fields.processInstanceKey,
+        String.valueOf(processInstanceKey));
+    query.addTermQuery(
+        ZeebeProcessInstanceRecordDto.Fields.value
+            + "."
+            + ZeebeProcessInstanceDataDto.Fields.elementId,
+        elementId);
+    waitUntilRecordMatchingQueryExported(
+        1, DatabaseConstants.ZEEBE_PROCESS_INSTANCE_INDEX_NAME, query);
+  }
+
+  private void waitUntilIncidentRecordForInstanceExported(final long processInstanceKey) {
+    final TermsQueryContainer query = new TermsQueryContainer();
+    query.addTermQuery(
+        ZeebeIncidentRecordDto.Fields.value + "." + ZeebeIncidentDataDto.Fields.processInstanceKey,
+        String.valueOf(processInstanceKey));
+    waitUntilRecordMatchingQueryExported(1, DatabaseConstants.ZEEBE_INCIDENT_INDEX_NAME, query);
   }
 
   private TermsQueryContainer getQueryForIncidentEvents() {
@@ -318,15 +359,5 @@ public class ZeebeIncidentImportIT extends AbstractCCSMIT {
       final ProcessInstanceDto processInstanceDto, final String activityId) {
     return getPropertyIdFromProcessInstanceForActivity(
         processInstanceDto, activityId, FlowNodeInstanceDto::getFlowNodeId);
-  }
-
-  private void waitUntilIncidentRecordsWithProcessIdExported(
-      final long minRecordCount, final String processId) {
-    final TermsQueryContainer query = new TermsQueryContainer();
-    query.addTermQuery(
-        ZeebeIncidentRecordDto.Fields.value + "." + ZeebeIncidentDataDto.Fields.bpmnProcessId,
-        processId);
-    waitUntilRecordMatchingQueryExported(
-        minRecordCount, DatabaseConstants.ZEEBE_INCIDENT_INDEX_NAME, query);
   }
 }

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebePositionBasedImportIndexIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebePositionBasedImportIndexIT.java
@@ -87,7 +87,7 @@ public class ZeebePositionBasedImportIndexIT extends AbstractCCSMIT {
 
     // when
     startAndUseNewOptimizeInstance();
-    setupZeebeImportAndReloadConfiguration();
+    configureZeebeImport();
     databaseIntegrationTestExtension.refreshAllOptimizeIndices();
 
     // then
@@ -111,7 +111,7 @@ public class ZeebePositionBasedImportIndexIT extends AbstractCCSMIT {
 
     // when
     startAndUseNewOptimizeInstance();
-    setupZeebeImportAndReloadConfiguration();
+    configureZeebeImport();
     databaseIntegrationTestExtension.refreshAllOptimizeIndices();
 
     // then

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeProcessInstanceImportIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeProcessInstanceImportIT.java
@@ -68,14 +68,11 @@ import io.camunda.optimize.dto.optimize.ProcessInstanceConstants;
 import io.camunda.optimize.dto.optimize.ProcessInstanceDto;
 import io.camunda.optimize.dto.optimize.query.process.FlowNodeInstanceDto;
 import io.camunda.optimize.dto.zeebe.process.ZeebeProcessInstanceRecordDto;
-import io.camunda.optimize.dto.zeebe.variable.ZeebeVariableRecordDto;
 import io.camunda.optimize.exception.OptimizeIntegrationTestException;
-import io.camunda.optimize.service.db.DatabaseConstants;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
-import io.camunda.optimize.test.it.extension.db.TermsQueryContainer;
+import io.camunda.optimize.service.util.IdGenerator;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
-import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import java.io.IOException;
 import java.time.Instant;
@@ -105,7 +102,8 @@ public class ZeebeProcessInstanceImportIT extends AbstractCCSMIT {
         deployAndStartInstanceForProcess(createStartEndProcess(processName));
 
     // when
-    waitUntilMinimumProcessInstanceEventsExportedCount(6);
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(
+        6, deployedInstance.getProcessInstanceKey());
     importAllZeebeEntitiesFromScratch();
 
     // then
@@ -165,10 +163,12 @@ public class ZeebeProcessInstanceImportIT extends AbstractCCSMIT {
         .getConfiguredZeebe()
         .setMaxImportPageSize(1);
     embeddedOptimizeExtension.reloadConfiguration();
-    deployAndStartInstanceForProcess(createStartEndProcess("someProcess"));
+    final ProcessInstanceEvent deployedInstance =
+        deployAndStartInstanceForProcess(createStartEndProcess("someProcess"));
 
     // when
-    waitUntilMinimumProcessInstanceEventsExportedCount(6);
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(
+        6, deployedInstance.getProcessInstanceKey());
     importAllZeebeEntitiesFromScratch();
 
     // then process activating event has been imported
@@ -232,7 +232,8 @@ public class ZeebeProcessInstanceImportIT extends AbstractCCSMIT {
         deployAndStartInstanceForProcess(createSimpleUserTaskProcess(processName));
 
     // when
-    waitUntilMinimumProcessInstanceEventsExportedCount(4);
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(
+        4, deployedInstance.getProcessInstanceKey());
     importAllZeebeEntitiesFromScratch();
 
     // then
@@ -297,9 +298,11 @@ public class ZeebeProcessInstanceImportIT extends AbstractCCSMIT {
     // We wait for the service task to be exported before cancelling the process
     // (1 * process event, 2 * "start_event" events). Then again for the import of cancellation
     // events (2 cancel events)
-    waitUntilMinimumProcessInstanceEventsExportedCount(4);
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(
+        4, deployedInstance.getProcessInstanceKey());
     zeebeExtension.cancelProcessInstance(deployedInstance.getProcessInstanceKey());
-    waitUntilMinimumProcessInstanceEventsExportedCount(6);
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(
+        6, deployedInstance.getProcessInstanceKey());
 
     // when
     importAllZeebeEntitiesFromScratch();
@@ -365,14 +368,16 @@ public class ZeebeProcessInstanceImportIT extends AbstractCCSMIT {
         deployAndStartInstanceForProcess(createSimpleServiceTaskProcess(processName));
 
     // when
-    waitUntilMinimumProcessInstanceEventsExportedCount(4);
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(
+        4, deployedInstance.getProcessInstanceKey());
     try {
       zeebeExtension.setClock(Instant.now().plus(1, ChronoUnit.DAYS));
     } catch (final IOException | InterruptedException e) {
       throw new OptimizeRuntimeException(e);
     }
     zeebeExtension.completeTaskForInstanceWithJobType(SERVICE_TASK);
-    waitUntilMinimumProcessInstanceEventsExportedCount(8);
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(
+        8, deployedInstance.getProcessInstanceKey());
     importAllZeebeEntitiesFromScratch();
 
     // then
@@ -430,8 +435,9 @@ public class ZeebeProcessInstanceImportIT extends AbstractCCSMIT {
 
   @Test
   public void importZeebeProcessInstanceData_multipleInstancesForSameProcess() {
-    // given
-    final String processName = "someProcess";
+    // given - unique name so version counter starts at 1 regardless of prior tests on the
+    // class-scoped broker
+    final String processName = "someProcess-" + IdGenerator.getNextId();
     final Process deployedProcess =
         zeebeExtension.deployProcess(createStartEndProcess(processName));
     final ProcessInstanceEvent firstInstance =
@@ -441,7 +447,10 @@ public class ZeebeProcessInstanceImportIT extends AbstractCCSMIT {
 
     // when
     // Each instance generates 6 events
-    waitUntilMinimumProcessInstanceEventsExportedCount(12);
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(
+        6, firstInstance.getProcessInstanceKey());
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(
+        6, secondInstance.getProcessInstanceKey());
     importAllZeebeEntitiesFromScratch();
 
     // then
@@ -468,7 +477,10 @@ public class ZeebeProcessInstanceImportIT extends AbstractCCSMIT {
 
     // when
     // both processes have 6 importable events, wait until all records for both have been exported
-    waitUntilMinimumProcessInstanceEventsExportedCount(12);
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(
+        6, firstInstance.getProcessInstanceKey());
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(
+        6, secondInstance.getProcessInstanceKey());
     importAllZeebeEntitiesFromScratch();
 
     // then
@@ -483,17 +495,19 @@ public class ZeebeProcessInstanceImportIT extends AbstractCCSMIT {
 
   @Test
   public void importZeebeProcessInstanceData_instancesWithDifferentVersionsOfSameProcess() {
-    // given
-    final String processName = "someProcess";
+    // given - use a unique process name so the version counter starts at 1 regardless of how many
+    // times the broker (which is class-scoped) has seen this process in prior tests
+    final String processName = "someProcess-" + IdGenerator.getNextId();
     final ProcessInstanceEvent v1Instance =
         deployAndStartInstanceForProcess(createStartEndProcess(processName, processName));
     final ProcessInstanceEvent v2Instance =
         deployAndStartInstanceForProcess(createStartEndProcess(processName, processName));
 
     // when
-    // The first instance generates 6 events, so the 7th indicates that both processes have been
-    // exported
-    waitUntilMinimumProcessInstanceEventsExportedCount(12);
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(
+        6, v1Instance.getProcessInstanceKey());
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(
+        6, v2Instance.getProcessInstanceKey());
     importAllZeebeEntitiesFromScratch();
 
     // then
@@ -512,13 +526,16 @@ public class ZeebeProcessInstanceImportIT extends AbstractCCSMIT {
   public void importZeebeProcessInstanceData_processContainsLoop() {
     // given
     final String processName = "someProcess";
-    deployAndStartInstanceForProcess(createLoopingProcess(processName));
+    final ProcessInstanceEvent deployedInstance =
+        deployAndStartInstanceForProcess(createLoopingProcess(processName));
 
     // when
-    waitUntilMinimumProcessInstanceEventsExportedCount(1);
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(
+        1, deployedInstance.getProcessInstanceKey());
     zeebeExtension.completeTaskForInstanceWithJobType(SERVICE_TASK, Map.of("loop", true));
     zeebeExtension.completeTaskForInstanceWithJobType(SERVICE_TASK, Map.of("loop", false));
-    waitUntilMinimumProcessInstanceEventsExportedCount(18);
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(
+        18, deployedInstance.getProcessInstanceKey());
     importAllZeebeEntitiesFromScratch();
 
     // then
@@ -564,10 +581,12 @@ public class ZeebeProcessInstanceImportIT extends AbstractCCSMIT {
   public void importZeebeProcessInstanceData_processContainsTerminateEndEvent() {
     // given
     final String processName = "someProcess";
-    deployAndStartInstanceForProcess(createTerminateEndEventProcess(processName));
+    final ProcessInstanceEvent deployedInstance =
+        deployAndStartInstanceForProcess(createTerminateEndEventProcess(processName));
 
     // when
-    waitUntilMinimumProcessInstanceEventsExportedCount(6);
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(
+        6, deployedInstance.getProcessInstanceKey());
     importAllZeebeEntitiesFromScratch();
 
     // then
@@ -588,11 +607,12 @@ public class ZeebeProcessInstanceImportIT extends AbstractCCSMIT {
     final String processName = "someProcess";
     final Process process =
         zeebeExtension.deployProcess(createInclusiveGatewayProcess(processName));
-    zeebeExtension.startProcessInstanceWithVariables(
-        process.getBpmnProcessId(), Map.of("varName", "a,b"));
+    final long instanceKey =
+        zeebeExtension.startProcessInstanceWithVariables(
+            process.getBpmnProcessId(), Map.of("varName", "a,b"));
 
     // when
-    waitUntilMinimumProcessInstanceEventsExportedCount(8);
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(8, instanceKey);
     importAllZeebeEntitiesFromScratch();
 
     // then
@@ -616,11 +636,12 @@ public class ZeebeProcessInstanceImportIT extends AbstractCCSMIT {
     final String processName = "someProcess";
     final Process process =
         zeebeExtension.deployProcess(createInclusiveGatewayProcessWithConverging(processName));
-    zeebeExtension.startProcessInstanceWithVariables(
-        process.getBpmnProcessId(), Map.of("varName", "a,b"));
+    final long instanceKey =
+        zeebeExtension.startProcessInstanceWithVariables(
+            process.getBpmnProcessId(), Map.of("varName", "a,b"));
 
     // when
-    waitUntilInstanceRecordWithElementIdExported(END_EVENT);
+    waitUntilInstanceRecordWithElementIdForInstanceExported(END_EVENT, instanceKey);
     importAllZeebeEntitiesFromScratch();
 
     // then
@@ -641,7 +662,8 @@ public class ZeebeProcessInstanceImportIT extends AbstractCCSMIT {
         deployAndStartInstanceForProcess(createSendTaskProcess("someProcess"));
 
     // when
-    waitUntilMinimumProcessInstanceEventsExportedCount(1);
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(
+        1, processInstance.getProcessInstanceKey());
     importAllZeebeEntitiesFromScratch();
 
     // then
@@ -679,11 +701,12 @@ public class ZeebeProcessInstanceImportIT extends AbstractCCSMIT {
     final BpmnModelInstance model =
         readProcessDiagramAsInstance("/bpmn/compatibility/adventure.bpmn");
     final String processId = zeebeExtension.deployProcess(model).getBpmnProcessId();
-    zeebeExtension.startProcessInstanceWithVariables(
-        processId, Map.of("space", true, "time", true));
+    final long instanceKey =
+        zeebeExtension.startProcessInstanceWithVariables(
+            processId, Map.of("space", true, "time", true));
 
     // when
-    waitUntilInstanceRecordWithElementIdExported("milkAdventureEndEventId");
+    waitUntilInstanceRecordWithElementIdForInstanceExported("milkAdventureEndEventId", instanceKey);
     importAllZeebeEntitiesFromScratch();
 
     // then all new events were imported
@@ -746,14 +769,16 @@ public class ZeebeProcessInstanceImportIT extends AbstractCCSMIT {
   @Test
   public void importZeebeProcessInstanceData_processContainsCompensationTasks() {
     // given
-    deployAndStartInstanceForProcess(createCompensationEventProcess());
+    final ProcessInstanceEvent deployedInstance =
+        deployAndStartInstanceForProcess(createCompensationEventProcess());
     zeebeExtension.completeTaskForInstanceWithJobType(SERVICE_TASK_WITH_COMPENSATION_EVENT);
     zeebeExtension.completeTaskForInstanceWithJobType(COMPENSATION_EVENT_TASK);
 
     // when
     waitUntilInstanceRecordWithElementTypeAndIntentExported(
         BpmnElementType.BOUNDARY_EVENT, ELEMENT_COMPLETED);
-    waitUntilMinimumProcessInstanceEventsExportedCount(12);
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(
+        12, deployedInstance.getProcessInstanceKey());
     importAllZeebeEntitiesFromScratch();
 
     // then
@@ -785,11 +810,12 @@ public class ZeebeProcessInstanceImportIT extends AbstractCCSMIT {
             process ->
                 process.zeebeActiveElementsCollectionExpression(ACTIVATE_ELEMENTS).task(TASK));
     final String processId = zeebeExtension.deployProcess(adHocSubProcessModel).getBpmnProcessId();
-    zeebeExtension.startProcessInstanceWithVariables(
-        processId, Map.of(ACTIVATE_ELEMENTS, List.of(TASK)));
+    final long instanceKey =
+        zeebeExtension.startProcessInstanceWithVariables(
+            processId, Map.of(ACTIVATE_ELEMENTS, List.of(TASK)));
 
     // when
-    waitUntilInstanceRecordWithElementIdExported(END_EVENT);
+    waitUntilInstanceRecordWithElementIdForInstanceExported(END_EVENT, instanceKey);
     importAllZeebeEntitiesFromScratch();
 
     // then
@@ -813,22 +839,27 @@ public class ZeebeProcessInstanceImportIT extends AbstractCCSMIT {
             deployedProcess.getProcessDefinitionKey(), Map.of("triggerStart", true));
 
     // when
-    waitUntilInstanceRecordWithElementIdExported(CONDITIONAL_PROCESS_SERVICE_TASK_1);
+    waitUntilInstanceRecordWithElementIdForInstanceExported(
+        CONDITIONAL_PROCESS_SERVICE_TASK_1, processInstanceKey);
     zeebeExtension.addVariablesToScope(
         processInstanceKey, Map.of("triggerBoundaryNonInt", true), false);
     zeebeExtension.addVariablesToScope(
         processInstanceKey, Map.of("triggerSubProcessNonInt", true), false);
     zeebeExtension.completeTaskForInstanceWithJobType(SERVICE_TASK);
-    waitUntilInstanceRecordWithElementIdExported(CONDITIONAL_INTERMEDIATE_CATCH);
+    waitUntilInstanceRecordWithElementIdForInstanceExported(
+        CONDITIONAL_INTERMEDIATE_CATCH, processInstanceKey);
     zeebeExtension.addVariablesToScope(
         processInstanceKey, Map.of("triggerIntermediate", true), false);
-    waitUntilInstanceRecordWithElementIdExported(CONDITIONAL_PROCESS_SERVICE_TASK_2);
+    waitUntilInstanceRecordWithElementIdForInstanceExported(
+        CONDITIONAL_PROCESS_SERVICE_TASK_2, processInstanceKey);
     zeebeExtension.addVariablesToScope(
         processInstanceKey, Map.of("triggerBoundaryInt", true), false);
-    waitUntilInstanceRecordWithElementIdExported("serviceTaskAfterBoundary");
+    waitUntilInstanceRecordWithElementIdForInstanceExported(
+        "serviceTaskAfterBoundary", processInstanceKey);
     zeebeExtension.addVariablesToScope(
         processInstanceKey, Map.of("triggerSubProcessInt", true), false);
-    waitUntilInstanceRecordWithElementIdExported("interruptingSubProcessEnd");
+    waitUntilInstanceRecordWithElementIdForInstanceExported(
+        "interruptingSubProcessEnd", processInstanceKey);
 
     importAllZeebeEntitiesFromScratch();
 
@@ -857,8 +888,10 @@ public class ZeebeProcessInstanceImportIT extends AbstractCCSMIT {
   public void importZeebeProcess_defaultTenantIdForRecordsWithoutTenantId() {
     // given a process deployed before zeebe implemented multi tenancy (pre 8.3.0 this test is
     // disabled)
-    deployAndStartInstanceForProcess(createStartEndProcess("someProcess"));
-    waitUntilInstanceRecordWithElementIdExported(START_EVENT);
+    final ProcessInstanceEvent deployedInstance =
+        deployAndStartInstanceForProcess(createStartEndProcess("someProcess"));
+    waitUntilInstanceRecordWithElementIdForInstanceExported(
+        START_EVENT, deployedInstance.getProcessInstanceKey());
 
     // when
     importAllZeebeEntitiesFromScratch();
@@ -881,22 +914,29 @@ public class ZeebeProcessInstanceImportIT extends AbstractCCSMIT {
   @Test
   public void importZeebeProcessInstanceData_tenantIdImported() {
     // given
-    deployAndStartInstanceForProcess(createStartEndProcess("aProcess"));
-    waitUntilInstanceRecordWithElementIdExported(START_EVENT);
+    final ProcessInstanceEvent deployedInstance =
+        deployAndStartInstanceForProcess(createStartEndProcess("aProcess"));
+    // Wait for all 6 process events (PROCESS + startEvent + endEvent, each ACTIVATED+COMPLETED)
+    // before patching tenant so the patch covers every flow-node record, not just startEvent
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(
+        6, deployedInstance.getProcessInstanceKey());
     final String expectedTenantId = "testTenant";
     setTenantIdForExportedZeebeRecords(ZEEBE_PROCESS_INSTANCE_INDEX_NAME, expectedTenantId);
 
     // when
     importAllZeebeEntitiesFromScratch();
 
-    // then
+    // then — filter by this test's instance key so stale records from prior tests don't interfere
+    final String instanceId = String.valueOf(deployedInstance.getProcessInstanceKey());
     final List<ProcessInstanceDto> instances =
         databaseIntegrationTestExtension.getAllProcessInstances();
     assertThat(instances)
+        .filteredOn(pi -> instanceId.equals(pi.getProcessInstanceId()))
         .extracting(ProcessInstanceDto::getTenantId)
         .singleElement()
         .isEqualTo(expectedTenantId);
     assertThat(instances)
+        .filteredOn(pi -> instanceId.equals(pi.getProcessInstanceId()))
         .flatExtracting(ProcessInstanceDto::getFlowNodeInstances)
         .extracting(FlowNodeInstanceDto::getTenantId)
         .hasSize(2)
@@ -917,7 +957,11 @@ public class ZeebeProcessInstanceImportIT extends AbstractCCSMIT {
     final long startedInstanceKey =
         zeebeExtension.startProcessInstanceWithVariables(
             deployedProcess.getBpmnProcessId(), processVariables);
-    waitUntilMinimumProcessInstanceEventsExportedCount(4);
+    // Wait for both process events AND the initial variables (var1, var2) to be exported so that
+    // the first import captures them — without this, currentNestedDocCount would be computed
+    // without variables and the nested-doc limit would be set too low for instance 2 to import.
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(4, startedInstanceKey);
+    waitUntilMinimumVariableDocumentsForInstanceExportedCount(2, startedInstanceKey);
     importAllZeebeEntitiesFromScratch();
     final ProcessInstanceDto firstInstanceOnFirstRoundImport =
         getProcessInstanceForId(String.valueOf(startedInstanceKey));
@@ -932,13 +976,17 @@ public class ZeebeProcessInstanceImportIT extends AbstractCCSMIT {
 
     // Now add additional variables to go beyond the nested document limit
     zeebeExtension.addVariablesToScope(startedInstanceKey, additionalVariables, true);
-    waitUntilMinimumVariableDocumentsExportedCount(2);
+    // Wait for var3 + var4 CREATED events for the first instance (total: 2 initial + 2 additional)
+    waitUntilMinimumVariableDocumentsForInstanceExportedCount(4, startedInstanceKey);
 
     // and start a second instance, which should still be imported
     final long secondInstanceKey =
         zeebeExtension.startProcessInstanceWithVariables(
             deployedProcess.getBpmnProcessId(), processVariables);
-    waitUntilMinimumProcessInstanceEventsExportedCount(8);
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(4, startedInstanceKey);
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(4, secondInstanceKey);
+    // Wait for instance 2's var1 + var2 CREATED events
+    waitUntilMinimumVariableDocumentsForInstanceExportedCount(2, secondInstanceKey);
 
     // when
     importAllZeebeEntitiesFromScratch();
@@ -1050,14 +1098,5 @@ public class ZeebeProcessInstanceImportIT extends AbstractCCSMIT {
       final String processDefinitionKey, final int nestedDocLimit) {
     databaseIntegrationTestExtension.updateProcessInstanceNestedDocLimit(
         processDefinitionKey, nestedDocLimit, embeddedOptimizeExtension.getConfigurationService());
-  }
-
-  private void waitUntilMinimumVariableDocumentsExportedCount(final int minExportedEventCount) {
-    final TermsQueryContainer variableBoolQuery = new TermsQueryContainer();
-    variableBoolQuery.addTermQuery(
-        ZeebeVariableRecordDto.Fields.intent, VariableIntent.CREATED.name());
-
-    waitUntilMinimumDataExportedCount(
-        minExportedEventCount, DatabaseConstants.ZEEBE_VARIABLE_INDEX_NAME, variableBoolQuery);
   }
 }

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeVariableCreationImportIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeVariableCreationImportIT.java
@@ -26,12 +26,8 @@ import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.optimize.AbstractCCSMIT;
 import io.camunda.optimize.dto.optimize.ProcessInstanceDto;
 import io.camunda.optimize.dto.optimize.query.variable.SimpleProcessVariableDto;
-import io.camunda.optimize.dto.zeebe.variable.ZeebeVariableRecordDto;
 import io.camunda.optimize.exception.OptimizeIntegrationTestException;
-import io.camunda.optimize.service.db.DatabaseConstants;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
-import io.camunda.optimize.test.it.extension.db.TermsQueryContainer;
-import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import java.io.IOException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -86,8 +82,8 @@ public class ZeebeVariableCreationImportIT extends AbstractCCSMIT {
     final Long processInstanceKey = deployProcessAndStartProcessInstanceWithVariables();
 
     // when
-    waitUntilMinimumProcessInstanceEventsExportedCount(4);
-    waitUntilMinimumVariableDocumentsExportedCount(1);
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(4, processInstanceKey);
+    waitUntilMinimumVariableDocumentsForInstanceExportedCount(5, processInstanceKey);
     importAllZeebeEntitiesFromScratch();
 
     // then
@@ -110,9 +106,8 @@ public class ZeebeVariableCreationImportIT extends AbstractCCSMIT {
             deployedProcess.getBpmnProcessId(), variables);
 
     // when
-    waitUntilNumberOfDefinitionsExported(1);
-    waitUntilMinimumProcessInstanceEventsExportedCount(4);
-    waitUntilMinimumVariableDocumentsExportedCount(1);
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(4, processInstanceKey);
+    waitUntilMinimumVariableDocumentsForInstanceExportedCount(1, processInstanceKey);
     importAllZeebeEntitiesFromScratch();
 
     // when
@@ -139,9 +134,8 @@ public class ZeebeVariableCreationImportIT extends AbstractCCSMIT {
         zeebeExtension.startProcessInstanceWithVariables(
             deployedProcess.getBpmnProcessId(), variables);
 
-    waitUntilNumberOfDefinitionsExported(1);
-    waitUntilMinimumProcessInstanceEventsExportedCount(4);
-    waitUntilMinimumVariableDocumentsExportedCount(1);
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(4, processInstanceKey);
+    waitUntilMinimumVariableDocumentsForInstanceExportedCount(1, processInstanceKey);
     importAllZeebeEntitiesFromScratch();
 
     // when
@@ -172,8 +166,8 @@ public class ZeebeVariableCreationImportIT extends AbstractCCSMIT {
     final long processInstanceKey =
         zeebeExtension.startProcessInstanceWithVariables(
             deployedProcess.getBpmnProcessId(), variables);
-    waitUntilMinimumProcessInstanceEventsExportedCount(4);
-    waitUntilMinimumVariableDocumentsExportedCount(1);
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(4, processInstanceKey);
+    waitUntilMinimumVariableDocumentsForInstanceExportedCount(1, processInstanceKey);
 
     // when
     importAllZeebeEntitiesFromScratch();
@@ -233,8 +227,8 @@ public class ZeebeVariableCreationImportIT extends AbstractCCSMIT {
         zeebeExtension.startProcessInstanceWithVariables(
             deployedProcess.getBpmnProcessId(), Map.of("numericStrings", numericStringList));
 
-    waitUntilMinimumProcessInstanceEventsExportedCount(4);
-    waitUntilMinimumVariableDocumentsExportedCount(1);
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(4, processInstanceKey);
+    waitUntilMinimumVariableDocumentsForInstanceExportedCount(1, processInstanceKey);
 
     // when
     importAllZeebeEntitiesFromScratch();
@@ -256,10 +250,12 @@ public class ZeebeVariableCreationImportIT extends AbstractCCSMIT {
   public void zeebeVariableImport_variablesAddedAfterProcessStarted() {
     // given
     final ProcessInstanceEvent processInstanceEvent = deployProcessAndStartProcessInstance();
-    waitUntilMinimumProcessInstanceEventsExportedCount(4);
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(
+        4, processInstanceEvent.getProcessInstanceKey());
     zeebeExtension.addVariablesToScope(
         processInstanceEvent.getProcessInstanceKey(), BASIC_VARIABLES, false);
-    waitUntilMinimumVariableDocumentsExportedCount(5);
+    waitUntilMinimumVariableDocumentsForInstanceExportedCount(
+        5, processInstanceEvent.getProcessInstanceKey());
 
     // when
     importAllZeebeEntitiesFromScratch();
@@ -278,8 +274,8 @@ public class ZeebeVariableCreationImportIT extends AbstractCCSMIT {
     final long startedInstanceKey =
         zeebeExtension.startProcessInstanceWithVariables(
             deployedProcess.getBpmnProcessId(), Map.of("var1", "someValue"));
-    waitUntilMinimumProcessInstanceEventsExportedCount(4);
-    waitUntilMinimumVariableDocumentsExportedCount(1);
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(4, startedInstanceKey);
+    waitUntilMinimumVariableDocumentsForInstanceExportedCount(1, startedInstanceKey);
     importAllZeebeEntitiesFromScratch();
     ProcessInstanceDto savedProcessInstance =
         getProcessInstanceForId(String.valueOf(startedInstanceKey));
@@ -287,7 +283,7 @@ public class ZeebeVariableCreationImportIT extends AbstractCCSMIT {
     final String flowNodeId =
         getFlowNodeInstanceIdFromProcessInstanceForActivity(savedProcessInstance, SERVICE_TASK);
     zeebeExtension.addVariablesToScope(Long.parseLong(flowNodeId), Map.of("var1", false), true);
-    waitUntilMinimumVariableDocumentsExportedCount(2);
+    waitUntilMinimumVariableDocumentsForInstanceExportedCount(2, startedInstanceKey);
 
     // when
     importAllZeebeEntitiesFromLastIndex();
@@ -309,7 +305,8 @@ public class ZeebeVariableCreationImportIT extends AbstractCCSMIT {
     // given
     final Map<String, Object> processVariable = Map.of("var1", "someValue");
     final ProcessInstanceEvent startedInstance = deployProcessAndStartProcessInstance();
-    waitUntilMinimumProcessInstanceEventsExportedCount(4);
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(
+        4, startedInstance.getProcessInstanceKey());
     importAllZeebeEntitiesFromScratch();
     ProcessInstanceDto savedProcessInstance =
         getProcessInstanceForId(String.valueOf(startedInstance.getProcessInstanceKey()));
@@ -317,7 +314,8 @@ public class ZeebeVariableCreationImportIT extends AbstractCCSMIT {
     final String flowNodeId =
         getFlowNodeInstanceIdFromProcessInstanceForActivity(savedProcessInstance, SERVICE_TASK);
     zeebeExtension.addVariablesToScope(Long.parseLong(flowNodeId), processVariable, false);
-    waitUntilMinimumVariableDocumentsExportedCount(1);
+    waitUntilMinimumVariableDocumentsForInstanceExportedCount(
+        1, startedInstance.getProcessInstanceKey());
 
     // when
     importAllZeebeEntitiesFromLastIndex();
@@ -338,8 +336,10 @@ public class ZeebeVariableCreationImportIT extends AbstractCCSMIT {
     // given
     final long deployedInstanceKey1 = deployProcessAndStartProcessInstanceWithVariables();
     final long deployedInstanceKey2 = deployProcessAndStartProcessInstanceWithVariables();
-    waitUntilMinimumProcessInstanceEventsExportedCount(8);
-    waitUntilMinimumVariableDocumentsExportedCount(10);
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(4, deployedInstanceKey1);
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(4, deployedInstanceKey2);
+    waitUntilMinimumVariableDocumentsForInstanceExportedCount(5, deployedInstanceKey1);
+    waitUntilMinimumVariableDocumentsForInstanceExportedCount(5, deployedInstanceKey2);
 
     // when
     importAllZeebeEntitiesFromScratch();
@@ -364,8 +364,10 @@ public class ZeebeVariableCreationImportIT extends AbstractCCSMIT {
     final long startedInstanceKey2 =
         zeebeExtension.startProcessInstanceWithVariables(
             deployedProcess2.getBpmnProcessId(), BASIC_VARIABLES);
-    waitUntilMinimumProcessInstanceEventsExportedCount(8);
-    waitUntilMinimumVariableDocumentsExportedCount(10);
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(4, startedInstanceKey1);
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(4, startedInstanceKey2);
+    waitUntilMinimumVariableDocumentsForInstanceExportedCount(5, startedInstanceKey1);
+    waitUntilMinimumVariableDocumentsForInstanceExportedCount(5, startedInstanceKey2);
 
     // when
     importAllZeebeEntitiesFromLastIndex();
@@ -390,8 +392,8 @@ public class ZeebeVariableCreationImportIT extends AbstractCCSMIT {
     final long processInstanceKey =
         zeebeExtension.startProcessInstanceWithVariables(
             deployedProcess.getBpmnProcessId(), supportedAndUnsupportedVariables);
-    waitUntilMinimumProcessInstanceEventsExportedCount(4);
-    waitUntilMinimumVariableDocumentsExportedCount(2);
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(4, processInstanceKey);
+    waitUntilMinimumVariableDocumentsForInstanceExportedCount(2, processInstanceKey);
 
     // when
     importAllZeebeEntitiesFromScratch();
@@ -417,8 +419,8 @@ public class ZeebeVariableCreationImportIT extends AbstractCCSMIT {
     final long processInstanceKey =
         zeebeExtension.startProcessInstanceWithVariables(
             deployedProcess.getBpmnProcessId(), variables);
-    waitUntilMinimumProcessInstanceEventsExportedCount(4);
-    waitUntilMinimumVariableDocumentsExportedCount(1);
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(4, processInstanceKey);
+    waitUntilMinimumVariableDocumentsForInstanceExportedCount(1, processInstanceKey);
 
     // when
     importAllZeebeEntitiesFromScratch();
@@ -471,8 +473,8 @@ public class ZeebeVariableCreationImportIT extends AbstractCCSMIT {
     final long processInstanceKey =
         zeebeExtension.startProcessInstanceWithVariables(
             deployedProcess.getBpmnProcessId(), variables);
-    waitUntilMinimumProcessInstanceEventsExportedCount(4);
-    waitUntilMinimumVariableDocumentsExportedCount(1);
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(4, processInstanceKey);
+    waitUntilMinimumVariableDocumentsForInstanceExportedCount(1, processInstanceKey);
 
     // when
     importAllZeebeEntitiesFromScratch();
@@ -495,8 +497,8 @@ public class ZeebeVariableCreationImportIT extends AbstractCCSMIT {
     final long processInstanceKey =
         zeebeExtension.startProcessInstanceWithVariables(
             deployedProcess.getBpmnProcessId(), Map.of("listVar", List.of("value1", "value2")));
-    waitUntilMinimumProcessInstanceEventsExportedCount(4);
-    waitUntilMinimumVariableDocumentsExportedCount(1);
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(4, processInstanceKey);
+    waitUntilMinimumVariableDocumentsForInstanceExportedCount(1, processInstanceKey);
 
     // when
     importAllZeebeEntitiesFromScratch();
@@ -528,9 +530,9 @@ public class ZeebeVariableCreationImportIT extends AbstractCCSMIT {
     final long startedInstanceKey =
         zeebeExtension.startProcessInstanceWithVariables(
             deployedProcess.getBpmnProcessId(), processVariables);
-    waitUntilMinimumProcessInstanceEventsExportedCount(4);
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(4, startedInstanceKey);
     zeebeExtension.addVariablesToScope(startedInstanceKey, processVariables, false);
-    waitUntilMinimumVariableDocumentsExportedCount(2);
+    waitUntilMinimumVariableDocumentsForInstanceExportedCount(2, startedInstanceKey);
 
     // when
     importAllZeebeEntitiesFromScratch();
@@ -569,8 +571,8 @@ public class ZeebeVariableCreationImportIT extends AbstractCCSMIT {
     zeebeExtension.addVariablesToScope(startedInstanceKey, Map.of("var2", "someValue2"), false);
 
     // when
-    waitUntilMinimumProcessInstanceEventsExportedCount(4);
-    waitUntilMinimumVariableDocumentsExportedCount(2);
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(4, startedInstanceKey);
+    waitUntilMinimumVariableDocumentsForInstanceExportedCount(2, startedInstanceKey);
     importAllZeebeEntitiesFromScratch();
 
     // then
@@ -597,15 +599,6 @@ public class ZeebeVariableCreationImportIT extends AbstractCCSMIT {
             () ->
                 new OptimizeIntegrationTestException(
                     "No process instance with id " + processInstanceId + " found"));
-  }
-
-  private void waitUntilMinimumVariableDocumentsExportedCount(final int minExportedEventCount) {
-    final TermsQueryContainer variableBoolQuery = new TermsQueryContainer();
-    variableBoolQuery.addTermQuery(
-        ZeebeVariableRecordDto.Fields.intent, VariableIntent.CREATED.name());
-
-    waitUntilMinimumDataExportedCount(
-        minExportedEventCount, DatabaseConstants.ZEEBE_VARIABLE_INDEX_NAME, variableBoolQuery);
   }
 
   private void assertThatVariablesHaveBeenImportedForProcessInstance(

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeVariableUpdateImportIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeVariableUpdateImportIT.java
@@ -23,10 +23,7 @@ import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.optimize.AbstractCCSMIT;
 import io.camunda.optimize.dto.optimize.ProcessInstanceDto;
 import io.camunda.optimize.dto.optimize.query.variable.SimpleProcessVariableDto;
-import io.camunda.optimize.dto.zeebe.variable.ZeebeVariableRecordDto;
 import io.camunda.optimize.exception.OptimizeIntegrationTestException;
-import io.camunda.optimize.service.db.DatabaseConstants;
-import io.camunda.optimize.test.it.extension.db.TermsQueryContainer;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import java.util.Collections;
 import java.util.HashMap;
@@ -48,8 +45,9 @@ public class ZeebeVariableUpdateImportIT extends AbstractCCSMIT {
     // given
     final long processInstanceKey = deployProcessAndStartProcessInstanceWithVariables(VARIABLES);
     zeebeExtension.addVariablesToScope(processInstanceKey, UPDATED_VARIABLES, true);
-    waitUntilNumberOfDefinitionsExported(1);
-    waitUntilMinimumVariableDocumentsWithUpdatedIntentExportedCount(5);
+    waitUntilDefinitionWithIdExported(PROCESS_ID);
+    waitUntilMinimumVariableDocumentsWithUpdatedIntentForInstanceExportedCount(
+        5, processInstanceKey);
 
     // when
     importAllZeebeEntitiesFromScratch();
@@ -65,10 +63,12 @@ public class ZeebeVariableUpdateImportIT extends AbstractCCSMIT {
       zeebeVariableImport_importRecordsForTheCreationAndTheUpdateOfProcessVariablesOnDifferentBatch() {
     // given
     final long processInstanceKey = deployProcessAndStartProcessInstanceWithVariables(VARIABLES);
-    waitUntilMinimumVariableDocumentsWithCreatedIntentExportedCount(5);
+    waitUntilMinimumVariableDocumentsWithCreatedIntentForInstanceExportedCount(
+        5, processInstanceKey);
     importAllZeebeEntitiesFromScratch();
     zeebeExtension.addVariablesToScope(processInstanceKey, UPDATED_VARIABLES, true);
-    waitUntilMinimumVariableDocumentsWithUpdatedIntentExportedCount(5);
+    waitUntilMinimumVariableDocumentsWithUpdatedIntentForInstanceExportedCount(
+        5, processInstanceKey);
 
     // when
     importAllZeebeEntitiesFromLastIndex();
@@ -90,10 +90,16 @@ public class ZeebeVariableUpdateImportIT extends AbstractCCSMIT {
     final long processInstanceKey2 =
         zeebeExtension.startProcessInstanceWithVariables(
             deployedProcess.getBpmnProcessId(), VARIABLES);
-    waitUntilMinimumVariableDocumentsWithCreatedIntentExportedCount(10);
+    waitUntilMinimumVariableDocumentsWithCreatedIntentForInstanceExportedCount(
+        5, processInstanceKey1);
+    waitUntilMinimumVariableDocumentsWithCreatedIntentForInstanceExportedCount(
+        5, processInstanceKey2);
     importAllZeebeEntitiesFromScratch();
     zeebeExtension.addVariablesToScope(processInstanceKey2, UPDATED_VARIABLES, true);
-    waitUntilMinimumVariableDocumentsWithUpdatedIntentExportedCount(10);
+    waitUntilMinimumVariableDocumentsWithUpdatedIntentForInstanceExportedCount(
+        5, processInstanceKey1);
+    waitUntilMinimumVariableDocumentsWithUpdatedIntentForInstanceExportedCount(
+        5, processInstanceKey2);
 
     // when
     importAllZeebeEntitiesFromLastIndex();
@@ -112,8 +118,9 @@ public class ZeebeVariableUpdateImportIT extends AbstractCCSMIT {
     // given
     final long processInstanceKey =
         deployProcessAndStartProcessInstanceWithVariables(Map.of("var1", "someValue"));
-    waitUntilMinimumProcessInstanceEventsExportedCount(1);
-    waitUntilMinimumVariableDocumentsWithCreatedIntentExportedCount(1);
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(1, processInstanceKey);
+    waitUntilMinimumVariableDocumentsWithCreatedIntentForInstanceExportedCount(
+        1, processInstanceKey);
     importAllZeebeEntitiesFromScratch();
     ProcessInstanceDto savedProcessInstance =
         getProcessInstanceForId(String.valueOf(processInstanceKey));
@@ -121,13 +128,15 @@ public class ZeebeVariableUpdateImportIT extends AbstractCCSMIT {
         getFlowNodeInstanceIdFromProcessInstanceForActivity(savedProcessInstance, SERVICE_TASK);
     zeebeExtension.addVariablesToScope(
         Long.parseLong(flowNodeId), Map.of("var1", "flowNodeInstanceScopeValue"), true);
-    waitUntilMinimumVariableDocumentsWithCreatedIntentExportedCount(2);
+    waitUntilMinimumVariableDocumentsWithCreatedIntentForInstanceExportedCount(
+        2, processInstanceKey);
     importAllZeebeEntitiesFromLastIndex();
     final Map<String, Object> newVariables = new HashMap<>();
     newVariables.put("var1", null);
     zeebeExtension.addVariablesToScope(processInstanceKey, newVariables, true);
     zeebeExtension.addVariablesToScope(Long.parseLong(flowNodeId), newVariables, true);
-    waitUntilMinimumVariableDocumentsWithUpdatedIntentExportedCount(2);
+    waitUntilMinimumVariableDocumentsWithUpdatedIntentForInstanceExportedCount(
+        2, processInstanceKey);
 
     // when
     importAllZeebeEntitiesFromLastIndex();
@@ -150,8 +159,9 @@ public class ZeebeVariableUpdateImportIT extends AbstractCCSMIT {
     // given
     final long processInstanceKey =
         deployProcessAndStartProcessInstanceWithVariables(Map.of("var1", "someValue"));
-    waitUntilMinimumProcessInstanceEventsExportedCount(4);
-    waitUntilMinimumVariableDocumentsWithCreatedIntentExportedCount(1);
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(4, processInstanceKey);
+    waitUntilMinimumVariableDocumentsWithCreatedIntentForInstanceExportedCount(
+        1, processInstanceKey);
     importAllZeebeEntitiesFromScratch();
     ProcessInstanceDto savedProcessInstance =
         getProcessInstanceForId(String.valueOf(processInstanceKey));
@@ -159,11 +169,13 @@ public class ZeebeVariableUpdateImportIT extends AbstractCCSMIT {
         getFlowNodeInstanceIdFromProcessInstanceForActivity(savedProcessInstance, SERVICE_TASK);
     zeebeExtension.addVariablesToScope(
         Long.parseLong(flowNodeId), Map.of("var1", "flowNodeInstanceScopeValue"), true);
-    waitUntilMinimumVariableDocumentsWithCreatedIntentExportedCount(2);
+    waitUntilMinimumVariableDocumentsWithCreatedIntentForInstanceExportedCount(
+        2, processInstanceKey);
     importAllZeebeEntitiesFromLastIndex();
     zeebeExtension.addVariablesToScope(
         processInstanceKey, Map.of("var1", "processInstanceScopeUpdatedValue"), true);
-    waitUntilMinimumVariableDocumentsWithUpdatedIntentExportedCount(1);
+    waitUntilMinimumVariableDocumentsWithUpdatedIntentForInstanceExportedCount(
+        1, processInstanceKey);
 
     // when
     importAllZeebeEntitiesFromLastIndex();
@@ -188,8 +200,9 @@ public class ZeebeVariableUpdateImportIT extends AbstractCCSMIT {
     final long processInstanceKey =
         deployProcessAndStartProcessInstanceWithVariables(
             Map.of("var1", "processInstanceScopeValue"));
-    waitUntilMinimumProcessInstanceEventsExportedCount(1);
-    waitUntilMinimumVariableDocumentsWithCreatedIntentExportedCount(1);
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(1, processInstanceKey);
+    waitUntilMinimumVariableDocumentsWithCreatedIntentForInstanceExportedCount(
+        1, processInstanceKey);
     importAllZeebeEntitiesFromScratch();
     ProcessInstanceDto savedProcessInstance =
         getProcessInstanceForId(String.valueOf(processInstanceKey));
@@ -197,11 +210,13 @@ public class ZeebeVariableUpdateImportIT extends AbstractCCSMIT {
         getFlowNodeInstanceIdFromProcessInstanceForActivity(savedProcessInstance, SERVICE_TASK);
     zeebeExtension.addVariablesToScope(
         Long.parseLong(flowNodeId), Map.of("var1", "flowNodeInstanceScopeValue"), true);
-    waitUntilMinimumVariableDocumentsWithCreatedIntentExportedCount(2);
+    waitUntilMinimumVariableDocumentsWithCreatedIntentForInstanceExportedCount(
+        2, processInstanceKey);
     importAllZeebeEntitiesFromLastIndex();
     zeebeExtension.addVariablesToScope(
         Long.parseLong(flowNodeId), Map.of("var1", "flowNodeInstanceScopeUpdatedValue"), true);
-    waitUntilMinimumVariableDocumentsWithUpdatedIntentExportedCount(1);
+    waitUntilMinimumVariableDocumentsWithUpdatedIntentForInstanceExportedCount(
+        1, processInstanceKey);
 
     // when
     importAllZeebeEntitiesFromLastIndex();
@@ -226,13 +241,15 @@ public class ZeebeVariableUpdateImportIT extends AbstractCCSMIT {
   public void zeebeVariableImport_updateTheTypeOfVariables() {
     // given
     final long processInstanceKey = deployProcessAndStartProcessInstanceWithVariables(VARIABLES);
-    waitUntilMinimumVariableDocumentsWithCreatedIntentExportedCount(5);
+    waitUntilMinimumVariableDocumentsWithCreatedIntentForInstanceExportedCount(
+        5, processInstanceKey);
     importAllZeebeEntitiesFromScratch();
     zeebeExtension.addVariablesToScope(
         processInstanceKey,
         Map.of("var1", false, "var2", "someValue", "var3", "", "var4", true, "var5", 123.0),
         true);
-    waitUntilMinimumVariableDocumentsWithUpdatedIntentExportedCount(5);
+    waitUntilMinimumVariableDocumentsWithUpdatedIntentForInstanceExportedCount(
+        5, processInstanceKey);
 
     // when
     importAllZeebeEntitiesFromLastIndex();
@@ -258,7 +275,8 @@ public class ZeebeVariableUpdateImportIT extends AbstractCCSMIT {
       zeebeVariableImport_updateFlowNodeLevelVariableWithPropagationOnlyUpdatesFlowNodeVariable() {
     // given
     final ProcessInstanceEvent processInstanceEvent = deployProcessAndStartProcessInstance();
-    waitUntilMinimumProcessInstanceEventsExportedCount(4);
+    waitUntilMinimumProcessInstanceEventsForInstanceExportedCount(
+        4, processInstanceEvent.getProcessInstanceKey());
     importAllZeebeEntitiesFromScratch();
     ProcessInstanceDto savedProcessInstance =
         getProcessInstanceForId(String.valueOf(processInstanceEvent.getProcessInstanceKey()));
@@ -270,11 +288,13 @@ public class ZeebeVariableUpdateImportIT extends AbstractCCSMIT {
         true);
     zeebeExtension.addVariablesToScope(
         Long.parseLong(flowNodeId), Map.of("var1", "flowNodeInstanceScopeValue"), true);
-    waitUntilMinimumVariableDocumentsWithCreatedIntentExportedCount(2);
+    waitUntilMinimumVariableDocumentsWithCreatedIntentForInstanceExportedCount(
+        2, processInstanceEvent.getProcessInstanceKey());
     importAllZeebeEntitiesFromLastIndex();
     zeebeExtension.addVariablesToScope(
         Long.parseLong(flowNodeId), Map.of("var1", "updatedValue"), false);
-    waitUntilMinimumVariableDocumentsWithUpdatedIntentExportedCount(1);
+    waitUntilMinimumVariableDocumentsWithUpdatedIntentForInstanceExportedCount(
+        1, processInstanceEvent.getProcessInstanceKey());
 
     // when
     importAllZeebeEntitiesFromLastIndex();
@@ -298,12 +318,14 @@ public class ZeebeVariableUpdateImportIT extends AbstractCCSMIT {
     // given
     final long processInstanceKey =
         deployProcessAndStartProcessInstanceWithVariables(Map.of("var1", "someValue"));
-    waitUntilMinimumVariableDocumentsWithCreatedIntentExportedCount(1);
+    waitUntilMinimumVariableDocumentsWithCreatedIntentForInstanceExportedCount(
+        1, processInstanceKey);
     importAllZeebeEntitiesFromScratch();
     zeebeExtension.addVariablesToScope(processInstanceKey, Map.of("var1", "firstUpdate"), true);
     zeebeExtension.addVariablesToScope(processInstanceKey, Map.of("var1", "secondUpdate"), true);
     importAllZeebeEntitiesFromLastIndex();
-    waitUntilMinimumVariableDocumentsWithUpdatedIntentExportedCount(2);
+    waitUntilMinimumVariableDocumentsWithUpdatedIntentForInstanceExportedCount(
+        2, processInstanceKey);
 
     // when
     importAllZeebeEntitiesFromLastIndex();
@@ -330,13 +352,16 @@ public class ZeebeVariableUpdateImportIT extends AbstractCCSMIT {
     embeddedOptimizeExtension.reloadConfiguration();
     final long processInstanceKey =
         deployProcessAndStartProcessInstanceWithVariables(Map.of("var1", "someValue"));
-    waitUntilMinimumVariableDocumentsWithCreatedIntentExportedCount(1);
+    waitUntilMinimumVariableDocumentsWithCreatedIntentForInstanceExportedCount(
+        1, processInstanceKey);
     importAllZeebeEntitiesFromScratch();
     zeebeExtension.addVariablesToScope(processInstanceKey, Map.of("var1", "firstUpdate"), true);
-    waitUntilMinimumVariableDocumentsWithUpdatedIntentExportedCount(1);
+    waitUntilMinimumVariableDocumentsWithUpdatedIntentForInstanceExportedCount(
+        1, processInstanceKey);
     importAllZeebeEntitiesFromLastIndex();
     zeebeExtension.addVariablesToScope(processInstanceKey, Map.of("var1", "secondUpdate"), true);
-    waitUntilMinimumVariableDocumentsWithUpdatedIntentExportedCount(2);
+    waitUntilMinimumVariableDocumentsWithUpdatedIntentForInstanceExportedCount(
+        2, processInstanceKey);
 
     // when
     importAllZeebeEntitiesFromLastIndex();
@@ -364,13 +389,15 @@ public class ZeebeVariableUpdateImportIT extends AbstractCCSMIT {
     final Map<String, Object> variables = new HashMap<>();
     variables.put("objectVar", objectVar);
     final long processInstanceKey = deployProcessAndStartProcessInstanceWithVariables(variables);
-    waitUntilMinimumVariableDocumentsWithCreatedIntentExportedCount(1);
+    waitUntilMinimumVariableDocumentsWithCreatedIntentForInstanceExportedCount(
+        1, processInstanceKey);
     importAllZeebeEntitiesFromScratch();
 
     objectVar.put("age", 29);
     objectVar.put("likes", List.of("optimize", "garlic", "tofu"));
     zeebeExtension.addVariablesToScope(processInstanceKey, variables, true);
-    waitUntilMinimumVariableDocumentsWithUpdatedIntentExportedCount(1);
+    waitUntilMinimumVariableDocumentsWithUpdatedIntentForInstanceExportedCount(
+        1, processInstanceKey);
 
     // when
     importAllZeebeEntitiesFromLastIndex();
@@ -424,24 +451,16 @@ public class ZeebeVariableUpdateImportIT extends AbstractCCSMIT {
                     "No process instance with id " + processInstanceId + "found"));
   }
 
-  private void waitUntilMinimumVariableDocumentsWithCreatedIntentExportedCount(
-      final int minExportedEventCount) {
-    waitUntilMinimumVariableDocumentsWithIntentExportedCount(
-        minExportedEventCount, VariableIntent.CREATED);
+  private void waitUntilMinimumVariableDocumentsWithCreatedIntentForInstanceExportedCount(
+      final int minExportedEventCount, final long processInstanceKey) {
+    waitUntilMinimumVariableDocumentsWithIntentForInstanceExportedCount(
+        minExportedEventCount, VariableIntent.CREATED, processInstanceKey);
   }
 
-  private void waitUntilMinimumVariableDocumentsWithUpdatedIntentExportedCount(
-      final int minExportedEventCount) {
-    waitUntilMinimumVariableDocumentsWithIntentExportedCount(
-        minExportedEventCount, VariableIntent.UPDATED);
-  }
-
-  private void waitUntilMinimumVariableDocumentsWithIntentExportedCount(
-      final int minExportedEventCount, final VariableIntent intent) {
-    final TermsQueryContainer variableBoolQuery = new TermsQueryContainer();
-    variableBoolQuery.addTermQuery(ZeebeVariableRecordDto.Fields.intent, intent.name());
-    waitUntilMinimumDataExportedCount(
-        minExportedEventCount, DatabaseConstants.ZEEBE_VARIABLE_INDEX_NAME, variableBoolQuery);
+  private void waitUntilMinimumVariableDocumentsWithUpdatedIntentForInstanceExportedCount(
+      final int minExportedEventCount, final long processInstanceKey) {
+    waitUntilMinimumVariableDocumentsWithIntentForInstanceExportedCount(
+        minExportedEventCount, VariableIntent.UPDATED, processInstanceKey);
   }
 
   private void assertThatVariablesHaveBeenImportedForProcessInstance(

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/importing/processdefinition/ZeebeProcessDefinitionImportIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/importing/processdefinition/ZeebeProcessDefinitionImportIT.java
@@ -39,6 +39,7 @@ import io.camunda.optimize.dto.optimize.DefinitionType;
 import io.camunda.optimize.dto.optimize.FlowNodeDataDto;
 import io.camunda.optimize.dto.optimize.ProcessDefinitionOptimizeDto;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
+import io.camunda.optimize.service.util.IdGenerator;
 import io.camunda.optimize.util.ZeebeBpmnModels;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
@@ -139,11 +140,12 @@ public class ZeebeProcessDefinitionImportIT extends AbstractCCSMIT {
   @Test
   public void importZeebeProcess_multipleProcessesDeployed() {
     // given
-    final String firstProcessName = "firstProcess";
+    final String firstProcessName = "firstProcess-" + IdGenerator.getNextId();
     deployProcessAndStartInstance(createSimpleServiceTaskProcess(firstProcessName));
-    final String secondProcessName = "secondProcess";
+    final String secondProcessName = "secondProcess-" + IdGenerator.getNextId();
     deployProcessAndStartInstance(createSimpleServiceTaskProcess(secondProcessName));
-    waitUntilNumberOfDefinitionsExported(2);
+    waitUntilDefinitionWithIdExported(firstProcessName);
+    waitUntilDefinitionWithIdExported(secondProcessName);
 
     // when
     importAllZeebeEntitiesFromScratch();
@@ -158,7 +160,7 @@ public class ZeebeProcessDefinitionImportIT extends AbstractCCSMIT {
   @Test
   public void importZeebeProcess_multipleProcessesDeployedOnDifferentDays() {
     // given
-    final String firstProcessName = "firstProcess";
+    final String firstProcessName = "firstProcess-" + IdGenerator.getNextId();
     deployProcessAndStartInstance(createSimpleServiceTaskProcess(firstProcessName));
 
     try {
@@ -166,7 +168,7 @@ public class ZeebeProcessDefinitionImportIT extends AbstractCCSMIT {
     } catch (final IOException | InterruptedException e) {
       throw new OptimizeRuntimeException(e);
     }
-    final String secondProcessName = "secondProcess";
+    final String secondProcessName = "secondProcess-" + IdGenerator.getNextId();
     deployProcessAndStartInstance(createSimpleServiceTaskProcess(secondProcessName));
     waitUntilDefinitionWithIdExported(firstProcessName);
     waitUntilDefinitionWithIdExported(secondProcessName);
@@ -215,11 +217,12 @@ public class ZeebeProcessDefinitionImportIT extends AbstractCCSMIT {
         .setMaxImportPageSize(1);
     embeddedOptimizeExtension.reloadConfiguration();
 
-    final String firstProcessName = "firstProcess";
+    final String firstProcessName = "firstProcess-" + IdGenerator.getNextId();
     deployProcessAndStartInstance(createSimpleServiceTaskProcess(firstProcessName));
-    final String secondProcessName = "secondProcess";
+    final String secondProcessName = "secondProcess-" + IdGenerator.getNextId();
     deployProcessAndStartInstance(createSimpleServiceTaskProcess(secondProcessName));
-    waitUntilNumberOfDefinitionsExported(2);
+    waitUntilDefinitionWithIdExported(firstProcessName);
+    waitUntilDefinitionWithIdExported(secondProcessName);
 
     // when
     importAllZeebeEntitiesFromScratch();

--- a/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/DatabaseIntegrationTestExtension.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/DatabaseIntegrationTestExtension.java
@@ -118,6 +118,10 @@ public class DatabaseIntegrationTestExtension implements BeforeEachCallback, Aft
     databaseTestService.deleteAllZeebeRecordsForPrefix(zeebeRecordPrefix);
   }
 
+  public void deleteAllZeebeIndicesForPrefix(final String zeebeRecordPrefix) {
+    databaseTestService.deleteAllZeebeIndicesForPrefix(zeebeRecordPrefix);
+  }
+
   public void deleteAllOtherZeebeRecordsWithPrefix(
       final String zeebeRecordPrefix, final String recordsToKeep) {
     databaseTestService.deleteAllOtherZeebeRecordsWithPrefix(zeebeRecordPrefix, recordsToKeep);

--- a/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/ZeebeExtension.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/ZeebeExtension.java
@@ -31,30 +31,51 @@ import io.camunda.zeebe.qa.util.cluster.TestZeebePort;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.extension.AfterEachCallback;
-import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.slf4j.Logger;
 import org.testcontainers.Testcontainers;
 
 /** Embedded Zeebe Extension */
-public class ZeebeExtension implements BeforeEachCallback, AfterEachCallback {
+public class ZeebeExtension implements BeforeAllCallback, AfterAllCallback {
 
   private static final Logger LOG = org.slf4j.LoggerFactory.getLogger(ZeebeExtension.class);
 
-  private final TestStandaloneBroker standaloneBroker;
+  private TestStandaloneBroker standaloneBroker;
   private CamundaClient camundaClient;
 
   private String zeebeRecordPrefix;
 
-  public ZeebeExtension() {
+  /** Keys of all process instances started during the current test. */
+  private final Set<Long> startedInstanceKeys = ConcurrentHashMap.newKeySet();
 
+  public ZeebeExtension() {
     System.setProperty("management.endpoints.web.exposure.include", "*");
+  }
+
+  @Override
+  public void beforeAll(final ExtensionContext extensionContext) {
+    zeebeRecordPrefix = ZeebeConstants.ZEEBE_RECORD_TEST_PREFIX + "-" + IdGenerator.getNextId();
+    final var dbType = IntegrationTestConfigurationUtil.getDatabaseType();
+    Testcontainers.exposeHostPorts(9200);
+    buildAndStartBroker(dbType);
+    createClient();
+  }
+
+  private void buildAndStartBroker(final DatabaseType dbType) {
+    final String exporterClassName =
+        dbType.equals(DatabaseType.OPENSEARCH)
+            ? ZEEBE_OPENSEARCH_EXPORTER
+            : ZEEBE_ELASTICSEARCH_EXPORTER;
 
     standaloneBroker =
         new TestStandaloneBroker()
@@ -74,20 +95,6 @@ public class ZeebeExtension implements BeforeEachCallback, AfterEachCallback {
             .withBasicAuth()
             .withUnauthenticatedAccess()
             .withAuthorizationsDisabled();
-  }
-
-  @Override
-  public void beforeEach(final ExtensionContext extensionContext) {
-    zeebeRecordPrefix = ZeebeConstants.ZEEBE_RECORD_TEST_PREFIX + "-" + IdGenerator.getNextId();
-    final var dbType = IntegrationTestConfigurationUtil.getDatabaseType();
-    final String zeebeExporterClassName;
-
-    if (dbType.equals(DatabaseType.OPENSEARCH)) {
-      zeebeExporterClassName = ZEEBE_OPENSEARCH_EXPORTER;
-    } else {
-      zeebeExporterClassName = ZEEBE_ELASTICSEARCH_EXPORTER;
-    }
-    Testcontainers.exposeHostPorts(9200);
 
     standaloneBroker
         .withUnifiedConfig(
@@ -116,7 +123,7 @@ public class ZeebeExtension implements BeforeEachCallback, AfterEachCallback {
         .withExporter(
             dbType.getId() + "exporter",
             cfg -> {
-              cfg.setClassName(zeebeExporterClassName);
+              cfg.setClassName(exporterClassName);
               cfg.setArgs(
                   Map.of(
                       "index",
@@ -144,13 +151,44 @@ public class ZeebeExtension implements BeforeEachCallback, AfterEachCallback {
                 "camunda.operate." + dbType.getId() + ".url",
                 "http://localhost:9200"))
         .start();
-    createClient();
   }
 
   @Override
-  public void afterEach(final ExtensionContext extensionContext) {
+  public void afterAll(final ExtensionContext extensionContext) {
     standaloneBroker.stop();
     destroyClient();
+  }
+
+  /**
+   * Cancels all still-running process instances started during the current test and returns the
+   * keys of the instances that were <em>successfully cancelled</em> (i.e., were still running).
+   * Instances that had already completed or terminated are silently skipped and are <em>not</em>
+   * included in the returned set.
+   *
+   * <p>Callers should wait for a PROCESS-level ELEMENT_TERMINATED record for every key in the
+   * returned set before running index cleanup. That record is the last one the broker generates for
+   * a cancelled instance; once it appears in ES every earlier record for that instance — including
+   * asynchronously-exported variable records — is guaranteed to already be there.
+   *
+   * <p>Already-completed instances are excluded because their terminal ELEMENT_COMPLETED record may
+   * have been deleted by a mid-test cleanup (e.g. {@code
+   * removeAllZeebeExportRecordsExceptUserTaskRecords}). Zeebe will not re-export it, so waiting for
+   * it would block forever. The retry cleanup loop in {@code after()} handles any residual records
+   * from completed instances without blocking.
+   */
+  public Set<Long> cancelAllStartedInstances() {
+    final Set<Long> keys = Set.copyOf(startedInstanceKeys);
+    startedInstanceKeys.clear();
+    final Set<Long> cancelledKeys = new HashSet<>();
+    for (final long key : keys) {
+      try {
+        camundaClient.newCancelInstanceCommand(key).send().join();
+        cancelledKeys.add(key);
+      } catch (final Exception e) {
+        // Instance already completed or terminated — no new terminal record will be generated.
+      }
+    }
+    return cancelledKeys;
   }
 
   public void createClient() {
@@ -191,7 +229,9 @@ public class ZeebeExtension implements BeforeEachCallback, AfterEachCallback {
                 .bpmnProcessId(bpmnProcessId)
                 .latestVersion()
                 .variables(variables);
-    return createProcessInstanceCommandStep3.send().join().getProcessInstanceKey();
+    final long key = createProcessInstanceCommandStep3.send().join().getProcessInstanceKey();
+    startedInstanceKeys.add(key);
+    return key;
   }
 
   public void startProcessInstanceWithSignal(final String signalName) {
@@ -204,21 +244,24 @@ public class ZeebeExtension implements BeforeEachCallback, AfterEachCallback {
 
   public long startProcessInstanceByConditionalEvaluation(
       final long processDefinitionKey, final Map<String, Object> variables) {
-    return camundaClient
-        .newEvaluateConditionalCommand()
-        .variables(variables)
-        .processDefinitionKey(processDefinitionKey)
-        .send()
-        .join()
-        .getProcessInstances()
-        .stream()
-        .findFirst()
-        .map(ProcessInstanceReference::getProcessInstanceKey)
-        .orElseThrow(
-            () ->
-                new RuntimeException(
-                    "No process instance created by conditional evaluation for process definition key: "
-                        + processDefinitionKey));
+    final long key =
+        camundaClient
+            .newEvaluateConditionalCommand()
+            .variables(variables)
+            .processDefinitionKey(processDefinitionKey)
+            .send()
+            .join()
+            .getProcessInstances()
+            .stream()
+            .findFirst()
+            .map(ProcessInstanceReference::getProcessInstanceKey)
+            .orElseThrow(
+                () ->
+                    new RuntimeException(
+                        "No process instance created by conditional evaluation for process definition key: "
+                            + processDefinitionKey));
+    startedInstanceKeys.add(key);
+    return key;
   }
 
   public void startProcessInstanceBeforeElementWithIds(
@@ -229,7 +272,8 @@ public class ZeebeExtension implements BeforeEachCallback, AfterEachCallback {
     for (final String elementId : elementIds) {
       createProcessInstanceCommandStep3.startBeforeElement(elementId);
     }
-    createProcessInstanceCommandStep3.send().join().getProcessInstanceKey();
+    final long key = createProcessInstanceCommandStep3.send().join().getProcessInstanceKey();
+    startedInstanceKeys.add(key);
   }
 
   public void addVariablesToScope(
@@ -251,11 +295,14 @@ public class ZeebeExtension implements BeforeEachCallback, AfterEachCallback {
   public ProcessInstanceEvent startProcessInstanceForProcess(final String processId) {
     final CreateProcessInstanceCommandStep1.CreateProcessInstanceCommandStep3 startInstanceCommand =
         camundaClient.newCreateInstanceCommand().bpmnProcessId(processId).latestVersion();
-    return startInstanceCommand.send().join();
+    final ProcessInstanceEvent event = startInstanceCommand.send().join();
+    startedInstanceKeys.add(event.getProcessInstanceKey());
+    return event;
   }
 
   public void cancelProcessInstance(final long processInstanceKey) {
     camundaClient.newCancelInstanceCommand(processInstanceKey).send().join();
+    startedInstanceKeys.remove(processInstanceKey);
   }
 
   public void completeTaskForInstanceWithJobType(final String jobType) {

--- a/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/db/DatabaseTestService.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/db/DatabaseTestService.java
@@ -135,6 +135,9 @@ public abstract class DatabaseTestService {
 
   public abstract void deleteAllZeebeRecordsForPrefix(final String zeebeRecordPrefix);
 
+  /** Physically deletes all indices matching the prefix. Call only from {@code @AfterAll}. */
+  public abstract void deleteAllZeebeIndicesForPrefix(final String zeebeRecordPrefix);
+
   public abstract void deleteAllOtherZeebeRecordsWithPrefix(
       final String zeebeRecordPrefix, final String recordsToKeep);
 

--- a/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/db/ElasticsearchDatabaseTestService.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/db/ElasticsearchDatabaseTestService.java
@@ -344,44 +344,86 @@ public class ElasticsearchDatabaseTestService extends DatabaseTestService {
 
   @Override
   public void deleteAllZeebeRecordsForPrefix(final String zeebeRecordPrefix) {
-    final String[] indicesToDelete;
+    // Force a refresh first so any records the exporter wrote without an explicit refresh become
+    // visible to the subsequent deleteByQuery. Without this, unrefreshed writes are invisible to
+    // the delete, pass the zero-count assertion, and then surface at the next automatic 1-second
+    // refresh — exactly when the next test starts. Two delete passes then catch any records that
+    // the exporter flushes in the window between the refresh and the delete's own refresh.
     try {
-      indicesToDelete =
-          getOptimizeElasticClient()
-              .getEsClient()
-              .indices()
-              .get(GetIndexRequest.of(r -> r.index(zeebeRecordPrefix + "*")))
-              .result()
-              .keySet()
-              .toArray(String[]::new);
+      getOptimizeElasticClient()
+          .getEsClient()
+          .indices()
+          .refresh(
+              RefreshRequest.of(
+                  r ->
+                      r.index(zeebeRecordPrefix + "*")
+                          .ignoreUnavailable(true)
+                          .allowNoIndices(true)));
+      for (int i = 0; i < 2; i++) {
+        getOptimizeElasticClient()
+            .getEsClient()
+            .deleteByQuery(
+                DeleteByQueryRequest.of(
+                    r ->
+                        r.index(zeebeRecordPrefix + "*")
+                            .query(Query.of(q -> q.matchAll(m -> m)))
+                            .refresh(true)
+                            .conflicts(Conflicts.Proceed)
+                            .allowNoIndices(true)
+                            .ignoreUnavailable(true)));
+      }
     } catch (final IOException e) {
       throw new OptimizeRuntimeException(e);
     }
-    if (indicesToDelete.length > 1) {
-      getOptimizeElasticClient().deleteIndexByRawIndexNames(indicesToDelete);
-    }
+  }
+
+  @Override
+  public void deleteAllZeebeIndicesForPrefix(final String zeebeRecordPrefix) {
+    // List matching indices explicitly first — wildcard DELETE is blocked by
+    // action.destructive_requires_name in the test ES cluster.
+    deleteZeebeIndicesByName(listZeebeIndicesForPrefix(zeebeRecordPrefix));
   }
 
   @Override
   public void deleteAllOtherZeebeRecordsWithPrefix(
       final String zeebeRecordPrefix, final String recordsToKeep) {
-    final String[] indicesToDelete;
+    final String[] indicesToDelete =
+        Arrays.stream(listZeebeIndicesForPrefix(zeebeRecordPrefix))
+            .filter(indexName -> !indexName.contains(recordsToKeep))
+            .toArray(String[]::new);
+    deleteZeebeIndicesByName(indicesToDelete);
+  }
+
+  private String[] listZeebeIndicesForPrefix(final String prefix) {
     try {
-      indicesToDelete =
-          getOptimizeElasticClient()
-              .elasticsearchClient()
-              .indices()
-              .get(GetIndexRequest.of(r -> r.index(zeebeRecordPrefix + "*")))
-              .result()
-              .keySet()
-              .stream()
-              .filter(indexName -> !indexName.contains(recordsToKeep))
-              .toArray(String[]::new);
+      return getOptimizeElasticClient()
+          .elasticsearchClient()
+          .indices()
+          .get(
+              GetIndexRequest.of(
+                  r -> r.index(prefix + "*").ignoreUnavailable(true).allowNoIndices(true)))
+          .result()
+          .keySet()
+          .toArray(String[]::new);
     } catch (final IOException e) {
       throw new OptimizeRuntimeException(e);
     }
-    if (indicesToDelete.length > 1) {
-      getOptimizeElasticClient().deleteIndexByRawIndexNames(indicesToDelete);
+  }
+
+  private void deleteZeebeIndicesByName(final String... indices) {
+    if (indices.length == 0) {
+      return;
+    }
+    // Wrap in a catch so that an ephemeral index (e.g. camunda-history-deletion in Zeebe 8.9)
+    // that vanishes between listing and deletion does not fail the cleanup.
+    try {
+      getOptimizeElasticClient().deleteIndexByRawIndexNames(indices);
+    } catch (final ElasticsearchException e) {
+      if ("index_not_found_exception".equals(e.error().type())) {
+        LOG.debug("Some Zeebe indices already gone by delete time, ignoring: {}", e.getMessage());
+      } else {
+        throw e;
+      }
     }
   }
 

--- a/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/db/OpenSearchDatabaseTestService.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/db/OpenSearchDatabaseTestService.java
@@ -29,7 +29,6 @@ import io.camunda.optimize.dto.zeebe.ZeebeRecordDto;
 import io.camunda.optimize.dto.zeebe.process.ZeebeProcessInstanceDataDto;
 import io.camunda.optimize.exception.OptimizeIntegrationTestException;
 import io.camunda.optimize.service.db.DatabaseClient;
-import io.camunda.optimize.service.db.os.ExtendedOpenSearchClient;
 import io.camunda.optimize.service.db.os.OptimizeOpenSearchClient;
 import io.camunda.optimize.service.db.os.builders.OptimizeIndexOperationOS;
 import io.camunda.optimize.service.db.os.client.dsl.AggregationDSL;
@@ -77,6 +76,7 @@ import java.util.stream.StreamSupport;
 import org.jetbrains.annotations.NotNull;
 import org.mockserver.integration.ClientAndServer;
 import org.opensearch.client.json.JsonData;
+import org.opensearch.client.opensearch._types.Conflicts;
 import org.opensearch.client.opensearch._types.Refresh;
 import org.opensearch.client.opensearch._types.aggregations.Aggregate;
 import org.opensearch.client.opensearch._types.aggregations.Aggregation;
@@ -86,6 +86,7 @@ import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch.cluster.PutClusterSettingsRequest;
 import org.opensearch.client.opensearch.core.BulkRequest;
+import org.opensearch.client.opensearch.core.DeleteByQueryRequest;
 import org.opensearch.client.opensearch.core.IndexRequest;
 import org.opensearch.client.opensearch.core.IndexResponse;
 import org.opensearch.client.opensearch.core.SearchRequest;
@@ -101,7 +102,6 @@ import org.opensearch.client.opensearch.indices.ExistsRequest;
 import org.opensearch.client.opensearch.indices.ExistsTemplateRequest;
 import org.opensearch.client.opensearch.indices.GetAliasRequest;
 import org.opensearch.client.opensearch.indices.GetAliasResponse;
-import org.opensearch.client.opensearch.indices.GetIndexResponse;
 import org.opensearch.client.opensearch.indices.GetMappingRequest;
 import org.opensearch.client.opensearch.indices.GetMappingResponse;
 import org.opensearch.client.opensearch.indices.IndexSettings;
@@ -125,7 +125,6 @@ public class OpenSearchDatabaseTestService extends DatabaseTestService {
   private String opensearchDatabaseVersion;
 
   private OptimizeOpenSearchClient prefixAwareOptimizeOpenSearchClient;
-  private ExtendedOpenSearchClient extendedOpenSearchClient;
 
   public OpenSearchDatabaseTestService(final String customIndexPrefix, final boolean haveToClean) {
     super(customIndexPrefix, haveToClean);
@@ -303,47 +302,87 @@ public class OpenSearchDatabaseTestService extends DatabaseTestService {
 
   @Override
   public void deleteAllZeebeRecordsForPrefix(final String zeebeRecordPrefix) {
-    final GetIndexResponse allIndices =
-        getOptimizeOpenSearchClient()
-            .getRichOpenSearchClient()
-            .index()
-            .get(RequestDSL.getIndexRequestBuilder("*").ignoreUnavailable(true));
-
-    final String[] indicesToDelete =
-        allIndices.result().keySet().stream()
-            .filter(indexName -> indexName.contains(zeebeRecordPrefix))
-            .toArray(String[]::new);
-
-    if (indicesToDelete.length > 1) {
-      deleteIndices(indicesToDelete);
+    // Force a refresh first so any records the exporter wrote without an explicit refresh become
+    // visible to the subsequent deleteByQuery. Without this, unrefreshed writes are invisible to
+    // the delete, pass the zero-count assertion, and then surface at the next automatic 1-second
+    // refresh — exactly when the next test starts. Two delete passes then catch any records that
+    // the exporter flushes in the window between the refresh and the delete's own refresh.
+    try {
+      getOptimizeOpenSearchClient()
+          .getOpenSearchClient()
+          .indices()
+          .refresh(
+              new RefreshRequest.Builder()
+                  .index(zeebeRecordPrefix + "*")
+                  .ignoreUnavailable(true)
+                  .allowNoIndices(true)
+                  .build());
+    } catch (final Exception e) {
+      // No indices exist yet (e.g., first test in class) — nothing to refresh
     }
+    for (int i = 0; i < 2; i++) {
+      try {
+        getOptimizeOpenSearchClient()
+            .getOpenSearchClient()
+            .deleteByQuery(
+                DeleteByQueryRequest.of(
+                    r ->
+                        r.index(zeebeRecordPrefix + "*")
+                            .query(QueryDSL.matchAll())
+                            .refresh(Refresh.True)
+                            .conflicts(Conflicts.Proceed)));
+      } catch (final Exception e) {
+        // No indices exist yet (e.g., first test in class) — nothing to clean up
+        break;
+      }
+    }
+  }
+
+  @Override
+  public void deleteAllZeebeIndicesForPrefix(final String zeebeRecordPrefix) {
+    // Use the raw OS client directly — deleteIndices() applies the Optimize index prefix which
+    // would corrupt Zeebe index names.
+    deleteZeebeIndicesByName(listZeebeIndicesForPrefix(zeebeRecordPrefix));
   }
 
   @Override
   public void deleteAllOtherZeebeRecordsWithPrefix(
       final String zeebeRecordPrefix, final String recordsToKeep) {
-    // Since we are retrieving zeebe records, we cannot use the rich opensearch client,
-    // because it will add optimize prefixes to the request
-    final GetIndexResponse allIndices;
+    final List<String> indicesToDelete =
+        listZeebeIndicesForPrefix(zeebeRecordPrefix).stream()
+            .filter(indexName -> !indexName.contains(recordsToKeep))
+            .toList();
+    deleteZeebeIndicesByName(indicesToDelete);
+  }
+
+  private List<String> listZeebeIndicesForPrefix(final String prefix) {
     try {
-      allIndices =
-          getOptimizeOpenSearchClient()
-              .getOpenSearchClient()
-              .indices()
-              .get(RequestDSL.getIndexRequestBuilder("*").ignoreUnavailable(true).build());
+      return getOptimizeOpenSearchClient()
+          .getOpenSearchClient()
+          .indices()
+          .get(RequestDSL.getIndexRequestBuilder(prefix + "*").ignoreUnavailable(true).build())
+          .result()
+          .keySet()
+          .stream()
+          .toList();
     } catch (final IOException e) {
-      throw new RuntimeException(e);
+      return List.of(); // No indices exist — nothing to clean
     }
+  }
 
-    final String[] indicesToDelete =
-        allIndices.result().keySet().stream()
-            .filter(
-                indexName ->
-                    indexName.contains(zeebeRecordPrefix) && !indexName.contains(recordsToKeep))
-            .toArray(String[]::new);
-
-    if (indicesToDelete.length > 1) {
-      deleteIndices(indicesToDelete);
+  private void deleteZeebeIndicesByName(final List<String> indices) {
+    if (indices.isEmpty()) {
+      return;
+    }
+    // Wrap in a catch so that an ephemeral index (e.g. camunda-history-deletion in Zeebe 8.9)
+    // that vanishes between listing and deletion does not fail the cleanup.
+    try {
+      getOptimizeOpenSearchClient()
+          .getOpenSearchClient()
+          .indices()
+          .delete(d -> d.index(indices).ignoreUnavailable(true));
+    } catch (final Exception e) {
+      LOG.debug("Some Zeebe indices already gone by delete time, ignoring: {}", e.getMessage());
     }
   }
 


### PR DESCRIPTION
## Description

Optimize CCSM integration tests previously started and stopped an embedded Zeebe broker for every test method, making the suite extremely slow. This PR restructures the test infrastructure so a single broker is shared across all tests in a class, with deterministic per-test data isolation replacing full broker restarts.                                                                

Infrastructure changes

ZeebeExtension — changed from BeforeEachCallback/AfterEachCallback to BeforeAllCallback/AfterAllCallback. All process-instance start methods now record started keys in startedInstanceKeys. A new cancelAllStartedInstances() cancels any still-running instances after each test and returns only the keys that were actually cancelled (already-completed instances are skipped). cancelProcessInstance() now removes the key from startedInstanceKeys to avoid a double-cancel attempt during cleanup.                                      

AbstractCCSMIT — replaced the simple deleteAllZeebeRecordsForPrefix call in @AfterEach with a three-step cleanup:                    
  1. Cancel all running instances and wait for their ELEMENT_TERMINATED record to appear in ES (guarantees all variable/incident records for those instances are already exported).                                                                                   
  2. Retry-loop that calls deleteByQuery (with explicit refresh) twice and asserts all processable records are gone — handles the window where the exporter flushes after the refresh but before the delete.                                                           
  3. An @AfterAll that physically deletes all Zeebe indices once the class finishes.                                                   
                                                                                    
Added a @BeforeEach @Order(1) safety net (ensureCleanZeebeState) that runs another cleanup pass before each test to catch records that arrived in the gap between @AfterEach and the next test start.                                                                  
   
DatabaseTestService / ES + OS implementations — deleteAllZeebeRecordsForPrefix now uses deleteByQuery with refresh=true and two passes instead of index deletion (preserving the index for the next test). A new deleteAllZeebeIndicesForPrefix handles physical index removal in @AfterAll.                                                                                                          
                                                                                                                                     
Test isolation fixes

Individual ITs (ZeebeIncidentImportIT, ZeebeProcessInstanceImportIT, ZeebeVariableCreationImportIT, ZeebeVariableUpdateImportIT, ZeebeProcessDefinitionImportIT) were updated to:
  - Scope all wait helpers to the specific process-instance key rather than the process ID, so records from concurrent or prior tests can't satisfy the wait.                                                                                                              
  - Filter assertions by instance key where needed.
  - Use new per-instance wait helpers added to AbstractCCSMIT (waitUntilMinimumProcessInstanceEventsForInstanceExportedCount, waitUntilMinimumVariableDocumentsForInstanceExportedCount, waitUntilInstanceRecordWithElementIdForInstanceExported).    
