### PR TITLE
fix: bump camunda helm to latest version

### DIFF
--- a/.ci/preview-environments/charts/c8sm/Chart.yaml
+++ b/.ci/preview-environments/charts/c8sm/Chart.yaml
@@ -14,4 +14,4 @@ dependencies:
   version: 1.8.7
 - name: camunda-platform
   repository: https://helm.camunda.io
-  version: 14.0.0
+  version: 14.0.1


### PR DESCRIPTION
## Description

This pull request makes a minor update to the `camunda-platform` Helm chart dependency, upgrading it from version 14.0.0 to 14.0.1 in the `Chart.yaml` file.

Related to #inc-5299

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
