### PR TITLE
Make PROCESS_INSTANCE_EXECUTION publish percentiles.

### DIFF
--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -1938,7 +1938,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 194
+            "y": 36
           },
           "id": 272,
           "options": {
@@ -1995,7 +1995,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 291
+            "y": 43
           },
           "id": 418,
           "options": {
@@ -2085,6 +2085,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": false,
                 "stacking": {
                   "group": "A",
@@ -2099,7 +2100,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -2114,7 +2116,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 291
+            "y": 43
           },
           "id": 421,
           "options": {
@@ -2186,6 +2188,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": false,
                 "stacking": {
                   "group": "A",
@@ -2200,7 +2203,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -2215,7 +2219,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 299
+            "y": 51
           },
           "id": 192,
           "options": {
@@ -2318,7 +2322,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   }
                 ]
               }
@@ -2329,7 +2334,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 299
+            "y": 51
           },
           "id": 602,
           "options": {
@@ -2424,6 +2429,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": false,
                 "stacking": {
                   "group": "A",
@@ -2438,7 +2444,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -2453,7 +2460,7 @@
             "h": 6,
             "w": 5,
             "x": 0,
-            "y": 307
+            "y": 59
           },
           "id": 194,
           "options": {
@@ -2504,6 +2511,9 @@
                 "cellOptions": {
                   "type": "auto"
                 },
+                "footer": {
+                  "reducers": []
+                },
                 "inspect": false
               },
               "mappings": [],
@@ -2511,7 +2521,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -2586,19 +2597,11 @@
             "h": 6,
             "w": 7,
             "x": 5,
-            "y": 307
+            "y": 59
           },
           "id": 199,
           "options": {
             "cellHeight": "sm",
-            "footer": {
-              "countRows": false,
-              "fields": "",
-              "reducer": [
-                "sum"
-              ],
-              "show": false
-            },
             "showHeader": true
           },
           "pluginVersion": "12.1.0",
@@ -2650,7 +2653,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -2725,19 +2729,11 @@
             "h": 4,
             "w": 7,
             "x": 12,
-            "y": 307
+            "y": 59
           },
           "id": 196,
           "options": {
             "cellHeight": "sm",
-            "footer": {
-              "countRows": false,
-              "fields": "",
-              "reducer": [
-                "sum"
-              ],
-              "show": false
-            },
             "showHeader": true
           },
           "pluginVersion": "12.1.0",
@@ -2864,19 +2860,11 @@
             "h": 4,
             "w": 5,
             "x": 19,
-            "y": 307
+            "y": 59
           },
           "id": 200,
           "options": {
             "cellHeight": "sm",
-            "footer": {
-              "countRows": false,
-              "fields": "",
-              "reducer": [
-                "sum"
-              ],
-              "show": false
-            },
             "showHeader": true
           },
           "pluginVersion": "12.1.0",
@@ -2921,6 +2909,9 @@
                 "cellOptions": {
                   "type": "auto"
                 },
+                "footer": {
+                  "reducers": []
+                },
                 "inspect": false
               },
               "mappings": [],
@@ -2928,7 +2919,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -3003,19 +2995,11 @@
             "h": 8,
             "w": 5,
             "x": 12,
-            "y": 311
+            "y": 63
           },
           "id": 198,
           "options": {
             "cellHeight": "sm",
-            "footer": {
-              "countRows": false,
-              "fields": "",
-              "reducer": [
-                "sum"
-              ],
-              "show": false
-            },
             "showHeader": true
           },
           "pluginVersion": "12.1.0",
@@ -3060,6 +3044,9 @@
                 "cellOptions": {
                   "type": "auto"
                 },
+                "footer": {
+                  "reducers": []
+                },
                 "inspect": false
               },
               "mappings": [],
@@ -3067,7 +3054,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -3142,19 +3130,11 @@
             "h": 8,
             "w": 7,
             "x": 17,
-            "y": 311
+            "y": 63
           },
           "id": 268,
           "options": {
             "cellHeight": "sm",
-            "footer": {
-              "countRows": false,
-              "fields": "",
-              "reducer": [
-                "sum"
-              ],
-              "show": false
-            },
             "showHeader": true
           },
           "pluginVersion": "12.1.0",
@@ -3218,6 +3198,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": false,
                 "stacking": {
                   "group": "A",
@@ -3232,7 +3213,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -3247,7 +3229,7 @@
             "h": 6,
             "w": 5,
             "x": 0,
-            "y": 313
+            "y": 65
           },
           "id": 189,
           "options": {
@@ -3300,6 +3282,9 @@
                 "cellOptions": {
                   "type": "auto"
                 },
+                "footer": {
+                  "reducers": []
+                },
                 "inspect": false
               },
               "mappings": [],
@@ -3307,7 +3292,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -3382,19 +3368,11 @@
             "h": 6,
             "w": 7,
             "x": 5,
-            "y": 313
+            "y": 65
           },
           "id": 201,
           "options": {
             "cellHeight": "sm",
-            "footer": {
-              "countRows": false,
-              "fields": "",
-              "reducer": [
-                "sum"
-              ],
-              "show": false
-            },
             "showHeader": true
           },
           "pluginVersion": "12.1.0",
@@ -3440,6 +3418,9 @@
                   "mode": "basic",
                   "type": "color-background"
                 },
+                "footer": {
+                  "reducers": []
+                },
                 "inspect": false
               },
               "links": [],
@@ -3479,7 +3460,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": 0
                   }
                 ]
               }
@@ -3505,21 +3487,13 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 319
+            "y": 71
           },
           "id": 604,
           "interval": "1s",
           "options": {
             "cellHeight": "sm",
-            "footer": {
-              "countRows": false,
-              "enablePagination": false,
-              "fields": "",
-              "reducer": [
-                "sum"
-              ],
-              "show": false
-            },
+            "enablePagination": false,
             "frameIndex": 0,
             "showHeader": true,
             "sortBy": []
@@ -3578,6 +3552,9 @@
                   "mode": "basic",
                   "type": "color-background"
                 },
+                "footer": {
+                  "reducers": []
+                },
                 "inspect": false
               },
               "links": [],
@@ -3607,7 +3584,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": 0
                   }
                 ]
               }
