### PR TITLE
feat: add new authorization system for PIK and EIK management

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/ExpressionEvaluateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/ExpressionEvaluateProcessor.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.expression;
 
 import io.camunda.zeebe.engine.processing.Rejection;
+import io.camunda.zeebe.engine.processing.expression.ExpressionValidator.ResolvedInstance;
 import io.camunda.zeebe.engine.processing.expression.ExpressionValidator.ValidatedCommand;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
@@ -65,34 +66,73 @@ public final class ExpressionEvaluateProcessor implements TypedRecordProcessor<E
     // Infer the tenant from the resolved instance so downstream auth and variable
     // resolution always operate against the instance's owning tenant. Done here
     // (in the processor) rather than in the validator to keep validation side effect free.
-    validated.resolvedTenantId().ifPresent(validated.record()::setTenantId);
+    validated
+        .resolvedInstance()
+        .map(ResolvedInstance::tenantId)
+        .ifPresent(validated.record()::setTenantId);
     return validated;
-  }
-
-  private Either<Rejection, ValidatedCommand> authorize(
-      final TypedRecord<ExpressionRecord> command, final ValidatedCommand validated) {
-    return isAuthorized(command, validated.record()).map(ignored -> validated);
   }
 
   private Either<Rejection, ExpressionRecord> evaluate(final ValidatedCommand validated) {
     return expressionBehavior.resolveExpression(validated.expression(), validated.record());
   }
 
