### PR TITLE
fix: handle new ref param for preview env build and deploy

### DIFF
--- a/.github/workflows/preview-env-build-and-deploy.yml
+++ b/.github/workflows/preview-env-build-and-deploy.yml
@@ -21,6 +21,13 @@ on:
         required: false
         type: string
         default: ''
+      ref:
+        description: |
+          Git ref for checkout and ArgoCD revision.
+          Required for cross-branch calls since reusable workflows inherit the caller's ref.
+        required: false
+        type: string
+        default: ''
       helm-extra-args:
         description: |
           Additional Helm arguments to pass to ArgoCD (newline-separated --helm-set pairs).
@@ -55,6 +62,13 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        ref: ${{ inputs.ref }}
+
+    - name: Resolve commit SHA
+      if: inputs.ref != ''
+      id: ref
+      run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
     - uses: ./.github/actions/setup-build
       with:
@@ -78,7 +92,7 @@ jobs:
         platforms: linux/amd64
         dockerfile: camunda.Dockerfile
         push: true
-        version: pr-${{ github.event.pull_request.head.sha || github.sha }}
+        version: pr-${{ steps.ref.outputs.sha || github.event.pull_request.head.sha || github.sha }}
 
     - name: Observe build status
       if: always()
@@ -105,9 +119,8 @@ jobs:
     uses: ./.github/workflows/optimize-ci-build-reusable.yml
     secrets: inherit
     with:
-      branch: ${{ github.head_ref || github.ref_name }}
+      branch: ${{ inputs.ref || github.head_ref || github.ref_name }}
       pushDocker: true
-      version: pr-${{ github.event.pull_request.head.sha || github.sha }}
 
   deploy-preview:
     # For workflow_call: inputs.app-name is set (github.event_name is inherited from caller, not 'workflow_call')
@@ -185,10 +198,20 @@ jobs:
           secret/data/products/camunda/ci/camunda ARGOCD_TOKEN;
 
     #########################################################################
-    # Setup: checkout code. This is required because we are using
-    # composite actions and deployment manifests.
+    # Checkout the specified workflow_call ref when provided; for pull_request
+    # runs, an empty inputs.ref lets checkout fall back to the event ref
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        ref: ${{ inputs.ref }}
+
+    #########################################################################
+    # Resolve commit SHA for docker image tagging only when workflow_call
+    # provides an explicit ref
+    - name: Resolve commit SHA
+      if: inputs.ref != ''
+      id: ref
+      run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
     #########################################################################
     # Determine the argocd arguments that need to be passed to the create app command
@@ -210,10 +233,10 @@ jobs:
           --helm-set git.branch=${revision} \
           --upsert ${label_args} ${helm_extra}" >> "$GITHUB_ENV"
       env:
-        docker_tag: pr-${{ github.event.pull_request.head.sha || github.sha }}
+        docker_tag: pr-${{ steps.ref.outputs.sha || github.event.pull_request.head.sha || github.sha }}
         helm_extra_args: ${{ inputs.helm-extra-args }}
         labels: ${{ inputs.labels }}
-        revision: ${{ github.head_ref || github.ref_name }}
+        revision: ${{ inputs.ref || github.head_ref || github.ref_name }}
         app_name: camunda-${{ steps.set-app-name.outputs.app-name }}
 
     #########################################################################
@@ -221,7 +244,7 @@ jobs:
     - name: Deploy Preview Environment for c8sm
       uses: camunda/infra-global-github-actions/preview-env/create@main
       with:
-        revision: ${{ github.head_ref || github.ref_name }}
+        revision: ${{ inputs.ref || github.head_ref || github.ref_name }}
         argocd_token: ${{ steps.secrets.outputs.ARGOCD_TOKEN }}
         app_name: camunda-${{ steps.set-app-name.outputs.app-name }}
         app_url: https://${{ steps.set-host-name.outputs.host-name }}

--- a/.github/workflows/preview-env-teardown.yml
+++ b/.github/workflows/preview-env-teardown.yml
@@ -13,6 +13,13 @@ on:
           ArgoCD app name to tear down
         required: true
         type: string
+      ref:
+        description: |
+          Git ref for checkout and ArgoCD revision.
+          Required for cross-branch calls since reusable workflows inherit the caller's ref.
+        required: false
+        type: string
+        default: ''
 
 jobs:
   teardown-preview:
@@ -67,17 +74,19 @@ jobs:
         vault-url: ${{ secrets.VAULT_ADDR }}
 
     #########################################################################
-    # Setup: checkout code. This is required because we are using
-    # composite actions and deployment manifests.
+    # Checkout the specified workflow_call ref when provided; for pull_request
+    # runs, an empty inputs.ref lets checkout fall back to the event ref
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        ref: ${{ inputs.ref }}
 
     #########################################################################
     # Tear down preview environment
     - name: Tear down Preview Environment
       uses: camunda/infra-global-github-actions/preview-env/destroy@main
       with:
-        revision: ${{ github.head_ref || github.ref_name }}
+        revision: ${{ inputs.ref || github.head_ref || github.ref_name }}
         argocd_token: ${{ steps.secrets.outputs.ARGOCD_TOKEN }}
         app_name: camunda-${{ inputs.app-name || steps.sanitize.outputs.branch_name }}
         argocd_server: argocd.int.camunda.com


### PR DESCRIPTION
## Description

This pull request enhances the `preview-env-build-and-deploy.yml` workflow to support cross-branch and cross-repository workflow calls by introducing a new `ref` input. This allows the workflow to check out and build from a specific Git reference, improving flexibility and correctness in reusable workflow scenarios. The changes ensure that Docker images and deployments are tagged and referenced with the correct commit SHA, even when the workflow is triggered from a branch or ref other than the default.

Related to #inc-5299, precisely: https://camunda.slack.com/archives/C0AV2GWNSAK/p1777399088763419?thread_ts=1777398380.706609&cid=C0AV2GWNSAK
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
