### PR TITLE
feat: introduce zeebe:jobPriorityDefinition extension element

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/Bpmn.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/Bpmn.java
@@ -227,6 +227,7 @@ import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeFormDefinitionImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeHeaderImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeInputImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeIoMappingImpl;
+import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeJobPriorityDefinitionImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeLinkedResourceImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeLinkedResourcesImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeLoopCharacteristicsImpl;
@@ -675,6 +676,7 @@ public class Bpmn {
     ZeebeTaskListenersImpl.registerType(bpmnModelBuilder);
     ZeebeTaskListenerImpl.registerType(bpmnModelBuilder);
     ZeebePriorityDefinitionImpl.registerType(bpmnModelBuilder);
+    ZeebeJobPriorityDefinitionImpl.registerType(bpmnModelBuilder);
     ZeebeVersionTagImpl.registerType(bpmnModelBuilder);
     ZeebeAdHocImpl.registerType(bpmnModelBuilder);
     ZeebeLinkedResourceImpl.registerType(bpmnModelBuilder);

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractJobWorkerTaskBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractJobWorkerTaskBuilder.java
@@ -18,6 +18,7 @@ package io.camunda.zeebe.model.bpmn.builder;
 
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.Task;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeJobPriorityDefinition;
 
 /**
  * A builder for tasks that are based on jobs and should be processed by job workers. For example,
@@ -60,5 +61,16 @@ public abstract class AbstractJobWorkerTaskBuilder<
   @Override
   public B zeebeTaskHeader(final String key, final String value) {
     return jobWorkerPropertiesBuilder.zeebeTaskHeader(key, value);
+  }
+
+  public B zeebeJobPriority(final String priority) {
+    final ZeebeJobPriorityDefinition jobPriorityDefinition =
+        myself.getCreateSingleExtensionElement(ZeebeJobPriorityDefinition.class);
+    jobPriorityDefinition.setPriority(priority);
+    return myself;
+  }
+
+  public B zeebeJobPriorityExpression(final String expression) {
+    return zeebeJobPriority(asZeebeExpression(expression));
   }
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractProcessBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractProcessBuilder.java
@@ -19,6 +19,7 @@ package io.camunda.zeebe.model.bpmn.builder;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.ProcessType;
 import io.camunda.zeebe.model.bpmn.instance.Process;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeJobPriorityDefinition;
 
 /**
  * @author Sebastian Menski
@@ -60,5 +61,16 @@ public abstract class AbstractProcessBuilder<B extends AbstractProcessBuilder<B>
   public B executable() {
     element.setExecutable(true);
     return myself;
+  }
+
+  public B zeebeJobPriority(final String priority) {
+    final ZeebeJobPriorityDefinition jobPriorityDefinition =
+        myself.getCreateSingleExtensionElement(ZeebeJobPriorityDefinition.class);
+    jobPriorityDefinition.setPriority(priority);
+    return myself;
+  }
+
+  public B zeebeJobPriorityExpression(final String expression) {
+    return zeebeJobPriority(asZeebeExpression(expression));
   }
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractServiceTaskBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractServiceTaskBuilder.java
@@ -19,6 +19,7 @@ package io.camunda.zeebe.model.bpmn.builder;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.ServiceTask;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeJobPriorityDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeLinkedResource;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeLinkedResources;
 import java.util.function.Consumer;
@@ -59,5 +60,16 @@ public abstract class AbstractServiceTaskBuilder<B extends AbstractServiceTaskBu
     final ZeebeLinkedResources linkedResources =
         myself.getCreateSingleExtensionElement(ZeebeLinkedResources.class);
     return myself.createChild(linkedResources, ZeebeLinkedResource.class);
+  }
+
+  public B zeebeJobPriority(final String priority) {
+    final ZeebeJobPriorityDefinition jobPriorityDefinition =
+        myself.getCreateSingleExtensionElement(ZeebeJobPriorityDefinition.class);
+    jobPriorityDefinition.setPriority(priority);
+    return myself;
+  }
+
+  public B zeebeJobPriorityExpression(final String expression) {
+    return zeebeJobPriority(asZeebeExpression(expression));
   }
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractServiceTaskBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractServiceTaskBuilder.java
@@ -19,7 +19,6 @@ package io.camunda.zeebe.model.bpmn.builder;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.ServiceTask;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
-import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeJobPriorityDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeLinkedResource;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeLinkedResources;
 import java.util.function.Consumer;
@@ -60,16 +59,5 @@ public abstract class AbstractServiceTaskBuilder<B extends AbstractServiceTaskBu
     final ZeebeLinkedResources linkedResources =
         myself.getCreateSingleExtensionElement(ZeebeLinkedResources.class);
     return myself.createChild(linkedResources, ZeebeLinkedResource.class);
-  }
-
-  public B zeebeJobPriority(final String priority) {
-    final ZeebeJobPriorityDefinition jobPriorityDefinition =
-        myself.getCreateSingleExtensionElement(ZeebeJobPriorityDefinition.class);
-    jobPriorityDefinition.setPriority(priority);
-    return myself;
-  }
-
-  public B zeebeJobPriorityExpression(final String expression) {
-    return zeebeJobPriority(asZeebeExpression(expression));
   }
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/ZeebeConstants.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/ZeebeConstants.java
@@ -118,6 +118,7 @@ public class ZeebeConstants {
   public static final String USER_TASK_FORM_KEY_BPMN_LOCATION = "bpmn";
 
   public static final String ELEMENT_PRIORITY_DEFINITION = "priorityDefinition";
+  public static final String ELEMENT_JOB_PRIORITY_DEFINITION = "jobPriorityDefinition";
 
   public static final String ELEMENT_AD_HOC = "adHoc";
 

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeJobPriorityDefinitionImpl.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeJobPriorityDefinitionImpl.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.impl.instance.zeebe;
+
+import io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants;
+import io.camunda.zeebe.model.bpmn.impl.ZeebeConstants;
+import io.camunda.zeebe.model.bpmn.impl.instance.BpmnModelElementInstanceImpl;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeJobPriorityDefinition;
+import org.camunda.bpm.model.xml.ModelBuilder;
+import org.camunda.bpm.model.xml.impl.instance.ModelTypeInstanceContext;
+import org.camunda.bpm.model.xml.type.ModelElementTypeBuilder;
+import org.camunda.bpm.model.xml.type.attribute.Attribute;
+
+public class ZeebeJobPriorityDefinitionImpl extends BpmnModelElementInstanceImpl
+    implements ZeebeJobPriorityDefinition {
+
+  private static Attribute<String> priorityAttribute;
+
+  public ZeebeJobPriorityDefinitionImpl(final ModelTypeInstanceContext instanceContext) {
+    super(instanceContext);
+  }
+
+  @Override
+  public String getPriority() {
+    return priorityAttribute.getValue(this);
+  }
+
+  @Override
+  public void setPriority(final String priority) {
+    priorityAttribute.setValue(this, priority);
+  }
+
+  public static void registerType(final ModelBuilder modelBuilder) {
+    final ModelElementTypeBuilder typeBuilder =
+        modelBuilder
+            .defineType(
+                ZeebeJobPriorityDefinition.class, ZeebeConstants.ELEMENT_JOB_PRIORITY_DEFINITION)
+            .namespaceUri(BpmnModelConstants.ZEEBE_NS)
+            .instanceProvider(ZeebeJobPriorityDefinitionImpl::new);
+
+    priorityAttribute =
+        typeBuilder
+            .stringAttribute(ZeebeConstants.ATTRIBUTE_PRIORITY)
+            .defaultValue(ZeebeJobPriorityDefinition.DEFAULT_LITERAL_PRIORITY)
+            .namespace(BpmnModelConstants.ZEEBE_NS)
+            .build();
+
+    typeBuilder.build();
+  }
+}

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeJobPriorityDefinition.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeJobPriorityDefinition.java
@@ -18,8 +18,18 @@ package io.camunda.zeebe.model.bpmn.instance.zeebe;
 import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstance;
 
 /**
- * Zeebe job priority for worker-activated jobs. Unbounded signed integer; default 0. Applied on
- * {@code <bpmn:process>} (process-wide default) or on a job-creating task (task-level override).
+ * Zeebe job priority for worker-activated jobs.
+ *
+ * <p>The priority value can be specified either as an integer literal in the 32-bit signed integer
+ * range, or as a FEEL expression prefixed with {@code =}. The default literal priority is {@code
+ * 0}.
+ *
+ * <p>Applied on {@code <bpmn:process>} (process-wide default) or on a job-creating task (task-level
+ * override).
+ *
+ * <p>Expression-based priorities are represented and stored as their raw string value, including
+ * the leading {@code =}, and are exposed via {@link #getPriority()} and {@link
+ * #setPriority(String)}.
  */
 public interface ZeebeJobPriorityDefinition extends BpmnModelElementInstance {
 

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeJobPriorityDefinition.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeJobPriorityDefinition.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.instance.zeebe;
+
+import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstance;
+
+/**
+ * Zeebe job priority for worker-activated jobs. Unbounded signed integer; default 0. Applied on
+ * {@code <bpmn:process>} (process-wide default) or on a job-creating task (task-level override).
+ */
+public interface ZeebeJobPriorityDefinition extends BpmnModelElementInstance {
+
+  String DEFAULT_LITERAL_PRIORITY = "0";
+
+  String getPriority();
+
+  void setPriority(String priority);
+}

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/BusinessRuleTaskValidator.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/BusinessRuleTaskValidator.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.model.bpmn.impl.ZeebeConstants;
 import io.camunda.zeebe.model.bpmn.instance.BusinessRuleTask;
 import io.camunda.zeebe.model.bpmn.instance.ExtensionElements;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledDecision;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeJobPriorityDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskDefinition;
 import java.util.Collection;
 import org.camunda.bpm.model.xml.validation.ModelElementValidator;
@@ -43,6 +44,15 @@ public final class BusinessRuleTaskValidator implements ModelElementValidator<Bu
               "Must have either one 'zeebe:%s' or one 'zeebe:%s' extension element",
               ZeebeConstants.ELEMENT_CALLED_DECISION, ZeebeConstants.ELEMENT_TASK_DEFINITION));
     }
