### PR TITLE
ci: future proof smoke tests next minor + properly call teardown on 8.9

### DIFF
--- a/.github/workflows/preview-env-build-and-deploy.yml
+++ b/.github/workflows/preview-env-build-and-deploy.yml
@@ -28,6 +28,13 @@ on:
         required: false
         type: string
         default: ''
+      ref:
+        description: |
+          Git ref for checkout and ArgoCD revision.
+          Required for cross-branch calls since reusable workflows inherit the caller's ref.
+        required: false
+        type: string
+        default: ''
     outputs:
       host-name:
         description: "Hostname of the deployed preview environment (e.g., smoke-123.camunda.camunda.cloud)"
@@ -55,6 +62,13 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        ref: ${{ inputs.ref }}
+
+    - name: Resolve commit SHA
+      if: inputs.ref != ''
+      id: ref
+      run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
     - uses: ./.github/actions/setup-build
       with:
@@ -78,7 +92,7 @@ jobs:
         platforms: linux/amd64
         dockerfile: camunda.Dockerfile
         push: true
-        version: pr-${{ github.event.pull_request.head.sha || github.sha }}
+        version: pr-${{ steps.ref.outputs.sha || github.event.pull_request.head.sha || github.sha }}
 
     - name: Observe build status
       if: always()
@@ -105,9 +119,8 @@ jobs:
     uses: ./.github/workflows/optimize-ci-build-reusable.yml
     secrets: inherit
     with:
-      branch: ${{ github.head_ref || github.ref_name }}
+      branch: ${{ inputs.ref || github.head_ref || github.ref_name }}
       pushDocker: true
-      version: pr-${{ github.event.pull_request.head.sha || github.sha }}
 
   deploy-preview:
     # For workflow_call: inputs.app-name is set (github.event_name is inherited from caller, not 'workflow_call')
@@ -185,10 +198,20 @@ jobs:
           secret/data/products/camunda/ci/camunda ARGOCD_TOKEN;
 
     #########################################################################
-    # Setup: checkout code. This is required because we are using
-    # composite actions and deployment manifests.
+    # Checkout the specified workflow_call ref when provided; for pull_request
+    # runs, an empty inputs.ref lets checkout fall back to the event ref
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        ref: ${{ inputs.ref }}
+
+    #########################################################################
+    # Resolve commit SHA for docker image tagging only when workflow_call
+    # provides an explicit ref
+    - name: Resolve commit SHA
+      if: inputs.ref != ''
+      id: ref
+      run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
     #########################################################################
     # Determine the argocd arguments that need to be passed to the create app command
@@ -210,10 +233,10 @@ jobs:
           --helm-set git.branch=${revision} \
           --upsert ${label_args} ${helm_extra}" >> "$GITHUB_ENV"
       env:
-        docker_tag: pr-${{ github.event.pull_request.head.sha || github.sha }}
+        docker_tag: pr-${{ steps.ref.outputs.sha || github.event.pull_request.head.sha || github.sha }}
         helm_extra_args: ${{ inputs.helm-extra-args }}
         labels: ${{ inputs.labels }}
-        revision: ${{ github.head_ref || github.ref_name }}
+        revision: ${{ inputs.ref || github.head_ref || github.ref_name }}
         app_name: camunda-${{ steps.set-app-name.outputs.app-name }}
 
     #########################################################################
@@ -221,7 +244,7 @@ jobs:
     - name: Deploy Preview Environment for c8sm
       uses: camunda/infra-global-github-actions/preview-env/create@main
       with:
-        revision: ${{ github.head_ref || github.ref_name }}
+        revision: ${{ inputs.ref || github.head_ref || github.ref_name }}
         argocd_token: ${{ steps.secrets.outputs.ARGOCD_TOKEN }}
         app_name: camunda-${{ steps.set-app-name.outputs.app-name }}
         app_url: https://${{ steps.set-host-name.outputs.host-name }}