@@ -3633,21 +3611,13 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 319
+            "y": 71
           },
           "id": 605,
           "interval": "1s",
           "options": {
             "cellHeight": "sm",
-            "footer": {
-              "countRows": false,
-              "enablePagination": false,
-              "fields": "",
-              "reducer": [
-                "sum"
-              ],
-              "show": false
-            },
+            "enablePagination": false,
             "frameIndex": 0,
             "showHeader": true,
             "sortBy": []
@@ -3724,6 +3694,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": false,
                 "stacking": {
                   "group": "A",
@@ -3738,7 +3709,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -3753,7 +3725,7 @@
             "h": 6,
             "w": 24,
             "x": 0,
-            "y": 325
+            "y": 77
           },
           "id": 543,
           "options": {
@@ -3821,6 +3793,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": false,
                 "stacking": {
                   "group": "A",
@@ -3835,7 +3808,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -3850,7 +3824,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 331
+            "y": 83
           },
           "id": 561,
           "options": {
@@ -3922,6 +3896,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": false,
                 "stacking": {
                   "group": "A",
@@ -3936,7 +3911,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -3951,7 +3927,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 331
+            "y": 83
           },
           "id": 594,
           "options": {
@@ -4059,7 +4035,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 1387
+            "y": 4872
           },
           "id": 12,
           "options": {
@@ -4160,7 +4136,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 1387
+            "y": 4872
           },
           "id": 13,
           "options": {
@@ -4269,7 +4245,7 @@
             "h": 6,
             "w": 24,
             "x": 0,
-            "y": 1482
+            "y": 4967
           },
           "id": 3,
           "options": {
@@ -4379,7 +4355,7 @@
             "h": 6,
             "w": 9,
             "x": 0,
-            "y": 1488
+            "y": 4973
           },
           "id": 4,
           "options": {
@@ -4480,7 +4456,7 @@
             "h": 6,
             "w": 7,
             "x": 9,
-            "y": 1488
+            "y": 4973
           },
           "id": 266,
           "options": {
@@ -4581,7 +4557,7 @@
             "h": 6,
             "w": 8,
             "x": 16,
-            "y": 1488
+            "y": 4973
           },
           "id": 267,
           "options": {
@@ -4682,7 +4658,7 @@
             "h": 8,
             "w": 6,
             "x": 0,
-            "y": 1494
+            "y": 4979
           },
           "id": 290,
           "options": {
@@ -4781,7 +4757,7 @@
             "h": 8,
             "w": 6,
             "x": 6,
-            "y": 1494
+            "y": 4979
           },
           "id": 291,
           "options": {
@@ -4880,7 +4856,7 @@
             "h": 8,
             "w": 6,
             "x": 12,
-            "y": 1494
+            "y": 4979
           },
           "id": 288,
           "options": {
@@ -4979,7 +4955,7 @@
             "h": 8,
             "w": 6,
             "x": 18,
-            "y": 1494
+            "y": 4979
           },
           "id": 289,
           "options": {
@@ -5091,7 +5067,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1388
+            "y": 4873
           },
           "id": 102,
           "options": {
@@ -5148,7 +5124,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1388
+            "y": 4873
           },
           "id": 112,
           "options": {
@@ -5287,7 +5263,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1486
+            "y": 4971
           },
           "id": 105,
           "options": {
@@ -5343,7 +5319,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1486
+            "y": 4971
           },
           "id": 106,
           "options": {
@@ -5466,7 +5442,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1494
+            "y": 4979
           },
           "id": 182,
           "options": {
@@ -5623,7 +5599,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 39
+            "y": 3524
           },
           "id": 261,
           "options": {
@@ -5799,7 +5775,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 39
+            "y": 3524
           },
           "id": 659,
           "options": {
@@ -5922,7 +5898,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 48
+            "y": 3533
           },
           "id": 98,
           "options": {
@@ -6065,7 +6041,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 48
+            "y": 3533
           },
           "id": 35,
           "options": {
@@ -6173,7 +6149,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 56
+            "y": 3541
           },
           "id": 579,
           "options": {
@@ -6269,7 +6245,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 56
+            "y": 3541
           },
           "id": 580,
           "options": {
@@ -6369,7 +6345,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 64
+            "y": 3549
           },
           "id": 285,
           "options": {
@@ -6481,7 +6457,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 64
+            "y": 3549
           },
           "id": 286,
           "options": {
@@ -6607,7 +6583,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 1618
+            "y": 5103
           },
           "id": 614,
           "options": {
@@ -6712,7 +6688,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1627
+            "y": 5112
           },
           "id": 64,
           "options": {
@@ -6818,7 +6794,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1627
+            "y": 5112
           },
           "id": 294,
           "options": {
@@ -6967,7 +6943,7 @@
             "h": 5,
             "w": 24,
             "x": 0,
-            "y": 1619
+            "y": 5104
           },
           "id": 260,
           "options": {
@@ -7061,7 +7037,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1624
+            "y": 5109
           },
           "id": 379,
           "options": {
@@ -7158,7 +7134,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1624
+            "y": 5109
           },
           "id": 381,
           "options": {
@@ -7281,7 +7257,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1632
+            "y": 5117
           },
           "id": 37,
           "options": {
@@ -7390,7 +7366,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1632
+            "y": 5117
           },
           "id": 40,
           "options": {
@@ -7490,7 +7466,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1640
+            "y": 5125
           },
           "id": 122,
           "options": {
@@ -7591,7 +7567,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1640
+            "y": 5125
           },
           "id": 124,
           "options": {
@@ -7690,7 +7666,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1648
+            "y": 5133
           },
           "id": 126,
           "options": {
@@ -7788,7 +7764,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1648
+            "y": 5133
           },
           "id": 127,
           "options": {
@@ -7860,7 +7836,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1620
+            "y": 5105
           },
           "id": 339,
           "options": {
@@ -7957,7 +7933,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1620
+            "y": 5105
           },
           "id": 341,
           "options": {
@@ -8094,7 +8070,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 1628
+            "y": 5113
           },
           "id": 343,
           "options": {
@@ -8218,7 +8194,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 1628
+            "y": 5113
           },
           "id": 345,
           "options": {
@@ -8340,7 +8316,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1638
+            "y": 5123
           },
           "id": 347,
           "options": {
@@ -8437,7 +8413,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1638
+            "y": 5123
           },
           "id": 349,
           "options": {
@@ -8533,7 +8509,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1646
+            "y": 5131
           },
           "id": 353,
           "options": {
@@ -8629,7 +8605,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1646
+            "y": 5131
           },
           "id": 351,
           "options": {
@@ -8699,7 +8675,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1621
+            "y": 43
           },
           "id": 692,
           "options": {
@@ -8791,6 +8767,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": false,
                 "stacking": {
                   "group": "A",
@@ -8822,7 +8799,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1621
+            "y": 43
           },
           "id": 693,
           "options": {
@@ -8892,105 +8869,6 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "$DS_PROMETHEUS"
-          },
-          "description": "Shows the execution time of a process instance. This means the time (latency) between creating the instance and completing it.",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "scaleDistribution": {
-                  "type": "linear"
-                }
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 1629
-          },
-          "id": 132,
-          "options": {
-            "calculate": false,
-            "calculation": {},
-            "cellGap": 2,
-            "cellValues": {},
-            "color": {
-              "exponent": 0.5,
-              "fill": "#ef843c",
-              "mode": "scheme",
-              "reverse": false,
-              "scale": "exponential",
-              "scheme": "Spectral",
-              "steps": 128
-            },
-            "exemplars": {
-              "color": "rgba(255,0,255,0.7)"
-            },
-            "filterValues": {
-              "le": 1e-9
-            },
-            "legend": {
-              "show": true
-            },
-            "rowsFrame": {
-              "layout": "auto"
-            },
-            "showValue": "never",
-            "tooltip": {
-              "mode": "single",
-              "showColorScale": false,
-              "yHistogram": false
-            },
-            "yAxis": {
-              "axisPlacement": "left",
-              "reverse": false,
-              "unit": "dtdurations"
-            }
-          },
-          "pluginVersion": "12.1.0",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "editorMode": "code",
-              "expr": "sum(rate(zeebe_process_instance_execution_time_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (le)",
-              "format": "heatmap",
-              "interval": "30s",
-              "intervalFactor": 1,
-              "legendFormat": "{{le}}",
-              "range": true,
-              "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "$DS_PROMETHEUS"
-              },
-              "editorMode": "code",
-              "expr": "sum(rate(zeebe_process_instance_execution_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (le)",
-              "format": "heatmap",
-              "instant": false,
-              "legendFormat": "__auto",
-              "range": true,
-              "refId": "B"
-            }
-          ],
-          "title": "Process Instance Execution Time",
-          "type": "heatmap"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
           "description": "Shows the execution time of a process instance. This means the time (latency) between creating the instance and completing it. This metric is only tracked in memory, therefore if the PI was started before the last broker restart it wont be included in the metric.",
