### PR TITLE
fix: Add Metric for Reindex by ID Retryer

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/DocumentBasedHistory.java
+++ b/configuration/src/main/java/io/camunda/configuration/DocumentBasedHistory.java
@@ -25,8 +25,9 @@ public class DocumentBasedHistory {
   private static final String DEFAULT_HISTORY_ELS_ROLLOVER_DATE_FORMAT = "date";
   private static final String DEFAULT_HISTORY_ROLLOVER_INTERVAL = "1d";
   private static final int DEFAULT_HISTORY_ROLLOVER_BATCH_SIZE = 100;
-  private static final int DEFAULT_HISTORY_REINDEX_BATCH_SIZE = 1000;
+  private static final int DEFAULT_HISTORY_REINDEX_BATCH_SIZE = 2500;
   private static final int DEFAULT_HISTORY_ARCHIVE_BY_ID_MAX_RETRY_ATTEMPTS = 3;
+  private static final int DEFAULT_HISTORY_ARCHIVE_BY_ID_RETRY_DELAY_MS = 1000;
   private static final String DEFAULT_HISTORY_WAIT_PERIOD_BEFORE_ARCHIVING = "1h";
   private static final Map<String, String> LEGACY_BROKER_PROPERTIES =
       Map.of(
@@ -81,6 +82,9 @@ public class DocumentBasedHistory {
 
   /** Maximum number of retries for archive-by-id batch operations on retryable errors */
   private int archiveByIdMaxRetryAttempts = DEFAULT_HISTORY_ARCHIVE_BY_ID_MAX_RETRY_ATTEMPTS;
+
+  /** Retry delay in millisecond interval when archive-by-id batch fails on retryable errors */
+  private int archiveByIdRetryDelayMs = DEFAULT_HISTORY_ARCHIVE_BY_ID_RETRY_DELAY_MS;
 
   /** Defines the name of the created and applied ILM policy. */
   private String policyName = DEFAULT_HISTORY_POLICY_NAME;
@@ -233,6 +237,14 @@ public class DocumentBasedHistory {
 
   public void setArchiveByIdMaxRetryAttempts(final int archiveByIdMaxRetryAttempts) {
     this.archiveByIdMaxRetryAttempts = archiveByIdMaxRetryAttempts;
+  }
+
+  public int getArchiveByIdRetryDelayMs() {
+    return archiveByIdRetryDelayMs;
+  }
+
+  public void setArchiveByIdRetryDelayMs(final int archiveByIdRetryDelayMs) {
+    this.archiveByIdRetryDelayMs = archiveByIdRetryDelayMs;
   }
 
   private Set<String> legacyPolicyNameProperties() {

--- a/configuration/src/main/java/io/camunda/configuration/DocumentBasedHistory.java
+++ b/configuration/src/main/java/io/camunda/configuration/DocumentBasedHistory.java
@@ -26,6 +26,7 @@ public class DocumentBasedHistory {
   private static final String DEFAULT_HISTORY_ROLLOVER_INTERVAL = "1d";
   private static final int DEFAULT_HISTORY_ROLLOVER_BATCH_SIZE = 100;
   private static final int DEFAULT_HISTORY_REINDEX_BATCH_SIZE = 1000;
+  private static final int DEFAULT_HISTORY_ARCHIVE_BY_ID_MAX_RETRY_ATTEMPTS = 3;
   private static final String DEFAULT_HISTORY_WAIT_PERIOD_BEFORE_ARCHIVING = "1h";
   private static final Map<String, String> LEGACY_BROKER_PROPERTIES =
       Map.of(
@@ -77,6 +78,9 @@ public class DocumentBasedHistory {
 
   /** Maximum millisecond interval between archiver runs due to failure backoffs */
   private Duration maxDelayBetweenRuns = DEFAULT_HISTORY_MAX_DELAY_BETWEEN_RUNS;
+
+  /** Maximum number of retries for archive-by-id batch operations on retryable errors */
+  private int archiveByIdMaxRetryAttempts = DEFAULT_HISTORY_ARCHIVE_BY_ID_MAX_RETRY_ATTEMPTS;
 
   /** Defines the name of the created and applied ILM policy. */
   private String policyName = DEFAULT_HISTORY_POLICY_NAME;
@@ -221,6 +225,14 @@ public class DocumentBasedHistory {
 
   public void setPolicyName(final String policyName) {
     this.policyName = policyName;
+  }
+
+  public int getArchiveByIdMaxRetryAttempts() {
+    return archiveByIdMaxRetryAttempts;
+  }
+
+  public void setArchiveByIdMaxRetryAttempts(final int archiveByIdMaxRetryAttempts) {
+    this.archiveByIdMaxRetryAttempts = archiveByIdMaxRetryAttempts;
   }
 
   private Set<String> legacyPolicyNameProperties() {

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/CamundaExporterConfigurationApplier.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/CamundaExporterConfigurationApplier.java
@@ -162,6 +162,7 @@ public final class CamundaExporterConfigurationApplier {
         Math.toIntExact(source.getHistory().getDelayBetweenRuns().toMillis()));
     target.setMaxDelayBetweenRuns(
         Math.toIntExact(source.getHistory().getMaxDelayBetweenRuns().toMillis()));
+    target.setArchiveByIdMaxRetryAttempts(source.getHistory().getArchiveByIdMaxRetryAttempts());
   }
 
   public static void applyPostExportConfiguration(

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/CamundaExporterConfigurationApplier.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/CamundaExporterConfigurationApplier.java
@@ -158,6 +158,7 @@ public final class CamundaExporterConfigurationApplier {
     target.setRolloverBatchSize(source.getHistory().getRolloverBatchSize());
     target.setReindexBatchSize(source.getHistory().getReindexBatchSize());
     target.setWaitPeriodBeforeArchiving(source.getHistory().getWaitPeriodBeforeArchiving());
+    target.setArchiveByIdRetryDelayMs(source.getHistory().getArchiveByIdRetryDelayMs());
     target.setDelayBetweenRuns(
         Math.toIntExact(source.getHistory().getDelayBetweenRuns().toMillis()));
     target.setMaxDelayBetweenRuns(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -240,8 +240,9 @@ public class ExporterConfiguration {
     private String rolloverInterval = "1d";
     private String usageMetricsRolloverInterval = "1M";
     private int rolloverBatchSize = 100;
-    private int reindexBatchSize = 1000;
+    private int reindexBatchSize = 2500;
     private int archiveByIdMaxRetryAttempts = 3;
+    private int archiveByIdRetryDelayMs = 1000;
     private String waitPeriodBeforeArchiving = "1h";
     private int delayBetweenRuns = 2000;
     private int maxDelayBetweenRuns = 60000;
@@ -325,6 +326,14 @@ public class ExporterConfiguration {
       this.archiveByIdMaxRetryAttempts = archiveByIdMaxRetryAttempts;
     }
 
+    public int getArchiveByIdRetryDelayMs() {
+      return archiveByIdRetryDelayMs;
+    }
+
+    public void setArchiveByIdRetryDelayMs(final int archiveByIdRetryDelayMs) {
+      this.archiveByIdRetryDelayMs = archiveByIdRetryDelayMs;
+    }
+
     public RetentionConfiguration getRetention() {
       return retention;
     }
@@ -390,6 +399,8 @@ public class ExporterConfiguration {
           + reindexBatchSize
           + ", archiveByIdMaxRetryAttempts="
           + archiveByIdMaxRetryAttempts
+          + ", archiveByIdMaxRetryDelayMs="
+          + archiveByIdRetryDelayMs
           + ", waitPeriodBeforeArchiving='"
           + waitPeriodBeforeArchiving
           + '\''

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -241,6 +241,7 @@ public class ExporterConfiguration {
     private String usageMetricsRolloverInterval = "1M";
     private int rolloverBatchSize = 100;
     private int reindexBatchSize = 1000;
+    private int archiveByIdMaxRetryAttempts = 3;
     private String waitPeriodBeforeArchiving = "1h";
     private int delayBetweenRuns = 2000;
     private int maxDelayBetweenRuns = 60000;
@@ -253,6 +254,15 @@ public class ExporterConfiguration {
 
     public void setProcessInstanceEnabled(final boolean processInstanceEnabled) {
       this.processInstanceEnabled = processInstanceEnabled;
+    }
+
+    public ProcessInstanceRetentionMode getProcessInstanceRetentionMode() {
+      return processInstanceRetentionMode;
+    }
+
+    public void setProcessInstanceRetentionMode(
+        final ProcessInstanceRetentionMode processInstanceRetentionMode) {
+      this.processInstanceRetentionMode = processInstanceRetentionMode;
     }
 
     public boolean isArchiveByIdEnabled() {
@@ -307,6 +317,14 @@ public class ExporterConfiguration {
       this.reindexBatchSize = reindexBatchSize;
     }
 
+    public int getArchiveByIdMaxRetryAttempts() {
+      return archiveByIdMaxRetryAttempts;
+    }
+
+    public void setArchiveByIdMaxRetryAttempts(final int archiveByIdMaxRetryAttempts) {
+      this.archiveByIdMaxRetryAttempts = archiveByIdMaxRetryAttempts;
+    }
+
     public RetentionConfiguration getRetention() {
       return retention;
     }
@@ -339,17 +357,39 @@ public class ExporterConfiguration {
       this.maxDelayBetweenRuns = maxDelayBetweenRuns;
     }
 
+    public boolean isTrackArchivalMetricsForProcessInstance() {
+      return trackArchivalMetricsForProcessInstance;
+    }
+
+    public void setTrackArchivalMetricsForProcessInstance(
+        final boolean trackArchivalMetricsForProcessInstance) {
+      this.trackArchivalMetricsForProcessInstance = trackArchivalMetricsForProcessInstance;
+    }
+
     @Override
     public String toString() {
       return "ArchiverConfiguration{"
+          + "processInstanceEnabled="
+          + processInstanceEnabled
+          + ", processInstanceRetentionMode="
+          + processInstanceRetentionMode
+          + ", archiveByIdEnabled="
+          + archiveByIdEnabled
           + ", elsRolloverDateFormat='"
           + elsRolloverDateFormat
           + '\''
           + ", rolloverInterval='"
           + rolloverInterval
           + '\''
+          + ", usageMetricsRolloverInterval='"
+          + usageMetricsRolloverInterval
+          + '\''
           + ", rolloverBatchSize="
           + rolloverBatchSize
+          + ", reindexBatchSize="
+          + reindexBatchSize
+          + ", archiveByIdMaxRetryAttempts="
+          + archiveByIdMaxRetryAttempts
           + ", waitPeriodBeforeArchiving='"
           + waitPeriodBeforeArchiving
           + '\''
@@ -361,27 +401,7 @@ public class ExporterConfiguration {
           + retention
           + ", trackArchivalMetricsForProcessInstance="
           + trackArchivalMetricsForProcessInstance
-          + ", retentionMode="
-          + processInstanceRetentionMode
           + '}';
-    }
-
-    public boolean isTrackArchivalMetricsForProcessInstance() {
-      return trackArchivalMetricsForProcessInstance;
-    }
-
-    public void setTrackArchivalMetricsForProcessInstance(
-        final boolean trackArchivalMetricsForProcessInstance) {
-      this.trackArchivalMetricsForProcessInstance = trackArchivalMetricsForProcessInstance;
-    }
-
-    public ProcessInstanceRetentionMode getProcessInstanceRetentionMode() {
-      return processInstanceRetentionMode;
-    }
-
-    public void setProcessInstanceRetentionMode(
-        final ProcessInstanceRetentionMode processInstanceRetentionMode) {
-      this.processInstanceRetentionMode = processInstanceRetentionMode;
     }
 
     public enum ProcessInstanceRetentionMode {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
@@ -91,6 +91,9 @@ public class CamundaExporterMetrics implements AutoCloseable {
   /** Count of document updated when incident updates were processed. */
   private final Counter incidentUpdatesDocumentsUpdated;
 
+  /** Count of archiver batch retries due to retryable errors. */
+  private final Counter archiverBatchRetries;
+
   /** Count of audit logs that are in progress of archiving. */
   private final Counter auditLogsArchiving;
 
@@ -164,6 +167,12 @@ public class CamundaExporterMetrics implements AutoCloseable {
             .tag("state", "archiving")
             .description(
                 "Count of completed batch operations that have been found, and are now in progress of archiving.")
+            .register(meterRegistry);
+    archiverBatchRetries =
+        Counter.builder(meterName("archiver.batch.retries"))
+            .description(
+                "Count of archiver batch retries due to retryable errors (e.g. socket timeouts, search engine exceptions).")
+            .tags("type", "docid-batch")
             .register(meterRegistry);
     usageMetricsArchived =
         Counter.builder(meterName("archiver.usage.metrics"))
@@ -447,6 +456,10 @@ public class CamundaExporterMetrics implements AutoCloseable {
     auditLogsArchiving.increment(count);
   }
 
+  public void recordArchiverBatchRetry() {
+    archiverBatchRetries.increment();
+  }
+
   public void recordJobBatchMetricsArchived(final int count) {
     jobBatchMetricsArchived.increment(count);
   }
@@ -592,6 +605,7 @@ public class CamundaExporterMetrics implements AutoCloseable {
     meterRegistry.remove(standaloneDecisionsArchived);
     meterRegistry.remove(auditLogsArchiving);
     meterRegistry.remove(auditLogsArchived);
+    meterRegistry.remove(archiverBatchRetries);
 
     meterRegistry.find(FLUSH_FAILURE_TYPE_METER_NAME).meters().forEach(meterRegistry::remove);
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplier.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplier.java
@@ -9,6 +9,8 @@ package io.camunda.exporter.tasks.archiver;
 
 import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import com.google.common.base.Stopwatch;
+import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
+import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.zeebe.util.function.TriFunction;
 import java.net.SocketTimeoutException;
 import java.util.List;
@@ -25,8 +27,8 @@ import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.slf4j.Logger;
 
 public class ArchiveByIdTaskSupplier<SortFieldType> {
-  private static final int MAX_RETRY_COUNT = 3;
 
+  private final HistoryConfiguration config;
   private final String sourceIdx;
   private final String destinationIdx;
   private final Function<List<SortFieldType>, CompletableFuture<ArchiveDocIdsBatch<SortFieldType>>>
@@ -34,6 +36,7 @@ public class ArchiveByIdTaskSupplier<SortFieldType> {
   private final TriFunction<String, String, List<String>, CompletableFuture<Long>> reindexer;
   private final BiFunction<String, List<String>, CompletableFuture<Long>> deleter;
   private final Executor executor;
+  private final CamundaExporterMetrics metrics;
   private final Logger logger;
 
   private final AtomicReference<ArchiveDocIdsBatch<SortFieldType>> lastSearchResponse =
@@ -45,6 +48,7 @@ public class ArchiveByIdTaskSupplier<SortFieldType> {
   private final AtomicLong totalTimeTakenMs = new AtomicLong(0);
 
   public ArchiveByIdTaskSupplier(
+      final HistoryConfiguration config,
       final String sourceIdx,
       final String destinationIdx,
       final Function<List<SortFieldType>, CompletableFuture<ArchiveDocIdsBatch<SortFieldType>>>
@@ -52,13 +56,16 @@ public class ArchiveByIdTaskSupplier<SortFieldType> {
       final TriFunction<String, String, List<String>, CompletableFuture<Long>> reindexer,
       final BiFunction<String, List<String>, CompletableFuture<Long>> deleter,
       final Executor executor,
+      final CamundaExporterMetrics metrics,
       final Logger logger) {
+    this.config = config;
     this.sourceIdx = sourceIdx;
     this.destinationIdx = destinationIdx;
     this.idsSupplier = idsSupplier;
     this.reindexer = reindexer;
     this.deleter = deleter;
     this.executor = executor;
+    this.metrics = metrics;
     this.logger = logger;
   }
 
@@ -99,15 +106,21 @@ public class ArchiveByIdTaskSupplier<SortFieldType> {
                   .exceptionally(
                       ex -> {
                         if (isRetryableError(ex)
-                            && retryCount.incrementAndGet() < MAX_RETRY_COUNT) {
-                          logger.debug(
+                            && retryCount.incrementAndGet()
+                                < config.getArchiveByIdMaxRetryAttempts()) {
+                          metrics.recordArchiverBatchRetry();
+                          logger.trace(
                               "Encountered retryable error when archiving docs from '{}' to '{}', "
-                                  + "retrying the batch. Error: {}",
+                                  + "retrying the batch (attempt {}/{}). Error: {}",
                               sourceIdx,
                               destinationIdx,
+                              retryCount.get(),
+                              config.getArchiveByIdMaxRetryAttempts(),
                               ex.getMessage());
                           return 0L;
                         }
+                        // reset retry count so the next batch starts with fresh retries
+                        retryCount.set(0);
                         // re-throw unexpected exceptions
                         throw ex instanceof final RuntimeException re
                             ? re

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplier.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplier.java
@@ -103,7 +103,7 @@ public class ArchiveByIdTaskSupplier<SortFieldType> {
                         retryCount.set(0);
                         return deletedCount;
                       })
-                  .exceptionally(
+                  .exceptionallyCompose(
                       ex -> {
                         if (isRetryableError(ex)
                             && retryCount.incrementAndGet()
@@ -117,7 +117,17 @@ public class ArchiveByIdTaskSupplier<SortFieldType> {
                               retryCount.get(),
                               config.getArchiveByIdMaxRetryAttempts(),
                               ex.getMessage());
-                          return 0L;
+
+                          // Whilst this is crude, we exploit the fact the ES/OS visibility is
+                          // around 2 second, and incrementing delay (default=1000ms) should give a
+                          // fighting chance to complete in the next attempt. If not will fail and
+                          // the next retry should take this over the full 2-second refresh interval
+                          final int retryDelayMs =
+                              config.getArchiveByIdRetryDelayMs() * retryCount.get();
+                          return CompletableFuture.supplyAsync(
+                              () -> 0L,
+                              CompletableFuture.delayedExecutor(
+                                  retryDelayMs, TimeUnit.MILLISECONDS, executor));
                         }
                         // reset retry count so the next batch starts with fresh retries
                         retryCount.set(0);
@@ -171,7 +181,8 @@ public class ArchiveByIdTaskSupplier<SortFieldType> {
     if (thr != null && thr.getCause() != null) {
       return thr.getCause() instanceof SocketTimeoutException
           || thr.getCause() instanceof ElasticsearchException
-          || thr.getCause() instanceof OpenSearchException;
+          || thr.getCause() instanceof OpenSearchException
+          || thr.getCause() instanceof BatchCountMismatchException;
     }
     return false;
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -358,6 +358,7 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
 
     final ArchiveByIdTaskSupplier<FieldValue> taskSupplier =
         new ArchiveByIdTaskSupplier<>(
+            config,
             sourceIndexName,
             destinationIndexName,
             searchAfter ->
@@ -366,6 +367,7 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
             this::reindexDocumentsById,
             this::deleteDocumentsById,
             executor,
+            metrics,
             logger);
 
     final var timer = Timer.start();
@@ -374,7 +376,7 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
         .thenComposeAsync(docIds -> setIndexLifeCycle(destinationIndexName), executor)
         .thenApply(
             ignored -> {
-              logger.debug(
+              logger.trace(
                   "Successfully completed archiving {} to the {} index, moved {} docs in {}s",
                   sourceIndexName,
                   destinationIndexName,
@@ -388,7 +390,7 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
         .whenComplete(
             (val, err) -> {
               if (err != null) {
-                logger.error(
+                logger.warn(
                     "Failed archiving {} to the {} index, moved {} docs so far in {}s, error={}",
                     sourceIndexName,
                     destinationIndexName,

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -369,6 +369,7 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
 
     final ArchiveByIdTaskSupplier<FieldValue> taskSupplier =
         new ArchiveByIdTaskSupplier<>(
+            config,
             sourceIndexName,
             destinationIndexName,
             searchAfter ->
@@ -377,6 +378,7 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
             this::reindexDocumentsById,
             this::deleteDocumentsById,
             executor,
+            metrics,
             logger);
 
     final var timer = Timer.start();
@@ -385,7 +387,7 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
         .thenComposeAsync(docIds -> setIndexLifeCycle(destinationIndexName), executor)
         .thenApply(
             ignored -> {
-              logger.debug(
+              logger.trace(
                   "Successfully completed archiving {} to the {} index, moved {} docs in {}s",
                   sourceIndexName,
                   destinationIndexName,
@@ -399,7 +401,7 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
         .whenComplete(
             (val, err) -> {
               if (err != null) {
-                logger.error(
+                logger.warn(
                     "Failed archiving {} to the {} index, moved {} docs so far in {}s, error={}",
                     sourceIndexName,
                     destinationIndexName,

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceByIdArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstanceByIdArchiverJob.java
@@ -57,7 +57,7 @@ public class ProcessInstanceByIdArchiverJob extends ProcessInstanceArchiverJob {
     // 1. First archive docs from dependent indices and `joinRelation={variable OR activity}`
     // from operate-list-view index
     // 2. Then archive all docs except `joinRelation=processInstance` from operate-list-view index
-    // 3. Then archive remaining docs from operate-list-view index (catch-all without filters)
+    // 3. Then archive all `joinRelation=processInstance` docs from operate-list-view index
     return archiveProcessDependants(batch)
         .thenComposeAsync(
             v ->
@@ -69,7 +69,16 @@ public class ProcessInstanceByIdArchiverJob extends ProcessInstanceArchiverJob {
                         ListViewTemplate.JOIN_RELATION,
                         ListViewTemplate.PROCESS_INSTANCE_JOIN_RELATION)),
             getExecutor())
-        .thenComposeAsync(ignored -> archive(templateDescriptor, batch, Map.of()), getExecutor())
+        .thenComposeAsync(
+            ignored ->
+                archive(
+                    templateDescriptor,
+                    batch,
+                    Map.of(
+                        ListViewTemplate.JOIN_RELATION,
+                        ListViewTemplate.PROCESS_INSTANCE_JOIN_RELATION),
+                    Map.of()),
+            getExecutor())
         .thenApply(FunctionUtil.peek(archived -> markBatchRecentlyArchived(batch)));
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplierTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplierTest.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.archiver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
+import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.tasks.archiver.ArchiveByIdTaskSupplier.ArchiveDocIdsBatch;
+import java.net.SocketTimeoutException;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class ArchiveByIdTaskSupplierTest {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ArchiveByIdTaskSupplierTest.class);
+  private static final Executor DIRECT_EXECUTOR = Runnable::run;
+
+  private final CamundaExporterMetrics metrics = mock(CamundaExporterMetrics.class);
+
+  @Test
+  void shouldRetryOnRetryableErrorAndRecordMetric() {
+    // given
+    final var retryableError = new CompletionException(new SocketTimeoutException("timeout"));
+    final var reindexCallCount = new AtomicInteger(0);
+
+    final var taskSupplier =
+        new ArchiveByIdTaskSupplier<>(
+            historyConfigWithMaxRetry(3),
+            "source-idx",
+            "destination-idx",
+            searchAfter ->
+                CompletableFuture.completedFuture(
+                    ArchiveDocIdsBatch.from(List.of("doc1", "doc2"), List.of("after1"))),
+            (source, dest, ids) -> {
+              if (reindexCallCount.incrementAndGet() <= 2) {
+                return CompletableFuture.failedFuture(retryableError);
+              }
+              return CompletableFuture.completedFuture((long) ids.size());
+            },
+            (source, ids) -> CompletableFuture.completedFuture((long) ids.size()),
+            DIRECT_EXECUTOR,
+            metrics,
+            LOGGER);
+
+    // when - first call should encounter retryable error and return 0
+    final var firstResult = taskSupplier.moveNextBatch().join();
+
+    // then - returns 0 to signal retry, metric recorded
+    assertThat(firstResult).isEqualTo(0L);
+    assertThat(taskSupplier.isComplete()).isFalse();
+    verify(metrics, times(1)).recordArchiverBatchRetry();
+
+    // when - second call also fails with retryable error
+    final var secondResult = taskSupplier.moveNextBatch().join();
+
+    // then - still retrying
+    assertThat(secondResult).isEqualTo(0L);
+    assertThat(taskSupplier.isComplete()).isFalse();
+    verify(metrics, times(2)).recordArchiverBatchRetry();
+
+    // when - third call succeeds because reindexCallCount > 2
+    final var thirdResult = taskSupplier.moveNextBatch().join();
+
+    // then - successfully archived
+    assertThat(thirdResult).isEqualTo(2L);
+  }
+
+  @Test
+  void shouldThrowWhenMaxRetriesExceeded() {
+    // given - maxRetryCount of 2, so only 1 retry is allowed
+    final var retryableError = new CompletionException(new SocketTimeoutException("timeout"));
+
+    final var taskSupplier =
+        new ArchiveByIdTaskSupplier<>(
+            historyConfigWithMaxRetry(2),
+            "source-idx",
+            "destination-idx",
+            searchAfter ->
+                CompletableFuture.completedFuture(
+                    ArchiveDocIdsBatch.from(List.of("doc1"), List.of("after1"))),
+            (source, dest, ids) -> CompletableFuture.failedFuture(retryableError),
+            (source, ids) -> CompletableFuture.completedFuture((long) ids.size()),
+            DIRECT_EXECUTOR,
+            metrics,
+            LOGGER);
+
+    // when - first call retries (retryCount becomes 1, which is < maxRetryCount 2)
+    final var firstResult = taskSupplier.moveNextBatch().join();
+    assertThat(firstResult).isEqualTo(0L);
+    verify(metrics, times(1)).recordArchiverBatchRetry();
+
+    // when - second call exceeds max retries (retryCount becomes 2, which is NOT < 2)
+    final var future = taskSupplier.moveNextBatch();
+
+    // then - should throw
+    assertThatThrownBy(future::join)
+        .isInstanceOf(CompletionException.class)
+        .hasCauseInstanceOf(SocketTimeoutException.class);
+  }
+
+  @Test
+  void shouldNotRetryOnNonRetryableError() {
+    // given
+    final var nonRetryableError = new CompletionException(new IllegalStateException("bad state"));
+
+    final var taskSupplier =
+        new ArchiveByIdTaskSupplier<>(
+            historyConfigWithMaxRetry(3),
+            "source-idx",
+            "destination-idx",
+            searchAfter ->
+                CompletableFuture.completedFuture(
+                    ArchiveDocIdsBatch.from(List.of("doc1"), List.of("after1"))),
+            (source, dest, ids) -> CompletableFuture.failedFuture(nonRetryableError),
+            (source, ids) -> CompletableFuture.completedFuture((long) ids.size()),
+            DIRECT_EXECUTOR,
+            metrics,
+            LOGGER);
+
+    // when
+    final var future = taskSupplier.moveNextBatch();
+
+    // then - should throw immediately without retrying
+    assertThatThrownBy(future::join).isInstanceOf(CompletionException.class);
+    verify(metrics, times(0)).recordArchiverBatchRetry();
+  }
+
+  @Test
+  void shouldCompleteWhenResponseIsEmpty() {
+    // given
+    final var taskSupplier =
+        new ArchiveByIdTaskSupplier<>(
+            historyConfigWithMaxRetry(3),
+            "source-idx",
+            "destination-idx",
+            searchAfter -> CompletableFuture.completedFuture(ArchiveDocIdsBatch.empty()),
+            (source, dest, ids) -> CompletableFuture.completedFuture((long) ids.size()),
+            (source, ids) -> CompletableFuture.completedFuture((long) ids.size()),
+            DIRECT_EXECUTOR,
+            metrics,
+            LOGGER);
+
+    // when
+    final var result = taskSupplier.moveNextBatch().join();
+
+    // then
+    assertThat(result).isEqualTo(0L);
+    assertThat(taskSupplier.isComplete()).isTrue();
+  }
+
+  @Test
+  void shouldResetRetryCountAfterSuccessfulBatch() {
+    // given - maxRetryAttempts=3 means 2 retries allowed before throwing on the 3rd failure.
+    // reindex calls 1, 3, 4, 5, 6 fail; calls 2, 7 succeed.
+    final var retryableError = new CompletionException(new SocketTimeoutException("timeout"));
+    final var reindexCallCount = new AtomicInteger(0);
+
+    final var taskSupplier =
+        new ArchiveByIdTaskSupplier<>(
+            historyConfigWithMaxRetry(3),
+            "source-idx",
+            "destination-idx",
+            searchAfter ->
+                CompletableFuture.completedFuture(
+                    ArchiveDocIdsBatch.from(List.of("doc1"), List.of("after1"))),
+            (source, dest, ids) -> {
+              final int call = reindexCallCount.incrementAndGet();
+              if (call != 2 && call != 7) {
+                return CompletableFuture.failedFuture(retryableError);
+              }
+              return CompletableFuture.completedFuture((long) ids.size());
+            },
+            (source, ids) -> CompletableFuture.completedFuture((long) ids.size()),
+            DIRECT_EXECUTOR,
+            metrics,
+            LOGGER);
+
+    // when - call 1 fails, triggers retry (retryCount=1)
+    assertThat(taskSupplier.moveNextBatch().join()).isEqualTo(0L);
+    verify(metrics, times(1)).recordArchiverBatchRetry();
+
+    // when - call 2 succeeds, resets retry count (retryCount=0)
+    assertThat(taskSupplier.moveNextBatch().join()).isEqualTo(1L);
+    assertThat(taskSupplier.getTotalArchived()).isEqualTo(1L);
+
+    // when - three consecutive failures exhaust retries
+    // call 3 fails (retryCount=1)
+    assertThat(taskSupplier.moveNextBatch().join()).isEqualTo(0L);
+    verify(metrics, times(2)).recordArchiverBatchRetry();
+
+    // call 4 fails (retryCount=2)
+    assertThat(taskSupplier.moveNextBatch().join()).isEqualTo(0L);
+    verify(metrics, times(3)).recordArchiverBatchRetry();
+
+    // call 5 fails (retryCount=3, NOT < maxRetryAttempts 3) — throws and resets retryCount
+    assertThatThrownBy(() -> taskSupplier.moveNextBatch().join())
+        .isInstanceOf(CompletionException.class)
+        .hasCauseInstanceOf(SocketTimeoutException.class);
+
+    // when - call 6 fails, retry works with fresh count proving reset on throw (retryCount=1)
+    assertThat(taskSupplier.moveNextBatch().join()).isEqualTo(0L);
+    verify(metrics, times(4)).recordArchiverBatchRetry();
+
+    // when - call 7 succeeds
+    assertThat(taskSupplier.moveNextBatch().join()).isEqualTo(1L);
+    assertThat(taskSupplier.getTotalArchived()).isEqualTo(2L);
+  }
+
+
+  private static HistoryConfiguration historyConfigWithMaxRetry(final int maxRetryCount) {
+    final var config = new HistoryConfiguration();
+    config.setArchiveByIdMaxRetryAttempts(maxRetryCount);
+    return config;
+  }
+
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplierTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplierTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -222,11 +223,48 @@ class ArchiveByIdTaskSupplierTest {
     assertThat(taskSupplier.getTotalArchived()).isEqualTo(2L);
   }
 
+  @Test
+  void shouldDelayBeforeRetryingRetryableError() {
+    // given
+    final var retryableError = new CompletionException(new SocketTimeoutException("timeout"));
+    final var reindexCallCount = new AtomicInteger(0);
+    final var config = historyConfigWithMaxRetry(3);
+    config.setArchiveByIdRetryDelayMs(500); // 500ms delay for testing
+
+    final var taskSupplier =
+        new ArchiveByIdTaskSupplier<>(
+            config,
+            "source-idx",
+            "destination-idx",
+            searchAfter ->
+                CompletableFuture.completedFuture(
+                    ArchiveDocIdsBatch.from(List.of("doc1"), List.of("after1"))),
+            (source, dest, ids) -> {
+              if (reindexCallCount.incrementAndGet() == 1) {
+                return CompletableFuture.failedFuture(retryableError);
+              }
+              return CompletableFuture.completedFuture((long) ids.size());
+            },
+            (source, ids) -> CompletableFuture.completedFuture((long) ids.size()),
+            DIRECT_EXECUTOR,
+            metrics,
+            LOGGER);
+
+    // when
+    final long startNanos = System.nanoTime();
+    final var result = taskSupplier.moveNextBatch().join();
+    final long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+
+    // then
+    assertThat(result).isEqualTo(0L);
+    assertThat(elapsedMs).isGreaterThanOrEqualTo(499); // 500ms delay
+    verify(metrics, times(1)).recordArchiverBatchRetry();
+  }
 
   private static HistoryConfiguration historyConfigWithMaxRetry(final int maxRetryCount) {
     final var config = new HistoryConfiguration();
     config.setArchiveByIdMaxRetryAttempts(maxRetryCount);
+    config.setArchiveByIdRetryDelayMs(0);
     return config;
   }
-
 }


### PR DESCRIPTION


## Description

At the moment, the retryer we added in retry-by-id is quite a bit noisy and seems to trigger a bit too often. It's okay that it is triggered, as it will retry things and they pass, but we want to make logs less noisy. Adding a metric instead.



## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
