### PR TITLE
feat: bootstrap webapp/ unified BFF backend

### DIFF
--- a/.codeowners
+++ b/.codeowners
@@ -241,8 +241,10 @@ optimize.Dockerfile         @camunda/core-features
 /document/                  @camunda/core-features
 /service/                   @camunda/core-features
 
-# Webapp Client (shared UI library)
+# Webapp (unified orchestration cluster BFF)
+/webapp/                @camunda/core-features
 /webapp/client/         @camunda/core-features
+/webapp/server/         @camunda/core-features
 
 # Gateways
 /gateways/gateway-mapping-http/ @camunda/core-features

--- a/.codeowners
+++ b/.codeowners
@@ -243,8 +243,6 @@ optimize.Dockerfile         @camunda/core-features
 
 # Webapp (unified orchestration cluster BFF)
 /webapp/                @camunda/core-features
-/webapp/client/         @camunda/core-features
-/webapp/server/         @camunda/core-features
 
 # Gateways
 /gateways/gateway-mapping-http/ @camunda/core-features

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -317,6 +317,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>webapp-server</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>webapps-common</artifactId>
     </dependency>
     <dependency>
@@ -1060,6 +1065,8 @@
             <dependency>io.camunda:operate-webapp</dependency>
 
             <dependency>io.camunda:tasklist-data-generator</dependency>
+
+            <dependency>io.camunda:webapp-server</dependency>
 
             <!-- Used to parse PKCS1 certificates -->
             <dependency>org.bouncycastle:bcprov-jdk18on</dependency>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -1066,8 +1066,6 @@
 
             <dependency>io.camunda:tasklist-data-generator</dependency>
 
-            <dependency>io.camunda:webapp-server</dependency>
-
             <!-- Used to parse PKCS1 certificates -->
             <dependency>org.bouncycastle:bcprov-jdk18on</dependency>
             <dependency>org.bouncycastle:bcpkix-jdk18on</dependency>

