### PR TITLE
fix: skip 8.10 smoke tests and pin ref for 8.9 runs

### DIFF
--- a/.ci/preview-environments/charts/c8sm/Chart.yaml
+++ b/.ci/preview-environments/charts/c8sm/Chart.yaml
@@ -14,4 +14,4 @@ dependencies:
   version: 1.8.7
 - name: camunda-platform
   repository: https://helm.camunda.io
-  version: 14.0.0-alpha5
+  version: 14.0.0-alpha5 #TODO: Update helm version once 8.10.0-alpha1 released, and re-enable 8.10 smoke tests in preview-env-smoke-test.yml

--- a/.github/workflows/preview-env-smoke-test.yml
+++ b/.github/workflows/preview-env-smoke-test.yml
@@ -49,6 +49,7 @@ jobs:
     secrets: inherit
     with:
       app-name: smoke89-${{ github.run_number }}
+      ref: stable/8.9
       labels: |
         preview=smoke-test
         repo=camunda_camunda
@@ -58,7 +59,11 @@ jobs:
 
   deploy-8-10:
     name: Deploy 8.10 Preview Environment
-    if: contains(fromJSON('["all", "8.10", ""]'), inputs.version)
+    # TODO(2026-05-11): Re-enable for scheduled/all runs once 8.10 helm chart (>=14.0.1) is released.
+    # if: contains(fromJSON('["all", "8.10", ""]'), inputs.version)
+    # Currently disabled because there is no 8.10 helm chart yet; deploy always fails.
+    # To test manually, use workflow_dispatch with version='8.10'.
+    if: inputs.version == '8.10'
     uses: ./.github/workflows/preview-env-build-and-deploy.yml
     secrets: inherit
     with:


### PR DESCRIPTION
## Description
This pull request includes minor updates to the Helm chart versioning and the GitHub Actions workflow for preview environment deployments. The main focus is on handling the upcoming 8.10 Helm chart release and ensuring the smoke tests and deployments behave correctly until the new version is available.

Helm chart versioning:

* Added a comment in `.ci/preview-environments/charts/c8sm/Chart.yaml` to clarify that the `camunda-platform` Helm chart version should be updated once `8.10.0-alpha1` is released, and to remind maintainers to re-enable the 8.10 smoke tests at that time.

Preview environment deployment workflow:

* Updated `.github/workflows/preview-env-smoke-test.yml` to explicitly set the `ref: stable/8.9` for the 8.9 deployment job, ensuring the correct workflow version is used.
* Temporarily disabled automatic deployment of the 8.10 preview environment in `.github/workflows/preview-env-smoke-test.yml`, restricting it to manual runs only, with explanatory comments and a TODO to re-enable once the 8.10 Helm chart (>=14.0.1) is released.

Related to #inc-5299

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
