### PR TITLE
test: add get decision bad request test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instances-get-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instances-get-api.spec.ts
@@ -14,6 +14,7 @@ import {
   assertStatusCode,
   assertEqualsForKeys,
   assertNotFoundRequest,
+  assertInvalidArgument,
 } from '../../../../utils/http';
 import {defaultAssertionOptions} from '../../../../utils/constants';
 import {
@@ -72,7 +73,7 @@ test.describe.parallel('Get Decision Instances API Tests', () => {
   });
 
   test('Get Decision Instance - Not found', async ({request}) => {
-    const someRandomNotExistingKey = '9999999999999999';
+    const someRandomNotExistingKey = '9999999999999999-1';
     await expect(async () => {
       const res = await request.get(
         buildUrl(`/decision-instances/${someRandomNotExistingKey}`),
@@ -105,5 +106,21 @@ test.describe.parallel('Get Decision Instances API Tests', () => {
 
       await assertUnauthorizedRequest(res);
     }).toPass(defaultAssertionOptions);
+  });
+
+  test('Get Decision Instance - Bad Request', async ({request}) => {
+    const invalidDecisionEvaluationInstanceKey = '+++';
+    const res = await request.get(
+      buildUrl(`/decision-instances/${invalidDecisionEvaluationInstanceKey}`),
+      {
+        headers: jsonHeaders(),
+        data: {},
+      },
+    );
+    await assertInvalidArgument(
+      res,
+      400,
+      `The provided decisionEvaluationInstanceKey '${invalidDecisionEvaluationInstanceKey}' is not a valid decision evaluation instance key.`,
+    );
   });
 });


### PR DESCRIPTION
## Description

This PR introduces bad request test for get decision instance api.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

related https://github.com/camunda/camunda/issues/43425

## On demand workflow
[Was all green](https://github.com/camunda/camunda/actions/runs/24999840037)