### PR TITLE
fix: align UC default number of replicas

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/DocumentBasedSecondaryStorageDatabase.java
+++ b/configuration/src/main/java/io/camunda/configuration/DocumentBasedSecondaryStorageDatabase.java
@@ -36,11 +36,11 @@ public abstract class DocumentBasedSecondaryStorageDatabase
   /** The connection timeout for ES and OS connector */
   private Duration connectionTimeout;
 
-  /** How many shards Elasticsearch uses for all Tasklist indices. */
+  /** How many shards the search engine database uses for all indices. */
   private int numberOfShards = 1;
 
-  /** How many replicas Elasticsearch uses for all indices. */
-  private int numberOfReplicas = 0;
+  /** How many replicas the search engine database uses for all indices. */
+  private int numberOfReplicas = 1;
 
   /** What default refresh interval we will use for all indices */
   private String refreshInterval;

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageElasticsearchTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageElasticsearchTest.java
@@ -1015,4 +1015,33 @@ public class SecondaryStorageElasticsearchTest {
       assertThat(proxy.getPassword()).isEqualTo(EXPECTED_PROXY_PASSWORD);
     }
   }
+
+  @Nested
+  @TestPropertySource(properties = {"camunda.data.secondary-storage.type=elasticsearch"})
+  class WithDefaultValues {
+
+    final Camunda camunda;
+    final SearchEngineIndexProperties searchEngineIndexProperties;
+
+    WithDefaultValues(
+        @Autowired final Camunda camunda,
+        @Autowired final SearchEngineIndexProperties searchEngineIndexProperties) {
+      this.camunda = camunda;
+      this.searchEngineIndexProperties = searchEngineIndexProperties;
+    }
+
+    @Test
+    void shouldNumberOfReplicasDefaultToOne() {
+      assertThat(camunda.getData().getSecondaryStorage().getElasticsearch().getNumberOfReplicas())
+          .isEqualTo(1);
+      assertThat(searchEngineIndexProperties.getNumberOfReplicas()).isEqualTo(1);
+    }
+
+    @Test
+    void shouldNumberOfShardsDefaultToOne() {
+      assertThat(camunda.getData().getSecondaryStorage().getElasticsearch().getNumberOfShards())
+          .isEqualTo(1);
+      assertThat(searchEngineIndexProperties.getNumberOfShards()).isEqualTo(1);
+    }
+  }
 }

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageOpensearchTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageOpensearchTest.java
@@ -923,4 +923,33 @@ public class SecondaryStorageOpensearchTest {
       assertThat(proxy.getPassword()).isEqualTo(EXPECTED_PROXY_PASSWORD);
     }
   }
+
+  @Nested
+  @TestPropertySource(properties = {"camunda.data.secondary-storage.type=opensearch"})
+  class WithDefaultValues {
+
+    final Camunda camunda;
+    final SearchEngineIndexProperties searchEngineIndexProperties;
+
+    WithDefaultValues(
+        @Autowired final Camunda camunda,
+        @Autowired final SearchEngineIndexProperties searchEngineIndexProperties) {
+      this.camunda = camunda;
+      this.searchEngineIndexProperties = searchEngineIndexProperties;
+    }
+
+    @Test
+    void shouldNumberOfReplicasDefaultToOne() {
+      assertThat(camunda.getData().getSecondaryStorage().getOpensearch().getNumberOfReplicas())
+          .isEqualTo(1);
+      assertThat(searchEngineIndexProperties.getNumberOfReplicas()).isEqualTo(1);
+    }
+
+    @Test
+    void shouldNumberOfShardsDefaultToOne() {
+      assertThat(camunda.getData().getSecondaryStorage().getOpensearch().getNumberOfShards())
+          .isEqualTo(1);
+      assertThat(searchEngineIndexProperties.getNumberOfShards()).isEqualTo(1);
+    }
+  }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Updates the default configuration of UC secondary storage's number of replicas from 0 to 1, to align it with the default value in the legacy configuration 

Relates to [#inc-ha-cluster-missing-index-replicas](https://camunda.slack.com/archives/C0AUP12QA2D)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
