### PR TITLE
[Backport stable/8.9] test: add E2E API tests for global user task listeners

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/global-task-listener/global-task-listener-create-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/global-task-listener/global-task-listener-create-api-tests.spec.ts
@@ -1,0 +1,317 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {
+  jsonHeaders,
+  buildUrl,
+  assertUnauthorizedRequest,
+  assertBadRequest,
+  assertConflictRequest,
+  assertStatusCode,
+  assertForbiddenRequest,
+  encode,
+} from '../../../../utils/http';
+import {
+  generateUniqueId,
+  defaultAssertionOptions,
+} from '../../../../utils/constants';
+import {validateResponse} from '../../../../json-body-assertions';
+import {cleanupGlobalTaskListeners} from '../../../../utils/globalTaskListenerCleanup';
+import {cleanupUsers} from '../../../../utils/usersCleanup';
+import {
+  createUser,
+  createComponentAuthorization,
+  cleanupAuthorizations,
+} from '@requestHelpers';
+
+function createUniqueGlobalTaskListenerBody(customId?: string) {
+  const id = customId ?? `test-gl-${generateUniqueId()}`;
+  return {
+    id,
+    type: `io.camunda.test.listener.${id}`,
+    eventTypes: ['creating', 'completing'],
+  };
+}
+
+/* eslint-disable playwright/expect-expect */
+test.describe.parallel('Global Task Listener API Tests - Create', () => {
+  const createdListenerIds: string[] = [];
+
+  test.afterAll(async ({request}) => {
+    await cleanupGlobalTaskListeners(request, createdListenerIds);
+  });
+
+  test('Create Global Task Listener - success with required fields', async ({
+    request,
+  }) => {
+    await expect(async () => {
+      const body = createUniqueGlobalTaskListenerBody();
+
+      const res = await request.post(buildUrl('/global-task-listeners'), {
+        headers: jsonHeaders(),
+        data: body,
+      });
+
+      await assertStatusCode(res, 201);
+      await validateResponse(
+        {path: '/global-task-listeners', method: 'POST', status: '201'},
+        res,
+      );
+      const json = await res.json();
+      expect(json.id).toBe(body.id);
+      expect(json.type).toBe(body.type);
+      expect(json.eventTypes).toEqual(expect.arrayContaining(body.eventTypes));
+      expect(json.source).toBe('API');
+
+      createdListenerIds.push(json.id);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Create Global Task Listener - success with all optional fields', async ({
+    request,
+  }) => {
+    await expect(async () => {
+      const body = {
+        ...createUniqueGlobalTaskListenerBody(),
+        eventTypes: ['all'],
+        retries: 3,
+        afterNonGlobal: true,
+        priority: 50,
+      };
+
+      const res = await request.post(buildUrl('/global-task-listeners'), {
+        headers: jsonHeaders(),
+        data: body,
+      });
+
+      await assertStatusCode(res, 201);
+      await validateResponse(
+        {path: '/global-task-listeners', method: 'POST', status: '201'},
+        res,
+      );
+      const json = await res.json();
+      expect(json.id).toBe(body.id);
+      expect(json.type).toBe(body.type);
+      expect(json.retries).toBe(3);
+      expect(json.afterNonGlobal).toBe(true);
+      expect(json.priority).toBe(50);
+      expect(json.source).toBe('API');
+
+      createdListenerIds.push(json.id);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Create Global Task Listener - unauthorized', async ({request}) => {
+    const body = createUniqueGlobalTaskListenerBody();
+
+    const res = await request.post(buildUrl('/global-task-listeners'), {
+      headers: {},
+      data: body,
+    });
+
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Create Global Task Listener - missing required id field', async ({
+    request,
+  }) => {
+    const unique = generateUniqueId();
+    const bodyWithoutId = {
+      type: `io.camunda.test.listener.${unique}`,
+      eventTypes: ['creating', 'completing'],
+    };
+
+    const res = await request.post(buildUrl('/global-task-listeners'), {
+      headers: jsonHeaders(),
+      data: bodyWithoutId,
+    });
+
+    await assertBadRequest(res, /id/i, 'INVALID_ARGUMENT');
+  });
+
+  test('Create Global Task Listener - missing required type field', async ({
+    request,
+  }) => {
+    const unique = generateUniqueId();
+    const bodyWithoutType = {
+      id: `test-gl-${unique}`,
+      eventTypes: ['creating', 'completing'],
+    };
+
+    const res = await request.post(buildUrl('/global-task-listeners'), {
+      headers: jsonHeaders(),
+      data: bodyWithoutType,
+    });
+
+    await assertBadRequest(res, /type/i, 'INVALID_ARGUMENT');
+  });
+
+  test('Create Global Task Listener - missing required eventTypes field', async ({
+    request,
+  }) => {
+    const unique = generateUniqueId();
+    const bodyWithoutEventTypes = {
+      id: `test-gl-${unique}`,
+      type: `io.camunda.test.listener.${unique}`,
+    };
+
+    const res = await request.post(buildUrl('/global-task-listeners'), {
+      headers: jsonHeaders(),
+      data: bodyWithoutEventTypes,
+    });
+
+    await assertBadRequest(res, /eventTypes/i, 'INVALID_ARGUMENT');
+  });
+
+  test('Create Global Task Listener - invalid eventType value', async ({
+    request,
+  }) => {
+    const body = {
+      ...createUniqueGlobalTaskListenerBody(),
+      eventTypes: ['INVALID_EVENT_TYPE'],
+    };
+
+    const res = await request.post(buildUrl('/global-task-listeners'), {
+      headers: jsonHeaders(),
+      data: body,
+    });
+
+    await assertBadRequest(res, /eventTypes|INVALID_EVENT_TYPE/i);
+  });
+
+  test('Create Global Task Listener - duplicate id conflict', async ({
+    request,
+  }) => {
+    const body = createUniqueGlobalTaskListenerBody();
+
+    await test.step('First creation should succeed', async () => {
+      await expect(async () => {
+        const firstRes = await request.post(
+          buildUrl('/global-task-listeners'),
+          {
+            headers: jsonHeaders(),
+            data: body,
+          },
+        );
+        await assertStatusCode(firstRes, 201);
+
+        const json = await firstRes.json();
+        if (!createdListenerIds.includes(json.id)) {
+          createdListenerIds.push(json.id);
+        }
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Second creation with the same id should return 409', async () => {
+      const secondRes = await request.post(buildUrl('/global-task-listeners'), {
+        headers: jsonHeaders(),
+        data: body,
+      });
+      await assertConflictRequest(secondRes);
+    });
+  });
+});
+
+test.describe('Global Task Listener API - Create Permission Tests', () => {
+  let userWithoutPermission: {
+    username: string;
+    name: string;
+    email: string;
+    password: string;
+  };
+  let userWithReadOnlyPermission: {
+    username: string;
+    name: string;
+    email: string;
+    password: string;
+  };
+
+  const createdListenerIds: string[] = [];
+  const authorizationKeys: string[] = [];
+
+  test.beforeAll(async ({request}) => {
+    userWithoutPermission = await createUser(request);
+
+    userWithReadOnlyPermission = await createUser(request);
+
+    const readOnlyAuthKey = await createComponentAuthorization(request, {
+      ownerId: userWithReadOnlyPermission.username,
+      ownerType: 'USER',
+      resourceType: 'GLOBAL_LISTENER',
+      resourceId: '*',
+      permissionTypes: ['READ_TASK_LISTENER'],
+    });
+    authorizationKeys.push(readOnlyAuthKey);
+  });
+
+  test.afterAll(async ({request}) => {
+    await cleanupAuthorizations(request, authorizationKeys);
+    await cleanupUsers(request, [
+      userWithoutPermission.username,
+      userWithReadOnlyPermission.username,
+    ]);
+    await cleanupGlobalTaskListeners(request, createdListenerIds);
+  });
+
+  test('Create Global Task Listener - 403 Forbidden - user with no GLOBAL_LISTENER permissions', async ({
+    request,
+  }) => {
+    const token = encode(
+      `${userWithoutPermission.username}:${userWithoutPermission.password}`,
+    );
+
+    await expect(async () => {
+      const res = await request.post(buildUrl('/global-task-listeners'), {
+        headers: jsonHeaders(token),
+        data: createUniqueGlobalTaskListenerBody(),
+      });
+
+      await assertForbiddenRequest(
+        res,
+        "Command 'CREATE' rejected with code 'FORBIDDEN': Insufficient permissions to perform operation 'CREATE_TASK_LISTENER' on resource 'GLOBAL_LISTENER'",
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Create Global Task Listener - 403 Forbidden - user with READ-only GLOBAL_LISTENER permission', async ({
+    request,
+  }) => {
+    const token = encode(
+      `${userWithReadOnlyPermission.username}:${userWithReadOnlyPermission.password}`,
+    );
+
+    await expect(async () => {
+      const res = await request.post(buildUrl('/global-task-listeners'), {
+        headers: jsonHeaders(token),
+        data: createUniqueGlobalTaskListenerBody(),
+      });
+
+      await assertForbiddenRequest(
+        res,
+        "Command 'CREATE' rejected with code 'FORBIDDEN': Insufficient permissions to perform operation 'CREATE_TASK_LISTENER' on resource 'GLOBAL_LISTENER'",
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Create Global Task Listener - 201 Success - admin user with full permissions', async ({
+    request,
+  }) => {
+    await expect(async () => {
+      const body = createUniqueGlobalTaskListenerBody();
+      const res = await request.post(buildUrl('/global-task-listeners'), {
+        headers: jsonHeaders(),
+        data: body,
+      });
+
+      await assertStatusCode(res, 201);
+      const json = await res.json();
+      createdListenerIds.push(json.id);
+    }).toPass(defaultAssertionOptions);
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/global-task-listener/global-task-listener-delete-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/global-task-listener/global-task-listener-delete-api-tests.spec.ts
@@ -28,15 +28,14 @@ test.describe.parallel('Global Task Listener API Tests - Delete', () => {
 
   test('Delete Global Task Listener - success', async ({request}) => {
     const created = await createGlobalTaskListener(request);
+    createdListenerIds.push(created.id);
 
-    // Delete the listener
     const deleteRes = await request.delete(
       buildUrl('/global-task-listeners/{id}', {id: created.id}),
       {headers: jsonHeaders()},
     );
     await assertStatusCode(deleteRes, 204);
 
-    // Verify it no longer exists
     await expect(async () => {
       const getRes = await request.get(
         buildUrl('/global-task-listeners/{id}', {id: created.id}),
@@ -71,15 +70,14 @@ test.describe.parallel('Global Task Listener API Tests - Delete', () => {
     request,
   }) => {
     const created = await createGlobalTaskListener(request);
+    createdListenerIds.push(created.id);
 
-    // First delete should succeed
     const firstDelete = await request.delete(
       buildUrl('/global-task-listeners/{id}', {id: created.id}),
       {headers: jsonHeaders()},
     );
     await assertStatusCode(firstDelete, 204);
 
-    // Second delete on the same id should return 404
     await expect(async () => {
       const secondDelete = await request.delete(
         buildUrl('/global-task-listeners/{id}', {id: created.id}),

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/global-task-listener/global-task-listener-delete-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/global-task-listener/global-task-listener-delete-api-tests.spec.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {
+  jsonHeaders,
+  buildUrl,
+  assertUnauthorizedRequest,
+  assertNotFoundRequest,
+  assertStatusCode,
+} from '../../../../utils/http';
+import {defaultAssertionOptions} from '../../../../utils/constants';
+import {cleanupGlobalTaskListeners} from '../../../../utils/globalTaskListenerCleanup';
+import {createGlobalTaskListener} from '@requestHelpers';
+
+/* eslint-disable playwright/expect-expect */
+test.describe.parallel('Global Task Listener API Tests - Delete', () => {
+  const createdListenerIds: string[] = [];
+
+  test.afterAll(async ({request}) => {
+    await cleanupGlobalTaskListeners(request, createdListenerIds);
+  });
+
+  test('Delete Global Task Listener - success', async ({request}) => {
+    const created = await createGlobalTaskListener(request);
+
+    // Delete the listener
+    const deleteRes = await request.delete(
+      buildUrl('/global-task-listeners/{id}', {id: created.id}),
+      {headers: jsonHeaders()},
+    );
+    await assertStatusCode(deleteRes, 204);
+
+    // Verify it no longer exists
+    await expect(async () => {
+      const getRes = await request.get(
+        buildUrl('/global-task-listeners/{id}', {id: created.id}),
+        {headers: jsonHeaders()},
+      );
+      await assertNotFoundRequest(getRes, created.id);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Delete Global Task Listener - unauthorized', async ({request}) => {
+    const created = await createGlobalTaskListener(request);
+    createdListenerIds.push(created.id);
+
+    const res = await request.delete(
+      buildUrl('/global-task-listeners/{id}', {id: created.id}),
+      {headers: {}},
+    );
+
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Delete Global Task Listener - not found', async ({request}) => {
+    const res = await request.delete(
+      buildUrl('/global-task-listeners/{id}', {id: 'non-existent-id'}),
+      {headers: jsonHeaders()},
+    );
+
+    await assertNotFoundRequest(res, 'non-existent-id');
+  });
+
+  test('Delete Global Task Listener - already deleted returns not found', async ({
+    request,
+  }) => {
+    const created = await createGlobalTaskListener(request);
+
+    // First delete should succeed
+    const firstDelete = await request.delete(
+      buildUrl('/global-task-listeners/{id}', {id: created.id}),
+      {headers: jsonHeaders()},
+    );
+    await assertStatusCode(firstDelete, 204);
+
+    // Second delete on the same id should return 404
+    await expect(async () => {
+      const secondDelete = await request.delete(
+        buildUrl('/global-task-listeners/{id}', {id: created.id}),
+        {headers: jsonHeaders()},
+      );
+      await assertNotFoundRequest(secondDelete, created.id);
+    }).toPass(defaultAssertionOptions);
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/global-task-listener/global-task-listener-search-sort-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/global-task-listener/global-task-listener-search-sort-api-tests.spec.ts
@@ -1,0 +1,266 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {
+  jsonHeaders,
+  buildUrl,
+  assertUnauthorizedRequest,
+  assertBadRequest,
+  assertStatusCode,
+} from '../../../../utils/http';
+import {
+  generateUniqueId,
+  defaultAssertionOptions,
+} from '../../../../utils/constants';
+import {validateResponse} from '../../../../json-body-assertions';
+import {cleanupGlobalTaskListeners} from '../../../../utils/globalTaskListenerCleanup';
+import {createGlobalTaskListener} from '@requestHelpers';
+
+type GlobalTaskListenerItem = {
+  id: string;
+  type: string;
+  eventTypes: string[];
+  priority: number | null;
+  afterNonGlobal: boolean | null;
+  retries: number | null;
+  source: string;
+};
+
+/* eslint-disable playwright/expect-expect */
+test.describe.serial('Global Task Listener API Tests - Search and Sort', () => {
+  // Use a shared prefix to isolate listeners created by this test suite
+  const prefix = `sort-test-${generateUniqueId()}`;
+
+  // Listeners with distinct priorities and IDs for predictable ordering
+  const listeners = [
+    {
+      id: `${prefix}-c`,
+      type: `io.camunda.test.listener.${prefix}-c`,
+      eventTypes: ['creating'],
+      priority: 30,
+    },
+    {
+      id: `${prefix}-a`,
+      type: `io.camunda.test.listener.${prefix}-a`,
+      eventTypes: ['completing'],
+      priority: 10,
+    },
+    {
+      id: `${prefix}-b`,
+      type: `io.camunda.test.listener.${prefix}-b`,
+      eventTypes: ['assigning'],
+      priority: 20,
+    },
+  ];
+
+  test.beforeAll(async ({request}) => {
+    for (const listener of listeners) {
+      await createGlobalTaskListener(request, listener);
+    }
+  });
+
+  test.afterAll(async ({request}) => {
+    await cleanupGlobalTaskListeners(
+      request,
+      listeners.map((l) => l.id),
+    );
+  });
+
+  test('Search Global Task Listeners - sort by priority ASC', async ({
+    request,
+  }) => {
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/global-task-listeners/search'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {id: {$in: listeners.map((l) => l.id)}},
+            sort: [{field: 'priority', order: 'ASC'}],
+          },
+        },
+      );
+
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {path: '/global-task-listeners/search', method: 'POST', status: '200'},
+        res,
+      );
+      const body = await res.json();
+      expect(body.items.length).toBe(3);
+
+      const priorities = body.items.map(
+        (item: GlobalTaskListenerItem) => item.priority,
+      );
+      for (let i = 1; i < priorities.length; i++) {
+        expect(priorities[i - 1]).toBeLessThanOrEqual(priorities[i]);
+      }
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Global Task Listeners - sort by priority DESC', async ({
+    request,
+  }) => {
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/global-task-listeners/search'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {id: {$in: listeners.map((l) => l.id)}},
+            sort: [{field: 'priority', order: 'DESC'}],
+          },
+        },
+      );
+
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {path: '/global-task-listeners/search', method: 'POST', status: '200'},
+        res,
+      );
+      const body = await res.json();
+      expect(body.items.length).toBe(3);
+
+      const priorities = body.items.map(
+        (item: GlobalTaskListenerItem) => item.priority,
+      );
+      for (let i = 1; i < priorities.length; i++) {
+        expect(priorities[i - 1]).toBeGreaterThanOrEqual(priorities[i]);
+      }
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Global Task Listeners - sort by id ASC', async ({request}) => {
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/global-task-listeners/search'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {id: {$in: listeners.map((l) => l.id)}},
+            sort: [{field: 'id', order: 'ASC'}],
+          },
+        },
+      );
+
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {path: '/global-task-listeners/search', method: 'POST', status: '200'},
+        res,
+      );
+      const body = await res.json();
+      expect(body.items.length).toBe(3);
+
+      const ids = body.items.map((item: GlobalTaskListenerItem) => item.id);
+      // IDs end in -a, -b, -c so lexicographic ASC order is deterministic
+      expect(ids[0]).toBe(`${prefix}-a`);
+      expect(ids[1]).toBe(`${prefix}-b`);
+      expect(ids[2]).toBe(`${prefix}-c`);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Global Task Listeners - sort by id DESC', async ({request}) => {
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/global-task-listeners/search'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {id: {$in: listeners.map((l) => l.id)}},
+            sort: [{field: 'id', order: 'DESC'}],
+          },
+        },
+      );
+
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {path: '/global-task-listeners/search', method: 'POST', status: '200'},
+        res,
+      );
+      const body = await res.json();
+      expect(body.items.length).toBe(3);
+
+      const ids = body.items.map((item: GlobalTaskListenerItem) => item.id);
+      expect(ids[0]).toBe(`${prefix}-c`);
+      expect(ids[1]).toBe(`${prefix}-b`);
+      expect(ids[2]).toBe(`${prefix}-a`);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Global Task Listeners - sort by priority ASC then id ASC (compound sort)', async ({
+    request,
+  }) => {
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/global-task-listeners/search'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {id: {$in: listeners.map((l) => l.id)}},
+            sort: [
+              {field: 'priority', order: 'ASC'},
+              {field: 'id', order: 'ASC'},
+            ],
+          },
+        },
+      );
+
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {path: '/global-task-listeners/search', method: 'POST', status: '200'},
+        res,
+      );
+      const body = await res.json();
+      expect(body.items.length).toBe(3);
+
+      // priority 10 → -a, priority 20 → -b, priority 30 → -c
+      expect(body.items[0].id).toBe(`${prefix}-a`);
+      expect(body.items[0].priority).toBe(10);
+      expect(body.items[1].id).toBe(`${prefix}-b`);
+      expect(body.items[1].priority).toBe(20);
+      expect(body.items[2].id).toBe(`${prefix}-c`);
+      expect(body.items[2].priority).toBe(30);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Global Task Listeners - invalid sort field returns 400', async ({
+    request,
+  }) => {
+    const res = await request.post(buildUrl('/global-task-listeners/search'), {
+      headers: jsonHeaders(),
+      data: {
+        sort: [{field: 'invalidField', order: 'ASC'}],
+      },
+    });
+
+    await assertBadRequest(res, /invalidField/i);
+  });
+
+  test('Search Global Task Listeners - missing sort field returns 400', async ({
+    request,
+  }) => {
+    const res = await request.post(buildUrl('/global-task-listeners/search'), {
+      headers: jsonHeaders(),
+      data: {
+        sort: [{order: 'ASC'}],
+      },
+    });
+
+    await assertBadRequest(res, /field|sort/i, 'INVALID_ARGUMENT');
+  });
+
+  test('Search Global Task Listeners - unauthorized', async ({request}) => {
+    const res = await request.post(buildUrl('/global-task-listeners/search'), {
+      headers: {},
+      data: {},
+    });
+
+    await assertUnauthorizedRequest(res);
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/global-task-listener/global-task-listener-update-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/global-task-listener/global-task-listener-update-api-tests.spec.ts
@@ -1,0 +1,196 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {
+  jsonHeaders,
+  buildUrl,
+  assertUnauthorizedRequest,
+  assertBadRequest,
+  assertNotFoundRequest,
+  assertStatusCode,
+} from '../../../../utils/http';
+import {defaultAssertionOptions} from '../../../../utils/constants';
+import {validateResponse} from '../../../../json-body-assertions';
+import {cleanupGlobalTaskListeners} from '../../../../utils/globalTaskListenerCleanup';
+import {createGlobalTaskListener} from '@requestHelpers';
+
+/* eslint-disable playwright/expect-expect */
+test.describe.parallel('Global Task Listener API Tests - Update', () => {
+  const createdListenerIds: string[] = [];
+
+  test.afterAll(async ({request}) => {
+    await cleanupGlobalTaskListeners(request, createdListenerIds);
+  });
+
+  test('Update Global Task Listener - success updating all fields', async ({
+    request,
+  }) => {
+    const created = await createGlobalTaskListener(request);
+    createdListenerIds.push(created.id);
+
+    const updateBody = {
+      type: `io.camunda.test.listener.updated.${created.id}`,
+      eventTypes: ['assigning', 'canceling'],
+      retries: 5,
+      afterNonGlobal: true,
+      priority: 75,
+    };
+
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/global-task-listeners/{id}', {id: created.id}),
+        {
+          headers: jsonHeaders(),
+          data: updateBody,
+        },
+      );
+
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {path: '/global-task-listeners/{id}', method: 'PUT', status: '200'},
+        res,
+      );
+      const json = await res.json();
+      expect(json.id).toBe(created.id);
+      expect(json.type).toBe(updateBody.type);
+      expect(json.eventTypes).toEqual(
+        expect.arrayContaining(updateBody.eventTypes),
+      );
+      expect(json.retries).toBe(5);
+      expect(json.afterNonGlobal).toBe(true);
+      expect(json.priority).toBe(75);
+      expect(json.source).toBe('API');
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Update Global Task Listener - success updating required fields only', async ({
+    request,
+  }) => {
+    const created = await createGlobalTaskListener(request, {
+      retries: 3,
+      afterNonGlobal: true,
+      priority: 50,
+    });
+    createdListenerIds.push(created.id);
+
+    const updateBody = {
+      type: `io.camunda.test.listener.updated.${created.id}`,
+      eventTypes: ['all'],
+    };
+
+    await expect(async () => {
+      const res = await request.put(
+        buildUrl('/global-task-listeners/{id}', {id: created.id}),
+        {
+          headers: jsonHeaders(),
+          data: updateBody,
+        },
+      );
+
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {path: '/global-task-listeners/{id}', method: 'PUT', status: '200'},
+        res,
+      );
+      const json = await res.json();
+      expect(json.id).toBe(created.id);
+      expect(json.type).toBe(updateBody.type);
+      expect(json.eventTypes).toEqual(
+        expect.arrayContaining(updateBody.eventTypes),
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Update Global Task Listener - unauthorized', async ({request}) => {
+    const created = await createGlobalTaskListener(request);
+    createdListenerIds.push(created.id);
+
+    const res = await request.put(
+      buildUrl('/global-task-listeners/{id}', {id: created.id}),
+      {
+        headers: {},
+        data: {
+          type: created.type,
+          eventTypes: created.eventTypes,
+        },
+      },
+    );
+
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Update Global Task Listener - not found', async ({request}) => {
+    const res = await request.put(
+      buildUrl('/global-task-listeners/{id}', {id: 'non-existent-id'}),
+      {
+        headers: jsonHeaders(),
+        data: {
+          type: 'io.camunda.test.listener.dummy',
+          eventTypes: ['creating'],
+        },
+      },
+    );
+
+    await assertNotFoundRequest(res, 'non-existent-id');
+  });
+
+  test('Update Global Task Listener - missing required type field', async ({
+    request,
+  }) => {
+    const created = await createGlobalTaskListener(request);
+    createdListenerIds.push(created.id);
+
+    const res = await request.put(
+      buildUrl('/global-task-listeners/{id}', {id: created.id}),
+      {
+        headers: jsonHeaders(),
+        data: {eventTypes: ['creating']},
+      },
+    );
+
+    await assertBadRequest(res, /type/i, 'INVALID_ARGUMENT');
+  });
+
+  test('Update Global Task Listener - missing required eventTypes field', async ({
+    request,
+  }) => {
+    const created = await createGlobalTaskListener(request);
+    createdListenerIds.push(created.id);
+
+    const res = await request.put(
+      buildUrl('/global-task-listeners/{id}', {id: created.id}),
+      {
+        headers: jsonHeaders(),
+        data: {type: created.type},
+      },
+    );
+
+    await assertBadRequest(res, /eventTypes/i, 'INVALID_ARGUMENT');
+  });
+
+  test('Update Global Task Listener - invalid eventType value', async ({
+    request,
+  }) => {
+    const created = await createGlobalTaskListener(request);
+    createdListenerIds.push(created.id);
+
+    const res = await request.put(
+      buildUrl('/global-task-listeners/{id}', {id: created.id}),
+      {
+        headers: jsonHeaders(),
+        data: {
+          type: created.type,
+          eventTypes: ['INVALID_EVENT_TYPE'],
+        },
+      },
+    );
+
+    await assertBadRequest(res, /eventTypes|INVALID_EVENT_TYPE/i);
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/globalTaskListenerCleanup.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/globalTaskListenerCleanup.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {APIRequestContext} from '@playwright/test';
+import {jsonHeaders, buildUrl} from './http';
+
+export async function cleanupGlobalTaskListeners(
+  request: APIRequestContext,
+  ids: string[],
+): Promise<void> {
+  if (ids.length === 0) return;
+
+  await Promise.allSettled(
+    ids.map(async (id) => {
+      try {
+        await request.delete(
+          buildUrl('/global-task-listeners/{id}', {id}),
+          {headers: jsonHeaders()},
+        );
+      } catch {}
+    }),
+  );
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/globalTaskListenerCleanup.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/globalTaskListenerCleanup.ts
@@ -13,16 +13,50 @@ export async function cleanupGlobalTaskListeners(
   request: APIRequestContext,
   ids: string[],
 ): Promise<void> {
-  if (ids.length === 0) return;
+  const uniqueIds = [...new Set(ids)];
+  if (uniqueIds.length === 0) return;
 
-  await Promise.allSettled(
-    ids.map(async (id) => {
+  console.log(
+    `Cleaning up ${uniqueIds.length} global task listeners via API...`,
+  );
+
+  const results = await Promise.allSettled(
+    uniqueIds.map(async (id) => {
       try {
-        await request.delete(
+        const response = await request.delete(
           buildUrl('/global-task-listeners/{id}', {id}),
           {headers: jsonHeaders()},
         );
-      } catch {}
+        if (response.status() === 204) {
+          console.log(`Successfully deleted global task listener: ${id}`);
+          return {id, status: 'deleted'};
+        } else if (response.status() === 404) {
+          console.log(
+            `Global task listener already deleted or doesn't exist: ${id}`,
+          );
+          return {id, status: 'not_found'};
+        } else {
+          console.warn(
+            `Unexpected response status ${response.status()} for global task listener ${id}`,
+          );
+          return {id, status: 'error', statusCode: response.status()};
+        }
+      } catch (error) {
+        console.error(`Failed to delete global task listener ${id}:`, error);
+        return {id, status: 'failed', error};
+      }
     }),
   );
+
+  const failed = results.filter(
+    (result) =>
+      result.status === 'rejected' ||
+      (result.status === 'fulfilled' && result.value.status === 'failed'),
+  );
+
+  if (failed.length > 0) {
+    console.warn(
+      `Failed to clean up ${failed.length} global task listeners`,
+    );
+  }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/global-task-listener-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/global-task-listener-requestHelpers.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {APIRequestContext} from 'playwright-core';
+import {expect} from '@playwright/test';
+import {assertStatusCode, buildUrl, jsonHeaders} from '../http';
+import {defaultAssertionOptions, generateUniqueId} from '../constants';
+import {validateResponse} from '../../json-body-assertions';
+
+export type GlobalTaskListenerBody = {
+  id: string;
+  type: string;
+  eventTypes: string[];
+  retries?: number;
+  afterNonGlobal?: boolean;
+  priority?: number;
+};
+
+export async function createGlobalTaskListener(
+  request: APIRequestContext,
+  overrides?: Partial<GlobalTaskListenerBody>,
+): Promise<GlobalTaskListenerBody> {
+  const id = overrides?.id ?? `test-gl-${generateUniqueId()}`;
+  const body: GlobalTaskListenerBody = {
+    id,
+    type: `io.camunda.test.listener.${id}`,
+    eventTypes: ['creating', 'completing'],
+    ...overrides,
+  };
+
+  await expect(async () => {
+    const res = await request.post(buildUrl('/global-task-listeners'), {
+      headers: jsonHeaders(),
+      data: body,
+    });
+    await assertStatusCode(res, 201);
+    await validateResponse(
+      {path: '/global-task-listeners', method: 'POST', status: '201'},
+      res,
+    );
+  }).toPass(defaultAssertionOptions);
+
+  return body;
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/global-task-listener-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/global-task-listener-requestHelpers.ts
@@ -25,15 +25,17 @@ export async function createGlobalTaskListener(
   request: APIRequestContext,
   overrides?: Partial<GlobalTaskListenerBody>,
 ): Promise<GlobalTaskListenerBody> {
-  const id = overrides?.id ?? `test-gl-${generateUniqueId()}`;
-  const body: GlobalTaskListenerBody = {
-    id,
-    type: `io.camunda.test.listener.${id}`,
-    eventTypes: ['creating', 'completing'],
-    ...overrides,
-  };
+  let createdBody: GlobalTaskListenerBody | undefined;
 
   await expect(async () => {
+    const id = overrides?.id ?? `test-gl-${generateUniqueId()}`;
+    const body: GlobalTaskListenerBody = {
+      id,
+      type: `io.camunda.test.listener.${id}`,
+      eventTypes: ['creating', 'completing'],
+      ...overrides,
+    };
+
     const res = await request.post(buildUrl('/global-task-listeners'), {
       headers: jsonHeaders(),
       data: body,
@@ -43,7 +45,8 @@ export async function createGlobalTaskListener(
       {path: '/global-task-listeners', method: 'POST', status: '201'},
       res,
     );
+    createdBody = body;
   }).toPass(defaultAssertionOptions);
 
-  return body;
+  return createdBody!;
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
@@ -90,5 +90,9 @@ export {
   searchCorrelatedMessageSubscriptions,
   CORRELATED_MESSAGE_SUBSCRIPTION_SEARCH_ENDPOINT,
 } from './message-requestHelpers';
+export {
+  createGlobalTaskListener,
+  type GlobalTaskListenerBody,
+} from './global-task-listener-requestHelpers';
 export {type AuditLog} from './audit-log-requestHelpers';
 export {evaluateExpression, EXPRESSION_URL} from './expression-requestHelpers';


### PR DESCRIPTION
Backport of #49399 to `stable/8.9`.

Manual backport required because the original PR contained merge commits which prevented the automatic backport action from running.

## Changes
Cherry-picked commit from #49399 with one conflict resolved in `qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts` (kept both the `global-task-listener-requestHelpers` export added by this PR and the `expression-requestHelpers` export that was already present in `stable/8.9`).

## Files changed
- `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/global-task-listener/` — new E2E API tests for global user task listeners (CRUD, permissions, search/sort)
- `qa/c8-orchestration-cluster-e2e-test-suite/utils/globalTaskListenerCleanup.ts` — cleanup utility
- `qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/global-task-listener-requestHelpers.ts` — request helpers
- `qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts` — re-exports