--- a/dist/src/main/java/io/camunda/application/Profile.java
+++ b/dist/src/main/java/io/camunda/application/Profile.java
@@ -23,6 +23,9 @@ public enum Profile {
   TASKLIST("tasklist"),
   IDENTITY("identity"), // Legacy, use "admin" instead
   ADMIN("admin"),
+  TMP_WEBAPP(
+      "tmp-webapp"), // Temporary profile for the unified BFF migration; removed at end of epic
+  // #51309
 
   // environment profiles
   TEST("test"),
@@ -48,7 +51,7 @@ public enum Profile {
   }
 
   public static Set<Profile> getWebappProfiles() {
-    return Set.of(TASKLIST, IDENTITY, OPERATE, ADMIN);
+    return Set.of(TASKLIST, IDENTITY, OPERATE, ADMIN, TMP_WEBAPP);
   }
 
   @Override

--- a/dist/src/main/java/io/camunda/application/Profile.java
+++ b/dist/src/main/java/io/camunda/application/Profile.java
@@ -25,7 +25,7 @@ public enum Profile {
   ADMIN("admin"),
   TMP_WEBAPP(
       "tmp-webapp"), // Temporary profile for the unified BFF migration; removed at end of epic
-  // #51309
+  // https://github.com/camunda/product-hub/issues/3456
 
   // environment profiles
   TEST("test"),

--- a/dist/src/main/java/io/camunda/application/StandaloneCamunda.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneCamunda.java
@@ -32,6 +32,7 @@ import io.camunda.configuration.beanoverrides.TasklistPropertiesOverride;
 import io.camunda.identity.IdentityModuleConfiguration;
 import io.camunda.operate.OperateModuleConfiguration;
 import io.camunda.tasklist.TasklistModuleConfiguration;
+import io.camunda.webapp.WebappModuleConfiguration;
 import io.camunda.webapps.WebappsModuleConfiguration;
 import io.camunda.zeebe.broker.BrokerModuleConfiguration;
 import io.camunda.zeebe.gateway.GatewayModuleConfiguration;
@@ -81,6 +82,7 @@ public class StandaloneCamunda {
                 OperateModuleConfiguration.class,
                 TasklistModuleConfiguration.class,
                 IdentityModuleConfiguration.class,
+                WebappModuleConfiguration.class,
                 WebappsModuleConfiguration.class,
                 BrokerModuleConfiguration.class,
                 GatewayModuleConfiguration.class)

--- a/dist/src/main/java/io/camunda/application/initializers/WebappsConfigurationInitializer.java
+++ b/dist/src/main/java/io/camunda/application/initializers/WebappsConfigurationInitializer.java
@@ -12,6 +12,7 @@ import static io.camunda.application.Profile.IDENTITY;
 import static io.camunda.application.Profile.OPERATE;
 import static io.camunda.application.Profile.STANDALONE;
 import static io.camunda.application.Profile.TASKLIST;
+import static io.camunda.application.Profile.TMP_WEBAPP;
 import static io.camunda.authentication.config.AuthenticationProperties.METHOD;
 
 import io.camunda.authentication.config.WebSecurityConfig;
@@ -31,7 +32,8 @@ public class WebappsConfigurationInitializer
 
   public static final String CAMUNDA_WEBAPPS_ENABLED_PROPERTY = "camunda.webapps.enabled";
   private static final Set<String> WEBAPPS_PROFILES =
-      Set.of(OPERATE.getId(), TASKLIST.getId(), IDENTITY.getId(), ADMIN.getId());
+      Set.of(
+          OPERATE.getId(), TASKLIST.getId(), IDENTITY.getId(), ADMIN.getId(), TMP_WEBAPP.getId());
   private static final String DEFAULT_RESOURCES_LOCATION = "classpath:/META-INF/resources/";
   private static final String AUTHORIZATIONS_ENABLED_PROPERTY =
       "camunda.security.authorizations.enabled";
@@ -109,6 +111,13 @@ public class WebappsConfigurationInitializer
       if (defaultWebapp == null) {
         defaultWebapp = ADMIN.getId();
       }
+    }
+
+    // Unified Webapp (tmp-webapp profile) — temporary; removed at end of epic #51309
+    // Deliberately does NOT set defaultWebapp: legacy profiles win the home-page contest if mixed.
+
+    if (activeProfiles.contains(TMP_WEBAPP.getId())) {
+      locations.add(DEFAULT_RESOURCES_LOCATION + "webapp/");
     }
 
     // Store locations, default homepage and merge everything

--- a/dist/src/main/java/io/camunda/application/initializers/WebappsConfigurationInitializer.java
+++ b/dist/src/main/java/io/camunda/application/initializers/WebappsConfigurationInitializer.java
@@ -113,8 +113,10 @@ public class WebappsConfigurationInitializer
       }
     }
 