-  private Either<Rejection, ExpressionRecord> isAuthorized(
-      final TypedRecord<ExpressionRecord> command, final ExpressionRecord record) {
-    final var tenantId = record.getTenantId();
-    final var authRequestBuilder =
-        AuthorizationRequest.builder()
-            .command(command)
-            .resourceType(AuthorizationResourceType.EXPRESSION)
-            .permissionType(PermissionType.EVALUATE);
+  private Either<Rejection, ValidatedCommand> authorize(
+      final TypedRecord<ExpressionRecord> command, final ValidatedCommand validated) {
+    final var tenantId = validated.record().getTenantId();
 
+    return checkCanEvaluateExpression(command, tenantId)
+        .flatMap(__ -> checkCanReadInstanceIfScoped(command, validated, tenantId))
+        .map(__ -> validated);
+  }
+
+  private Either<Rejection, Void> checkCanEvaluateExpression(
+      final TypedRecord<ExpressionRecord> command, final String tenantId) {
+    return checkAuthorized(
+        withTenantIfPresent(
+                AuthorizationRequest.builder()
+                    .command(command)
+                    .resourceType(AuthorizationResourceType.EXPRESSION)
+                    .permissionType(PermissionType.EVALUATE),
+                tenantId)
+            .build());
+  }
+
+  private Either<Rejection, Void> checkCanReadInstanceIfScoped(
+      final TypedRecord<ExpressionRecord> command,
+      final ValidatedCommand validated,
+      final String tenantId) {
+    return validated
+        .resolvedInstance()
+        .map(instance -> checkCanReadProcessInstance(command, tenantId, instance.bpmnProcessId()))
+        .orElseGet(() -> Either.right(null));
+  }
+
+  private Either<Rejection, Void> checkCanReadProcessInstance(
+      final TypedRecord<ExpressionRecord> command,
+      final String tenantId,
+      final String bpmnProcessId) {
+    return checkAuthorized(
+        withTenantIfPresent(
+                AuthorizationRequest.builder()
+                    .command(command)
+                    .resourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+                    .permissionType(PermissionType.READ_PROCESS_INSTANCE)
+                    .addResourceId(bpmnProcessId),
+                tenantId)
+            .build());
+  }
+
+  private Either<Rejection, Void> checkAuthorized(final AuthorizationRequest request) {
+    return authCheckBehavior.isAuthorizedOrInternalCommand(request).map(__ -> null);
+  }
+
+  private static AuthorizationRequest.Builder withTenantIfPresent(
+      final AuthorizationRequest.Builder builder, final String tenantId) {
     if (tenantId != null && !tenantId.isEmpty()) {
-      authRequestBuilder.tenantId(tenantId);
+      builder.tenantId(tenantId);
     }
-
-    final var authRequest = authRequestBuilder.build();
-    return authCheckBehavior.isAuthorizedOrInternalCommand(authRequest).map(unused -> record);
+    return builder;
   }
 
   private void rejectCommand(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/ExpressionValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/ExpressionValidator.java
@@ -51,7 +51,9 @@ public final class ExpressionValidator {
         .flatMap(
             expression ->
                 validateScope(record)
-                    .map(tenantId -> new ValidatedCommand(expression, record, tenantId)));
+                    .map(
+                        resolvedInstance ->
+                            new ValidatedCommand(expression, record, resolvedInstance)));
   }
 
   /** Combines text-level validation and FEEL parsing — they always travel together. */
@@ -79,7 +81,8 @@ public final class ExpressionValidator {
    * Returns {@code Optional.empty()} when no scope was supplied — this is a valid state, not an
    * error.
    */
-  private Either<Rejection, Optional<String>> validateScope(final ExpressionRecord record) {
+  private Either<Rejection, Optional<ResolvedInstance>> validateScope(
+      final ExpressionRecord record) {
     final boolean hasProcessInstanceKey = isSet(record.getProcessInstanceKey());
     final boolean hasElementInstanceKey = isSet(record.getElementInstanceKey());
 
@@ -98,10 +101,10 @@ public final class ExpressionValidator {
             ? ScopeTarget.elementInstance(record.getElementInstanceKey())
             : ScopeTarget.processInstance(record.getProcessInstanceKey());
 
-    return validateInstanceTenant(record, target).map(Optional::of);
+    return validateInstance(record, target).map(Optional::of);
   }
 
-  private Either<Rejection, String> validateInstanceTenant(
+  private Either<Rejection, ResolvedInstance> validateInstance(
       final ExpressionRecord record, final ScopeTarget target) {
     final var instance = elementInstanceState.getInstance(target.key());
 
@@ -121,7 +124,8 @@ public final class ExpressionValidator {
       return reject(RejectionType.NOT_FOUND, target.tenantMismatchMessage(providedTenantId));
     }
 
-    return Either.right(actualTenantId);
+    return Either.right(
+        new ResolvedInstance(actualTenantId, instance.getValue().getBpmnProcessId()));
   }
 
   private static boolean isSet(final long key) {
@@ -133,7 +137,15 @@ public final class ExpressionValidator {
   }
 
   public record ValidatedCommand(
-      Expression expression, ExpressionRecord record, Optional<String> resolvedTenantId) {}
+      Expression expression,
+      ExpressionRecord record,
+      Optional<ResolvedInstance> resolvedInstance) {}
+
+  /**
+   * Metadata derived from the resolved scope instance — captured here so the processor can reuse it
+   * (tenant inference, authorization checks) without a second state lookup.
+   */
+  public record ResolvedInstance(String tenantId, String bpmnProcessId) {}
 
   private record ProcessInstanceScopeTarget(long key) implements ScopeTarget {
     @Override

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/ResolveExpressionAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/ResolveExpressionAuthorizationTest.java
@@ -13,12 +13,15 @@ import io.camunda.security.configuration.ConfiguredUser;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.engine.util.EngineRule.ResetRecordingExporterMode;
 import io.camunda.zeebe.engine.util.EngineRule.ResetRecordingExporterTestWatcherMode;
+import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ExpressionIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
@@ -108,6 +111,349 @@ public class ResolveExpressionAuthorizationTest {
         .hasRejectionType(RejectionType.FORBIDDEN)
         .hasRejectionReason(
             "Insufficient permissions to perform operation 'EVALUATE' on resource 'EXPRESSION'");
+  }
+
+  @Test
+  public void shouldBeAuthorizedWithProcessInstanceKeyWhenUserHasBothPermissions() {
+    // given - a user with both EXPRESSION:EVALUATE and PROCESS_DEFINITION:READ_PROCESS_INSTANCE
+    final var bpmnProcessId = "auth_pi_" + UUID.randomUUID();
+    deployProcess(bpmnProcessId);
+    final var processInstanceKey = createProcessInstance(bpmnProcessId);
+
+    final var user = createUser();
+    addPermissionsToUser(
+        user,
+        AuthorizationResourceType.EXPRESSION,
+        PermissionType.EVALUATE,
+        AuthorizationResourceMatcher.ANY,
+        "*");
+    addPermissionsToUser(
+        user,
+        AuthorizationResourceType.PROCESS_DEFINITION,
+        PermissionType.READ_PROCESS_INSTANCE,
+        AuthorizationResourceMatcher.ID,
+        bpmnProcessId);
+
+    // when
+    engine
+        .expression()
+        .withExpression(EXPRESSION)
+        .withProcessInstanceKey(processInstanceKey)
+        .resolve(user.getUsername());
+
+    // then
+    assertThat(
+            RecordingExporter.expressionRecords()
+                .withIntent(ExpressionIntent.EVALUATED)
+                .withExpression(EXPRESSION)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldBeAuthorizedWithElementInstanceKeyWhenUserHasBothPermissions() {
+    // given
+    final var bpmnProcessId = "auth_ei_" + UUID.randomUUID();
+    deployProcess(bpmnProcessId);
+    final var processInstanceKey = createProcessInstance(bpmnProcessId);
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .getFirst()
+            .getKey();
+
+    final var user = createUser();
+    addPermissionsToUser(
+        user,
+        AuthorizationResourceType.EXPRESSION,
+        PermissionType.EVALUATE,
+        AuthorizationResourceMatcher.ANY,
+        "*");
+    addPermissionsToUser(
+        user,
+        AuthorizationResourceType.PROCESS_DEFINITION,
+        PermissionType.READ_PROCESS_INSTANCE,
+        AuthorizationResourceMatcher.ID,
+        bpmnProcessId);
+
+    // when
+    engine
+        .expression()
+        .withExpression(EXPRESSION)
+        .withElementInstanceKey(elementInstanceKey)
+        .resolve(user.getUsername());
+
+    // then
+    assertThat(
+            RecordingExporter.expressionRecords()
+                .withIntent(ExpressionIntent.EVALUATED)
+                .withExpression(EXPRESSION)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldBeAuthorizedWithProcessInstanceKeyWhenUserHasWildcardPermissions() {
+    // given - wildcard EXPRESSION:EVALUATE and PROCESS_DEFINITION:READ_PROCESS_INSTANCE
+    final var bpmnProcessId = "auth_wildcard_" + UUID.randomUUID();
+    deployProcess(bpmnProcessId);
+    final var processInstanceKey = createProcessInstance(bpmnProcessId);
+
+    final var user = createUser();
+    addPermissionsToUser(
+        user,
+        AuthorizationResourceType.EXPRESSION,
+        PermissionType.EVALUATE,
+        AuthorizationResourceMatcher.ANY,
+        "*");
+    addPermissionsToUser(
+        user,
+        AuthorizationResourceType.PROCESS_DEFINITION,
+        PermissionType.READ_PROCESS_INSTANCE,
+        AuthorizationResourceMatcher.ANY,
+        "*");
+
+    // when
+    engine
+        .expression()
+        .withExpression(EXPRESSION)
+        .withProcessInstanceKey(processInstanceKey)
+        .resolve(user.getUsername());
+
+    // then
+    assertThat(
+            RecordingExporter.expressionRecords()
+                .withIntent(ExpressionIntent.EVALUATED)
+                .withExpression(EXPRESSION)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldBeUnauthorizedWithProcessInstanceKeyIfNoPermissions() {
+    // given
+    final var bpmnProcessId = "auth_pi_no_perm_" + UUID.randomUUID();
+    deployProcess(bpmnProcessId);
+    final var processInstanceKey = createProcessInstance(bpmnProcessId);
+
+    final var user = createUser();
+
+    // when
+    final var rejection =
+        engine
+            .expression()
+            .withExpression(EXPRESSION)
+            .withProcessInstanceKey(processInstanceKey)
+            .expectRejection()
+            .resolve(user.getUsername());
+
+    // then - EXPRESSION:EVALUATE is checked first and the user has no permissions at all
+    Assertions.assertThat(rejection)
+        .hasRejectionType(RejectionType.FORBIDDEN)
+        .hasRejectionReason(
+            "Insufficient permissions to perform operation 'EVALUATE' on resource 'EXPRESSION'");
+  }
+
+  @Test
+  public void shouldBeUnauthorizedWithElementInstanceKeyIfNoPermissions() {
+    // given
+    final var bpmnProcessId = "auth_ei_no_perm_" + UUID.randomUUID();
+    deployProcess(bpmnProcessId);
+    final var processInstanceKey = createProcessInstance(bpmnProcessId);
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .getFirst()
+            .getKey();
+
+    final var user = createUser();
+
+    // when
+    final var rejection =
+        engine
+            .expression()
+            .withExpression(EXPRESSION)
+            .withElementInstanceKey(elementInstanceKey)
+            .expectRejection()
+            .resolve(user.getUsername());
+
+    // then - EXPRESSION:EVALUATE is checked first and the user has no permissions at all
+    Assertions.assertThat(rejection)
+        .hasRejectionType(RejectionType.FORBIDDEN)
+        .hasRejectionReason(
+            "Insufficient permissions to perform operation 'EVALUATE' on resource 'EXPRESSION'");
+  }
+
+  @Test
+  public void shouldBeUnauthorizedWithProcessInstanceKeyIfOnlyEvaluateExpressionPermission() {
+    // given - user has EXPRESSION:EVALUATE but not PROCESS_DEFINITION:READ_PROCESS_INSTANCE
+    final var bpmnProcessId = "auth_pi_only_evaluate_" + UUID.randomUUID();
+    deployProcess(bpmnProcessId);
+    final var processInstanceKey = createProcessInstance(bpmnProcessId);
+
+    final var user = createUser();
+    addPermissionsToUser(
+        user,
+        AuthorizationResourceType.EXPRESSION,
+        PermissionType.EVALUATE,
+        AuthorizationResourceMatcher.ANY,
+        "*");
+
+    // when
+    final var rejection =
+        engine
+            .expression()
+            .withExpression(EXPRESSION)
+            .withProcessInstanceKey(processInstanceKey)
+            .expectRejection()
+            .resolve(user.getUsername());
+
+    // then - scope is provided so EXPRESSION:EVALUATE is irrelevant; auth fails on
+    // PROCESS_DEFINITION:READ_PROCESS_INSTANCE.
+    Assertions.assertThat(rejection)
+        .hasRejectionType(RejectionType.FORBIDDEN)
+        .hasRejectionReason(
+            "Insufficient permissions to perform operation 'READ_PROCESS_INSTANCE' on resource"
+                + " 'PROCESS_DEFINITION', required resource identifiers are one of '[*, "
+                + bpmnProcessId
+                + "]'");
+  }
+
+  @Test
+  public void shouldBeUnauthorizedWithProcessInstanceKeyIfPermissionOnDifferentProcessId() {
+    // given - user has EXPRESSION:EVALUATE and READ_PROCESS_INSTANCE on processB,
+    // but the call targets processA so the second check must fail.
+    final var processA = "auth_pi_proc_a_" + UUID.randomUUID();
+    final var processB = "auth_pi_proc_b_" + UUID.randomUUID();
+    deployProcess(processA);
+    deployProcess(processB);
+    final var processAInstanceKey = createProcessInstance(processA);
+
+    final var user = createUser();
+    addPermissionsToUser(
+        user,
+        AuthorizationResourceType.EXPRESSION,
+        PermissionType.EVALUATE,
+        AuthorizationResourceMatcher.ANY,
+        "*");
+    addPermissionsToUser(
+        user,
+        AuthorizationResourceType.PROCESS_DEFINITION,
+        PermissionType.READ_PROCESS_INSTANCE,
+        AuthorizationResourceMatcher.ID,
+        processB);
+
+    // when
+    final var rejection =
+        engine
+            .expression()
+            .withExpression(EXPRESSION)
+            .withProcessInstanceKey(processAInstanceKey)
+            .expectRejection()
+            .resolve(user.getUsername());
+
+    // then
+    Assertions.assertThat(rejection)
+        .hasRejectionType(RejectionType.FORBIDDEN)
+        .hasRejectionReason(
+            "Insufficient permissions to perform operation 'READ_PROCESS_INSTANCE' on resource"
+                + " 'PROCESS_DEFINITION', required resource identifiers are one of '[*, "
+                + processA
+                + "]'");
+  }
+
+  @Test
+  public void shouldBeUnauthorizedWithElementInstanceKeyIfOnlyEvaluateExpressionPermission() {
+    // given - user has EXPRESSION:EVALUATE but not PROCESS_DEFINITION:READ_PROCESS_INSTANCE,
+    // so the second check fails for the resolved scope.
+    final var bpmnProcessId = "auth_ei_only_evaluate_" + UUID.randomUUID();
+    deployProcess(bpmnProcessId);
+    final var processInstanceKey = createProcessInstance(bpmnProcessId);
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .getFirst()
+            .getKey();
+
+    final var user = createUser();
+    addPermissionsToUser(
+        user,
+        AuthorizationResourceType.EXPRESSION,
+        PermissionType.EVALUATE,
+        AuthorizationResourceMatcher.ANY,
+        "*");
+
+    // when
+    final var rejection =
+        engine
+            .expression()
+            .withExpression(EXPRESSION)
+            .withElementInstanceKey(elementInstanceKey)
+            .expectRejection()
+            .resolve(user.getUsername());
+
+    // then
+    Assertions.assertThat(rejection)
+        .hasRejectionType(RejectionType.FORBIDDEN)
+        .hasRejectionReason(
+            "Insufficient permissions to perform operation 'READ_PROCESS_INSTANCE' on resource"
+                + " 'PROCESS_DEFINITION', required resource identifiers are one of '[*, "
+                + bpmnProcessId
+                + "]'");
+  }
+
+  @Test
+  public void shouldBeUnauthorizedWithProcessInstanceKeyIfOnlyReadProcessInstancePermission() {
+    // given - user has PROCESS_DEFINITION:READ_PROCESS_INSTANCE but no EXPRESSION:EVALUATE,
+    // so the first (always-required) check must fail.
+    final var bpmnProcessId = "auth_pi_only_read_" + UUID.randomUUID();
+    deployProcess(bpmnProcessId);
+    final var processInstanceKey = createProcessInstance(bpmnProcessId);
+
+    final var user = createUser();
+    addPermissionsToUser(
+        user,
+        AuthorizationResourceType.PROCESS_DEFINITION,
+        PermissionType.READ_PROCESS_INSTANCE,
+        AuthorizationResourceMatcher.ID,
+        bpmnProcessId);
+
+    // when
+    final var rejection =
+        engine
+            .expression()
+            .withExpression(EXPRESSION)
+            .withProcessInstanceKey(processInstanceKey)
+            .expectRejection()
+            .resolve(user.getUsername());
+
+    // then
+    Assertions.assertThat(rejection)
+        .hasRejectionType(RejectionType.FORBIDDEN)
+        .hasRejectionReason(
+            "Insufficient permissions to perform operation 'EVALUATE' on resource 'EXPRESSION'");
+  }
+
+  private void deployProcess(final String bpmnProcessId) {
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(bpmnProcessId)
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType("test"))
+                .endEvent()
+                .done())
+        .deploy(DEFAULT_USER.getUsername());
+  }
+
+  private long createProcessInstance(final String bpmnProcessId) {
+    return engine
+        .processInstance()
+        .ofBpmnProcessId(bpmnProcessId)
+        .create(DEFAULT_USER.getUsername());
   }
 
   private UserRecordValue createUser() {


### PR DESCRIPTION
This pull request refactors and strengthens the authorization logic for expression evaluation in the Zeebe engine. It introduces a two-step authorization process when resolving expressions scoped to process or element instances: first checking for `EXPRESSION:EVALUATE` permission, then (if scoped) requiring `PROCESS_DEFINITION:READ_PROCESS_INSTANCE` on the specific process. The changes also refactor validation to pass richer instance metadata and add comprehensive tests for all relevant authorization scenarios.

**Authorization Logic Improvements**
- Refactored the authorization checks in `ExpressionEvaluateProcessor` to require both `EXPRESSION:EVALUATE` and (when scoped) `PROCESS_DEFINITION:READ_PROCESS_INSTANCE` permissions, ensuring that users must have the correct permissions for both the expression and the underlying process instance.
- Added helper methods for building authorization requests with tenant information and for performing the new two-step authorization process.

**Validation Refactoring**
- Changed the validation flow in `ExpressionValidator` to return a `ResolvedInstance` record (containing both tenant ID and BPMN process ID) instead of just the tenant ID, enabling the processor to perform more informed authorization checks without redundant state lookups. [[1]](diffhunk://#diff-7126ce3b818a3d8cb058bbb6eaa269884bdb7de442085b1862df3216c97bd673L54-R56) [[2]](diffhunk://#diff-7126ce3b818a3d8cb058bbb6eaa269884bdb7de442085b1862df3216c97bd673L82-R85) [[3]](diffhunk://#diff-7126ce3b818a3d8cb058bbb6eaa269884bdb7de442085b1862df3216c97bd673L101-R107) [[4]](diffhunk://#diff-7126ce3b818a3d8cb058bbb6eaa269884bdb7de442085b1862df3216c97bd673L124-R128) [[5]](diffhunk://#diff-7126ce3b818a3d8cb058bbb6eaa269884bdb7de442085b1862df3216c97bd673L136-R148)
- Updated the `ValidatedCommand` record to include the resolved instance metadata.

**Test Coverage**
- Added extensive tests to `ResolveExpressionAuthorizationTest` to verify all combinations of permissions and scoping, including both authorized and unauthorized scenarios for process and element instance keys, wildcard permissions, and mismatched process IDs.

**Code Cleanliness**
- Removed obsolete methods and streamlined the processor and validator code to reflect the new authorization and validation flows. [[1]](diffhunk://#diff-574ce05a225cc4e37f1ecde34a70c070acf35b223c7591ff2d01dffeed3a8ebdL68-R135) [[2]](diffhunk://#diff-7126ce3b818a3d8cb058bbb6eaa269884bdb7de442085b1862df3216c97bd673L101-R107)

**Imports and Minor Updates**
- Added necessary imports in test files to support new test cases.

These changes significantly improve the security and correctness of expression evaluation authorization, especially in multi-tenant and scoped contexts.