@@ -9023,6 +8901,7 @@
                   "type": "linear"
                 },
                 "showPoints": "never",
+                "showValues": false,
                 "spanNulls": false,
                 "stacking": {
                   "group": "A",
@@ -9053,9 +8932,9 @@
           },
           "gridPos": {
             "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 1629
+            "w": 24,
+            "x": 0,
+            "y": 51
           },
           "id": 222,
           "options": {
@@ -9104,7 +8983,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.50, sum(rate(zeebe_process_instance_execution_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval])) by (partition, le))",
+              "expr": "zeebe_process_instance_execution_time_seconds{quantile=\"0.5\", cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}  > 0",
               "instant": false,
               "legendFormat": "Partition: {{partition}} quantile-50th",
               "range": true,
@@ -9116,7 +8995,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.90, sum(rate(zeebe_process_instance_execution_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval])) by (partition, le))",
+              "expr": "zeebe_process_instance_execution_time_seconds{quantile=\"0.9\", cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}  > 0",
               "instant": false,
               "legendFormat": "Partition: {{partition}} quantile-90th",
               "range": true,
@@ -9128,7 +9007,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.99, sum(rate(zeebe_process_instance_execution_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval])) by (partition, le))",
+              "expr": "zeebe_process_instance_execution_time_seconds{quantile=\"0.99\", cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}  > 0",
               "instant": false,
               "legendFormat": "Partition: {{partition}} quantile-99th",
               "range": true,
