### PR TITLE
[PoC] Engine records design for agent instance metrics

### DIFF
--- a/alignment-decisions.md
+++ b/alignment-decisions.md
@@ -107,3 +107,35 @@ mentioned.
 The connector tracing design will need to expand `LimitsInfo` to carry
 `maxTokens` and `maxToolCalls` when creating the execution entity. This is
 additive on the connector side and does not require engine changes.
+
+## 7. Concern: tracing event volume vs. RAFT commit cost
+
+**Date**: 2026-04-24
+**Status**: Open concern
+**Context**: The tracing design's API (`POST /agent-executions/{key}/events`)
+is implemented by appending commands to Zeebe. Every command goes through full
+RAFT consensus including replication. The design document does not acknowledge
+this cost — it treats the backend as an opaque HTTP endpoint with cheap writes
+(section 10.2: "Best-effort — failures are logged but do not fail the job",
+section 10.3: "stateless transport abstraction").
+
+The design buffers events and flushes them at 3 points per iteration (before
+LLM call, after iteration completion, job completion safety net). A typical
+2-iteration agent run with 2 tool calls produces roughly 10-12 individual
+events across these flush points.
+
+**Concern**: If each flush maps to **one Zeebe command** carrying the event
+batch as payload, that's 2-3 additional RAFT commits per iteration — comparable
+to what Zeebe already does for the job lifecycle and likely acceptable.
+
+If each event in a flush batch becomes **its own Zeebe command**, the cost
+scales with the number of events. A single iteration with 2 tool results
+generates 6-7 commands. An agent calling 5 tools in one turn produces ~10
+commands for that iteration alone. This is too much additional load on the
+partition.
+
+**Recommendation**: The connector team should ensure that each flush maps to
+exactly one Zeebe command, with the batch of events carried as payload within
+that single command. The design's existing flush-point model (3 flushes per
+iteration) is a reasonable upper bound if this batching is enforced. The number
+of events within a batch should not affect the number of RAFT commits.

--- a/alignment-decisions.md
+++ b/alignment-decisions.md
@@ -74,25 +74,30 @@ record has a field named `provider` that holds the same data.
 generic `type` and aligns with other engine records that use descriptive field
 names.
 
-## 5. Keep current status enum (IDLE, THINKING, CALLING_TOOL)
+## 5. Expand status enum to model the full agent lifecycle
 
-**Date**: 2026-04-24
-**Status**: Accepted
-**Context**: The tracing design derives a richer status model from the event
-stream (initializing, discovering, ready/idle, reasoning, calling_tool,
-responded, failed). Our engine record has three statuses.
+**Date**: 2026-04-28
+**Status**: Accepted (supersedes the 2026-04-24 decision to keep IDLE / THINKING
+/ CALLING_TOOL)
+**Context**: The original three-state enum (IDLE, THINKING, CALLING_TOOL) did
+not cover the initial state right after creation, the tool-discovery phase, or
+the deletion of an agent instance. Without explicit states the engine record
+could not distinguish "just created" from "idle awaiting input", and there was
+no terminal state for deleted instances.
 
-**Decision**: Keep the current enum. The engine status represents the
-BPMN-visible operational state. The tracing design explicitly states "Execution
-activity is determined by BPMN state, not by tracing events" (design.md section
-4). Fine-grained status derivation belongs to the tracing layer, not the engine
-record.
+**Decision**: Use the following states with these transitions:
 
-**Note**: The `initializing` and `discovering` states in the tracing design
-occur inside the connector before the engine's CREATE command is sent, so they
-are not applicable to the engine record. The `responded` and `failed` states
-map to BPMN lifecycle events (AHSP completion, incidents) rather than the agent
-instance's operational status.
+- `INITIALIZING` — initial state after creation, before the first update.
+- `INITIALIZING` → `TOOL_DISCOVERY` or `THINKING`.
+- `TOOL_DISCOVERY` → `THINKING`.
+- `THINKING` → `TOOL_CALLING` or `IDLE`.
+- `TOOL_CALLING` → `THINKING`.
+- `IDLE` → `THINKING`.
+- From any status → `DELETED` (terminal).
+
+The enum value `CALLING_TOOL` is renamed to `TOOL_CALLING` for naming
+consistency with `TOOL_DISCOVERY`. The default value of the status property
+becomes `INITIALIZING`.
 
 ## 6. Engine record limits are ahead of the tracing design
 