-    // Unified Webapp (tmp-webapp profile) — temporary; removed at end of epic #51309
-    // Deliberately does NOT set defaultWebapp: legacy profiles win the home-page contest if mixed.
+    // The tmp-webapp is temporary profile while the FUA
+    // https://github.com/camunda/product-hub/issues/3456
+    // project is in progress. Deliberately does NOT set defaultWebapp: legacy profiles win the
+    // home-page contest if mixed.
 
     if (activeProfiles.contains(TMP_WEBAPP.getId())) {
       locations.add(DEFAULT_RESOURCES_LOCATION + "webapp/");

--- a/dist/src/test/java/io/camunda/application/initializers/WebappsConfigurationInitializerTest.java
+++ b/dist/src/test/java/io/camunda/application/initializers/WebappsConfigurationInitializerTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.initializers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.application.Profile;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.support.GenericApplicationContext;
+
+class WebappsConfigurationInitializerTest {
+
+  private static final String CAMUNDA_WEBAPPS_ENABLED = "camunda.webapps.enabled";
+  private static final String STATIC_LOCATIONS = "spring.web.resources.static-locations";
+  private static final String DEFAULT_APP = "camunda.webapps.default-app";
+  private static final String WEBAPP_LOCATION = "classpath:/META-INF/resources/webapp/";
+  private static final String TASKLIST_LOCATION = "classpath:/META-INF/resources/tasklist/";
+
+  @Test
+  void shouldNotActivateWebappsWhenNoWebappsProfileIsActive() {
+    // given a context with only a non-webapps profile (broker)
+    final GenericApplicationContext context = new GenericApplicationContext();
+    context.getEnvironment().setActiveProfiles(Profile.BROKER.getId());
+
+    // when the initializer runs
+    new WebappsConfigurationInitializer().initialize(context);
+
+    // then webapps is not enabled and the webapp/ static location is not added
+    assertThat(context.getEnvironment().getProperty(CAMUNDA_WEBAPPS_ENABLED)).isNull();
+    assertThat(context.getEnvironment().getProperty(STATIC_LOCATIONS, String.class))
+        .doesNotContain(WEBAPP_LOCATION);
+  }
+
+  @Test
+  void shouldAddWebappStaticLocationWhenTmpWebappProfileIsActive() {
+    // given a context with only the tmp-webapp profile
+    final GenericApplicationContext context = new GenericApplicationContext();
+    context.getEnvironment().setActiveProfiles(Profile.TMP_WEBAPP.getId());
+
+    // when the initializer runs
+    new WebappsConfigurationInitializer().initialize(context);
+
+    // then webapps is enabled and the webapp/ static location is registered
+    assertThat(context.getEnvironment().getProperty(CAMUNDA_WEBAPPS_ENABLED, Boolean.class))
+        .isTrue();
+    assertThat(context.getEnvironment().getProperty(STATIC_LOCATIONS, String.class))
+        .contains(WEBAPP_LOCATION);
+    // and tmp-webapp is deliberately NOT set as the default app (no / redirect fallback)
+    assertThat(context.getEnvironment().getProperty(DEFAULT_APP)).isNull();
+  }
+
+  @Test
+  void shouldNotMakeTmpWebappTheDefaultWhenLegacyProfileIsAlsoActive() {
+    // given a context with both tasklist and tmp-webapp profiles active
+    final GenericApplicationContext context = new GenericApplicationContext();
+    context
+        .getEnvironment()
+        .setActiveProfiles(Profile.TASKLIST.getId(), Profile.TMP_WEBAPP.getId());
+
+    // when the initializer runs
+    new WebappsConfigurationInitializer().initialize(context);
+
+    // then both static locations are present
+    final String locations = context.getEnvironment().getProperty(STATIC_LOCATIONS, String.class);
+    assertThat(locations).contains(TASKLIST_LOCATION).contains(WEBAPP_LOCATION);
+    // and tasklist wins the default-app contest, not tmp-webapp
+    assertThat(context.getEnvironment().getProperty(DEFAULT_APP))
+        .isEqualTo(Profile.TASKLIST.getId());
+  }
+}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -782,6 +782,19 @@
         <scope>test</scope>
       </dependency>
 
+      <!-- Webapp Modules (orchestration cluster unified BFF) -->
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>webapp-webjar</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>webapp-server</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>document-api</artifactId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -781,8 +781,7 @@
         <version>${project.version}</version>
         <scope>test</scope>
       </dependency>
-
-      <!-- Webapp Modules (orchestration cluster unified BFF) -->
+      
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>webapp-webjar</artifactId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -781,7 +781,7 @@
         <version>${project.version}</version>
         <scope>test</scope>
       </dependency>
-      
+
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>webapp-webjar</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
     <module>operate</module>
     <module>tasklist</module>
     <module>identity</module>
+    <module>webapp</module>
     <module>webapps-common</module>
     <module>webapps-schema</module>
     <module>webapps-backup</module>

--- a/webapp/client/pom.xml
+++ b/webapp/client/pom.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.camunda</groupId>
+    <artifactId>webapp-parent</artifactId>
+    <version>8.10.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <name>Webapp Webjar</name>
+  <artifactId>webapp-webjar</artifactId>
+  <packaging>jar</packaging>
+
+  <build>
+
+    <plugins>
+
+      <plugin>
+        <groupId>com.github.eirslett</groupId>
+        <artifactId>frontend-maven-plugin</artifactId>
+
+        <configuration>
+          <installDirectory>target</installDirectory>
+        </configuration>
+
+        <executions>
+          <execution>
+            <id>install node and npm</id>
+            <goals>
+              <goal>install-node-and-npm</goal>
+            </goals>
+            <configuration>
+              <skip>${skip.fe.build}</skip>
+              <nodeVersion>${version.node}</nodeVersion>
+              <npmVersion>${version.npm}</npmVersion>
+            </configuration>
+          </execution>
+
+           <execution>
+            <id>update package.json version</id>
+            <goals>
+              <goal>npm</goal>
+            </goals>
+            <configuration>
+              <skip>${skip.fe.build}</skip>
+              <arguments>version ${project.version} --no-git-tag-version --allow-same-version</arguments>
+            </configuration>
+          </execution>
+
+          <execution>
+            <id>npm install</id>
+            <goals>
+              <goal>npm</goal>
+            </goals>
+            <configuration>
+              <skip>${skip.fe.build}</skip>
+              <arguments>ci</arguments>
+            </configuration>
+          </execution>
+
+          <execution>
+            <id>npm build</id>
+            <goals>
+              <goal>npm</goal>
+            </goals>
+            <configuration>
+              <skip>${skip.fe.build}</skip>
+              <arguments>run build</arguments>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+    <pluginManagement>
+      <plugins>
+        <!-- skip spotless formatter as client has its own formatter -->
+        <plugin>
+          <groupId>com.diffplug.spotless</groupId>
+          <artifactId>spotless-maven-plugin</artifactId>
+          <configuration>
+            <skip>true</skip>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
+    <resources>
+      <resource>
+        <directory>apps/orchestration-cluster-webapp/dist</directory>
+        <targetPath>${project.build.outputDirectory}/META-INF/resources/webapp</targetPath>
+      </resource>
+    </resources>
+
+  </build>
+
+  <profiles>
+    <profile>
+      <id>skipFrontendBuild</id>
+      <properties>
+        <skip.fe.build>true</skip.fe.build>
+      </properties>
+    </profile>
+  </profiles>
+
+</project>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.camunda</groupId>
+    <artifactId>zeebe-parent</artifactId>
+    <version>8.10.0-SNAPSHOT</version>
+    <relativePath>../parent/pom.xml</relativePath>
+  </parent>
+  <artifactId>webapp-parent</artifactId>
+  <packaging>pom</packaging>
+
+  <name>Webapp Parent</name>
+
+  <modules>
+    <module>client</module>
+    <module>server</module>
+  </modules>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+    <maven.compiler.target>21</maven.compiler.target>
+    <maven.compiler.source>21</maven.compiler.source>
+
+    <maven.javadoc.skip>true</maven.javadoc.skip>
+  </properties>
+
+</project>

--- a/webapp/server/pom.xml
+++ b/webapp/server/pom.xml
@@ -15,6 +15,7 @@
   <name>Webapp Server</name>
 
   <dependencies>
+    <!-- Camunda modules -->
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>webapps-common</artifactId>
@@ -25,14 +26,44 @@
       <artifactId>camunda-spring-utils</artifactId>
     </dependency>
 
+    <!-- Static resources (FE webjar). Only used at runtime; not referenced at compile time. -->
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>webapp-webjar</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+
+    <!-- Jakarta -->
+    <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-web</artifactId>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+    </dependency>
+
+    <!-- Logging -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <!-- Spring -->
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-beans</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
     </dependency>
 
     <dependency>
@@ -40,9 +71,10 @@
       <artifactId>spring-security-core</artifactId>
     </dependency>
 
+    <!-- Test -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
 
@@ -64,5 +96,21 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <usedDependencies>
+            <!-- webapp-webjar ships static resources (META-INF/resources/webapp/*) consumed at
+                 runtime by Spring Boot's resource handler; no compile-time class references. -->
+            <dependency>io.camunda:webapp-webjar</dependency>
+          </usedDependencies>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>

--- a/webapp/server/pom.xml
+++ b/webapp/server/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.camunda</groupId>
+    <artifactId>webapp-parent</artifactId>
+    <version>8.10.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>webapp-server</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Webapp Server</name>
+
+</project>

--- a/webapp/server/pom.xml
+++ b/webapp/server/pom.xml
@@ -14,4 +14,31 @@
 
   <name>Webapp Server</name>
 
+  <dependencies>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>webapps-common</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-spring-utils</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>webapp-webjar</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-core</artifactId>
+    </dependency>
+  </dependencies>
+
 </project>

--- a/webapp/server/pom.xml
+++ b/webapp/server/pom.xml
@@ -39,6 +39,30 @@
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/webapp/server/src/main/java/io/camunda/webapp/WebappModuleConfiguration.java
+++ b/webapp/server/src/main/java/io/camunda/webapp/WebappModuleConfiguration.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapp;
+
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGenerator;
+import org.springframework.context.annotation.Profile;
+
+/**
+ * Entry point for the unified BFF webapp module. Active only when the {@code tmp-webapp} Spring
+ * profile is enabled (i.e., dormant in all default deployments). The {@code tmp-webapp} profile is
+ * temporary; it will be removed at the end of the <a
+ * href="https://github.com/camunda/product-hub/issues/3456">epic</a> when the webapp module becomes
+ * the default BFF for the legacy apps (Tasklist/Operate/Admin).
+ */
+@Configuration(proxyBeanMethods = false)
+@ComponentScan(
+    basePackages = "io.camunda.webapp",
+    nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
+@Profile("tmp-webapp")
+public class WebappModuleConfiguration {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(WebappModuleConfiguration.class);
+
+  @PostConstruct
+  public void logModule() {
+    LOGGER.info("Starting module: webapp");
+  }
+}

--- a/webapp/server/src/main/java/io/camunda/webapp/controllers/WebappIndexController.java
+++ b/webapp/server/src/main/java/io/camunda/webapp/controllers/WebappIndexController.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapp.controllers;
+
+import static io.camunda.webapps.util.HttpUtils.REQUESTED_URL;
+import static io.camunda.webapps.util.HttpUtils.getRequestedUrl;
+
+import io.camunda.spring.utils.ConditionalOnWebappUiEnabled;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@ConditionalOnWebappUiEnabled("tmp-webapp")
+public class WebappIndexController {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(WebappIndexController.class);
+
+  private static final String LOGIN_RESOURCE = "/login";
+
+  private final ServletContext context;
+
+  private final boolean loginDelegated;
+
+  public WebappIndexController(
+      final ServletContext context,
+      @Value("${camunda.webapps.login-delegated:false}") final boolean loginDelegated) {
+    this.context = context;
+    this.loginDelegated = loginDelegated;
+  }
+
+  @GetMapping({"/webapp", "/webapp/", "/webapp/index.html"})
+  public String webapp(final Model model) {
+    model.addAttribute("contextPath", context.getContextPath() + "/webapp/");
+    return "webapp/index";
+  }
+
+  /**
+   * Forwards SPA routes to index.html, excluding static assets.
+   *
+   * <p>The regex pattern uses negative lookahead to prevent matching paths starting with "assets":
+   *
+   * <ul>
+   *   <li>{@code (?!assets)} - excludes "assets"
+   *   <li>{@code .*} - matches any other path segment
+   * </ul>
+   *
+   * <p>This exclusion is necessary because PathPatternParser (Spring Framework 6+) gives controller
+   * mappings higher precedence than static resource handlers. Without this pattern, requests like
+   * {@code /webapp/assets/index.css} would be forwarded to index.html instead of being served as
+   * static files.
+   *
+   * <p>The forward + login-redirect logic is intentionally inlined here rather than reusing the
+   * legacy {@code WebappsRequestForwardManager} from {@code dist/}. Once Tasklist/Operate/Admin
+   * have all been migrated onto this BFF, the legacy manager and its consumers in {@code dist/} are
+   * deleted, leaving this controller as the sole implementation. Bounded duplication during the
+   * migration window is an explicit choice.
+   */
+  @RequestMapping(value = {"/webapp/{path:^(?!assets).*}", "/webapp/{path:^(?!assets).*}/**"})
+  public String forwardToWebapp(final HttpServletRequest request) {
+    if (loginDelegated && isNotLoggedIn()) {
+      return saveRequestAndRedirectToLogin(request);
+    } else {
+      return "forward:/webapp";
+    }
+  }
+
+  private String saveRequestAndRedirectToLogin(final HttpServletRequest request) {
+    final String requestedUrl = getRequestedUrl(request);
+    request.getSession(true).setAttribute(REQUESTED_URL, requestedUrl);
+    LOGGER.warn(
+        "Requested path {}, but not authenticated. Redirect to {}",
+        request.getRequestURI().substring(request.getContextPath().length()),
+        LOGIN_RESOURCE);
+    return "forward:" + LOGIN_RESOURCE;
+  }
+
+  private boolean isNotLoggedIn() {
+    final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    return (authentication instanceof AnonymousAuthenticationToken)
+        || !authentication.isAuthenticated();
+  }
+}

--- a/webapp/server/src/test/java/io/camunda/webapp/controllers/WebappIndexControllerTest.java
+++ b/webapp/server/src/test/java/io/camunda/webapp/controllers/WebappIndexControllerTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapp.controllers;
+
+import static io.camunda.webapps.util.HttpUtils.REQUESTED_URL;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.ui.ExtendedModelMap;
+
+@ExtendWith(MockitoExtension.class)
+class WebappIndexControllerTest {
+
+  @Mock private ServletContext servletContext;
+  @Mock private HttpServletRequest request;
+
+  @Test
+  void shouldReturnWebappIndexView() {
+    // given
+    when(servletContext.getContextPath()).thenReturn("/camunda");
+    final WebappIndexController controller = new WebappIndexController(servletContext, false);
+    final ExtendedModelMap model = new ExtendedModelMap();
+
+    // when
+    final String viewName = controller.webapp(model);
+
+    // then
+    assertThat(viewName).isEqualTo("webapp/index");
+    assertThat(model.getAttribute("contextPath")).isEqualTo("/camunda/webapp/");
+  }
+
+  @Test
+  void shouldForwardToWebappWhenLoginNotDelegated() {
+    // given
+    final WebappIndexController controller = new WebappIndexController(servletContext, false);
+
+    // when
+    final String result = controller.forwardToWebapp(request);
+
+    // then no auth check is performed; result is unconditional forward to /webapp
+    assertThat(result).isEqualTo("forward:/webapp");
+  }
+
+  @Test
+  void shouldForwardToWebappWhenLoginDelegatedAndUserAuthenticated() {
+    // given
+    final WebappIndexController controller = new WebappIndexController(servletContext, true);
+    final Authentication authentication = mock(Authentication.class);
+    when(authentication.isAuthenticated()).thenReturn(true);
+
+    try (final MockedStatic<SecurityContextHolder> mocked =
+        mockStatic(SecurityContextHolder.class)) {
+      final SecurityContext securityContext = mock(SecurityContext.class);
+      when(securityContext.getAuthentication()).thenReturn(authentication);
+      mocked.when(SecurityContextHolder::getContext).thenReturn(securityContext);
+
+      // when
+      final String result = controller.forwardToWebapp(request);
+
+      // then
+      assertThat(result).isEqualTo("forward:/webapp");
+    }
+  }
+
+  @Test
+  void shouldForwardToLoginAndStashUrlWhenLoginDelegatedAndUserUnauthenticated() {
+    // given
+    final WebappIndexController controller = new WebappIndexController(servletContext, true);
+    final HttpSession session = mock(HttpSession.class);
+    final AnonymousAuthenticationToken anonymous = mock(AnonymousAuthenticationToken.class);
+
+    when(request.getRequestURI()).thenReturn("/webapp/foo/bar");
+    when(request.getContextPath()).thenReturn("");
+    when(request.getSession(true)).thenReturn(session);
+
+    try (final MockedStatic<SecurityContextHolder> mocked =
+        mockStatic(SecurityContextHolder.class)) {
+      final SecurityContext securityContext = mock(SecurityContext.class);
+      when(securityContext.getAuthentication()).thenReturn(anonymous);
+      mocked.when(SecurityContextHolder::getContext).thenReturn(securityContext);
+
+      // when
+      final String result = controller.forwardToWebapp(request);
+
+      // then the URL is stashed in the session and the request is forwarded to /login
+      assertThat(result).isEqualTo("forward:/login");
+      verify(session).setAttribute(REQUESTED_URL, "/webapp/foo/bar");
+    }
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR creates a dormant `webapp/` Maven module hierarchy that ships in the distribution but is gated behind the temporary `tmp-webapp` Spring profile, so it's invisible to all current customer deployments until future FE tasks begin migrating routes onto it.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #51310
