### PR TITLE
feat: add basic configuration and infrastructure for RDBMS async repl…

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Rdbms.java
+++ b/configuration/src/main/java/io/camunda/configuration/Rdbms.java
@@ -76,6 +76,9 @@ public class Rdbms extends SecondaryStorageDatabase<RdbmsHistory> {
   @NestedConfigurationProperty
   private RdbmsInsertBatching insertBatching = new RdbmsInsertBatching();
 
+  @NestedConfigurationProperty
+  private RdbmsAsyncReplication asyncReplication = new RdbmsAsyncReplication();
+
   @NestedConfigurationProperty private RdbmsQuery query = new RdbmsQuery();
 
   public Boolean getAutoDdl() {
@@ -180,6 +183,14 @@ public class Rdbms extends SecondaryStorageDatabase<RdbmsHistory> {
 
   public void setInsertBatching(final RdbmsInsertBatching insertBatching) {
     this.insertBatching = insertBatching;
+  }
+
+  public RdbmsAsyncReplication getAsyncReplication() {
+    return asyncReplication;
+  }
+
+  public void setAsyncReplication(final RdbmsAsyncReplication asyncReplication) {
+    this.asyncReplication = asyncReplication;
   }
 
   public RdbmsQuery getQuery() {

--- a/configuration/src/main/java/io/camunda/configuration/RdbmsAsyncReplication.java
+++ b/configuration/src/main/java/io/camunda/configuration/RdbmsAsyncReplication.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import io.camunda.exporter.rdbms.ExporterConfiguration.ReplicationConfiguration;
+import java.time.Duration;
+
+public class RdbmsAsyncReplication {
+
+  private boolean enabled = ReplicationConfiguration.DEFAULT_ENABLED;
+  private Duration pollingInterval = ReplicationConfiguration.DEFAULT_POLLING_INTERVAL;
+  private int minSyncReplicas = ReplicationConfiguration.DEFAULT_MIN_SYNC_REPLICAS;
+  private Duration maxLag = ReplicationConfiguration.DEFAULT_MAX_LAG;
+  private boolean pauseOnMaxLagExceeded =
+      ReplicationConfiguration.DEFAULT_PAUSE_ON_MAX_LAG_EXCEEDED;
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(final boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public Duration getPollingInterval() {
+    return pollingInterval;
+  }
+
+  public void setPollingInterval(final Duration pollingInterval) {
+    this.pollingInterval = pollingInterval;
+  }
+
+  public int getMinSyncReplicas() {
+    return minSyncReplicas;
+  }
+
+  public void setMinSyncReplicas(final int minSyncReplicas) {
+    this.minSyncReplicas = minSyncReplicas;
+  }
+
+  public Duration getMaxLag() {
+    return maxLag;
+  }
+
+  public void setMaxLag(final Duration maxLag) {
+    this.maxLag = maxLag;
+  }
+
+  public boolean isPauseOnMaxLagExceeded() {
+    return pauseOnMaxLagExceeded;
+  }
+
+  public void setPauseOnMaxLagExceeded(final boolean pauseOnMaxLagExceeded) {
+    this.pauseOnMaxLagExceeded = pauseOnMaxLagExceeded;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -965,6 +965,21 @@ public class BrokerBasedPropertiesOverride {
                         .setMaxFlowNodeInsertBatchSize(
                             database.getInsertBatching().getMaxFlowNodeInsertBatchSize());
                   }
+
+                  if (database.getAsyncReplication() != null) {
+                    final var asyncReplication = database.getAsyncReplication();
+                    config.getAsyncReplication().setEnabled(asyncReplication.isEnabled());
+                    config
+                        .getAsyncReplication()
+                        .setPollingInterval(asyncReplication.getPollingInterval());
+                    config
+                        .getAsyncReplication()
+                        .setMinSyncReplicas(asyncReplication.getMinSyncReplicas());
+                    config.getAsyncReplication().setMaxLag(asyncReplication.getMaxLag());
+                    config
+                        .getAsyncReplication()
+                        .setPauseOnMaxLagExceeded(asyncReplication.isPauseOnMaxLagExceeded());
+                  }
                 })
             .toArgs());
   }

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageRdbmsTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageRdbmsTest.java
@@ -63,6 +63,8 @@ public class SecondaryStorageRdbmsTest {
   private static final int HISTORY_CLEANUP_PROCESS_INSTANCE_BATCH_SIZE = 1000;
   private static final String HISTORY_USAGE_METRICS_CLEANUP_INTERVAL = "PT48H";
   private static final String HISTORY_USAGE_METRICS_TTL = "PT1H";
+  private static final String ASYNC_REPLICATION_POLLING_INTERVAL = "PT30S";
+  private static final String ASYNC_REPLICATION_MAX_LAG = "PT5M";
 
   private static final int MAX_PROCESS_CACHE_SIZE = 4711;
   private static final int MAX_BATCH_OPERATIONS_CACHE_SIZE = 4711;
@@ -105,6 +107,13 @@ public class SecondaryStorageRdbmsTest {
         "camunda.data.secondary-storage.rdbms.exportBatchOperationItemsOnCreation=false",
         "camunda.data.secondary-storage.rdbms.batchOperationItemInsertBlockSize=1234",
         "camunda.data.secondary-storage.rdbms.insert-batching.max-audit-log-insert-batch-size=50",
+        "camunda.data.secondary-storage.rdbms.async-replication.enabled=true",
+        "camunda.data.secondary-storage.rdbms.async-replication.polling-interval="
+            + ASYNC_REPLICATION_POLLING_INTERVAL,
+        "camunda.data.secondary-storage.rdbms.async-replication.min-sync-replicas=2",
+        "camunda.data.secondary-storage.rdbms.async-replication.max-lag="
+            + ASYNC_REPLICATION_MAX_LAG,
+        "camunda.data.secondary-storage.rdbms.async-replication.pause-on-max-lag-exceeded=true",
         "camunda.data.secondary-storage.rdbms.max-varchar-field-length=200",
       })
   class WithOnlyUnifiedConfigSet {
@@ -184,6 +193,13 @@ public class SecondaryStorageRdbmsTest {
       assertThat(exporterConfiguration.getBatchOperationItemInsertBlockSize()).isEqualTo(1234);
       assertThat(exporterConfiguration.getInsertBatching().getMaxAuditLogInsertBatchSize())
           .isEqualTo(50);
+      assertThat(exporterConfiguration.getAsyncReplication().isEnabled()).isTrue();
+      assertThat(exporterConfiguration.getAsyncReplication().getPollingInterval())
+          .isEqualTo(Duration.parse(ASYNC_REPLICATION_POLLING_INTERVAL));
+      assertThat(exporterConfiguration.getAsyncReplication().getMinSyncReplicas()).isEqualTo(2);
+      assertThat(exporterConfiguration.getAsyncReplication().getMaxLag())
+          .isEqualTo(Duration.parse(ASYNC_REPLICATION_MAX_LAG));
+      assertThat(exporterConfiguration.getAsyncReplication().isPauseOnMaxLagExceeded()).isTrue();
     }
 
     @Test

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
@@ -43,6 +43,7 @@ public class ExporterConfiguration {
   private CacheConfiguration processCache = new CacheConfiguration();
   private CacheConfiguration decisionRequirementsCache = new CacheConfiguration();
   private CacheConfiguration batchOperationCache = new CacheConfiguration();
+  private ReplicationConfiguration asyncReplication = new ReplicationConfiguration();
 
   public AuditLogConfiguration getAuditLog() {
     return auditLog;
@@ -141,10 +142,19 @@ public class ExporterConfiguration {
     this.insertBatching = insertBatching;
   }
 
+  public ReplicationConfiguration getAsyncReplication() {
+    return asyncReplication;
+  }
+
+  public void setAsyncReplication(final ReplicationConfiguration asyncReplication) {
+    this.asyncReplication = asyncReplication;
+  }
+
   public void validate() {
 
     final List<String> errors = new ArrayList<>(history.validate());
     errors.addAll(insertBatching.validate());
+    errors.addAll(asyncReplication.validate());
 
     if (flushInterval.isNegative()) {
       errors.add(
@@ -295,6 +305,8 @@ public class ExporterConfiguration {
         + decisionRequirementsCache
         + ", batchOperationCache="
         + batchOperationCache
+        + ", asyncReplication="
+        + asyncReplication
         + '}';
   }
 
@@ -608,6 +620,81 @@ public class ExporterConfiguration {
 
     public void setMaxHistoryCleanupUsage(final double maxHistoryCleanupUsage) {
       this.maxHistoryCleanupUsage = maxHistoryCleanupUsage;
+    }
+  }
+
+  public static class ReplicationConfiguration {
+    public static final boolean DEFAULT_ENABLED = false;
+    public static final Duration DEFAULT_POLLING_INTERVAL = Duration.ofSeconds(15);
+    public static final Duration DEFAULT_MAX_LAG = Duration.ofMinutes(15);
+    public static final int DEFAULT_MIN_SYNC_REPLICAS = 1;
+    public static final boolean DEFAULT_PAUSE_ON_MAX_LAG_EXCEEDED = false;
+
+    private boolean enabled = DEFAULT_ENABLED;
+    private Duration pollingInterval = DEFAULT_POLLING_INTERVAL;
+    private int minSyncReplicas = DEFAULT_MIN_SYNC_REPLICAS;
+    private Duration maxLag = DEFAULT_MAX_LAG;
+    private boolean pauseOnMaxLagExceeded = DEFAULT_PAUSE_ON_MAX_LAG_EXCEEDED;
+
+    public boolean isEnabled() {
+      return enabled;
+    }
+
+    public void setEnabled(final boolean enabled) {
+      this.enabled = enabled;
+    }
+
+    public Duration getPollingInterval() {
+      return pollingInterval;
+    }
+
+    public void setPollingInterval(final Duration pollingInterval) {
+      this.pollingInterval = pollingInterval;
+    }
+
+    public int getMinSyncReplicas() {
+      return minSyncReplicas;
+    }
+
+    public void setMinSyncReplicas(final int minSyncReplicas) {
+      this.minSyncReplicas = minSyncReplicas;
+    }
+
+    public Duration getMaxLag() {
+      return maxLag;
+    }
+
+    public void setMaxLag(final Duration maxLag) {
+      this.maxLag = maxLag;
+    }
+
+    public boolean isPauseOnMaxLagExceeded() {
+      return pauseOnMaxLagExceeded;
+    }
+
+    public void setPauseOnMaxLagExceeded(final boolean pauseOnMaxLagExceeded) {
+      this.pauseOnMaxLagExceeded = pauseOnMaxLagExceeded;
+    }
+
+    public List<String> validate() {
+      final List<String> errors = new ArrayList<>();
+      if (enabled && (pollingInterval.isNegative() || pollingInterval.isZero())) {
+        errors.add(
+            String.format(
+                "asyncReplication.pollingInterval must be a positive duration but was %s",
+                pollingInterval));
+      }
+      if (minSyncReplicas <= 0) {
+        errors.add(
+            String.format(
+                "asyncReplication.minSyncReplicas must be greater 0 but was %d", minSyncReplicas));
+      }
+      if (enabled && (maxLag.isNegative() || maxLag.isZero())) {
+        errors.add(
+            String.format(
+                "asyncReplication.maxLag must be a positive duration but was %s", maxLag));
+      }
+      return errors;
     }
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
@@ -13,6 +13,8 @@ import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.db.rdbms.write.domain.ExporterPositionModel;
 import io.camunda.db.rdbms.write.service.HistoryCleanupService;
 import io.camunda.db.rdbms.write.service.HistoryDeletionService;
+import io.camunda.exporter.rdbms.replication.ReplicationController;
+import io.camunda.exporter.rdbms.replication.ReplicationControllerFactory;
 import io.camunda.exporter.rdbms.tasks.RdbmsBackgroundTaskManager;
 import io.camunda.zeebe.exporter.api.ExporterException;
 import io.camunda.zeebe.exporter.api.context.Controller;
@@ -60,6 +62,10 @@ public final class RdbmsExporter {
   // Track the oldest record timestamp in the current batch for exporting latency calculation
   private long oldestRecordTimestampInBatch = -1;
 
+  // Async replication support — null when disabled
+  private final ReplicationControllerFactory replicationControllerFactory;
+  private ReplicationController replicationController;
+
   private RdbmsExporter(
       final int partitionId,
       final Duration flushInterval,
@@ -68,7 +74,8 @@ public final class RdbmsExporter {
       final Map<ValueType, List<RdbmsExportHandler>> handlers,
       final RdbmsSchemaManager rdbmsSchemaManager,
       final HistoryCleanupService historyCleanupService,
-      final HistoryDeletionService historyDeletionService) {
+      final HistoryDeletionService historyDeletionService,
+      final ReplicationControllerFactory replicationControllerFactory) {
     this.historyCleanupService = historyCleanupService;
     this.rdbmsWriters = rdbmsWriters;
     registeredHandlers = handlers;
@@ -78,6 +85,7 @@ public final class RdbmsExporter {
     this.queueSize = queueSize;
     this.rdbmsSchemaManager = rdbmsSchemaManager;
     this.historyDeletionService = historyDeletionService;
+    this.replicationControllerFactory = replicationControllerFactory;
 
     LOG.info(
         "[RDBMS Exporter P{}] RdbmsExporter created with Configuration: flushInterval={}, queueSize={}",
@@ -132,13 +140,19 @@ public final class RdbmsExporter {
     }
     lastFlushedPosition = lastPosition;
 
+    replicationController = replicationControllerFactory.createReplicationController(controller);
     rdbmsWriters
         .getExporterPositionService()
         .registerLockPositionHook(partitionId, () -> lastFlushedPosition);
 
     rdbmsWriters.getExecutionQueue().registerPreFlushListener(this::updatePositionInRdbms);
-    rdbmsWriters.getExecutionQueue().registerPostFlushListener(this::updatePositionInBroker);
     rdbmsWriters.getExecutionQueue().registerPostFlushListener(this::recordExportingLatency);
+    rdbmsWriters
+        .getExecutionQueue()
+        .registerPostFlushListener(() -> lastFlushedPosition = lastPosition);
+    rdbmsWriters
+        .getExecutionQueue()
+        .registerPostFlushListener(() -> replicationController.onFlush(lastPosition));
 
     if (!flushAfterEachRecord()) {
       currentFlushTask =
@@ -177,6 +191,11 @@ public final class RdbmsExporter {
             partitionId);
         throw e;
       }
+
+      if (replicationController != null) {
+        replicationController.close();
+        replicationController = null;
+      }
     } catch (final Exception e) {
       LOG.warn(
           "[RDBMS Exporter P{}] Failed to flush records before closing exporter.", partitionId, e);
@@ -190,6 +209,13 @@ public final class RdbmsExporter {
   }
 
   public void export(final Record<?> record) {
+    if (!replicationController.isReplicationInSync()) {
+      throw new ExporterException(
+          String.format(
+              "[RDBMS Exporter P%d] Exporting paused: DB-reported lag exceeded maxLag. Retry later.",
+              partitionId));
+    }
+
     LOG.trace(
         "[RDBMS Exporter P{}] Process record {}-{} - {}:{}",
         partitionId,
@@ -285,7 +311,6 @@ public final class RdbmsExporter {
 
   private void updatePositionInBroker() {
     LOG.trace("[RDBMS Exporter P{}] Updating position to {} in broker", partitionId, lastPosition);
-    lastFlushedPosition = lastPosition;
     controller.updateLastExportedRecordPosition(lastPosition);
   }
 
@@ -387,6 +412,7 @@ public final class RdbmsExporter {
     private Map<ValueType, List<RdbmsExportHandler>> handlers = new EnumMap<>(ValueType.class);
     private HistoryCleanupService historyCleanupService;
     private HistoryDeletionService historyDeletionService;
+    private ReplicationControllerFactory replicationControllerFactory;
 
     public Builder partitionId(final int value) {
       partitionId = value;
@@ -437,6 +463,12 @@ public final class RdbmsExporter {
       return this;
     }
 
+    public Builder replicationControllerFactory(
+        final ReplicationControllerFactory replicationControllerFactory) {
+      this.replicationControllerFactory = replicationControllerFactory;
+      return this;
+    }
+
     public RdbmsExporter build() {
       return new RdbmsExporter(
           partitionId,
@@ -446,7 +478,8 @@ public final class RdbmsExporter {
           handlers,
           rdbmsSchemaManager,
           historyCleanupService,
-          historyDeletionService);
+          historyDeletionService,
+          replicationControllerFactory);
     }
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -56,6 +56,7 @@ import io.camunda.exporter.rdbms.handlers.batchoperation.ProcessInstanceCancella
 import io.camunda.exporter.rdbms.handlers.batchoperation.ProcessInstanceHistoryDeletionBatchOperationExportHandler;
 import io.camunda.exporter.rdbms.handlers.batchoperation.ProcessInstanceMigrationBatchOperationExportHandler;
 import io.camunda.exporter.rdbms.handlers.batchoperation.ProcessInstanceModificationBatchOperationExportHandler;
+import io.camunda.exporter.rdbms.replication.ReplicationControllerFactory;
 import io.camunda.search.entities.BatchOperationType;
 import io.camunda.zeebe.exporter.api.Exporter;
 import io.camunda.zeebe.exporter.api.context.Context;
@@ -126,6 +127,7 @@ public class RdbmsExporterWrapper implements Exporter {
                 config.getHistoryDeletion().getDependentRowLimit()),
             context.clock());
     builder.historyDeletionService(historyDeletionService);
+    builder.replicationControllerFactory(ReplicationControllerFactory.noop());
 
     createHandlers(partitionId, rdbmsWriters, builder, config, historyCleanupService);
     createBatchOperationHandlers(rdbmsWriters, builder, historyCleanupService);

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/replication/NoopReplicationController.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/replication/NoopReplicationController.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.replication;
+
+import io.camunda.zeebe.exporter.api.context.Controller;
+
+public class NoopReplicationController implements ReplicationController {
+
+  private final Controller controller;
+
+  public NoopReplicationController(final Controller controller) {
+    this.controller = controller;
+  }
+
+  @Override
+  public void onFlush(final long exporterPosition) {
+    controller.updateLastExportedRecordPosition(exporterPosition);
+  }
+
+  @Override
+  public void close() throws Exception {
+    // noop
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/replication/ReplicationController.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/replication/ReplicationController.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.replication;
+
+public interface ReplicationController extends AutoCloseable {
+
+  void onFlush(long exporterPosition);
+
+  /**
+   * Returns {@code true} as long as the async replication is in sync, otherwise {@code false}.
+   *
+   * @return if the replication is in sync
+   */
+  default boolean isReplicationInSync() {
+    return true;
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/replication/ReplicationControllerFactory.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/replication/ReplicationControllerFactory.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.replication;
+
+import io.camunda.zeebe.exporter.api.context.Controller;
+
+public interface ReplicationControllerFactory {
+
+  static ReplicationControllerFactory noop() {
+    return NoopReplicationController::new;
+  }
+
+  ReplicationController createReplicationController(Controller controller);
+}

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/ExporterConfigurationTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/ExporterConfigurationTest.java
@@ -13,9 +13,15 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
+import io.camunda.exporter.rdbms.ExporterConfiguration.ReplicationConfiguration;
 import java.time.Duration;
 import java.time.InstantSource;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class ExporterConfigurationTest {
 
@@ -512,5 +518,92 @@ class ExporterConfigurationTest {
 
     assertThatThrownBy(configuration::validate)
         .hasMessageContaining("maxHistoryCleanupUsage must be between");
+  }
+
+  // ReplicationConfiguration tests
+
+  @Test
+  public void shouldBeOkWithEnabledReplicationAndValidConfig() {
+    // given
+    final ExporterConfiguration configuration = new ExporterConfiguration();
+    final ReplicationConfiguration replication = new ReplicationConfiguration();
+    replication.setEnabled(true);
+    replication.setPollingInterval(Duration.ofSeconds(10));
+    replication.setMinSyncReplicas(1);
+    replication.setMaxLag(Duration.ofMinutes(5));
+    configuration.setAsyncReplication(replication);
+
+    // when
+    configuration.validate();
+
+    // then - no error
+  }
+
+  @Test
+  public void shouldNotFailWhenReplicationDisabledWithCompletelyWrongConfig() {
+    // given - completely invalid configuration, but replication is disabled
+    final ExporterConfiguration configuration = new ExporterConfiguration();
+    final ReplicationConfiguration replication = new ReplicationConfiguration();
+    replication.setEnabled(false);
+    replication.setPollingInterval(Duration.ofMillis(-1000));
+    replication.setMaxLag(Duration.ofMillis(-1000));
+    configuration.setAsyncReplication(replication);
+
+    // when
+    configuration.validate();
+
+    // then - no error, pollingInterval and maxLag are only validated when replication is enabled
+  }
+
+  @ParameterizedTest
+  @MethodSource("invalidReplicationConfigurations")
+  public void shouldFailValidationForReplicationConfiguration(
+      final Consumer<ReplicationConfiguration> configurer, final String expectedMessage) {
+    // given
+    final ExporterConfiguration configuration = new ExporterConfiguration();
+    final ReplicationConfiguration replication = new ReplicationConfiguration();
+    configurer.accept(replication);
+    configuration.setAsyncReplication(replication);
+
+    // when / then
+    assertThatThrownBy(configuration::validate).hasMessageContaining(expectedMessage);
+  }
+
+  static Stream<Arguments> invalidReplicationConfigurations() {
+    return Stream.of(
+        Arguments.of(
+            (Consumer<ReplicationConfiguration>)
+                r -> {
+                  r.setEnabled(true);
+                  r.setPollingInterval(Duration.ofMillis(-1000));
+                },
+            "asyncReplication.pollingInterval must be a positive duration"),
+        Arguments.of(
+            (Consumer<ReplicationConfiguration>)
+                r -> {
+                  r.setEnabled(true);
+                  r.setPollingInterval(Duration.ZERO);
+                },
+            "asyncReplication.pollingInterval must be a positive duration"),
+        Arguments.of(
+            (Consumer<ReplicationConfiguration>) r -> r.setMinSyncReplicas(-1),
+            "asyncReplication.minSyncReplicas must be greater 0"),
+        Arguments.of(
+            (Consumer<ReplicationConfiguration>) r -> r.setMinSyncReplicas(0),
+            "asyncReplication.minSyncReplicas must be greater 0"),
+        Arguments.of(
+            (Consumer<ReplicationConfiguration>)
+                r -> {
+                  r.setEnabled(true);
+                  r.setMaxLag(Duration.ofMillis(-1000));
+                },
+            "asyncReplication.maxLag must be a positive duration"),
+        Arguments.of(
+            (Consumer<ReplicationConfiguration>)
+                r -> {
+                  r.setEnabled(true);
+                  r.setMaxLag(Duration.ZERO);
+                },
+            "asyncReplication.maxLag must be a positive duration"));
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.db.rdbms.RdbmsSchemaManager;
 import io.camunda.db.rdbms.write.RdbmsWriterMetrics;
 import io.camunda.db.rdbms.write.RdbmsWriters;
+import io.camunda.db.rdbms.write.domain.ExporterPositionModel;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.InTransactionHook;
 import io.camunda.db.rdbms.write.queue.PostFlushListener;
@@ -34,12 +35,15 @@ import io.camunda.db.rdbms.write.service.ExporterPositionService;
 import io.camunda.db.rdbms.write.service.HistoryCleanupService;
 import io.camunda.db.rdbms.write.service.HistoryDeletionService;
 import io.camunda.db.rdbms.write.service.RdbmsPurger;
+import io.camunda.exporter.rdbms.replication.ReplicationController;
+import io.camunda.exporter.rdbms.replication.ReplicationControllerFactory;
 import io.camunda.zeebe.exporter.api.ExporterException;
 import io.camunda.zeebe.exporter.api.context.Controller;
 import io.camunda.zeebe.exporter.api.context.ScheduledTask;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
@@ -59,6 +63,8 @@ class RdbmsExporterTest {
   private HistoryDeletionService historyDeletionService;
   private RdbmsWriterMetrics metrics;
   private RdbmsSchemaManager schemaManager;
+  private ReplicationControllerFactory replicationControllerFactory;
+  private ReplicationController replicationController;
 
   private ScheduledTask flushTask;
   private RdbmsPurger rdbmsPurger;
@@ -192,6 +198,7 @@ class RdbmsExporterTest {
 
     // then
     verify(positionService).update(Mockito.argThat(p -> p.lastExportedPosition() == 2));
+    verify(replicationController).onFlush(2L);
   }
 
   @Test
@@ -206,6 +213,7 @@ class RdbmsExporterTest {
 
     // then - position should be updated even for ignored records
     verify(positionService).update(Mockito.argThat(p -> p.lastExportedPosition() == 2));
+    verify(replicationController).onFlush(2L);
   }
 
   @Test
@@ -216,12 +224,14 @@ class RdbmsExporterTest {
     // when
     exporter.export(mockRecord(ValueType.JOB, 1));
     exporter.export(mockRecord(ValueType.JOB, 2));
-    executionQueue.flush();
 
     // then
     verify(positionService, times(2)).update(any());
     verify(positionService).update(Mockito.argThat(p -> p.lastExportedPosition() == 1));
     verify(positionService).update(Mockito.argThat(p -> p.lastExportedPosition() == 2));
+    verify(replicationController, times(2)).onFlush(anyLong());
+    verify(replicationController).onFlush(1L);
+    verify(replicationController).onFlush(2L);
   }
 
   @Test
@@ -233,12 +243,14 @@ class RdbmsExporterTest {
     // when
     exporter.export(mockRecord(ValueType.JOB, 1));
     exporter.export(mockRecord(ValueType.JOB, 2));
-    executionQueue.flush();
 
     // then
     verify(positionService, times(2)).update(any());
     verify(positionService).update(Mockito.argThat(p -> p.lastExportedPosition() == 1));
     verify(positionService).update(Mockito.argThat(p -> p.lastExportedPosition() == 2));
+    verify(replicationController, times(2)).onFlush(anyLong());
+    verify(replicationController).onFlush(1L);
+    verify(replicationController).onFlush(2L);
   }
 
   @Test
@@ -252,7 +264,27 @@ class RdbmsExporterTest {
 
     // then
     verify(positionService).update(Mockito.argThat(p -> p.lastExportedPosition() == 1));
+    verify(replicationController).onFlush(1L);
     verify(flushTask).cancel();
+
+    // set null to avoid tear down flush
+    exporter = null;
+  }
+
+  @Test
+  void shouldCloseEverythingOnClose() throws Exception {
+    // given
+    createExporter(b -> b.withHandler(ValueType.JOB, mockHandler(ValueType.JOB)));
+
+    // when
+    exporter.close();
+
+    // then
+    verify(replicationController).close();
+    verify(flushTask).cancel();
+
+    // set null to avoid tear down flush
+    exporter = null;
   }
 
   @Test
@@ -420,7 +452,7 @@ class RdbmsExporterTest {
   @Test
   void shouldThrowExceptionWhenSchemaIsNotInitialized() {
     // given - schema manager returns false for isInitialized
-    createExporter(b -> b, false, false);
+    createExporter(b -> b, false, false, null);
 
     // when + then
     assertThatThrownBy(() -> exporter.open(controller))
@@ -509,6 +541,21 @@ class RdbmsExporterTest {
     verify(controller, never()).requestReplay(Mockito.anyLong());
   }
 
+  @Test
+  void shouldThrowExceptionWhenReplicationControllerIsPaused() {
+    createExporter(b -> b.withHandler(ValueType.JOB, mockHandler(ValueType.JOB)));
+
+    when(replicationController.isReplicationInSync()).thenReturn(false);
+    final var record = mockRecord(ValueType.JOB, 1);
+    when(record.getTimestamp()).thenReturn(0L); // Unix epoch
+
+    // when
+    final var exceptionAssert = assertThatThrownBy(() -> exporter.export(record));
+
+    // then
+    exceptionAssert.isInstanceOf(ExporterException.class);
+  }
+
   // ------------------------------------------------
   // mocks and stubs
   // ------------------------------------------------
@@ -521,50 +568,16 @@ class RdbmsExporterTest {
   private void createExporterWithRdbmsPosition(
       final long brokerPosition, final long rdbmsPosition) {
     final var existingRdbmsPositionModel =
-        new io.camunda.db.rdbms.write.domain.ExporterPositionModel(
+        new ExporterPositionModel(
             0,
             RdbmsExporter.class.getSimpleName(),
             rdbmsPosition,
-            java.time.LocalDateTime.now(),
-            java.time.LocalDateTime.now());
+            LocalDateTime.now(),
+            LocalDateTime.now());
 
-    flushTask = mock(ScheduledTask.class);
-    controller = mock(Controller.class);
+    createExporter(b -> b, true, false, existingRdbmsPositionModel);
+
     when(controller.getLastExportedRecordPosition()).thenReturn(brokerPosition);
-    when(controller.scheduleCancellableTask(any(), any())).thenReturn(flushTask);
-
-    rdbmsWriters = mock(RdbmsWriters.class);
-    executionQueue = new StubExecutionQueue();
-    positionService = mock(ExporterPositionService.class);
-    when(positionService.findOne(anyInt())).thenReturn(existingRdbmsPositionModel);
-    rdbmsPurger = mock(RdbmsPurger.class);
-    historyCleanupService = mock(HistoryCleanupService.class);
-    when(historyCleanupService.cleanupHistory(anyInt(), any())).thenReturn(Duration.ofSeconds(1));
-    when(historyCleanupService.cleanupUsageMetricsHistory(anyInt(), any()))
-        .thenReturn(Duration.ofSeconds(1));
-    when(historyCleanupService.cleanupJobBatchMetricsHistory(anyInt(), any()))
-        .thenReturn(Duration.ofSeconds(1));
-    historyDeletionService = mock(HistoryDeletionService.class);
-    when(historyDeletionService.deleteHistory(anyInt())).thenReturn(Duration.ofSeconds(1));
-    when(rdbmsWriters.getExporterPositionService()).thenReturn(positionService);
-    when(rdbmsWriters.getExecutionQueue()).thenReturn(executionQueue);
-    when(rdbmsWriters.getRdbmsPurger()).thenReturn(rdbmsPurger);
-    metrics = mock(RdbmsWriterMetrics.class);
-    when(rdbmsWriters.getMetrics()).thenReturn(metrics);
-    schemaManager = mock(RdbmsSchemaManager.class);
-    when(schemaManager.isInitialized()).thenReturn(true);
-    doAnswer((invocation) -> executionQueue.checkQueueForFlush()).when(rdbmsWriters).flush(false);
-
-    exporter =
-        new RdbmsExporter.Builder()
-            .rdbmsWriter(rdbmsWriters)
-            .partitionId(0)
-            .flushInterval(Duration.ofMillis(500))
-            .queueSize(100)
-            .rdbmsSchemaManager(schemaManager)
-            .historyCleanupService(historyCleanupService)
-            .historyDeletionService(historyDeletionService)
-            .build();
   }
 
   private RdbmsExportHandler mockHandler(final ValueType valueType) {
@@ -589,19 +602,20 @@ class RdbmsExporterTest {
 
   private void createExporter(
       final Function<RdbmsExporter.Builder, RdbmsExporter.Builder> builderFunction) {
-    createExporter(builderFunction, true, true);
+    createExporter(builderFunction, true, true, null);
   }
 
   private void createExporter(
       final Function<RdbmsExporter.Builder, RdbmsExporter.Builder> builderFunction,
       final boolean schemaInitialized) {
-    createExporter(builderFunction, schemaInitialized, true);
+    createExporter(builderFunction, schemaInitialized, true, null);
   }
 
   private void createExporter(
       final Function<RdbmsExporter.Builder, RdbmsExporter.Builder> builderFunction,
       final boolean schemaInitialized,
-      final boolean openExporter) {
+      final boolean openExporter,
+      final ExporterPositionModel exporterPositionModel) {
     flushTask = mock(ScheduledTask.class);
 
     controller = mock(Controller.class);
@@ -611,7 +625,7 @@ class RdbmsExporterTest {
     rdbmsWriters = mock(RdbmsWriters.class);
     executionQueue = new StubExecutionQueue();
     positionService = mock(ExporterPositionService.class);
-    when(positionService.findOne(anyInt())).thenReturn(null);
+    when(positionService.findOne(anyInt())).thenReturn(exporterPositionModel);
     rdbmsPurger = mock(RdbmsPurger.class);
 
     historyCleanupService = mock(HistoryCleanupService.class);
@@ -627,6 +641,13 @@ class RdbmsExporterTest {
     when(rdbmsWriters.getExporterPositionService()).thenReturn(positionService);
     when(rdbmsWriters.getExecutionQueue()).thenReturn(executionQueue);
     when(rdbmsWriters.getRdbmsPurger()).thenReturn(rdbmsPurger);
+
+    // Mock replicationController
+    replicationControllerFactory = mock(ReplicationControllerFactory.class);
+    replicationController = mock(ReplicationController.class);
+    when(replicationControllerFactory.createReplicationController(any()))
+        .thenReturn(replicationController);
+    when(replicationController.isReplicationInSync()).thenReturn(true);
 
     // Mock getMetrics() to return a mock metrics instance by default
     metrics = mock(RdbmsWriterMetrics.class);
@@ -653,7 +674,8 @@ class RdbmsExporterTest {
             .queueSize(100)
             .rdbmsSchemaManager(schemaManager)
             .historyCleanupService(historyCleanupService)
-            .historyDeletionService(historyDeletionService);
+            .historyDeletionService(historyDeletionService)
+            .replicationControllerFactory(replicationControllerFactory);
 
     exporter = builderFunction.apply(builder).build();
     if (openExporter) {


### PR DESCRIPTION
## Description

This PR adds basic infrastructure and `RdbmsExporter` behaviour for the async replication monitoring:
- add the `ReplicationController` with a default `NoopReplicationController`
- add a configuration `asyncReplication` to both unified config and Rdbms `ExporterConfiguration`
- ensure, that the exporter stops/pauses as soon as the `ReplicationController` signals an async lag

## Related issues

closes #51588