--- a/.github/workflows/preview-env-smoke-test.yml
+++ b/.github/workflows/preview-env-smoke-test.yml
@@ -237,10 +237,11 @@ jobs:
     needs:
     - deploy-8-9
     - test
-    uses: ./.github/workflows/preview-env-teardown.yml
+    uses: camunda/camunda/.github/workflows/preview-env-teardown.yml@stable/8.9
     secrets: inherit
     with:
       app-name: smoke89-${{ github.run_number }}
+      ref: stable/8.9
 
   teardown-8-10:
     name: Teardown 8.10 Preview Environment

--- a/.github/workflows/preview-env-teardown.yml
+++ b/.github/workflows/preview-env-teardown.yml
@@ -13,6 +13,13 @@ on:
           ArgoCD app name to tear down
         required: true
         type: string
+      ref:
+        description: |
+          Git ref for checkout and ArgoCD revision.
+          Required for cross-branch calls since reusable workflows inherit the caller's ref.
+        required: false
+        type: string
+        default: ''
 
 jobs:
   teardown-preview:
@@ -67,17 +74,19 @@ jobs:
         vault-url: ${{ secrets.VAULT_ADDR }}
 
     #########################################################################
-    # Setup: checkout code. This is required because we are using
-    # composite actions and deployment manifests.
+    # Checkout the specified workflow_call ref when provided; for pull_request
+    # runs, an empty inputs.ref lets checkout fall back to the event ref
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        ref: ${{ inputs.ref }}
 
     #########################################################################
     # Tear down preview environment
     - name: Tear down Preview Environment
       uses: camunda/infra-global-github-actions/preview-env/destroy@main
       with:
-        revision: ${{ github.head_ref || github.ref_name }}
+        revision: ${{ inputs.ref || github.head_ref || github.ref_name }}
         argocd_token: ${{ steps.secrets.outputs.ARGOCD_TOKEN }}
         app_name: camunda-${{ inputs.app-name || steps.sanitize.outputs.branch_name }}
         argocd_server: argocd.int.camunda.com


### PR DESCRIPTION
## Description

We have an ongoing incident ([Slack thread](https://camunda.slack.com/archives/C0AV2GWNSAK)) where the weekly preview-env smoke tests deploy the wrong versions. The `smoke89` and `smoke810` environments both show ArgoCD `Target Revision: main` instead of their respective stable branches, causing them to run an `8.9.0-alpha5` stack regardless of labels. Meanwhile `smoke88` works correctly because `stable/8.8` already has the `ref` input wired through its reusable workflows.

**Root cause**

The preview-env-smoke-test.yml on `main` passes `ref: stable/8.9` to the reusable `preview-env-build-and-deploy.yml@stable/8.9`, but that workflow's `workflow_call` definition did not declare a `ref` input — so GitHub rejects the call. Without `ref`, the deploy job falls back to `github.ref_name` (which resolves to `main` on scheduled runs), building and deploying from the wrong branch entirely. Fixed on: https://github.com/camunda/camunda/pull/52055

The same gap existed in preview-env-teardown.yml, and neither workflow on `main` had the input either — meaning `stable/8.10` would inherit the same problem when branched.

**What this PR does**

- Adds the `ref` input to preview-env-build-and-deploy.yml and preview-env-teardown.yml (matching the existing `stable/8.8` implementation), and wires it through checkout, docker image tagging, Optimize build, and ArgoCD revision references
- Fixes `teardown-8-9` in the smoke test to call `@stable/8.9` with `ref: stable/8.9` (consistent with the 8.8 pattern)
- Drops the explicit `version` passthrough to the Optimize reusable build so both Camunda and Optimize images are tagged from the same resolved commit SHA
- Applies the [same changes](https://github.com/camunda/camunda/pull/52055) on `main` so that `stable/8.10` inherits the `ref` input when branched, preventing this class of issue from recurring on every future minor

Related to #inc-5299. Follow up on https://github.com/camunda/camunda/pull/52055.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