--- a/alignment-decisions.md
+++ b/alignment-decisions.md
@@ -1,0 +1,109 @@
+# Agent Instance Record — Alignment Decisions
+
+Decisions made while aligning the engine record schema with the connector
+tracing design (camunda/connectors#7029).
+
+## 1. Add `elementId` field to match CreateAgentExecutionRequest
+
+**Date**: 2026-04-24
+**Status**: Accepted
+**Context**: The connector tracing design's `CreateAgentExecutionRequest`
+includes an `elementId` field (the BPMN element ID of the Ad-Hoc Sub-Process).
+This is the static model-level identifier, as opposed to `elementInstanceKey`
+which is the runtime key. Many other Zeebe records carry `elementId`
+(ProcessInstanceRecord, JobRecord, IncidentRecord, etc.).
+
+**Decision**: Add `getElementId()` to `AgentInstanceRecordValue` and
+`elementId` (String, default `""`) to `AgentInstanceRecord`. This field is set
+once at creation and carried unchanged on subsequent events.
+
+**Rationale**: `elementId` is needed for definition-level aggregation — the
+tracing design's metrics at process-definition scope (#26, #33, #35, #36) group
+by element ID to compare behavior across instances of the same BPMN element. It
+also enables joining agent instances to their BPMN definition elements for
+tooling and visualization. Adding it follows the established convention in the
+codebase.
+
+## 2. Add `toolCalls` metric field
+
+**Date**: 2026-04-24
+**Status**: Accepted
+**Context**: The tracing design defines "tool call count" as metric #12:
+`SUM(TOOL_CALLS_EMITTED.toolCalls.size())`. The engine record already carries
+three aggregate metrics (inputTokens, outputTokens, modelCalls) but was missing
+tool calls.
+
+**Decision**: Add `getToolCalls()` to `AgentInstanceRecordValue` and
+`toolCalls` (long, default 0) to `AgentInstanceRecord`. Follows the same
+delta/aggregate semantics as the other metric fields: UPDATE commands carry
+deltas, UPDATED events carry aggregated totals.
+
+**Rationale**: Tool call count is a key operational metric for agent visibility.
+The tracing design tracks it at both agent scope (#12) and process-definition
+scope (#33). Having it as an aggregate on the engine record alongside the other
+metrics keeps the record self-consistent and allows the engine to expose it
+without requiring consumers to replay the fine-grained event stream.
+
+## 3. Keep `agentInstanceKey` naming (do not rename to agentExecutionKey)
+
+**Date**: 2026-04-24
+**Status**: Accepted
+**Context**: The connector tracing design uses `agentExecutionKey` for the
+server-assigned identifier. Our engine record uses `agentInstanceKey`. These
+refer to the same concept.
+
+**Decision**: Keep `agentInstanceKey` in the engine protocol. The connector
+maps between naming conventions at the boundary.
+
+**Rationale**: The Zeebe engine consistently uses "instance" terminology
+(processInstanceKey, elementInstanceKey, etc.). Renaming to "execution" would
+break this convention for one record type. The connector side is free to use its
+own terminology. The tracing design already bridges this gap — its
+`CreateAgentExecutionRequest` returns an `agentExecutionKey` which is the same
+Long value as the engine's `agentInstanceKey`.
+
+## 4. Keep `provider` field naming (do not rename to providerType)
+
+**Date**: 2026-04-24
+**Status**: Accepted
+**Context**: The tracing design uses `ProviderInfo(String type, String model)`
+where `type` holds the provider identifier (e.g., "openai", "anthropic"). Our
+record has a field named `provider` that holds the same data.
+
+**Decision**: Keep the field named `provider`. It is more descriptive than the
+generic `type` and aligns with other engine records that use descriptive field
+names.
+
+## 5. Keep current status enum (IDLE, THINKING, CALLING_TOOL)
+
+**Date**: 2026-04-24
+**Status**: Accepted
+**Context**: The tracing design derives a richer status model from the event
+stream (initializing, discovering, ready/idle, reasoning, calling_tool,
+responded, failed). Our engine record has three statuses.
+
+**Decision**: Keep the current enum. The engine status represents the
+BPMN-visible operational state. The tracing design explicitly states "Execution
+activity is determined by BPMN state, not by tracing events" (design.md section
+4). Fine-grained status derivation belongs to the tracing layer, not the engine
+record.
+
+**Note**: The `initializing` and `discovering` states in the tracing design
+occur inside the connector before the engine's CREATE command is sent, so they
+are not applicable to the engine record. The `responded` and `failed` states
+map to BPMN lifecycle events (AHSP completion, incidents) rather than the agent
+instance's operational status.
+
+## 6. Engine record limits are ahead of the tracing design
+
+**Date**: 2026-04-24
+**Status**: Noted
+**Context**: Our record has `maxTokens`, `maxModelCalls`, and `maxToolCalls`.
+The tracing design's `LimitsInfo` currently only has `maxModelCalls`, with
+`maxTokens` noted as planned (design.md section 15.1) and `maxToolCalls` not
+mentioned.
+
+**Decision**: No change to the engine record — it already has the right fields.
+The connector tracing design will need to expand `LimitsInfo` to carry
+`maxTokens` and `maxToolCalls` when creating the execution entity. This is
+additive on the connector side and does not require engine changes.

--- a/decisions.md
+++ b/decisions.md
@@ -1,0 +1,57 @@
+# Agent Instance — Design Decisions
+
+## 1. Metric fields carry deltas on commands, aggregates on events
+
+**Date**: 2026-04-24
+**Status**: Accepted
+**Context**: The connector needs to report token consumption incrementally (per
+LLM call), and the engine must maintain running totals. The BI team will also
+consume this data for analysis.
+
+**Decision**: The `inputTokens`, `outputTokens`, and `modelCalls` fields on an
+`AgentInstanceRecord` have different semantics depending on the record type:
+
+- **UPDATE command**: fields carry *deltas* (e.g. "this call used 500 input
+  tokens").
+- **UPDATED event**: fields carry *aggregated totals* after the engine applies
+  the delta to its state.
+
+This means the engine processor adds the command's values to the current state
+and writes the new totals on the event.
+
+**Rationale**: This design keeps the record schema simple (no separate delta
+fields) while still allowing the engine to aggregate. It follows the existing
+Zeebe convention where command records and event records share the same value
+type but carry different semantic meaning — the processor transforms the
+command into the event.
+
+**Trade-off**: Consumers that want to see both incremental updates *and*
+aggregates need to look at both the UPDATE command records and the UPDATED
+event records. The BI team may want both views (e.g. per-call cost breakdown
+vs. total cost per agent run). This is possible because both command and event
+records are exported to secondary storage, but it requires the BI team to be
+aware of the dual semantics.
+
+**Open question for BI team**: Do they need access to the per-call deltas
+(command records), the running totals (event records), or both? If both are
+needed, the current design supports it — the BI team queries UPDATE commands
+for deltas and UPDATED events for totals. If only totals are needed, they can
+ignore command records entirely. Discuss with the BI team to confirm their
+requirements before finalizing the exporter configuration.
+
+## 2. Limit fields are creation-time immutable metadata
+
+**Date**: 2026-04-24
+**Status**: Accepted
+**Context**: The connector sets limits when creating an agent instance. These
+do not change over the lifetime of the agent instance.
+
+**Decision**: Three limit fields are included on the record:
+
+- `maxTokens` — combined input + output token limit
+- `maxModelCalls` — maximum number of LLM calls
+- `maxToolCalls` — maximum number of tool invocations
+
+All default to `-1` (meaning not set), following the codebase convention
+where `-1` indicates an optional value that was not configured. They are set
+once on the CREATE command and carried unchanged on all subsequent events.

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/UnifiedRecordValue.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/UnifiedRecordValue.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.AsyncRequestRecord;
 import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessInstructionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.IdentitySetupRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRuleRecord;
@@ -147,6 +148,7 @@ public class UnifiedRecordValue extends UnpackedObject implements RecordValue {
 
   public static UnifiedRecordValue fromValueType(final ValueType valueType) {
     return switch (valueType) {
+      case ValueType.AGENT_INSTANCE -> new AgentInstanceRecord();
       case ValueType.DEPLOYMENT -> new DeploymentRecord();
       case ValueType.JOB -> new JobRecord();
       case ValueType.PROCESS_INSTANCE -> new ProcessInstanceRecord();

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecord.java
@@ -22,6 +22,7 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
 
   private static final StringValue AGENT_INSTANCE_KEY_KEY = new StringValue("agentInstanceKey");
   private static final StringValue ELEMENT_INSTANCE_KEY_KEY = new StringValue("elementInstanceKey");
+  private static final StringValue ELEMENT_ID_KEY = new StringValue("elementId");
   private static final StringValue PROCESS_INSTANCE_KEY_KEY = new StringValue("processInstanceKey");
   private static final StringValue PROCESS_DEFINITION_KEY_KEY =
       new StringValue("processDefinitionKey");
@@ -33,6 +34,7 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
   private static final StringValue INPUT_TOKENS_KEY = new StringValue("inputTokens");
   private static final StringValue OUTPUT_TOKENS_KEY = new StringValue("outputTokens");
   private static final StringValue MODEL_CALLS_KEY = new StringValue("modelCalls");
+  private static final StringValue TOOL_CALLS_KEY = new StringValue("toolCalls");
   private static final StringValue MAX_TOKENS_KEY = new StringValue("maxTokens");
   private static final StringValue MAX_MODEL_CALLS_KEY = new StringValue("maxModelCalls");
   private static final StringValue MAX_TOOL_CALLS_KEY = new StringValue("maxToolCalls");
@@ -40,6 +42,7 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
   private final LongProperty agentInstanceKeyProp = new LongProperty(AGENT_INSTANCE_KEY_KEY, -1L);
   private final LongProperty elementInstanceKeyProp =
       new LongProperty(ELEMENT_INSTANCE_KEY_KEY, -1L);
+  private final StringProperty elementIdProp = new StringProperty(ELEMENT_ID_KEY, "");
   private final LongProperty processInstanceKeyProp =
       new LongProperty(PROCESS_INSTANCE_KEY_KEY, -1L);
   private final LongProperty processDefinitionKeyProp =
@@ -54,14 +57,16 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
   private final LongProperty inputTokensProp = new LongProperty(INPUT_TOKENS_KEY, 0);
   private final LongProperty outputTokensProp = new LongProperty(OUTPUT_TOKENS_KEY, 0);
   private final LongProperty modelCallsProp = new LongProperty(MODEL_CALLS_KEY, 0);
+  private final LongProperty toolCallsProp = new LongProperty(TOOL_CALLS_KEY, 0);
   private final LongProperty maxTokensProp = new LongProperty(MAX_TOKENS_KEY, -1L);
   private final LongProperty maxModelCallsProp = new LongProperty(MAX_MODEL_CALLS_KEY, -1L);
   private final LongProperty maxToolCallsProp = new LongProperty(MAX_TOOL_CALLS_KEY, -1L);
 
   public AgentInstanceRecord() {
-    super(15);
+    super(17);
     declareProperty(agentInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
+        .declareProperty(elementIdProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(processDefinitionKeyProp)
         .declareProperty(tenantIdProp)
@@ -72,6 +77,7 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
         .declareProperty(inputTokensProp)
         .declareProperty(outputTokensProp)
         .declareProperty(modelCallsProp)
+        .declareProperty(toolCallsProp)
         .declareProperty(maxTokensProp)
         .declareProperty(maxModelCallsProp)
         .declareProperty(maxToolCallsProp);
@@ -94,6 +100,16 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
 
   public AgentInstanceRecord setElementInstanceKey(final long key) {
     elementInstanceKeyProp.setValue(key);
+    return this;
+  }
+
+  @Override
+  public String getElementId() {
+    return bufferAsString(elementIdProp.getValue());
+  }
+
+  public AgentInstanceRecord setElementId(final String elementId) {
+    elementIdProp.setValue(elementId);
     return this;
   }
 
@@ -194,6 +210,16 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
 
   public AgentInstanceRecord setModelCalls(final long modelCalls) {
     modelCallsProp.setValue(modelCalls);
+    return this;
+  }
+
+  @Override
+  public long getToolCalls() {
+    return toolCallsProp.getValue();
+  }
+
+  public AgentInstanceRecord setToolCalls(final long toolCalls) {
+    toolCallsProp.setValue(toolCalls);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecord.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.agentinstance;
+
+import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
+
+import io.camunda.zeebe.msgpack.property.EnumProperty;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.StringValue;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.AgentInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+
+public final class AgentInstanceRecord extends UnifiedRecordValue
+    implements AgentInstanceRecordValue {
+
+  private static final StringValue AGENT_INSTANCE_KEY_KEY = new StringValue("agentInstanceKey");
+  private static final StringValue ELEMENT_INSTANCE_KEY_KEY = new StringValue("elementInstanceKey");
+  private static final StringValue PROCESS_INSTANCE_KEY_KEY = new StringValue("processInstanceKey");
+  private static final StringValue PROCESS_DEFINITION_KEY_KEY =
+      new StringValue("processDefinitionKey");
+  private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
+  private static final StringValue STATUS_KEY = new StringValue("status");
+  private static final StringValue MODEL_KEY = new StringValue("model");
+  private static final StringValue PROVIDER_KEY = new StringValue("provider");
+  private static final StringValue SYSTEM_PROMPT_KEY = new StringValue("systemPrompt");
+  private static final StringValue INPUT_TOKENS_KEY = new StringValue("inputTokens");
+  private static final StringValue OUTPUT_TOKENS_KEY = new StringValue("outputTokens");
+  private static final StringValue MODEL_CALLS_KEY = new StringValue("modelCalls");
+  private static final StringValue MAX_TOKENS_KEY = new StringValue("maxTokens");
+  private static final StringValue MAX_MODEL_CALLS_KEY = new StringValue("maxModelCalls");
+  private static final StringValue MAX_TOOL_CALLS_KEY = new StringValue("maxToolCalls");
+
+  private final LongProperty agentInstanceKeyProp = new LongProperty(AGENT_INSTANCE_KEY_KEY, -1L);
+  private final LongProperty elementInstanceKeyProp =
+      new LongProperty(ELEMENT_INSTANCE_KEY_KEY, -1L);
+  private final LongProperty processInstanceKeyProp =
+      new LongProperty(PROCESS_INSTANCE_KEY_KEY, -1L);
+  private final LongProperty processDefinitionKeyProp =
+      new LongProperty(PROCESS_DEFINITION_KEY_KEY, -1L);
+  private final StringProperty tenantIdProp =
+      new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final EnumProperty<AgentInstanceStatus> statusProp =
+      new EnumProperty<>(STATUS_KEY, AgentInstanceStatus.class, AgentInstanceStatus.IDLE);
+  private final StringProperty modelProp = new StringProperty(MODEL_KEY, "");
+  private final StringProperty providerProp = new StringProperty(PROVIDER_KEY, "");
+  private final StringProperty systemPromptProp = new StringProperty(SYSTEM_PROMPT_KEY, "");
+  private final LongProperty inputTokensProp = new LongProperty(INPUT_TOKENS_KEY, 0);
+  private final LongProperty outputTokensProp = new LongProperty(OUTPUT_TOKENS_KEY, 0);
+  private final LongProperty modelCallsProp = new LongProperty(MODEL_CALLS_KEY, 0);
+  private final LongProperty maxTokensProp = new LongProperty(MAX_TOKENS_KEY, -1L);
+  private final LongProperty maxModelCallsProp = new LongProperty(MAX_MODEL_CALLS_KEY, -1L);
+  private final LongProperty maxToolCallsProp = new LongProperty(MAX_TOOL_CALLS_KEY, -1L);
+
+  public AgentInstanceRecord() {
+    super(15);
+    declareProperty(agentInstanceKeyProp)
+        .declareProperty(elementInstanceKeyProp)
+        .declareProperty(processInstanceKeyProp)
+        .declareProperty(processDefinitionKeyProp)
+        .declareProperty(tenantIdProp)
+        .declareProperty(statusProp)
+        .declareProperty(modelProp)
+        .declareProperty(providerProp)
+        .declareProperty(systemPromptProp)
+        .declareProperty(inputTokensProp)
+        .declareProperty(outputTokensProp)
+        .declareProperty(modelCallsProp)
+        .declareProperty(maxTokensProp)
+        .declareProperty(maxModelCallsProp)
+        .declareProperty(maxToolCallsProp);
+  }
+
+  @Override
+  public long getAgentInstanceKey() {
+    return agentInstanceKeyProp.getValue();
+  }
+
+  public AgentInstanceRecord setAgentInstanceKey(final long key) {
+    agentInstanceKeyProp.setValue(key);
+    return this;
+  }
+
+  @Override
+  public long getElementInstanceKey() {
+    return elementInstanceKeyProp.getValue();
+  }
+
+  public AgentInstanceRecord setElementInstanceKey(final long key) {
+    elementInstanceKeyProp.setValue(key);
+    return this;
+  }
+
+  @Override
+  public long getProcessInstanceKey() {
+    return processInstanceKeyProp.getValue();
+  }
+
+  public AgentInstanceRecord setProcessInstanceKey(final long key) {
+    processInstanceKeyProp.setValue(key);
+    return this;
+  }
+
+  @Override
+  public long getProcessDefinitionKey() {
+    return processDefinitionKeyProp.getValue();
+  }
+
+  public AgentInstanceRecord setProcessDefinitionKey(final long key) {
+    processDefinitionKeyProp.setValue(key);
+    return this;
+  }
+
+  @Override
+  public String getTenantId() {
+    return bufferAsString(tenantIdProp.getValue());
+  }
+
+  public AgentInstanceRecord setTenantId(final String tenantId) {
+    tenantIdProp.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public AgentInstanceStatus getStatus() {
+    return statusProp.getValue();
+  }
+
+  public AgentInstanceRecord setStatus(final AgentInstanceStatus status) {
+    statusProp.setValue(status);
+    return this;
+  }
+
+  @Override
+  public String getModel() {
+    return bufferAsString(modelProp.getValue());
+  }
+
+  public AgentInstanceRecord setModel(final String model) {
+    modelProp.setValue(model);
+    return this;
+  }
+
+  @Override
+  public String getProvider() {
+    return bufferAsString(providerProp.getValue());
+  }
+
+  public AgentInstanceRecord setProvider(final String provider) {
+    providerProp.setValue(provider);
+    return this;
+  }
+
+  @Override
+  public String getSystemPrompt() {
+    return bufferAsString(systemPromptProp.getValue());
+  }
+
+  public AgentInstanceRecord setSystemPrompt(final String systemPrompt) {
+    systemPromptProp.setValue(systemPrompt);
+    return this;
+  }
+
+  @Override
+  public long getInputTokens() {
+    return inputTokensProp.getValue();
+  }
+
+  public AgentInstanceRecord setInputTokens(final long inputTokens) {
+    inputTokensProp.setValue(inputTokens);
+    return this;
+  }
+
+  @Override
+  public long getOutputTokens() {
+    return outputTokensProp.getValue();
+  }
+
+  public AgentInstanceRecord setOutputTokens(final long outputTokens) {
+    outputTokensProp.setValue(outputTokens);
+    return this;
+  }
+
+  @Override
+  public long getModelCalls() {
+    return modelCallsProp.getValue();
+  }
+
+  public AgentInstanceRecord setModelCalls(final long modelCalls) {
+    modelCallsProp.setValue(modelCalls);
+    return this;
+  }
+
+  @Override
+  public long getMaxTokens() {
+    return maxTokensProp.getValue();
+  }
+
+  public AgentInstanceRecord setMaxTokens(final long maxTokens) {
+    maxTokensProp.setValue(maxTokens);
+    return this;
+  }
+
+  @Override
+  public long getMaxModelCalls() {
+    return maxModelCallsProp.getValue();
+  }
+
+  public AgentInstanceRecord setMaxModelCalls(final long maxModelCalls) {
+    maxModelCallsProp.setValue(maxModelCalls);
+    return this;
+  }
+
+  @Override
+  public long getMaxToolCalls() {
+    return maxToolCallsProp.getValue();
+  }
+
+  public AgentInstanceRecord setMaxToolCalls(final long maxToolCalls) {
+    maxToolCallsProp.setValue(maxToolCalls);
+    return this;
+  }
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecord.java
@@ -50,7 +50,7 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
   private final StringProperty tenantIdProp =
       new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final EnumProperty<AgentInstanceStatus> statusProp =
-      new EnumProperty<>(STATUS_KEY, AgentInstanceStatus.class, AgentInstanceStatus.IDLE);
+      new EnumProperty<>(STATUS_KEY, AgentInstanceStatus.class, AgentInstanceStatus.INITIALIZING);
   private final StringProperty modelProp = new StringProperty(MODEL_KEY, "");
   private final StringProperty providerProp = new StringProperty(PROVIDER_KEY, "");
   private final StringProperty systemPromptProp = new StringProperty(SYSTEM_PROMPT_KEY, "");

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.impl.record.VersionInfo;
 import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessInstructionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.IdentitySetupRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRuleRecord;
@@ -96,6 +97,7 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.intent.HistoryDeletionIntent;
+import io.camunda.zeebe.protocol.record.value.AgentInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
@@ -4622,6 +4624,71 @@ final class JsonSerializableToJsonTest {
       "source": "CONFIGURATION",
       "listenerType": "USER_TASK",
       "configKey": -1
+    }
+    """
+      },
+      //////////////////////////////////// AgentInstanceRecord /////////////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "AgentInstanceRecord",
+        (Supplier<AgentInstanceRecord>)
+            () ->
+                new AgentInstanceRecord()
+                    .setAgentInstanceKey(100L)
+                    .setElementInstanceKey(200L)
+                    .setProcessInstanceKey(300L)
+                    .setProcessDefinitionKey(400L)
+                    .setTenantId("tenant-1")
+                    .setStatus(AgentInstanceRecordValue.AgentInstanceStatus.THINKING)
+                    .setModel("gpt-4")
+                    .setProvider("openai")
+                    .setSystemPrompt("You are a helpful assistant.")
+                    .setInputTokens(1500)
+                    .setOutputTokens(500)
+                    .setModelCalls(3)
+                    .setMaxTokens(10000)
+                    .setMaxModelCalls(50)
+                    .setMaxToolCalls(100),
+        """
+    {
+      "agentInstanceKey": 100,
+      "elementInstanceKey": 200,
+      "processInstanceKey": 300,
+      "processDefinitionKey": 400,
+      "tenantId": "tenant-1",
+      "status": "THINKING",
+      "model": "gpt-4",
+      "provider": "openai",
+      "systemPrompt": "You are a helpful assistant.",
+      "inputTokens": 1500,
+      "outputTokens": 500,
+      "modelCalls": 3,
+      "maxTokens": 10000,
+      "maxModelCalls": 50,
+      "maxToolCalls": 100
+    }
+    """
+      },
+      {
+        "Empty AgentInstanceRecord",
+        (Supplier<AgentInstanceRecord>) AgentInstanceRecord::new,
+        """
+    {
+      "agentInstanceKey": -1,
+      "elementInstanceKey": -1,
+      "processInstanceKey": -1,
+      "processDefinitionKey": -1,
+      "tenantId": "<default>",
+      "status": "IDLE",
+      "model": "",
+      "provider": "",
+      "systemPrompt": "",
+      "inputTokens": 0,
+      "outputTokens": 0,
+      "modelCalls": 0,
+      "maxTokens": -1,
+      "maxModelCalls": -1,
+      "maxToolCalls": -1
     }
     """
       }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -4636,6 +4636,7 @@ final class JsonSerializableToJsonTest {
                 new AgentInstanceRecord()
                     .setAgentInstanceKey(100L)
                     .setElementInstanceKey(200L)
+                    .setElementId("Activity_agent_1")
                     .setProcessInstanceKey(300L)
                     .setProcessDefinitionKey(400L)
                     .setTenantId("tenant-1")
@@ -4646,6 +4647,7 @@ final class JsonSerializableToJsonTest {
                     .setInputTokens(1500)
                     .setOutputTokens(500)
                     .setModelCalls(3)
+                    .setToolCalls(7)
                     .setMaxTokens(10000)
                     .setMaxModelCalls(50)
                     .setMaxToolCalls(100),
@@ -4653,6 +4655,7 @@ final class JsonSerializableToJsonTest {
     {
       "agentInstanceKey": 100,
       "elementInstanceKey": 200,
+      "elementId": "Activity_agent_1",
       "processInstanceKey": 300,
       "processDefinitionKey": 400,
       "tenantId": "tenant-1",
@@ -4663,6 +4666,7 @@ final class JsonSerializableToJsonTest {
       "inputTokens": 1500,
       "outputTokens": 500,
       "modelCalls": 3,
+      "toolCalls": 7,
       "maxTokens": 10000,
       "maxModelCalls": 50,
       "maxToolCalls": 100
@@ -4676,6 +4680,7 @@ final class JsonSerializableToJsonTest {
     {
       "agentInstanceKey": -1,
       "elementInstanceKey": -1,
+      "elementId": "",
       "processInstanceKey": -1,
       "processDefinitionKey": -1,
       "tenantId": "<default>",
@@ -4686,6 +4691,7 @@ final class JsonSerializableToJsonTest {
       "inputTokens": 0,
       "outputTokens": 0,
       "modelCalls": 0,
+      "toolCalls": 0,
       "maxTokens": -1,
       "maxModelCalls": -1,
       "maxToolCalls": -1

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentInstanceRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentInstanceRecord.golden
@@ -22,6 +22,7 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
 
   private static final StringValue AGENT_INSTANCE_KEY_KEY = new StringValue("agentInstanceKey");
   private static final StringValue ELEMENT_INSTANCE_KEY_KEY = new StringValue("elementInstanceKey");
+  private static final StringValue ELEMENT_ID_KEY = new StringValue("elementId");
   private static final StringValue PROCESS_INSTANCE_KEY_KEY = new StringValue("processInstanceKey");
   private static final StringValue PROCESS_DEFINITION_KEY_KEY =
       new StringValue("processDefinitionKey");
@@ -33,6 +34,7 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
   private static final StringValue INPUT_TOKENS_KEY = new StringValue("inputTokens");
   private static final StringValue OUTPUT_TOKENS_KEY = new StringValue("outputTokens");
   private static final StringValue MODEL_CALLS_KEY = new StringValue("modelCalls");
+  private static final StringValue TOOL_CALLS_KEY = new StringValue("toolCalls");
   private static final StringValue MAX_TOKENS_KEY = new StringValue("maxTokens");
   private static final StringValue MAX_MODEL_CALLS_KEY = new StringValue("maxModelCalls");
   private static final StringValue MAX_TOOL_CALLS_KEY = new StringValue("maxToolCalls");
@@ -40,6 +42,7 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
   private final LongProperty agentInstanceKeyProp = new LongProperty(AGENT_INSTANCE_KEY_KEY, -1L);
   private final LongProperty elementInstanceKeyProp =
       new LongProperty(ELEMENT_INSTANCE_KEY_KEY, -1L);
+  private final StringProperty elementIdProp = new StringProperty(ELEMENT_ID_KEY, "");
   private final LongProperty processInstanceKeyProp =
       new LongProperty(PROCESS_INSTANCE_KEY_KEY, -1L);
   private final LongProperty processDefinitionKeyProp =
@@ -54,14 +57,16 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
   private final LongProperty inputTokensProp = new LongProperty(INPUT_TOKENS_KEY, 0);
   private final LongProperty outputTokensProp = new LongProperty(OUTPUT_TOKENS_KEY, 0);
   private final LongProperty modelCallsProp = new LongProperty(MODEL_CALLS_KEY, 0);
+  private final LongProperty toolCallsProp = new LongProperty(TOOL_CALLS_KEY, 0);
   private final LongProperty maxTokensProp = new LongProperty(MAX_TOKENS_KEY, -1L);
   private final LongProperty maxModelCallsProp = new LongProperty(MAX_MODEL_CALLS_KEY, -1L);
   private final LongProperty maxToolCallsProp = new LongProperty(MAX_TOOL_CALLS_KEY, -1L);
 
   public AgentInstanceRecord() {
-    super(15);
+    super(17);
     declareProperty(agentInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
+        .declareProperty(elementIdProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(processDefinitionKeyProp)
         .declareProperty(tenantIdProp)
@@ -72,6 +77,7 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
         .declareProperty(inputTokensProp)
         .declareProperty(outputTokensProp)
         .declareProperty(modelCallsProp)
+        .declareProperty(toolCallsProp)
         .declareProperty(maxTokensProp)
         .declareProperty(maxModelCallsProp)
         .declareProperty(maxToolCallsProp);
@@ -94,6 +100,16 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
 
   public AgentInstanceRecord setElementInstanceKey(final long key) {
     elementInstanceKeyProp.setValue(key);
+    return this;
+  }
+
+  @Override
+  public String getElementId() {
+    return bufferAsString(elementIdProp.getValue());
+  }
+
+  public AgentInstanceRecord setElementId(final String elementId) {
+    elementIdProp.setValue(elementId);
     return this;
   }
 
@@ -194,6 +210,16 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
 
   public AgentInstanceRecord setModelCalls(final long modelCalls) {
     modelCallsProp.setValue(modelCalls);
+    return this;
+  }
+
+  @Override
+  public long getToolCalls() {
+    return toolCallsProp.getValue();
+  }
+
+  public AgentInstanceRecord setToolCalls(final long toolCalls) {
+    toolCallsProp.setValue(toolCalls);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentInstanceRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentInstanceRecord.golden
@@ -1,0 +1,229 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.agentinstance;
+
+import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
+
+import io.camunda.zeebe.msgpack.property.EnumProperty;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.StringValue;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.AgentInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+
+public final class AgentInstanceRecord extends UnifiedRecordValue
+    implements AgentInstanceRecordValue {
+
+  private static final StringValue AGENT_INSTANCE_KEY_KEY = new StringValue("agentInstanceKey");
+  private static final StringValue ELEMENT_INSTANCE_KEY_KEY = new StringValue("elementInstanceKey");
+  private static final StringValue PROCESS_INSTANCE_KEY_KEY = new StringValue("processInstanceKey");
+  private static final StringValue PROCESS_DEFINITION_KEY_KEY =
+      new StringValue("processDefinitionKey");
+  private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
+  private static final StringValue STATUS_KEY = new StringValue("status");
+  private static final StringValue MODEL_KEY = new StringValue("model");
+  private static final StringValue PROVIDER_KEY = new StringValue("provider");
+  private static final StringValue SYSTEM_PROMPT_KEY = new StringValue("systemPrompt");
+  private static final StringValue INPUT_TOKENS_KEY = new StringValue("inputTokens");
+  private static final StringValue OUTPUT_TOKENS_KEY = new StringValue("outputTokens");
+  private static final StringValue MODEL_CALLS_KEY = new StringValue("modelCalls");
+  private static final StringValue MAX_TOKENS_KEY = new StringValue("maxTokens");
+  private static final StringValue MAX_MODEL_CALLS_KEY = new StringValue("maxModelCalls");
+  private static final StringValue MAX_TOOL_CALLS_KEY = new StringValue("maxToolCalls");
+
+  private final LongProperty agentInstanceKeyProp = new LongProperty(AGENT_INSTANCE_KEY_KEY, -1L);
+  private final LongProperty elementInstanceKeyProp =
+      new LongProperty(ELEMENT_INSTANCE_KEY_KEY, -1L);
+  private final LongProperty processInstanceKeyProp =
+      new LongProperty(PROCESS_INSTANCE_KEY_KEY, -1L);
+  private final LongProperty processDefinitionKeyProp =
+      new LongProperty(PROCESS_DEFINITION_KEY_KEY, -1L);
+  private final StringProperty tenantIdProp =
+      new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final EnumProperty<AgentInstanceStatus> statusProp =
+      new EnumProperty<>(STATUS_KEY, AgentInstanceStatus.class, AgentInstanceStatus.IDLE);
+  private final StringProperty modelProp = new StringProperty(MODEL_KEY, "");
+  private final StringProperty providerProp = new StringProperty(PROVIDER_KEY, "");
+  private final StringProperty systemPromptProp = new StringProperty(SYSTEM_PROMPT_KEY, "");
+  private final LongProperty inputTokensProp = new LongProperty(INPUT_TOKENS_KEY, 0);
+  private final LongProperty outputTokensProp = new LongProperty(OUTPUT_TOKENS_KEY, 0);
+  private final LongProperty modelCallsProp = new LongProperty(MODEL_CALLS_KEY, 0);
+  private final LongProperty maxTokensProp = new LongProperty(MAX_TOKENS_KEY, -1L);
+  private final LongProperty maxModelCallsProp = new LongProperty(MAX_MODEL_CALLS_KEY, -1L);
+  private final LongProperty maxToolCallsProp = new LongProperty(MAX_TOOL_CALLS_KEY, -1L);
+
+  public AgentInstanceRecord() {
+    super(15);
+    declareProperty(agentInstanceKeyProp)
+        .declareProperty(elementInstanceKeyProp)
+        .declareProperty(processInstanceKeyProp)
+        .declareProperty(processDefinitionKeyProp)
+        .declareProperty(tenantIdProp)
+        .declareProperty(statusProp)
+        .declareProperty(modelProp)
+        .declareProperty(providerProp)
+        .declareProperty(systemPromptProp)
+        .declareProperty(inputTokensProp)
+        .declareProperty(outputTokensProp)
+        .declareProperty(modelCallsProp)
+        .declareProperty(maxTokensProp)
+        .declareProperty(maxModelCallsProp)
+        .declareProperty(maxToolCallsProp);
+  }
+
+  @Override
+  public long getAgentInstanceKey() {
+    return agentInstanceKeyProp.getValue();
+  }
+
+  public AgentInstanceRecord setAgentInstanceKey(final long key) {
+    agentInstanceKeyProp.setValue(key);
+    return this;
+  }
+
+  @Override
+  public long getElementInstanceKey() {
+    return elementInstanceKeyProp.getValue();
+  }
+
+  public AgentInstanceRecord setElementInstanceKey(final long key) {
+    elementInstanceKeyProp.setValue(key);
+    return this;
+  }
+
+  @Override
+  public long getProcessInstanceKey() {
+    return processInstanceKeyProp.getValue();
+  }
+
+  public AgentInstanceRecord setProcessInstanceKey(final long key) {
+    processInstanceKeyProp.setValue(key);
+    return this;
+  }
+
+  @Override
+  public long getProcessDefinitionKey() {
+    return processDefinitionKeyProp.getValue();
+  }
+
+  public AgentInstanceRecord setProcessDefinitionKey(final long key) {
+    processDefinitionKeyProp.setValue(key);
+    return this;
+  }
+
+  @Override
+  public String getTenantId() {
+    return bufferAsString(tenantIdProp.getValue());
+  }
+
+  public AgentInstanceRecord setTenantId(final String tenantId) {
+    tenantIdProp.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public AgentInstanceStatus getStatus() {
+    return statusProp.getValue();
+  }
+
+  public AgentInstanceRecord setStatus(final AgentInstanceStatus status) {
+    statusProp.setValue(status);
+    return this;
+  }
+
+  @Override
+  public String getModel() {
+    return bufferAsString(modelProp.getValue());
+  }
+
+  public AgentInstanceRecord setModel(final String model) {
+    modelProp.setValue(model);
+    return this;
+  }
+
+  @Override
+  public String getProvider() {
+    return bufferAsString(providerProp.getValue());
+  }
+
+  public AgentInstanceRecord setProvider(final String provider) {
+    providerProp.setValue(provider);
+    return this;
+  }
+
+  @Override
+  public String getSystemPrompt() {
+    return bufferAsString(systemPromptProp.getValue());
+  }
+
+  public AgentInstanceRecord setSystemPrompt(final String systemPrompt) {
+    systemPromptProp.setValue(systemPrompt);
+    return this;
+  }
+
+  @Override
+  public long getInputTokens() {
+    return inputTokensProp.getValue();
+  }
+
+  public AgentInstanceRecord setInputTokens(final long inputTokens) {
+    inputTokensProp.setValue(inputTokens);
+    return this;
+  }
+
+  @Override
+  public long getOutputTokens() {
+    return outputTokensProp.getValue();
+  }
+
+  public AgentInstanceRecord setOutputTokens(final long outputTokens) {
+    outputTokensProp.setValue(outputTokens);
+    return this;
+  }
+
+  @Override
+  public long getModelCalls() {
+    return modelCallsProp.getValue();
+  }
+
+  public AgentInstanceRecord setModelCalls(final long modelCalls) {
+    modelCallsProp.setValue(modelCalls);
+    return this;
+  }
+
+  @Override
+  public long getMaxTokens() {
+    return maxTokensProp.getValue();
+  }
+
+  public AgentInstanceRecord setMaxTokens(final long maxTokens) {
+    maxTokensProp.setValue(maxTokens);
+    return this;
+  }
+
+  @Override
+  public long getMaxModelCalls() {
+    return maxModelCallsProp.getValue();
+  }
+
+  public AgentInstanceRecord setMaxModelCalls(final long maxModelCalls) {
+    maxModelCallsProp.setValue(maxModelCalls);
+    return this;
+  }
+
+  @Override
+  public long getMaxToolCalls() {
+    return maxToolCallsProp.getValue();
+  }
+
+  public AgentInstanceRecord setMaxToolCalls(final long maxToolCalls) {
+    maxToolCallsProp.setValue(maxToolCalls);
+    return this;
+  }
+}

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentInstanceRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentInstanceRecord.golden
@@ -50,7 +50,7 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
   private final StringProperty tenantIdProp =
       new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final EnumProperty<AgentInstanceStatus> statusProp =
-      new EnumProperty<>(STATUS_KEY, AgentInstanceStatus.class, AgentInstanceStatus.IDLE);
+      new EnumProperty<>(STATUS_KEY, AgentInstanceStatus.class, AgentInstanceStatus.INITIALIZING);
   private final StringProperty modelProp = new StringProperty(MODEL_KEY, "");
   private final StringProperty providerProp = new StringProperty(PROVIDER_KEY, "");
   private final StringProperty systemPromptProp = new StringProperty(SYSTEM_PROMPT_KEY, "");

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
@@ -16,6 +16,7 @@
 package io.camunda.zeebe.protocol.record;
 
 import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessInstructionIntent;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.AsyncRequestIntent;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationChunkIntent;
@@ -78,6 +79,7 @@ import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
 import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
 import io.camunda.zeebe.protocol.record.value.AdHocSubProcessInstructionRecordValue;
+import io.camunda.zeebe.protocol.record.value.AgentInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.AsyncRequestRecordValue;
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue;
@@ -196,6 +198,9 @@ public final class ValueTypeMapping {
   private Map<ValueType, Mapping<?, ?>> loadValueTypes() {
     final Map<ValueType, Mapping<?, ?>> mapping = new EnumMap<>(ValueType.class);
 
+    mapping.put(
+        ValueType.AGENT_INSTANCE,
+        new Mapping<>(AgentInstanceRecordValue.class, AgentInstanceIntent.class));
     mapping.put(ValueType.DECISION, new Mapping<>(DecisionRecordValue.class, DecisionIntent.class));
     mapping.put(
         ValueType.DECISION_EVALUATION,

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypes.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypes.java
@@ -41,6 +41,7 @@ public final class ValueTypes {
           ValueType.USER_TASK,
           ValueType.PROCESS_INSTANCE_MIGRATION,
           ValueType.AD_HOC_SUB_PROCESS_INSTRUCTION,
+          ValueType.AGENT_INSTANCE,
           ValueType.COMPENSATION_SUBSCRIPTION,
           ValueType.MESSAGE_CORRELATION,
           ValueType.USER,

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/AgentInstanceIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/AgentInstanceIntent.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.intent;
+
+public enum AgentInstanceIntent implements Intent {
+  CREATE(0, false),
+  CREATED(1, true),
+  UPDATE(2, false),
+  UPDATED(3, true),
+  DELETE(4, false),
+  DELETED(5, true);
+
+  private final short value;
+  private final boolean event;
+
+  AgentInstanceIntent(final int value, final boolean event) {
+    this.value = (short) value;
+    this.event = event;
+  }
+
+  @Override
+  public short value() {
+    return value;
+  }
+
+  @Override
+  public boolean isEvent() {
+    return event;
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -35,6 +35,7 @@ public interface Intent {
   static Map<ValueType, Class<? extends Intent>> computeValueTypeToIntentMap() {
     final Map<ValueType, Class<? extends Intent>> map = new LinkedHashMap<>();
     map.put(ValueType.AD_HOC_SUB_PROCESS_INSTRUCTION, AdHocSubProcessInstructionIntent.class);
+    map.put(ValueType.AGENT_INSTANCE, AgentInstanceIntent.class);
     map.put(ValueType.ASYNC_REQUEST, AsyncRequestIntent.class);
     map.put(ValueType.AUTHORIZATION, AuthorizationIntent.class);
     map.put(ValueType.BATCH_OPERATION_CHUNK, BatchOperationChunkIntent.class);

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentInstanceRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentInstanceRecordValue.java
@@ -100,10 +100,54 @@ public interface AgentInstanceRecordValue extends RecordValue, ProcessInstanceRe
    */
   long getMaxToolCalls();
 
-  /** The status of an agent instance. */
+  /**
+   * The status of an agent instance.
+   *
+   * <p>An agent instance starts in {@link #INITIALIZING} after creation. From there it transitions
+   * to either {@link #TOOL_DISCOVERY} (to discover the tools available to it) or directly to {@link
+   * #THINKING}. {@link #THINKING} is the central state from which the agent either issues tool
+   * calls ({@link #TOOL_CALLING}) or settles into {@link #IDLE} awaiting external input. Both
+   * {@link #TOOL_CALLING} and {@link #IDLE} only transition back to {@link #THINKING}. From any
+   * status the agent instance can be deleted, transitioning to {@link #DELETED}, which is terminal.
+   *
+   * <p>State diagram:
+   *
+   * <pre>{@code
+   *                  +----------------+
+   *                  | INITIALIZING   |
+   *                  +----------------+
+   *                     |          |
+   *                     v          v
+   *              +--------------+  |
+   *              |TOOL_DISCOVERY|  |
+   *              +--------------+  |
+   *                     |          |
+   *                     v          v
+   *                  +----------------+
+   *             +--->|    THINKING    |<---+
+   *             |    +----------------+    |
+   *             |       |          |       |
+   *             |       v          v       |
+   *             |  +---------+  +------+   |
+   *             +--|  IDLE   |  |TOOL_ |---+
+   *                +---------+  |CALLING|
+   *                             +------+
+   *
+   * (from any state) ----> DELETED  [terminal]
+   * }</pre>
+   */
   enum AgentInstanceStatus {
-    IDLE,
+    /** Initial state right after creation, before the first update from the connector. */
+    INITIALIZING,
+    /** Agent is discovering the tools available to it. */
+    TOOL_DISCOVERY,
+    /** Agent is reasoning, typically performing a model call. */
     THINKING,
-    CALLING_TOOL
+    /** Agent is executing a tool call. */
+    TOOL_CALLING,
+    /** Agent is waiting for external input (e.g. user response). */
+    IDLE,
+    /** Terminal state after the agent instance has been deleted. */
+    DELETED
   }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentInstanceRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentInstanceRecordValue.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import org.immutables.value.Value;
+
+/**
+ * Represents an agent instance in the Zeebe protocol.
+ *
+ * <p>An agent instance is the engine-side representation of an AI agent execution's shared context.
+ * It tracks the agent's definition, aggregate metrics (token usage, model calls), and status.
+ *
+ * <p><b>Metric semantics differ by record type:</b> On UPDATE commands, the metric fields ({@link
+ * #getInputTokens()}, {@link #getOutputTokens()}, {@link #getModelCalls()}) carry <em>deltas</em>
+ * (increments from a single interaction). On UPDATED events, the same fields carry the
+ * <em>aggregated totals</em> after the engine has applied the deltas to its state. This allows the
+ * connector to report consumption incrementally while the engine maintains the running totals.
+ */
+@Value.Immutable
+@ImmutableProtocol(builder = ImmutableAgentInstanceRecordValue.Builder.class)
+public interface AgentInstanceRecordValue extends RecordValue, ProcessInstanceRelated, TenantOwned {
+
+  /** Returns the key of the agent instance. */
+  long getAgentInstanceKey();
+
+  /** Returns the key of the element instance (Ad-Hoc Sub-Process) this agent belongs to. */
+  long getElementInstanceKey();
+
+  /** Returns the current status of the agent instance. */
+  AgentInstanceStatus getStatus();
+
+  /** Returns the name of the LLM model used by this agent. */
+  String getModel();
+
+  /** Returns the LLM provider for this agent. */
+  String getProvider();
+
+  /** Returns the system prompt configured for this agent. */
+  String getSystemPrompt();
+
+  /**
+   * Returns input token count. On UPDATE commands this is a delta; on UPDATED events this is the
+   * aggregate total.
+   */
+  long getInputTokens();
+
+  /**
+   * Returns output token count. On UPDATE commands this is a delta; on UPDATED events this is the
+   * aggregate total.
+   */
+  long getOutputTokens();
+
+  /**
+   * Returns model call count. On UPDATE commands this is a delta; on UPDATED events this is the
+   * aggregate total.
+   */
+  long getModelCalls();
+
+  /**
+   * Returns the maximum number of tokens (input + output combined) this agent is allowed to
+   * consume. Set once at creation, immutable afterwards. A value of {@code -1} means not set.
+   */
+  long getMaxTokens();
+
+  /**
+   * Returns the maximum number of model calls this agent is allowed to make. Set once at creation,
+   * immutable afterwards. A value of {@code -1} means not set.
+   */
+  long getMaxModelCalls();
+
+  /**
+   * Returns the maximum number of tool calls this agent is allowed to make. Set once at creation,
+   * immutable afterwards. A value of {@code -1} means not set.
+   */
+  long getMaxToolCalls();
+
+  /** The status of an agent instance. */
+  enum AgentInstanceStatus {
+    IDLE,
+    THINKING,
+    CALLING_TOOL
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentInstanceRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentInstanceRecordValue.java
@@ -23,13 +23,15 @@ import org.immutables.value.Value;
  * Represents an agent instance in the Zeebe protocol.
  *
  * <p>An agent instance is the engine-side representation of an AI agent execution's shared context.
- * It tracks the agent's definition, aggregate metrics (token usage, model calls), and status.
+ * It tracks the agent's definition, aggregate metrics (token usage, model calls, tool calls), and
+ * status.
  *
  * <p><b>Metric semantics differ by record type:</b> On UPDATE commands, the metric fields ({@link
- * #getInputTokens()}, {@link #getOutputTokens()}, {@link #getModelCalls()}) carry <em>deltas</em>
- * (increments from a single interaction). On UPDATED events, the same fields carry the
- * <em>aggregated totals</em> after the engine has applied the deltas to its state. This allows the
- * connector to report consumption incrementally while the engine maintains the running totals.
+ * #getInputTokens()}, {@link #getOutputTokens()}, {@link #getModelCalls()}, {@link
+ * #getToolCalls()}) carry <em>deltas</em> (increments from a single interaction). On UPDATED
+ * events, the same fields carry the <em>aggregated totals</em> after the engine has applied the
+ * deltas to its state. This allows the connector to report consumption incrementally while the
+ * engine maintains the running totals.
  */
 @Value.Immutable
 @ImmutableProtocol(builder = ImmutableAgentInstanceRecordValue.Builder.class)
@@ -40,6 +42,9 @@ public interface AgentInstanceRecordValue extends RecordValue, ProcessInstanceRe
 
   /** Returns the key of the element instance (Ad-Hoc Sub-Process) this agent belongs to. */
   long getElementInstanceKey();
+
+  /** Returns the BPMN element ID of the Ad-Hoc Sub-Process this agent belongs to. */
+  String getElementId();
 
   /** Returns the current status of the agent instance. */
   AgentInstanceStatus getStatus();
@@ -70,6 +75,12 @@ public interface AgentInstanceRecordValue extends RecordValue, ProcessInstanceRe
    * aggregate total.
    */
   long getModelCalls();
+
+  /**
+   * Returns tool call count. On UPDATE commands this is a delta; on UPDATED events this is the
+   * aggregate total.
+   */
+  long getToolCalls();
 
   /**
    * Returns the maximum number of tokens (input + output combined) this agent is allowed to

--- a/zeebe/protocol/src/main/resources/protocol.xml
+++ b/zeebe/protocol/src/main/resources/protocol.xml
@@ -84,6 +84,7 @@
       <validValue name="EXPRESSION">66</validValue>
       <validValue name="JOB_METRICS_BATCH">67</validValue>
       <validValue name="GLOBAL_LISTENER">68</validValue>
+      <validValue name="AGENT_INSTANCE">69</validValue>
 
       <!-- Management records / record not related to process automation -->
       <!-- value 252 was used for "REDISTRIBUTION, do not use-->


### PR DESCRIPTION
## Description

> [!WARNING]
> This is a PoC only! DO NOT MERGE!

Introduces the protocol-level building blocks for AI agent instance metrics in the Zeebe engine:

- **`ValueType.AGENT_INSTANCE`** — new value type, registered in `ValueTypes`, `ValueTypeMapping`, `Intent`, and `protocol.xml`.
- **`AgentInstanceIntent`** — defines the lifecycle and metric intents (e.g. `CREATE`/`CREATED`, `UPDATE`/`UPDATED`, `DELETE/DELETED`) for agent instances.
- **`AgentInstanceRecordValue`** (public interface) and **`AgentInstanceRecord`** (impl, extending `UnifiedRecordValue`) — carry:
  - **Identity:** `agentInstanceKey`, `elementInstanceKey`, `elementId`, `processInstanceKey`, `processDefinitionKey`, `tenantId` (but we can also add: `processDefinitionVersion` and `versionTag`)
  - **Definition** (set once at creation): `model`, `provider`, `systemPrompt`
  - **Limits** (set once; `-1` = unset): `maxTokens`, `maxModelCalls`, `maxToolCalls`
  - **Metrics** with dual semantics — deltas on `UPDATE` commands, engine-aggregated totals on `UPDATED` events: `inputTokens`, `outputTokens`, `modelCalls`, `toolCalls`
  - **Status:** `INITIALIZING`, `TOOL_DISCOVERY`, `THINKING`, `TOOL_CALLING`, `IDLE`, `DELETED`

This dual-semantics approach lets connectors report per-call consumption while the engine maintains running totals; both views are exported to secondary storage for downstream consumers.

### Agent instance status state diagram

```mermaid
stateDiagram-v2
    [*] --> INITIALIZING
    INITIALIZING --> TOOL_DISCOVERY
    INITIALIZING --> THINKING
    TOOL_DISCOVERY --> THINKING
    THINKING --> TOOL_CALLING
    THINKING --> IDLE
    TOOL_CALLING --> THINKING
    IDLE --> THINKING
    INITIALIZING --> DELETED
    TOOL_DISCOVERY --> DELETED
    THINKING --> DELETED
    TOOL_CALLING --> DELETED
    IDLE --> DELETED
    DELETED --> [*]
```

## Related issues

relates to #51505