### PR TITLE
chore: align doc and code for load tests

### DIFF
--- a/docs/debug-distributed-application.md
+++ b/docs/debug-distributed-application.md
@@ -79,10 +79,10 @@ To get a shell with a jdk on a node you can use the following command:
 > [!Note]
 >
 > You need to replace `<broker-0>` with the pod name you want to profile below.
-
-```sh
-kubectl debug -it -c debugger --profile=restricted --image=eclipse-temurin:21.0.3_9-jdk-alpine --target=zeebe <broker-0> -- /bin/bash
-```
+>
+> ```sh
+> kubectl debug -it -c debugger --profile=restricted --image=eclipse-temurin:21.0.3_9-jdk-alpine --target=zeebe <broker-0> -- /bin/bash
+> ```
 
 ## Thread dump
 

--- a/load-tests/setup/README.md
+++ b/load-tests/setup/README.md
@@ -87,13 +87,14 @@ All components are configured in `camunda-platform-values.yaml`.
 If you run `newLoadTest.sh` without arguments, it will display the following help message.
 
 ```sh
-Usage: newLoadTest.sh <namespace> [secondaryStorage] [ttl_days] [enable_optimize]
+Usage: newLoadTest.sh <namespace> [secondaryStorage] [ttl_days] [enable_optimize] [enable_single_zone]
 
 Arguments:
   namespace          Base namespace name. Will be prefixed with "c8-" if missing.
   secondaryStorage   Optional. One of: elasticsearch, opensearch, postgresql, mysql, mariadb, mssql, oracle, none. Default: elasticsearch.
   ttl_days           Optional. Positive integer for namespace TTL in days. Default: 1.
-  enable_optimize    Optional. true|false to enable Optimize. Default: false.
+  enable_optimize    Optional. true|false to enable Optimize. Default: true.
+  enable_single_zone Optional. true|false to deploy the cluster on a single zone. Default: true
 
 Options:
   -h, --help         Show this help message.

--- a/load-tests/setup/default/createCredsLoadTest.sh
+++ b/load-tests/setup/default/createCredsLoadTest.sh
@@ -16,8 +16,8 @@ if kubectl -n "$NS" get secret camunda-credentials &>/dev/null; then
   echo "Secret 'camunda-credentials' already exists in namespace '$NS'. Skipping creation."
   echo "Reading existing orchestration secret from 'camunda-credentials' in namespace '$NS'."
   ORCHESTRATION_SECRET=$(kubectl -n "$NS" get secret camunda-credentials -o jsonpath='{.data.orchestration-security-authentication-oidc-secret}' | base64 -d)
-  echo "Done Replacing __SECRET__ in load-test-values.yaml with existing orchestration secret."
   sed_inplace "s/__SECRET__/${ORCHESTRATION_SECRET}/g" load-test-values.yaml
+  echo "Done replacing __SECRET__ in load-test-values.yaml with existing orchestration secret."
   exit 0
 fi
 
@@ -61,7 +61,7 @@ stringData:
   identity-optimize-client-token: "${IDENTITY_OPTIMIZE_CLIENT_TOKEN}"
 EOF
 
-# Replace __SECRET__ in load-test-values.yaml with the generated orchestration secret 
+# Replace __SECRET__ in load-test-values.yaml with the generated orchestration secret
 sed_inplace "s/__SECRET__/${ORCHESTRATION_SECRET}/g" load-test-values.yaml
 
 echo "Done. Secret 'camunda-credentials' created in namespace '$NS'."


### PR DESCRIPTION
## Description

This aligns the configuration with what we have now for 8.7 and 8.8.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
