### PR TITLE
Feat/exporter replay review fixes

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainer.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainer.java
@@ -203,20 +203,18 @@ final class ExporterContainer implements Controller {
   }
 
   @Override
-  public boolean requestReplay(final long fromPosition) {
-    final long replayPosition = fromPosition - 1;
+  public boolean requestReplay(final long lastExportedPosition) {
     LOG.info(
-        "Replay requested for exporter '{}': resetting position from {} to {} and replaying from {}",
+        "Replay requested for exporter '{}': resetting position from {} to {}",
         getId(),
         position,
-        replayPosition,
-        fromPosition);
-    position = replayPosition;
-    lastUnacknowledgedPosition = replayPosition;
-    lastAcknowledgedPosition = replayPosition;
+        lastExportedPosition);
+    position = lastExportedPosition;
+    lastUnacknowledgedPosition = lastExportedPosition;
+    lastAcknowledgedPosition = lastExportedPosition;
     lastExportedMetadata = null;
-    exportersState.setPosition(getId(), replayPosition);
-    return replayControl.requestReplay(replayPosition);
+    exportersState.setPosition(getId(), lastExportedPosition);
+    return replayControl.requestReplay(lastExportedPosition);
   }
 
   public String getId() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainer.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainer.java
@@ -209,12 +209,16 @@ final class ExporterContainer implements Controller {
         getId(),
         position,
         lastExportedPosition);
-    position = lastExportedPosition;
-    lastUnacknowledgedPosition = lastExportedPosition;
-    lastAcknowledgedPosition = lastExportedPosition;
-    lastExportedMetadata = null;
-    exportersState.setPosition(getId(), lastExportedPosition);
-    return replayControl.requestReplay(lastExportedPosition);
+
+    final boolean replayResult = replayControl.requestReplay(lastExportedPosition);
+    if (replayResult) {
+      position = lastExportedPosition;
+      lastUnacknowledgedPosition = lastExportedPosition;
+      lastAcknowledgedPosition = lastExportedPosition;
+      lastExportedMetadata = null;
+      exportersState.setPosition(getId(), lastExportedPosition);
+    }
+    return replayResult;
   }
 
   public String getId() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -616,51 +616,43 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
   }
 
   /**
-   * Handles a replay request from an exporter container. Seeks the log reader to the first position
-   * to replay ({@code state.getLowestPosition() + 1}) and resumes reading if all exporters are
-   * already opened and the director is not currently mid-export.
+   * Handles a replay request from an exporter container. Seeks the log reader to {@code
+   * lastExportedPosition} so that records from that position onward will be re-exported.
    *
-   * <p>If called during startup (before all exporters are opened), the seek is still performed now
-   * so that the result can be returned to the caller. {@link #startActiveExportingFrom(long)} will
-   * perform a redundant but harmless seek afterward using {@link
-   * ExportersState#getLowestPosition()}.
+   * <p>Replay is only valid during startup, i.e. while exporters are still being opened. If all
+   * exporters have already been opened ({@code allExportersOpened == true}) or the director is
+   * currently mid-export ({@code inExportingPhase == true}), the request is rejected with a warning
+   * and {@code false} is returned.
    *
-   * <p>If called while the director is currently exporting a record ({@code inExportingPhase ==
-   * true}), {@code readNextEvent()} is NOT submitted here — the normal export-completion callback
-   * will resume processing with the reader already positioned for replay.
-   *
-   * @param requestedPosition the position to which the exporter's state was reset (i.e., {@code
-   *     fromPosition - 1})
-   * @return {@code true} if the seek to the replay position succeeded, {@code false} if the
+   * @param lastExportedPosition the position to seek the log reader to for replay
+   * @return {@code true} if the seek succeeded, {@code false} if the request was rejected or the
    *     required log segments are no longer available
    */
-  private boolean onReplayRequested(final long requestedPosition) {
+  private boolean onReplayRequested(final long lastExportedPosition) {
     if (logStreamReader == null) {
       LOG.warn(
           "Cannot process replay request at position {}: log stream reader is not available.",
-          requestedPosition);
+          lastExportedPosition);
       return false;
     }
 
-    final long newLowestPosition = state.getLowestPosition();
-    final long replayFromPosition = newLowestPosition + 1;
-    LOG.info(
-        "Replay requested: seeking log reader to position {} (lowest exporter position + 1)",
-        replayFromPosition);
+    if (allExportersOpened || inExportingPhase) {
+      LOG.warn(
+          "Replay requested at position {}, but all exporters are already opened and exporting started. Request should only be triggered during exporter opening. Ignoring replay request.",
+          lastExportedPosition);
+      return false;
+    }
 
-    final boolean sought = logStreamReader.seek(replayFromPosition);
+    LOG.info("Replay requested: seeking log reader to position {}", lastExportedPosition);
+
+    final boolean sought = logStreamReader.seek(lastExportedPosition);
     if (!sought) {
       LOG.warn(
           "Could not seek log reader to replay position {}. Log segments may have been deleted.",
-          replayFromPosition);
+          lastExportedPosition);
       return false;
     }
 
