### PR TITLE
refactor: use getopts to parse CLI flags in load test scripts

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -481,8 +481,14 @@ jobs:
           # The namespace label created-by will not be able resolve the actual user which triggered
           # the GitHub action by default. We need to correctly configure the git user here to make it work
           git config user.name ${{ github.actor }}
+          # Build newLoadTest.sh flags
+          flags="-s ${{ inputs.secondary-storage-type }} -t ${{ inputs.ttl }}"
+          if [[ "${{ inputs.enable-optimize }}" == "false" ]]; then
+            flags="$flags -O"
+          fi
           # Create the namespace for the load test
-          ./newLoadTest.sh ${{ env.NAMESPACE }} ${{ inputs.secondary-storage-type }} ${{ inputs.ttl }} ${{ inputs.enable-optimize }}
+          # shellcheck disable=SC2086
+          ./newLoadTest.sh $flags "${{ env.NAMESPACE }}"
           # Annotate namespace with the workflow run URL for traceability
           kubectl annotate namespace ${{ env.NAMESPACE }} \
             "github.com/workflow-run-url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \

--- a/load-tests/setup/README.md
+++ b/load-tests/setup/README.md
@@ -84,27 +84,28 @@ All components are configured in `camunda-platform-values.yaml`.
 
 ### How to set up a load test namespace
 
-If you run `newLoadTest.sh` without arguments, it will display the following help message.
+Run `./newLoadTest.sh -h` to display the help message:
 
 ```sh
-Usage: newLoadTest.sh <namespace> [secondaryStorage] [ttl_days] [enable_optimize] [enable_single_zone]
+Usage: newLoadTest.sh [options] <namespace>
 
 Arguments:
-  namespace          Base namespace name. Will be prefixed with "c8-" if missing.
-  secondaryStorage   Optional. One of: elasticsearch, opensearch, postgresql, mysql, mariadb, mssql, oracle, none. Default: elasticsearch.
-  ttl_days           Optional. Positive integer for namespace TTL in days. Default: 1.
-  enable_optimize    Optional. true|false to enable Optimize. Default: true.
-  enable_single_zone Optional. true|false to deploy the cluster on a single zone. Default: true
+  namespace    Base namespace name. Will be prefixed with "c8-" if missing.
 
 Options:
-  -h, --help         Show this help message.
+  -s <type>          Secondary storage type. One of: elasticsearch, opensearch, postgresql,
+                     mysql, mariadb, mssql, oracle, none. Default: elasticsearch.
+  -t <days>          Namespace TTL in days (positive integer). Default: 1.
+  -O                 Disable Optimize. Default: enabled.
+  -z                 Deploy across multiple zones. Default: single zone.
+  -h                 Show this help message.
 
 Examples:
   ./newLoadTest.sh demo
-  ./newLoadTest.sh perf opensearch 3 true
+  ./newLoadTest.sh perf -s opensearch -t 3 -O
 ```
 
-As you can see, you can create a test (namespace) by passing a name; other parameters are optional. Like, secondary storage, TTL, and whether Optimize should be enabled.
+You can create a test namespace by passing a name; all other parameters are optional flags.
 
 Example:
 
@@ -117,27 +118,28 @@ If you used `.` before `./newLoadTest.sh`, the script will change your directory
 
 #### Secondary storage options
 