+
+    if (hasJobPriorityDefinitionWithoutTaskDefinition(element)) {
+      validationResultCollector.addError(
+          0,
+          String.format(
+              "'zeebe:%s' is only allowed in job-worker mode ('zeebe:%s')",
+              ZeebeConstants.ELEMENT_JOB_PRIORITY_DEFINITION,
+              ZeebeConstants.ELEMENT_TASK_DEFINITION));
+    }
   }
 
   private boolean hasExactlyOneExtension(final BusinessRuleTask element) {
@@ -59,5 +69,17 @@ public final class BusinessRuleTaskValidator implements ModelElementValidator<Bu
 
     return calledDecisionExtensions.size() == 1 && taskDefinitionExtensions.isEmpty()
         || calledDecisionExtensions.isEmpty() && taskDefinitionExtensions.size() == 1;
+  }
+
+  private boolean hasJobPriorityDefinitionWithoutTaskDefinition(final BusinessRuleTask element) {
+    final ExtensionElements extensionElements = element.getExtensionElements();
+    if (extensionElements == null) {
+      return false;
+    }
+    final boolean hasJobPriorityDefinition =
+        !extensionElements.getChildElementsByType(ZeebeJobPriorityDefinition.class).isEmpty();
+    final boolean hasTaskDefinition =
+        !extensionElements.getChildElementsByType(ZeebeTaskDefinition.class).isEmpty();
+    return hasJobPriorityDefinition && !hasTaskDefinition;
   }
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ExtensionElementDuplicationValidators.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ExtensionElementDuplicationValidators.java
@@ -32,6 +32,7 @@ import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledDecision;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListeners;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeFormDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeIoMapping;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeJobPriorityDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeLinkedResources;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebePriorityDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeScript;
@@ -51,6 +52,9 @@ public class ExtensionElementDuplicationValidators {
           // process
           ExtensionElementsDuplicationValidator.verifyThat(Process.class)
               .hasSingleExtensionElement(ZeebeVersionTag.class, ZeebeConstants.ELEMENT_VERSION_TAG),
+          ExtensionElementsDuplicationValidator.verifyThat(Process.class)
+              .hasSingleExtensionElement(
+                  ZeebeJobPriorityDefinition.class, ZeebeConstants.ELEMENT_JOB_PRIORITY_DEFINITION),
 
           // flow node
           ExtensionElementsDuplicationValidator.verifyThat(FlowNode.class)
@@ -66,6 +70,9 @@ public class ExtensionElementDuplicationValidators {
           ExtensionElementsDuplicationValidator.verifyThat(ServiceTask.class)
               .hasSingleExtensionElement(
                   ZeebeLinkedResources.class, ZeebeConstants.ELEMENT_LINKED_RESOURCES),
+          ExtensionElementsDuplicationValidator.verifyThat(ServiceTask.class)
+              .hasSingleExtensionElement(
+                  ZeebeJobPriorityDefinition.class, ZeebeConstants.ELEMENT_JOB_PRIORITY_DEFINITION),
           ExtensionElementsDuplicationValidator.verifyThat(SendTask.class)
               .hasSingleExtensionElement(
                   ZeebeTaskHeaders.class, ZeebeConstants.ELEMENT_TASK_HEADERS),

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ExtensionElementDuplicationValidators.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ExtensionElementDuplicationValidators.java
@@ -79,6 +79,9 @@ public class ExtensionElementDuplicationValidators {
           ExtensionElementsDuplicationValidator.verifyThat(SendTask.class)
               .hasSingleExtensionElement(
                   ZeebeLinkedResources.class, ZeebeConstants.ELEMENT_LINKED_RESOURCES),
+          ExtensionElementsDuplicationValidator.verifyThat(SendTask.class)
+              .hasSingleExtensionElement(
+                  ZeebeJobPriorityDefinition.class, ZeebeConstants.ELEMENT_JOB_PRIORITY_DEFINITION),
 
           // user task
           ExtensionElementsDuplicationValidator.verifyThat(UserTask.class)
@@ -112,6 +115,9 @@ public class ExtensionElementDuplicationValidators {
           ExtensionElementsDuplicationValidator.verifyThat(BusinessRuleTask.class)
               .hasSingleExtensionElement(
                   ZeebeCalledDecision.class, ZeebeConstants.ELEMENT_CALLED_DECISION),
+          ExtensionElementsDuplicationValidator.verifyThat(BusinessRuleTask.class)
+              .hasSingleExtensionElement(
+                  ZeebeJobPriorityDefinition.class, ZeebeConstants.ELEMENT_JOB_PRIORITY_DEFINITION),
 
           // script task
           ExtensionElementsDuplicationValidator.verifyThat(ScriptTask.class)
@@ -122,6 +128,9 @@ public class ExtensionElementDuplicationValidators {
           ExtensionElementsDuplicationValidator.verifyThat(ScriptTask.class)
               .hasSingleExtensionElement(
                   ZeebeTaskHeaders.class, ZeebeConstants.ELEMENT_TASK_HEADERS),
+          ExtensionElementsDuplicationValidator.verifyThat(ScriptTask.class)
+              .hasSingleExtensionElement(
+                  ZeebeJobPriorityDefinition.class, ZeebeConstants.ELEMENT_JOB_PRIORITY_DEFINITION),
 
           // ad-hoc subprocess
           ExtensionElementsDuplicationValidator.verifyThat(AdHocSubProcess.class)

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ScriptTaskValidator.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ScriptTaskValidator.java
@@ -18,6 +18,7 @@ package io.camunda.zeebe.model.bpmn.validation.zeebe;
 import io.camunda.zeebe.model.bpmn.impl.ZeebeConstants;
 import io.camunda.zeebe.model.bpmn.instance.ExtensionElements;
 import io.camunda.zeebe.model.bpmn.instance.ScriptTask;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeJobPriorityDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeScript;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskDefinition;
 import java.util.Collection;
@@ -43,6 +44,15 @@ public final class ScriptTaskValidator implements ModelElementValidator<ScriptTa
               "Must have either one 'zeebe:%s' or one 'zeebe:%s' extension element",
               ZeebeConstants.ELEMENT_SCRIPT, ZeebeConstants.ELEMENT_TASK_DEFINITION));
     }
+
+    if (hasJobPriorityDefinitionWithoutTaskDefinition(element)) {
+      validationResultCollector.addError(
+          0,
+          String.format(
+              "'zeebe:%s' is only allowed in job-worker mode ('zeebe:%s')",
+              ZeebeConstants.ELEMENT_JOB_PRIORITY_DEFINITION,
+              ZeebeConstants.ELEMENT_TASK_DEFINITION));
+    }
   }
 
   private boolean hasExactlyOneExtension(final ScriptTask element) {
@@ -59,5 +69,17 @@ public final class ScriptTaskValidator implements ModelElementValidator<ScriptTa
 
     return scriptExtensions.size() == 1 && taskDefinitionExtensions.isEmpty()
         || scriptExtensions.isEmpty() && taskDefinitionExtensions.size() == 1;
+  }
+
+  private boolean hasJobPriorityDefinitionWithoutTaskDefinition(final ScriptTask element) {
+    final ExtensionElements extensionElements = element.getExtensionElements();
+    if (extensionElements == null) {
+      return false;
+    }
+    final boolean hasJobPriorityDefinition =
+        !extensionElements.getChildElementsByType(ZeebeJobPriorityDefinition.class).isEmpty();
+    final boolean hasTaskDefinition =
+        !extensionElements.getChildElementsByType(ZeebeTaskDefinition.class).isEmpty();
+    return hasJobPriorityDefinition && !hasTaskDefinition;
   }
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/SendTaskValidator.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/SendTaskValidator.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.model.bpmn.impl.ZeebeConstants;
 import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstance;
 import io.camunda.zeebe.model.bpmn.instance.ExtensionElements;
 import io.camunda.zeebe.model.bpmn.instance.SendTask;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeJobPriorityDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebePublishMessage;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskDefinition;
 import java.util.Collection;
@@ -55,6 +56,16 @@ public final class SendTaskValidator implements ModelElementValidator<SendTask> 
     if (!publishMessageExtensions.isEmpty() && element.getMessage() == null) {
       validationResultCollector.addError(0, "Must reference a message");
     }
+
+    if (hasJobPriorityDefinitionWithoutTaskDefinition(
+        extensionElements, taskDefinitionExtensions)) {
+      validationResultCollector.addError(
+          0,
+          String.format(
+              "'zeebe:%s' is only allowed in job-worker mode ('zeebe:%s')",
+              ZeebeConstants.ELEMENT_JOB_PRIORITY_DEFINITION,
+              ZeebeConstants.ELEMENT_TASK_DEFINITION));
+    }
   }
 
   public <T extends BpmnModelElementInstance> Collection<T> getExtensionElementsByType(
@@ -70,5 +81,16 @@ public final class SendTaskValidator implements ModelElementValidator<SendTask> 
       final Collection<ZeebeTaskDefinition> taskDefinitionExtensions) {
     return publishMessageExtensions.size() == 1 && taskDefinitionExtensions.isEmpty()
         || publishMessageExtensions.isEmpty() && taskDefinitionExtensions.size() == 1;
+  }
+
+  private boolean hasJobPriorityDefinitionWithoutTaskDefinition(
+      final ExtensionElements extensionElements,
+      final Collection<ZeebeTaskDefinition> taskDefinitionExtensions) {
+    if (extensionElements == null) {
+      return false;
+    }
+    final boolean hasJobPriorityDefinition =
+        !extensionElements.getChildElementsByType(ZeebeJobPriorityDefinition.class).isEmpty();
+    return hasJobPriorityDefinition && taskDefinitionExtensions.isEmpty();
   }
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ZeebeDesignTimeValidators.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ZeebeDesignTimeValidators.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledDecision;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledElement;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListener;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeFormDefinition;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeJobPriorityDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeLinkedResource;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeLoopCharacteristics;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebePriorityDefinition;
@@ -151,6 +152,11 @@ public final class ZeebeDesignTimeValidators {
         ZeebeElementValidator.verifyThat(ZeebePriorityDefinition.class)
             .hasNonEmptyAttribute(
                 ZeebePriorityDefinition::getPriority, ZeebeConstants.ATTRIBUTE_PRIORITY));
