### PR TITLE
Bump backport-action to v4.5.0 and enable summary comments

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -74,6 +74,7 @@ jobs:
 
           add_author_as_assignee: true
           add_author_as_reviewer: true
+          comment_style: summary
           experimental: >
             {
               "conflict_resolution": "draft_commit_conflicts"

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -49,7 +49,7 @@ jobs:
           # Token for git actions, e.g. git push
           token: ${{ steps.github-token.outputs.token }}
       - name: Create backport PRs
-        uses: korthout/backport-action@3c06f323a58619da1e8522229ebc8d5de2633e46 # v4.3.0
+        uses: korthout/backport-action@7c3f6cd5843cac11bc59a04a1b7699af93261670 # v4.5.0
         with:
           # Token to authenticate requests to GitHub
           github_token: ${{ steps.github-token.outputs.token }}


### PR DESCRIPTION
## Description

Bumps `korthout/backport-action` from v4.3.0 to v4.5.0 and opts in to the new `comment_style: summary` option. The summary style posts a single progressively-updated comment per workflow run with a status table for each target branch and recovery hints for known failure modes (e.g. cherry-pick conflicts, push permission denied), instead of one comment per target.

Release notes: https://github.com/korthout/backport-action/releases/tag/v4.5.0

Here's what a `summary` comment can look like mid-run:

> [Backport-action](https://github.com/korthout/backport-action) is backporting this pull request in [workflow run 15439584062](https://github.com/korthout/backport-action/actions/runs/15439584062).
>
> | Target | Status |
> |--------|--------|
> | `stable/8.7` | :white_check_mark: Created #612 |
> | `stable/8.6` | :warning: Drafted with conflicts #613 |
> | `stable/8.5` | :x: Failed |
> | `stable/8.4` | :heavy_minus_sign: Skipped (PR already exists) |
> | `stable/8.3` | :hourglass: Pending |
>
> <details><summary>:x: stable/8.5 — unable to cherry-pick</summary>
>
> Tried to cherry-pick commits onto `stable/8.5`, but the cherry-pick failed.
>
> Please cherry-pick the changes locally and resolve any conflicts.
> ```bash
> git fetch origin stable/8.5
> git worktree add -d .worktree/stable/8.5 origin/stable/8.5
> cd .worktree/stable/8.5
> git switch --create <backport-branch-name>
> git cherry-pick -x a1b2c3d e4f5g6h
> ```
>
> </details>

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

No related issue