-You can specify a secondary storage type as the second argument:
+You can specify a secondary storage type with the `-s` flag:
 
 ```sh
-. ./newLoadTest.sh my-load-test-name elasticsearch  # Default - uses Elasticsearch
-. ./newLoadTest.sh my-load-test-name opensearch     # Uses OpenSearch
-. ./newLoadTest.sh my-load-test-name postgresql     # Uses PostgreSQL (RDBMS)
-. ./newLoadTest.sh my-load-test-name mysql          # Uses MySQL (RDBMS)
-. ./newLoadTest.sh my-load-test-name mariadb        # Uses MariaDB (RDBMS)
-. ./newLoadTest.sh my-load-test-name mssql          # Uses Microsoft SQL Server (RDBMS)
-. ./newLoadTest.sh my-load-test-name oracle         # Uses Oracle (RDBMS)
-. ./newLoadTest.sh my-load-test-name none           # No secondary storage
+. ./newLoadTest.sh my-load-test-name                        # Default - uses Elasticsearch
+. ./newLoadTest.sh my-load-test-name -s elasticsearch       # Explicit Elasticsearch
+. ./newLoadTest.sh my-load-test-name -s opensearch          # Uses OpenSearch
+. ./newLoadTest.sh my-load-test-name -s postgresql          # Uses PostgreSQL (RDBMS)
+. ./newLoadTest.sh my-load-test-name -s mysql               # Uses MySQL (RDBMS)
+. ./newLoadTest.sh my-load-test-name -s mariadb             # Uses MariaDB (RDBMS)
+. ./newLoadTest.sh my-load-test-name -s mssql               # Uses Microsoft SQL Server (RDBMS)
+. ./newLoadTest.sh my-load-test-name -s oracle              # Uses Oracle (RDBMS)
+. ./newLoadTest.sh my-load-test-name -s none                # No secondary storage
 ```
 
 The `none` option runs load tests without any secondary storage, which disables Camunda exporters. This is useful for testing the core orchestration engine performance in isolation.
 
 #### Disabling Optimize
 
-Optimize is enabled by default. To disable it, pass `false` as the fourth argument:
+Optimize is enabled by default. To disable it, pass the `-O` flag:
 
-```
-. ./newLoadTest.sh my-load-test-name elasticsearch 1 false
+```sh
+. ./newLoadTest.sh my-load-test-name -O
 ```
 
 In the GitHub workflow, set the `enable-optimize` input to `false`.

--- a/load-tests/setup/deleteLoadTest.sh
+++ b/load-tests/setup/deleteLoadTest.sh
@@ -1,15 +1,40 @@
 #!/bin/bash
-set -exo pipefail
 
-if [ -z $1 ]
-then
-  echo "Please provide an namespace name!"
+. utils.sh
+
+usage() {
+  cat <<'EOF'
+Usage: deleteLoadTest.sh <namespace>
+
+Arguments:
+  namespace    Name of the load test namespace to delete.
+
+Options:
+  -h           Show this help message.
+
+Examples:
+  ./deleteLoadTest.sh c8-demo
+EOF
+}
+
+while getopts ":h" opt; do
+  case "$opt" in
+    h) usage; exit 0 ;;
+    \?) echo "Error: Unknown option -$OPTARG." >&2; usage; exit 1 ;;
+  esac
+done
+shift $((OPTIND - 1))
+
+if [ -z "$1" ]; then
+  echo "Error: Missing namespace name." >&2
+  usage
   exit 1
 fi
 
+set -exo pipefail
 
 ### Load test helper script
-### First parameter is used as namespace name
+### Namespace name is the only required positional argument
 ### Given namespace will be completely deleted.
 
 namespace=${1//\//} # remove trailing slashes

--- a/load-tests/setup/newCloudLoadTest.sh
+++ b/load-tests/setup/newCloudLoadTest.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -exo pipefail
 
 # Contains OS specific sed function
 . utils.sh
@@ -9,10 +8,10 @@ usage() {
 Usage: newCloudLoadTest.sh <namespace>
 
 Arguments:
-  namespace          Base namespace name. Will be prefixed with "c8-" if missing.
+  namespace    Base namespace name. Will be prefixed with "c8-" if missing.
 
 Options:
-  -h, --help         Show this help message.
+  -h           Show this help message.
 
 Examples:
   ./newCloudLoadTest.sh demo
@@ -20,29 +19,27 @@ Examples:
 EOF
 }
 
-if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
-  usage
-  exit 0
-fi
+while getopts ":h" opt; do
+  case "$opt" in
+    h) usage; exit 0 ;;
+    \?) echo "Error: Unknown option -$OPTARG." >&2; usage; exit 1 ;;
+  esac
+done
+shift $((OPTIND - 1))
 
 if [ -z "$1" ]; then
-  echo "Error: Missing namespace name."
+  echo "Error: Missing namespace name." >&2
   usage
   exit 1
 fi
 
+set -exo pipefail
+
 ### Cloud load test helper script
-### First parameter is used as namespace name
+### Namespace name is the only required positional argument
 ### For a new namespace a new folder will be created
 
-
-namespace=$1
-
-# Add c8- prefix if not present
-if [[ ! "$namespace" =~ ^c8- ]]; then
-  namespace="c8-$namespace"
-  echo "Namespace prefix added: $namespace"
-fi
+namespace="$(namespace_name "$1")"
 
 kubectl create namespace $namespace
 
@@ -51,7 +48,6 @@ kubectl label namespace "$namespace" registry=harbor --overwrite
 
 cp -rv cloud-default/ $namespace
 cd $namespace
-
 
 # Update Makefile to use the namespace
 sed_inplace "s/__NAMESPACE__/$namespace/" Makefile

--- a/load-tests/setup/newLoadTest.sh
+++ b/load-tests/setup/newLoadTest.sh
@@ -3,100 +3,58 @@
 # Contains OS specific sed function
 . utils.sh
 
-set -exo pipefail
-
 usage() {
   cat <<'EOF'
-Usage: newLoadTest.sh <namespace> [secondaryStorage] [ttl_days] [enable_optimize] [enable_single_zone]
+Usage: newLoadTest.sh [options] <namespace>
 
 Arguments:
-  namespace          Base namespace name. Will be prefixed with "c8-" if missing.
-  secondaryStorage   Optional. One of: elasticsearch, opensearch, postgresql, mysql, mariadb, mssql, oracle, none. Default: elasticsearch.
-  ttl_days           Optional. Positive integer for namespace TTL in days. Default: 1.
-  enable_optimize    Optional. true|false to enable Optimize. Default: true.
-  enable_single_zone Optional. true|false to deploy the cluster on a single zone. Default: true
+  namespace    Base namespace name. Will be prefixed with "c8-" if missing.
 
 Options:
-  -h, --help         Show this help message.
+  -s <type>          Secondary storage type. One of: elasticsearch, opensearch, postgresql, mysql, mariadb, mssql, oracle, none. Default: elasticsearch.
+  -t <days>          Namespace TTL in days (positive integer). Default: 1.
+  -O                 Disable Optimize. Default: enabled.
+  -z                 Deploy across multiple zones. Default: single zone.
+  -h                 Show this help message.
 
 Examples:
   ./newLoadTest.sh demo
-  ./newLoadTest.sh perf opensearch 3 false
+  ./newLoadTest.sh perf -s opensearch -t 3 -O
 EOF
 }
 
-if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
-  usage
-  exit 0
-fi
+secondaryStorage="elasticsearch"
+ttl_days=1
+enable_optimize="true"
+enable_single_zone="true"
+
+while getopts ":hs:t:Oz" opt; do
+  case "$opt" in
+    h) usage; exit 0 ;;
+    s) validate_secondary_storage "$OPTARG" || { usage; exit 1; }; secondaryStorage="$OPTARG" ;;
+    t) validate_ttl "$OPTARG" || { usage; exit 1; }; ttl_days="$OPTARG" ;;
+    O) enable_optimize="false" ;;
+    z) enable_single_zone="false" ;;
+    :) echo "Error: Option -$OPTARG requires an argument." >&2; usage; exit 1 ;;
+    \?) echo "Error: Unknown option -$OPTARG." >&2; usage; exit 1 ;;
+  esac
+done
+shift $((OPTIND - 1))
 
 if [ -z "$1" ]; then
-  echo "Error: Missing namespace name."
+  echo "Error: Missing namespace name." >&2
   usage
   exit 1
 fi
 
+set -exo pipefail
+
 ### Load test helper script
-### First parameter is used as namespace name
+### Namespace name is the only required positional argument
 ### For a new namespace a new folder will be created
 
 helm_chart="camunda-platform-8.10"
-namespace="$1"
-
-# Add c8- prefix if not present
-if [[ ! "$namespace" =~ ^c8- ]]; then
-  namespace="c8-$namespace"
-  echo "Namespace prefix added: $namespace"
-fi
-
-# Validate secondaryStorage value
-secondaryStorage="${2:-elasticsearch}"
-if [[ "$secondaryStorage" != "elasticsearch" && "$secondaryStorage" != "opensearch" && "$secondaryStorage" != "postgresql" && "$secondaryStorage" != "mysql" && "$secondaryStorage" != "mariadb" && "$secondaryStorage" != "mssql" && "$secondaryStorage" != "oracle" && "$secondaryStorage" != "none" ]]; then
-  echo "Error: Invalid secondary storage type '$secondaryStorage'"
-  echo "Allowed values are: elasticsearch, opensearch, postgresql, mysql, mariadb, mssql, oracle, none"
-  exit 1
-fi
-
-# Validate TTL value
-ttl_days="${3:-1}"
-numberRegex='^[0-9]+$'
-if ! [[ $ttl_days =~ $numberRegex ]] ; then
-   echo "Error: TTL '$ttl_days' is not a number"
-   exit 1
-fi
-
-# Validate enable_optimize value
-enable_optimize="${4:-true}"
-enable_optimize=$(echo "$enable_optimize" | tr '[:upper:]' '[:lower:]')
-if [[ "$enable_optimize" != "true" && "$enable_optimize" != "false" ]]; then
-  echo "Error: Invalid enable_optimize value '$enable_optimize'"
-  echo "Allowed values are: true or false"
-  exit 1
-fi
-
-# Pick a "random" zone, selected from the input value.
-function hashmod_zone() {
-    local input="${1?"Specify an initial value to compute the zone from"}"
-
-    # We can get the list of zones with already created nodes with:
-    # kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.labels.topology\.kubernetes\.io\/zone}{"\n"}{end}' | sort | uniq -c
-    zones=(
-        europe-west1-b
-        europe-west1-c
-        europe-west1-d
-    )
-    nb_zones=${#zones[@]}
-
-    # bc only accept hexadecimal with capitalized letters
-    checksum="$(echo "$input" | md5sum | cut -c 1-32 | tr "a-z" "A-Z")"
-    hashmod="$(echo "ibase=16; $checksum % $nb_zones" | bc)"
-
-    zone="${zones[$hashmod]}"
-    echo "$zone"
-}
-
-enable_single_zone="${5:-true}"
-enable_single_zone=$(echo "$enable_single_zone" | tr '[:upper:]' '[:lower:]')
+namespace="$(namespace_name "$1")"
 single_zone_annotation_name="topology.kubernetes.io/zone"
 availability_zone="~"
 
@@ -119,23 +77,6 @@ else
   echo "Namespace ${namespace} has previously been configured to run on the single availability zone: $availability_zone"
 fi
 
-# Sanitize a string to be a valid Kubernetes label value
-sanitize_k8s_label() {
-  local value="$1"
-  # Replace invalid characters with hyphens
-  value=$(echo "$value" | sed 's/[^A-Za-z0-9_.-]/-/g')
-  # Remove leading non-alphanumeric characters
-  value=$(echo "$value" | sed 's/^[^A-Za-z0-9]\+//')
-  # Remove trailing non-alphanumeric characters
-  value=$(echo "$value" | sed 's/[^A-Za-z0-9]\+$//')
-  # Truncate to 63 characters as required by Kubernetes label values
-  value=${value:0:63}
-  # Fallback if the result is empty
-  if [ -z "$value" ]; then
-    value="unknown"
-  fi
-  echo "$value"
-}
 
 # Label to easily find related namespaces
 kubectl label namespace "$namespace" "camunda.io/purpose=load-test" --overwrite
@@ -145,16 +86,8 @@ raw_git_author=$(git config user.name || echo "unknown")
 git_author=$(sanitize_k8s_label "$raw_git_author")
 kubectl label namespace "$namespace" created-by="$git_author" --overwrite
 
-# Label namespace with TTL deadline (default: 1 day from now)
-# Try GNU date format first (Linux), then BSD/macOS format
-if deadline_date=$(date -d "+${ttl_days} days" +%Y-%m-%d 2>/dev/null); then
-  : # GNU date succeeded
-elif deadline_date=$(date -v +${ttl_days}d +%Y-%m-%d 2>/dev/null); then
-  : # BSD/macOS date succeeded
-else
-  echo "Warning: Could not calculate deadline date. Supported on Linux and macOS only."
-  deadline_date="unknown"
-fi
+# Label namespace with TTL deadline
+deadline_date="$(new_deadline_date "$ttl_days")"
 kubectl label namespace $namespace deadline-date="${deadline_date}" --overwrite
 
 # Label namespace with registry (required to inject image pull secrets)

--- a/load-tests/setup/utils.sh
+++ b/load-tests/setup/utils.sh
@@ -25,9 +25,95 @@ function sed_inplace() {
   detect_os
 
   if [ "${GO_OS}" == "darwin" ]; then
-    sed -i '' -e $@ 
+    sed -i '' -e $@
   else
     sed -i -e $@
   fi
+}
 
+function namespace_name() {
+  local namespace="$1"
+
+  # Add c8- prefix if not present
+  if [[ ! "$namespace" =~ ^c8- ]]; then
+    namespace="c8-$namespace"
+  fi
+  echo "$namespace"
+}
+
+
+function new_deadline_date() {
+  local ttl_days="$1"
+  local value="unknown"
+  if value=$(date -d "+${ttl_days} days" +%Y-%m-%d 2>/dev/null); then
+    # GNU date
+    :
+  elif value=$(date -v +${ttl_days}d +%Y-%m-%d 2>/dev/null); then
+    # BSD/macOS date
+    :
+  else
+    echo "Warning: Could not calculate deadline date. Supported on Linux and macOS only." >&2
+  fi
+  echo "$value"
+}
+
+# Sanitize a string to be a valid Kubernetes label value
+sanitize_k8s_label() {
+  local value="$1"
+  # Replace invalid characters with hyphens
+  value=$(echo "$value" | sed 's/[^A-Za-z0-9_.-]/-/g')
+  # Remove leading non-alphanumeric characters
+  value=$(echo "$value" | sed 's/^[^A-Za-z0-9]\+//')
+  # Remove trailing non-alphanumeric characters
+  value=$(echo "$value" | sed 's/[^A-Za-z0-9]\+$//')
+  # Truncate to 63 characters as required by Kubernetes label values
+  value=${value:0:63}
+  # Fallback if the result is empty
+  if [ -z "$value" ]; then
+    value="unknown"
+  fi
+  echo "$value"
+}
+
+function validate_secondary_storage() {
+  local value="$1"
+  case "$value" in
+    elasticsearch|opensearch|postgresql|mysql|mariadb|mssql|oracle|none)
+      return 0
+      ;;
+    *)
+      echo "Error: Invalid secondary storage type '$value'." >&2
+      echo "Allowed values are: elasticsearch, opensearch, postgresql, mysql, mariadb, mssql, oracle, none" >&2
+      return 1
+      ;;
+  esac
+}
+
+function validate_ttl() {
+  local value="$1"
+  if ! [[ "$value" =~ ^[0-9]+$ ]]; then
+    echo "Error: TTL '$value' is not a valid number." >&2
+    return 1
+  fi
+}
+
+# Pick a "random" zone, selected from the input value.
+function hashmod_zone() {
+  local value="$1"
+
+  # We can get the list of zones with already created nodes with:
+  # kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.labels.topology\.kubernetes\.io\/zone}{"\n"}{end}' | sort | uniq -c
+  local zones=(
+    europe-west1-b
+    europe-west1-c
+    europe-west1-d
+  )
+  local nb_zones=${#zones[@]}
+
+  # bc only accept hexadecimal with capitalized letters
+  local checksum="$(echo "$value" | md5sum | cut -c 1-32 | tr "a-z" "A-Z")"
+  local hashmod="$(echo "ibase=16; $checksum % $nb_zones" | bc)"
+
+  local zone="${zones[$hashmod]}"
+  echo "$zone"
 }


### PR DESCRIPTION
## Description

We don't have to assume that option X will be at position Y and flags can be more easily extended to support more flags or different options.

Also moved all the CLI flags validation (+ utility functions) into the `utils.sh` file: this should make the scripts a bit easier to read by focusing on the useful code and delegating utilities to the utils script.

I plan to extend the CLI flags after this is merged with the ability to label load test in specific way, when a load test is created.

Note:

* `getopts` is a [bash built-in](https://www.gnu.org/software/bash/manual/bash.html#index-getopts) and should be available both on Linux and MacOS
* it doesn't support long options, so we are stuck with short ones

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
