### PR TITLE
feat: propagate author and purpose labels to all core Helm resources in load tests

### DIFF
--- a/load-tests/camunda-platform-values.yaml
+++ b/load-tests/camunda-platform-values.yaml
@@ -15,7 +15,7 @@
 ########################################################################################
 global:
   commonLabels:
-    created-by: __AUTHOR__
+    "camunda.io/created-by": __AUTHOR__
     "camunda.io/purpose": load-test
   # Our default is ELASTICSEARCH
   # We need to explicitly enable ELS as per default this is disabled now

--- a/load-tests/camunda-platform-values.yaml
+++ b/load-tests/camunda-platform-values.yaml
@@ -14,6 +14,9 @@
 ################################################### Global cluster configuration
 ########################################################################################
 global:
+  commonLabels:
+    created-by: __AUTHOR__
+    "camunda.io/purpose": load-test
   # Our default is ELASTICSEARCH
   # We need to explicitly enable ELS as per default this is disabled now
   # THIS GETS OVERRIDDEN IN THE OTHER VALUES FILES, e.g. for OpenSearch and RDBMS

--- a/load-tests/camunda-platform-values.yaml
+++ b/load-tests/camunda-platform-values.yaml
@@ -15,8 +15,8 @@
 ########################################################################################
 global:
   commonLabels:
-    "camunda.io/created-by": __AUTHOR__
-    "camunda.io/purpose": load-test
+    camunda.io/created-by: __AUTHOR__
+    camunda.io/purpose: load-test
   # Our default is ELASTICSEARCH
   # We need to explicitly enable ELS as per default this is disabled now
   # THIS GETS OVERRIDDEN IN THE OTHER VALUES FILES, e.g. for OpenSearch and RDBMS

--- a/load-tests/load-test-values.yaml
+++ b/load-tests/load-test-values.yaml
@@ -1,6 +1,6 @@
 global:
   commonLabels:
-    created-by: __AUTHOR__
+    "camunda.io/created-by": __AUTHOR__
     "camunda.io/purpose": load-test
   image:
     repository: registry.camunda.cloud/team-zeebe

--- a/load-tests/load-test-values.yaml
+++ b/load-tests/load-test-values.yaml
@@ -1,7 +1,7 @@
 global:
   commonLabels:
-    "camunda.io/created-by": __AUTHOR__
-    "camunda.io/purpose": load-test
+    camunda.io/created-by: __AUTHOR__
+    camunda.io/purpose: load-test
   image:
     repository: registry.camunda.cloud/team-zeebe
     pullSecrets:

--- a/load-tests/load-test-values.yaml
+++ b/load-tests/load-test-values.yaml
@@ -1,4 +1,7 @@
 global:
+  commonLabels:
+    created-by: __AUTHOR__
+    "camunda.io/purpose": load-test
   image:
     repository: registry.camunda.cloud/team-zeebe
     pullSecrets:

--- a/load-tests/prometheus-elasticsearch-exporter-values.yaml
+++ b/load-tests/prometheus-elasticsearch-exporter-values.yaml
@@ -1,8 +1,8 @@
 fullnameOverride: "prom-els-exporter"
 
 commonLabels:
-  "camunda.io/created-by": __AUTHOR__
-  "camunda.io/purpose": load-test
+  camunda.io/created-by: __AUTHOR__
+  camunda.io/purpose: load-test
 
 image:
   # Route through colocated GAR pull-through cache to avoid quay.io rate limiting

--- a/load-tests/prometheus-elasticsearch-exporter-values.yaml
+++ b/load-tests/prometheus-elasticsearch-exporter-values.yaml
@@ -1,5 +1,9 @@
 fullnameOverride: "prom-els-exporter"
 
+commonLabels:
+  created-by: __AUTHOR__
+  "camunda.io/purpose": load-test
+
 image:
   # Route through colocated GAR pull-through cache to avoid quay.io rate limiting
   # Original: quay.io/prometheuscommunity/elasticsearch-exporter

--- a/load-tests/prometheus-elasticsearch-exporter-values.yaml
+++ b/load-tests/prometheus-elasticsearch-exporter-values.yaml
@@ -1,7 +1,7 @@
 fullnameOverride: "prom-els-exporter"
 
 commonLabels:
-  created-by: __AUTHOR__
+  "camunda.io/created-by": __AUTHOR__
   "camunda.io/purpose": load-test
 
 image:

--- a/load-tests/setup/cloud-default/Makefile
+++ b/load-tests/setup/cloud-default/Makefile
@@ -38,6 +38,7 @@ install-load-test:
 		--set saas.credentials.authType="OAUTH" \
 		--set saas.credentials.zeebeGrpcAddress="$${ZEEBE_GRPC_ADDRESS}" \
 		--set saas.credentials.authorizationAudience="$${ZEEBE_TOKEN_AUDIENCE}" \
+		-f load-test-values.yaml \
 		$(additional_load_test_configuration)
 
 .PHONY: clean

