### PR TITLE
fix: do not leak `innerInstance` variables to parent scope

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
@@ -140,8 +140,12 @@ public final class BpmnVariableMappingBehavior {
           .map(
               localScopeVars -> {
                 // For multi-instance inner activities, scopeKey == elementInstanceKey.
+                // For activities directly inside an ad-hoc sub-process inner instance, the flow
+                // scope carries variables that were set local to that scope
+                // on activation (e.g. `toolCall`, `toolCallResult` for the AI Agent connector).
                 final DirectBuffer resultDoc;
-                if (isMultiInstanceActivity(elementInstanceKey)) {
+                if (isMultiInstanceActivity(elementInstanceKey)
+                    || isAdHocSubProcessInnerInstance(context)) {
                   resultDoc = localScopeVars;
                 } else {
                   final DirectBuffer parentScopeVars =
@@ -199,6 +203,17 @@ public final class BpmnVariableMappingBehavior {
 
   private boolean isMultiInstanceActivity(final long elementInstanceKey) {
     return elementInstanceState.getInstance(elementInstanceKey).getMultiInstanceLoopCounter() > 0;
+  }
+
+  private boolean isAdHocSubProcessInnerInstance(final BpmnElementContext context) {
+    final var flowScopeKey = context.getFlowScopeKey();
+    if (flowScopeKey < 0) {
+      return false;
+    }
+    final var flowScopeInstance = elementInstanceState.getInstance(flowScopeKey);
+    return flowScopeInstance != null
+        && BpmnElementType.AD_HOC_SUB_PROCESS_INNER_INSTANCE
+            == flowScopeInstance.getValue().getBpmnElementType();
   }
 
   private boolean isConnectedToEventBasedGateway(final ExecutableFlowNode element) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobBasedAdHocSubProcessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobBasedAdHocSubProcessTest.java
@@ -1203,6 +1203,65 @@ public class JobBasedAdHocSubProcessTest {
         .allMatch(r -> AHSP_ELEMENT_ID.equals(r.getAgent().getElementId()));
   }
 
+  @Test
+  public void shouldNotLeakInnerInstanceLocalVariablesWhenActivityHasOutputMapping() {
+    // given
+    final var ahspJobType = UUID.randomUUID().toString();
+    final var taskJobType = UUID.randomUUID().toString();
+    final BpmnModelInstance process =
+        process(
+            ahspJobType,
+            adHocSubProcess ->
+                adHocSubProcess
+                    .serviceTask("A", t -> t.zeebeJobType(taskJobType))
+                    .zeebeOutputExpression("=1", "outputResult"));
+    ENGINE.deployment().withXmlResource(process).deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when - the ad-hoc job worker activates A and sets `toolCall` local on the inner instance
+    completeJob(ahspJobType, false, false, activateElement("A", Map.of("toolCall", "abc")));
+
+    // ... and the activated service task completes, triggering applyOutputMappings on A
+    final var taskJobKey =
+        ENGINE.jobs().withType(taskJobType).activate().getValue().getJobKeys().getFirst();
+    ENGINE.job().withKey(taskJobKey).complete();
+
+    // then - wait for A's inner instance to complete (output mapping has run by then)
+    final var innerInstanceCompleted =
+        RecordingExporter.processInstanceRecords(ELEMENT_COMPLETED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId(AHSP_INNER_ELEMENT_ID)
+            .getFirst();
+
+    // complete the ad-hoc sub-process
+    // guaranteed that all variable records of interest have been exported
+    completeJob(ahspJobType, true, false);
+    final var processCompleted =
+        RecordingExporter.processInstanceRecords(ELEMENT_COMPLETED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId(PROCESS_ID)
+            .getFirst();
+
+    // sanity check: the output mapping was actually applied
+    Assertions.assertThat(
+            RecordingExporter.variableRecords(VariableIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withName("outputResult")
+                .exists())
+        .as("output mapping for service task A must have produced `outputResult`")
+        .isTrue();
+
+    Assertions.assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getPosition() >= processCompleted.getPosition())
+                .variableRecords()
+                .withIntents(VariableIntent.CREATED, VariableIntent.UPDATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withName("toolCall"))
+        .extracting(r -> r.getValue().getScopeKey())
+        .containsOnly(innerInstanceCompleted.getKey());
+  }
+
   private void completeJob(
       final String jobType,
       final boolean completionConditionFulfilled,


### PR DESCRIPTION
## Description

Fixes unintended variable propagation from ad-hoc sub-process activations introduced in 8.9.1, which caused `toolCall` data to leak into parent and event sub-process scopes.
Restores expected scoping behavior so variables created during inner activations remain local unless explicitly mapped.
Ensures AI Agent interaction patterns work correctly again, preventing duplicate tool call IDs and incorrect `toolCallResults`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #51939
