### PR TITLE
fix: uncover batch operation monitoring FE polling and BE record type bugs in e2e tests

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/batchOperations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/batchOperations.spec.ts
@@ -12,7 +12,6 @@ import {deploy} from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {
-  cancelBatchOperation,
   createCancellationBatch,
   expectBatchState,
   findCompletedBatchKey,
@@ -200,15 +199,59 @@ test.describe('Batch Operations', () => {
         },
       });
       await operateOperationsDetailsPage.suspendButton.click();
-      await suspendBatchOperation(request, batchKey).catch(() => {});
     });
 
     await test.step('Verify state indicator shows Suspended', async () => {
+      await expect(operateOperationsDetailsPage.state).toContainText(
+        'Suspended',
+        {timeout: 20000},
+      );
+      await expect(operateOperationsDetailsPage.resumeButton).toBeVisible();
+      await expect(operateOperationsDetailsPage.suspendButton).toBeHidden();
+    });
+  });
+
+  test('Suspend state persists after page reload (BE command reaches engine)', async ({
+    page,
+    request,
+    operateOperationsDetailsPage,
+  }) => {
+    // This test validates Mustafa's hypothesis: although the UI badge does not
+    // auto-update after clicking Suspend (FE polling bug), the suspend command
+    // does reach the engine and the state IS persisted. A manual reload should
+    // always reflect the correct SUSPENDED state.
+    test.slow();
+    const batchKey = await createCancellationBatch(
+      request,
+      2000,
+      'batch_suspension_long_process',
+    );
+    await operateOperationsDetailsPage.goto(batchKey);
+
+    await test.step('Wait for active state and click Suspend', async () => {
       await waitForAssertion({
         assertion: async () => {
+          await expect(operateOperationsDetailsPage.suspendButton).toBeVisible({
+            timeout: 20000,
+          });
+          await expect(
+            operateOperationsDetailsPage.suspendButton,
+          ).toBeEnabled();
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+      await operateOperationsDetailsPage.suspendButton.click();
+    });
+
+    await test.step('Reload the page and verify state shows Suspended', async () => {
+      await waitForAssertion({
+        assertion: async () => {
+          await page.reload();
           await expect(operateOperationsDetailsPage.state).toContainText(
             'Suspended',
-            {timeout: 15000},
+            {timeout: 20000},
           );
         },
         onFailure: async () => {
@@ -245,21 +288,13 @@ test.describe('Batch Operations', () => {
         },
       });
       await operateOperationsDetailsPage.clickCancelFromOptionsMenu();
-      await cancelBatchOperation(request, batchKey).catch(() => {});
     });
 
     await test.step('Verify state indicator shows Canceled', async () => {
-      await waitForAssertion({
-        assertion: async () => {
-          await expect(operateOperationsDetailsPage.state).toContainText(
-            'Canceled',
-            {timeout: 15000},
-          );
-        },
-        onFailure: async () => {
-          await page.reload();
-        },
-      });
+      await expect(operateOperationsDetailsPage.state).toContainText(
+        'Canceled',
+        {timeout: 20000},
+      );
       await expect(operateOperationsDetailsPage.suspendButton).toBeHidden();
       await expect(operateOperationsDetailsPage.resumeButton).toBeHidden();
     });
@@ -297,17 +332,10 @@ test.describe('Batch Operations', () => {
     });
 
     await test.step('Verify state indicator shows Canceled', async () => {
-      await waitForAssertion({
-        assertion: async () => {
-          await expect(operateOperationsDetailsPage.state).toContainText(
-            'Canceled',
-            {timeout: 15000},
-          );
-        },
-        onFailure: async () => {
-          await page.reload();
-        },
-      });
+      await expect(operateOperationsDetailsPage.state).toContainText(
+        'Canceled',
+        {timeout: 20000},
+      );
       await expect(operateOperationsDetailsPage.resumeButton).toBeHidden();
       await expect(operateOperationsDetailsPage.optionsMenuButton).toBeHidden();
     });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/batchOperations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/batchOperations.spec.ts
@@ -176,11 +176,7 @@ test.describe('Batch Operations', () => {
     request,
     operateOperationsDetailsPage,
   }) => {
-    // Skipped until useBatchOperation.ts is fixed to poll with refetchInterval.
-    // Without polling the state badge never auto-updates after a suspend/cancel
-    // mutation; this test is expected to time out at the state assertion.
-    // Re-enable once the FE fix is merged (tracks the issue in the PR description
-    // of https://github.com/camunda/camunda/pull/52029).
+    // Skipped due to 52021: camunda/camunda#52021
     test.skip(true, 'FE polling bug: useBatchOperation has no refetchInterval');
     test.slow();
     const batchKey = await createCancellationBatch(
@@ -274,8 +270,7 @@ test.describe('Batch Operations', () => {
     request,
     operateOperationsDetailsPage,
   }) => {
-    // Skipped until useBatchOperation.ts is fixed to poll with refetchInterval.
-    // See https://github.com/camunda/camunda/pull/52029
+    // Skipped due to 52021: camunda/camunda#52021
     test.skip(true, 'FE polling bug: useBatchOperation has no refetchInterval');
     test.slow();
     const batchKey = await createCancellationBatch(
@@ -314,8 +309,7 @@ test.describe('Batch Operations', () => {
     request,
     operateOperationsDetailsPage,
   }) => {
-    // Skipped until useBatchOperation.ts is fixed to poll with refetchInterval.
-    // See https://github.com/camunda/camunda/pull/52029
+    // Skipped due to 52021: camunda/camunda#52021
     test.skip(true, 'FE polling bug: useBatchOperation has no refetchInterval');
     test.slow();
     const batchKey = await createCancellationBatch(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/batchOperations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/batchOperations.spec.ts
@@ -176,6 +176,12 @@ test.describe('Batch Operations', () => {
     request,
     operateOperationsDetailsPage,
   }) => {
+    // Skipped until useBatchOperation.ts is fixed to poll with refetchInterval.
+    // Without polling the state badge never auto-updates after a suspend/cancel
+    // mutation; this test is expected to time out at the state assertion.
+    // Re-enable once the FE fix is merged (tracks the issue in the PR description
+    // of https://github.com/camunda/camunda/pull/52029).
+    test.skip(true, 'FE polling bug: useBatchOperation has no refetchInterval');
     test.slow();
     const batchKey = await createCancellationBatch(
       request,
@@ -268,6 +274,9 @@ test.describe('Batch Operations', () => {
     request,
     operateOperationsDetailsPage,
   }) => {
+    // Skipped until useBatchOperation.ts is fixed to poll with refetchInterval.
+    // See https://github.com/camunda/camunda/pull/52029
+    test.skip(true, 'FE polling bug: useBatchOperation has no refetchInterval');
     test.slow();
     const batchKey = await createCancellationBatch(
       request,
@@ -305,6 +314,9 @@ test.describe('Batch Operations', () => {
     request,
     operateOperationsDetailsPage,
   }) => {
+    // Skipped until useBatchOperation.ts is fixed to poll with refetchInterval.
+    // See https://github.com/camunda/camunda/pull/52029
+    test.skip(true, 'FE polling bug: useBatchOperation has no refetchInterval');
     test.slow();
     const batchKey = await createCancellationBatch(
       request,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/batchOperations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/batchOperations.spec.ts
@@ -218,10 +218,6 @@ test.describe('Batch Operations', () => {
     request,
     operateOperationsDetailsPage,
   }) => {
-    // This test validates Mustafa's hypothesis: although the UI badge does not
-    // auto-update after clicking Suspend (FE polling bug), the suspend command
-    // does reach the engine and the state IS persisted. A manual reload should
-    // always reflect the correct SUSPENDED state.
     test.slow();
     const batchKey = await createCancellationBatch(
       request,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/batchOperations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/batchOperations.spec.ts
@@ -176,7 +176,7 @@ test.describe('Batch Operations', () => {
     request,
     operateOperationsDetailsPage,
   }) => {
-    // Skipped due to 52021: camunda/camunda#52021
+    // Skipped due to bug #52021: https://github.com/camunda/camunda/issues/52021
     test.skip(true, 'FE polling bug: useBatchOperation has no refetchInterval');
     test.slow();
     const batchKey = await createCancellationBatch(
@@ -266,7 +266,7 @@ test.describe('Batch Operations', () => {
     request,
     operateOperationsDetailsPage,
   }) => {
-    // Skipped due to 52021: camunda/camunda#52021
+    // Skipped due to bug #52021: https://github.com/camunda/camunda/issues/52021
     test.skip(true, 'FE polling bug: useBatchOperation has no refetchInterval');
     test.slow();
     const batchKey = await createCancellationBatch(
@@ -305,7 +305,7 @@ test.describe('Batch Operations', () => {
     request,
     operateOperationsDetailsPage,
   }) => {
-    // Skipped due to 52021: camunda/camunda#52021
+    // Skipped due to bug #52021: https://github.com/camunda/camunda/issues/52021
     test.skip(true, 'FE polling bug: useBatchOperation has no refetchInterval');
     test.slow();
     const batchKey = await createCancellationBatch(


### PR DESCRIPTION
## Why

Two bugs were being masked by the batch operations lifecycle e2e tests:

**1. FE – no polling after lifecycle mutations**
`useBatchOperation` has no `refetchInterval`, so after a suspend/cancel the state badge never auto-updates; it only reflects the new state after a manual page reload. The `waitForAssertion` helper was calling `page.reload()` on every retry, hiding this completely.

**2. BE – wrong record type in suspend request**
`BrokerSuspendBatchOperationRequest` uses `BatchOperationExecutionRecord` instead of `BatchOperationLifecycleManagementRecord`. Tests were also issuing a direct `suspendBatchOperation()` API call after clicking the UI button, so they passed even if the button itself did nothing.

## Changes

- Remove `suspendBatchOperation()` / `cancelBatchOperation()` API fallback calls from lifecycle tests so the UI must drive the action.
- Replace `waitForAssertion+reload` badge assertions with plain `expect()` so the badge must auto-update without a reload.
- Add a **"suspend then reload"** test that proves the suspend command reaches the engine and state is persisted — this passes today and is unaffected by the FE polling bug.
- Skip the 3 broken lifecycle tests with an explicit reason message until the FE fix lands.

## Bugs exposed (not fixed here)

- **FE**: `useBatchOperation.ts` needs a `refetchInterval` so the badge self-updates after a lifecycle mutation.
- **BE**: `BrokerSuspendBatchOperationRequest` must use `BatchOperationLifecycleManagementRecord`.
