### PR TITLE
feat: enable Stackdriver JSON logging for load-tester

### DIFF
--- a/load-tests/load-test-values.yaml
+++ b/load-tests/load-test-values.yaml
@@ -20,6 +20,20 @@ global:
       value: n2-standard-4
       effect: NoSchedule
 
+  # Enable Stackdriver-formatted JSON logging on starter and worker pods so
+  # Cloud Logging picks up severity, sourceLocation, and serviceContext the
+  # same way it does for zeebe/operate/etc. Toggle is read by
+  # load-tests/load-tester/src/main/resources/log4j2.xml.
+  extraEnvVars:
+    - name: LOAD_TESTER_LOG_APPENDER
+      value: Stackdriver
+    - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+      value: load-tester
+    - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+
 # Saas configuration to run load tests against Camunda SaaS environment
 saas:
   # Saas.enabled if true enables the load tests to run against Camunda SaaS

--- a/load-tests/load-tester/pom.xml
+++ b/load-tests/load-tester/pom.xml
@@ -38,6 +38,12 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-spring-boot-starter</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- Webflux (Netty) instead of Web (Tomcat) to minimize memory footprint.
@@ -47,11 +53,23 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-webflux</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -82,6 +100,39 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <!-- Log4j2 backend with Stackdriver-formatted JSON layout. Mirrors the
+         dist module's setup so load-tester pods emit the same JSON shape as
+         zeebe/operate/etc. Toggled by LOAD_TESTER_LOG_APPENDER (see
+         src/main/resources/log4j2.xml).
+
+         Declared explicitly rather than via spring-boot-starter-log4j2:
+         the parent pom pins log4j-core and log4j-slf4j2-impl to test scope,
+         and Maven's "direct beats transitive" rule keeps them at test scope
+         when the starter brings them transitively. Since the load-tester
+         ships as its own jib container (not bundled into dist), test-scope
+         deps are excluded from the runtime image and SLF4J falls back to
+         NOP — silent pods. Re-declaring at compile scope here overrides
+         the parent's test-scope pin. -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-layout-template-json</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
     </dependency>
 
     <dependency>
@@ -264,6 +315,11 @@
             <dependency>org.springframework.boot:spring-boot-starter-actuator</dependency>
             <dependency>org.springframework.boot:spring-boot-starter-test</dependency>
             <dependency>com.fasterxml.jackson.datatype:jackson-datatype-jsr310</dependency>
+            <!-- Log4j2 runtime deps loaded via SPI / log4j2.xml, not direct imports -->
+            <dependency>org.apache.logging.log4j:log4j-api</dependency>
+            <dependency>org.apache.logging.log4j:log4j-core</dependency>
+            <dependency>org.apache.logging.log4j:log4j-slf4j2-impl</dependency>
+            <dependency>org.apache.logging.log4j:log4j-layout-template-json</dependency>
           </usedDependencies>
         </configuration>
       </plugin>

--- a/load-tests/load-tester/src/main/resources/log4j2.xml
+++ b/load-tests/load-tester/src/main/resources/log4j2.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration xmlns="https://logging.apache.org/xml/ns"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="
+                   https://logging.apache.org/xml/ns
+                   https://logging.apache.org/xml/ns/log4j-config-2.xsd"
+  status="WARN" shutdownHook="disable">
+  <Properties>
+    <Property name="log.pattern"
+              value="[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%t] %notEmpty{[%X] }%-5level &#9;%logger{36} - %msg%n" />
+  </Properties>
+
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="${log.pattern}"/>
+    </Console>
+
+    <Console name="Stackdriver" target="SYSTEM_OUT">
+      <JsonTemplateLayout charset="UTF-8"
+        eventTemplateUri="classpath:logging/StackdriverLayout.json"
+        locationInfoEnabled="true"
+        stackTraceEnabled="true"/>
+    </Console>
+  </Appenders>
+
+  <Loggers>
+    <!-- Bootstrap default. Spring Boot's LoggingSystem replaces this with
+         logging.level.* from application.yaml ~500ms after JVM start, so
+         this only governs the very first init lines. Reading the same
+         LOG_LEVEL env var as application.yaml keeps the bootstrap window
+         consistent with the steady-state runtime level. -->
+    <Root level="${env:LOG_LEVEL:-WARN}">
+      <AppenderRef ref="${env:LOAD_TESTER_LOG_APPENDER:-Console}"/>
+    </Root>
+  </Loggers>
+
+</Configuration>