-    if (allExportersOpened && !inExportingPhase) {
-      actor.submit(this::readNextEvent);
-    }
-    // If not allExportersOpened, startActiveExportingFrom() will seek again and start reading.
-    // If currently exporting, the normal export completion callback will resume processing.
     return true;
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterReplayControl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterReplayControl.java
@@ -19,12 +19,12 @@ interface ExporterReplayControl {
   /**
    * Called when an exporter requests a replay after resetting to the given position.
    *
-   * @param resetPosition the exclusive lower bound for the replay, i.e. the log position that was
-   *     reset and after which replay should resume ({@code fromPosition - 1} in terms of the {@link
-   *     io.camunda.zeebe.exporter.api.context.Controller#requestReplay} API)
+   * @param lastExportedPosition the exclusive lower bound for the replay, i.e. the log position
+   *     that was reset and after which replay should resume ({@code lastExportedPosition} in terms
+   *     of the {@link io.camunda.zeebe.exporter.api.context.Controller#requestReplay} API)
    * @return {@code true} if the replay request was accepted and the log reader was successfully
    *     seeked, {@code false} if it was rejected (e.g. because the log segment is no longer
    *     available)
    */
-  boolean requestReplay(long resetPosition);
+  boolean requestReplay(long lastExportedPosition);
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerRuntime.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerRuntime.java
@@ -91,6 +91,15 @@ public final class ExporterContainerRuntime implements CloseableSilently {
       final int partitionId,
       final ExporterInitializationInfo initializationInfo,
       final MeterRegistry meterRegistry) {
+    return newContainer(descriptor, partitionId, initializationInfo, meterRegistry, pos -> true);
+  }
+
+  public ExporterContainer newContainer(
+      final ExporterDescriptor descriptor,
+      final int partitionId,
+      final ExporterInitializationInfo initializationInfo,
+      final MeterRegistry meterRegistry,
+      final ExporterReplayControl replayControl) {
 
     final var container =
         new ExporterContainer(
@@ -99,7 +108,7 @@ public final class ExporterContainerRuntime implements CloseableSilently {
             initializationInfo,
             meterRegistry,
             InstantSource.system(),
-            pos -> true);
+            replayControl);
     container.initContainer(actor.getActorControl(), metrics, state, ExporterPhase.EXPORTING);
 
     return container;

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerTest.java
@@ -804,6 +804,76 @@ final class ExporterContainerTest {
   }
 
   @Nested
+  class RequestReplay {
+
+    private static final long INITIAL_POSITION = 10L;
+    private static final long REPLAY_POSITION = 5L;
+
+    @BeforeEach
+    void beforeEach(final @TempDir Path storagePath) throws ExporterLoadException {
+      runtime = new ExporterContainerRuntime(storagePath);
+    }
+
+    @Test
+    void shouldRequestReplaySuccessfully() throws Exception {
+      // given
+      final var descriptor =
+          runtime
+              .getRepository()
+              .validateAndAddExporterDescriptor(
+                  EXPORTER_ID, FakeExporter.class, Map.of("key", "value"));
+      exporterContainer =
+          runtime.newContainer(
+              descriptor,
+              PARTITION_ID,
+              new ExporterInitializationInfo(0, null),
+              new SimpleMeterRegistry(),
+              pos -> true);
+      exporterContainer.configureExporter();
+      runtime.getState().setPosition(EXPORTER_ID, INITIAL_POSITION);
+      exporterContainer.initMetadata();
+
+      // when
+      final boolean result = exporterContainer.requestReplay(REPLAY_POSITION);
+
+      // then
+      assertThat(result).isTrue();
+      assertThat(exporterContainer.getPosition()).isEqualTo(REPLAY_POSITION);
+      assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(REPLAY_POSITION);
+      assertThat(runtime.getState().getPosition(EXPORTER_ID)).isEqualTo(REPLAY_POSITION);
+    }
+
+    @Test
+    void shouldNotUpdateStateWhenReplayRequestIsRejected() throws Exception {
+      // given
+      final var descriptor =
+          runtime
+              .getRepository()
+              .validateAndAddExporterDescriptor(
+                  EXPORTER_ID, FakeExporter.class, Map.of("key", "value"));
+      exporterContainer =
+          runtime.newContainer(
+              descriptor,
+              PARTITION_ID,
+              new ExporterInitializationInfo(0, null),
+              new SimpleMeterRegistry(),
+              pos -> false);
+      exporterContainer.configureExporter();
+      runtime.getState().setPosition(EXPORTER_ID, INITIAL_POSITION);
+      exporterContainer.initMetadata();
+
+      // when
+      final boolean result = exporterContainer.requestReplay(REPLAY_POSITION);
+
+      // then
+      assertThat(result).isFalse();
+      assertThat(exporterContainer.getPosition()).isEqualTo(INITIAL_POSITION);
+      assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(INITIAL_POSITION);
+      assertThat(runtime.getState().getPosition(EXPORTER_ID)).isEqualTo(INITIAL_POSITION);
+    }
+  }
+
+  @Nested
   class RecordFilterConditions {
 
     @BeforeEach

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorTest.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.broker.exporter.util.PojoConfigurationExporter;
 import io.camunda.zeebe.broker.exporter.util.PojoConfigurationExporter.PojoExporterConfiguration;
 import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.exporter.api.context.Context;
+import io.camunda.zeebe.exporter.api.context.Controller;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
@@ -863,8 +864,8 @@ public final class ExporterDirectorTest {
 
     // Simulate: exporter 0's DB was restored to eventPosition2 — records 3 and 4 are missing
     exporters
-        .get(0)
-        .onOpen(controller -> replayAccepted.set(controller.requestReplay(eventPosition2 + 1)))
+        .getFirst()
+        .onOpen(controller -> replayAccepted.set(controller.requestReplay(eventPosition2)))
         .shouldAutoUpdatePosition(true);
     exporters.get(1).shouldAutoUpdatePosition(true);
 
@@ -884,6 +885,34 @@ public final class ExporterDirectorTest {
 
     // exporter 1 should not re-export anything
     assertThat(exporters.get(1).getExportedRecords()).isEmpty();
+  }
+
+  @Test
+  public void shouldNotReplayRecordsWhenExporting() throws Exception {
+    // given - write 4 events
+    final long eventPosition1 = writeEvent();
+    final long eventPosition2 = writeEvent();
+    final long eventPosition3 = writeEvent();
+    final long eventPosition4 = writeEvent();
+
+    final AtomicReference<Controller> controllerRef = new AtomicReference<>();
+    final var replayAccepted = new AtomicBoolean(false);
+    exporters
+        .getFirst()
+        .onOpen(controllerRef::set)
+        .onExport(
+            r -> {
+              if (r.getPosition() == eventPosition4) {
+                replayAccepted.set(controllerRef.get().requestReplay(eventPosition2));
+              }
+            });
+
+    // when
+    rule.startExporterDirector(exporterDescriptors);
+    waitUntil(() -> exporters.getFirst().getExportedRecords().size() == 4);
+
+    // then
+    assertThat(replayAccepted.get()).isFalse();
   }
 
   @Test

--- a/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Controller.java
+++ b/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Controller.java
@@ -60,17 +60,17 @@ public interface Controller {
   Optional<byte[]> readMetadata();
 
   /**
-   * Requests that the exporter replay records starting from the given position. This is useful when
-   * the exporter's secondary storage is behind the broker's acknowledged position, for example
+   * Requests that the exporter replay records starting after the given position. This is useful
+   * when the exporter's secondary storage is behind the broker's acknowledged position, for example
    * after a database restore or an automatic failover in an async-replicated setup.
    *
-   * <p>The broker will reset the exporter's position to {@code fromPosition - 1} and replay all log
-   * stream records from {@code fromPosition} onward. Replay is only possible as far back as log
-   * segments are still available.
+   * <p>The broker will reset the exporter's position to {@code lastExportedPosition} and replay all
+   * log stream records from after {@code lastExportedPosition} onward. Replay is only possible as
+   * far back as log segments are still available.
    *
-   * @param fromPosition the position to start replaying from (inclusive)
+   * @param lastExportedPosition the position to start replaying from (exclusive)
    * @return {@code true} if the log stream reader was successfully seeked to the requested
    *     position, {@code false} if the log segments for that position are no longer available
    */
-  boolean requestReplay(final long fromPosition);
+  boolean requestReplay(final long lastExportedPosition);
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/exporter/ExporterReplayTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/exporter/ExporterReplayTest.java
@@ -78,7 +78,7 @@ final class ExporterReplayTest {
     assertThat(recordsBeforeRestart).isGreaterThan(0);
 
     final var positionsBeforeRestart = List.copyOf(TestExporter.EXPORTED_RECORD_POSITIONS);
-    TestExporter.prepareReplayFrom(positionsBeforeRestart.getFirst());
+    TestExporter.prepareReplayFrom(positionsBeforeRestart.getFirst() - 1);
 
     // when
     cluster.shutdown();


### PR DESCRIPTION
## Description

Late review feedback adjustments for PR https://github.com/camunda/camunda/pull/51062:
- align the exporterPosition parameter for replay. Before there was some unnecessary `position - 1` and `position + 1` in the different layers. Now it is always the `lastExportedPosition`
- only allow replay in `Exporter#open()` and before exporting started. Otherwise reject
- only update the ExporterContainer state when the replay was actually successfull

## Related issues

closes #51048 
