### PR TITLE
fix: Archive Batch Operations and Dependents with GUID Key

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJob.java
@@ -18,12 +18,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 
 public class BatchOperationArchiverJob extends ArchiverJob<ArchiveBatch.BasicArchiveBatch> {
 
   private final BatchOperationTemplate batchOperationTemplate;
   private final List<BatchOperationDependant> batchOperationDependants;
+  private final Logger logger;
 
   public BatchOperationArchiverJob(
       final ArchiverRepository repository,
@@ -44,6 +46,7 @@ public class BatchOperationArchiverJob extends ArchiverJob<ArchiveBatch.BasicArc
         batchOperationDependants.stream()
             .sorted(Comparator.comparing(BatchOperationDependant::getFullQualifiedName))
             .toList(); // sort to ensure the execution order is stable
+    this.logger = logger;
   }
 
   @Override
@@ -71,16 +74,30 @@ public class BatchOperationArchiverJob extends ArchiverJob<ArchiveBatch.BasicArc
   @Override
   protected Map<String, List<String>> createIdsByFieldMap(
       final IndexTemplateDescriptor templateDescriptor, final BasicArchiveBatch batch) {
-    final String field =
-        switch (templateDescriptor) {
-          case final BatchOperationTemplate ignored -> BatchOperationTemplate.ID;
-          case final BatchOperationDependant dependant ->
-              dependant.getBatchOperationDependantField();
-          default ->
-              throw new IllegalArgumentException(
-                  "Unsupported template descriptor: " + templateDescriptor.getClass().getName());
-        };
-    return Map.of(field, batch.ids());
+    final String field;
+    final List<String> ids;
+
+    switch (templateDescriptor) {
+      case final BatchOperationTemplate ignored:
+        field = BatchOperationTemplate.ID;
+        ids = batch.ids();
+        break;
+      case final BatchOperationDependant dependant:
+        field = dependant.getBatchOperationDependantField();
+        ids = batch.ids().stream().filter(StringUtils::isNumeric).toList();
+        final int skipped = batch.ids().size() - ids.size();
+        if (skipped > 0) {
+          logger.debug(
+              "Skipping {} non-numeric batch operation ID(s) when archiving batch dependents from {} index.",
+              skipped,
+              dependant.getFullQualifiedName());
+        }
+        break;
+      default:
+        throw new IllegalArgumentException(
+            "Unsupported template descriptor: " + templateDescriptor.getClass().getName());
+    }
+    return Map.of(field, ids);
   }
 
   private CompletableFuture<Void> archiveBatchDependants(final BasicArchiveBatch batch) {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AbstractProcessInstanceArchiverJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AbstractProcessInstanceArchiverJobIT.java
@@ -203,23 +203,6 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
         });
   }
 
