### PR TITLE
[PoC] AI Agent Instances based on record schema

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.engine.metrics.DistributionMetrics;
 import io.camunda.zeebe.engine.metrics.IncidentMetrics;
 import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
 import io.camunda.zeebe.engine.metrics.ProcessEngineMetrics;
+import io.camunda.zeebe.engine.processing.agentinstance.AgentInstanceProcessors;
 import io.camunda.zeebe.engine.processing.batchoperation.BatchOperationSetupProcessors;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviorsImpl;
@@ -380,6 +381,9 @@ public final class EngineProcessors {
         commandDistributionBehavior,
         authCheckBehavior,
         config);
+
+    AgentInstanceProcessors.addAgentInstanceProcessors(
+        keyGenerator, typedRecordProcessors, writers);
 
     UsageMetricsProcessors.addUsageMetricsProcessors(
         typedRecordProcessors, config, clock, processingState, writers, keyGenerator);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceProcessors.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.agentinstance;
+
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+
+public final class AgentInstanceProcessors {
+
+  private AgentInstanceProcessors() {}
+
+  public static void addAgentInstanceProcessors(
+      final KeyGenerator keyGenerator,
+      final TypedRecordProcessors typedRecordProcessors,
+      final Writers writers) {
+    typedRecordProcessors.onCommand(
+        ValueType.AGENT_INSTANCE,
+        AgentInstanceIntent.CREATE,
+        new AgentInstanceCreateProcessor(keyGenerator, writers.state()));
+    typedRecordProcessors.onCommand(
+        ValueType.AGENT_INSTANCE,
+        AgentInstanceIntent.UPDATE,
+        new AgentInstanceLifecycleProcessor(writers.state(), AgentInstanceIntent.UPDATED));
+    typedRecordProcessors.onCommand(
+        ValueType.AGENT_INSTANCE,
+        AgentInstanceIntent.DELETE,
+        new AgentInstanceLifecycleProcessor(writers.state(), AgentInstanceIntent.DELETED));
+  }
+
+  @ExcludeAuthorizationCheck
+  static final class AgentInstanceCreateProcessor
+      implements TypedRecordProcessor<AgentInstanceRecord> {
+
+    private final KeyGenerator keyGenerator;
+    private final StateWriter stateWriter;
+
+    AgentInstanceCreateProcessor(final KeyGenerator keyGenerator, final StateWriter stateWriter) {
+      this.keyGenerator = keyGenerator;
+      this.stateWriter = stateWriter;
+    }
+
+    @Override
+    public void processRecord(final TypedRecord<AgentInstanceRecord> command) {
+      final var record = command.getValue();
+      final long key = keyGenerator.nextKey();
+      record.setAgentInstanceKey(key);
+      stateWriter.appendFollowUpEvent(key, AgentInstanceIntent.CREATED, record);
+    }
+  }
+
+  @ExcludeAuthorizationCheck
+  static final class AgentInstanceLifecycleProcessor
+      implements TypedRecordProcessor<AgentInstanceRecord> {
+
+    private final StateWriter stateWriter;
+    private final AgentInstanceIntent followUpIntent;
+
+    AgentInstanceLifecycleProcessor(
+        final StateWriter stateWriter, final AgentInstanceIntent followUpIntent) {
+      this.stateWriter = stateWriter;
+      this.followUpIntent = followUpIntent;
+    }
+
+    @Override
+    public void processRecord(final TypedRecord<AgentInstanceRecord> command) {
+      final var record = command.getValue();
+      stateWriter.appendFollowUpEvent(record.getAgentInstanceKey(), followUpIntent, record);
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessInstructionIntent;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.AsyncRequestIntent;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationChunkIntent;
@@ -158,7 +159,14 @@ public final class EventAppliers implements EventApplier {
     registerExpressionEvaluationEventAppliers();
     registerGlobalListenersEventAppliers(state);
     registerJobMetricsBatchEventAppliers(state);
+    registerAgentInstanceEventAppliers();
     return this;
+  }
+
+  private void registerAgentInstanceEventAppliers() {
+    register(AgentInstanceIntent.CREATED, NOOP_EVENT_APPLIER);
+    register(AgentInstanceIntent.UPDATED, NOOP_EVENT_APPLIER);
+    register(AgentInstanceIntent.DELETED, NOOP_EVENT_APPLIER);
   }
 
   private void registerJobMetricsBatchEventAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceLifecycleTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceLifecycleTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.agentinstance;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.AgentInstanceRecordValue.AgentInstanceStatus;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class AgentInstanceLifecycleTest {
+
+  @ClassRule public static final EngineRule ENGINE_RULE = EngineRule.singlePartition();
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldEmitCreatedEventForCreateCommand() {
+    // when
+    final var record =
+        ENGINE_RULE
+            .agentInstances()
+            .withProcessInstanceKey(123L)
+            .withProcessDefinitionKey(456L)
+            .withElementInstanceKey(789L)
+            .withElementId("agent-task")
+            .withModel("claude-opus-4-7")
+            .withProvider("anthropic")
+            .create();
+
+    // then
+    Assertions.assertThat(record)
+        .hasIntent(AgentInstanceIntent.CREATED)
+        .hasRecordType(RecordType.EVENT);
+  }
+
+  @Test
+  public void shouldEmitUpdatedEventForUpdateCommand() {
+    // given
+    final var created =
+        ENGINE_RULE
+            .agentInstances()
+            .withProcessInstanceKey(124L)
+            .withProcessDefinitionKey(456L)
+            .withElementInstanceKey(790L)
+            .withElementId("agent-task")
+            .withModel("claude-opus-4-7")
+            .withProvider("anthropic")
+            .create();
+    final long agentInstanceKey = created.getValue().getAgentInstanceKey();
+
+    // when
+    final var record =
+        ENGINE_RULE
+            .agentInstances()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withStatus(AgentInstanceStatus.THINKING)
+            .withInputTokens(100L)
+            .withOutputTokens(200L)
+            .withModelCalls(1L)
+            .update();
+
+    // then
+    Assertions.assertThat(record)
+        .hasIntent(AgentInstanceIntent.UPDATED)
+        .hasRecordType(RecordType.EVENT);
+  }
+
+  @Test
+  public void shouldEmitDeletedEventForDeleteCommand() {
+    // given
+    final var created =
+        ENGINE_RULE
+            .agentInstances()
+            .withProcessInstanceKey(125L)
+            .withProcessDefinitionKey(456L)
+            .withElementInstanceKey(791L)
+            .withElementId("agent-task")
+            .withModel("claude-opus-4-7")
+            .withProvider("anthropic")
+            .create();
+    final long agentInstanceKey = created.getValue().getAgentInstanceKey();
+
+    // when
+    final var record = ENGINE_RULE.agentInstances().withAgentInstanceKey(agentInstanceKey).delete();
+
+    // then
+    Assertions.assertThat(record)
+        .hasIntent(AgentInstanceIntent.DELETED)
+        .hasRecordType(RecordType.EVENT);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.engine.state.immutable.RoutingState;
 import io.camunda.zeebe.engine.state.migration.DbMigratorImpl;
 import io.camunda.zeebe.engine.util.TestInterPartitionCommandSender.CommandInterceptor;
 import io.camunda.zeebe.engine.util.client.AdHocSubProcessActivityClient;
+import io.camunda.zeebe.engine.util.client.AgentInstanceClient;
 import io.camunda.zeebe.engine.util.client.AuthorizationClient;
 import io.camunda.zeebe.engine.util.client.BatchOperationClient;
 import io.camunda.zeebe.engine.util.client.ClockClient;
@@ -496,6 +497,10 @@ public final class EngineRule extends ExternalResource {
 
   public ClusterVariableClient clusterVariables() {
     return new ClusterVariableClient(environmentRule);
+  }
+
+  public AgentInstanceClient agentInstances() {
+    return new AgentInstanceClient(environmentRule);
   }
 
   public JobMetricsBatchClient jobMetricsBatch() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AgentInstanceClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AgentInstanceClient.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.util.client;
+
+import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.AgentInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.AgentInstanceRecordValue.AgentInstanceStatus;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.Random;
+import java.util.function.LongFunction;
+
+public final class AgentInstanceClient {
+
+  private static final long DEFAULT_KEY = -1L;
+
+  private static final LongFunction<Record<AgentInstanceRecordValue>> SUCCESS_SUPPLIER =
+      (sourceRecordPosition) ->
+          RecordingExporter.agentInstanceRecords()
+              .onlyEvents()
+              .withSourceRecordPosition(sourceRecordPosition)
+              .getFirst();
+  private static final LongFunction<Record<AgentInstanceRecordValue>> REJECTION_SUPPLIER =
+      (sourceRecordPosition) ->
+          RecordingExporter.agentInstanceRecords()
+              .onlyCommandRejections()
+              .withSourceRecordPosition(sourceRecordPosition)
+              .getFirst();
+
+  private final long requestId = new Random().nextLong();
+  private final int requestStreamId = new Random().nextInt();
+
+  private final AgentInstanceRecord agentInstanceRecord = new AgentInstanceRecord();
+  private final CommandWriter writer;
+  private LongFunction<Record<AgentInstanceRecordValue>> expectation = SUCCESS_SUPPLIER;
+
+  public AgentInstanceClient(final CommandWriter writer) {
+    this.writer = writer;
+  }
+
+  public AgentInstanceClient withAgentInstanceKey(final long key) {
+    agentInstanceRecord.setAgentInstanceKey(key);
+    return this;
+  }
+
+  public AgentInstanceClient withElementInstanceKey(final long key) {
+    agentInstanceRecord.setElementInstanceKey(key);
+    return this;
+  }
+
+  public AgentInstanceClient withElementId(final String elementId) {
+    agentInstanceRecord.setElementId(elementId);
+    return this;
+  }
+
+  public AgentInstanceClient withProcessInstanceKey(final long key) {
+    agentInstanceRecord.setProcessInstanceKey(key);
+    return this;
+  }
+
+  public AgentInstanceClient withProcessDefinitionKey(final long key) {
+    agentInstanceRecord.setProcessDefinitionKey(key);
+    return this;
+  }
+
+  public AgentInstanceClient withTenantId(final String tenantId) {
+    agentInstanceRecord.setTenantId(tenantId);
+    return this;
+  }
+
+  public AgentInstanceClient withStatus(final AgentInstanceStatus status) {
+    agentInstanceRecord.setStatus(status);
+    return this;
+  }
+
+  public AgentInstanceClient withModel(final String model) {
+    agentInstanceRecord.setModel(model);
+    return this;
+  }
+
+  public AgentInstanceClient withProvider(final String provider) {
+    agentInstanceRecord.setProvider(provider);
+    return this;
+  }
+
+  public AgentInstanceClient withInputTokens(final long inputTokens) {
+    agentInstanceRecord.setInputTokens(inputTokens);
+    return this;
+  }
+
+  public AgentInstanceClient withOutputTokens(final long outputTokens) {
+    agentInstanceRecord.setOutputTokens(outputTokens);
+    return this;
+  }
+
+  public AgentInstanceClient withModelCalls(final long modelCalls) {
+    agentInstanceRecord.setModelCalls(modelCalls);
+    return this;
+  }
+
+  public AgentInstanceClient withToolCalls(final long toolCalls) {
+    agentInstanceRecord.setToolCalls(toolCalls);
+    return this;
+  }
+
+  public AgentInstanceClient expectRejection() {
+    expectation = REJECTION_SUPPLIER;
+    return this;
+  }
+
+  public Record<AgentInstanceRecordValue> create() {
+    final long position =
+        writer.writeCommand(
+            DEFAULT_KEY,
+            requestStreamId,
+            requestId,
+            AgentInstanceIntent.CREATE,
+            agentInstanceRecord);
+    return expectation.apply(position);
+  }
+
+  public Record<AgentInstanceRecordValue> update() {
+    final long position =
+        writer.writeCommand(
+            DEFAULT_KEY,
+            requestStreamId,
+            requestId,
+            AgentInstanceIntent.UPDATE,
+            agentInstanceRecord);
+    return expectation.apply(position);
+  }
+
+  public Record<AgentInstanceRecordValue> delete() {
+    final long position =
+        writer.writeCommand(
+            DEFAULT_KEY,
+            requestStreamId,
+            requestId,
+            AgentInstanceIntent.DELETE,
+            agentInstanceRecord);
+    return expectation.apply(position);
+  }
+}

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/AgentInstanceRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/AgentInstanceRecordStream.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.test.util.record;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.AgentInstanceRecordValue;
+import java.util.stream.Stream;
+
+public final class AgentInstanceRecordStream
+    extends ExporterRecordStream<AgentInstanceRecordValue, AgentInstanceRecordStream> {
+
+  public AgentInstanceRecordStream(final Stream<Record<AgentInstanceRecordValue>> wrappedStream) {
+    super(wrappedStream);
+  }
+
+  @Override
+  protected AgentInstanceRecordStream supply(
+      final Stream<Record<AgentInstanceRecordValue>> wrappedStream) {
+    return new AgentInstanceRecordStream(wrappedStream);
+  }
+
+  public AgentInstanceRecordStream withAgentInstanceKey(final long agentInstanceKey) {
+    return valueFilter(v -> v.getAgentInstanceKey() == agentInstanceKey);
+  }
+
+  public AgentInstanceRecordStream withProcessInstanceKey(final long processInstanceKey) {
+    return valueFilter(v -> v.getProcessInstanceKey() == processInstanceKey);
+  }
+
+  public AgentInstanceRecordStream withElementInstanceKey(final long elementInstanceKey) {
+    return valueFilter(v -> v.getElementInstanceKey() == elementInstanceKey);
+  }
+}

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.test.util.record;
 
 import static io.camunda.zeebe.protocol.record.ValueType.AD_HOC_SUB_PROCESS_INSTRUCTION;
+import static io.camunda.zeebe.protocol.record.ValueType.AGENT_INSTANCE;
 import static io.camunda.zeebe.protocol.record.ValueType.ASYNC_REQUEST;
 import static io.camunda.zeebe.protocol.record.ValueType.AUTHORIZATION;
 import static io.camunda.zeebe.protocol.record.ValueType.CHECKPOINT;
@@ -73,6 +74,7 @@ import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
 import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
 import io.camunda.zeebe.protocol.record.value.AdHocSubProcessInstructionRecordValue;
+import io.camunda.zeebe.protocol.record.value.AgentInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.AsyncRequestRecordValue;
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
@@ -184,6 +186,7 @@ public class CompactRecordLogger {
           entry(UPDATE_DENIED.name(), "UPDT_DENIED"),
           entry(SEQUENCE_FLOW_TAKEN.name(), "SQ_FLW_TKN"),
           entry(AD_HOC_SUB_PROCESS_INSTRUCTION.name(), "AHSP_INST"),
+          entry(AGENT_INSTANCE.name(), "AGENT_INST"),
           entry(PROCESS_INSTANCE_CREATION.name(), "CREA"),
           entry(PROCESS_INSTANCE_MODIFICATION.name(), "MOD"),
           entry(PROCESS_INSTANCE_MIGRATION.name(), "PI_MIGR"),
@@ -270,6 +273,7 @@ public class CompactRecordLogger {
         ValueType.PROCESS_MESSAGE_SUBSCRIPTION, this::summarizeProcessInstanceSubscription);
     valueLoggers.put(
         ValueType.AD_HOC_SUB_PROCESS_INSTRUCTION, this::summarizeAdHocSubProcessInstruction);
+    valueLoggers.put(ValueType.AGENT_INSTANCE, this::summarizeAgentInstance);
     valueLoggers.put(ValueType.VARIABLE, this::summarizeVariable);
     valueLoggers.put(ValueType.VARIABLE_DOCUMENT, this::summarizeVariableDocument);
     valueLoggers.put(ValueType.TIMER, this::summarizeTimer);
@@ -960,6 +964,19 @@ public class CompactRecordLogger {
             String.format(
                 " in ad-hoc sub-process [%s]", shortenKey(value.getAdHocSubProcessInstanceKey())));
     return builder.toString();
+  }
+
+  private String summarizeAgentInstance(final Record<?> record) {
+    final var value = (AgentInstanceRecordValue) record.getValue();
+    return new StringBuilder()
+        .append(String.format("[%s]", shortenKey(value.getAgentInstanceKey())))
+        .append(String.format(" \"%s\"", value.getElementId()))
+        .append(String.format(" %s", value.getStatus()))
+        .append(String.format(" tools=%d", value.getToolCalls()))
+        .append(String.format(" models=%d", value.getModelCalls()))
+        .append(String.format(" tokens=%d/%d", value.getInputTokens(), value.getOutputTokens()))
+        .append(formatTenant(value))
+        .toString();
   }
 
   private String summarizeVariable(final Record<?> record) {

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -56,6 +56,7 @@ import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
 import io.camunda.zeebe.protocol.record.value.AdHocSubProcessInstructionRecordValue;
+import io.camunda.zeebe.protocol.record.value.AgentInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.AsyncRequestRecordValue;
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue;
@@ -404,6 +405,11 @@ public final class RecordingExporter implements Exporter {
   public static ClusterVariableRecordStream clusterVariableRecords() {
     return new ClusterVariableRecordStream(
         records(ValueType.CLUSTER_VARIABLE, ClusterVariableRecordValue.class));
+  }
+
+  public static AgentInstanceRecordStream agentInstanceRecords() {
+    return new AgentInstanceRecordStream(
+        records(ValueType.AGENT_INSTANCE, AgentInstanceRecordValue.class));
   }
 
   public static ExpressionRecordStream expressionRecords() {


### PR DESCRIPTION
Proof of concept building on the AgentInstance record schema introduced for #51505 in #52010. Adds engine processing for the AgentInstance lifecycle so commands produce the expected events end-to-end. More changes will follow on top of this branch.

## What's here
- `CompactRecordLogger` summarizer for the new `AGENT_INSTANCE` value type (fixes the parameterized coverage test)
- Engine-level lifecycle tests asserting CREATE→CREATED, UPDATE→UPDATED, DELETE→DELETED
- Minimal stream processors emitting the expected follow-up events; no-op event appliers (exporter owns persistence for now)

🤖 Generated with [Claude Code](https://claude.com/claude-code)