### PR TITLE
fix: pin global listeners config for CLAIMING user task events

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -614,7 +614,8 @@ public final class EventAppliers implements EventApplier {
     register(UserTaskIntent.ASSIGNED, 2, new UserTaskAssignedV2Applier(state));
     register(UserTaskIntent.ASSIGNED, 3, new UserTaskAssignedV3Applier(state));
     register(UserTaskIntent.ASSIGNED, 4, new UserTaskAssignedV4Applier(state));
-    register(UserTaskIntent.CLAIMING, new UserTaskClaimingApplier(state));
+    register(UserTaskIntent.CLAIMING, 1, new UserTaskClaimingV1Applier(state));
+    register(UserTaskIntent.CLAIMING, 2, new UserTaskClaimingV2Applier(state));
     register(UserTaskIntent.UPDATING, 1, new UserTaskUpdatingV1Applier(state));
     register(UserTaskIntent.UPDATING, 2, new UserTaskUpdatingV2Applier(state));
     register(UserTaskIntent.UPDATING, 3, new UserTaskUpdatingV3Applier(state));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskClaimingV1Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskClaimingV1Applier.java
@@ -14,11 +14,12 @@ import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 
-public class UserTaskClaimingApplier implements TypedEventApplier<UserTaskIntent, UserTaskRecord> {
+public class UserTaskClaimingV1Applier
+    implements TypedEventApplier<UserTaskIntent, UserTaskRecord> {
 
   private final MutableUserTaskState userTaskState;
 
-  public UserTaskClaimingApplier(final MutableProcessingState processingState) {
+  public UserTaskClaimingV1Applier(final MutableProcessingState processingState) {
     userTaskState = processingState.getUserTaskState();
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskClaimingV2Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskClaimingV2Applier.java
@@ -8,24 +8,50 @@
 package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.globallistener.MutableGlobalListenersState;
 import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 
-public class UserTaskClaimingV1Applier
+public final class UserTaskClaimingV2Applier
     implements TypedEventApplier<UserTaskIntent, UserTaskRecord> {
 
   private final MutableUserTaskState userTaskState;
+  private final MutableGlobalListenersState globalListenersState;
 
-  public UserTaskClaimingV1Applier(final MutableProcessingState processingState) {
+  public UserTaskClaimingV2Applier(final MutableProcessingState processingState) {
     userTaskState = processingState.getUserTaskState();
+    globalListenersState = processingState.getGlobalListenersState();
   }
 
   @Override
   public void applyState(final long key, final UserTaskRecord value) {
     userTaskState.updateUserTaskLifecycleState(key, LifecycleState.CLAIMING);
+    pinGlobalListenersConfig(value);
     userTaskState.storeIntermediateState(value, LifecycleState.CLAIMING);
+  }
+
+  private void pinGlobalListenersConfig(final UserTaskRecord userTaskRecord) {
+    // Only pin the configuration if it exists
+    final var currentConfig = globalListenersState.getCurrentConfig();
+    if (currentConfig == null) {
+      return;
+    }
+
+    final long currentConfigKey = currentConfig.getGlobalListenerBatchKey();
+
+    // Create versioned config if it does not exist
+    if (!globalListenersState.isConfigurationVersionStored(currentConfigKey)) {
+      globalListenersState.storeConfigurationVersion(currentConfig);
+    }
+
+    // Create pinned entry
+    globalListenersState.pinConfiguration(currentConfigKey, userTaskRecord.getUserTaskKey());
+
+    // Update user task record to reference the pinned config
+    // Note: this value is then stored in the intermediate state
+    userTaskRecord.setListenersConfigKey(currentConfigKey);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/ClaimUserTaskWithGlobalListenerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/ClaimUserTaskWithGlobalListenerTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.usertask;
+
+import static io.camunda.zeebe.test.util.record.RecordingExporter.jobRecords;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskListenerEventType;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.protocol.record.value.JobKind;
+import io.camunda.zeebe.protocol.record.value.JobListenerEventType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ClaimUserTaskWithGlobalListenerTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final String PROCESS_ID = "process";
+  private static final String GLOBAL_LISTENER_TYPE = "globalAssigningListener";
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldTriggerGlobalAssigningListenerWhenClaimingUserTask() {
+    // given
+    ENGINE
+        .globalListener()
+        .withId("GlobalUserTaskListener_Assigning")
+        .withType(GLOBAL_LISTENER_TYPE)
+        .withEventTypes(ZeebeTaskListenerEventType.assigning.name())
+        .create();
+
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .userTask("task")
+                .zeebeUserTask()
+                .endEvent()
+                .done())
+        .deploy();
+
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    final long userTaskKey =
+        RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst()
+            .getKey();
+
+    // when — claim the task
+    ENGINE.userTask().withKey(userTaskKey).withAssignee("demo").claim();
+
+    // then — global "assigning" listener job must be created
+    jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withJobKind(JobKind.TASK_LISTENER)
+        .withJobListenerEventType(JobListenerEventType.ASSIGNING)
+        .withType(GLOBAL_LISTENER_TYPE)
+        .getFirst();
+  }
+}

--- a/zeebe/engine/src/test/resources/state/appliers/golden/UserTask_CLAIMING_v2.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/UserTask_CLAIMING_v2.golden
@@ -8,24 +8,45 @@
 package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.globallistener.MutableGlobalListenersState;
 import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 
-public class UserTaskClaimingV1Applier
+public final class UserTaskClaimingV2Applier
     implements TypedEventApplier<UserTaskIntent, UserTaskRecord> {
 
   private final MutableUserTaskState userTaskState;
+  private final MutableGlobalListenersState globalListenersState;
 
-  public UserTaskClaimingV1Applier(final MutableProcessingState processingState) {
+  public UserTaskClaimingV2Applier(final MutableProcessingState processingState) {
     userTaskState = processingState.getUserTaskState();
+    globalListenersState = processingState.getGlobalListenersState();
   }
 
   @Override
   public void applyState(final long key, final UserTaskRecord value) {
     userTaskState.updateUserTaskLifecycleState(key, LifecycleState.CLAIMING);
+    pinGlobalListenersConfig(value);
     userTaskState.storeIntermediateState(value, LifecycleState.CLAIMING);
+  }
+
+  private void pinGlobalListenersConfig(final UserTaskRecord userTaskRecord) {
+    final var currentConfig = globalListenersState.getCurrentConfig();
+    if (currentConfig == null) {
+      return;
+    }
+
+    final long currentConfigKey = currentConfig.getGlobalListenerBatchKey();
+
+    if (!globalListenersState.isConfigurationVersionStored(currentConfigKey)) {
+      globalListenersState.storeConfigurationVersion(currentConfig);
+    }
+
+    globalListenersState.pinConfiguration(currentConfigKey, userTaskRecord.getUserTaskKey());
+
+    userTaskRecord.setListenersConfigKey(currentConfigKey);
   }
 }

--- a/zeebe/engine/src/test/resources/state/appliers/golden/UserTask_CLAIMING_v2.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/UserTask_CLAIMING_v2.golden
@@ -34,6 +34,7 @@ public final class UserTaskClaimingV2Applier
   }
 
   private void pinGlobalListenersConfig(final UserTaskRecord userTaskRecord) {
+    // Only pin the configuration if it exists
     final var currentConfig = globalListenersState.getCurrentConfig();
     if (currentConfig == null) {
       return;
@@ -41,12 +42,16 @@ public final class UserTaskClaimingV2Applier
 
     final long currentConfigKey = currentConfig.getGlobalListenerBatchKey();
 
+    // Create versioned config if it does not exist
     if (!globalListenersState.isConfigurationVersionStored(currentConfigKey)) {
       globalListenersState.storeConfigurationVersion(currentConfig);
     }
 
+    // Create pinned entry
     globalListenersState.pinConfiguration(currentConfigKey, userTaskRecord.getUserTaskKey());
 
+    // Update user task record to reference the pinned config
+    // Note: this value is then stored in the intermediate state
     userTaskRecord.setListenersConfigKey(currentConfigKey);
   }
 }


### PR DESCRIPTION
## Summary

- `UserTaskClaimingApplier` was missing a call to `pinGlobalListenersConfig()`, so no `listenersConfigKey` was stored in the intermediate state for CLAIM operations
- `BpmnUserTaskBehavior.getTaskListeners()` uses this key to load the global listener config; without it the list was always empty for CLAIM, silently skipping all global assigning listeners
- Affects all CLAIM commands (REST API `POST /user-tasks/{key}/assignment` with `allowOverride=false`, Java client default)
- ASSIGN commands (`allowOverride=true`) were unaffected because `UserTaskAssigningV3Applier` already pins the config

**Fix:** Added `UserTaskClaimingV2Applier` that mirrors the `pinGlobalListenersConfig()` logic from `UserTaskAssigningV3Applier`, registered as version 2 for `UserTaskIntent.CLAIMING`. The original applier is kept as version 1 for backwards-compatible replay of events already in the log.

**Reproducer:** `ClaimUserTaskWithGlobalListenerTest` — configures a global "assigning" listener, claims a user task, and asserts the listener job is triggered before the task reaches ASSIGNED state.

## Links

Closes #51990

https://claude.ai/code/session_01QJauDR2Gm2bUjDkorJNbyn