-  private void store(
-      final IndexTemplateDescriptor template,
-      final SearchClientAdapter client,
-      final ExporterEntity<?> entity)
-      throws IOException {
-    client.index(entity.getId(), template.getFullQualifiedName(), entity);
-  }
-
-  private void store(
-      final IndexTemplateDescriptor template,
-      final SearchClientAdapter client,
-      final ExporterEntity<?> parent,
-      final ExporterEntity<?> child)
-      throws IOException {
-    client.index(child.getId(), parent.getId(), template.getFullQualifiedName(), child);
-  }
-
   private ProcessInstanceForListViewEntity processInstanceForListViewEntity(final String endDate) {
     final ProcessInstanceForListViewEntity processInstance = new ProcessInstanceForListViewEntity();
     final long id = ID_GENERATOR.incrementAndGet();
@@ -264,47 +247,9 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
       final IndexTemplateDescriptor templateDescriptor,
       final SearchClientAdapter client,
       final ExporterEntity<?> entity,
-      final String datedIndexSuffix)
-      throws IOException {
-    verifyMoved(templateDescriptor, client, entity, (String) null, datedIndexSuffix);
-  }
-
-  private void verifyMoved(
-      final IndexTemplateDescriptor templateDescriptor,
-      final SearchClientAdapter client,
       final ExporterEntity<?> parent,
-      final ExporterEntity<?> entity,
       final String datedIndexSuffix)
       throws IOException {
     verifyMoved(templateDescriptor, client, entity, parent.getId(), datedIndexSuffix);
-  }
-
-  private void verifyMoved(
-      final IndexTemplateDescriptor templateDescriptor,
-      final SearchClientAdapter client,
-      final ExporterEntity<?> entity,
-      final String routing,
-      final String datedIndexSuffix)
-      throws IOException {
-    // should no longer be in the original index
-    final var originalIndexEntity =
-        client.get(
-            entity.getId(), routing, templateDescriptor.getFullQualifiedName(), entity.getClass());
-    assertThat(originalIndexEntity).isNull();
-
-    // should now be in the dated index
-    final var dateIndex = templateDescriptor.getFullQualifiedName() + datedIndexSuffix;
-    final var newIndexEntity = client.get(entity.getId(), routing, dateIndex, entity.getClass());
-    assertThat(newIndexEntity).isEqualTo(entity);
-  }
-
-  private void verifyNotMoved(
-      final IndexTemplateDescriptor templateDescriptor,
-      final SearchClientAdapter client,
-      final ExporterEntity<?> entity)
-      throws IOException {
-    final var originalIndexEntity =
-        client.get(entity.getId(), templateDescriptor.getFullQualifiedName(), entity.getClass());
-    assertThat(originalIndexEntity).isEqualTo(entity);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiverJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiverJobIT.java
@@ -29,8 +29,11 @@ import io.camunda.search.connect.os.OpensearchConnector;
 import io.camunda.search.test.utils.SearchClientAdapter;
 import io.camunda.search.test.utils.SearchDBExtension;
 import io.camunda.search.test.utils.TestObjectMapper;
+import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
+import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.zeebe.exporter.api.context.Context;
 import io.camunda.zeebe.exporter.test.ExporterTestContext;
+import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -114,6 +117,61 @@ public abstract class ArchiverJobIT<T extends ArchiverJob<?>> {
     try (final T job = createArchiveJob(config, exporterResourceProvider, repository)) {
       jobConsumer.accept(job, exporterResourceProvider);
     }
+  }
+
+  protected void store(
+      final IndexTemplateDescriptor template,
+      final SearchClientAdapter client,
+      final ExporterEntity<?> entity)
+      throws IOException {
+    client.index(entity.getId(), template.getFullQualifiedName(), entity);
+  }
+
+  protected void store(
+      final IndexTemplateDescriptor template,
+      final SearchClientAdapter client,
+      final ExporterEntity<?> parent,
+      final ExporterEntity<?> child)
+      throws IOException {
+    client.index(child.getId(), parent.getId(), template.getFullQualifiedName(), child);
+  }
+
+  protected void verifyMoved(
+      final IndexTemplateDescriptor templateDescriptor,
+      final SearchClientAdapter client,
+      final ExporterEntity<?> entity,
+      final String datedIndexSuffix)
+      throws IOException {
+    verifyMoved(templateDescriptor, client, entity, (String) null, datedIndexSuffix);
+  }
+
+  protected void verifyMoved(
+      final IndexTemplateDescriptor templateDescriptor,
+      final SearchClientAdapter client,
+      final ExporterEntity<?> entity,
+      final String routing,
+      final String datedIndexSuffix)
+      throws IOException {
+    // should no longer be in the original index
+    final var originalIndexEntity =
+        client.get(
+            entity.getId(), routing, templateDescriptor.getFullQualifiedName(), entity.getClass());
+    assertThat(originalIndexEntity).isNull();
+
+    // should now be in the dated index
+    final var dateIndex = templateDescriptor.getFullQualifiedName() + datedIndexSuffix;
+    final var newIndexEntity = client.get(entity.getId(), routing, dateIndex, entity.getClass());
+    assertThat(newIndexEntity).isEqualTo(entity);
+  }
+
+  protected void verifyNotMoved(
+      final IndexTemplateDescriptor templateDescriptor,
+      final SearchClientAdapter client,
+      final ExporterEntity<?> entity)
+      throws IOException {
+    final var originalIndexEntity =
+        client.get(entity.getId(), templateDescriptor.getFullQualifiedName(), entity.getClass());
+    assertThat(originalIndexEntity).isEqualTo(entity);
   }
 
   private ExporterResourceProvider exporterResourceProvider(final ExporterConfiguration config) {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJobIT.java
@@ -7,15 +7,30 @@
  */
 package io.camunda.exporter.tasks.archiver;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.camunda.exporter.ExporterResourceProvider;
 import io.camunda.exporter.config.ExporterConfiguration;
+import io.camunda.search.test.utils.SearchClientAdapter;
 import io.camunda.webapps.schema.descriptors.BatchOperationDependant;
+import io.camunda.webapps.schema.descriptors.template.AuditLogTemplate;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
+import io.camunda.webapps.schema.entities.auditlog.AuditLogEntity;
+import io.camunda.webapps.schema.entities.auditlog.AuditLogEntityType;
+import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
+import io.camunda.webapps.schema.entities.operation.BatchOperationEntity.BatchOperationState;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.TestTemplate;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class BatchOperationArchiverJobIT extends ArchiverJobIT<BatchOperationArchiverJob> {
+
+  private static final AtomicLong ID_GENERATOR = new AtomicLong(1);
+
   @Override
   BatchOperationArchiverJob createArchiveJob(
       final ExporterConfiguration config,
@@ -35,5 +50,115 @@ public class BatchOperationArchiverJobIT extends ArchiverJobIT<BatchOperationArc
         exporterMetrics,
         LOGGER,
         executor);
+  }
+
+  @TestTemplate
+  void shouldArchiveBatchOperationAndDependantAuditLog(
+      final ExporterConfiguration config, final SearchClientAdapter client) throws Exception {
+    withArchiverJob(
+        config,
+        (job, resourceProvider) -> {
+          // given - batch operation with numeric ID and matching audit log entry
+          final var batchOpTemplate =
+              resourceProvider.getIndexTemplateDescriptor(BatchOperationTemplate.class);
+          final var auditLogTemplate =
+              resourceProvider.getIndexTemplateDescriptor(AuditLogTemplate.class);
+
+          final var batchOp = batchOperationEntity("100", "2020-01-01T00:00:00+00:00");
+          final var auditLog = auditLogEntity(100L);
+
+          store(batchOpTemplate, client, batchOp);
+          store(auditLogTemplate, client, auditLog);
+          client.refresh();
+
+          // when
+          final var archived = job.execute();
+
+          // then
+          assertThat(archived).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(1);
+          verifyMoved(batchOpTemplate, client, batchOp, "2020-01-01");
+          verifyMoved(auditLogTemplate, client, auditLog, "2020-01-01");
+        });
+  }
+
+  @TestTemplate
+  void shouldArchiveBatchOperationWithGuidIdWithoutFailure(
+      final ExporterConfiguration config, final SearchClientAdapter client) throws Exception {
+    withArchiverJob(
+        config,
+        (job, resourceProvider) -> {
+          // given - legacy 8.8 batch operation with GUID id
+          final var batchOpTemplate =
+              resourceProvider.getIndexTemplateDescriptor(BatchOperationTemplate.class);
+          final var auditLogTemplate =
+              resourceProvider.getIndexTemplateDescriptor(AuditLogTemplate.class);
+
+          final var batchOp = batchOperationEntity("abc-def-123-guid", "2020-01-01T00:00:00+00:00");
+          // unrelated audit log entry that should NOT be archived with this batch operation
+          final var auditLog = auditLogEntity(999L);
+
+          store(batchOpTemplate, client, batchOp);
+          store(auditLogTemplate, client, auditLog);
+          client.refresh();
+
+          // when - should complete without number_format_exception
+          final var archived = job.execute();
+
+          // then
+          assertThat(archived).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(1);
+          verifyMoved(batchOpTemplate, client, batchOp, "2020-01-01");
+          verifyNotMoved(auditLogTemplate, client, auditLog);
+        });
+  }
+
+  @TestTemplate
+  void shouldArchiveMixedBatchOperationsAndOnlyMatchNumericDependants(
+      final ExporterConfiguration config, final SearchClientAdapter client) throws Exception {
+    withArchiverJob(
+        config,
+        (job, resourceProvider) -> {
+          // given - mix of 8.8 GUID and 8.9 numeric batch operation IDs with same end date
+          final var batchOpTemplate =
+              resourceProvider.getIndexTemplateDescriptor(BatchOperationTemplate.class);
+          final var auditLogTemplate =
+              resourceProvider.getIndexTemplateDescriptor(AuditLogTemplate.class);
+
+          final var numericBatchOp = batchOperationEntity("200", "2020-01-01T00:00:00+00:00");
+          final var guidBatchOp =
+              batchOperationEntity("abc-def-456-guid", "2020-01-01T00:00:00+00:00");
+          final var matchingAuditLog = auditLogEntity(200L);
+          final var unrelatedAuditLog = auditLogEntity(999L);
+
+          store(batchOpTemplate, client, numericBatchOp);
+          store(batchOpTemplate, client, guidBatchOp);
+          store(auditLogTemplate, client, matchingAuditLog);
+          store(auditLogTemplate, client, unrelatedAuditLog);
+          client.refresh();
+
+          // when - should complete without error, GUID filtered out for dependant query
+          final var archived = job.execute();
+
+          // then
+          assertThat(archived).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(2);
+          verifyMoved(batchOpTemplate, client, numericBatchOp, "2020-01-01");
+          verifyMoved(batchOpTemplate, client, guidBatchOp, "2020-01-01");
+          verifyMoved(auditLogTemplate, client, matchingAuditLog, "2020-01-01");
+          verifyNotMoved(auditLogTemplate, client, unrelatedAuditLog);
+        });
+  }
+
+  private BatchOperationEntity batchOperationEntity(final String id, final String endDate) {
+    return new BatchOperationEntity()
+        .setId(id)
+        .setEndDate(OffsetDateTime.parse(endDate))
+        .setState(BatchOperationState.COMPLETED);
+  }
+
+  private AuditLogEntity auditLogEntity(final Long batchOperationKey) {
+    final var entity = new AuditLogEntity();
+    entity.setId(String.valueOf(ID_GENERATOR.incrementAndGet()));
+    entity.setBatchOperationKey(batchOperationKey);
+    entity.setEntityType(AuditLogEntityType.BATCH);
+    return entity;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJobTest.java
@@ -89,4 +89,61 @@ final class BatchOperationArchiverJobTest extends ArchiverJobRecordingMetricsAbs
                 Map.of(BatchOperationTemplate.ID, List.of("1", "2", "3")),
                 executor));
   }
