### PR TITLE
Backport 40004 lightweight pom checks to 88

### DIFF
--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -40,8 +40,11 @@ outputs:
     description: Output whether flattened POM metadata validation should be run
     value: >-
       ${{
-          steps.filter-common.outputs.maven-change == 'true' ||
-          steps.filter-common.outputs.validate-pom-metadata-extra-change == 'true'
+        github.event_name == 'push' ||
+        github.event_name == 'schedule' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.maven-change == 'true' ||
+        steps.filter-common.outputs.validate-pom-metadata-extra-change == 'true'
       }}
   java-code-changes:
     description: Output whether jobs depending on Java code changes should be run, related checks are based on GitHub events and java files changes

--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -36,6 +36,13 @@ outputs:
         steps.filter-common.outputs.maven-change == 'true' ||
         steps.filter-common.outputs.markdown-change == 'true'
       }}
+  validate-pom-metadata:
+    description: Output whether flattened POM metadata validation should be run
+    value: >-
+      ${{
+          steps.filter-common.outputs.maven-change == 'true' ||
+          steps.filter-common.outputs.validate-pom-metadata-extra-change == 'true'
+      }}
   java-code-changes:
     description: Output whether jobs depending on Java code changes should be run, related checks are based on GitHub events and java files changes
     value: >-
@@ -237,6 +244,11 @@ runs:
           - 'parent/**'
           - '**/pom.xml'
           - '.mvn/**'
+
+        validate-pom-metadata-extra-change:
+          - 'mvnw'
+          - 'mvnw.cmd'
+          - '.github/scripts/validate-flattened-poms.sh'
 
         dockerfile-change:
           - 'Dockerfile'

--- a/.github/actions/validate-pom-metadata/action.yml
+++ b/.github/actions/validate-pom-metadata/action.yml
@@ -1,0 +1,20 @@
+---
+name: Validate flattened POM metadata
+description: Installs xmllint and validates flattened Maven POM metadata
+
+inputs:
+  search-root:
+    description: Directory root to scan for .flattened-pom.xml files
+    default: "."
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Install xmllint
+      shell: bash
+      run: sudo apt-get update && sudo apt-get install -y libxml2-utils
+
+    - name: Validate flattened POM metadata
+      shell: bash
+      run: bash .github/scripts/validate-flattened-poms.sh "${{ inputs.search-root }}"

--- a/.github/scripts/validate-flattened-poms.sh
+++ b/.github/scripts/validate-flattened-poms.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if ! command -v xmllint >/dev/null 2>&1; then
+  echo "ERROR: xmllint is required but not available in PATH." >&2
+  exit 1
+fi
+
+if [[ "$#" -eq 0 ]]; then
+  search_roots=(.)
+else
+  search_roots=("$@")
+fi
+
+required_tags=(name description url licenses developers scm)
+
+read_xml_value() {
+  local file_path="$1"
+  local tag_name="$2"
+  xmllint --xpath "string(/*[local-name()='project']/*[local-name()='${tag_name}'])" "${file_path}" 2>/dev/null || true
+}
+
+failures=0
+
+while IFS= read -r flattened_pom; do
+  module_dir="$(dirname "${flattened_pom}")"
+  source_pom="${module_dir}/pom.xml"
+
+  if [[ ! -f "${source_pom}" ]]; then
+    source_pom="pom.xml"
+  fi
+
+  missing_tags=()
+  for tag in "${required_tags[@]}"; do
+    value="$(read_xml_value "${flattened_pom}" "${tag}")"
+    if [[ -z "${value}" ]]; then
+      missing_tags+=("${tag}")
+    fi
+  done
+
+  source_packaging="$(read_xml_value "${source_pom}" "packaging")"
+  if [[ -z "${source_packaging}" ]]; then
+    source_packaging="jar"
+  fi
+
+  flattened_packaging="$(read_xml_value "${flattened_pom}" "packaging")"
+  if [[ "${source_packaging}" != "jar" && -z "${flattened_packaging}" ]]; then
+    missing_tags+=("packaging")
+  fi
+
+  if [[ "${#missing_tags[@]}" -gt 0 ]]; then
+    failures=$((failures + 1))
+    joined_missing="$(printf '%s, ' "${missing_tags[@]}")"
+    joined_missing="${joined_missing%, }"
+    echo "ERROR: ${flattened_pom} is missing required metadata: ${joined_missing}" >&2
+    echo "  Fix: add/adjust metadata in ${source_pom} so flatten produces required values." >&2
+  fi
+done < <(find "${search_roots[@]}" -name '.flattened-pom.xml' -type f | sort)
+
+if [[ "${failures}" -gt 0 ]]; then
+  echo "Validation failed: ${failures} flattened POM file(s) are missing required metadata." >&2
+  exit 1
+fi
+
+echo "Validation passed: all flattened POM files contain required Maven Central metadata."

