### PR TITLE
fix: ignore test results in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,5 @@ cmd/renovate/renovate*/
 .c8dev
 /output/
 scripts/codeowners-utils/output/
+
+**/test-results


### PR DESCRIPTION
## Description

fix: ignore test results in .gitignore

**Ignore this PR. This is just created in order to create a load test profile against** 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
