### PR TITLE
49826 ITs for PI archive job child entities

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AbstractProcessInstanceArchiverJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AbstractProcessInstanceArchiverJobIT.java
@@ -87,6 +87,46 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
   }
 
   @TestTemplate
+  void shouldOnlyArchiveOneBatchAtATime(
+      final ExporterConfiguration config, final SearchClientAdapter client) throws Exception {
+    final int batchSize = 5;
+    config.getHistory().setRolloverBatchSize(batchSize);
+    withArchiverJob(
+        config,
+        (job, resourceProvider) -> {
+          // given
+          final var listViewTemplate =
+              resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class);
+
+          final List<ProcessInstanceForListViewEntity> processInstances = new ArrayList<>();
+          for (var i = 0; i < batchSize; i++) {
+            processInstances.add(processInstanceForListViewEntity("2020-01-01T00:00:00+00:00"));
+          }
+          // slightly later end date, so should not be in first batch
+          processInstances.add(processInstanceForListViewEntity("2020-01-01T00:00:10+00:00"));
+
+          for (final var processInstance : processInstances) {
+            store(listViewTemplate, client, processInstance);
+          }
+
+          client.refresh();
+
+          // when
+          final var archived = job.execute();
+
+          // then
+          assertThat(archived).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(5);
+
+          // check that the first batch of processes are no longer in the main index
+          for (var i = 0; i < batchSize; i++) {
+            verifyMoved(listViewTemplate, client, processInstances.get(i), "2020-01-01");
+          }
+          // but the last doc is still there
+          verifyNotMoved(listViewTemplate, client, processInstances.getLast());
+        });
+  }
+
+  @TestTemplate
   void shouldOnlyArchiveFinishedProcessInstances(
       final ExporterConfiguration config, final SearchClientAdapter client) throws Exception {
     withArchiverJob(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AbstractProcessInstanceArchiverJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AbstractProcessInstanceArchiverJobIT.java
@@ -39,6 +39,7 @@ import io.camunda.webapps.schema.entities.flownode.FlowNodeInstanceEntity;
 import io.camunda.webapps.schema.entities.incident.IncidentEntity;
 import io.camunda.webapps.schema.entities.listview.FlowNodeInstanceForListViewEntity;
 import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
+import io.camunda.webapps.schema.entities.listview.VariableForListViewEntity;
 import io.camunda.webapps.schema.entities.messagesubscription.MessageSubscriptionEntity;
 import io.camunda.webapps.schema.entities.operation.OperationEntity;
 import io.camunda.webapps.schema.entities.post.PostImporterQueueEntity;
@@ -149,7 +150,7 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
   }
 
   @TestTemplate
-  void shouldArchiveProcessInstanceAndDependentListViewFlowNodes(
+  void shouldArchiveProcessInstanceAndDependentChildListViewEntities(
       final ExporterConfiguration config, final SearchClientAdapter client) throws Exception {
     withArchiverJob(
         config,
@@ -161,15 +162,15 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
           final ProcessInstanceForListViewEntity processInstance =
               processInstanceForListViewEntity("2020-01-01T00:00:00+00:00");
 
-          final List<FlowNodeInstanceForListViewEntity> flowNodes =
+          final List<ExporterEntity<?>> childEntities =
               List.of(
                   flowNodeInstanceForListViewEntity(processInstance),
                   flowNodeInstanceForListViewEntity(processInstance),
-                  flowNodeInstanceForListViewEntity(processInstance));
+                  variableForListViewEntity(processInstance));
 
           store(listViewTemplate, client, processInstance);
-          for (final var flowNode : flowNodes) {
-            store(listViewTemplate, client, processInstance, flowNode);
+          for (final var child : childEntities) {
+            store(listViewTemplate, client, processInstance, child);
           }
 
           client.refresh();
@@ -182,8 +183,67 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
 
           // check that the process is no longer in the main index
           verifyMoved(listViewTemplate, client, processInstance, "2020-01-01");
-          for (final var flowNode : flowNodes) {
-            verifyMoved(listViewTemplate, client, processInstance, flowNode, "2020-01-01");
+          for (final var child : childEntities) {
+            verifyMoved(listViewTemplate, client, processInstance, child, "2020-01-01");
+          }
+        });
+  }
+
+  @TestTemplate
+  void shouldOnlyArchiveFinishedProcessInstanceAndDependentChildListViewEntities(
+      final ExporterConfiguration config, final SearchClientAdapter client) throws Exception {
+    withArchiverJob(
+        config,
+        (job, resourceProvider) -> {
+          // given
+          final var listViewTemplate =
+              resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class);
+
+          final ProcessInstanceForListViewEntity finishedInstance =
+              processInstanceForListViewEntity("2020-01-01T00:00:00+00:00");
+
+          final List<ExporterEntity<?>> finishedChildEntities =
+              List.of(
+                  flowNodeInstanceForListViewEntity(finishedInstance),
+                  flowNodeInstanceForListViewEntity(finishedInstance),
+                  variableForListViewEntity(finishedInstance));
+
+          store(listViewTemplate, client, finishedInstance);
+          for (final var child : finishedChildEntities) {
+            store(listViewTemplate, client, finishedInstance, child);
+          }
+
+          final ProcessInstanceForListViewEntity unfinishedInstance =
+              processInstanceForListViewEntity(null);
+
+          final List<ExporterEntity<?>> unfinishedChildEntities =
+              List.of(
+                  flowNodeInstanceForListViewEntity(unfinishedInstance),
+                  flowNodeInstanceForListViewEntity(unfinishedInstance),
+                  variableForListViewEntity(unfinishedInstance));
+
+          store(listViewTemplate, client, unfinishedInstance);
+          for (final var child : unfinishedChildEntities) {
+            store(listViewTemplate, client, unfinishedInstance, child);
+          }
+
+          client.refresh();
+
+          // when
+          final var archived = job.execute();
+
+          // then
+          assertThat(archived).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(1);
+
+          // check that the process is no longer in the main index
+          verifyMoved(listViewTemplate, client, finishedInstance, "2020-01-01");
+          for (final var child : finishedChildEntities) {
+            verifyMoved(listViewTemplate, client, finishedInstance, child, "2020-01-01");
+          }
+
+          verifyNotMoved(listViewTemplate, client, unfinishedInstance);
+          for (final var child : unfinishedChildEntities) {
+            verifyNotMoved(listViewTemplate, client, unfinishedInstance, child);
           }
         });
   }
@@ -378,6 +438,16 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
   private FlowNodeInstanceForListViewEntity flowNodeInstanceForListViewEntity(
       final ProcessInstanceForListViewEntity processInstance) {
     final FlowNodeInstanceForListViewEntity entity = create(FlowNodeInstanceForListViewEntity::new);
+    entity.setProcessInstanceKey(processInstance.getKey());
+    entity.setRootProcessInstanceKey(processInstance.getKey());
+    entity.getJoinRelation().setParent(processInstance.getKey());
+
+    return entity;
+  }
+
+  private VariableForListViewEntity variableForListViewEntity(
+      final ProcessInstanceForListViewEntity processInstance) {
+    final VariableForListViewEntity entity = create(VariableForListViewEntity::new);
     entity.setProcessInstanceKey(processInstance.getKey());
     entity.setRootProcessInstanceKey(processInstance.getKey());
     entity.getJoinRelation().setParent(processInstance.getKey());

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AbstractProcessInstanceArchiverJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AbstractProcessInstanceArchiverJobIT.java
@@ -47,6 +47,7 @@ import io.camunda.webapps.schema.entities.usertask.SnapshotTaskVariableEntity;
 import io.camunda.webapps.schema.entities.usertask.TaskEntity;
 import java.time.Duration;
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
@@ -167,6 +168,48 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
                   flowNodeInstanceForListViewEntity(processInstance),
                   flowNodeInstanceForListViewEntity(processInstance),
                   variableForListViewEntity(processInstance));
+
+          store(listViewTemplate, client, processInstance);
+          for (final var child : childEntities) {
+            store(listViewTemplate, client, processInstance, child);
+          }
+
+          client.refresh();
+
+          // when
+          final var archived = job.execute();
+
+          // then
+          assertThat(archived).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(1);
+
+          // check that the process is no longer in the main index
+          verifyMoved(listViewTemplate, client, processInstance, "2020-01-01");
+          for (final var child : childEntities) {
+            verifyMoved(listViewTemplate, client, processInstance, child, "2020-01-01");
+          }
+        });
+  }
+
+  @TestTemplate
+  void shouldArchiveProcessInstanceAndLargeNumberOfDependentChildListViewEntities(
+      final ExporterConfiguration config, final SearchClientAdapter client) throws Exception {
+    // set smaller reindex batch size to verify things work when multiple batches are needed
+    config.getHistory().setReindexBatchSize(10);
+    withArchiverJob(
+        config,
+        (job, resourceProvider) -> {
+          // given
+          final var listViewTemplate =
+              resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class);
+
+          final ProcessInstanceForListViewEntity processInstance =
+              processInstanceForListViewEntity("2020-01-01T00:00:00+00:00");
+
+          final List<ExporterEntity<?>> childEntities = new ArrayList<>();
+          for (var i = 0; i < 90; i++) {
+            childEntities.add(flowNodeInstanceForListViewEntity(processInstance));
+            childEntities.add(variableForListViewEntity(processInstance));
+          }
 
           store(listViewTemplate, client, processInstance);
           for (final var child : childEntities) {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiverJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiverJobIT.java
@@ -186,8 +186,27 @@ public abstract class ArchiverJobIT<T extends ArchiverJob<?>> {
       final SearchClientAdapter client,
       final ExporterEntity<?> entity)
       throws IOException {
+    verifyNotMoved(templateDescriptor, client, entity, (String) null);
+  }
+
+  protected void verifyNotMoved(
+      final IndexTemplateDescriptor templateDescriptor,
+      final SearchClientAdapter client,
+      final ExporterEntity<?> parent,
+      final ExporterEntity<?> entity)
+      throws IOException {
+    verifyNotMoved(templateDescriptor, client, entity, parent.getId());
+  }
+
+  private void verifyNotMoved(
+      final IndexTemplateDescriptor templateDescriptor,
+      final SearchClientAdapter client,
+      final ExporterEntity<?> entity,
+      final String routing)
+      throws IOException {
     final var originalIndexEntity =
-        client.get(entity.getId(), templateDescriptor.getFullQualifiedName(), entity.getClass());
+        client.get(
+            entity.getId(), routing, templateDescriptor.getFullQualifiedName(), entity.getClass());
     assertThat(originalIndexEntity)
         .describedAs(
             "Expected %s to still be in %s", entity, templateDescriptor.getFullQualifiedName())


### PR DESCRIPTION
Another expansion of the ITs for PI archiving.  This one expands the test related to child entities in list view (add variables + check unfinished child entities are not archived) and also checks that we only archive one batch of PIs at a time:

refs #49826
