### PR TITLE
fix: restore memory settings for Zeebe

### DIFF
--- a/load-tests/camunda-platform-values.yaml
+++ b/load-tests/camunda-platform-values.yaml
@@ -230,10 +230,10 @@ zeebe:
   resources:
     requests:
       cpu: 3000m
-      memory: 2Gi
+      memory: 4Gi
     limits:
       cpu: 3000m
-      memory: 2Gi
+      memory: 4Gi
   nodeSelector:
     topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
   tolerations:


### PR DESCRIPTION


## Description

In c8a163fd66e75206d6d7bdd88eab952d2db88e87, we aligned the Zeebe memory settings to what we have for 8.8+ (2 GB), but we actually need more to on this version/configuration, possibly due to the configuration difference f RocksDB.

Cf. Slack: https://camunda.slack.com/archives/C0A22S6M4TF/p1777043386146129

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

* https://github.com/camunda/camunda/pull/51619