--- a/load-tests/setup/cloud-default/load-test-values.yaml
+++ b/load-tests/setup/cloud-default/load-test-values.yaml
@@ -1,4 +1,4 @@
 global:
   commonLabels:
-    created-by: __AUTHOR__
+    "camunda.io/created-by": __AUTHOR__
     "camunda.io/purpose": load-test

--- a/load-tests/setup/cloud-default/load-test-values.yaml
+++ b/load-tests/setup/cloud-default/load-test-values.yaml
@@ -1,0 +1,4 @@
+global:
+  commonLabels:
+    created-by: __AUTHOR__
+    "camunda.io/purpose": load-test

--- a/load-tests/setup/cloud-default/load-test-values.yaml
+++ b/load-tests/setup/cloud-default/load-test-values.yaml
@@ -1,4 +1,4 @@
 global:
   commonLabels:
-    "camunda.io/created-by": __AUTHOR__
-    "camunda.io/purpose": load-test
+    camunda.io/created-by: __AUTHOR__
+    camunda.io/purpose: load-test

--- a/load-tests/setup/newCloudLoadTest.sh
+++ b/load-tests/setup/newCloudLoadTest.sh
@@ -49,9 +49,15 @@ kubectl create namespace $namespace
 # Label namespace with registry (required to inject image pull secrets)
 kubectl label namespace "$namespace" registry=harbor --overwrite
 
+# Label namespace with author and purpose
+git_author=$(compute_git_author)
+kubectl label namespace "$namespace" "camunda.io/purpose=load-test" --overwrite
+kubectl label namespace "$namespace" created-by="$git_author" --overwrite
+
 cp -rv cloud-default/ $namespace
 cd $namespace
 
 
 # Update Makefile to use the namespace
 sed_inplace "s/__NAMESPACE__/$namespace/" Makefile
+sed_inplace "s/__AUTHOR__/$git_author/" *.yaml

--- a/load-tests/setup/newCloudLoadTest.sh
+++ b/load-tests/setup/newCloudLoadTest.sh
@@ -52,7 +52,7 @@ kubectl label namespace "$namespace" registry=harbor --overwrite
 # Label namespace with author and purpose
 git_author=$(compute_git_author)
 kubectl label namespace "$namespace" "camunda.io/purpose=load-test" --overwrite
-kubectl label namespace "$namespace" created-by="$git_author" --overwrite
+kubectl label namespace "$namespace" "camunda.io/created-by"="$git_author" --overwrite
 
 cp -rv cloud-default/ $namespace
 cd $namespace

--- a/load-tests/setup/newCloudLoadTest.sh
+++ b/load-tests/setup/newCloudLoadTest.sh
@@ -51,8 +51,8 @@ kubectl label namespace "$namespace" registry=harbor --overwrite
 
 # Label namespace with author and purpose
 git_author=$(compute_git_author)
-kubectl label namespace "$namespace" "camunda.io/purpose=load-test" --overwrite
-kubectl label namespace "$namespace" "camunda.io/created-by"="$git_author" --overwrite
+kubectl label namespace "$namespace" camunda.io/purpose=load-test --overwrite
+kubectl label namespace "$namespace" camunda.io/created-by="$git_author" --overwrite
 
 cp -rv cloud-default/ $namespace
 cd $namespace

--- a/load-tests/setup/newLoadTest.sh
+++ b/load-tests/setup/newLoadTest.sh
@@ -120,11 +120,11 @@ else
 fi
 
 # Label to easily find related namespaces
-kubectl label namespace "$namespace" "camunda.io/purpose=load-test" --overwrite
+kubectl label namespace "$namespace" camunda.io/purpose=load-test --overwrite
 
 # Label namespace with author (based on git author)
 git_author=$(compute_git_author)
-kubectl label namespace "$namespace" "camunda.io/created-by"="$git_author" --overwrite
+kubectl label namespace "$namespace" camunda.io/created-by="$git_author" --overwrite
 
 # Label namespace with TTL deadline (default: 1 day from now)
 # Try GNU date format first (Linux), then BSD/macOS format

