### PR TITLE
fix: load-test setup fails on databases/*.yaml glob (stable/8.7)

### DIFF
--- a/load-tests/setup/newLoadTest.sh
+++ b/load-tests/setup/newLoadTest.sh
@@ -166,7 +166,7 @@ sed_inplace "s/__STORAGE_TYPE__/$secondaryStorage/" Makefile
 sed_inplace "s/__ENABLE_OPTIMIZE__/$enable_optimize/" Makefile
 sed_inplace "s/__ENABLE_WEBAPPS__/$enable_webapps/" Makefile
 sed_inplace "s/__AVAILABILITY_ZONE__/$availability_zone/" *.yaml
-sed_inplace "s/__AUTHOR__/$git_author/" *.yaml databases/*.yaml
+sed_inplace "s/__AUTHOR__/$git_author/" *.yaml
 
 # Add/update helm repositories
 helm repo add camunda https://helm.camunda.io/ --force-update


### PR DESCRIPTION
## Description

CI load-test deployments on `stable/8.7` are failing at `load-tests/setup/newLoadTest.sh:169` with:

```
sed: can't read databases/*.yaml: No such file or directory
```

PR #51954 (backport `c011acb9ec3`, original `5c01412aad9`) added a `databases/*.yaml` argument to the `__AUTHOR__` sed call. That glob was introduced on `main` together with the additional-RDBMS feature (MSSQL / Oracle / MariaDB templates under `load-tests/setup/default/databases/`), which was **not** backported to `stable/8.7`. With no matching files and no `nullglob`, bash leaves the literal `databases/*.yaml` in the args, sed treats it as a missing filename, and the script aborts before the deployment can run.

This PR drops the unsupported `databases/*.yaml` argument on `stable/8.7`. The remaining `*.yaml` glob still picks up `camunda-platform-values.yaml`, `load-test-values.yaml`, `prometheus-elasticsearch-exporter-values.yaml`, etc., so the `__AUTHOR__` substitution from #51954 keeps working — only the dead reference to the missing `databases/` directory is removed.

If/when the RDBMS feature gets backported to `stable/8.7`, the glob can be reintroduced as part of that backport.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

Follow-up to #51954