### PR TITLE
feat: identify brokers as $zone/$nodeId when zone is configured

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/response/BrokerInfo.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/BrokerInfo.java
@@ -32,10 +32,7 @@ public interface BrokerInfo {
    * @return the member ID of the broker: {@code "$zone/$nodeId"} when the cluster is zone-aware
    *     (e.g. {@code "us-east/0"}), or the bare node ID otherwise (e.g. {@code "0"})
    */
-  default String getMemberId() {
-    final String zone = getZone();
-    return zone == null ? String.valueOf(getNodeId()) : zone + "/" + getNodeId();
-  }
+  String getMemberId();
 
   /**
    * @return the address host of the broker

--- a/clients/java/src/main/java/io/camunda/client/api/response/BrokerInfo.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/BrokerInfo.java
@@ -24,6 +24,20 @@ public interface BrokerInfo {
   int getNodeId();
 
   /**
+   * @return the zone of the broker, or {@code null} when the cluster is not zone-aware
+   */
+  String getZone();
+
+  /**
+   * @return the member ID of the broker: {@code "$zone/$nodeId"} when the cluster is zone-aware
+   *     (e.g. {@code "us-east/0"}), or the bare node ID otherwise (e.g. {@code "0"})
+   */
+  default String getMemberId() {
+    final String zone = getZone();
+    return zone == null ? String.valueOf(getNodeId()) : zone + "/" + getNodeId();
+  }
+
+  /**
    * @return the address host of the broker
    */
   String getHost();

--- a/clients/java/src/main/java/io/camunda/client/impl/response/BrokerInfoImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/BrokerInfoImpl.java
@@ -27,6 +27,7 @@ public final class BrokerInfoImpl implements BrokerInfo {
 
   private final int nodeId;
   private final String zone;
+  private final String memberId;
   private final String host;
   private final int port;
   private final String version;
@@ -36,6 +37,7 @@ public final class BrokerInfoImpl implements BrokerInfo {
     nodeId = grpcBrokerInfo.getNodeId();
     // TODO: use grpcBrokerInfo.getZone() once the gRPC protocol carries the zone (see #51586)
     zone = null;
+    memberId = null;
     host = grpcBrokerInfo.getHost();
     port = grpcBrokerInfo.getPort();
     version = grpcBrokerInfo.getVersion();
@@ -50,6 +52,7 @@ public final class BrokerInfoImpl implements BrokerInfo {
     nodeId = httpBrokerInfo.getNodeId();
     // TODO: use httpBrokerInfo.getZone() once the REST protocol carries the zone (see #51998)
     zone = null;
+    memberId = null;
     host = httpBrokerInfo.getHost();
     port = httpBrokerInfo.getPort();
     version = httpBrokerInfo.getVersion();
@@ -68,6 +71,15 @@ public final class BrokerInfoImpl implements BrokerInfo {
   @Override
   public String getZone() {
     return zone;
+  }
+
+  @Override
+  public String getMemberId() {
+    if (memberId == null) {
+      return String.valueOf(nodeId);
+    } else {
+      return memberId;
+    }
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/response/BrokerInfoImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/BrokerInfoImpl.java
@@ -36,8 +36,8 @@ public final class BrokerInfoImpl implements BrokerInfo {
   public BrokerInfoImpl(final GatewayOuterClass.BrokerInfo grpcBrokerInfo) {
     nodeId = grpcBrokerInfo.getNodeId();
     // TODO: use grpcBrokerInfo.getZone() once the gRPC protocol carries the zone (see #51586)
-    zone = null;
-    memberId = null;
+    zone = "";
+    memberId = "";
     host = grpcBrokerInfo.getHost();
     port = grpcBrokerInfo.getPort();
     version = grpcBrokerInfo.getVersion();
@@ -51,8 +51,8 @@ public final class BrokerInfoImpl implements BrokerInfo {
   public BrokerInfoImpl(final io.camunda.client.protocol.rest.BrokerInfo httpBrokerInfo) {
     nodeId = httpBrokerInfo.getNodeId();
     // TODO: use httpBrokerInfo.getZone() once the REST protocol carries the zone (see #51998)
-    zone = null;
-    memberId = null;
+    zone = "";
+    memberId = "";
     host = httpBrokerInfo.getHost();
     port = httpBrokerInfo.getPort();
     version = httpBrokerInfo.getVersion();
@@ -75,7 +75,7 @@ public final class BrokerInfoImpl implements BrokerInfo {
 
   @Override
   public String getMemberId() {
-    if (memberId == null) {
+    if (memberId == null || memberId.isEmpty()) {
       return String.valueOf(nodeId);
     } else {
       return memberId;

--- a/clients/java/src/main/java/io/camunda/client/impl/response/BrokerInfoImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/BrokerInfoImpl.java
@@ -26,6 +26,7 @@ import java.util.Objects;
 public final class BrokerInfoImpl implements BrokerInfo {
 
   private final int nodeId;
+  private final String zone;
   private final String host;
   private final int port;
   private final String version;
@@ -33,6 +34,8 @@ public final class BrokerInfoImpl implements BrokerInfo {
 
   public BrokerInfoImpl(final GatewayOuterClass.BrokerInfo grpcBrokerInfo) {
     nodeId = grpcBrokerInfo.getNodeId();
+    // TODO: use grpcBrokerInfo.getZone() once the gRPC protocol carries the zone (see #51586)
+    zone = null;
     host = grpcBrokerInfo.getHost();
     port = grpcBrokerInfo.getPort();
     version = grpcBrokerInfo.getVersion();
@@ -45,6 +48,8 @@ public final class BrokerInfoImpl implements BrokerInfo {
 
   public BrokerInfoImpl(final io.camunda.client.protocol.rest.BrokerInfo httpBrokerInfo) {
     nodeId = httpBrokerInfo.getNodeId();
+    // TODO: use httpBrokerInfo.getZone() once the REST protocol carries the zone (see #51998)
+    zone = null;
     host = httpBrokerInfo.getHost();
     port = httpBrokerInfo.getPort();
     version = httpBrokerInfo.getVersion();
@@ -58,6 +63,11 @@ public final class BrokerInfoImpl implements BrokerInfo {
   @Override
   public int getNodeId() {
     return nodeId;
+  }
+
+  @Override
+  public String getZone() {
+    return zone;
   }
 
   @Override
@@ -87,7 +97,7 @@ public final class BrokerInfoImpl implements BrokerInfo {
 
   @Override
   public int hashCode() {
-    return Objects.hash(nodeId, host, port, version, partitions);
+    return Objects.hash(nodeId, zone, host, port, version, partitions);
   }
 
   @Override
@@ -103,6 +113,7 @@ public final class BrokerInfoImpl implements BrokerInfo {
     final BrokerInfoImpl that = (BrokerInfoImpl) o;
     return nodeId == that.nodeId
         && port == that.port
+        && Objects.equals(zone, that.zone)
         && Objects.equals(host, that.host)
         && Objects.equals(version, that.version)
         && Objects.equals(partitions, that.partitions);
@@ -113,6 +124,9 @@ public final class BrokerInfoImpl implements BrokerInfo {
     return "BrokerInfoImpl{"
         + "nodeId="
         + nodeId
+        + ", zone='"
+        + zone
+        + '\''
         + ", host='"
         + host
         + '\''

--- a/zeebe/atomix/cluster/pom.xml
+++ b/zeebe/atomix/cluster/pom.xml
@@ -148,6 +148,11 @@
       <artifactId>netty-codec-dns</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+    </dependency>
+
     <!-- test dependencies -->
     <dependency>
       <groupId>io.camunda</groupId>

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/Member.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/Member.java
@@ -29,6 +29,8 @@ import org.jspecify.annotations.Nullable;
 public class Member extends Node {
 
   private static final int UNKNOWN_TIMESTAMP = 0;
+  private static final String ZONE_ID_MISMATCH =
+      "Expected id to start with zone %s, but did not: id=%s";
 
   private final MemberId id;
   private final @Nullable String zone;
@@ -46,7 +48,9 @@ public class Member extends Node {
     nodeVersion = config.getNodeVersion();
     properties = new Properties();
     properties.putAll(config.getProperties());
-    MemberId.validateZonePrefix(zone, id);
+    if (id != null && !id.isInZone(zone)) {
+      throw new IllegalArgumentException(String.format(ZONE_ID_MISMATCH, zone, id));
+    }
   }
 
   protected Member(final MemberId id, final Address address) {
@@ -65,7 +69,9 @@ public class Member extends Node {
     this.id = checkNotNull(id, "id cannot be null");
     this.nodeVersion = nodeVersion;
     this.zone = zone;
-    MemberId.validateZonePrefix(zone, id);
+    if (id != null && !id.isInZone(zone)) {
+      throw new IllegalArgumentException(String.format(ZONE_ID_MISMATCH, zone, id));
+    }
     this.rack = rack;
     this.host = host;
     this.properties = properties;

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/Member.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/Member.java
@@ -23,9 +23,11 @@ import io.atomix.utils.Version;
 import io.atomix.utils.net.Address;
 import java.util.Objects;
 import java.util.Properties;
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 /** Represents a node as a member in a cluster. */
+@NullMarked
 public class Member extends Node {
 
   private static final int UNKNOWN_TIMESTAMP = 0;
@@ -69,7 +71,7 @@ public class Member extends Node {
     this.id = checkNotNull(id, "id cannot be null");
     this.nodeVersion = nodeVersion;
     this.zone = zone;
-    if (id != null && !id.isInZone(zone)) {
+    if (!id.isInZone(zone)) {
       throw new IllegalArgumentException(String.format(ZONE_ID_MISMATCH, zone, id));
     }
     this.rack = rack;
@@ -173,12 +175,12 @@ public class Member extends Node {
   }
 
   @Override
-  public boolean equals(final Object o) {
+  public boolean equals(final @Nullable Object o) {
     if (this == o) {
       return true;
     }
 
-    if (!(o instanceof Member)) {
+    if (!(o instanceof final Member member)) {
       return false;
     }
 
@@ -186,7 +188,6 @@ public class Member extends Node {
       return false;
     }
 
-    final Member member = (Member) o;
     return Objects.equals(id, member.id)
         && Objects.equals(nodeVersion, member.nodeVersion)
         && Objects.equals(zone, member.zone)
@@ -282,7 +283,7 @@ public class Member extends Node {
    *
    * @return the node version
    */
-  public Version version() {
+  public @Nullable Version version() {
     return null;
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/Member.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/Member.java
@@ -46,12 +46,7 @@ public class Member extends Node {
     nodeVersion = config.getNodeVersion();
     properties = new Properties();
     properties.putAll(config.getProperties());
-    if (zone != null && id != null) {
-      if (!id.id().startsWith(zone + "/")) {
-        throw new IllegalArgumentException(
-            String.format("Expected id to start with zone %s, but did not: id=%s", zone, id));
-      }
-    }
+    MemberId.validateZonePrefix(zone, id);
   }
 
   protected Member(final MemberId id, final Address address) {
@@ -70,12 +65,7 @@ public class Member extends Node {
     this.id = checkNotNull(id, "id cannot be null");
     this.nodeVersion = nodeVersion;
     this.zone = zone;
-    if (zone != null) {
-      if (!id.id().startsWith(zone + "/")) {
-        throw new IllegalArgumentException(
-            String.format("Expected id to start with zone %s, but did not: id=%s", zone, id));
-      }
-    }
+    MemberId.validateZonePrefix(zone, id);
     this.rack = rack;
     this.host = host;
     this.properties = properties;

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/Member.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/Member.java
@@ -45,6 +45,12 @@ public class Member extends Node {
     nodeVersion = config.getNodeVersion();
     properties = new Properties();
     properties.putAll(config.getProperties());
+    if (zone != null && id != null) {
+      if (!id.id().startsWith(zone + "/")) {
+        throw new IllegalArgumentException(
+            String.format("Expected id to start with zone %s, but did not: id=%s", zone, id));
+      }
+    }
   }
 
   protected Member(final MemberId id, final Address address) {
@@ -64,7 +70,7 @@ public class Member extends Node {
     this.nodeVersion = nodeVersion;
     this.zone = zone;
     if (zone != null) {
-      if (!id.id().startsWith(zone)) {
+      if (!id.id().startsWith(zone + "/")) {
         throw new IllegalArgumentException(
             String.format("Expected id to start with zone %s, but did not: id=%s", zone, id));
       }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/Member.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/Member.java
@@ -26,6 +26,7 @@ import java.util.Properties;
 
 /** Represents a node as a member in a cluster. */
 public class Member extends Node {
+
   private static final int UNKNOWN_TIMESTAMP = 0;
 
   private final MemberId id;
@@ -62,6 +63,12 @@ public class Member extends Node {
     this.id = checkNotNull(id, "id cannot be null");
     this.nodeVersion = nodeVersion;
     this.zone = zone;
+    if (zone != null) {
+      if (!id.id().startsWith(zone)) {
+        throw new IllegalArgumentException(
+            String.format("Expected id to start with zone %s, but did not: id=%s", zone, id));
+      }
+    }
     this.rack = rack;
     this.host = host;
     this.properties = properties;

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/Member.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/Member.java
@@ -23,6 +23,7 @@ import io.atomix.utils.Version;
 import io.atomix.utils.net.Address;
 import java.util.Objects;
 import java.util.Properties;
+import org.jspecify.annotations.Nullable;
 
 /** Represents a node as a member in a cluster. */
 public class Member extends Node {
@@ -30,9 +31,9 @@ public class Member extends Node {
   private static final int UNKNOWN_TIMESTAMP = 0;
 
   private final MemberId id;
-  private final String zone;
-  private final String rack;
-  private final String host;
+  private final @Nullable String zone;
+  private final @Nullable String rack;
+  private final @Nullable String host;
   private final Properties properties;
   private final long nodeVersion;
 
@@ -61,9 +62,9 @@ public class Member extends Node {
       final MemberId id,
       final long nodeVersion,
       final Address address,
-      final String zone,
-      final String rack,
-      final String host,
+      final @Nullable String zone,
+      final @Nullable String rack,
+      final @Nullable String host,
       final Properties properties) {
     super(id, address);
     this.id = checkNotNull(id, "id cannot be null");
@@ -249,7 +250,7 @@ public class Member extends Node {
    *
    * @return the zone to which the member belongs
    */
-  public String zone() {
+  public @Nullable String zone() {
     return zone;
   }
 
@@ -258,7 +259,7 @@ public class Member extends Node {
    *
    * @return the rack to which the member belongs
    */
-  public String rack() {
+  public @Nullable String rack() {
     return rack;
   }
 
@@ -267,7 +268,7 @@ public class Member extends Node {
    *
    * @return the host to which the member belongs
    */
-  public String host() {
+  public @Nullable String host() {
     return host;
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/MemberConfig.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/MemberConfig.java
@@ -19,13 +19,14 @@ package io.atomix.cluster;
 import io.atomix.utils.net.Address;
 import java.util.Map;
 import java.util.Properties;
+import org.jspecify.annotations.Nullable;
 
 /** Member configuration. */
 public class MemberConfig extends NodeConfig {
   private MemberId id = MemberId.anonymous();
-  private String zoneId;
-  private String rackId;
-  private String hostId;
+  private @Nullable String zoneId;
+  private @Nullable String rackId;
+  private @Nullable String hostId;
   private Properties properties = new Properties();
 
   /**
@@ -94,7 +95,7 @@ public class MemberConfig extends NodeConfig {
    *
    * @return the member zone
    */
-  public String getZoneId() {
+  public @Nullable String getZoneId() {
     return zoneId;
   }
 
@@ -114,7 +115,7 @@ public class MemberConfig extends NodeConfig {
    *
    * @return the member rack
    */
-  public String getRackId() {
+  public @Nullable String getRackId() {
     return rackId;
   }
 
@@ -134,7 +135,7 @@ public class MemberConfig extends NodeConfig {
    *
    * @return the member host
    */
-  public String getHostId() {
+  public @Nullable String getHostId() {
     return hostId;
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/MemberId.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/MemberId.java
@@ -33,6 +33,7 @@ public class MemberId extends NodeId {
   /** Null when the member is not zone aware */
   private final @Nullable String zone;
 
+  // id must be created in the factory method as it's a required argument of the super constructor
   private MemberId(final @Nullable String zone, final @Nullable Integer nodeIdx, final String id) {
     super(id);
     this.nodeIdx = validateNodeIdx(nodeIdx);
@@ -54,6 +55,8 @@ public class MemberId extends NodeId {
       throw new IllegalArgumentException(
           "Expected id to be of the form $zone/$id or $id, but got " + id);
     }
+    validateZone(zone);
+    validateNodeIdx(nodeIdx);
   }
 
   /**
@@ -112,7 +115,7 @@ public class MemberId extends NodeId {
 
   private static @Nullable String validateZone(final @Nullable String zone) {
     if (zone != null && zone.isBlank()) {
-      throw new IllegalArgumentException("Expected zone to be non-empty, but got " + zone);
+      throw new IllegalArgumentException("Expected zone to be non-empty, but was empty");
     }
     return zone != null ? zone.strip() : null;
   }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/MemberId.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/MemberId.java
@@ -18,14 +18,16 @@ package io.atomix.cluster;
 
 import java.util.Objects;
 import java.util.UUID;
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 /** Controller cluster identity. */
+@NullMarked
 public class MemberId extends NodeId {
   private final @Nullable Integer nodeIdx;
   private final @Nullable String zone;
 
-  private MemberId(final @Nullable String zone, final Integer nodeIdx, final String id) {
+  private MemberId(final @Nullable String zone, final @Nullable Integer nodeIdx, final String id) {
     super(id);
     this.nodeIdx = validateNodeIdx(nodeIdx);
     this.zone = validateZone(zone);
@@ -91,7 +93,7 @@ public class MemberId extends NodeId {
     return Objects.equals(this.zone, zone);
   }
 
-  private Integer validateNodeIdx(final Integer nodeIdx) {
+  private @Nullable Integer validateNodeIdx(final @Nullable Integer nodeIdx) {
     if (nodeIdx != null && nodeIdx < 0) {
       throw new IllegalArgumentException("Expected nodeIdx to be >= 0, but got " + nodeIdx);
     }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/MemberId.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/MemberId.java
@@ -40,13 +40,21 @@ public class MemberId extends NodeId {
       throw new IllegalArgumentException("Expected id to be of the form $zone/$id, but got " + id);
     } else if (parts.length == 2) {
       zone = parts[0];
-      nodeIdx = Integer.parseInt(parts[1]);
+      nodeIdx = tryParseInt(parts[1]);
     } else if (parts.length == 1) {
       zone = null;
-      nodeIdx = Integer.parseInt(parts[0]);
+      nodeIdx = tryParseInt(parts[0]);
     } else {
       throw new IllegalArgumentException(
           "Expected id to be of the form $zone/$id or $id, but got " + id);
+    }
+  }
+
+  private static @Nullable Integer tryParseInt(final String s) {
+    try {
+      return Integer.parseInt(s);
+    } catch (final NumberFormatException e) {
+      return null;
     }
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/MemberId.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/MemberId.java
@@ -16,14 +16,36 @@
  */
 package io.atomix.cluster;
 
+import java.util.Objects;
 import java.util.UUID;
 import org.jspecify.annotations.Nullable;
 
 /** Controller cluster identity. */
 public class MemberId extends NodeId {
+  private final @Nullable Integer nodeIdx;
+  private final @Nullable String zone;
+
+  private MemberId(final @Nullable String zone, final Integer nodeIdx, final String id) {
+    super(id);
+    this.nodeIdx = validateNodeIdx(nodeIdx);
+    this.zone = validateZone(zone);
+  }
 
   public MemberId(final String id) {
     super(id);
+    final var parts = id.split("/");
+    if (parts.length > 2) {
+      throw new IllegalArgumentException("Expected id to be of the form $zone/$id, but got " + id);
+    } else if (parts.length == 2) {
+      zone = parts[0];
+      nodeIdx = Integer.parseInt(parts[1]);
+    } else if (parts.length == 1) {
+      zone = null;
+      nodeIdx = Integer.parseInt(parts[0]);
+    } else {
+      throw new IllegalArgumentException(
+          "Expected id to be of the form $zone/$id or $id, but got " + id);
+    }
   }
 
   /**
@@ -32,7 +54,7 @@ public class MemberId extends NodeId {
    * @return node id
    */
   public static MemberId anonymous() {
-    return new MemberId(UUID.randomUUID().toString());
+    return new MemberId(null, null, UUID.randomUUID().toString());
   }
 
   /**
@@ -52,35 +74,42 @@ public class MemberId extends NodeId {
    * otherwise it is {@code "$zone/$nodeId"}.
    */
   public static MemberId from(final @Nullable String zone, final int nodeId) {
-    final var normalizedZone = zone == null ? null : zone.strip();
-    if (normalizedZone == null || normalizedZone.isEmpty()) {
-      return new MemberId(Integer.toString(nodeId));
+    return new MemberId(zone, nodeId, buildMemberIdString(zone, nodeId));
+  }
+
+  public int nodeIdx() {
+    if (nodeIdx == null) {
+      throw new IllegalStateException("No nodeIdx in this memberId: " + this);
     }
-    return new MemberId(normalizedZone + "/" + nodeId);
+    return nodeIdx;
   }
 
   /**
-   * Extracts the numeric node id from a {@link MemberId}.
-   *
-   * <p>Accepts both the bare form ({@code "0"}) and the zone-prefixed form ({@code "us-east/0"}).
-   * The numeric portion is always the trailing path segment.
-   *
-   * @throws NumberFormatException if the trailing segment is not a parseable int
-   */
-  public static int extractNodeId(final MemberId memberId) {
-    final var id = memberId.id();
-    final var slash = id.lastIndexOf('/');
-    return Integer.parseInt(slash >= 0 ? id.substring(slash + 1) : id);
-  }
-
-  /**
-   * Returns {@code true} if this member id belongs to the given zone, i.e. the id starts with
-   * {@code "$zone/"}. Always returns {@code true} when {@code zone} is {@code null}.
+   * @return {@code true} if this member id belongs to the given zone.
    */
   public boolean isInZone(final @Nullable String zone) {
-    if (zone == null) {
-      return !id().contains("/");
+    return Objects.equals(this.zone, zone);
+  }
+
+  private Integer validateNodeIdx(final Integer nodeIdx) {
+    if (nodeIdx != null && nodeIdx < 0) {
+      throw new IllegalArgumentException("Expected nodeIdx to be >= 0, but got " + nodeIdx);
     }
-    return id().startsWith(zone + "/");
+    return nodeIdx;
+  }
+
+  private @Nullable String validateZone(final @Nullable String zone) {
+    if (zone != null && zone.isBlank()) {
+      throw new IllegalArgumentException("Expected zone to be non-empty, but got " + zone);
+    }
+    return zone != null ? zone.strip() : null;
+  }
+
+  private static String buildMemberIdString(final @Nullable String zone, final int nodeIdx) {
+    if (zone == null) {
+      return Integer.toString(nodeIdx);
+    } else {
+      return zone + "/" + nodeIdx;
+    }
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/MemberId.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/MemberId.java
@@ -43,4 +43,25 @@ public class MemberId extends NodeId {
   public static MemberId from(final String id) {
     return new MemberId(id);
   }
+
+  public static MemberId from(final String zone, final int nodeId) {
+    if (zone == null) {
+      return new MemberId(Integer.toString(nodeId));
+    }
+    return new MemberId(zone + "/" + nodeId);
+  }
+
+  /**
+   * Extracts the numeric node id from a {@link MemberId}.
+   *
+   * <p>Accepts both the bare form ({@code "0"}) and the zone-prefixed form ({@code "us-east/0"}).
+   * The numeric portion is always the trailing path segment.
+   *
+   * @throws NumberFormatException if the trailing segment is not a parseable int
+   */
+  public static int extractNodeId(final MemberId memberId) {
+    final var id = memberId.id();
+    final var slash = id.lastIndexOf('/');
+    return Integer.parseInt(slash >= 0 ? id.substring(slash + 1) : id);
+  }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/MemberId.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/MemberId.java
@@ -44,6 +44,12 @@ public class MemberId extends NodeId {
     return new MemberId(id);
   }
 
+  /**
+   * Creates a zone-aware member identifier.
+   *
+   * <p>When {@code zone} is {@code null} the result is the bare form {@code "$nodeId"}; otherwise
+   * it is {@code "$zone/$nodeId"}.
+   */
   public static MemberId from(final String zone, final int nodeId) {
     if (zone == null) {
       return new MemberId(Integer.toString(nodeId));

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/MemberId.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/MemberId.java
@@ -24,7 +24,13 @@ import org.jspecify.annotations.Nullable;
 /** Controller cluster identity. */
 @NullMarked
 public class MemberId extends NodeId {
+  /**
+   * Null when the member is anonymous When a zone is present, this is the node index in the local
+   * cluster (e.g. 0, 1, 2, 3...) If a zone is not present, it's equal to the id
+   */
   private final @Nullable Integer nodeIdx;
+
+  /** Null when the member is not zone aware */
   private final @Nullable String zone;
 
   private MemberId(final @Nullable String zone, final @Nullable Integer nodeIdx, final String id) {
@@ -47,14 +53,6 @@ public class MemberId extends NodeId {
     } else {
       throw new IllegalArgumentException(
           "Expected id to be of the form $zone/$id or $id, but got " + id);
-    }
-  }
-
-  private static @Nullable Integer tryParseInt(final String s) {
-    try {
-      return Integer.parseInt(s);
-    } catch (final NumberFormatException e) {
-      return null;
     }
   }
 
@@ -84,8 +82,7 @@ public class MemberId extends NodeId {
    * it is {@code "$zone/$nodeId"}. Leading/trailing whitespace is stripped from {@code zone}.
    */
   public static MemberId from(final @Nullable String zone, final int nodeId) {
-    final String stripped = zone == null ? null : zone.strip();
-    return new MemberId(stripped, nodeId, buildMemberIdString(stripped, nodeId));
+    return new MemberId(zone, nodeId, buildMemberIdString(zone, nodeId));
   }
 
   public int nodeIdx() {
@@ -95,6 +92,10 @@ public class MemberId extends NodeId {
     return nodeIdx;
   }
 
+  public @Nullable String zone() {
+    return zone;
+  }
+
   /**
    * @return {@code true} if this member id belongs to the given zone.
    */
@@ -102,14 +103,14 @@ public class MemberId extends NodeId {
     return Objects.equals(this.zone, zone);
   }
 
-  private @Nullable Integer validateNodeIdx(final @Nullable Integer nodeIdx) {
+  private static @Nullable Integer validateNodeIdx(final @Nullable Integer nodeIdx) {
     if (nodeIdx != null && nodeIdx < 0) {
       throw new IllegalArgumentException("Expected nodeIdx to be >= 0, but got " + nodeIdx);
     }
     return nodeIdx;
   }
 
-  private @Nullable String validateZone(final @Nullable String zone) {
+  private static @Nullable String validateZone(final @Nullable String zone) {
     if (zone != null && zone.isBlank()) {
       throw new IllegalArgumentException("Expected zone to be non-empty, but got " + zone);
     }
@@ -120,7 +121,15 @@ public class MemberId extends NodeId {
     if (zone == null) {
       return Integer.toString(nodeIdx);
     } else {
-      return zone + "/" + nodeIdx;
+      return validateZone(zone) + "/" + nodeIdx;
+    }
+  }
+
+  private static @Nullable Integer tryParseInt(final String s) {
+    try {
+      return Integer.parseInt(s);
+    } catch (final NumberFormatException e) {
+      return null;
     }
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/MemberId.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/MemberId.java
@@ -72,4 +72,18 @@ public class MemberId extends NodeId {
     final var slash = id.lastIndexOf('/');
     return Integer.parseInt(slash >= 0 ? id.substring(slash + 1) : id);
   }
+
+  /**
+   * Validates that a {@link MemberId} is consistent with a zone, i.e. that the id starts with
+   * {@code "$zone/"}.
+   *
+   * @throws IllegalArgumentException if {@code zone} and {@code id} are both non-null but the id
+   *     does not start with the zone prefix
+   */
+  static void validateZonePrefix(final @Nullable String zone, final @Nullable MemberId id) {
+    if (zone != null && id != null && !id.id().startsWith(zone + "/")) {
+      throw new IllegalArgumentException(
+          String.format("Expected id to start with zone %s, but did not: id=%s", zone, id));
+    }
+  }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/MemberId.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/MemberId.java
@@ -72,11 +72,12 @@ public class MemberId extends NodeId {
   /**
    * Creates a zone-aware member identifier.
    *
-   * <p>When {@code zone} is {@code null} or blank the result is the bare form {@code "$nodeId"};
-   * otherwise it is {@code "$zone/$nodeId"}.
+   * <p>When {@code zone} is {@code null} the result is the bare form {@code "$nodeId"}; otherwise
+   * it is {@code "$zone/$nodeId"}. Leading/trailing whitespace is stripped from {@code zone}.
    */
   public static MemberId from(final @Nullable String zone, final int nodeId) {
-    return new MemberId(zone, nodeId, buildMemberIdString(zone, nodeId));
+    final String stripped = zone == null ? null : zone.strip();
+    return new MemberId(stripped, nodeId, buildMemberIdString(stripped, nodeId));
   }
 
   public int nodeIdx() {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/MemberId.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/MemberId.java
@@ -48,14 +48,15 @@ public class MemberId extends NodeId {
   /**
    * Creates a zone-aware member identifier.
    *
-   * <p>When {@code zone} is {@code null} the result is the bare form {@code "$nodeId"}; otherwise
-   * it is {@code "$zone/$nodeId"}.
+   * <p>When {@code zone} is {@code null} or blank the result is the bare form {@code "$nodeId"};
+   * otherwise it is {@code "$zone/$nodeId"}.
    */
   public static MemberId from(final @Nullable String zone, final int nodeId) {
-    if (zone == null) {
+    final var normalizedZone = zone == null ? null : zone.strip();
+    if (normalizedZone == null || normalizedZone.isEmpty()) {
       return new MemberId(Integer.toString(nodeId));
     }
-    return new MemberId(zone + "/" + nodeId);
+    return new MemberId(normalizedZone + "/" + nodeId);
   }
 
   /**

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/MemberId.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/MemberId.java
@@ -74,16 +74,13 @@ public class MemberId extends NodeId {
   }
 
   /**
-   * Validates that a {@link MemberId} is consistent with a zone, i.e. that the id starts with
-   * {@code "$zone/"}.
-   *
-   * @throws IllegalArgumentException if {@code zone} and {@code id} are both non-null but the id
-   *     does not start with the zone prefix
+   * Returns {@code true} if this member id belongs to the given zone, i.e. the id starts with
+   * {@code "$zone/"}. Always returns {@code true} when {@code zone} is {@code null}.
    */
-  static void validateZonePrefix(final @Nullable String zone, final @Nullable MemberId id) {
-    if (zone != null && id != null && !id.id().startsWith(zone + "/")) {
-      throw new IllegalArgumentException(
-          String.format("Expected id to start with zone %s, but did not: id=%s", zone, id));
+  public boolean isInZone(final @Nullable String zone) {
+    if (zone == null) {
+      return !id().contains("/");
     }
+    return id().startsWith(zone + "/");
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/MemberId.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/MemberId.java
@@ -17,6 +17,7 @@
 package io.atomix.cluster;
 
 import java.util.UUID;
+import org.jspecify.annotations.Nullable;
 
 /** Controller cluster identity. */
 public class MemberId extends NodeId {
@@ -50,7 +51,7 @@ public class MemberId extends NodeId {
    * <p>When {@code zone} is {@code null} the result is the bare form {@code "$nodeId"}; otherwise
    * it is {@code "$zone/$nodeId"}.
    */
-  public static MemberId from(final String zone, final int nodeId) {
+  public static MemberId from(final @Nullable String zone, final int nodeId) {
     if (zone == null) {
       return new MemberId(Integer.toString(nodeId));
     }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/MemberIdTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/MemberIdTest.java
@@ -78,7 +78,7 @@ final class MemberIdTest {
     final var memberId = MemberId.from("3");
 
     // when
-    final var nodeId = MemberId.extractNodeId(memberId);
+    final var nodeId = memberId.nodeIdx();
 
     // then
     assertThat(nodeId).isEqualTo(3);
@@ -90,7 +90,7 @@ final class MemberIdTest {
     final var memberId = MemberId.from("us-east/12");
 
     // when
-    final var nodeId = MemberId.extractNodeId(memberId);
+    final var nodeId = memberId.nodeIdx();
 
     // then
     assertThat(nodeId).isEqualTo(12);
@@ -102,8 +102,7 @@ final class MemberIdTest {
     final var memberId = MemberId.from("anonymous");
 
     // then
-    assertThatThrownBy(() -> MemberId.extractNodeId(memberId))
-        .isInstanceOf(NumberFormatException.class);
+    assertThatThrownBy(memberId::nodeIdx).isInstanceOf(NumberFormatException.class);
   }
 
   static Stream<Arguments> isInZoneCases() {

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/MemberIdTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/MemberIdTest.java
@@ -19,7 +19,11 @@ package io.atomix.cluster;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 final class MemberIdTest {
 
@@ -100,6 +104,23 @@ final class MemberIdTest {
     // then
     assertThatThrownBy(() -> MemberId.extractNodeId(memberId))
         .isInstanceOf(NumberFormatException.class);
+  }
+
+  static Stream<Arguments> isInZoneCases() {
+    return Stream.of(
+        //          id            zone        expected
+        Arguments.of("us-east/7", "us-east", true), // matching zone
+        Arguments.of("us-east/7", "eu-west", false), // different zone
+        Arguments.of("7", "us-east", false), // zone set but id is bare
+        Arguments.of("7", null, true), // null zone, bare id
+        Arguments.of("us-east/1", null, false) // null zone, zoned id
+        );
+  }
+
+  @ParameterizedTest
+  @MethodSource("isInZoneCases")
+  void shouldCheckIsInZone(final String id, final String zone, final boolean expected) {
+    assertThat(MemberId.from(id).isInZone(zone)).isEqualTo(expected);
   }
 
   @Test

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/MemberIdTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/MemberIdTest.java
@@ -16,6 +16,7 @@
 package io.atomix.cluster;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.stream.Stream;
@@ -32,7 +33,11 @@ final class MemberIdTest {
     final var memberId = MemberId.from(null, 7);
 
     // then
-    assertThat(memberId.id()).isEqualTo("7");
+
+    assertThat(memberId)
+        .returns(7, MemberId::nodeIdx)
+        .returns(null, MemberId::zone)
+        .returns("7", MemberId::id);
   }
 
   @Test
@@ -53,7 +58,10 @@ final class MemberIdTest {
     final var memberId = MemberId.from("  eu-west  ", 7);
 
     // then
-    assertThat(memberId.id()).isEqualTo("eu-west/7");
+    assertThat(memberId)
+        .returns(7, MemberId::nodeIdx)
+        .returns("eu-west", MemberId::zone)
+        .returns("eu-west/7", MemberId::id);
   }
 
   @Test
@@ -62,7 +70,10 @@ final class MemberIdTest {
     final var memberId = MemberId.from("us-east", 7);
 
     // then
-    assertThat(memberId.id()).isEqualTo("us-east/7");
+    assertThat(memberId)
+        .returns(7, MemberId::nodeIdx)
+        .returns("us-east", MemberId::zone)
+        .returns("us-east/7", MemberId::id);
   }
 
   @Test
@@ -70,23 +81,20 @@ final class MemberIdTest {
     // given
     final var memberId = MemberId.from("3");
 
-    // when
-    final var nodeId = memberId.nodeIdx();
-
-    // then
-    assertThat(nodeId).isEqualTo(3);
+    // when / then
+    assertThat(memberId).returns(3, MemberId::nodeIdx).returns(null, MemberId::zone);
   }
 
   @Test
-  void shouldExtractNodeIdFromZonedForm() {
+  void shouldExtractComponentsFromZonedForm() {
     // given
     final var memberId = MemberId.from("us-east/12");
 
-    // when
-    final var nodeId = memberId.nodeIdx();
-
-    // then
-    assertThat(nodeId).isEqualTo(12);
+    // when / then
+    assertThat(memberId)
+        .returns(12, MemberId::nodeIdx)
+        .returns("us-east", MemberId::zone)
+        .returns("us-east/12", MemberId::id);
   }
 
   @Test
@@ -96,6 +104,12 @@ final class MemberIdTest {
 
     // when / then
     assertThatThrownBy(memberId::nodeIdx).isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void shouldNotThrowForAnonymous() {
+    // given / when / then
+    assertThatNoException().isThrownBy(MemberId::anonymous);
   }
 
   static Stream<Arguments> isInZoneCases() {

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/MemberIdTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/MemberIdTest.java
@@ -1,12 +1,11 @@
 /*
- * Copyright 2014-present Open Networking Foundation
  * Copyright © 2020 camunda services GmbH (info@camunda.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -37,21 +36,15 @@ final class MemberIdTest {
   }
 
   @Test
-  void shouldFormatIdWithoutZoneWhenZoneIsEmpty() {
-    // given / when
-    final var memberId = MemberId.from("", 7);
-
-    // then
-    assertThat(memberId.id()).isEqualTo("7");
+  void shouldThrowWhenZoneIsEmpty() {
+    // given / when / then
+    assertThatThrownBy(() -> MemberId.from("", 7)).isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
-  void shouldFormatIdWithoutZoneWhenZoneIsBlank() {
-    // given / when
-    final var memberId = MemberId.from("   ", 7);
-
-    // then
-    assertThat(memberId.id()).isEqualTo("7");
+  void shouldThrowWhenZoneIsBlank() {
+    // given / when / then
+    assertThatThrownBy(() -> MemberId.from("   ", 7)).isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
@@ -98,16 +91,12 @@ final class MemberIdTest {
 
   @Test
   void shouldThrowWhenIdHasNoNumericSuffix() {
-    // given
-    final var memberId = MemberId.from("anonymous");
-
-    // then
-    assertThatThrownBy(memberId::nodeIdx).isInstanceOf(NumberFormatException.class);
+    // given / when / then
+    assertThatThrownBy(() -> MemberId.from("anonymous")).isInstanceOf(NumberFormatException.class);
   }
 
   static Stream<Arguments> isInZoneCases() {
     return Stream.of(
-        //          id            zone        expected
         Arguments.of("us-east/7", "us-east", true), // matching zone
         Arguments.of("us-east/7", "eu-west", false), // different zone
         Arguments.of("7", "us-east", false), // zone set but id is bare
@@ -119,6 +108,7 @@ final class MemberIdTest {
   @ParameterizedTest
   @MethodSource("isInZoneCases")
   void shouldCheckIsInZone(final String id, final String zone, final boolean expected) {
+    // given / when / then
     assertThat(MemberId.from(id).isInZone(zone)).isEqualTo(expected);
   }
 

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/MemberIdTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/MemberIdTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2014-present Open Networking Foundation
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.cluster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+final class MemberIdTest {
+
+  @Test
+  void shouldFormatIdWithoutZoneWhenZoneIsNull() {
+    // given / when
+    final var memberId = MemberId.from(null, 7);
+
+    // then
+    assertThat(memberId.id()).isEqualTo("7");
+  }
+
+  @Test
+  void shouldFormatIdWithZonePrefixWhenZoneIsSet() {
+    // given / when
+    final var memberId = MemberId.from("us-east", 7);
+
+    // then
+    assertThat(memberId.id()).isEqualTo("us-east/7");
+  }
+
+  @Test
+  void shouldExtractNodeIdFromBareIntegerForm() {
+    // given
+    final var memberId = MemberId.from("3");
+
+    // when
+    final var nodeId = MemberId.extractNodeId(memberId);
+
+    // then
+    assertThat(nodeId).isEqualTo(3);
+  }
+
+  @Test
+  void shouldExtractNodeIdFromZonedForm() {
+    // given
+    final var memberId = MemberId.from("us-east/12");
+
+    // when
+    final var nodeId = MemberId.extractNodeId(memberId);
+
+    // then
+    assertThat(nodeId).isEqualTo(12);
+  }
+
+  @Test
+  void shouldThrowWhenIdHasNoNumericSuffix() {
+    // given
+    final var memberId = MemberId.from("anonymous");
+
+    // then
+    assertThatThrownBy(() -> MemberId.extractNodeId(memberId))
+        .isInstanceOf(NumberFormatException.class);
+  }
+}

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/MemberIdTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/MemberIdTest.java
@@ -74,4 +74,14 @@ final class MemberIdTest {
     assertThatThrownBy(() -> MemberId.extractNodeId(memberId))
         .isInstanceOf(NumberFormatException.class);
   }
+
+  @Test
+  void shouldThrowWhenMemberZoneDoesNotMatchMemberIdPrefix() {
+    // given
+    final var memberId = MemberId.from("us-east/0");
+
+    // then
+    assertThatThrownBy(() -> Member.builder(memberId).withZoneId("us").build())
+        .isInstanceOf(IllegalArgumentException.class);
+  }
 }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/MemberIdTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/MemberIdTest.java
@@ -91,8 +91,11 @@ final class MemberIdTest {
 
   @Test
   void shouldThrowWhenIdHasNoNumericSuffix() {
-    // given / when / then
-    assertThatThrownBy(() -> MemberId.from("anonymous")).isInstanceOf(NumberFormatException.class);
+    // given
+    final var memberId = MemberId.from("anonymous");
+
+    // when / then
+    assertThatThrownBy(memberId::nodeIdx).isInstanceOf(IllegalStateException.class);
   }
 
   static Stream<Arguments> isInZoneCases() {

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/MemberIdTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/MemberIdTest.java
@@ -33,6 +33,33 @@ final class MemberIdTest {
   }
 
   @Test
+  void shouldFormatIdWithoutZoneWhenZoneIsEmpty() {
+    // given / when
+    final var memberId = MemberId.from("", 7);
+
+    // then
+    assertThat(memberId.id()).isEqualTo("7");
+  }
+
+  @Test
+  void shouldFormatIdWithoutZoneWhenZoneIsBlank() {
+    // given / when
+    final var memberId = MemberId.from("   ", 7);
+
+    // then
+    assertThat(memberId.id()).isEqualTo("7");
+  }
+
+  @Test
+  void shouldStripSurroundingWhitespaceFromZone() {
+    // given / when
+    final var memberId = MemberId.from("  eu-west  ", 7);
+
+    // then
+    assertThat(memberId.id()).isEqualTo("eu-west/7");
+  }
+
+  @Test
   void shouldFormatIdWithZonePrefixWhenZoneIsSet() {
     // given / when
     final var memberId = MemberId.from("us-east", 7);

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
@@ -71,9 +71,7 @@ public final class BrokerTopologyManagerImpl extends Actor
     actor.run(
         () -> {
           topologyListeners.add(listener);
-          topology.getBrokers().stream()
-              .map(b -> MemberId.from(String.valueOf(b)))
-              .forEach(listener::brokerAdded);
+          memberProperties.keySet().forEach(listener::brokerAdded);
         });
   }
 

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
@@ -545,6 +545,31 @@ final class BrokerTopologyManagerTest {
     assertThat(topologyManager.getTopology().getPartitionsCount()).isEqualTo(2);
   }
 
+  @Test
+  void shouldBackfillNewListenerWithCanonicalZoneAwareMemberId() {
+    // given — broker 0 joined with a zone-aware id
+    final var broker = createBroker(0);
+    final var zonedMemberId = MemberId.from("eu-west/0");
+    final var member = new Member(new MemberConfig().setId(zonedMemberId.id()));
+    broker.writeIntoProperties(member.properties());
+    members.add(member);
+    notifyEvent(new ClusterMembershipEvent(Type.MEMBER_ADDED, member));
+
+    // when — a new listener is added after the broker is already known
+    final var capturedIds = new java.util.concurrent.CopyOnWriteArrayList<MemberId>();
+    topologyManager.addTopologyListener(
+        new BrokerTopologyListener() {
+          @Override
+          public void brokerAdded(final MemberId memberId) {
+            capturedIds.add(memberId);
+          }
+        });
+    actorSchedulerRule.workUntilDone();
+
+    // then — the listener is backfilled with the zone-aware id, not the bare int "0"
+    assertThat(capturedIds).containsExactly(zonedMemberId);
+  }
+
   private void addTopologyListener(final BrokerTopologyListener listener) {
     topologyManager.addTopologyListener(listener);
     actorSchedulerRule.workUntilDone();

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
@@ -551,7 +551,7 @@ final class BrokerTopologyManagerTest {
     // given — broker 0 joined with a zone-aware id
     final var broker = createBroker(0);
     final var zonedMemberId = MemberId.from("eu-west/0");
-    final var member = new Member(new MemberConfig().setId(zonedMemberId.id()));
+    final var member = new Member(new MemberConfig().setId(zonedMemberId).setZoneId("eu-west"));
     broker.writeIntoProperties(member.properties());
     members.add(member);
     notifyEvent(new ClusterMembershipEvent(Type.MEMBER_ADDED, member));

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CopyOnWriteArraySet;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
@@ -556,7 +557,7 @@ final class BrokerTopologyManagerTest {
     notifyEvent(new ClusterMembershipEvent(Type.MEMBER_ADDED, member));
 
     // when — a new listener is added after the broker is already known
-    final var capturedIds = new java.util.concurrent.CopyOnWriteArrayList<MemberId>();
+    final var capturedIds = new CopyOnWriteArrayList<MemberId>();
     topologyManager.addTopologyListener(
         new BrokerTopologyListener() {
           @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -65,7 +65,8 @@ public final class Broker implements AutoCloseable {
 
     final ActorScheduler scheduler = this.systemContext.getScheduler();
     final BrokerInfo localBroker = createBrokerInfo(getConfig());
-    final var nodeId = MemberId.from(String.valueOf(getConfig().getCluster().getNodeId()));
+    final var cluster = getConfig().getCluster();
+    final var nodeId = MemberId.from(cluster.getZone(), cluster.getNodeId());
 
     healthCheckService =
         new BrokerHealthCheckService(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
@@ -58,12 +58,16 @@ final class PartitionManagerStep extends AbstractBrokerStartupStep {
             brokerStartupContext
                 .getClusterConfigurationService()
                 .registerInconsistentConfigurationListener(
-                    (newTopology, oldTopology) ->
-                        shutdownOnInconsistentTopology(
-                            brokerStartupContext.getBrokerInfo().getNodeId(),
-                            brokerStartupContext.getSpringBrokerBridge(),
-                            newTopology,
-                            oldTopology));
+                    (newTopology, oldTopology) -> {
+                      final var clusterCfg =
+                          brokerStartupContext.getBrokerConfiguration().getCluster();
+                      shutdownOnInconsistentTopology(
+                          clusterCfg.getZone(),
+                          clusterCfg.getNodeId(),
+                          brokerStartupContext.getSpringBrokerBridge(),
+                          newTopology,
+                          oldTopology);
+                    });
             partitionManager.start();
             brokerStartupContext.setPartitionManager(partitionManager);
             brokerStartupContext
@@ -106,11 +110,12 @@ final class PartitionManagerStep extends AbstractBrokerStartupStep {
   }
 
   private void shutdownOnInconsistentTopology(
+      final String zone,
       final int localBrokerId,
       final SpringBrokerBridge springBrokerBridge,
       final ClusterConfiguration newTopology,
       final ClusterConfiguration oldTopology) {
-    final MemberId localMemberId = MemberId.from(String.valueOf(localBrokerId));
+    final MemberId localMemberId = MemberId.from(zone, localBrokerId);
     LOGGER.warn(
         """
           Received a newer topology which has a different state for this broker.

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.broker.partitioning.PartitionManagerImpl;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 
 final class PartitionManagerStep extends AbstractBrokerStartupStep {
@@ -110,7 +111,7 @@ final class PartitionManagerStep extends AbstractBrokerStartupStep {
   }
 
   private void shutdownOnInconsistentTopology(
-      final String zone,
+      final @Nullable String zone,
       final int localBrokerId,
       final SpringBrokerBridge springBrokerBridge,
       final ClusterConfiguration newTopology,

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/clustering/ClusterConfigFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/clustering/ClusterConfigFactory.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker.clustering;
 
 import io.atomix.cluster.ClusterConfig;
 import io.atomix.cluster.MemberConfig;
+import io.atomix.cluster.MemberId;
 import io.atomix.cluster.discovery.DynamicDiscoveryConfig;
 import io.atomix.cluster.messaging.MessagingConfig;
 import io.atomix.cluster.protocol.SwimMembershipProtocolConfig;
@@ -31,9 +32,7 @@ public final class ClusterConfigFactory {
     final var network = config.getNetwork();
 
     final var messaging = messagingConfig(cluster, network);
-    final var member =
-        memberConfig(
-            network.getInternalApi(), cluster.getNodeId(), config.getCluster().getNodeVersion());
+    final var member = memberConfig(network.getInternalApi(), cluster);
 
     return new ClusterConfig()
         .setClusterId(name)
@@ -43,15 +42,15 @@ public final class ClusterConfigFactory {
         .setProtocolConfig(membership);
   }
 
-  private MemberConfig memberConfig(
-      final SocketBindingCfg network, final int nodeId, final long nodeVersion) {
+  private MemberConfig memberConfig(final SocketBindingCfg network, final ClusterCfg cluster) {
     final var advertisedAddress =
         Address.from(network.getAdvertisedHost(), network.getAdvertisedPort());
 
     return new MemberConfig()
         .setAddress(advertisedAddress)
-        .setId(String.valueOf(nodeId))
-        .setNodeVersion(nodeVersion);
+        .setId(MemberId.from(cluster.getZone(), cluster.getNodeId()))
+        .setZoneId(cluster.getZone())
+        .setNodeVersion(cluster.getNodeVersion());
   }
 
   private SwimMembershipProtocolConfig membershipConfig(final MembershipCfg config) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImpl.java
@@ -274,7 +274,7 @@ public final class TopologyManagerImpl extends Actor
             id -> {
               try {
                 return id.isInZone(localBroker.zone()) && id.nodeIdx() == nodeId;
-              } catch (final Exception e) {
+              } catch (final IllegalStateException e) {
                 return false;
               }
             })

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImpl.java
@@ -270,7 +270,14 @@ public final class TopologyManagerImpl extends Actor
   private MemberId resolveMemberId(final int nodeId) {
     return membershipService.getMembers().stream()
         .map(Member::id)
-        .filter(id -> MemberId.extractNodeId(id) == nodeId)
+        .filter(
+            id -> {
+              try {
+                return MemberId.extractNodeId(id) == nodeId;
+              } catch (final NumberFormatException e) {
+                return false;
+              }
+            })
         .findFirst()
         .orElseGet(
             () -> {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImpl.java
@@ -12,6 +12,7 @@ import io.atomix.cluster.ClusterMembershipEvent.Type;
 import io.atomix.cluster.ClusterMembershipEventListener;
 import io.atomix.cluster.ClusterMembershipService;
 import io.atomix.cluster.Member;
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.engine.state.QueryService;
@@ -228,7 +229,10 @@ public final class TopologyManagerImpl extends Actor
           partitionLeaders.forEach(
               (partitionId, leader) ->
                   LogUtil.catchAndLog(
-                      LOG, () -> listener.onPartitionLeaderUpdated(partitionId, leader)));
+                      LOG,
+                      () ->
+                          listener.onPartitionLeaderUpdated(
+                              partitionId, resolveMemberId(leader.getNodeId()))));
         });
   }
 
@@ -257,8 +261,17 @@ public final class TopologyManagerImpl extends Actor
   }
 
   private void notifyPartitionLeaderUpdated(final int partitionId, final BrokerInfo member) {
+    final var leaderId = resolveMemberId(member.getNodeId());
     for (final TopologyPartitionListener listener : topologyPartitionListeners) {
-      LogUtil.catchAndLog(LOG, () -> listener.onPartitionLeaderUpdated(partitionId, member));
+      LogUtil.catchAndLog(LOG, () -> listener.onPartitionLeaderUpdated(partitionId, leaderId));
     }
+  }
+
+  private MemberId resolveMemberId(final int nodeId) {
+    return membershipService.getMembers().stream()
+        .map(Member::id)
+        .filter(id -> MemberId.extractNodeId(id) == nodeId)
+        .findFirst()
+        .orElseGet(() -> MemberId.from(Integer.toString(nodeId)));
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImpl.java
@@ -272,6 +272,12 @@ public final class TopologyManagerImpl extends Actor
         .map(Member::id)
         .filter(id -> MemberId.extractNodeId(id) == nodeId)
         .findFirst()
-        .orElseGet(() -> MemberId.from(Integer.toString(nodeId)));
+        .orElseGet(
+            () -> {
+              LOG.warn(
+                  "No cluster member found for nodeId {}; falling back to bare MemberId — zone-aware routing will not work for this member",
+                  nodeId);
+              return MemberId.from(Integer.toString(nodeId));
+            });
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImpl.java
@@ -232,7 +232,7 @@ public final class TopologyManagerImpl extends Actor
                       LOG,
                       () ->
                           listener.onPartitionLeaderUpdated(
-                              partitionId, resolveMemberId(leader.getNodeId()))));
+                              partitionId, resolveMemberIdInZone(leader.getNodeId()))));
         });
   }
 
@@ -261,20 +261,20 @@ public final class TopologyManagerImpl extends Actor
   }
 
   private void notifyPartitionLeaderUpdated(final int partitionId, final BrokerInfo member) {
-    final var leaderId = resolveMemberId(member.getNodeId());
+    final var leaderId = resolveMemberIdInZone(member.getNodeId());
     for (final TopologyPartitionListener listener : topologyPartitionListeners) {
       LogUtil.catchAndLog(LOG, () -> listener.onPartitionLeaderUpdated(partitionId, leaderId));
     }
   }
 
-  private MemberId resolveMemberId(final int nodeId) {
+  private MemberId resolveMemberIdInZone(final int nodeId) {
     return membershipService.getMembers().stream()
         .map(Member::id)
         .filter(
             id -> {
               try {
-                return MemberId.extractNodeId(id) == nodeId;
-              } catch (final NumberFormatException e) {
+                return id.isInZone(localBroker.zone()) && id.nodeIdx() == nodeId;
+              } catch (final Exception e) {
                 return false;
               }
             })

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyPartitionListener.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyPartitionListener.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.zeebe.broker.partitioning.topology;
 
-import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
+import io.atomix.cluster.MemberId;
 
 public interface TopologyPartitionListener {
-  void onPartitionLeaderUpdated(int partitionId, BrokerInfo member);
+  void onPartitionLeaderUpdated(int partitionId, MemberId leaderId);
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ClusterCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ClusterCfg.java
@@ -225,7 +225,7 @@ public final class ClusterCfg implements ConfigurationEntry {
     return zone;
   }
 
-  public void setZone(@Nullable final String zone) {
+  public void setZone(final @Nullable String zone) {
     this.zone = zone;
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/AdminApiRequestHandlerStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/AdminApiRequestHandlerStep.java
@@ -45,7 +45,8 @@ public final class AdminApiRequestHandlerStep implements PartitionTransitionStep
             context.getAdminAccess(),
             context.getRaftPartition(),
             context.getClusterConfigurationService(),
-            context.getNodeId());
+            context.getNodeId(),
+            context.getBrokerCfg().getCluster().getZone());
     final var submitFuture = schedulingService.submitActor(handler);
     concurrencyControl.runOnCompletion(
         submitFuture,

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandler.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.transport.RequestType;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
 import io.camunda.zeebe.util.Either;
 import java.io.IOException;
+import org.jspecify.annotations.Nullable;
 
 public class AdminApiRequestHandler
     extends AsyncApiRequestHandler<ApiRequestReader, ApiResponseWriter> {
@@ -31,7 +32,7 @@ public class AdminApiRequestHandler
   private final RaftPartition raftPartition;
   private final ClusterConfigurationService clusterConfigurationService;
   private final int nodeId;
-  private final String zone;
+  private final @Nullable String zone;
 
   public AdminApiRequestHandler(
       final AtomixServerTransport transport,
@@ -39,7 +40,7 @@ public class AdminApiRequestHandler
       final RaftPartition raftPartition,
       final ClusterConfigurationService clusterConfigurationService,
       final int nodeId,
-      final String zone) {
+      final @Nullable String zone) {
     super(ApiRequestReader::new, ApiResponseWriter::new);
     this.transport = transport;
     this.adminAccess = adminAccess;

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandler.java
@@ -31,13 +31,15 @@ public class AdminApiRequestHandler
   private final RaftPartition raftPartition;
   private final ClusterConfigurationService clusterConfigurationService;
   private final int nodeId;
+  private final String zone;
 
   public AdminApiRequestHandler(
       final AtomixServerTransport transport,
       final PartitionAdminAccess adminAccess,
       final RaftPartition raftPartition,
       final ClusterConfigurationService clusterConfigurationService,
-      final int nodeId) {
+      final int nodeId,
+      final String zone) {
     super(ApiRequestReader::new, ApiResponseWriter::new);
     this.transport = transport;
     this.adminAccess = adminAccess;
@@ -45,6 +47,7 @@ public class AdminApiRequestHandler
     this.raftPartition = raftPartition;
     this.clusterConfigurationService = clusterConfigurationService;
     this.nodeId = nodeId;
+    this.zone = zone;
   }
 
   @Override
@@ -282,7 +285,7 @@ public class AdminApiRequestHandler
     // Fire-and-forget: return success immediately, then process asynchronously
     actor.run(
         () -> {
-          final MemberId currentMemberId = MemberId.from(String.valueOf(nodeId));
+          final MemberId currentMemberId = MemberId.from(zone, nodeId);
           clusterConfigurationService
               .getLatestClusterConfiguration()
               .onComplete(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandSenderImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandSenderImpl.java
@@ -22,7 +22,7 @@ import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.Objects;
-import org.agrona.collections.Int2IntHashMap;
+import org.agrona.collections.Int2ObjectHashMap;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.slf4j.Logger;
 
@@ -34,7 +34,7 @@ public final class InterPartitionCommandSenderImpl implements InterPartitionComm
   private static final Logger LOG = Loggers.TRANSPORT_LOGGER;
   private final ClusterCommunicationService communicationService;
 
-  private final Int2IntHashMap partitionLeaders = new Int2IntHashMap(-1);
+  private final Int2ObjectHashMap<MemberId> partitionLeaders = new Int2ObjectHashMap<>();
   private long checkpointId = CheckpointState.NO_CHECKPOINT;
   private CheckpointType checkpointType = CheckpointType.MANUAL_BACKUP;
   private final String sendingSubjectPrefix;
@@ -72,7 +72,8 @@ public final class InterPartitionCommandSenderImpl implements InterPartitionComm
       final Long recordKey,
       final UnifiedRecordValue command,
       final AuthInfo authInfo) {
-    if (!partitionLeaders.containsKey(receiverPartitionId)) {
+    final MemberId partitionLeader = partitionLeaders.get(receiverPartitionId);
+    if (partitionLeader == null) {
       LOG.warn(
           "Not sending command {} {} to {}, no known leader for this partition",
           valueType,
@@ -80,7 +81,6 @@ public final class InterPartitionCommandSenderImpl implements InterPartitionComm
           receiverPartitionId);
       return;
     }
-    final int partitionLeader = partitionLeaders.get(receiverPartitionId);
 
     LOG.trace(
         "Sending command {} {} to partition {}, leader {}",
@@ -104,7 +104,7 @@ public final class InterPartitionCommandSenderImpl implements InterPartitionComm
         sendingSubjectPrefix + receiverPartitionId,
         message,
         DefaultSerializers.BASIC::encode,
-        MemberId.from("" + partitionLeader),
+        partitionLeader,
         true);
   }
 
@@ -113,8 +113,8 @@ public final class InterPartitionCommandSenderImpl implements InterPartitionComm
     this.checkpointType = checkpointType;
   }
 
-  void setCurrentLeader(final int partitionId, final int currentLeader) {
-    partitionLeaders.put(partitionId, currentLeader);
+  void setCurrentLeader(final int partitionId, final MemberId leaderId) {
+    partitionLeaders.put(partitionId, leaderId);
   }
 
   private static final class Encoder {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandSenderService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandSenderService.java
@@ -74,7 +74,7 @@ public final class InterPartitionCommandSenderService extends Actor
   }
 
   @Override
-  public void onPartitionLeaderUpdated(final int partitionId, final MemberId leaderId) {
-    actor.submit(() -> commandSender.setCurrentLeader(partitionId, leaderId));
+  public void onPartitionLeaderUpdated(final int leaderPartitionId, final MemberId leaderId) {
+    actor.submit(() -> commandSender.setCurrentLeader(leaderPartitionId, leaderId));
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandSenderService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandSenderService.java
@@ -7,11 +7,11 @@
  */
 package io.camunda.zeebe.broker.transport.partitionapi;
 
+import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.camunda.zeebe.backup.api.CheckpointListener;
 import io.camunda.zeebe.broker.partitioning.topology.TopologyPartitionListener;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
-import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
@@ -74,7 +74,7 @@ public final class InterPartitionCommandSenderService extends Actor
   }
 
   @Override
-  public void onPartitionLeaderUpdated(final int partitionId, final BrokerInfo member) {
-    actor.submit(() -> commandSender.setCurrentLeader(partitionId, member.getNodeId()));
+  public void onPartitionLeaderUpdated(final int partitionId, final MemberId leaderId) {
+    actor.submit(() -> commandSender.setCurrentLeader(partitionId, leaderId));
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/clustering/ClusterConfigFactoryTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/clustering/ClusterConfigFactoryTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.clustering;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import org.junit.jupiter.api.Test;
+
+final class ClusterConfigFactoryTest {
+
+  @Test
+  void shouldSetZoneAwareMemberIdAndZoneIdWhenZoneIsConfigured() {
+    // given
+    final var cfg = new BrokerCfg();
+    cfg.getCluster().setNodeId(2);
+    cfg.getCluster().setZone("eu-central-1a");
+    cfg.getNetwork().getInternalApi().setHost("localhost");
+    cfg.getNetwork().getInternalApi().setPort(26502);
+    cfg.getNetwork().getInternalApi().setAdvertisedHost("localhost");
+    cfg.getNetwork().getInternalApi().setAdvertisedPort(26502);
+
+    // when
+    final var clusterConfig = new ClusterConfigFactory().mapConfiguration(cfg);
+
+    // then
+    assertThat(clusterConfig.getNodeConfig().getId().id()).isEqualTo("eu-central-1a/2");
+    assertThat(clusterConfig.getNodeConfig().getZoneId()).isEqualTo("eu-central-1a");
+  }
+
+  @Test
+  void shouldSetBareMemberIdWhenZoneIsNull() {
+    // given
+    final var cfg = new BrokerCfg();
+    cfg.getCluster().setNodeId(2);
+    cfg.getCluster().setZone(null);
+    cfg.getNetwork().getInternalApi().setHost("localhost");
+    cfg.getNetwork().getInternalApi().setPort(26502);
+    cfg.getNetwork().getInternalApi().setAdvertisedHost("localhost");
+    cfg.getNetwork().getInternalApi().setAdvertisedPort(26502);
+
+    // when
+    final var clusterConfig = new ClusterConfigFactory().mapConfiguration(cfg);
+
+    // then
+    assertThat(clusterConfig.getNodeConfig().getId().id()).isEqualTo("2");
+    assertThat(clusterConfig.getNodeConfig().getZoneId()).isNull();
+  }
+}

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandlerTest.java
@@ -105,7 +105,7 @@ final class AdminApiRequestHandlerTest {
         @Mock final ClusterConfigurationService clusterConfigurationService) {
       handler =
           new AdminApiRequestHandler(
-              transport, adminAccess, raftPartition, clusterConfigurationService, 1);
+              transport, adminAccess, raftPartition, clusterConfigurationService, 1, null);
     }
 
     @BeforeEach
@@ -149,7 +149,7 @@ final class AdminApiRequestHandlerTest {
       when(adminAccess.forPartition(partitionId)).thenReturn(Optional.of(adminAccess));
       handler =
           new AdminApiRequestHandler(
-              transport, adminAccess, raftPartition, clusterConfigurationService, 1);
+              transport, adminAccess, raftPartition, clusterConfigurationService, 1, null);
 
       request = new AdminRequest();
       request.setPartitionId(partitionId);
@@ -226,7 +226,7 @@ final class AdminApiRequestHandlerTest {
       when(adminAccess.forPartition(partitionId)).thenReturn(Optional.of(adminAccess));
       handler =
           new AdminApiRequestHandler(
-              transport, adminAccess, raftPartition, clusterConfigurationService, 1);
+              transport, adminAccess, raftPartition, clusterConfigurationService, 1, null);
 
       request = new AdminRequest();
       request.setPartitionId(partitionId);
@@ -303,7 +303,7 @@ final class AdminApiRequestHandlerTest {
       when(adminAccess.forPartition(partitionId)).thenReturn(Optional.of(adminAccess));
       handler =
           new AdminApiRequestHandler(
-              transport, adminAccess, raftPartition, clusterConfigurationService, 1);
+              transport, adminAccess, raftPartition, clusterConfigurationService, 1, null);
 
       request = new AdminRequest();
       request.setPartitionId(partitionId);
@@ -380,7 +380,7 @@ final class AdminApiRequestHandlerTest {
       this.clusterConfigurationService = clusterConfigurationService;
       handler =
           new AdminApiRequestHandler(
-              transport, adminAccess, raftPartition, clusterConfigurationService, nodeId);
+              transport, adminAccess, raftPartition, clusterConfigurationService, nodeId, null);
     }
 
     @BeforeEach

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandCheckpointTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandCheckpointTest.java
@@ -55,7 +55,7 @@ final class InterPartitionCommandCheckpointTest {
     this.logStreamWriter = logStreamWriter;
 
     sender = new InterPartitionCommandSenderImpl(communicationService, LEGACY_TOPIC_PREFIX);
-    sender.setCurrentLeader(1, 2);
+    sender.setCurrentLeader(1, MemberId.from("2"));
     receiver = new InterPartitionCommandReceiverImpl(logStreamWriter);
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverTest.java
@@ -331,7 +331,7 @@ final class InterPartitionCommandReceiverTest {
 
     final var sender =
         new InterPartitionCommandSenderImpl(communicationService, LEGACY_TOPIC_PREFIX);
-    sender.setCurrentLeader(receiverPartitionId, receiverBrokerId);
+    sender.setCurrentLeader(receiverPartitionId, MemberId.from(String.valueOf(receiverBrokerId)));
 
     sender.sendCommand(receiverPartitionId, valueType, intent, recordKey, recordValue, authInfo);
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandSenderImplTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandSenderImplTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.transport.partitionapi;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.cluster.messaging.ClusterCommunicationService;
+import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+final class InterPartitionCommandSenderImplTest {
+
+  @Mock private ClusterCommunicationService communicationService;
+
+  private InterPartitionCommandSenderImpl sender;
+
+  @BeforeEach
+  void setUp() {
+    sender = new InterPartitionCommandSenderImpl(communicationService, "test-");
+  }
+
+  @Test
+  void shouldNotSendCommandWhenNoLeaderKnown() {
+    // given — no leader set for partition 1
+
+    // when
+    sender.sendCommand(1, ValueType.CHECKPOINT, CheckpointIntent.CREATE, new CheckpointRecord());
+
+    // then
+    verify(communicationService, never()).unicast(any(), any(), any(), any(), any(boolean.class));
+  }
+
+  @Test
+  void shouldSendCommandToZonedMemberId() {
+    // given
+    final var leaderId = MemberId.from("eu-west/2");
+    sender.setCurrentLeader(1, leaderId);
+
+    // when
+    sender.sendCommand(1, ValueType.CHECKPOINT, CheckpointIntent.CREATE, new CheckpointRecord());
+
+    // then
+    verify(communicationService).unicast(eq("test-1"), any(), any(), eq(leaderId), eq(true));
+  }
+
+  @Test
+  void shouldSendCommandToBareIntMemberId() {
+    // given
+    final var leaderId = MemberId.from("2");
+    sender.setCurrentLeader(1, leaderId);
+
+    // when
+    sender.sendCommand(1, ValueType.CHECKPOINT, CheckpointIntent.CREATE, new CheckpointRecord());
+
+    // then
+    verify(communicationService).unicast(eq("test-1"), any(), any(), eq(leaderId), eq(true));
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
@@ -48,7 +48,7 @@ public final class ClusterConfigurationManagerService
   public static final String TOPOLOGY_FILE_NAME = ".topology.meta";
   // Use a node 0 as always the coordinator. Later we can make it configurable or allow changing it
   // dynamically.
-  private static final String COORDINATOR_ID = "0";
+  private static final int COORDINATOR_NODE_ID = 0;
   private final ClusterConfigurationManagerImpl clusterConfigurationManager;
   private final ClusterConfigurationGossiper clusterConfigurationGossiper;
   private final boolean isCoordinator;
@@ -98,7 +98,7 @@ public final class ClusterConfigurationManagerService
             config,
             clusterConfigurationManager::onGossipReceived,
             topologyMetrics);
-    isCoordinator = localMemberId.id().equals(COORDINATOR_ID);
+    isCoordinator = MemberId.extractNodeId(localMemberId) == COORDINATOR_NODE_ID;
     configurationChangeCoordinator =
         new ConfigurationChangeCoordinatorImpl(
             clusterConfigurationManager, localMemberId, managerActor);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
@@ -98,7 +98,7 @@ public final class ClusterConfigurationManagerService
             config,
             clusterConfigurationManager::onGossipReceived,
             topologyMetrics);
-    isCoordinator = MemberId.extractNodeId(localMemberId) == COORDINATOR_NODE_ID;
+    isCoordinator = localMemberId.nodeIdx() == COORDINATOR_NODE_ID;
     configurationChangeCoordinator =
         new ConfigurationChangeCoordinatorImpl(
             clusterConfigurationManager, localMemberId, managerActor);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/RoundRobinPartitionDistributor.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/RoundRobinPartitionDistributor.java
@@ -45,7 +45,7 @@ public final class RoundRobinPartitionDistributor implements PartitionDistributo
       final List<PartitionId> sortedPartitionIds,
       final int replicationFactor) {
     final List<MemberId> sorted = new ArrayList<>(clusterMembers);
-    sorted.sort(Comparator.comparingInt(MemberId::extractNodeId));
+    sorted.sort(Comparator.comparingInt(MemberId::nodeIdx));
 
     final int length = sorted.size();
     final int count = Math.min(replicationFactor, length);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/RoundRobinPartitionDistributor.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/RoundRobinPartitionDistributor.java
@@ -45,9 +45,7 @@ public final class RoundRobinPartitionDistributor implements PartitionDistributo
       final List<PartitionId> sortedPartitionIds,
       final int replicationFactor) {
     final List<MemberId> sorted = new ArrayList<>(clusterMembers);
-    // We know that the memberIds are always integer. Sort it based on the integer value instead of
-    // string.
-    sorted.sort(Comparator.comparing(m -> Integer.parseInt(m.id())));
+    sorted.sort(Comparator.comparingInt(MemberId::extractNodeId));
 
     final int length = sorted.size();
     final int count = Math.min(replicationFactor, length);

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/RoundRobinPartitionDistributorTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/RoundRobinPartitionDistributorTest.java
@@ -120,7 +120,7 @@ final class RoundRobinPartitionDistributorTest {
               .members()
               .forEach(
                   member -> {
-                    final int nodeId = MemberId.extractNodeId(member);
+                    final int nodeId = member.nodeIdx();
                     assertThat(metadata.getPriority(member))
                         .describedAs(
                             "Priority should be set for nodeId %d in partition %d",

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/RoundRobinPartitionDistributorTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/RoundRobinPartitionDistributorTest.java
@@ -16,6 +16,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -97,6 +98,36 @@ final class RoundRobinPartitionDistributorTest {
               {1, 2, 3, 0, 2, 1, 3, 0, 1, 2, 3, 0},
               {0, 1, 2, 3, 0, 2, 1, 3, 0, 1, 2, 3},
             }));
+  }
+
+  @Test
+  void shouldDistributePartitionsAcrossZoneAwareMembers() {
+    // given
+    final var members =
+        Set.of(MemberId.from("eu-west/0"), MemberId.from("eu-west/1"), MemberId.from("eu-west/2"));
+
+    // when
+    final var distribution =
+        new RoundRobinPartitionDistributor()
+            .distributePartitions(members, getSortedPartitionIds(3), 3);
+
+    // then — distribution completes without NumberFormatException and covers all partitions
+    assertThat(distribution).hasSize(3);
+    distribution.forEach(
+        metadata -> {
+          assertThat(metadata.members()).hasSize(3);
+          metadata
+              .members()
+              .forEach(
+                  member -> {
+                    final int nodeId = MemberId.extractNodeId(member);
+                    assertThat(metadata.getPriority(member))
+                        .describedAs(
+                            "Priority should be set for nodeId %d in partition %d",
+                            nodeId, metadata.id().id())
+                        .isPositive();
+                  });
+        });
   }
 
   private Set<MemberId> getMembers(final int nodeCount) {

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProvider.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProvider.java
@@ -324,7 +324,7 @@ public class RepositoryNodeIdProvider implements NodeIdProvider, AutoCloseable {
     final var nodeInstances =
         currentMembers.stream()
             .filter(m -> isBroker(m.id()))
-            .map(m -> Map.entry(Integer.parseInt(m.id().id()), Version.of(m.nodeVersion())))
+            .map(m -> Map.entry(MemberId.extractNodeId(m.id()), Version.of(m.nodeVersion())))
             .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
     knownVersionMappings = new VersionMappings(nodeInstances);
     LOG.trace("Updating known version mappings to {}", knownVersionMappings);
@@ -333,8 +333,7 @@ public class RepositoryNodeIdProvider implements NodeIdProvider, AutoCloseable {
   private boolean isBroker(final MemberId memberId) {
     // TODO improve the way we identify brokers vs gateways
     try {
-      final var id = Integer.parseInt(memberId.id());
-      return id >= 0;
+      return MemberId.extractNodeId(memberId) >= 0;
     } catch (final NumberFormatException e) {
       return false;
     }

--- a/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProvider.java
+++ b/zeebe/dynamic-node-id-provider/src/main/java/io/camunda/zeebe/dynamic/nodeid/RepositoryNodeIdProvider.java
@@ -324,7 +324,7 @@ public class RepositoryNodeIdProvider implements NodeIdProvider, AutoCloseable {
     final var nodeInstances =
         currentMembers.stream()
             .filter(m -> isBroker(m.id()))
-            .map(m -> Map.entry(MemberId.extractNodeId(m.id()), Version.of(m.nodeVersion())))
+            .map(m -> Map.entry(m.id().nodeIdx(), Version.of(m.nodeVersion())))
             .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
     knownVersionMappings = new VersionMappings(nodeInstances);
     LOG.trace("Updating known version mappings to {}", knownVersionMappings);
@@ -333,8 +333,8 @@ public class RepositoryNodeIdProvider implements NodeIdProvider, AutoCloseable {
   private boolean isBroker(final MemberId memberId) {
     // TODO improve the way we identify brokers vs gateways
     try {
-      return MemberId.extractNodeId(memberId) >= 0;
-    } catch (final NumberFormatException e) {
+      return memberId.nodeIdx() >= 0;
+    } catch (final Exception e) {
       return false;
     }
   }

--- a/zeebe/protocol-impl/pom.xml
+++ b/zeebe/protocol-impl/pom.xml
@@ -82,6 +82,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
@@ -47,6 +47,7 @@ import java.util.function.ObjLongConsumer;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 
 public final class BrokerInfo implements BufferReader, BufferWriter {
@@ -120,6 +121,16 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
   public BrokerInfo setNodeId(final int nodeId) {
     this.nodeId = nodeId;
     return this;
+  }
+
+  public @Nullable String zone() {
+    // TODO: to be fixed in #52070
+    return null;
+  }
+
+  public String getMemberId() {
+    // TODO: to be fixed in #52070
+    return String.valueOf(nodeId);
   }
 
   public int getPartitionsCount() {

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
@@ -328,8 +328,8 @@ public class RestoreManager implements CloseableSilently {
   }
 
   private Set<InstrumentedRaftPartition> collectPartitions() {
-    final var localBrokerId = configuration.getCluster().getNodeId();
-    final var localMember = MemberId.from(String.valueOf(localBrokerId));
+    final var cluster = configuration.getCluster();
+    final var localMember = MemberId.from(cluster.getZone(), cluster.getNodeId());
     final var clusterTopology =
         new PartitionDistribution(
             StaticConfigurationGenerator.getStaticConfiguration(configuration, localMember)

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreValidator.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreValidator.java
@@ -35,8 +35,8 @@ public class RestoreValidator {
    * be used as a basic sanity check after the restore process completes.
    */
   public static boolean validate(final BrokerCfg configuration) {
-    final var localBrokerId = configuration.getCluster().getNodeId();
-    final var localMember = MemberId.from(String.valueOf(localBrokerId));
+    final var cluster = configuration.getCluster();
+    final var localMember = MemberId.from(cluster.getZone(), cluster.getNodeId());
     final var clusterTopology =
         new PartitionDistribution(
             StaticConfigurationGenerator.getStaticConfiguration(configuration, localMember)
@@ -52,7 +52,7 @@ public class RestoreValidator {
         LOGGER.error(
             "Expected to find restored partition {} on broker {}, but the partition directory {} is empty or does not exist.",
             partitionMetadata.id(),
-            localBrokerId,
+            localMember,
             getPartitionDirectory(partitionMetadata.id(), configuration.getData().getDirectory()));
         return false;
       }
@@ -61,7 +61,7 @@ public class RestoreValidator {
     if (!checkTopologyFileIsRestored(configuration)) {
       LOGGER.error(
           "Expected to find restored topology file on broker {}, but it is missing in the data directory {}.",
-          localBrokerId,
+          localMember,
           configuration.getData().getDirectory());
       return false;
     }

--- a/zeebe/test-util/src/test/java/io/camunda/zeebe/test/util/asserts/TestTopology.java
+++ b/zeebe/test-util/src/test/java/io/camunda/zeebe/test/util/asserts/TestTopology.java
@@ -20,10 +20,22 @@ import java.util.List;
  * and its protocol.
  */
 record TestTopology(
-    int clusterSize, int partitionsCount, int replicationFactor, List<BrokerInfo> brokers)
+    int clusterSize,
+    int partitionsCount,
+    int replicationFactor,
+    List<BrokerInfo> brokers,
+    String zone)
     implements Topology {
 
   private static final String HARDCODED_VERSION = VersionUtil.getVersion();
+
+  TestTopology(
+      final int clusterSize,
+      final int partitionsCount,
+      final int replicationFactor,
+      final List<BrokerInfo> brokers) {
+    this(clusterSize, partitionsCount, replicationFactor, brokers, null);
+  }
 
   @Override
   public List<BrokerInfo> getBrokers() {
@@ -79,11 +91,25 @@ record TestTopology(
     }
   }
 
-  record TestBroker(int nodeId, List<PartitionInfo> partitions) implements BrokerInfo {
+  record TestBroker(int nodeId, String zone, List<PartitionInfo> partitions) implements BrokerInfo {
+
+    public TestBroker(final int nodeId, final List<PartitionInfo> partitions) {
+      this(nodeId, null, partitions);
+    }
 
     @Override
     public int getNodeId() {
       return nodeId;
+    }
+
+    @Override
+    public String getZone() {
+      return "";
+    }
+
+    @Override
+    public String getMemberId() {
+      return zone + "/" + nodeId;
     }
 
     @Override

--- a/zeebe/test-util/src/test/java/io/camunda/zeebe/test/util/asserts/TestTopology.java
+++ b/zeebe/test-util/src/test/java/io/camunda/zeebe/test/util/asserts/TestTopology.java
@@ -104,12 +104,16 @@ record TestTopology(
 
     @Override
     public String getZone() {
-      return "";
+      return zone;
     }
 
     @Override
     public String getMemberId() {
-      return zone + "/" + nodeId;
+      if (zone == null) {
+        return String.valueOf(nodeId);
+      } else {
+        return zone + "/" + nodeId;
+      }
     }
 
     @Override


### PR DESCRIPTION
## Description

When a broker has \`cluster.zone\` configured, it now identifies itself in the Atomix cluster as \`"\$zone/\$nodeId"\` instead of the bare \`"\$nodeId"\`. This enables downstream features (e.g. zone-aware partition distribution) to know which zone a broker is in by inspecting its \`MemberId\`.

## Changes

**New helpers (atomix-cluster):**
- \`MemberId.from(@Nullable String zone, int nodeId)\` — produces \`"\$zone/\$nodeId"\` or bare \`"\$nodeId"\` when zone is null
- \`MemberId.nodeIdx()\` — instance method returning the trailing int from both \`"0"\` and \`"us-east/0"\` forms
- \`MemberId.isInZone(@Nullable String zone)\` — instance predicate; null zone means bare (no zone prefix)
- \`Member\` constructor invariant: \`id.isInZone(zone)\` must hold

**Self-id sites updated to use zone:**
- \`ClusterConfigFactory\` — sets zone-aware \`MemberId\` AND \`MemberConfig.zoneId\` at Atomix bootstrap
- \`Broker\`, \`PartitionManagerStep\`, \`AdminApiRequestHandler\`, \`RestoreManager\`, \`RestoreValidator\` — all local self-id construction

**Peer-id resolution fixed:**
- \`InterPartitionCommandSenderImpl\` — no longer reconstructs peer MemberId from bare int; topology listener now passes canonical \`MemberId\` (resolved via \`ClusterMembershipService\` in \`TopologyManagerImpl\`)
- \`BrokerTopologyManagerImpl.addTopologyListener\` — backfills with canonical MemberIds from \`memberProperties.keySet()\` instead of \`topology.getBrokers()\` (List<Integer>)

**Numeric comparisons updated:**
- \`ClusterConfigurationManagerService\` — coordinator check uses \`memberId.nodeIdx() == 0\` instead of \`"0".equals(id)\`
- \`RoundRobinPartitionDistributor\` — sorts by \`memberId.nodeIdx()\` instead of \`Integer.parseInt\`
- \`RepositoryNodeIdProvider\` — \`isBroker\` and version mapping use \`nodeIdx()\` to handle zone-prefixed ids

## Deferred (follow-up PRs)

These sites need a \`PartitionDistributionStrategy\` redesign and are tracked separately:
- \`ClusterScaleRequestTransformer.java\` — generates new member set from int range
- \`StaticConfigurationGenerator.java\` and \`FixedPartitionDistributorBuilder.java\` — boot-time peer construction
- \`ClusterEndpoint.java\` / \`ClusterApiUtils.java\` — REST management API (product decision)
- Gateway zone-awareness — separate PR

## Testing

- Unit tests added/extended in every touched module
- All modules green: \`zeebe/atomix/cluster\`, \`zeebe/broker\`, \`zeebe/broker-client\`, \`zeebe/dynamic-config\`, \`zeebe/restore\`, \`zeebe/dynamic-node-id-provider\`

## Inventory

| # | File | Change |
|---|---|---|
| 1 | \`MemberId.java\` | Add \`from(zone, nodeId)\`, \`nodeIdx()\`, \`isInZone(zone)\` |
| 2 | \`Member.java\` | Zone invariant via \`isInZone\` + \`@Nullable\` annotations |
| 3 | \`ClusterConfigFactory.java\` | Zone-aware self-id at bootstrap |
| 4 | \`Broker.java\`, \`PartitionManagerStep.java\`, \`AdminApiRequestHandler.java\`, \`RestoreManager.java\`, \`RestoreValidator.java\` | Thread zone through self-id |
| 5 | \`TopologyManagerImpl.java\` + \`TopologyPartitionListener.java\` | Pass canonical \`MemberId\` from membership to listeners |
| 6 | \`InterPartitionCommandSenderImpl.java\` | Use stored canonical \`MemberId\` for unicast |
| 7 | \`BrokerTopologyManagerImpl.java\` | Backfill listeners from \`memberProperties.keySet()\` |
| 8 | \`ClusterConfigurationManagerService.java\` | Coordinator check via \`nodeIdx()\` |
| 9 | \`RoundRobinPartitionDistributor.java\` | Sort by \`nodeIdx()\` |
| 10 | \`RepositoryNodeIdProvider.java\` | \`isBroker\` + version mapping via \`nodeIdx()\` |

closes #51585