--- a/load-tests/setup/newLoadTest.sh
+++ b/load-tests/setup/newLoadTest.sh
@@ -155,6 +155,7 @@ sed_inplace "s/__NAMESPACE__/$namespace/" load-test-values.yaml
 sed_inplace "s/__STORAGE_TYPE__/$secondaryStorage/" Makefile
 sed_inplace "s/__ENABLE_OPTIMIZE__/$enable_optimize/" Makefile
 sed_inplace "s/__AVAILABILITY_ZONE__/$availability_zone/" *.yaml databases/*.yaml
+sed_inplace "s/__AUTHOR__/$git_author/" *.yaml databases/*.yaml
 
 # Add/update helm repositories
 helm repo add camunda https://helm.camunda.io/ --force-update

--- a/load-tests/setup/newLoadTest.sh
+++ b/load-tests/setup/newLoadTest.sh
@@ -124,7 +124,7 @@ kubectl label namespace "$namespace" "camunda.io/purpose=load-test" --overwrite
 
 # Label namespace with author (based on git author)
 git_author=$(compute_git_author)
-kubectl label namespace "$namespace" created-by="$git_author" --overwrite
+kubectl label namespace "$namespace" "camunda.io/created-by"="$git_author" --overwrite
 
 # Label namespace with TTL deadline (default: 1 day from now)
 # Try GNU date format first (Linux), then BSD/macOS format

--- a/load-tests/setup/newLoadTest.sh
+++ b/load-tests/setup/newLoadTest.sh
@@ -119,30 +119,11 @@ else
   echo "Namespace ${namespace} has previously been configured to run on the single availability zone: $availability_zone"
 fi
 
-# Sanitize a string to be a valid Kubernetes label value
-sanitize_k8s_label() {
-  local value="$1"
-  # Replace invalid characters with hyphens
-  value=$(echo "$value" | sed 's/[^A-Za-z0-9_.-]/-/g')
-  # Remove leading non-alphanumeric characters
-  value=$(echo "$value" | sed 's/^[^A-Za-z0-9]\+//')
-  # Remove trailing non-alphanumeric characters
-  value=$(echo "$value" | sed 's/[^A-Za-z0-9]\+$//')
-  # Truncate to 63 characters as required by Kubernetes label values
-  value=${value:0:63}
-  # Fallback if the result is empty
-  if [ -z "$value" ]; then
-    value="unknown"
-  fi
-  echo "$value"
-}
-
 # Label to easily find related namespaces
 kubectl label namespace "$namespace" "camunda.io/purpose=load-test" --overwrite
 
 # Label namespace with author (based on git author)
-raw_git_author=$(git config user.name || echo "unknown")
-git_author=$(sanitize_k8s_label "$raw_git_author")
+git_author=$(compute_git_author)
 kubectl label namespace "$namespace" created-by="$git_author" --overwrite
 
 # Label namespace with TTL deadline (default: 1 day from now)

--- a/load-tests/setup/utils.sh
+++ b/load-tests/setup/utils.sh
@@ -25,9 +25,28 @@ function sed_inplace() {
   detect_os
 
   if [ "${GO_OS}" == "darwin" ]; then
-    sed -i '' -e $@ 
+    sed -i '' -e $@
   else
     sed -i -e $@
   fi
 
+}
+
+# Sanitize a string to be a valid Kubernetes label value (max 63 chars, alphanumeric/.-_)
+sanitize_k8s_label() {
+  local value="$1"
+  value=$(echo "$value" | sed 's/[^A-Za-z0-9_.-]/-/g')
+  value=$(echo "$value" | sed -E 's/^[^A-Za-z0-9]+//')
+  value=${value:0:63}
+  value=$(echo "$value" | sed -E 's/[^A-Za-z0-9]+$//')
+  if [ -z "$value" ]; then
+    value="unknown"
+  fi
+  echo "$value"
+}
+
+compute_git_author() {
+  local raw
+  raw=$(git config user.name 2>/dev/null || echo "unknown")
+  sanitize_k8s_label "$raw"
 }


### PR DESCRIPTION
## Motivation

Previously only namespaces carried author and purpose labels, making it impossible to correlate individual resource metrics (CPU, memory, logs) directly to a test owner without first resolving the namespace. With labels on every Pod, Deployment, and Service we can:

- Filter logs and logging alerts by `camunda.io/created-by` or `camunda.io/purpose` without a namespace lookup
- Attribute infrastructure cost per author or per load-test purpose in our cost tracking dashboards

## Summary

- Extends the existing `__AVAILABILITY_ZONE__` placeholder pattern with `__AUTHOR__` in the three core Helm values files and in a new `cloud-default/load-test-values.yaml`.
- `newLoadTest.sh` and `newCloudLoadTest.sh` resolve `__AUTHOR__` at setup time via `sed_inplace`, using the sanitized git author name (same value already applied to the namespace `camunda.io/created-by` label).
- Cloud load test namespaces now also receive `camunda.io/purpose=load-test` and `camunda.io/created-by` labels — previously only `registry=harbor` was applied there.
- `sanitize_k8s_label` and `compute_git_author` extracted to `utils.sh` to avoid duplication between the two setup scripts; the truncation/trailing-strip ordering bug in the original `sanitize_k8s_label` was fixed as part of the refactor.

## Labels added to all core Helm resources

| Label | Value | Scope |
|-------|-------|-------|
| `camunda.io/created-by` | sanitized git author name | all resources in all load tests |
| `camunda.io/purpose` | `load-test` | all resources in all load tests |

## Charts affected

| Chart | Mechanism | Status |
|-------|-----------|--------|
| Camunda Platform (`global.commonLabels`) | native chart support | ✅ active |
| Elasticsearch exporter (`commonLabels`) | native chart support | ✅ active |
| Load-tester workload (`global.commonLabels`) | pending chart support in `camunda-load-tests-helm` | ⏳ no-op until chart is updated |

## Out of scope

Secondary storage charts (PostgreSQL, MySQL, MariaDB, OpenSearch) — can be added later via `--set commonLabels` in the Makefile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
