### PR TITLE
[PoC] Align AgentInstance intents with status state diagram

### DIFF
--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/AgentInstanceIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/AgentInstanceIntent.java
@@ -15,13 +15,80 @@
  */
 package io.camunda.zeebe.protocol.record.intent;
 
+/**
+ * Intents for agent instance records, aligned 1:1 with the {@code AgentInstanceStatus} state
+ * diagram.
+ *
+ * <p>Instead of a generic {@code UPDATE}/{@code UPDATED} pair carrying a {@code status} payload,
+ * each connector-reported state transition has its own command/event pair. This makes the event
+ * stream self-describing — exporters and downstream consumers can filter by intent without decoding
+ * the record body.
+ *
+ * <h2>Lifecycle intents (connector-driven)</h2>
+ *
+ * <ul>
+ *   <li>{@link #CREATE} / {@link #CREATED} — agent instance enters {@code INITIALIZING}.
+ *   <li>{@link #DISCOVER_TOOLS} / {@link #TOOLS_DISCOVERED} — agent enters {@code TOOL_DISCOVERY}
+ *       to enumerate available tools.
+ *   <li>{@link #THINK} / {@link #THOUGHT} — agent enters {@code THINKING}; the connector is about
+ *       to (or just did) call the LLM.
+ *   <li>{@link #CALL_TOOL} / {@link #TOOL_CALLED} — agent enters {@code TOOL_CALLING}; the LLM
+ *       chose a tool. Carries the metric deltas accrued during the just-finished {@code THINKING}
+ *       phase (one model call + tokens).
+ *   <li>{@link #WAIT_FOR_INPUT} / {@link #WAITING_FOR_INPUT} — agent enters {@code IDLE}; the LLM
+ *       returned a final answer and the agent is awaiting external input. Carries the metric deltas
+ *       from the just-finished {@code THINKING} phase.
+ *   <li>{@link #DELETE} / {@link #DELETED} — terminal; reachable from any state.
+ * </ul>
+ *
+ * <h2>Engine-driven intents</h2>
+ *
+ * <ul>
+ *   <li>{@link #LIMIT_EXCEEDED} — engine-emitted event when a transition command would cause {@code
+ *       maxTokens}, {@code maxModelCalls}, or {@code maxToolCalls} to be exceeded. Distinct from a
+ *       generic command rejection so downstream consumers (incidents, telemetry) can react without
+ *       parsing rejection reasons. Considered terminal for the agent instance.
+ * </ul>
+ *
+ * <h2>Metric semantics</h2>
+ *
+ * <p>On commands, metric fields ({@code inputTokens}, {@code outputTokens}, {@code modelCalls},
+ * {@code toolCalls}) carry <em>deltas</em> for the work performed during the state being
+ * <em>left</em>. On events, the same fields carry the engine-aggregated <em>totals</em>. This
+ * preserves the dual-semantics behavior of the generic-update design while pinning each delta to
+ * the transition it belongs to.
+ *
+ * <h2>Trade-offs vs. generic UPDATE/UPDATED</h2>
+ *
+ * <p><b>Pros:</b> self-describing event stream; per-intent payload validation (e.g. {@code
+ * CALL_TOOL} can require {@code toolCalls=1}); no redundant {@code status} field needed on the
+ * event (intent encodes it); easier downstream filtering.
+ *
+ * <p><b>Cons:</b> every new state requires an intent pair (protocol churn); transitions are
+ * connector-reported, not engine-controlled, so the engine cannot strictly enforce the state
+ * machine the way it does for {@code ProcessInstanceIntent}; intent count grows from 6 to 13.
+ */
 public enum AgentInstanceIntent implements Intent {
   CREATE(0, false),
   CREATED(1, true),
-  UPDATE(2, false),
-  UPDATED(3, true),
-  DELETE(4, false),
-  DELETED(5, true);
+
+  DISCOVER_TOOLS(2, false),
+  TOOLS_DISCOVERED(3, true),
+
+  THINK(4, false),
+  THOUGHT(5, true),
+
+  CALL_TOOL(6, false),
+  TOOL_CALLED(7, true),
+
+  WAIT_FOR_INPUT(8, false),
+  WAITING_FOR_INPUT(9, true),
+
+  DELETE(10, false),
+  DELETED(11, true),
+
+  /** Engine-emitted event; no command counterpart. */
+  LIMIT_EXCEEDED(12, true);
 
   private final short value;
   private final boolean event;

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/AgentInstanceIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/AgentInstanceIntent.java
@@ -28,13 +28,13 @@ package io.camunda.zeebe.protocol.record.intent;
  *
  * <ul>
  *   <li>{@link #CREATE} / {@link #CREATED} — agent instance enters {@code INITIALIZING}.
- *   <li>{@link #DISCOVER_TOOLS} / {@link #TOOLS_DISCOVERED} — agent enters {@code TOOL_DISCOVERY}
+ *   <li>{@link #DISCOVER_TOOLS} / {@link #DISCOVERING_TOOLS} — agent enters {@code TOOL_DISCOVERY}
  *       to enumerate available tools.
- *   <li>{@link #THINK} / {@link #THOUGHT} — agent enters {@code THINKING}; the connector is about
+ *   <li>{@link #THINK} / {@link #THINKING} — agent enters {@code THINKING}; the connector is about
  *       to (or just did) call the LLM.
- *   <li>{@link #CALL_TOOL} / {@link #TOOL_CALLED} — agent enters {@code TOOL_CALLING}; the LLM
- *       chose a tool. Carries the metric deltas accrued during the just-finished {@code THINKING}
- *       phase (one model call + tokens).
+ *   <li>{@link #CALL_TOOLS} / {@link #TOOL_CALLING} — agent enters {@code TOOL_CALLING}; the LLM
+ *       chose one or more tools. Carries the metric deltas accrued during the just-finished {@code
+ *       THINKING} phase (one model call + tokens).
  *   <li>{@link #WAIT_FOR_INPUT} / {@link #WAITING_FOR_INPUT} — agent enters {@code IDLE}; the LLM
  *       returned a final answer and the agent is awaiting external input. Carries the metric deltas
  *       from the just-finished {@code THINKING} phase.
@@ -61,7 +61,7 @@ package io.camunda.zeebe.protocol.record.intent;
  * <h2>Trade-offs vs. generic UPDATE/UPDATED</h2>
  *
  * <p><b>Pros:</b> self-describing event stream; per-intent payload validation (e.g. {@code
- * CALL_TOOL} can require {@code toolCalls=1}); no redundant {@code status} field needed on the
+ * CALL_TOOLS} can require {@code toolCalls>=1}); no redundant {@code status} field needed on the
  * event (intent encodes it); easier downstream filtering.
  *
  * <p><b>Cons:</b> every new state requires an intent pair (protocol churn); transitions are
@@ -73,13 +73,13 @@ public enum AgentInstanceIntent implements Intent {
   CREATED(1, true),
 
   DISCOVER_TOOLS(2, false),
-  TOOLS_DISCOVERED(3, true),
+  DISCOVERING_TOOLS(3, true),
 
   THINK(4, false),
-  THOUGHT(5, true),
+  THINKING(5, true),
 
-  CALL_TOOL(6, false),
-  TOOL_CALLED(7, true),
+  CALL_TOOLS(6, false),
+  TOOL_CALLING(7, true),
 
   WAIT_FOR_INPUT(8, false),
   WAITING_FOR_INPUT(9, true),

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentInstanceRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentInstanceRecordValue.java
@@ -140,7 +140,7 @@ public interface AgentInstanceRecordValue extends RecordValue, ProcessInstanceRe
    * }</pre>
    *
    * <p>In the state-aligned intent design, status is redundant with the latest intent ({@code
-   * TOOLS_DISCOVERED} → {@code TOOL_DISCOVERY}, {@code THOUGHT} → {@code THINKING}, etc.). It is
+   * DISCOVERING_TOOLS} → {@code TOOL_DISCOVERY}, {@code THINKING} → {@code THINKING}, etc.). It is
    * retained for entity-snapshot queries that don't want to derive state from intent history.
    */
   enum AgentInstanceStatus {

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentInstanceRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentInstanceRecordValue.java
@@ -109,6 +109,8 @@ public interface AgentInstanceRecordValue extends RecordValue, ProcessInstanceRe
    * calls ({@link #TOOL_CALLING}) or settles into {@link #IDLE} awaiting external input. Both
    * {@link #TOOL_CALLING} and {@link #IDLE} only transition back to {@link #THINKING}. From any
    * status the agent instance can be deleted, transitioning to {@link #DELETED}, which is terminal.
+   * The engine may also reject any transition with {@link #LIMIT_EXCEEDED} when {@code maxTokens},
+   * {@code maxModelCalls}, or {@code maxToolCalls} would be breached; this is also terminal.
    *
    * <p>State diagram:
    *
@@ -133,8 +135,13 @@ public interface AgentInstanceRecordValue extends RecordValue, ProcessInstanceRe
    *                +---------+  |CALLING|
    *                             +------+
    *
-   * (from any state) ----> DELETED  [terminal]
+   * (from any state) ----> DELETED         [terminal]
+   * (from any state) ----> LIMIT_EXCEEDED  [terminal, engine-driven]
    * }</pre>
+   *
+   * <p>In the state-aligned intent design, status is redundant with the latest intent ({@code
+   * TOOLS_DISCOVERED} → {@code TOOL_DISCOVERY}, {@code THOUGHT} → {@code THINKING}, etc.). It is
+   * retained for entity-snapshot queries that don't want to derive state from intent history.
    */
   enum AgentInstanceStatus {
     /** Initial state right after creation, before the first update from the connector. */
@@ -148,6 +155,8 @@ public interface AgentInstanceRecordValue extends RecordValue, ProcessInstanceRe
     /** Agent is waiting for external input (e.g. user response). */
     IDLE,
     /** Terminal state after the agent instance has been deleted. */
-    DELETED
+    DELETED,
+    /** Terminal state after the engine rejected a transition for breaching a configured limit. */
+    LIMIT_EXCEEDED
   }
 }


### PR DESCRIPTION
## Description

> [!WARNING]
> PoC only — explores an alternative design. DO NOT MERGE.

Alternative to the generic `CREATE`/`UPDATE`/`DELETE` intent set on the parent PoC branch (#52010): one command/event pair per state transition, plus an engine-driven `LIMIT_EXCEEDED` event.

### Intent design

| Command | Event | Resulting status |
|---|---|---|
| `CREATE` | `CREATED` | `INITIALIZING` |
| `DISCOVER_TOOLS` | `DISCOVERING_TOOLS` | `TOOL_DISCOVERY` |
| `THINK` | `THINKING` | `THINKING` |
| `CALL_TOOLS` | `TOOL_CALLING` | `TOOL_CALLING` |
| `WAIT_FOR_INPUT` | `WAITING_FOR_INPUT` | `IDLE` |
| `DELETE` | `DELETED` | `DELETED` (terminal) |
| _(none)_ | `LIMIT_EXCEEDED` | `LIMIT_EXCEEDED` (terminal, engine-driven) |

Event intents use the present participle of the command, matching the resulting status (`Intent` and `AgentInstanceStatus` are separate enums, so the name overlap is fine).

### Metric semantics

Each transition command carries the metric deltas accrued during the state being _left_; events carry engine-aggregated totals. This preserves the dual-semantics of the generic-update design while pinning each delta to the transition it belongs to (e.g. `CALL_TOOLS` carries the tokens of the THINKING phase that just chose the tools).

### Trade-offs vs. generic UPDATE/UPDATED (#52010)

**Pros**
- Self-describing event stream — exporters/consumers filter by intent without decoding the body.
- Per-intent payload validation possible (e.g. `CALL_TOOLS` could require `toolCalls>=1`).
- `LIMIT_EXCEEDED` becomes a first-class event, not a parsed rejection reason.
- Status field becomes redundant on events (intent encodes it) — could be dropped if desired.

**Cons**
- Intent count grows from 6 to 13.
- Every new state requires a new intent pair (protocol churn).
- Transitions are connector-reported, not engine-controlled, so unlike `ProcessInstanceIntent` the engine cannot strictly enforce the state machine — risk of intent/state drift.
- Metric payload shape is identical across `CALL_TOOLS` / `WAIT_FOR_INPUT` / `THINK`; renaming alone doesn't add information.

### State diagram

```mermaid
stateDiagram-v2
    [*] --> INITIALIZING
    INITIALIZING --> TOOL_DISCOVERY
    INITIALIZING --> THINKING
    TOOL_DISCOVERY --> THINKING
    THINKING --> TOOL_CALLING
    THINKING --> IDLE
    TOOL_CALLING --> THINKING
    IDLE --> THINKING
    state "any non-terminal state" as ANY
    ANY --> DELETED
    ANY --> LIMIT_EXCEEDED
    DELETED --> [*]
    LIMIT_EXCEEDED --> [*]
```

## Checklist

- [ ] N/A — PoC, do not merge.

## Related issues

relates to #51505
alternative to #52010
