### PR TITLE
fix: skip moveDocuments when all ID lists in keysByField are empty

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverRepository.java
@@ -78,6 +78,9 @@ public interface ArchiverRepository extends AutoCloseable {
       final Map<String, List<String>> keysByField,
       final Map<String, String> filters,
       final Executor executor) {
+    if (keysByField.isEmpty() || keysByField.values().stream().allMatch(List::isEmpty)) {
+      return CompletableFuture.completedFuture(null);
+    }
     return reindexDocuments(sourceIndexName, destinationIndexName, keysByField, filters)
         .thenComposeAsync(ok -> setIndexLifeCycle(destinationIndexName), executor)
         .thenComposeAsync(ok -> deleteDocuments(sourceIndexName, keysByField, filters), executor);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiverJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiverJobIT.java
@@ -109,6 +109,7 @@ public abstract class ArchiverJobIT<T extends ArchiverJob<?>> {
 
   void withArchiverJob(final ExporterConfiguration config, final ArchiveJobConsumer<T> jobConsumer)
       throws Exception {
+    config.getHistory().getRetention().setEnabled(true);
     createSchemas(config);
 
     final ExporterResourceProvider exporterResourceProvider = exporterResourceProvider(config);


### PR DESCRIPTION
batch operation dependants with only non-numeric (GUID) IDs can produce an empty value list in keysByField. The map itself was non-empty so the existing isEmpty() guard did not trigger, causing unnecessary reindex/lifecycle/delete calls against non-existent destination indices. Add an additional check in ArchiverRepository.moveDocuments to return early when every value list is empty. 
Also enable retention in all ArchiverJobIT tests so setIndexLifeCycle is exercised.

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
