### PR TITLE
fix: use lifecycle record as suspend batch operation request DTO

### DIFF
--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerSuspendBatchOperationRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerSuspendBatchOperationRequest.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.gateway.impl.broker.request;
 
 import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
-import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationExecutionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationLifecycleManagementRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
@@ -17,7 +16,8 @@ import org.agrona.DirectBuffer;
 public class BrokerSuspendBatchOperationRequest
     extends BrokerExecuteCommand<BatchOperationLifecycleManagementRecord> {
 
-  BatchOperationExecutionRecord requestDto = new BatchOperationExecutionRecord();
+  BatchOperationLifecycleManagementRecord requestDto =
+      new BatchOperationLifecycleManagementRecord();
 
   public BrokerSuspendBatchOperationRequest() {
     super(ValueType.BATCH_OPERATION_LIFECYCLE_MANAGEMENT, BatchOperationIntent.SUSPEND);
@@ -29,7 +29,7 @@ public class BrokerSuspendBatchOperationRequest
   }
 
   @Override
-  public BatchOperationExecutionRecord getRequestWriter() {
+  public BatchOperationLifecycleManagementRecord getRequestWriter() {
     return requestDto;
   }
 


### PR DESCRIPTION
## Description

The gateway request for the `SUSPEND` batch operation intent was writing its payload from a `BatchOperationExecutionRecord`, while the `SUSPEND` intent on the broker side belongs to the lifecycle management value type and is decoded as a `BatchOperationLifecycleManagementRecord`. 

The mismatch went unnoticed because both records happen to share a `batchOperationKey` property with the same name and type, and the suspend processor only reads that single field; so the wire payload remained accidentally compatible.

This is fragile: any future field added to either record (for example, populating errors on the command, or relying on itemKeys) would silently corrupt the request or break decoding without any obvious cause. 

Using the correct DTO also aligns this request with the cancel and resume counterparts, keeping the lifecycle management commands consistent and making it safe to evolve the lifecycle record going forward.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #52022
