### PR TITLE
51749 expression evaluation record state changes for processelement context

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -401,6 +401,7 @@ public final class EngineProcessors {
         writers,
         bpmnBehaviors.expressionBehavior(),
         bpmnBehaviors.expressionLanguage(),
+        processingState.getElementInstanceState(),
         authCheckBehavior);
 
     JobMetricsProcessors.addJobMetricsProcessors(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -127,7 +127,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
         new ExpressionBehavior(
             namespaceFullClusterContext,
             expressionLanguage,
-            config.getExpressionEvaluationTimeout());
+            config.getExpressionEvaluationTimeout(),
+            processingState.getVariableState());
 
     conditionalBehavior =
         new BpmnConditionalBehavior(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/ExpressionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/ExpressionBehavior.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.common.Failure;
+import io.camunda.zeebe.engine.state.immutable.VariableState;
 import io.camunda.zeebe.protocol.impl.record.value.expression.ExpressionRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.util.Either;
@@ -23,25 +24,59 @@ import java.util.Map;
 public class ExpressionBehavior {
 
   private final ExpressionProcessor clusterExpressionProcessor;
+  private final VariableState variableState;
 
   public ExpressionBehavior(
       final NamespacedEvaluationContext namespaceFullClusterContext,
       final ExpressionLanguage expressionLanguage,
-      final Duration expressionEvaluationTimeout) {
+      final Duration expressionEvaluationTimeout,
+      final VariableState variableState) {
     clusterExpressionProcessor =
         new ExpressionProcessor(
             expressionLanguage, namespaceFullClusterContext, expressionEvaluationTimeout);
+    this.variableState = variableState;
   }
 
+  /**
+   * Evaluates the given expression with the following variable resolution priority (highest first):
+   *
+   * <ol>
+   *   <li>Variables provided in the record body.
+   *   <li>Process/element instance variables visible from the record's scope (the element-instance
+   *       key if set, otherwise the process-instance key), walked up the scope tree.
+   *   <li>Tenant-scoped cluster variables.
+   *   <li>Global cluster variables.
+   * </ol>
+   */
   public Either<Rejection, ExpressionRecord> resolveExpression(
       final Expression expression, final ExpressionRecord expressionRecord) {
+    final long scopeKey = resolveScopeKey(expressionRecord);
     final var variables = expressionRecord.getVariables();
-    final var contextAsEvaluationContext =
+    final var bodyContext =
         variables == null
             ? new InMemoryVariableEvaluationContext(Map.of())
             : new InMemoryVariableEvaluationContext(variables);
-    return evaluate(expression, contextAsEvaluationContext, expressionRecord.getTenantId())
+
+    ExpressionProcessor processor = clusterExpressionProcessor;
+    if (scopeKey >= 0) {
+      // Process/element instance variables: walked up from scopeKey by VariableState#getVariable.
+      processor = processor.prependContext(new VariableEvaluationContext(variableState));
+    }
+    // Body-provided variables take precedence over everything else.
+    processor = processor.prependContext(bodyContext);
+
+    return processor
+        .evaluateAnyExpression(expression, scopeKey, expressionRecord.getTenantId())
+        .mapLeft(this::mapEvaluationFailure)
+        .flatMap(this::rejectIfEvaluationFailed)
         .map(evaluationResult -> mapSuccess(evaluationResult, expressionRecord));
+  }
+
+  private static long resolveScopeKey(final ExpressionRecord record) {
+    if (record.getElementInstanceKey() >= 0) {
+      return record.getElementInstanceKey();
+    }
+    return record.getProcessInstanceKey();
   }
 
   private Either<Rejection, EvaluationResult> rejectIfEvaluationFailed(
@@ -56,15 +91,6 @@ public class ExpressionBehavior {
     }
   }
 
-  private Either<Rejection, EvaluationResult> evaluate(
-      final Expression expression, final ScopedEvaluationContext context, final String tenantId) {
-    return clusterExpressionProcessor
-        .prependContext(context)
-        .evaluateAnyExpression(expression, -1, tenantId)
-        .mapLeft(this::mapEvaluationFailure)
-        .flatMap(this::rejectIfEvaluationFailed);
-  }
-
   private Rejection mapEvaluationFailure(final Failure failure) {
     return new Rejection(RejectionType.PROCESSING_ERROR, failure.getMessage());
   }
@@ -75,6 +101,8 @@ public class ExpressionBehavior {
         .setTenantId(expressionRecord.getTenantId())
         .setExpression(expressionRecord.getExpression())
         .setVariables(expressionRecord.getVariablesBuffer())
+        .setProcessInstanceKey(expressionRecord.getProcessInstanceKey())
+        .setElementInstanceKey(expressionRecord.getElementInstanceKey())
         .setWarnings(
             evaluationResult.getWarnings().stream().map(EvaluationWarning::getMessage).toList())
         .setResultValue(evaluationResult.toBuffer());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/ExpressionEvaluateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/ExpressionEvaluateProcessor.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.zeebe.engine.processing.expression;
 
-import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.engine.processing.Rejection;
+import io.camunda.zeebe.engine.processing.expression.ExpressionValidator.ValidatedCommand;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
@@ -51,20 +51,27 @@ public final class ExpressionEvaluateProcessor implements TypedRecordProcessor<E
 
   @Override
   public void processRecord(final TypedRecord<ExpressionRecord> command) {
-    final var record = command.getValue();
     validator
-        .ensureNotBlank(command)
-        .flatMap(validator::isValid)
-        .flatMap(expression -> isAuthorized(command, expression))
-        .flatMap(expression -> expressionBehavior.resolveExpression(expression, record))
+        .validate(command)
+        .flatMap(validated -> authorize(command, validated))
+        .flatMap(this::evaluate)
         .ifRightOrLeft(
             resolvedRecord -> acceptCommand(command, resolvedRecord),
             rejection -> rejectCommand(command, rejection));
   }
 
-  private Either<Rejection, Expression> isAuthorized(
-      final TypedRecord<ExpressionRecord> command, final Expression expression) {
-    final var tenantId = command.getValue().getTenantId();
+  private Either<Rejection, ValidatedCommand> authorize(
+      final TypedRecord<ExpressionRecord> command, final ValidatedCommand validated) {
+    return isAuthorized(command, validated.record()).map(ignored -> validated);
+  }
+
+  private Either<Rejection, ExpressionRecord> evaluate(final ValidatedCommand validated) {
+    return expressionBehavior.resolveExpression(validated.expression(), validated.record());
+  }
+
+  private Either<Rejection, ExpressionRecord> isAuthorized(
+      final TypedRecord<ExpressionRecord> command, final ExpressionRecord record) {
+    final var tenantId = record.getTenantId();
     final var authRequestBuilder =
         AuthorizationRequest.builder()
             .command(command)
@@ -76,7 +83,7 @@ public final class ExpressionEvaluateProcessor implements TypedRecordProcessor<E
     }
 
     final var authRequest = authRequestBuilder.build();
-    return authCheckBehavior.isAuthorizedOrInternalCommand(authRequest).map(unused -> expression);
+    return authCheckBehavior.isAuthorizedOrInternalCommand(authRequest).map(unused -> record);
   }
 
   private void rejectCommand(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/ExpressionEvaluateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/ExpressionEvaluateProcessor.java
@@ -53,11 +53,20 @@ public final class ExpressionEvaluateProcessor implements TypedRecordProcessor<E
   public void processRecord(final TypedRecord<ExpressionRecord> command) {
     validator
         .validate(command)
+        .map(this::applyResolvedTenant)
         .flatMap(validated -> authorize(command, validated))
         .flatMap(this::evaluate)
         .ifRightOrLeft(
             resolvedRecord -> acceptCommand(command, resolvedRecord),
             rejection -> rejectCommand(command, rejection));
+  }
+
+  private ValidatedCommand applyResolvedTenant(final ValidatedCommand validated) {
+    // Infer the tenant from the resolved instance so downstream auth and variable
+    // resolution always operate against the instance's owning tenant. Done here
+    // (in the processor) rather than in the validator to keep validation side effect free.
+    validated.resolvedTenantId().ifPresent(validated.record()::setTenantId);
+    return validated;
   }
 
   private Either<Rejection, ValidatedCommand> authorize(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/ExpressionProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/ExpressionProcessors.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ExpressionIntent;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
@@ -25,8 +26,9 @@ public final class ExpressionProcessors {
       final Writers writers,
       final ExpressionBehavior expressionBehavior,
       final ExpressionLanguage expressionLanguage,
+      final ElementInstanceState elementInstanceState,
       final AuthorizationCheckBehavior authCheckBehavior) {
-    final var validator = new ExpressionValidator(expressionLanguage);
+    final var validator = new ExpressionValidator(expressionLanguage, elementInstanceState);
     typedRecordProcessors.onCommand(
         ValueType.EXPRESSION,
         ExpressionIntent.EVALUATE,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/ExpressionValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/ExpressionValidator.java
@@ -19,10 +19,12 @@ import java.util.Optional;
 
 public final class ExpressionValidator {
 
+  private static final long UNSET_KEY = -1L;
+
   private static final String ERROR_MESSAGE_EMPTY_EXPRESSION = "No expression provided";
   private static final String ERROR_MESSAGE_BLANK_EXPRESSION =
       "The expression must not be blank or empty";
-  private static final String ERROR_MESSAGE_EITHER_OR =
+  private static final String ERROR_MESSAGE_BOTH_KEYS_PROVIDED =
       "Either 'processInstanceKey' or 'elementInstanceKey' must be provided, not both";
   private static final String ERROR_MESSAGE_PROCESS_INSTANCE_NOT_FOUND =
       "No process instance found with key '%d'";
@@ -45,79 +47,61 @@ public final class ExpressionValidator {
 
   public Either<Rejection, ValidatedCommand> validate(final TypedRecord<ExpressionRecord> command) {
     final var record = command.getValue();
-
-    return validateExpressionText(record)
-        .flatMap(this::parseExpression)
+    return parseValidExpression(record)
         .flatMap(
             expression ->
-                resolveScopedContext(record)
-                    .map(resolvedRecord -> new ValidatedCommand(expression, resolvedRecord)));
+                validateScope(record)
+                    .map(tenantId -> new ValidatedCommand(expression, record, tenantId)));
   }
 
-  private Either<Rejection, String> validateExpressionText(final ExpressionRecord record) {
-    final var expression = record.getExpression();
+  /** Combines text-level validation and FEEL parsing — they always travel together. */
+  private Either<Rejection, Expression> parseValidExpression(final ExpressionRecord record) {
+    final var text = record.getExpression();
 
-    // No expression field at all → caller omitted it from the request body.
-    if (expression == null) {
+    if (text == null) {
       return reject(RejectionType.INVALID_ARGUMENT, ERROR_MESSAGE_EMPTY_EXPRESSION);
     }
-
-    // Present but whitespace-only → reject separately to give a clearer error.
-    if (expression.isBlank()) {
+    if (text.isBlank()) {
       return reject(RejectionType.INVALID_ARGUMENT, ERROR_MESSAGE_BLANK_EXPRESSION);
     }
 
-    return Either.right(expression);
-  }
-
-  private Either<Rejection, Expression> parseExpression(final String expressionText) {
-    final var expression = expressionLanguage.parseExpression(expressionText);
-
-    // FEEL parser rejected the input (syntax error, unknown function, etc.).
+    final var expression = expressionLanguage.parseExpression(text);
     if (!expression.isValid()) {
       return reject(
           RejectionType.INVALID_ARGUMENT,
           "Failed to parse expression: " + expression.getFailureMessage());
     }
-
     return Either.right(expression);
   }
 
-  private Either<Rejection, ExpressionRecord> resolveScopedContext(final ExpressionRecord record) {
-    return resolveScopeTarget(record)
-        .flatMap(
-            target ->
-                target
-                    // A scope was provided → look it up and validate tenant ownership.
-                    .map(scopedTarget -> resolveInstance(record, scopedTarget))
-                    // No scope provided → record passes through unchanged.
-                    .orElseGet(() -> Either.right(record)));
-  }
+  /**
+   * Identifies the (optional) scope and, if present, validates that the caller's tenant owns it.
+   * Returns {@code Optional.empty()} when no scope was supplied — this is a valid state, not an
+   * error.
+   */
+  private Either<Rejection, Optional<String>> validateScope(final ExpressionRecord record) {
+    final boolean hasProcessInstanceKey = isSet(record.getProcessInstanceKey());
+    final boolean hasElementInstanceKey = isSet(record.getElementInstanceKey());
 
-  private Either<Rejection, Optional<ScopeTarget>> resolveScopeTarget(
-      final ExpressionRecord record) {
-    final boolean hasProcessInstanceKey = record.getProcessInstanceKey() >= 0;
-    final boolean hasElementInstanceKey = record.getElementInstanceKey() >= 0;
-
-    // Both keys are mutually exclusive — supplying both is a client-side error.
+    // Mutually exclusive — supplying both is a client-side error.
     if (hasProcessInstanceKey && hasElementInstanceKey) {
-      return reject(RejectionType.INVALID_ARGUMENT, ERROR_MESSAGE_EITHER_OR);
+      return reject(RejectionType.INVALID_ARGUMENT, ERROR_MESSAGE_BOTH_KEYS_PROVIDED);
     }
 
-    // Neither key set → evaluation runs without an instance scope (cluster-only variables).
+    // Neither set → evaluation runs without an instance scope.
     if (!hasProcessInstanceKey && !hasElementInstanceKey) {
       return Either.right(Optional.empty());
     }
 
-    // Exactly one key is set → classify it into the matching scope target.
-    return Either.right(
-        Optional.of(
-            hasElementInstanceKey
-                ? ScopeTarget.elementInstance(record.getElementInstanceKey())
-                : ScopeTarget.processInstance(record.getProcessInstanceKey())));
+    final var target =
+        hasElementInstanceKey
+            ? ScopeTarget.elementInstance(record.getElementInstanceKey())
+            : ScopeTarget.processInstance(record.getProcessInstanceKey());
+
+    return validateInstanceTenant(record, target).map(Optional::of);
   }
 
-  private Either<Rejection, ExpressionRecord> resolveInstance(
+  private Either<Rejection, String> validateInstanceTenant(
       final ExpressionRecord record, final ScopeTarget target) {
     final var instance = elementInstanceState.getInstance(target.key());
 
@@ -129,25 +113,27 @@ public final class ExpressionValidator {
     final var providedTenantId = record.getTenantId();
     final var actualTenantId = instance.getValue().getTenantId();
 
-    // Caller supplied a tenant that doesn't own the instance → treat as not-found
-    // to avoid confirming the instance exists under a different tenant.
+    // Tenant mismatch is also reported as not-found so we don't confirm the instance
+    // exists under a different tenant.
     if (providedTenantId != null
         && !providedTenantId.isEmpty()
         && !providedTenantId.equals(actualTenantId)) {
       return reject(RejectionType.NOT_FOUND, target.tenantMismatchMessage(providedTenantId));
     }
 
-    // Infer the tenant from the instance so downstream auth / variable resolution
-    // always operate against the instance's owning tenant.
-    record.setTenantId(actualTenantId);
-    return Either.right(record);
+    return Either.right(actualTenantId);
+  }
+
+  private static boolean isSet(final long key) {
+    return key != UNSET_KEY;
   }
 
   private static <T> Either<Rejection, T> reject(final RejectionType type, final String message) {
     return Either.left(new Rejection(type, message));
   }
 
-  public record ValidatedCommand(Expression expression, ExpressionRecord record) {}
+  public record ValidatedCommand(
+      Expression expression, ExpressionRecord record, Optional<String> resolvedTenantId) {}
 
   private record ProcessInstanceScopeTarget(long key) implements ScopeTarget {
     @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/ExpressionValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/ExpressionValidator.java
@@ -10,59 +10,183 @@ package io.camunda.zeebe.engine.processing.expression;
 import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.engine.processing.Rejection;
+import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.protocol.impl.record.value.expression.ExpressionRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.Either;
 import java.util.Optional;
 
-public class ExpressionValidator {
+public final class ExpressionValidator {
 
   private static final String ERROR_MESSAGE_EMPTY_EXPRESSION = "No expression provided";
   private static final String ERROR_MESSAGE_BLANK_EXPRESSION =
       "The expression must not be blank or empty";
+  private static final String ERROR_MESSAGE_EITHER_OR =
+      "Either 'processInstanceKey' or 'elementInstanceKey' must be provided, not both";
+  private static final String ERROR_MESSAGE_PROCESS_INSTANCE_NOT_FOUND =
+      "No process instance found with key '%d'";
+  private static final String ERROR_MESSAGE_ELEMENT_INSTANCE_NOT_FOUND =
+      "No element instance found with key '%d'";
+  private static final String ERROR_MESSAGE_TENANT_MISMATCH_PROCESS_INSTANCE =
+      "No process instance found with key '%d' for tenant '%s'";
+  private static final String ERROR_MESSAGE_TENANT_MISMATCH_ELEMENT_INSTANCE =
+      "No element instance found with key '%d' for tenant '%s'";
 
   private final ExpressionLanguage expressionLanguage;
+  private final ElementInstanceState elementInstanceState;
 
-  public ExpressionValidator(final ExpressionLanguage expressionLanguage) {
+  public ExpressionValidator(
+      final ExpressionLanguage expressionLanguage,
+      final ElementInstanceState elementInstanceState) {
     this.expressionLanguage = expressionLanguage;
+    this.elementInstanceState = elementInstanceState;
   }
 
-  /**
-   * Validates that the expression is not null or empty.
-   *
-   * @param command the command containing the expression record
-   * @return Either a rejection if validation fails, or the expression string
-   */
-  public Either<Rejection, String> ensureNotBlank(final TypedRecord<ExpressionRecord> command) {
-    final String expression = command.getValue().getExpression();
-    return Optional.ofNullable(expression)
-        .filter(expr -> !expr.isBlank())
-        .map(Either::<Rejection, String>right)
-        .orElseGet(
-            () ->
-                Either.left(
-                    new Rejection(
-                        RejectionType.INVALID_ARGUMENT,
-                        expression == null
-                            ? ERROR_MESSAGE_EMPTY_EXPRESSION
-                            : ERROR_MESSAGE_BLANK_EXPRESSION)));
+  public Either<Rejection, ValidatedCommand> validate(final TypedRecord<ExpressionRecord> command) {
+    final var record = command.getValue();
+
+    return validateExpressionText(record)
+        .flatMap(this::parseExpression)
+        .flatMap(
+            expression ->
+                resolveScopedContext(record)
+                    .map(resolvedRecord -> new ValidatedCommand(expression, resolvedRecord)));
   }
 
-  /**
-   * Validates that the expression is syntactically valid by parsing it.
-   *
-   * @param expressionString the expression string to validate
-   * @return Either a rejection if validation fails, or the parsed Expression
-   */
-  public Either<Rejection, Expression> isValid(final String expressionString) {
-    final var expression = expressionLanguage.parseExpression(expressionString);
-    if (!expression.isValid()) {
-      return Either.left(
-          new Rejection(
-              RejectionType.INVALID_ARGUMENT,
-              "Failed to parse expression: " + expression.getFailureMessage()));
+  private Either<Rejection, String> validateExpressionText(final ExpressionRecord record) {
+    final var expression = record.getExpression();
+
+    // No expression field at all → caller omitted it from the request body.
+    if (expression == null) {
+      return reject(RejectionType.INVALID_ARGUMENT, ERROR_MESSAGE_EMPTY_EXPRESSION);
     }
+
+    // Present but whitespace-only → reject separately to give a clearer error.
+    if (expression.isBlank()) {
+      return reject(RejectionType.INVALID_ARGUMENT, ERROR_MESSAGE_BLANK_EXPRESSION);
+    }
+
     return Either.right(expression);
+  }
+
+  private Either<Rejection, Expression> parseExpression(final String expressionText) {
+    final var expression = expressionLanguage.parseExpression(expressionText);
+
+    // FEEL parser rejected the input (syntax error, unknown function, etc.).
+    if (!expression.isValid()) {
+      return reject(
+          RejectionType.INVALID_ARGUMENT,
+          "Failed to parse expression: " + expression.getFailureMessage());
+    }
+
+    return Either.right(expression);
+  }
+
+  private Either<Rejection, ExpressionRecord> resolveScopedContext(final ExpressionRecord record) {
+    return resolveScopeTarget(record)
+        .flatMap(
+            target ->
+                target
+                    // A scope was provided → look it up and validate tenant ownership.
+                    .map(scopedTarget -> resolveInstance(record, scopedTarget))
+                    // No scope provided → record passes through unchanged.
+                    .orElseGet(() -> Either.right(record)));
+  }
+
+  private Either<Rejection, Optional<ScopeTarget>> resolveScopeTarget(
+      final ExpressionRecord record) {
+    final boolean hasProcessInstanceKey = record.getProcessInstanceKey() >= 0;
+    final boolean hasElementInstanceKey = record.getElementInstanceKey() >= 0;
+
+    // Both keys are mutually exclusive — supplying both is a client-side error.
+    if (hasProcessInstanceKey && hasElementInstanceKey) {
+      return reject(RejectionType.INVALID_ARGUMENT, ERROR_MESSAGE_EITHER_OR);
+    }
+
+    // Neither key set → evaluation runs without an instance scope (cluster-only variables).
+    if (!hasProcessInstanceKey && !hasElementInstanceKey) {
+      return Either.right(Optional.empty());
+    }
+
+    // Exactly one key is set → classify it into the matching scope target.
+    return Either.right(
+        Optional.of(
+            hasElementInstanceKey
+                ? ScopeTarget.elementInstance(record.getElementInstanceKey())
+                : ScopeTarget.processInstance(record.getProcessInstanceKey())));
+  }
+
+  private Either<Rejection, ExpressionRecord> resolveInstance(
+      final ExpressionRecord record, final ScopeTarget target) {
+    final var instance = elementInstanceState.getInstance(target.key());
+
+    // Unknown key → 404 rather than leaking details about what exists.
+    if (instance == null) {
+      return reject(RejectionType.NOT_FOUND, target.notFoundMessage());
+    }
+
+    final var providedTenantId = record.getTenantId();
+    final var actualTenantId = instance.getValue().getTenantId();
+
+    // Caller supplied a tenant that doesn't own the instance → treat as not-found
+    // to avoid confirming the instance exists under a different tenant.
+    if (providedTenantId != null
+        && !providedTenantId.isEmpty()
+        && !providedTenantId.equals(actualTenantId)) {
+      return reject(RejectionType.NOT_FOUND, target.tenantMismatchMessage(providedTenantId));
+    }
+
+    // Infer the tenant from the instance so downstream auth / variable resolution
+    // always operate against the instance's owning tenant.
+    record.setTenantId(actualTenantId);
+    return Either.right(record);
+  }
+
+  private static <T> Either<Rejection, T> reject(final RejectionType type, final String message) {
+    return Either.left(new Rejection(type, message));
+  }
+
+  public record ValidatedCommand(Expression expression, ExpressionRecord record) {}
+
+  private record ProcessInstanceScopeTarget(long key) implements ScopeTarget {
+    @Override
+    public String notFoundMessage() {
+      return ERROR_MESSAGE_PROCESS_INSTANCE_NOT_FOUND.formatted(key);
+    }
+
+    @Override
+    public String tenantMismatchMessage(final String tenantId) {
+      return ERROR_MESSAGE_TENANT_MISMATCH_PROCESS_INSTANCE.formatted(key, tenantId);
+    }
+  }
+
+  private record ElementInstanceScopeTarget(long key) implements ScopeTarget {
+    @Override
+    public String notFoundMessage() {
+      return ERROR_MESSAGE_ELEMENT_INSTANCE_NOT_FOUND.formatted(key);
+    }
+
+    @Override
+    public String tenantMismatchMessage(final String tenantId) {
+      return ERROR_MESSAGE_TENANT_MISMATCH_ELEMENT_INSTANCE.formatted(key, tenantId);
+    }
+  }
+
+  private sealed interface ScopeTarget
+      permits ProcessInstanceScopeTarget, ElementInstanceScopeTarget {
+    long key();
+
+    String notFoundMessage();
+
+    String tenantMismatchMessage(String tenantId);
+
+    static ScopeTarget processInstance(final long key) {
+      return new ProcessInstanceScopeTarget(key);
+    }
+
+    static ScopeTarget elementInstance(final long key) {
+      return new ElementInstanceScopeTarget(key);
+    }
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/ResolveFeelExpressionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/ResolveFeelExpressionTest.java
@@ -801,6 +801,101 @@ public class ResolveFeelExpressionTest {
   }
 
   @Test
+  public void shouldResolveVariableLocalToIntermediateCatchEventScope() {
+    // given - a process waiting on an intermediate catch event (the typical Connector use case)
+    ENGINE_RULE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("processWithCatchEvent")
+                .startEvent()
+                .intermediateCatchEvent("catch-event", e -> e.timerWithDuration("PT1H"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    final var processInstanceKey =
+        ENGINE_RULE.processInstance().ofBpmnProcessId("processWithCatchEvent").create();
+
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.INTERMEDIATE_CATCH_EVENT)
+            .getFirst()
+            .getKey();
+
+    // a variable created by the catch event itself (local to its own scope),
+    // simulating a Connector writing its result onto the catch event instance
+    ENGINE_RULE
+        .variables()
+        .ofScope(elementInstanceKey)
+        .withDocument(Map.of("catchVar", "hello from catch event"))
+        .withLocalSemantic()
+        .update();
+
+    // when
+    final var record =
+        ENGINE_RULE
+            .expression()
+            .withExpression("=catchVar")
+            .withElementInstanceKey(elementInstanceKey)
+            .resolve();
+
+    // then
+    Assertions.assertThat(record)
+        .hasIntent(ExpressionIntent.EVALUATED)
+        .hasRecordType(RecordType.EVENT);
+    assertThat(record.getValue().getResultValue()).isEqualTo("hello from catch event");
+  }
+
+  @Test
+  public void shouldResolveVariableLocalToServiceTaskWithBoundaryEventScope() {
+    // given - a service task with a boundary event (the typical Connector use case)
+    ENGINE_RULE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("processWithBoundaryEvent")
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType("test"))
+                .boundaryEvent("boundary-event", b -> b.timerWithDuration("PT1H"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    final var processInstanceKey =
+        ENGINE_RULE.processInstance().ofBpmnProcessId("processWithBoundaryEvent").create();
+
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .getFirst()
+            .getKey();
+
+    // a variable created by the service task itself (local to its own scope),
+    // simulating a Connector writing its result onto the service task instance
+    ENGINE_RULE
+        .variables()
+        .ofScope(elementInstanceKey)
+        .withDocument(Map.of("boundaryVar", 123))
+        .withLocalSemantic()
+        .update();
+
+    // when
+    final var record =
+        ENGINE_RULE
+            .expression()
+            .withExpression("=boundaryVar")
+            .withElementInstanceKey(elementInstanceKey)
+            .resolve();
+
+    // then
+    Assertions.assertThat(record)
+        .hasIntent(ExpressionIntent.EVALUATED)
+        .hasRecordType(RecordType.EVENT);
+    assertThat(record.getValue().getResultValue()).isEqualTo(123);
+  }
+
+  @Test
   public void shouldRejectWhenBothProcessInstanceKeyAndElementInstanceKeyProvided() {
     // when
     final var record =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/ResolveFeelExpressionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/ResolveFeelExpressionTest.java
@@ -988,14 +988,15 @@ public class ResolveFeelExpressionTest {
   }
 
   @Test
-  public void shouldResolveProcessScopeVariablesWhenElementInstanceKeyProvided() {
-    // given - variable "score" is on the process instance scope (visible from any element in it)
+  public void shouldPrioritizeElementInstanceVariablesOverProcessInstanceVariables() {
+    // given - process instance has "score = 1", same name will be set locally on the
+    // service task scope below
     ENGINE_RULE
         .deployment()
         .withXmlResource(
-            Bpmn.createExecutableProcess("elementScopeResolvesProcessVars")
+            Bpmn.createExecutableProcess("priorityElementOverProcess")
                 .startEvent()
-                .serviceTask("elementTask", t -> t.zeebeJobType("elementTest"))
+                .serviceTask("task", t -> t.zeebeJobType("test"))
                 .endEvent()
                 .done())
         .deploy();
@@ -1003,8 +1004,8 @@ public class ResolveFeelExpressionTest {
     final var processInstanceKey =
         ENGINE_RULE
             .processInstance()
-            .ofBpmnProcessId("elementScopeResolvesProcessVars")
-            .withVariables(Map.of("score", 42))
+            .ofBpmnProcessId("priorityElementOverProcess")
+            .withVariables(Map.of("score", 1))
             .create();
 
     final var elementInstanceKey =
@@ -1014,7 +1015,16 @@ public class ResolveFeelExpressionTest {
             .getFirst()
             .getKey();
 
-    // when - element instance key is provided; process-scope variable is visible from it
+    // and - "score = 99" written locally onto the element instance scope, shadowing
+    // the process-scope value of the same name
+    ENGINE_RULE
+        .variables()
+        .ofScope(elementInstanceKey)
+        .withDocument(Map.of("score", 99))
+        .withLocalSemantic()
+        .update();
+
+    // when - resolved through the element instance key, scope walk-up starts at the element
     final var record =
         ENGINE_RULE
             .expression()
@@ -1022,11 +1032,11 @@ public class ResolveFeelExpressionTest {
             .withElementInstanceKey(elementInstanceKey)
             .resolve();
 
-    // then - process-scope variable is resolved through the element instance
+    // then - element-scope variable shadows the process-scope one
     Assertions.assertThat(record)
         .hasIntent(ExpressionIntent.EVALUATED)
         .hasRecordType(RecordType.EVENT);
-    assertThat(record.getValue().getResultValue()).isEqualTo(42);
+    assertThat(record.getValue().getResultValue()).isEqualTo(99);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/ResolveFeelExpressionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/ResolveFeelExpressionTest.java
@@ -10,10 +10,14 @@ package io.camunda.zeebe.engine.processing.expression;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ExpressionIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.time.Duration;
 import java.util.Map;
@@ -717,5 +721,286 @@ public class ResolveFeelExpressionTest {
         .hasIntent(ExpressionIntent.EVALUATED)
         .hasRecordType(RecordType.EVENT);
     assertThat(record.getValue().getResultValue()).isEqualTo("Alice is 30 years old");
+  }
+
+  @Test
+  public void shouldResolveVariablesFromProcessInstanceScope() {
+    // given
+    ENGINE_RULE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("processWithVars")
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType("test"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    final var processInstanceKey =
+        ENGINE_RULE
+            .processInstance()
+            .ofBpmnProcessId("processWithVars")
+            .withVariables(Map.of("myVar", "hello from process"))
+            .create();
+
+    // when
+    final var record =
+        ENGINE_RULE
+            .expression()
+            .withExpression("=myVar")
+            .withProcessInstanceKey(processInstanceKey)
+            .resolve();
+
+    // then
+    Assertions.assertThat(record)
+        .hasIntent(ExpressionIntent.EVALUATED)
+        .hasRecordType(RecordType.EVENT);
+    assertThat(record.getValue().getResultValue()).isEqualTo("hello from process");
+  }
+
+  @Test
+  public void shouldResolveVariablesFromElementInstanceScope() {
+    // given
+    ENGINE_RULE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("processForElement")
+                .startEvent()
+                .serviceTask("elementTask", t -> t.zeebeJobType("elementTest"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    final var processInstanceKey =
+        ENGINE_RULE
+            .processInstance()
+            .ofBpmnProcessId("processForElement")
+            .withVariables(Map.of("elemVar", 42))
+            .create();
+
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .getFirst()
+            .getKey();
+
+    // when
+    final var record =
+        ENGINE_RULE
+            .expression()
+            .withExpression("=elemVar")
+            .withElementInstanceKey(elementInstanceKey)
+            .resolve();
+
+    // then
+    Assertions.assertThat(record)
+        .hasIntent(ExpressionIntent.EVALUATED)
+        .hasRecordType(RecordType.EVENT);
+    assertThat(record.getValue().getResultValue()).isEqualTo(42);
+  }
+
+  @Test
+  public void shouldRejectWhenBothProcessInstanceKeyAndElementInstanceKeyProvided() {
+    // when
+    final var record =
+        ENGINE_RULE
+            .expression()
+            .withExpression("=1")
+            .withProcessInstanceKey(1L)
+            .withElementInstanceKey(2L)
+            .expectRejection()
+            .resolve();
+
+    // then
+    Assertions.assertThat(record)
+        .hasIntent(ExpressionIntent.EVALUATE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+    assertThat(record.getRejectionReason())
+        .contains("Either 'processInstanceKey' or 'elementInstanceKey' must be provided, not both");
+  }
+
+  @Test
+  public void shouldRejectWhenProcessInstanceKeyNotFound() {
+    // when
+    final var record =
+        ENGINE_RULE
+            .expression()
+            .withExpression("=1")
+            .withProcessInstanceKey(999999L)
+            .expectRejection()
+            .resolve();
+
+    // then
+    Assertions.assertThat(record)
+        .hasIntent(ExpressionIntent.EVALUATE)
+        .hasRejectionType(RejectionType.NOT_FOUND);
+    assertThat(record.getRejectionReason()).contains("999999");
+  }
+
+  @Test
+  public void shouldRejectWhenElementInstanceKeyNotFound() {
+    // when
+    final var record =
+        ENGINE_RULE
+            .expression()
+            .withExpression("=1")
+            .withElementInstanceKey(999999L)
+            .expectRejection()
+            .resolve();
+
+    // then
+    Assertions.assertThat(record)
+        .hasIntent(ExpressionIntent.EVALUATE)
+        .hasRejectionType(RejectionType.NOT_FOUND);
+    assertThat(record.getRejectionReason()).contains("999999");
+  }
+
+  @Test
+  public void shouldPrioritizeBodyVariablesOverProcessInstanceVariables() {
+    // given - process instance has "score = 1"
+    ENGINE_RULE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("priorityBodyOverProcess")
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType("test"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    final var processInstanceKey =
+        ENGINE_RULE
+            .processInstance()
+            .ofBpmnProcessId("priorityBodyOverProcess")
+            .withVariables(Map.of("score", 1))
+            .create();
+
+    // when - body also has "score = 99", body takes precedence
+    final var record =
+        ENGINE_RULE
+            .expression()
+            .withExpression("=score")
+            .withProcessInstanceKey(processInstanceKey)
+            .withVariables(Map.of("score", 99))
+            .resolve();
+
+    // then - body variable wins
+    Assertions.assertThat(record)
+        .hasIntent(ExpressionIntent.EVALUATED)
+        .hasRecordType(RecordType.EVENT);
+    assertThat(record.getValue().getResultValue()).isEqualTo(99);
+  }
+
+  @Test
+  public void shouldResolveProcessScopeVariablesWhenElementInstanceKeyProvided() {
+    // given - variable "score" is on the process instance scope (visible from any element in it)
+    ENGINE_RULE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("elementScopeResolvesProcessVars")
+                .startEvent()
+                .serviceTask("elementTask", t -> t.zeebeJobType("elementTest"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    final var processInstanceKey =
+        ENGINE_RULE
+            .processInstance()
+            .ofBpmnProcessId("elementScopeResolvesProcessVars")
+            .withVariables(Map.of("score", 42))
+            .create();
+
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .getFirst()
+            .getKey();
+
+    // when - element instance key is provided; process-scope variable is visible from it
+    final var record =
+        ENGINE_RULE
+            .expression()
+            .withExpression("=score")
+            .withElementInstanceKey(elementInstanceKey)
+            .resolve();
+
+    // then - process-scope variable is resolved through the element instance
+    Assertions.assertThat(record)
+        .hasIntent(ExpressionIntent.EVALUATED)
+        .hasRecordType(RecordType.EVENT);
+    assertThat(record.getValue().getResultValue()).isEqualTo(42);
+  }
+
+  @Test
+  public void shouldPrioritizeProcessInstanceVariablesOverClusterVariables() {
+    // given - cluster has "score = 1", process instance also has "score = 99"
+    ENGINE_RULE.clusterVariables().withName("score").setGlobalScope().withValue("1").create();
+
+    ENGINE_RULE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("priorityProcessOverCluster")
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType("test"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    final var processInstanceKey =
+        ENGINE_RULE
+            .processInstance()
+            .ofBpmnProcessId("priorityProcessOverCluster")
+            .withVariables(Map.of("score", 99))
+            .create();
+
+    // when - process instance variable has "score", takes precedence over cluster
+    final var record =
+        ENGINE_RULE
+            .expression()
+            .withExpression("=score")
+            .withProcessInstanceKey(processInstanceKey)
+            .resolve();
+
+    // then - process instance variable wins over cluster variable
+    Assertions.assertThat(record)
+        .hasIntent(ExpressionIntent.EVALUATED)
+        .hasRecordType(RecordType.EVENT);
+    assertThat(record.getValue().getResultValue()).isEqualTo(99);
+  }
+
+  @Test
+  public void shouldRejectWhenTenantDoesNotMatchProcessInstance() {
+    // given
+    ENGINE_RULE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("processTenantA")
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType("test"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    final var processInstanceKey =
+        ENGINE_RULE.processInstance().ofBpmnProcessId("processTenantA").create();
+
+    // when - request with a tenant that does not own this process instance
+    final var record =
+        ENGINE_RULE
+            .expression()
+            .withExpression("=1")
+            .withProcessInstanceKey(processInstanceKey)
+            .withTenantId("wrong-tenant")
+            .expectRejection()
+            .resolve();
+
+    // then
+    Assertions.assertThat(record)
+        .hasIntent(ExpressionIntent.EVALUATE)
+        .hasRejectionType(RejectionType.NOT_FOUND);
+    assertThat(record.getRejectionReason()).contains("wrong-tenant");
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ExpressionClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ExpressionClient.java
@@ -62,6 +62,16 @@ public final class ExpressionClient {
     return this;
   }
 
+  public ExpressionClient withProcessInstanceKey(final long key) {
+    expressionRecord.setProcessInstanceKey(key);
+    return this;
+  }
+
+  public ExpressionClient withElementInstanceKey(final long key) {
+    expressionRecord.setElementInstanceKey(key);
+    return this;
+  }
+
   public ExpressionClient expectRejection() {
     expectation = REJECTION_SUPPLIER;
     return this;

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/expression/ExpressionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/expression/ExpressionRecord.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
+import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
@@ -31,6 +32,8 @@ public class ExpressionRecord extends UnifiedRecordValue implements ExpressionRe
   private static final StringValue WARNINGS_KEY = new StringValue("warnings");
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
   private static final StringValue VARIABLES_KEY = new StringValue("variables");
+  private static final StringValue PROCESS_INSTANCE_KEY_KEY = new StringValue("processInstanceKey");
+  private static final StringValue ELEMENT_INSTANCE_KEY_KEY = new StringValue("elementInstanceKey");
 
   private final StringProperty expressionProp = new StringProperty(EXPRESSION_KEY);
 
@@ -43,13 +46,21 @@ public class ExpressionRecord extends UnifiedRecordValue implements ExpressionRe
 
   private final DocumentProperty variablesProp = new DocumentProperty(VARIABLES_KEY);
 
+  private final LongProperty processInstanceKeyProp =
+      new LongProperty(PROCESS_INSTANCE_KEY_KEY, -1L);
+
+  private final LongProperty elementInstanceKeyProp =
+      new LongProperty(ELEMENT_INSTANCE_KEY_KEY, -1L);
+
   public ExpressionRecord() {
-    super(5);
+    super(7);
     declareProperty(expressionProp)
         .declareProperty(resultValueProp)
         .declareProperty(warningsProp)
         .declareProperty(tenantIdProp)
-        .declareProperty(variablesProp);
+        .declareProperty(variablesProp)
+        .declareProperty(processInstanceKeyProp)
+        .declareProperty(elementInstanceKeyProp);
   }
 
   @Override
@@ -110,6 +121,26 @@ public class ExpressionRecord extends UnifiedRecordValue implements ExpressionRe
 
   public ExpressionRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public long getProcessInstanceKey() {
+    return processInstanceKeyProp.getValue();
+  }
+
+  public ExpressionRecord setProcessInstanceKey(final long processInstanceKey) {
+    processInstanceKeyProp.setValue(processInstanceKey);
+    return this;
+  }
+
+  @Override
+  public long getElementInstanceKey() {
+    return elementInstanceKeyProp.getValue();
+  }
+
+  public ExpressionRecord setElementInstanceKey(final long elementInstanceKey) {
+    elementInstanceKeyProp.setValue(elementInstanceKey);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -652,6 +652,8 @@ final class JsonSerializableToJsonTest {
               record
                   .setExpression("=10 + 5")
                   .setResultValue(wrapString("15"))
+                  .setProcessInstanceKey(1)
+                  .setElementInstanceKey(2)
                   .setTenantId("test-tenant")
                   .setWarnings(List.of("warning1", "warning2"))
                   .setVariables(VARIABLES_MSGPACK);
@@ -662,6 +664,8 @@ final class JsonSerializableToJsonTest {
                   "tenantId":"test-tenant",
                   "expression":"=10 + 5",
                   "resultValue":49,
+                  "processInstanceKey":1,
+                  "elementInstanceKey":2,
                   "warnings":["warning1","warning2"],
                   "variables":{
                     "foo":"bar"

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ExpressionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ExpressionRecord.golden
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
+import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
@@ -31,6 +32,8 @@ public class ExpressionRecord extends UnifiedRecordValue implements ExpressionRe
   private static final StringValue WARNINGS_KEY = new StringValue("warnings");
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
   private static final StringValue VARIABLES_KEY = new StringValue("variables");
+  private static final StringValue PROCESS_INSTANCE_KEY_KEY = new StringValue("processInstanceKey");
+  private static final StringValue ELEMENT_INSTANCE_KEY_KEY = new StringValue("elementInstanceKey");
 
   private final StringProperty expressionProp = new StringProperty(EXPRESSION_KEY);
 
@@ -43,13 +46,21 @@ public class ExpressionRecord extends UnifiedRecordValue implements ExpressionRe
 
   private final DocumentProperty variablesProp = new DocumentProperty(VARIABLES_KEY);
 
+  private final LongProperty processInstanceKeyProp =
+      new LongProperty(PROCESS_INSTANCE_KEY_KEY, -1L);
+
+  private final LongProperty elementInstanceKeyProp =
+      new LongProperty(ELEMENT_INSTANCE_KEY_KEY, -1L);
+
   public ExpressionRecord() {
-    super(5);
+    super(7);
     declareProperty(expressionProp)
         .declareProperty(resultValueProp)
         .declareProperty(warningsProp)
         .declareProperty(tenantIdProp)
-        .declareProperty(variablesProp);
+        .declareProperty(variablesProp)
+        .declareProperty(processInstanceKeyProp)
+        .declareProperty(elementInstanceKeyProp);
   }
 
   @Override
@@ -110,6 +121,26 @@ public class ExpressionRecord extends UnifiedRecordValue implements ExpressionRe
 
   public ExpressionRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public long getProcessInstanceKey() {
+    return processInstanceKeyProp.getValue();
+  }
+
+  public ExpressionRecord setProcessInstanceKey(final long processInstanceKey) {
+    processInstanceKeyProp.setValue(processInstanceKey);
+    return this;
+  }
+
+  @Override
+  public long getElementInstanceKey() {
+    return elementInstanceKeyProp.getValue();
+  }
+
+  public ExpressionRecord setElementInstanceKey(final long elementInstanceKey) {
+    elementInstanceKeyProp.setValue(elementInstanceKey);
     return this;
   }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ExpressionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ExpressionRecordValue.java
@@ -65,4 +65,18 @@ public interface ExpressionRecordValue extends RecordValue, TenantOwned, RecordV
    * @return the list of warnings (never {@code null}, but can be empty)
    */
   List<String> getWarnings();
+
+  /**
+   * Returns the process instance key that provides context for this expression evaluation.
+   *
+   * @return the process instance key, or {@code -1} if not set
+   */
+  long getProcessInstanceKey();
+
+  /**
+   * Returns the element instance key that provides context for this expression evaluation.
+   *
+   * @return the element instance key, or {@code -1} if not set
+   */
+  long getElementInstanceKey();
 }


### PR DESCRIPTION
This pull request significantly improves the validation, authorization, and evaluation flow for FEEL expression evaluation in the engine. The changes introduce stricter validation of input, better tenant and scope handling, and improved variable resolution priority. The most important changes are grouped as follows:

**Validation and Scope Resolution Improvements:**

* Refactored `ExpressionValidator` to validate that exactly one of `processInstanceKey` or `elementInstanceKey` is provided (not both), to check for the existence of the referenced instance, and to ensure tenant ownership matches. Now, the validator returns a new `ValidatedCommand` record containing both the parsed `Expression` and the resolved `ExpressionRecord`.
* Updated `ExpressionProcessors` and `EngineProcessors` to pass the required `ElementInstanceState` to the validator, enabling instance lookups during validation. [[1]](diffhunk://#diff-2a945044d4b2a949195e94f6eef167100b5f38becd1bdb820b53502d1ab480ddR29-R31) [[2]](diffhunk://#diff-54653cd8c67cd91fe5aba63bd7e7b723c0b8178340c3fbf63a60699ab52db5e5R404)

**Authorization and Processing Flow Refactoring:**

* Refactored `ExpressionEvaluateProcessor` to use the new validation flow, separating validation, authorization, and evaluation into distinct steps using the new `ValidatedCommand` record.
* Authorization now checks tenant ownership against the resolved instance, and the process flow ensures that only valid and authorized expressions are evaluated.

**Variable Resolution and Expression Evaluation:**

* Enhanced `ExpressionBehavior` to resolve variables in a prioritized order: variables from the record body, process/element instance variables (walked up the scope tree), tenant-scoped cluster variables, and finally global cluster variables. This uses the injected `VariableState` and improved context handling.
* The evaluation result now includes both the `processInstanceKey` and `elementInstanceKey` in the returned `ExpressionRecord`, ensuring downstream consumers have full context.

These changes collectively make FEEL expression evaluation more robust, secure, and predictable, especially in multi-tenant and scoped environments.