@@ -9163,7 +9042,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1637
+            "y": 59
           },
           "id": 133,
           "options": {
@@ -9262,7 +9141,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1637
+            "y": 59
           },
           "id": 135,
           "options": {
@@ -9360,7 +9239,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 1645
+            "y": 67
           },
           "id": 28,
           "options": {
@@ -9456,6 +9335,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": false,
                 "stacking": {
                   "group": "A",
@@ -9470,7 +9350,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "red",
@@ -9485,7 +9366,7 @@
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 1652
+            "y": 74
           },
           "id": 593,
           "options": {
@@ -9573,7 +9454,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 1662
+            "y": 84
           },
           "id": 233,
           "options": {
@@ -9658,7 +9539,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 1662
+            "y": 84
           },
           "id": 269,
           "options": {
@@ -9742,7 +9623,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 1669
+            "y": 91
           },
           "id": 690,
           "options": {
@@ -9828,7 +9709,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 1669
+            "y": 91
           },
           "id": 691,
           "options": {
@@ -9914,7 +9795,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 1676
+            "y": 98
           },
           "id": 420,
           "options": {
@@ -9996,7 +9877,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 1676
+            "y": 98
           },
           "id": 419,
           "options": {
@@ -10118,7 +9999,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 1683
+            "y": 105
           },
           "id": 710,
           "options": {
@@ -10253,7 +10134,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 1683
+            "y": 105
           },
           "id": 711,
           "options": {
@@ -10387,7 +10268,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 1690
+            "y": 112
           },
           "id": 310,
           "options": {
@@ -10514,7 +10395,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 1690
+            "y": 112
           },
           "id": 311,
           "options": {
@@ -10600,7 +10481,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 1697
+            "y": 119
           },
           "id": 235,
           "options": {
@@ -10683,7 +10564,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 1697
+            "y": 119
           },
           "id": 234,
           "options": {
@@ -10822,7 +10703,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 1622
+            "y": 5107
           },
           "id": 26,
           "options": {
@@ -10921,7 +10802,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 1622
+            "y": 5107
           },
           "id": 27,
           "options": {
@@ -10989,7 +10870,7 @@
             "h": 9,
             "w": 8,
             "x": 0,
-            "y": 1629
+            "y": 5114
           },
           "id": 22,
           "options": {
@@ -11083,7 +10964,7 @@
             "h": 9,
             "w": 8,
             "x": 8,
-            "y": 1629
+            "y": 5114
           },
           "id": 23,
           "options": {
@@ -11177,7 +11058,7 @@
             "h": 9,
             "w": 8,
             "x": 16,
-            "y": 1629
+            "y": 5114
           },
           "id": 24,
           "options": {
@@ -11286,7 +11167,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 1395
+            "y": 4880
           },
           "id": 164,
           "options": {
@@ -11444,7 +11325,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1460
+            "y": 4945
           },
           "id": 166,
           "options": {
@@ -11565,7 +11446,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1460
+            "y": 4945
           },
           "id": 168,
           "options": {
@@ -11718,7 +11599,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 1396
+            "y": 4881
           },
           "id": 278,
           "options": {
@@ -11860,7 +11741,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 1396
+            "y": 4881
           },
           "id": 283,
           "options": {
@@ -11959,7 +11840,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 1460
+            "y": 4945
           },
           "id": 373,
           "options": {
@@ -12059,7 +11940,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 1468
+            "y": 4953
           },
           "id": 363,
           "options": {
@@ -12159,7 +12040,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 1468
+            "y": 4953
           },
           "id": 406,
           "options": {
@@ -12259,7 +12140,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 1475
+            "y": 4960
           },
           "id": 79,
           "options": {
@@ -12359,7 +12240,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 1475
+            "y": 4960
           },
           "id": 114,
           "options": {
@@ -12414,7 +12295,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 1482
+            "y": 4967
           },
           "id": 86,
           "options": {
@@ -12537,7 +12418,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 1482
+            "y": 4967
           },
           "id": 305,
           "options": {
@@ -12644,9 +12525,9 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 1482
+            "y": 4967
           },
-          "id": 305,
+          "id": 712,
           "options": {
             "legend": {
               "calcs": [],
@@ -12741,9 +12622,9 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 1482
+            "y": 4967
           },
-          "id": 305,
+          "id": 713,
           "options": {
             "legend": {
               "calcs": [],
@@ -12796,7 +12677,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1489
+            "y": 4974
           },
           "id": 70,
           "options": {
@@ -12942,7 +12823,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1489
+            "y": 4974
           },
           "id": 72,
           "options": {
@@ -13044,7 +12925,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1497
+            "y": 4982
           },
           "id": 432,
           "interval": "1s",
@@ -13188,7 +13069,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1497
+            "y": 4982
           },
           "id": 95,
           "interval": "1s",
@@ -13307,7 +13188,7 @@
             "h": 5,
             "w": 24,
             "x": 0,
-            "y": 1505
+            "y": 4990
           },
           "id": 205,
           "options": {
@@ -13434,7 +13315,7 @@
             "h": 5,
             "w": 24,
             "x": 0,
-            "y": 1510
+            "y": 4995
           },
           "id": 209,
           "options": {
@@ -13510,7 +13391,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 1515
+            "y": 5000
           },
           "id": 215,
           "options": {
@@ -13576,7 +13457,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 1515
+            "y": 5000
           },
           "id": 396,
           "options": {
@@ -13651,7 +13532,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 1397
+            "y": 4882
           },
           "id": 78,
           "options": {
@@ -13775,7 +13656,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 1460
+            "y": 4945
           },
           "id": 180,
           "options": {
@@ -13874,7 +13755,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 1468
+            "y": 4953
           },
           "id": 368,
           "options": {
@@ -13974,7 +13855,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 1468
+            "y": 4953
           },
           "id": 411,
           "options": {
@@ -14073,7 +13954,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 1475
+            "y": 4960
           },
           "id": 300,
           "options": {
@@ -14185,9 +14066,9 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 1475
+            "y": 4960
           },
-          "id": 300,
+          "id": 714,
           "options": {
             "legend": {
               "calcs": [],
@@ -14285,9 +14166,9 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 1475
+            "y": 4960
           },
-          "id": 300,
+          "id": 715,
           "options": {
             "legend": {
               "calcs": [],
@@ -14344,7 +14225,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 1475
+            "y": 4960
           },
           "id": 89,
           "options": {
@@ -14428,7 +14309,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 1482
+            "y": 4967
           },
           "id": 401,
           "options": {
@@ -14553,7 +14434,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 1482
+            "y": 4967
           },
           "id": 416,
           "options": {
@@ -14644,7 +14525,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 1489
+            "y": 4974
           },
           "id": 386,
           "options": {
@@ -14727,7 +14608,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 1489
+            "y": 4974
           },
           "id": 81,
           "options": {
@@ -14812,7 +14693,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 1495
+            "y": 4980
           },
           "id": 426,
           "options": {
@@ -14936,7 +14817,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 1495
+            "y": 4980
           },
           "id": 427,
           "options": {
@@ -15044,9 +14925,9 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 1495
+            "y": 4980
           },
-          "id": 427,
+          "id": 716,
           "options": {
             "legend": {
               "calcs": [],
@@ -15142,9 +15023,9 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 1495
+            "y": 4980
           },
-          "id": 427,
+          "id": 717,
           "options": {
             "legend": {
               "calcs": [],
@@ -15240,7 +15121,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 1502
+            "y": 4987
           },
           "id": 304,
           "options": {
@@ -15311,7 +15192,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 1502
+            "y": 4987
           },
           "id": 391,
           "options": {
@@ -15395,7 +15276,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 1508
+            "y": 4993
           },
           "id": 687,
           "options": {
@@ -15515,7 +15396,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 1508
+            "y": 4993
           },
           "id": 560,
           "options": {
@@ -15626,7 +15507,7 @@
             "h": 6,
             "w": 24,
             "x": 0,
-            "y": 385
+            "y": 3870
           },
           "id": 356,
           "options": {
@@ -15688,7 +15569,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 468
+            "y": 3953
           },
           "id": 357,
           "options": {
@@ -15773,7 +15654,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 468
+            "y": 3953
           },
           "id": 358,
           "options": {
@@ -15897,7 +15778,7 @@
             "h": 9,
             "w": 8,
             "x": 0,
-            "y": 476
+            "y": 3961
           },
           "id": 586,
           "options": {
@@ -15996,7 +15877,7 @@
             "h": 9,
             "w": 8,
             "x": 8,
-            "y": 476
+            "y": 3961
           },
           "id": 589,
           "options": {
@@ -16095,7 +15976,7 @@
             "h": 9,
             "w": 8,
             "x": 16,
-            "y": 476
+            "y": 3961
           },
           "id": 590,
           "options": {
@@ -16194,7 +16075,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 485
+            "y": 3970
           },
           "id": 606,
           "options": {
@@ -16295,7 +16176,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 485
+            "y": 3970
           },
           "id": 607,
           "options": {
@@ -16405,7 +16286,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 493
+            "y": 3978
           },
           "id": 608,
           "options": {
@@ -16499,7 +16380,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 493
+            "y": 3978
           },
           "id": 609,
           "options": {
@@ -16597,7 +16478,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 501
+            "y": 3986
           },
           "id": 610,
           "options": {
@@ -16708,7 +16589,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 501
+            "y": 3986
           },
           "id": 611,
           "options": {
@@ -16771,7 +16652,7 @@
             "h": 9,
             "w": 6,
             "x": 0,
-            "y": 509
+            "y": 3994
           },
           "id": 588,
           "options": {
@@ -16843,7 +16724,7 @@
             "h": 9,
             "w": 6,
             "x": 6,
-            "y": 509
+            "y": 3994
           },
           "id": 591,
           "options": {
@@ -16916,7 +16797,7 @@
             "h": 9,
             "w": 5,
             "x": 12,
-            "y": 509
+            "y": 3994
           },
           "id": 592,
           "options": {
@@ -16995,7 +16876,7 @@
             "h": 9,
             "w": 7,
             "x": 17,
-            "y": 509
+            "y": 3994
           },
           "id": 613,
           "options": {
@@ -17113,7 +16994,7 @@
             "h": 12,
             "w": 12,
             "x": 0,
-            "y": 397
+            "y": 3882
           },
           "id": 154,
           "options": {
@@ -17213,7 +17094,7 @@
             "h": 6,
             "w": 7,
             "x": 12,
-            "y": 397
+            "y": 3882
           },
           "id": 144,
           "options": {
@@ -17396,7 +17277,7 @@
             "h": 6,
             "w": 5,
             "x": 19,
-            "y": 397
+            "y": 3882
           },
           "id": 706,
           "options": {
@@ -17499,7 +17380,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 403
+            "y": 3888
           },
           "id": 142,
           "options": {
@@ -17598,7 +17479,7 @@
             "h": 12,
             "w": 12,
             "x": 0,
-            "y": 409
+            "y": 3894
           },
           "id": 151,
           "options": {
@@ -17697,7 +17578,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 409
+            "y": 3894
           },
           "id": 152,
           "options": {
@@ -17796,7 +17677,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 415
+            "y": 3900
           },
           "id": 150,
           "options": {
@@ -17895,7 +17776,7 @@
             "h": 13,
             "w": 12,
             "x": 0,
-            "y": 421
+            "y": 3906
           },
           "id": 147,
           "options": {
@@ -17996,7 +17877,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 421
+            "y": 3906
           },
           "id": 149,
           "options": {
@@ -18096,7 +17977,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 428
+            "y": 3913
           },
           "id": 148,
           "options": {
@@ -18196,7 +18077,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 434
+            "y": 3919
           },
           "id": 155,
           "options": {
@@ -18294,7 +18175,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 434
+            "y": 3919
           },
           "id": 156,
           "options": {
@@ -18390,7 +18271,7 @@
             "h": 6,
             "w": 6,
             "x": 0,
-            "y": 442
+            "y": 3927
           },
           "id": 158,
           "options": {
@@ -18489,7 +18370,7 @@
             "h": 6,
             "w": 6,
             "x": 6,
-            "y": 442
+            "y": 3927
           },
           "id": 157,
           "options": {
@@ -18587,7 +18468,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 442
+            "y": 3927
           },
           "id": 146,
           "options": {
@@ -18685,7 +18566,7 @@
             "h": 7,
             "w": 6,
             "x": 0,
-            "y": 448
+            "y": 3933
           },
           "id": 159,
           "options": {
@@ -18783,7 +18664,7 @@
             "h": 7,
             "w": 6,
             "x": 6,
-            "y": 448
+            "y": 3933
           },
           "id": 160,
           "options": {
@@ -18882,7 +18763,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 448
+            "y": 3933
           },
           "id": 153,
           "options": {
@@ -18982,7 +18863,7 @@
             "h": 11,
             "w": 24,
             "x": 0,
-            "y": 455
+            "y": 3940
           },
           "id": 603,
           "options": {
@@ -19065,7 +18946,7 @@
             "h": 8,
             "w": 4,
             "x": 0,
-            "y": 1400
+            "y": 4885
           },
           "id": 675,
           "options": {
@@ -19129,7 +19010,7 @@
             "h": 8,
             "w": 10,
             "x": 4,
-            "y": 1400
+            "y": 4885
           },
           "id": 676,
           "options": {
@@ -19202,7 +19083,7 @@
             "h": 8,
             "w": 10,
             "x": 14,
-            "y": 1400
+            "y": 4885
           },
           "id": 677,
           "options": {
@@ -19315,7 +19196,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1465
+            "y": 4950
           },
           "id": 667,
           "options": {
@@ -19416,7 +19297,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1465
+            "y": 4950
           },
           "id": 683,
           "options": {
@@ -19473,7 +19354,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1473
+            "y": 4958
           },
           "id": 670,
           "options": {
@@ -19558,7 +19439,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1473
+            "y": 4958
           },
           "id": 673,
           "options": {
@@ -19638,7 +19519,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1481
+            "y": 4966
           },
           "id": 669,
           "maxDataPoints": 494,
@@ -19767,7 +19648,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1481
+            "y": 4966
           },
           "id": 674,
           "options": {
@@ -19830,7 +19711,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1489
+            "y": 4974
           },
           "id": 678,
           "options": {
@@ -19914,7 +19795,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1489
+            "y": 4974
           },
           "id": 668,
           "options": {
@@ -20000,7 +19881,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1497
+            "y": 4982
           },
           "id": 672,
           "options": {
@@ -20121,7 +20002,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1497
+            "y": 4982
           },
           "id": 665,
           "options": {
@@ -20196,7 +20077,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 1401
+            "y": 4886
           },
           "id": 20,
           "options": {
@@ -20322,7 +20203,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 1401
+            "y": 4886
           },
           "id": 255,
           "options": {
@@ -20379,7 +20260,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 1468
+            "y": 4953
           },
           "id": 21,
           "options": {
@@ -20504,7 +20385,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 1468
+            "y": 4953
           },
           "id": 185,
           "options": {
@@ -20609,7 +20490,7 @@
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 1478
+            "y": 4963
           },
           "id": 52,
           "options": {
@@ -20685,7 +20566,7 @@
             "h": 9,
             "w": 10,
             "x": 0,
-            "y": 1402
+            "y": 4887
           },
           "id": 616,
           "options": {
@@ -20780,7 +20661,7 @@
             "h": 9,
             "w": 3,
             "x": 10,
-            "y": 1402
+            "y": 4887
           },
           "id": 617,
           "options": {
@@ -20886,7 +20767,7 @@
             "h": 9,
             "w": 11,
             "x": 13,
-            "y": 1402
+            "y": 4887
           },
           "id": 621,
           "options": {
@@ -20945,7 +20826,7 @@
             "h": 5,
             "w": 24,
             "x": 0,
-            "y": 1468
+            "y": 4953
           },
           "id": 618,
           "options": {
@@ -21071,7 +20952,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 1473
+            "y": 4958
           },
           "id": 628,
           "options": {
@@ -21184,7 +21065,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 1473
+            "y": 4958
           },
           "id": 623,
           "options": {
@@ -21243,7 +21124,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 1480
+            "y": 4965
           },
           "id": 626,
           "options": {
@@ -21385,7 +21266,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 1480
+            "y": 4965
           },
           "id": 627,
           "options": {
@@ -21498,7 +21379,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 1486
+            "y": 4971
           },
           "id": 643,
           "options": {
@@ -21573,7 +21454,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 1495
+            "y": 4980
           },
           "id": 647,
           "options": {
@@ -21656,7 +21537,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 1503
+            "y": 4988
           },
           "id": 646,
           "options": {
@@ -21754,7 +21635,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 1503
+            "y": 4988
           },
           "id": 645,
           "options": {
@@ -21836,7 +21717,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 1503
+            "y": 4988
           },
           "id": 658,
           "options": {
@@ -21931,7 +21812,7 @@
             "h": 9,
             "w": 10,
             "x": 0,
-            "y": 1238
+            "y": 4723
           },
           "id": 630,
           "options": {
@@ -22018,7 +21899,7 @@
             "h": 9,
             "w": 11,
             "x": 10,
-            "y": 1238
+            "y": 4723
           },
           "id": 636,
           "options": {
@@ -22114,7 +21995,7 @@
             "h": 9,
             "w": 3,
             "x": 21,
-            "y": 1238
+            "y": 4723
           },
           "id": 634,
           "options": {
@@ -22192,7 +22073,7 @@
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 1247
+            "y": 4732
           },
           "id": 633,
           "options": {
@@ -22278,7 +22159,7 @@
             "h": 8,
             "w": 8,
             "x": 9,
-            "y": 1247
+            "y": 4732
           },
           "id": 688,
           "options": {
@@ -22418,7 +22299,7 @@
             "h": 8,
             "w": 7,
             "x": 17,
-            "y": 1247
+            "y": 4732
           },
           "id": 697,
           "options": {
@@ -22556,7 +22437,7 @@
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 1255
+            "y": 4740
           },
           "id": 684,
           "options": {
@@ -22748,7 +22629,7 @@
             "h": 8,
             "w": 8,
             "x": 9,
-            "y": 1255
+            "y": 4740
           },
           "id": 685,
           "options": {
@@ -22835,7 +22716,7 @@
             "h": 8,
             "w": 7,
             "x": 17,
-            "y": 1255
+            "y": 4740
           },
           "id": 686,
           "options": {
@@ -22920,7 +22801,7 @@
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 1263
+            "y": 4748
           },
           "id": 694,
           "options": {
@@ -23048,7 +22929,7 @@
             "h": 8,
             "w": 8,
             "x": 9,
-            "y": 1263
+            "y": 4748
           },
           "id": 696,
           "options": {
@@ -23108,7 +22989,7 @@
             "h": 8,
             "w": 7,
             "x": 17,
-            "y": 1263
+            "y": 4748
           },
           "id": 704,
           "options": {
@@ -23234,7 +23115,7 @@
             "h": 8,
             "w": 9,
             "x": 0,
-            "y": 1271
+            "y": 4756
           },
           "id": 689,
           "options": {
@@ -23320,7 +23201,7 @@
             "h": 6,
             "w": 24,
             "x": 0,
-            "y": 2094
+            "y": 5579
           },
           "id": 170,
           "maxPerRow": 6,
@@ -23405,7 +23286,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 2106
+            "y": 5591
           },
           "id": 174,
           "options": {
@@ -23482,7 +23363,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 2106
+            "y": 5591
           },
           "id": 265,
           "options": {
@@ -23562,7 +23443,7 @@
             "h": 3,
             "w": 12,
             "x": 0,
-            "y": 1281
+            "y": 4766
           },
           "id": 701,
           "options": {
@@ -23625,7 +23506,7 @@
             "h": 4,
             "w": 6,
             "x": 12,
-            "y": 1281
+            "y": 4766
           },
           "id": 702,
           "options": {
@@ -23679,7 +23560,7 @@
             "h": 4,
             "w": 6,
             "x": 12,
-            "y": 1285
+            "y": 4770
           },
           "id": 695,
           "options": {
@@ -23733,7 +23614,7 @@
             "h": 4,
             "w": 6,
             "x": 18,
-            "y": 1285
+            "y": 4770
           },
           "id": 698,
           "options": {
@@ -23787,7 +23668,7 @@
             "h": 4,
             "w": 6,
             "x": 18,
-            "y": 1285
+            "y": 4770
           },
           "id": 703,
           "options": {
@@ -23841,7 +23722,7 @@
             "h": 4,
             "w": 6,
             "x": 12,
-            "y": 1289
+            "y": 4774
           },
           "id": 705,
           "options": {
@@ -23898,7 +23779,7 @@
             "h": 4,
             "w": 6,
             "x": 18,
-            "y": 1289
+            "y": 4774
           },
           "id": 700,
           "options": {
@@ -23960,7 +23841,7 @@
             "h": 9,
             "w": 6,
             "x": 12,
-            "y": 1293
+            "y": 4778
           },
           "id": 707,
           "options": {
@@ -24052,7 +23933,7 @@
             "h": 9,
             "w": 6,
             "x": 18,
-            "y": 1293
+            "y": 4778
           },
           "id": 708,
           "options": {
@@ -24133,7 +24014,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2095
+            "y": 5580
           },
           "id": 319,
           "options": {
@@ -24194,7 +24075,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2109
+            "y": 5594
           },
           "id": 323,
           "maxDataPoints": 25,
@@ -24285,7 +24166,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2109
+            "y": 5594
           },
           "id": 325,
           "options": {
@@ -24384,7 +24265,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2117
+            "y": 5602
           },
           "id": 313,
           "options": {
@@ -24444,7 +24325,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2117
+            "y": 5602
           },
           "id": 321,
           "options": {
@@ -24541,7 +24422,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2125
+            "y": 5610
           },
           "id": 335,
           "options": {
@@ -24599,7 +24480,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2125
+            "y": 5610
           },
           "id": 317,
           "options": {
@@ -24661,7 +24542,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2133
+            "y": 5618
           },
           "id": 327,
           "options": {
@@ -24736,7 +24617,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2096
+            "y": 5581
           },
           "id": 538,
           "options": {
@@ -24821,7 +24702,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2096
+            "y": 5581
           },
           "id": 540,
           "options": {
@@ -24948,7 +24829,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2110
+            "y": 5595
           },
           "id": 444,
           "options": {
@@ -25061,7 +24942,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2110
+            "y": 5595
           },
           "id": 446,
           "options": {
@@ -25173,7 +25054,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2118
+            "y": 5603
           },
           "id": 440,
           "options": {
@@ -25271,7 +25152,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2118
+            "y": 5603
           },
           "id": 442,
           "options": {
@@ -25343,7 +25224,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2097
+            "y": 5582
           },
           "id": 547,
           "options": {
@@ -25468,7 +25349,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2097
+            "y": 5582
           },
           "id": 549,
           "options": {
@@ -25584,7 +25465,7 @@
             "h": 6,
             "w": 8,
             "x": 0,
-            "y": 2098
+            "y": 5583
           },
           "id": 562,
           "options": {
@@ -25686,7 +25567,7 @@
             "h": 6,
             "w": 9,
             "x": 8,
-            "y": 2098
+            "y": 5583
           },
           "id": 563,
           "options": {
@@ -25788,7 +25669,7 @@
             "h": 6,
             "w": 7,
             "x": 17,
-            "y": 2098
+            "y": 5583
           },
           "id": 564,
           "options": {
@@ -25911,7 +25792,7 @@
             "h": 6,
             "w": 8,
             "x": 0,
-            "y": 2099
+            "y": 5584
           },
           "id": 566,
           "options": {
@@ -26011,7 +25892,7 @@
             "h": 6,
             "w": 8,
             "x": 8,
-            "y": 2099
+            "y": 5584
           },
           "id": 567,
           "options": {
@@ -26111,7 +25992,7 @@
             "h": 6,
             "w": 8,
             "x": 16,
-            "y": 2099
+            "y": 5584
           },
           "id": 568,
           "options": {
@@ -26243,7 +26124,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2106
+            "y": 5591
           },
           "id": 573,
           "options": {
@@ -26372,7 +26253,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2106
+            "y": 5591
           },
           "id": 574,
           "options": {
@@ -26489,7 +26370,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2114
+            "y": 5599
           },
           "id": 600,
           "options": {
@@ -26596,7 +26477,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2114
+            "y": 5599
           },
           "id": 601,
           "options": {
@@ -26694,7 +26575,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2122
+            "y": 5607
           },
           "id": 575,
           "options": {
@@ -26804,7 +26685,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2101
+            "y": 5586
           },
           "id": 570,
           "options": {
@@ -26912,7 +26793,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2101
+            "y": 5586
           },
           "id": 577,
           "options": {
@@ -27019,7 +26900,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2109
+            "y": 5594
           },
           "id": 578,
           "options": {
@@ -27117,7 +26998,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2109
+            "y": 5594
           },
           "id": 571,
           "options": {
@@ -27226,7 +27107,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 2102
+            "y": 5587
           },
           "id": 582,
           "options": {
@@ -27321,7 +27202,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 2102
+            "y": 5587
           },
           "id": 583,
           "options": {
@@ -27416,7 +27297,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 2102
+            "y": 5587
           },
           "id": 584,
           "options": {
@@ -27524,7 +27405,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2103
+            "y": 5588
           },
           "id": 596,
           "options": {
@@ -27622,7 +27503,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2103
+            "y": 5588
           },
           "id": 597,
           "options": {
@@ -27684,7 +27565,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2111
+            "y": 5596
           },
           "id": 598,
           "options": {
@@ -27809,7 +27690,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2111
+            "y": 5596
           },
           "id": 599,
           "options": {
@@ -27933,7 +27814,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2104
+            "y": 5589
           },
           "id": 680,
           "options": {
@@ -28034,7 +27915,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2104
+            "y": 5589
           },
           "id": 666,
           "options": {
@@ -28092,7 +27973,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2112
+            "y": 5597
           },
           "id": 681,
           "options": {
@@ -28190,7 +28071,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2112
+            "y": 5597
           },
           "id": 682,
           "options": {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/ExecutionLatencyMetrics.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/ExecutionLatencyMetrics.java
@@ -36,8 +36,7 @@ public class ExecutionLatencyMetrics {
   public ExecutionLatencyMetrics(final MeterRegistry meterRegistry) {
 
     processInstanceExecutionTime =
-        Timer.builder(PROCESS_INSTANCE_EXECUTION.getName())
-            .description(PROCESS_INSTANCE_EXECUTION.getDescription())
+        MicrometerUtil.buildTimer(PROCESS_INSTANCE_EXECUTION)
             .publishPercentiles(0.5, 0.9, 0.99)
             .register(meterRegistry);
     jobLifeTime = MicrometerUtil.buildTimer(JOB_LIFETIME).register(meterRegistry);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/ExecutionLatencyMetrics.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/ExecutionLatencyMetrics.java
@@ -36,7 +36,10 @@ public class ExecutionLatencyMetrics {
   public ExecutionLatencyMetrics(final MeterRegistry meterRegistry) {
 
     processInstanceExecutionTime =
-        MicrometerUtil.buildTimer(PROCESS_INSTANCE_EXECUTION).register(meterRegistry);
+        Timer.builder(PROCESS_INSTANCE_EXECUTION.getName())
+            .description(PROCESS_INSTANCE_EXECUTION.getDescription())
+            .publishPercentiles(0.5, 0.9, 0.99)
+            .register(meterRegistry);
     jobLifeTime = MicrometerUtil.buildTimer(JOB_LIFETIME).register(meterRegistry);
     jobActivationTime = MicrometerUtil.buildTimer(JOB_ACTIVATION_TIME).register(meterRegistry);
     currentCacheInstanceProcessInstances =

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/ExecutionLatencyMetricsDoc.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/ExecutionLatencyMetricsDoc.java
@@ -51,10 +51,28 @@ public enum ExecutionLatencyMetricsDoc implements ExtendedMeterDocumentation {
   },
 
   /**
-   * The execution time of processing a complete process instance. Publishes pre-computed
-   * percentiles (p50, p90, p99) rather than histogram buckets; see {@link ExecutionLatencyMetrics}.
+   * The execution time of processing a complete process instance. Publishes both SLO histogram
+   * buckets (for cluster-level aggregation via {@code histogram_quantile()}) and pre-computed
+   * percentiles (p50, p90, p99) for convenience; see {@link ExecutionLatencyMetrics}.
    */
   PROCESS_INSTANCE_EXECUTION {
+    private static final Duration[] BUCKETS = {
+      Duration.ofMillis(50),
+      Duration.ofMillis(75),
+      Duration.ofMillis(100),
+      Duration.ofMillis(250),
+      Duration.ofMillis(500),
+      Duration.ofMillis(750),
+      Duration.ofSeconds(1),
+      Duration.ofMillis(2500),
+      Duration.ofSeconds(5),
+      Duration.ofSeconds(10),
+      Duration.ofSeconds(15),
+      Duration.ofSeconds(30),
+      Duration.ofSeconds(45),
+      Duration.ofSeconds(60)
+    };
+
     @Override
     public String getDescription() {
       return "The execution time of processing a complete process instance";
@@ -72,7 +90,7 @@ public enum ExecutionLatencyMetricsDoc implements ExtendedMeterDocumentation {
 
     @Override
     public Duration[] getTimerSLOs() {
-      return new Duration[0];
+      return BUCKETS;
     }
   },
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/ExecutionLatencyMetricsDoc.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/ExecutionLatencyMetricsDoc.java
@@ -50,25 +50,11 @@ public enum ExecutionLatencyMetricsDoc implements ExtendedMeterDocumentation {
     }
   },
 
-  /** The execution time of processing a complete process instance */
+  /**
+   * The execution time of processing a complete process instance. Publishes pre-computed
+   * percentiles (p50, p90, p99) rather than histogram buckets; see {@link ExecutionLatencyMetrics}.
+   */
   PROCESS_INSTANCE_EXECUTION {
-    private static final Duration[] BUCKETS = {
-      Duration.ofMillis(50),
-      Duration.ofMillis(75),
-      Duration.ofMillis(100),
-      Duration.ofMillis(250),
-      Duration.ofMillis(500),
-      Duration.ofMillis(750),
-      Duration.ofSeconds(1),
-      Duration.ofMillis(2500),
-      Duration.ofSeconds(5),
-      Duration.ofSeconds(10),
-      Duration.ofSeconds(15),
-      Duration.ofSeconds(30),
-      Duration.ofSeconds(45),
-      Duration.ofMinutes(1)
-    };
-
     @Override
     public String getDescription() {
       return "The execution time of processing a complete process instance";
@@ -82,11 +68,6 @@ public enum ExecutionLatencyMetricsDoc implements ExtendedMeterDocumentation {
     @Override
     public Type getType() {
       return Type.TIMER;
-    }
-
-    @Override
-    public Duration[] getTimerSLOs() {
-      return BUCKETS;
     }
   },
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/ExecutionLatencyMetricsDoc.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/ExecutionLatencyMetricsDoc.java
@@ -69,6 +69,11 @@ public enum ExecutionLatencyMetricsDoc implements ExtendedMeterDocumentation {
     public Type getType() {
       return Type.TIMER;
     }
+
+    @Override
+    public Duration[] getTimerSLOs() {
+      return new Duration[0];
+    }
   },
 
   /** The lifetime of a job */

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/metrics/MetricsExporterTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/metrics/MetricsExporterTest.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.micrometer.core.instrument.distribution.ValueAtPercentile;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
@@ -98,6 +99,56 @@ class MetricsExporterTest {
                 .anyMatch(bucket -> bucket.bucket(TimeUnit.SECONDS) == 2.5 && bucket.count() == 1))
         .isTrue()
         .describedAs("Expected the correct job_life_time bucket to have counted the event");
+  }
+
+  @Test
+  void shouldObserveProcessInstanceExecutionTimeWithPercentiles() throws Exception {
+    // given
+    final var exporter = new MetricsExporter();
+    exporter.configure(context);
+    exporter.open(new ExporterTestController());
+
+    // when
+    exporter.export(
+        ImmutableRecord.<ProcessInstanceRecord>builder()
+            .withRecordType(RecordType.EVENT)
+            .withValueType(ValueType.PROCESS_INSTANCE)
+            .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withTimestamp(1651505728460L)
+            .withKey(Protocol.encodePartitionId(1, 1))
+            .withValue(new ProcessInstanceRecord().setBpmnElementType(BpmnElementType.PROCESS))
+            .build());
+    exporter.export(
+        ImmutableRecord.<ProcessInstanceRecord>builder()
+            .withRecordType(RecordType.EVENT)
+            .withValueType(ValueType.PROCESS_INSTANCE)
+            .withIntent(ProcessInstanceIntent.ELEMENT_COMPLETED)
+            .withTimestamp(1651505730960L)
+            .withKey(Protocol.encodePartitionId(1, 1))
+            .withValue(new ProcessInstanceRecord().setBpmnElementType(BpmnElementType.PROCESS))
+            .build());
+
+    // then
+    final var executionTimer =
+        context.getMeterRegistry().timer("zeebe.process.instance.execution.time");
+
+    assertThat(executionTimer.count())
+        .isOne()
+        .describedAs("Expected exactly 1 observed process instance execution time sample counted");
+
+    assertThat(
+            Arrays.stream(executionTimer.takeSnapshot().percentileValues())
+                .map(ValueAtPercentile::percentile)
+                .toList())
+        .describedAs("Expected p50, p90, and p99 percentiles to be published")
+        .containsExactlyInAnyOrder(0.5, 0.9, 0.99);
+
+    assertThat(
+            Arrays.stream(executionTimer.takeSnapshot().histogramCounts())
+                .anyMatch(bucket -> bucket.bucket(TimeUnit.SECONDS) == 2.5 && bucket.count() == 1))
+        .isTrue()
+        .describedAs(
+            "Expected SLO histogram buckets to be published (required for zeebe_process_instance_execution_time_seconds_bucket in Prometheus)");
   }
 
   @Test

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/metrics/MetricsExporterTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/metrics/MetricsExporterTest.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.micrometer.core.instrument.distribution.ValueAtPercentile;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
@@ -102,39 +103,18 @@ class MetricsExporterTest {
   }
 
   @Test
-  void shouldObserveProcessInstanceExecutionTimeWithPercentiles() throws Exception {
+  void shouldObserveProcessInstanceExecutionTimeWithPercentiles() {
     // given
-    final var exporter = new MetricsExporter();
-    exporter.configure(context);
-    exporter.open(new ExporterTestController());
+    final var registry = new SimpleMeterRegistry();
+    final var metrics = new ExecutionLatencyMetrics(registry);
 
     // when
-    exporter.export(
-        ImmutableRecord.<ProcessInstanceRecord>builder()
-            .withRecordType(RecordType.EVENT)
-            .withValueType(ValueType.PROCESS_INSTANCE)
-            .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATING)
-            .withTimestamp(1651505728460L)
-            .withKey(Protocol.encodePartitionId(1, 1))
-            .withValue(new ProcessInstanceRecord().setBpmnElementType(BpmnElementType.PROCESS))
-            .build());
-    exporter.export(
-        ImmutableRecord.<ProcessInstanceRecord>builder()
-            .withRecordType(RecordType.EVENT)
-            .withValueType(ValueType.PROCESS_INSTANCE)
-            .withIntent(ProcessInstanceIntent.ELEMENT_COMPLETED)
-            .withTimestamp(1651505730960L)
-            .withKey(Protocol.encodePartitionId(1, 1))
-            .withValue(new ProcessInstanceRecord().setBpmnElementType(BpmnElementType.PROCESS))
-            .build());
+    metrics.observeProcessInstanceExecutionTime(0L, 2500L);
 
     // then
-    final var executionTimer =
-        context.getMeterRegistry().timer("zeebe.process.instance.execution.time");
+    final var executionTimer = registry.timer("zeebe.process.instance.execution.time");
 
-    assertThat(executionTimer.count())
-        .isOne()
-        .describedAs("Expected exactly 1 observed process instance execution time sample counted");
+    assertThat(executionTimer.count()).isOne();
 
     assertThat(
             Arrays.stream(executionTimer.takeSnapshot().percentileValues())


### PR DESCRIPTION
## Description

This PR switches the PROCESS_INSTANCE_EXECUTION timer from SLO histogram buckets to pre-computed percentiles (p50, p90, p99) in ExecutionLatencyMetrics.java and ExecutionLatencyMetricsDoc.java.                         
In the zeebe grafana dashboard we remove the "Proce Instance Execution Time" panel, since we loose the ablitiy to aggregate times at the cluster level once we publish percentiles.

From:
<img width="1306" height="447" alt="image" src="https://github.com/user-attachments/assets/7dbb5bc9-8320-4f93-8e0c-1bd530c5b979" />
To:
<img width="1310" height="419" alt="image" src="https://github.com/user-attachments/assets/f722faf4-c696-4173-b3d1-6a69af20e4d1" />


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

retales to https://github.com/camunda/camunda/issues/46237