+    validators.add(
+        ZeebeElementValidator.verifyThat(ZeebeJobPriorityDefinition.class)
+            .hasNonEmptyAttribute(
+                ZeebeJobPriorityDefinition::getPriority, ZeebeConstants.ATTRIBUTE_PRIORITY));
+    validators.add(new ZeebeJobPriorityDefinitionValidator());
     validators.add(
         ZeebeElementValidator.verifyThat(Condition.class)
             .hasNonEmptyAttribute(Condition::getTextContent, ZeebeConstants.ATTRIBUTE_CONDITION));

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ZeebeJobPriorityDefinitionValidator.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ZeebeJobPriorityDefinitionValidator.java
@@ -32,9 +32,6 @@ public class ZeebeJobPriorityDefinitionValidator
       final ZeebeJobPriorityDefinition element,
       final ValidationResultCollector validationResultCollector) {
     final String priority = element.getPriority();
-    if (priority == null || priority.isEmpty()) {
-      return; // already reported by the non-empty ZeebeElementValidator
-    }
     if (priority.startsWith("=")) {
       // FEEL expression — syntax validation is deferred to the engine transformer
       return;

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ZeebeJobPriorityDefinitionValidator.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ZeebeJobPriorityDefinitionValidator.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.validation.zeebe;
+
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeJobPriorityDefinition;
+import org.camunda.bpm.model.xml.validation.ModelElementValidator;
+import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
+
+public class ZeebeJobPriorityDefinitionValidator
+    implements ModelElementValidator<ZeebeJobPriorityDefinition> {
+
+  @Override
+  public Class<ZeebeJobPriorityDefinition> getElementType() {
+    return ZeebeJobPriorityDefinition.class;
+  }
+
+  @Override
+  public void validate(
+      final ZeebeJobPriorityDefinition element,
+      final ValidationResultCollector validationResultCollector) {
+    final String priority = element.getPriority();
+    if (priority == null || priority.isEmpty()) {
+      return; // already reported by the non-empty ZeebeElementValidator
+    }
+    if (priority.startsWith("=")) {
+      // FEEL expression — syntax validation is deferred to the engine transformer
+      return;
+    }
+    try {
+      Integer.parseInt(priority);
+    } catch (final NumberFormatException e) {
+      validationResultCollector.addError(
+          0,
+          String.format(
+              "Expected 'priority' to be a literal integer or a FEEL expression (starting with '='), but got '%s'.",
+              priority));
+    }
+  }
+}

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/BusinessRuleTaskBuilderTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/BusinessRuleTaskBuilderTest.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.ExtensionElements;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledDecision;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeJobPriorityDefinition;
 import org.camunda.bpm.model.xml.instance.ModelElementInstance;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -127,6 +128,47 @@ public class BusinessRuleTaskBuilderTest {
         .hasSize(1)
         .extracting(ZeebeCalledDecision::getBindingType)
         .containsExactly(bindingType);
+  }
+
+  @Test
+  void shouldSetJobPriorityAsLiteralOnBusinessRuleTask() {
+    // given / when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .businessRuleTask("task", t -> t.zeebeJobType("type").zeebeJobPriority("42"))
+            .endEvent()
+            .done();
+
+    // then
+    final ModelElementInstance businessRuleTask = instance.getModelElementById("task");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) businessRuleTask.getUniqueChildElementByType(ExtensionElements.class);
+    assertThat(extensionElements.getChildElementsByType(ZeebeJobPriorityDefinition.class))
+        .singleElement()
+        .extracting(ZeebeJobPriorityDefinition::getPriority)
+        .isEqualTo("42");
+  }
+
+  @Test
+  void shouldSetJobPriorityAsExpressionOnBusinessRuleTask() {
+    // given / when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .businessRuleTask(
+                "task", t -> t.zeebeJobType("type").zeebeJobPriorityExpression("priority"))
+            .endEvent()
+            .done();
+
+    // then
+    final ModelElementInstance businessRuleTask = instance.getModelElementById("task");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) businessRuleTask.getUniqueChildElementByType(ExtensionElements.class);
+    assertThat(extensionElements.getChildElementsByType(ZeebeJobPriorityDefinition.class))
+        .singleElement()
+        .extracting(ZeebeJobPriorityDefinition::getPriority)
+        .isEqualTo("=priority");
   }
 
   @Test

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/ProcessBuilderTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/ProcessBuilderTest.java
@@ -51,6 +51,7 @@ import io.camunda.zeebe.model.bpmn.instance.Escalation;
 import io.camunda.zeebe.model.bpmn.instance.EscalationEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.Event;
 import io.camunda.zeebe.model.bpmn.instance.EventDefinition;
+import io.camunda.zeebe.model.bpmn.instance.ExtensionElements;
 import io.camunda.zeebe.model.bpmn.instance.FlowElement;
 import io.camunda.zeebe.model.bpmn.instance.FlowNode;
 import io.camunda.zeebe.model.bpmn.instance.Gateway;
@@ -75,6 +76,7 @@ import io.camunda.zeebe.model.bpmn.instance.TimeDuration;
 import io.camunda.zeebe.model.bpmn.instance.TimerEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.Transaction;
 import io.camunda.zeebe.model.bpmn.instance.UserTask;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeJobPriorityDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeProperties;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeProperty;
 import java.util.Collection;
@@ -2137,6 +2139,46 @@ public class ProcessBuilderTest {
                 properties.stream()
                     .collect(Collectors.toMap(ZeebeProperty::getName, ZeebeProperty::getValue)))
         .orElseGet(Collections::emptyMap);
+  }
+
+  @Test
+  public void shouldSetJobPriorityAsLiteralOnProcess() {
+    // given / when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .zeebeJobPriority("10")
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType("type"))
+            .done();
+
+    // then
+    final Process process = instance.getModelElementById("process");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) process.getUniqueChildElementByType(ExtensionElements.class);
+    assertThat(extensionElements.getChildElementsByType(ZeebeJobPriorityDefinition.class))
+        .singleElement()
+        .extracting(ZeebeJobPriorityDefinition::getPriority)
+        .isEqualTo("10");
+  }
+
+  @Test
+  public void shouldSetJobPriorityAsExpressionOnProcess() {
+    // given / when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .zeebeJobPriorityExpression("processPriority")
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType("type"))
+            .done();
+
+    // then
+    final Process process = instance.getModelElementById("process");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) process.getUniqueChildElementByType(ExtensionElements.class);
+    assertThat(extensionElements.getChildElementsByType(ZeebeJobPriorityDefinition.class))
+        .singleElement()
+        .extracting(ZeebeJobPriorityDefinition::getPriority)
+        .isEqualTo("=processPriority");
   }
 
   @Test

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/ScriptTaskBuilderTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/ScriptTaskBuilderTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.tuple;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.ExtensionElements;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeJobPriorityDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeScript;
 import org.camunda.bpm.model.xml.instance.ModelElementInstance;
 import org.junit.jupiter.api.Test;
@@ -63,6 +64,46 @@ public class ScriptTaskBuilderTest {
         .hasSize(1)
         .extracting(ZeebeScript::getResultVariable)
         .containsExactly("result");
+  }
+
+  @Test
+  void shouldSetJobPriorityAsLiteralOnScriptTask() {
+    // given / when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .scriptTask("task", t -> t.zeebeJobType("type").zeebeJobPriority("42"))
+            .endEvent()
+            .done();
+
+    // then
+    final ModelElementInstance scriptTask = instance.getModelElementById("task");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) scriptTask.getUniqueChildElementByType(ExtensionElements.class);
+    assertThat(extensionElements.getChildElementsByType(ZeebeJobPriorityDefinition.class))
+        .singleElement()
+        .extracting(ZeebeJobPriorityDefinition::getPriority)
+        .isEqualTo("42");
+  }
+
+  @Test
+  void shouldSetJobPriorityAsExpressionOnScriptTask() {
+    // given / when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .scriptTask("task", t -> t.zeebeJobType("type").zeebeJobPriorityExpression("priority"))
+            .endEvent()
+            .done();
+
+    // then
+    final ModelElementInstance scriptTask = instance.getModelElementById("task");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) scriptTask.getUniqueChildElementByType(ExtensionElements.class);
+    assertThat(extensionElements.getChildElementsByType(ZeebeJobPriorityDefinition.class))
+        .singleElement()
+        .extracting(ZeebeJobPriorityDefinition::getPriority)
+        .isEqualTo("=priority");
   }
 
   @Test

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/SendTaskBuilderTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/SendTaskBuilderTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.tuple;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.ExtensionElements;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeJobPriorityDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebePublishMessage;
 import org.camunda.bpm.model.xml.instance.ModelElementInstance;
 import org.junit.jupiter.api.Test;
@@ -151,6 +152,46 @@ public class SendTaskBuilderTest {
         .hasSize(1)
         .extracting(ZeebePublishMessage::getTimeToLive)
         .containsExactly("=timeToLiveExpr");
+  }
+
+  @Test
+  void shouldSetJobPriorityAsLiteralOnSendTask() {
+    // given / when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .sendTask("task", t -> t.zeebeJobType("type").zeebeJobPriority("42"))
+            .endEvent()
+            .done();
+
+    // then
+    final ModelElementInstance sendTask = instance.getModelElementById("task");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) sendTask.getUniqueChildElementByType(ExtensionElements.class);
+    assertThat(extensionElements.getChildElementsByType(ZeebeJobPriorityDefinition.class))
+        .singleElement()
+        .extracting(ZeebeJobPriorityDefinition::getPriority)
+        .isEqualTo("42");
+  }
+
+  @Test
+  void shouldSetJobPriorityAsExpressionOnSendTask() {
+    // given / when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .sendTask("task", t -> t.zeebeJobType("type").zeebeJobPriorityExpression("priority"))
+            .endEvent()
+            .done();
+
+    // then
+    final ModelElementInstance sendTask = instance.getModelElementById("task");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) sendTask.getUniqueChildElementByType(ExtensionElements.class);
+    assertThat(extensionElements.getChildElementsByType(ZeebeJobPriorityDefinition.class))
+        .singleElement()
+        .extracting(ZeebeJobPriorityDefinition::getPriority)
+        .isEqualTo("=priority");
   }
 
   @Test

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/ServiceTaskBuilderTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/ServiceTaskBuilderTest.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.model.bpmn.instance.ExtensionElements;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListener;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListeners;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeHeader;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeJobPriorityDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskDefinition;
 import java.util.Collection;
 import org.camunda.bpm.model.xml.instance.ModelElementInstance;
@@ -183,5 +184,45 @@ public class ServiceTaskBuilderTest {
         .getUniqueChildElementByType(ExtensionElements.class)
         .getUniqueChildElementByType(ZeebeExecutionListeners.class)
         .getChildElementsByType(ZeebeExecutionListener.class);
+  }
+
+  @Test
+  void shouldSetJobPriorityAsLiteralOnServiceTask() {
+    // given / when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType("type").zeebeJobPriority("42"))
+            .endEvent()
+            .done();
+
+    // then
+    final ModelElementInstance serviceTask = instance.getModelElementById("task");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) serviceTask.getUniqueChildElementByType(ExtensionElements.class);
+    assertThat(extensionElements.getChildElementsByType(ZeebeJobPriorityDefinition.class))
+        .singleElement()
+        .extracting(ZeebeJobPriorityDefinition::getPriority)
+        .isEqualTo("42");
+  }
+
+  @Test
+  void shouldSetJobPriorityAsExpressionOnServiceTask() {
+    // given / when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType("type").zeebeJobPriorityExpression("priority"))
+            .endEvent()
+            .done();
+
+    // then
+    final ModelElementInstance serviceTask = instance.getModelElementById("task");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) serviceTask.getUniqueChildElementByType(ExtensionElements.class);
+    assertThat(extensionElements.getChildElementsByType(ZeebeJobPriorityDefinition.class))
+        .singleElement()
+        .extracting(ZeebeJobPriorityDefinition::getPriority)
+        .isEqualTo("=priority");
   }
 }

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeJobPriorityDefinitionTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeJobPriorityDefinitionTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.instance.zeebe;
+
+import io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants;
+import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstanceTest;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+public class ZeebeJobPriorityDefinitionTest extends BpmnModelElementInstanceTest {
+
+  @Override
+  public TypeAssumption getTypeAssumption() {
+    return new TypeAssumption(BpmnModelConstants.ZEEBE_NS, false);
+  }
+
+  @Override
+  public Collection<ChildElementAssumption> getChildElementAssumptions() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public Collection<AttributeAssumption> getAttributesAssumptions() {
+    return Arrays.asList(
+        new AttributeAssumption(
+            BpmnModelConstants.ZEEBE_NS,
+            "priority",
+            false,
+            false,
+            ZeebeJobPriorityDefinition.DEFAULT_LITERAL_PRIORITY));
+  }
+}

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/BusinessRuleTaskValidatorTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/BusinessRuleTaskValidatorTest.java
@@ -177,6 +177,34 @@ class BusinessRuleTaskValidatorTest {
             "Must have either one 'zeebe:calledDecision' or one 'zeebe:taskDefinition' extension element"));
   }
 
+  @Test
+  void jobPriorityDefinitionNotAllowedWithCalledDecision() {
+    // given / when
+    final BpmnModelInstance process =
+        process(
+            task ->
+                task.zeebeCalledDecisionId("decisionId")
+                    .zeebeResultVariable("result")
+                    .zeebeJobPriority("42"));
+
+    // then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(
+            BusinessRuleTask.class,
+            "'zeebe:jobPriorityDefinition' is only allowed in job-worker mode ('zeebe:taskDefinition')"));
+  }
+
+  @Test
+  void jobPriorityDefinitionAllowedWithTaskDefinition() {
+    // given / when
+    final BpmnModelInstance process =
+        process(task -> task.zeebeJobType("type").zeebeJobPriority("42"));
+
+    // then
+    ProcessValidationUtil.assertThatProcessIsValid(process);
+  }
+
   private BpmnModelInstance process(final Consumer<BusinessRuleTaskBuilder> taskBuilder) {
     return Bpmn.createExecutableProcess("process")
         .startEvent()

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeJobPriorityDefinitionValidationTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeJobPriorityDefinitionValidationTest.java
@@ -82,6 +82,36 @@ public class ZeebeJobPriorityDefinitionValidationTest {
     ProcessValidationUtil.assertThatProcessIsValid(process);
   }
 
+  @Test
+  void shouldBeValidWithBareEqualsAsFeelExpressionOnProcess() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .zeebeJobPriority("=")
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType("type"))
+            .endEvent()
+            .done();
+
+    // when / then
+    ProcessValidationUtil.assertThatProcessIsValid(process);
+  }
+
+  @Test
+  void shouldBeValidWithEmptyPriorityAttributeOnProcess() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .zeebeJobPriority("")
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType("type"))
+            .endEvent()
+            .done();
+
+    // when / then
+    ProcessValidationUtil.assertThatProcessIsValid(process);
+  }
+
   @ParameterizedTest
   @ValueSource(strings = {"high", "not-a-number", "2147483648", "-2147483649"})
   void shouldRejectInvalidLiteralOnProcess(final String priority) {
@@ -150,6 +180,34 @@ public class ZeebeJobPriorityDefinitionValidationTest {
     ProcessValidationUtil.assertThatProcessIsValid(process);
   }
 
+  @Test
+  void shouldBeValidWithBareEqualsAsFeelExpressionOnServiceTask() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType("type").zeebeJobPriority("="))
+            .endEvent()
+            .done();
+
+    // when / then
+    ProcessValidationUtil.assertThatProcessIsValid(process);
+  }
+
+  @Test
+  void shouldBeValidWithEmptyPriorityAttributeOnServiceTask() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType("type").zeebeJobPriority(""))
+            .endEvent()
+            .done();
+
+    // when / then
+    ProcessValidationUtil.assertThatProcessIsValid(process);
+  }
+
   @ParameterizedTest
   @ValueSource(strings = {"high", "not-a-number", "2147483648", "-2147483649"})
   void shouldRejectInvalidLiteralOnServiceTask(final String priority) {
@@ -203,6 +261,34 @@ public class ZeebeJobPriorityDefinitionValidationTest {
   }
 
   @Test
+  void shouldBeValidWithBareEqualsAsFeelExpressionOnSendTask() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .sendTask("task", t -> t.zeebeJobType("type").zeebeJobPriority("="))
+            .endEvent()
+            .done();
+
+    // when / then
+    ProcessValidationUtil.assertThatProcessIsValid(process);
+  }
+
+  @Test
+  void shouldBeValidWithEmptyPriorityAttributeOnSendTask() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .sendTask("task", t -> t.zeebeJobType("type").zeebeJobPriority(""))
+            .endEvent()
+            .done();
+
+    // when / then
+    ProcessValidationUtil.assertThatProcessIsValid(process);
+  }
+
+  @Test
   void shouldRejectDuplicatedJobPriorityDefinitionOnSendTask() {
     // given
     final BpmnModelInstance process =
@@ -226,6 +312,34 @@ public class ZeebeJobPriorityDefinitionValidationTest {
         Bpmn.createExecutableProcess("process")
             .startEvent()
             .businessRuleTask("task", t -> t.zeebeJobType("type").zeebeJobPriority("42"))
+            .endEvent()
+            .done();
+
+    // when / then
+    ProcessValidationUtil.assertThatProcessIsValid(process);
+  }
+
+  @Test
+  void shouldBeValidWithBareEqualsAsFeelExpressionOnBusinessRuleTask() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .businessRuleTask("task", t -> t.zeebeJobType("type").zeebeJobPriority("="))
+            .endEvent()
+            .done();
+
+    // when / then
+    ProcessValidationUtil.assertThatProcessIsValid(process);
+  }
+
+  @Test
+  void shouldBeValidWithEmptyPriorityAttributeOnBusinessRuleTask() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .businessRuleTask("task", t -> t.zeebeJobType("type").zeebeJobPriority(""))
             .endEvent()
             .done();
 
@@ -258,6 +372,34 @@ public class ZeebeJobPriorityDefinitionValidationTest {
         Bpmn.createExecutableProcess("process")
             .startEvent()
             .scriptTask("task", t -> t.zeebeJobType("type").zeebeJobPriority("42"))
+            .endEvent()
+            .done();
+
+    // when / then
+    ProcessValidationUtil.assertThatProcessIsValid(process);
+  }
+
+  @Test
+  void shouldBeValidWithBareEqualsAsFeelExpressionOnScriptTask() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .scriptTask("task", t -> t.zeebeJobType("type").zeebeJobPriority("="))
+            .endEvent()
+            .done();
+
+    // when / then
+    ProcessValidationUtil.assertThatProcessIsValid(process);
+  }
+
+  @Test
+  void shouldBeValidWithEmptyPriorityAttributeOnScriptTask() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .scriptTask("task", t -> t.zeebeJobType("type").zeebeJobPriority(""))
             .endEvent()
             .done();
 

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeJobPriorityDefinitionValidationTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeJobPriorityDefinitionValidationTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.validation;
+
+import static io.camunda.zeebe.model.bpmn.validation.ExpectedValidationResult.expect;
+
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.instance.Process;
+import io.camunda.zeebe.model.bpmn.instance.ServiceTask;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeJobPriorityDefinition;
+import org.camunda.bpm.model.xml.impl.util.ReflectUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class ZeebeJobPriorityDefinitionValidationTest {
+
+  @Test
+  void shouldBeValidWithJobPriorityDefinitionOnBothProcessAndServiceTask() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .zeebeJobPriority("10")
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType("type").zeebeJobPriority("90"))
+            .endEvent()
+            .done();
+
+    // when / then
+    ProcessValidationUtil.assertThatProcessIsValid(process);
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
+  // Process-level
+  ////////////////////////////////////////////////////////////////////////////
+
+  @ParameterizedTest
+  @ValueSource(strings = {"0", "42", "-100", "-2147483648", "2147483647"})
+  void shouldBeValidWithLiteralPriorityOnProcess(final String priority) {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .zeebeJobPriority(priority)
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType("type"))
+            .endEvent()
+            .done();
+
+    // when / then
+    ProcessValidationUtil.assertThatProcessIsValid(process);
+  }
+
+  @Test
+  void shouldBeValidWithFeelExpressionOnProcess() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .zeebeJobPriorityExpression("processPriority")
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType("type"))
+            .endEvent()
+            .done();
+
+    // when / then
+    ProcessValidationUtil.assertThatProcessIsValid(process);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"high", "not-a-number", "2147483648", "-2147483649"})
+  void shouldRejectInvalidLiteralOnProcess(final String priority) {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .zeebeJobPriority(priority)
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType("type"))
+            .endEvent()
+            .done();
+
+    // when / then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(
+            ZeebeJobPriorityDefinition.class,
+            "Expected 'priority' to be a literal integer or a FEEL expression (starting with '='), but got '"
+                + priority
+                + "'."));
+  }
+
+  @Test
+  void shouldRejectDuplicatedJobPriorityDefinitionOnProcess() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.readModelFromStream(
+            ReflectUtil.getResourceAsStream(
+                "io/camunda/zeebe/model/bpmn/validation/ZeebeJobPriorityDefinitionValidationTest.duplicatedProcess.bpmn"));
+
+    // when / then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process, expect(Process.class, "Must have exactly one 'zeebe:jobPriorityDefinition'"));
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
+  // Task-level
+  ////////////////////////////////////////////////////////////////////////////
+
+  @ParameterizedTest
+  @ValueSource(strings = {"0", "42", "-100", "-2147483648", "2147483647"})
+  void shouldBeValidWithLiteralPriorityOnServiceTask(final String priority) {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType("type").zeebeJobPriority(priority))
+            .endEvent()
+            .done();
+
+    // when / then
+    ProcessValidationUtil.assertThatProcessIsValid(process);
+  }
+
+  @Test
+  void shouldBeValidWithFeelExpressionOnServiceTask() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType("type").zeebeJobPriorityExpression("priority"))
+            .endEvent()
+            .done();
+
+    // when / then
+    ProcessValidationUtil.assertThatProcessIsValid(process);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"high", "not-a-number", "2147483648", "-2147483649"})
+  void shouldRejectInvalidLiteralOnServiceTask(final String priority) {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType("type").zeebeJobPriority(priority))
+            .endEvent()
+            .done();
+
+    // when / then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(
+            ZeebeJobPriorityDefinition.class,
+            "Expected 'priority' to be a literal integer or a FEEL expression (starting with '='), but got '"
+                + priority
+                + "'."));
+  }
+
+  @Test
+  void shouldRejectDuplicatedJobPriorityDefinitionOnServiceTask() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.readModelFromStream(
+            ReflectUtil.getResourceAsStream(
+                "io/camunda/zeebe/model/bpmn/validation/ZeebeJobPriorityDefinitionValidationTest.duplicatedServiceTask.bpmn"));
+
+    // when / then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process, expect(ServiceTask.class, "Must have exactly one 'zeebe:jobPriorityDefinition'"));
+  }
+
+  @Test
+  void shouldBeValidWithNoExplicitPriorityAttribute() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.readModelFromStream(
+            ReflectUtil.getResourceAsStream(
+                "io/camunda/zeebe/model/bpmn/validation/ZeebeJobPriorityDefinitionValidationTest.noExplicitPriority.bpmn"));
+
+    // when / then
+    ProcessValidationUtil.assertThatProcessIsValid(process);
+  }
+}

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeJobPriorityDefinitionValidationTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeJobPriorityDefinitionValidationTest.java
@@ -19,7 +19,10 @@ import static io.camunda.zeebe.model.bpmn.validation.ExpectedValidationResult.ex
 
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.instance.BusinessRuleTask;
 import io.camunda.zeebe.model.bpmn.instance.Process;
+import io.camunda.zeebe.model.bpmn.instance.ScriptTask;
+import io.camunda.zeebe.model.bpmn.instance.SendTask;
 import io.camunda.zeebe.model.bpmn.instance.ServiceTask;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeJobPriorityDefinition;
 import org.camunda.bpm.model.xml.impl.util.ReflectUtil;
@@ -115,7 +118,7 @@ public class ZeebeJobPriorityDefinitionValidationTest {
   }
 
   ////////////////////////////////////////////////////////////////////////////
-  // Task-level
+  // ServiceTask-level
   ////////////////////////////////////////////////////////////////////////////
 
   @ParameterizedTest
@@ -179,6 +182,100 @@ public class ZeebeJobPriorityDefinitionValidationTest {
     // when / then
     ProcessValidationUtil.assertThatProcessHasViolations(
         process, expect(ServiceTask.class, "Must have exactly one 'zeebe:jobPriorityDefinition'"));
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
+  // SendTask-level
+  ////////////////////////////////////////////////////////////////////////////
+
+  @Test
+  void shouldBeValidWithJobPriorityDefinitionOnSendTask() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .sendTask("task", t -> t.zeebeJobType("type").zeebeJobPriority("42"))
+            .endEvent()
+            .done();
+
+    // when / then
+    ProcessValidationUtil.assertThatProcessIsValid(process);
+  }
+
+  @Test
+  void shouldRejectDuplicatedJobPriorityDefinitionOnSendTask() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.readModelFromStream(
+            ReflectUtil.getResourceAsStream(
+                "io/camunda/zeebe/model/bpmn/validation/ZeebeJobPriorityDefinitionValidationTest.duplicatedSendTask.bpmn"));
+
+    // when / then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process, expect(SendTask.class, "Must have exactly one 'zeebe:jobPriorityDefinition'"));
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
+  // BusinessRuleTask-level
+  ////////////////////////////////////////////////////////////////////////////
+
+  @Test
+  void shouldBeValidWithJobPriorityDefinitionOnBusinessRuleTask() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .businessRuleTask("task", t -> t.zeebeJobType("type").zeebeJobPriority("42"))
+            .endEvent()
+            .done();
+
+    // when / then
+    ProcessValidationUtil.assertThatProcessIsValid(process);
+  }
+
+  @Test
+  void shouldRejectDuplicatedJobPriorityDefinitionOnBusinessRuleTask() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.readModelFromStream(
+            ReflectUtil.getResourceAsStream(
+                "io/camunda/zeebe/model/bpmn/validation/ZeebeJobPriorityDefinitionValidationTest.duplicatedBusinessRuleTask.bpmn"));
+
+    // when / then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(BusinessRuleTask.class, "Must have exactly one 'zeebe:jobPriorityDefinition'"));
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
+  // ScriptTask-level
+  ////////////////////////////////////////////////////////////////////////////
+
+  @Test
+  void shouldBeValidWithJobPriorityDefinitionOnScriptTask() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .scriptTask("task", t -> t.zeebeJobType("type").zeebeJobPriority("42"))
+            .endEvent()
+            .done();
+
+    // when / then
+    ProcessValidationUtil.assertThatProcessIsValid(process);
+  }
+
+  @Test
+  void shouldRejectDuplicatedJobPriorityDefinitionOnScriptTask() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.readModelFromStream(
+            ReflectUtil.getResourceAsStream(
+                "io/camunda/zeebe/model/bpmn/validation/ZeebeJobPriorityDefinitionValidationTest.duplicatedScriptTask.bpmn"));
+
+    // when / then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process, expect(ScriptTask.class, "Must have exactly one 'zeebe:jobPriorityDefinition'"));
   }
 
   @Test

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeScriptTaskValidatorTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeScriptTaskValidatorTest.java
@@ -91,6 +91,32 @@ class ZeebeScriptTaskValidatorTest {
             "Must have either one 'zeebe:script' or one 'zeebe:taskDefinition' extension element"));
   }
 
+  @Test
+  void jobPriorityDefinitionNotAllowedWithScript() {
+    // given / when
+    final BpmnModelInstance process =
+        process(
+            task ->
+                task.zeebeExpression("true").zeebeResultVariable("result").zeebeJobPriority("42"));
+
+    // then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(
+            ScriptTask.class,
+            "'zeebe:jobPriorityDefinition' is only allowed in job-worker mode ('zeebe:taskDefinition')"));
+  }
+
+  @Test
+  void jobPriorityDefinitionAllowedWithTaskDefinition() {
+    // given / when
+    final BpmnModelInstance process =
+        process(task -> task.zeebeJobType("type").zeebeJobPriority("42"));
+
+    // then
+    ProcessValidationUtil.assertThatProcessIsValid(process);
+  }
+
   private BpmnModelInstance process(final Consumer<ScriptTaskBuilder> taskBuilder) {
     return Bpmn.createExecutableProcess("process")
         .startEvent()

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeSendTaskValidatorTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeSendTaskValidatorTest.java
@@ -109,6 +109,38 @@ class ZeebeSendTaskValidatorTest {
             "Must have either one 'zeebe:publishMessage' or one 'zeebe:taskDefinition' extension element"));
   }
 
+  @Test
+  void jobPriorityDefinitionNotAllowedWithPublishMessage() {
+    // given / when
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .sendTask("task")
+            .message(b -> b.name("message-name").zeebeCorrelationKey("correlationKey"))
+            .zeebeJobPriority("42")
+            .done();
+
+    // then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(
+            SendTask.class,
+            "'zeebe:jobPriorityDefinition' is only allowed in job-worker mode ('zeebe:taskDefinition')"));
+  }
+
+  @Test
+  void jobPriorityDefinitionAllowedWithTaskDefinition() {
+    // given / when
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .sendTask("task", t -> t.zeebeJobType("type").zeebeJobPriority("42"))
+            .done();
+
+    // then
+    ProcessValidationUtil.assertThatProcessIsValid(process);
+  }
+
   private BpmnModelInstance process(final Consumer<PublishMessageBuilder> consumer) {
     return Bpmn.createExecutableProcess("process")
         .startEvent()

--- a/zeebe/bpmn-model/src/test/resources/io/camunda/zeebe/model/bpmn/validation/ZeebeJobPriorityDefinitionValidationTest.duplicatedBusinessRuleTask.bpmn
+++ b/zeebe/bpmn-model/src/test/resources/io/camunda/zeebe/model/bpmn/validation/ZeebeJobPriorityDefinitionValidationTest.duplicatedBusinessRuleTask.bpmn
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="process" isExecutable="true">
+    <bpmn:startEvent id="start"/>
+    <bpmn:businessRuleTask id="task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="service"/>
+        <zeebe:jobPriorityDefinition priority="10"/>
+        <zeebe:jobPriorityDefinition priority="20"/>
+      </bpmn:extensionElements>
+    </bpmn:businessRuleTask>
+  </bpmn:process>
+</bpmn:definitions>

--- a/zeebe/bpmn-model/src/test/resources/io/camunda/zeebe/model/bpmn/validation/ZeebeJobPriorityDefinitionValidationTest.duplicatedProcess.bpmn
+++ b/zeebe/bpmn-model/src/test/resources/io/camunda/zeebe/model/bpmn/validation/ZeebeJobPriorityDefinitionValidationTest.duplicatedProcess.bpmn
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="process" isExecutable="true">
+    <bpmn:extensionElements>
+      <zeebe:jobPriorityDefinition priority="5"/>
+      <zeebe:jobPriorityDefinition priority="15"/>
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="start"/>
+    <bpmn:serviceTask id="task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="service"/>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+  </bpmn:process>
+</bpmn:definitions>

--- a/zeebe/bpmn-model/src/test/resources/io/camunda/zeebe/model/bpmn/validation/ZeebeJobPriorityDefinitionValidationTest.duplicatedScriptTask.bpmn
+++ b/zeebe/bpmn-model/src/test/resources/io/camunda/zeebe/model/bpmn/validation/ZeebeJobPriorityDefinitionValidationTest.duplicatedScriptTask.bpmn
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="process" isExecutable="true">
+    <bpmn:startEvent id="start"/>
+    <bpmn:scriptTask id="task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="service"/>
+        <zeebe:jobPriorityDefinition priority="10"/>
+        <zeebe:jobPriorityDefinition priority="20"/>
+      </bpmn:extensionElements>
+    </bpmn:scriptTask>
+  </bpmn:process>
+</bpmn:definitions>

--- a/zeebe/bpmn-model/src/test/resources/io/camunda/zeebe/model/bpmn/validation/ZeebeJobPriorityDefinitionValidationTest.duplicatedSendTask.bpmn
+++ b/zeebe/bpmn-model/src/test/resources/io/camunda/zeebe/model/bpmn/validation/ZeebeJobPriorityDefinitionValidationTest.duplicatedSendTask.bpmn
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="process" isExecutable="true">
+    <bpmn:startEvent id="start"/>
+    <bpmn:sendTask id="task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="service"/>
+        <zeebe:jobPriorityDefinition priority="10"/>
+        <zeebe:jobPriorityDefinition priority="20"/>
+      </bpmn:extensionElements>
+    </bpmn:sendTask>
+  </bpmn:process>
+</bpmn:definitions>

--- a/zeebe/bpmn-model/src/test/resources/io/camunda/zeebe/model/bpmn/validation/ZeebeJobPriorityDefinitionValidationTest.duplicatedServiceTask.bpmn
+++ b/zeebe/bpmn-model/src/test/resources/io/camunda/zeebe/model/bpmn/validation/ZeebeJobPriorityDefinitionValidationTest.duplicatedServiceTask.bpmn
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="process" isExecutable="true">
+    <bpmn:startEvent id="start"/>
+    <bpmn:serviceTask id="task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="service"/>
+        <zeebe:jobPriorityDefinition priority="10"/>
+        <zeebe:jobPriorityDefinition priority="20"/>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+  </bpmn:process>
+</bpmn:definitions>

--- a/zeebe/bpmn-model/src/test/resources/io/camunda/zeebe/model/bpmn/validation/ZeebeJobPriorityDefinitionValidationTest.noExplicitPriority.bpmn
+++ b/zeebe/bpmn-model/src/test/resources/io/camunda/zeebe/model/bpmn/validation/ZeebeJobPriorityDefinitionValidationTest.noExplicitPriority.bpmn
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="process" isExecutable="true">
+    <bpmn:startEvent id="start"/>
+    <bpmn:serviceTask id="task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="service"/>
+        <zeebe:jobPriorityDefinition/>
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+  </bpmn:process>
+</bpmn:definitions>


### PR DESCRIPTION
## Description

Introduces `<zeebe:jobPriorityDefinition>` extension element.

This element can be used on:
* a process definition level
* a task level for
  * service tasks
  * send tasks
  * business rule tasks (when using job implementation)
  * script tasks (when using job implementation)

Right now this element is not used for anything. In the future it will be used to evaluate the priority level of jobs.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes https://github.com/camunda/camunda/issues/51844
