### PR TITLE
Cherry-picked missing commit to stable/8.8

### DIFF
--- a/load-tests/setup/newLoadTest.sh
+++ b/load-tests/setup/newLoadTest.sh
@@ -120,24 +120,6 @@ else
   echo "Namespace ${namespace} has previously been configured to run on the single availability zone: $availability_zone"
 fi
 
-# Sanitize a string to be a valid Kubernetes label value
-sanitize_k8s_label() {
-  local value="$1"
-  # Replace invalid characters with hyphens
-  value=$(echo "$value" | sed 's/[^A-Za-z0-9_.-]/-/g')
-  # Remove leading non-alphanumeric characters
-  value=$(echo "$value" | sed 's/^[^A-Za-z0-9]\+//')
-  # Remove trailing non-alphanumeric characters
-  value=$(echo "$value" | sed 's/[^A-Za-z0-9]\+$//')
-  # Truncate to 63 characters as required by Kubernetes label values
-  value=${value:0:63}
-  # Fallback if the result is empty
-  if [ -z "$value" ]; then
-    value="unknown"
-  fi
-  echo "$value"
-}
-
 # Label to easily find related namespaces
 kubectl label namespace "$namespace" camunda.io/purpose=load-test --overwrite
 

--- a/load-tests/setup/utils.sh
+++ b/load-tests/setup/utils.sh
@@ -25,9 +25,28 @@ function sed_inplace() {
   detect_os
 
   if [ "${GO_OS}" == "darwin" ]; then
-    sed -i '' -e $@ 
+    sed -i '' -e $@
   else
     sed -i -e $@
   fi
 
+}
+
+# Sanitize a string to be a valid Kubernetes label value (max 63 chars, alphanumeric/.-_)
+sanitize_k8s_label() {
+  local value="$1"
+  value=$(echo "$value" | sed 's/[^A-Za-z0-9_.-]/-/g')
+  value=$(echo "$value" | sed -E 's/^[^A-Za-z0-9]+//')
+  value=${value:0:63}
+  value=$(echo "$value" | sed -E 's/[^A-Za-z0-9]+$//')
+  if [ -z "$value" ]; then
+    value="unknown"
+  fi
+  echo "$value"
+}
+
+compute_git_author() {
+  local raw
+  raw=$(git config user.name 2>/dev/null || echo "unknown")
+  sanitize_k8s_label "$raw"
 }


### PR DESCRIPTION
## Description

Cherry-picked the missing commit for 8.8, moving/extracting functions to utils.sh

refactor: extract label sanitization and author computation to utils.sh
(cherry picked from commit cafe5d4e2e7c38630463c1c43fa7f0a64e0a4ffb)


## Related issues

see https://camunda.slack.com/archives/C0807665N8G/p1777386485053549