--- a/.github/scripts/validate-flattened-poms.sh
+++ b/.github/scripts/validate-flattened-poms.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Validates generated .flattened-pom.xml files contain required Maven Central metadata
+# (name, description, url, licenses, developers, scm), and packaging when the source POM is non-jar.
+
 set -euo pipefail
 
 if ! command -v xmllint >/dev/null 2>&1; then

--- a/.github/scripts/validate-flattened-poms.sh
+++ b/.github/scripts/validate-flattened-poms.sh
@@ -15,20 +15,45 @@ fi
 
 required_tags=(name description url licenses developers scm)
 
+validate_xml_well_formed() {
+  local file_path="$1"
+  local error_output
+  if ! error_output="$(xmllint --noout "${file_path}" 2>&1)"; then
+    echo "ERROR: ${file_path} is not a well-formed XML file." >&2
+    echo "  xmllint output:" >&2
+    while IFS= read -r line; do
+      echo "    ${line}" >&2
+    done <<< "${error_output}"
+    return 1
+  fi
+}
+
 read_xml_value() {
   local file_path="$1"
   local tag_name="$2"
-  xmllint --xpath "string(/*[local-name()='project']/*[local-name()='${tag_name}'])" "${file_path}" 2>/dev/null || true
+  xmllint --xpath "normalize-space(string(/*[local-name()='project']/*[local-name()='${tag_name}']))" "${file_path}"
 }
 
 failures=0
+flattened_poms_found=0
 
 while IFS= read -r flattened_pom; do
+  flattened_poms_found=$((flattened_poms_found + 1))
   module_dir="$(dirname "${flattened_pom}")"
   source_pom="${module_dir}/pom.xml"
 
   if [[ ! -f "${source_pom}" ]]; then
     source_pom="pom.xml"
+  fi
+
+  if ! validate_xml_well_formed "${flattened_pom}"; then
+    failures=$((failures + 1))
+    continue
+  fi
+
+  if ! validate_xml_well_formed "${source_pom}"; then
+    failures=$((failures + 1))
+    continue
   fi
 
   missing_tags=()
@@ -57,6 +82,12 @@ while IFS= read -r flattened_pom; do
     echo "  Fix: add/adjust metadata in ${source_pom} so flatten produces required values." >&2
   fi
 done < <(find "${search_roots[@]}" -name '.flattened-pom.xml' -type f | sort)
+
+if [[ "${flattened_poms_found}" -eq 0 ]]; then
+  echo "Validation failed: no .flattened-pom.xml files were found under: ${search_roots[*]}" >&2
+  echo "  Fix: ensure flattening runs before validation (e.g. process-resources with flatten plugin enabled)." >&2
+  exit 1
+fi
 
 if [[ "${failures}" -gt 0 ]]; then
   echo "Validation failed: ${failures} flattened POM file(s) are missing required metadata." >&2

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -250,6 +250,11 @@ jobs:
           export TAG_REVISION
           echo "tagRevision=${TAG_REVISION}" >> "$GITHUB_OUTPUT"
           popd