--- a/load-tests/load-tester/src/main/resources/logging/StackdriverLayout.json
+++ b/load-tests/load-tester/src/main/resources/logging/StackdriverLayout.json
@@ -1,0 +1,72 @@
+{
+  "timestampSeconds": {
+    "$resolver": "timestamp",
+    "epoch": {
+      "unit": "secs",
+      "rounded": true
+    }
+  },
+  "timestampNanos": {
+    "$resolver": "timestamp",
+    "epoch": {
+      "unit": "secs.nanos"
+    }
+  },
+  "severity": {
+    "$resolver": "pattern",
+    "pattern": "%level{OFF=DEFAULT, ALL=DEFAULT, TRACE=DEBUG, DEBUG=DEBUG, INFO=INFO, WARN=WARNING, ERROR=ERROR, FATAL=CRITICAL}",
+    "stackTraceEnabled": false
+  },
+  "message": {
+    "$resolver": "pattern",
+    "pattern": "%m",
+    "stackTraceEnabled": false
+  },
+  "logging.googleapis.com/sourceLocation": {
+    "file": {
+      "$resolver": "source",
+      "field": "fileName"
+    },
+    "line": {
+      "$resolver": "source",
+      "field": "lineNumber"
+    },
+    "function": {
+      "$resolver": "pattern",
+      "pattern": "%replace{%C.%M}{^\\?\\.$}{}",
+      "stackTraceEnabled": false
+    }
+  },
+  "logging.googleapis.com/labels": {
+    "$resolver": "mdc"
+  },
+  "threadContext": {
+    "id": {
+      "$resolver": "thread",
+      "field": "id"
+    },
+    "name": {
+      "$resolver": "thread",
+      "field": "name"
+    },
+    "priority": {
+      "$resolver": "thread",
+      "field": "priority"
+    }
+  },
+  "loggerName": {
+    "$resolver": "logger",
+    "field": "name"
+  },
+  "serviceContext": {
+    "service": "${env:LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME:-load-tester}",
+    "version": "${env:LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION:-}"
+  },
+  "exception": {
+    "$resolver": "exception",
+    "field": "stackTrace",
+    "stackTrace": {
+      "stringified": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Enable Stackdriver-formatted JSON logging for the load-tester so its starter and worker pods integrate into Cloud Logging the same way zeebe/operate/optimize/connectors do. Default stays plain text, so local runs and developer workflows are unaffected.

## What changed

- **Logging backend**: switched the load-tester from Logback (Spring Boot default) to Log4j2 via `spring-boot-starter-log4j2` + `log4j-layout-template-json`. Same pattern as `operate/webapp` and `tasklist/webapp`.
- **`log4j2.xml`** *(new)* at `load-tests/load-tester/src/main/resources/log4j2.xml`: defines a text `Console` appender and a JSON `Stackdriver` appender. Root logger picks one via `${env:LOAD_TESTER_LOG_APPENDER:-Console}`.
- **`StackdriverLayout.json`** *(new)* at `load-tests/load-tester/src/main/resources/logging/`: trimmed copy of `dist/src/main/resources/logging/StackdriverLayout.json`. Same JSON shape as the rest of the platform (severity, message, `logging.googleapis.com/sourceLocation`, `logging.googleapis.com/labels`, `serviceContext`, `threadContext`, `loggerName`, timestamps, exception). The dist-only `@type` and `reportLocation` resolver fields are intentionally omitted — they require a custom Log4j2 plugin (`StackdriverResolverFactory`) that lives only in the dist module and only feeds GCP Error Reporting, which isn't relevant for a benchmark tool.
- **`load-test-values.yaml`**: appended three entries to `global.extraEnvVars` to flip the appender to `Stackdriver` and populate `serviceContext.service`/`version`. The chart already templates `extraEnvVars` into both starter and worker deployments, so no chart change is needed.

Behavior:

| Mode | How to enable | Output |
|------|--------------|--------|
| Text (default) | nothing — empty/unset env var | `[time] [thread] LEVEL  logger - message` |
| JSON | `LOAD_TESTER_LOG_APPENDER=Stackdriver` | Stackdriver-shaped JSON, one line per event |

Existing log-level controls (`LOG_LEVEL`, `LOGGING_LEVEL_IO_CAMUNDA_ZEEBE`, `application.yaml`'s `logging.level.*`) are unchanged — Spring Boot's `LoggingSystem` translates those into Log4j2 logger configs at startup, so per-package level overrides keep working as before.

## Test plan

- [x] Module build green: `./mvnw install -pl load-tests/load-tester -am -Dquickly -T1C`
- [x] Module unit tests pass (20/20): `./mvnw verify -pl load-tests/load-tester -Dquickly -DskipTests=false -DskipITs -T1C`
- [x] `dependency:tree` confirms Logback removed; Log4j2 + JUL bridge present at runtime
- [x] Local smoke (text mode): output matches the existing pattern format
- [x] Local smoke (JSON mode): valid JSON with `severity`, `message`, `serviceContext.service`, `logging.googleapis.com/sourceLocation`
- [x] Cluster smoke test in `c8-pg-spring-logging` namespace on `camunda-benchmark-prod`: starter and worker pods emit JSON; `serviceContext.version` populated from `metadata.namespace` via the downward API

## Backporting

Per `.github/instructions/load-tests.instructions.md`, this should be backported to active maintenance branches once merged. Path mapping for stable/8.6–8.8: `load-tests/load-tester/` → `zeebe/benchmarks/project/`, `load-tests/load-test-values.yaml` → `zeebe/benchmarks/<values-file>`. Verify each target branch is on Spring Boot 4 / `camunda-spring-boot-starter` before applying — older HOCON-based load-tester branches need a different approach.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #