### PR TITLE
refactor: add nullness annotations for clusterId

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/configuration/BrokerBasedConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/configuration/BrokerBasedConfiguration.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.gateway.rest.impl.filters.FilterRepository;
 import jakarta.servlet.Filter;
 import java.time.Duration;
 import java.util.List;
+import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.context.LifecycleProperties;
 import org.springframework.context.annotation.Bean;
@@ -109,7 +110,7 @@ public class BrokerBasedConfiguration {
   }
 
   @Bean
-  public String clusterId() {
+  public @Nullable String clusterId() {
     return properties.getCluster().getClusterId();
   }
 }

--- a/zeebe/dynamic-config/pom.xml
+++ b/zeebe/dynamic-config/pom.xml
@@ -64,6 +64,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterIdInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterIdInitializer.java
@@ -12,6 +12,8 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import java.util.Optional;
 import java.util.UUID;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -20,12 +22,13 @@ import org.slf4j.LoggerFactory;
  * enabled. All members will initialize the same routing state (as long as their statically
  * configured partition counts match).
  */
+@NullMarked
 public class ClusterIdInitializer implements ClusterConfigurationModifier {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ClusterIdInitializer.class);
   private final String clusterId;
 
-  public ClusterIdInitializer(final String clusterId) {
+  public ClusterIdInitializer(@Nullable final String clusterId) {
     // if not cluster id is configured a new one is generated.
     this.clusterId = Optional.ofNullable(clusterId).orElse(UUID.randomUUID().toString());
   }
@@ -50,7 +53,7 @@ public class ClusterIdInitializer implements ClusterConfigurationModifier {
             configuration.lastChange(),
             configuration.pendingChanges(),
             configuration.routingState(),
-            Optional.ofNullable(clusterId),
+            Optional.of(clusterId),
             configuration.incarnationNumber());
     return CompletableActorFuture.completed(withClusterId);
   }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/StaticConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/StaticConfiguration.java
@@ -15,7 +15,10 @@ import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
 import java.util.List;
 import java.util.Set;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
+@NullMarked
 public record StaticConfiguration(
     PartitionDistributor partitionDistributor,
     Set<MemberId> clusterMembers,
@@ -23,7 +26,7 @@ public record StaticConfiguration(
     List<PartitionId> partitionIds,
     int replicationFactor,
     DynamicPartitionConfig partitionConfig,
-    String clusterId) {
+    @Nullable String clusterId) {
 
   public int partitionCount() {
     return partitionIds.size();

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtil.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtil.java
@@ -22,6 +22,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.jspecify.annotations.Nullable;
 
 public final class ConfigurationUtil {
 
@@ -30,7 +31,7 @@ public final class ConfigurationUtil {
   public static ClusterConfiguration getClusterConfigFrom(
       final Set<PartitionMetadata> partitionDistribution,
       final DynamicPartitionConfig partitionConfig,
-      final String clusterId) {
+      @Nullable final String clusterId) {
     final var partitionStatesByMember = new HashMap<MemberId, Map<Integer, PartitionState>>();
     for (final var partitionMetadata : partitionDistribution) {
       final var partitionId = partitionMetadata.id().id();


### PR DESCRIPTION
## Description
`clusterId` was marked as `@Nullable` in #51729. I propagated the nullness annotations to everywhere it was used. 
No big change, just an unnecessary `Optional.ofNullable` instead of `Optional.of`