+      - name: Validate flattened POM metadata
+        if: ${{ inputs.dryRun }}
+        uses: ./.github/actions/validate-pom-metadata
+        with:
+          search-root: target/checkout
       - name: Debug Optimize Versions after updating to development version
         if: ${{ inputs.includeOptimize && inputs.dryRun }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
       actionlint: ${{ steps.filter.outputs.actionlint }}
       commitlint: ${{ steps.filter.outputs.commitlint }}
       maven-spotless-linter: ${{ steps.filter.outputs.maven-spotless-linter }}
+      validate-pom-metadata: ${{ steps.filter.outputs.validate-pom-metadata }}
       java-code-changes: ${{ steps.filter.outputs.java-code-changes }}
       camunda-docker-tests: ${{ steps.filter.outputs.camunda-docker-tests}}
       identity-frontend-tests: ${{ steps.filter.outputs.identity-frontend-tests }}
@@ -175,6 +176,39 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Check for missing junit-vintage-engine
         run: .ci/scripts/ci/check-junit-vintage-engine.sh .
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          
+  validate-pom-metadata:
+    if: needs.detect-changes.outputs.validate-pom-metadata == 'true'
+    name: "Lint / Flattened POM Metadata"
+    needs: [ detect-changes ]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions: { }  # GITHUB_TOKEN unused in this job
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/setup-build
+        with:
+          maven-cache-key-modifier: validate-pom-metadata
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      - name: Install xmllint
+        run: sudo apt-get update && sudo apt-get install -y libxml2-utils
+      - name: Generate flattened POMs
+        run: ./mvnw -B -T1C -DskipChecks=true -DskipTests=true -Dquickly=false -PskipFrontendBuild process-resources
+      - name: Validate flattened POM metadata
+        run: bash .github/scripts/validate-flattened-poms.sh
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -1529,6 +1563,7 @@ jobs:
       - setup-tests
       - shell-script-tests
       - tasklist-ci
+      - validate-pom-metadata
       - zeebe-ci
       - zeebe-unit-tests
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,8 +203,8 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-      - name: Bootstrap Zeebe build tools
-        run: ./mvnw -B -T1C --no-snapshot-updates -DskipChecks=true -DskipTests=true -Dquickly=true -pl build-tools -am install
+      - name: Bootstrap reactor modules
+        run: ./mvnw -B -T1C --no-snapshot-updates -DskipChecks=true -DskipTests=true -Dquickly=true install
       - name: Generate flattened POMs
         run: ./mvnw -B -T1C --no-snapshot-updates -DskipChecks=true -Dcheckstyle.skip=true -DskipTests=true -Dquickly=false -PskipFrontendBuild process-resources
       - name: Validate flattened POM metadata

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
     name: "Lint / Flattened POM Metadata"
     needs: [ detect-changes ]
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 10
     permissions: { }  # GITHUB_TOKEN unused in this job
     steps:
       - uses: actions/checkout@v6
@@ -204,7 +204,7 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
       - name: Bootstrap reactor modules
-        run: ./mvnw clean install -B -T1C --no-snapshot-updates -DskipChecks=true -DskipTests=true
+        run: ./mvnw clean install -B -T1C --no-snapshot-updates -DskipChecks=true -DskipTests=true -PskipFrontendBuild
       - name: Generate flattened POMs
         run: ./mvnw -B -T1C --no-snapshot-updates -DskipChecks=true -Dcheckstyle.skip=true -DskipTests=true -Dquickly=false -PskipFrontendBuild process-resources
       - name: Validate flattened POM metadata

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
     name: "Lint / Flattened POM Metadata"
     needs: [ detect-changes ]
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     permissions: { }  # GITHUB_TOKEN unused in this job
     steps:
       - uses: actions/checkout@v6
@@ -204,7 +204,7 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
       - name: Bootstrap reactor modules
-        run: ./mvnw -B -T1C --no-snapshot-updates -DskipChecks=true -DskipTests=true -Dquickly=true install
+        run: ./mvnw clean install -B -T1C --no-snapshot-updates -DskipChecks=true -DskipTests=true
       - name: Generate flattened POMs
         run: ./mvnw -B -T1C --no-snapshot-updates -DskipChecks=true -Dcheckstyle.skip=true -DskipTests=true -Dquickly=false -PskipFrontendBuild process-resources
       - name: Validate flattened POM metadata

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
     name: "Lint / Flattened POM Metadata"
     needs: [ detect-changes ]
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 10
     permissions: { }  # GITHUB_TOKEN unused in this job
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,7 +206,7 @@ jobs:
       - name: Install xmllint
         run: sudo apt-get update && sudo apt-get install -y libxml2-utils
       - name: Generate flattened POMs
-        run: ./mvnw -B -T1C -DskipChecks=true -DskipTests=true -Dquickly=false -PskipFrontendBuild process-resources
+        run: ./mvnw -B -T1C -DskipChecks=true -Dcheckstyle.skip=true -DskipTests=true -Dquickly=false -PskipFrontendBuild process-resources
       - name: Validate flattened POM metadata
         run: bash .github/scripts/validate-flattened-poms.sh
       - name: Observe build status

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,8 +205,10 @@ jobs:
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
       - name: Install xmllint
         run: sudo apt-get update && sudo apt-get install -y libxml2-utils
+      - name: Bootstrap Zeebe build tools
+        run: ./mvnw -B -T1C --no-snapshot-updates -DskipChecks=true -DskipTests=true -Dquickly=true -pl build-tools -am install
       - name: Generate flattened POMs
-        run: ./mvnw -B -T1C -DskipChecks=true -Dcheckstyle.skip=true -DskipTests=true -Dquickly=false -PskipFrontendBuild process-resources
+        run: ./mvnw -B -T1C --no-snapshot-updates -DskipChecks=true -Dcheckstyle.skip=true -DskipTests=true -Dquickly=false -PskipFrontendBuild process-resources
       - name: Validate flattened POM metadata
         run: bash .github/scripts/validate-flattened-poms.sh
       - name: Observe build status

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,14 +203,12 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-      - name: Install xmllint
-        run: sudo apt-get update && sudo apt-get install -y libxml2-utils
       - name: Bootstrap Zeebe build tools
         run: ./mvnw -B -T1C --no-snapshot-updates -DskipChecks=true -DskipTests=true -Dquickly=true -pl build-tools -am install
       - name: Generate flattened POMs
         run: ./mvnw -B -T1C --no-snapshot-updates -DskipChecks=true -Dcheckstyle.skip=true -DskipTests=true -Dquickly=false -PskipFrontendBuild process-resources
       - name: Validate flattened POM metadata
-        run: bash .github/scripts/validate-flattened-poms.sh
+        uses: ./.github/actions/validate-pom-metadata
       - name: Observe build status
         if: always()
         continue-on-error: true


### PR DESCRIPTION
## Description

This pull request introduces a new CI job and supporting scripts to validate that all generated `.flattened-pom.xml` files contain the required Maven Central metadata. It adds a reusable GitHub Action, a shell script for validation, and integrates the check into both the main CI workflow and the release workflow. The validation is triggered automatically when relevant files change or on certain GitHub events. All in accordance with https://github.com/camunda/camunda/issues/40004?reload=1


These changes help prevent accidental publication of incomplete or non-compliant Maven artifacts by enforcing metadata requirements early in the CI process. The commits here were picked up from the following backports that weren't merged because they needed Optimize to be included first:
- https://github.com/camunda/camunda/pull/49178
- https://github.com/camunda/camunda/pull/50685
- https://github.com/camunda/camunda/pull/50764
- https://github.com/camunda/camunda/pull/50278

# :test_tube: Release dry-run:
https://github.com/camunda/camunda/actions/runs/25010497240
<img width="1846" height="812" alt="image" src="https://github.com/user-attachments/assets/34e94d0e-b02e-47df-a94d-a2a7065cd28d" />


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