+
+  @Test
+  void shouldNotPassStringIdsToDependantsWhenAllIdsAreStrings() {
+    // given - all IDs are GUIDs (non-numeric), simulating legacy 8.8 batch operations
+    repository.batches =
+        List.of(
+            new BasicArchiveBatch(
+                "2024-01-01", List.of("abc-def-123", "guid-456-xyz", "non-numeric-id")));
+
+    // when
+    final int count = job.execute().toCompletableFuture().join();
+
+    // then - dependant receives empty IDs (all filtered out), batch operation gets all IDs
+    assertThat(count).isEqualTo(3);
+    assertThat(repository.moves)
+        .containsExactly(
+            new DocumentMove(
+                auditLogTemplate.getFullQualifiedName(),
+                auditLogTemplate.getFullQualifiedName() + "2024-01-01",
+                Map.of(AuditLogTemplate.BATCH_OPERATION_KEY, List.of()),
+                Map.of(AuditLogTemplate.ENTITY_TYPE, "BATCH"),
+                executor),
+            new DocumentMove(
+                batchOperationTemplate.getFullQualifiedName(),
+                batchOperationTemplate.getFullQualifiedName() + "2024-01-01",
+                Map.of(
+                    BatchOperationTemplate.ID,
+                    List.of("abc-def-123", "guid-456-xyz", "non-numeric-id")),
+                executor));
+  }
+
+  @Test
+  void shouldOnlyPassNumericIdsToDependantsWhenMixed() {
+    // given - mix of GUID strings and numeric longs, simulating 8.8 -> 8.9 migration
+    repository.batches =
+        List.of(
+            new BasicArchiveBatch("2024-01-01", List.of("1", "abc-def-123", "2", "guid-456-xyz")));
+
+    // when
+    final int count = job.execute().toCompletableFuture().join();
+
+    // then - audit log dependant receives only numeric IDs, batch operation gets all IDs
+    assertThat(count).isEqualTo(4);
+    assertThat(repository.moves)
+        .containsExactly(
+            new DocumentMove(
+                auditLogTemplate.getFullQualifiedName(),
+                auditLogTemplate.getFullQualifiedName() + "2024-01-01",
+                Map.of(AuditLogTemplate.BATCH_OPERATION_KEY, List.of("1", "2")),
+                Map.of(AuditLogTemplate.ENTITY_TYPE, "BATCH"),
+                executor),
+            new DocumentMove(
+                batchOperationTemplate.getFullQualifiedName(),
+                batchOperationTemplate.getFullQualifiedName() + "2024-01-01",
+                Map.of(BatchOperationTemplate.ID, List.of("1", "abc-def-123", "2", "guid-456-xyz")),
+                executor));
+  }
 }


### PR DESCRIPTION


## Description

In previous versions, the batch operations key was a GUID. From 8.9 onward, it is a long generated in the engine. Along with that, from 8.9 onward we save audit logs for batch operations, linked by the ID, and in the audit log the batchOperationKey is stored as a long.

After migrating to 8.9, if there are batch operations from 8.8 still in the index, we attempt to archive them. The first step of the new archiver is to archive the dependents. To do that, we try to reindex from the audit log, but because the old key is a GUID, ES/OS throws a number format exception.

This change avoids that issue by removing any IDs that are strings when running the archive dependent data option.



## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/51910
