### PR TITLE
Add engine-expert skill

### DIFF
--- a/.claude/skills/engine-expert/SKILL.md
+++ b/.claude/skills/engine-expert/SKILL.md
@@ -1,0 +1,65 @@
+---
+
+name: engine-expert
+description: Use when implementing new capabilities or fixing bugs in the Zeebe workflow engine in zeebe/engine/ — BPMN process execution, DMN decision evaluation, job lifecycle, user/identity management, batch operations, process variables, deployments, signals, messages, timers, multi-tenancy, or authorization. Use when adding or modifying processors, event appliers, state classes, record value types, intents, or engine tests.
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+# Engine Expert
+
+Reference for making changes to the Zeebe workflow engine with confidence. The engine processes thousands of commands per second on a single thread, state is rebuilt from the log on every restart, and partitions communicate over an unreliable network. Mistakes here cause leader/follower divergence, upgrade-path breakage, or production performance regressions. This skill exists to prevent the well-known classes of mistake.
+
+## Iron rules
+
+These are summaries. The reference files (linked below) are authoritative — they carry the rationale, exceptions, and worked examples.
+
+- No state mutation from processors. State changes only through events applied by event appliers.
+- Released event appliers — and any method on a `Mutable*State` interface or anything transitively called from an applier — must not change in logic. Add a new version/method instead. Cosmetic changes (formatting, imports, comments, behavior-equivalent renames) are fine. No golden file protects state class methods — extra care required.
+- Processors must end the command's processing by appending an event or a rejection. Exceptions are a last-resort rollback mechanism and are expensive — prefer pre-validation.
+- Generated keys must be used as the record key of at least one appended record. Otherwise the key generator can't be rehydrated on replay and may hand out a duplicate.
+- Inter-partition command receivers must be idempotent. Prefer reject-redundant-command over re-emitting events.
+- Hot paths log at trace level only. INFO/DEBUG on a hot path is a performance regression at engine throughput.
+
+## Where to read next
+
+|                                                 If you are…                                                  |        Read         |
+|--------------------------------------------------------------------------------------------------------------|---------------------|
+| Designing or extending a record value type, intent, or `ValueType`                                           | `records.md`        |
+| Editing or creating a processor, behavior class, validation, or rejection                                    | `processors.md`     |
+| Editing or creating an event applier, a `Mutable*State` interface method, or anything called from an applier | `event-appliers.md` |
+| Writing or modifying engine tests                                                                            | `testing.md`        |
+
+## Local checks before commit
+
+Run only the tests relevant to your change — running the full engine test suite locally takes a long time and is what CI is for.
+
+```bash
+# 1. Format (mandatory before commit when touching Java/markdown/pom.xml).
+./mvnw license:format spotless:apply -pl zeebe/engine -T1C
+
+# 2. Tests scoped to your change (single class or small pattern). Use
+#    -Dtest=YourTest, comma-separated classes, or a glob like '*UserTest*'.
+./mvnw verify -pl zeebe/engine \
+  -Dtest='YourTest' -DskipTests=false -DskipITs -Dquickly
+
+# 3. If you touched an event applier, a Mutable*State method, or anything
+#    transitively called from an applier — also run the golden file check.
+./mvnw verify -pl zeebe/engine -Dtest=NoChangesTest \
+  -DskipTests=false -DskipITs -Dquickly
+```
+
+Re-run any new or modified test at least 3× to catch flakiness. Push and let CI run the comprehensive suite.
+
+## Recommended workflow for new processor logic
+
+1. Write the test first, using `EngineRule` and `RecordingExporter` against appended records (see `testing.md`). Run it — confirm it fails.
+2. Implement the processor (and its event applier + state changes).
+3. Re-run the test 3+ times. Then run the local checks block above.
+
+## Canonical docs
+
+- `zeebe/engine/README.md` — architecture, do's and don'ts.
+- `docs/zeebe/event-applier-golden-files.md` — golden files, versioning, port rules.
+- `docs/zeebe/developer_handbook.md` — step-by-step for new records, REST endpoints, authorization.
+- `docs/zeebe/engine_questions.md` — FAQ on tokens, joining gateways, variable scoping.
+- https://github.com/camunda/camunda/wiki/Logging — logging guidance.
+

--- a/.claude/skills/engine-expert/SKILL.md
+++ b/.claude/skills/engine-expert/SKILL.md
@@ -19,6 +19,7 @@ These are summaries. The reference files (linked below) are authoritative — th
 - Generated keys must be used as the record key of at least one appended record. Otherwise the key generator can't be rehydrated on replay and may hand out a duplicate.
 - Inter-partition command receivers must be idempotent. Prefer reject-redundant-command over re-emitting events.
 - Hot paths log at trace level only. INFO/DEBUG on a hot path is a performance regression at engine throughput.
+- Values returned from `ColumnFamily.get(...)` / state reads are backed by a shared, mutable buffer reused on the next read of the same column family. Never cache them or hold them across another read — `copyFrom(...)` if you need to keep the value, or use `get(key, valueSupplier)` to allocate a fresh instance.
 
 ## Where to read next
 

--- a/.claude/skills/engine-expert/SKILL.md
+++ b/.claude/skills/engine-expert/SKILL.md
@@ -63,4 +63,5 @@ Re-run any new or modified test at least 3× to catch flakiness. Push and let CI
 - `docs/zeebe/developer_handbook.md` — step-by-step for new records, REST endpoints, authorization.
 - `docs/zeebe/engine_questions.md` — FAQ on tokens, joining gateways, variable scoping.
 - https://github.com/camunda/camunda/wiki/Logging — logging guidance.
+- https://github.com/camunda/camunda/wiki/Error-Guidelines — error message format and rejection vs. exception.
 

--- a/.claude/skills/engine-expert/SKILL.md
+++ b/.claude/skills/engine-expert/SKILL.md
@@ -20,6 +20,7 @@ These are summaries. The reference files (linked below) are authoritative — th
 - Inter-partition command receivers must be idempotent. Prefer reject-redundant-command over re-emitting events.
 - Hot paths log at trace level only. INFO/DEBUG on a hot path is a performance regression at engine throughput.
 - Values returned from `ColumnFamily.get(...)` / state reads are backed by a shared, mutable buffer reused on the next read of the same column family. Never cache them or hold them across another read — `copyFrom(...)` if you need to keep the value, or use `get(key, valueSupplier)` to allocate a fresh instance.
+- Non-transactional side effects (metrics, post-commit hooks) run only after all state and follow-up command writes that could throw. Exceptions roll back state, but already-executed side effects don't roll back — counters drift.
 
 ## Where to read next
 

--- a/.claude/skills/engine-expert/SKILL.md
+++ b/.claude/skills/engine-expert/SKILL.md
@@ -2,7 +2,8 @@
 
 name: engine-expert
 description: Use when implementing new capabilities or fixing bugs in the Zeebe workflow engine in zeebe/engine/ — BPMN process execution, DMN decision evaluation, job lifecycle, user/identity management, batch operations, process variables, deployments, signals, messages, timers, multi-tenancy, or authorization. Use when adding or modifying processors, event appliers, state classes, record value types, intents, or engine tests.
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+---
 
 # Engine Expert
 
@@ -34,7 +35,7 @@ Run only the tests relevant to your change — running the full engine test suit
 
 ```bash
 # 1. Format (mandatory before commit when touching Java/markdown/pom.xml).
-./mvnw license:format spotless:apply -pl zeebe/engine -T1C
+./mvnw license:format spotless:apply -T1C
 
 # 2. Tests scoped to your change (single class or small pattern). Use
 #    -Dtest=YourTest, comma-separated classes, or a glob like '*UserTest*'.

--- a/.claude/skills/engine-expert/SKILL.md
+++ b/.claude/skills/engine-expert/SKILL.md
@@ -15,6 +15,7 @@ These are summaries. The reference files (linked below) are authoritative — th
 
 - No state mutation from processors. State changes only through events applied by event appliers.
 - Released event appliers — and any method on a `Mutable*State` interface or anything transitively called from an applier — must not change in logic. Add a new version/method instead. Cosmetic changes (formatting, imports, comments, behavior-equivalent renames) are fine. No golden file protects state class methods — extra care required.
+- New event applier versions must reach every newer minor before its initial release. A version that ships only in an older minor's patch breaks upgrade replay — dead partitions, unrecoverable without an ad-hoc patch. See `event-appliers.md`.
 - Processors must end the command's processing by appending an event or a rejection. Exceptions are a last-resort rollback mechanism and are expensive — prefer pre-validation.
 - Generated keys must be used as the record key of at least one appended record. Otherwise the key generator can't be rehydrated on replay and may hand out a duplicate.
 - Inter-partition command receivers must be idempotent. Prefer reject-redundant-command over re-emitting events.

--- a/.claude/skills/engine-expert/event-appliers.md
+++ b/.claude/skills/engine-expert/event-appliers.md
@@ -28,6 +28,17 @@ Before editing any applier file or any method reachable from an applier, run the
 
 The script name says "applier" but the rule applies equally to anything an applier transitively calls — most commonly methods on the state class implementation behind a `Mutable*State` interface. There is no golden file for state classes, so this manual check is the only guard.
 
+## State-class internals: shared-buffer pitfall
+
+State classes commonly read from a `ColumnFamily` and return the value to a caller — or worse, cache it. The returned value is backed by a **shared, mutable buffer** owned by the column family and is overwritten on the next `get(...)` of the same CF. Caching such a value (e.g. into a `Map` keyed by id) silently corrupts data: production incident INC-981 / #16311, where `DbFormState` cached the `persistedForm` returned from RocksDB without copying, and form ids ended up pointing to the wrong form objects.
+
+Two escape hatches:
+
+- `value.copyFrom(stateRead)` into an instance the state class owns (most common pattern).
+- `cf.get(key, valueSupplier)` allocates a fresh instance per call instead of returning the shared reference.
+
+Full explanation and rule of thumb: `processors.md` § *Reading state safely*.
+
 ## Workflow when behavior must change
 
 1. **Don't edit the existing class.** Create the next version, e.g. `XxxV2Applier.java`.

--- a/.claude/skills/engine-expert/event-appliers.md
+++ b/.claude/skills/engine-expert/event-appliers.md
@@ -1,0 +1,60 @@
+# Event Appliers
+
+Event appliers apply events to state. They run during processing (when events are first appended) AND during replay (when the engine rebuilds state from the log on restart). Replay must produce the *exact* same state mutations as the original processing — otherwise leaders and followers diverge. The `NoChangesTest` golden-file check enforces this, but only for the applier source itself.
+
+## Iron rules
+
+- **Bulk of logic lives in the processor, not here.** Appliers should be as simple as possible — apply event → state change. The processor's job is to compute what the state change should be; the applier just performs it.
+- **Released appliers must not change in logic.** Same for any method on a `Mutable*State` interface, and anything transitively called from an applier (helper methods, state-class internals). There is **no golden file** protecting state-class methods — this is a silent danger.
+- **Allowed:** cosmetic changes (formatting, imports, comments) and renames where behavior is unchanged. Golden-file diffs from these are fine to accept.
+- **Unreleased appliers can be modified freely.** Use the helper script (below) to determine status.
+
+## Pre-edit check
+
+Before editing any applier file or any method reachable from an applier, run the helper script with the file you're about to edit. This works for both applier classes and state class implementations:
+
+```bash
+# Applier
+.claude/skills/engine-expert/scripts/check-released-applier.sh \
+  zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserCreatedApplier.java
+
+# State class implementation reachable from an applier
+.claude/skills/engine-expert/scripts/check-released-applier.sh \
+  zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/DbUserState.java
+```
+
+- `RELEASED (first seen in <tag>)` → do not edit logic. Add a new version (for appliers) or a new method on the state class (for state-class methods reachable from an applier) instead.
+- `UNRELEASED` → edits are allowed. The first time the file ships in a release tag, it becomes immutable.
+
+The script name says "applier" but the rule applies equally to anything an applier transitively calls — most commonly methods on the state class implementation behind a `Mutable*State` interface. There is no golden file for state classes, so this manual check is the only guard.
+
+## Workflow when behavior must change
+
+1. **Don't edit the existing class.** Create the next version, e.g. `XxxV2Applier.java`.
+2. **Register the new version in `EventAppliers`** alongside the existing version.
+3. **Forward-port to all newer minor branches before their next release.**
+   - First check whether a release branch already exists for any newer minor (skip the fetch if working offline):
+
+     ```bash
+     git fetch --prune origin
+     git branch -r | grep -E 'origin/release-'
+     ```
+   - **If a release branch exists** for a newer minor, that minor's code is **already frozen**. Port to BOTH:
+     - the release branch (so it ships in that release), and
+     - the corresponding stable branch (so it lives in future patches/minors).
+       Alert the user explicitly when this case is detected — it's easy to miss.
+   - **If no release branch exists** for a newer minor → port to the stable branch only.
+   - **Skill-only pitfall** (not yet documented in `docs/zeebe/event-applier-golden-files.md`): a v2 shipped in `8.7.x` patch but missed in `8.8.0` breaks the upgrade path for `8.7.x` → `8.8.0`. The new version must reach every newer minor that ships next.
+4. **Format, then run `NoChangesTest`.** A new golden file should appear; create it from the failure message's `cp` command.
+
+## Templates
+
+- Applier: `zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserCreatedApplier.java`
+- Registration: `zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java`
+- State interface split: `zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/UserState.java` + `zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUserState.java`
+
+## Canonical docs
+
+- `docs/zeebe/event-applier-golden-files.md` — full golden-file guide, back/forward-port cases, allowed changes.
+- `zeebe/engine/README.md` § "Event appliers are not allowed to be changed after having been released".
+

--- a/.claude/skills/engine-expert/event-appliers.md
+++ b/.claude/skills/engine-expert/event-appliers.md
@@ -43,7 +43,7 @@ Full explanation and rule of thumb: `processors.md` § *Reading state safely*.
 
 1. **Don't edit the existing class.** Create the next version, e.g. `XxxV2Applier.java`.
 2. **Register the new version in `EventAppliers`** alongside the existing version.
-3. **Forward-port to all newer minor branches before their next release.**
+3. **Forward-port to all newer minor branches before their next release.** A new applier version that ships in a patch of an older minor but misses the next minor's initial release breaks the upgrade path: the new minor cannot replay events written with that version, leaving partitions dead until an ad-hoc patch ships (this hit 8.9.0 with `ProcessEvent.TRIGGERING` v2). Full context: `docs/zeebe/event-applier-golden-files.md`.
    - First check whether a release branch already exists for any newer minor (skip the fetch if working offline):
 
      ```bash
@@ -55,7 +55,6 @@ Full explanation and rule of thumb: `processors.md` § *Reading state safely*.
      - the corresponding stable branch (so it lives in future patches/minors).
        Alert the user explicitly when this case is detected — it's easy to miss.
    - **If no release branch exists** for a newer minor → port to the stable branch only.
-   - **Skill-only pitfall** (not yet documented in `docs/zeebe/event-applier-golden-files.md`): a v2 shipped in `8.7.x` patch but missed in `8.8.0` breaks the upgrade path for `8.7.x` → `8.8.0`. The new version must reach every newer minor that ships next.
 4. **Format, then run `NoChangesTest`.** A new golden file should appear; create it from the failure message's `cp` command.
 
 ## Templates

--- a/.claude/skills/engine-expert/processors.md
+++ b/.claude/skills/engine-expert/processors.md
@@ -1,0 +1,36 @@
+# Processors
+
+Processors are where the engine's logic lives. They consume commands and produce events, rejections, follow-up commands, and side-effects. The stream processor is **single-threaded** — only one command is processed at a time per partition.
+
+## Iron rules
+
+- **Bulk of logic lives here**, not in event appliers. Processors are easier to fix when bugs are found or behavior must be adjusted.
+- **Read-only state access only.** Mutation goes through events + appliers. Use the `*State` (read-only) interface from a processor, never the `Mutable*State` interface.
+- **Composition over inheritance.** Reuse logic via `Behavior` classes (e.g., `BpmnJobActivationBehavior`), not via subclasses.
+- **A processor must always end the command's processing by appending an event or a rejection.** A command is considered processed (after replay) when a follow-up record points to it.
+- **Exceptions are a last-resort rollback mechanism**, not a control-flow tool. They are expensive at engine throughput.
+  - Prefer pre-validation: validate the command before appending any events.
+  - Throw only when validation is only possible mid-processing, after some events have already been appended. The stream processor will roll back the appended records and call `tryHandleError`, where the processor typically appends a command rejection to recover.
+- **Don't trust data in a command's `RecordValue`** — it may be stale by the time the command is processed. Read the latest entity data from state. Use the command's data only as the *requested change* (e.g., new assignee), and use state as the *basis* for the change.
+- **Generated keys must be used as the record key of at least one appended record.** The key generator is rehydrated on replay by reading the keys of appended records. If a generated key is only stored inside a `RecordValue` (not used as a record key), the generator won't see it on replay and may hand out the same key again. Storing the key inside the record value as well is fine, but doesn't substitute for using it as a record key.
+- **Authorization checks belong on every user-triggered command**, before mutating state. Internal/engine-triggered events (e.g., `ProcessInstance.COMPLETE_ELEMENT` fired by the engine itself) do **not** require an authorization check — those state-machine transitions assume permissions were verified upstream.
+- **Inter-partition command receivers must be idempotent.** Prefer reject-redundant-command (write a rejection, no state change) over re-emitting the same events.
+- **Take small steps.** Append follow-up commands rather than doing everything in one processing cycle. The single thread is shared with every other command on this partition.
+
+## Logging
+
+- **Hot paths log at trace level only.** The engine processes thousands of commands per second; INFO/DEBUG on a hot path is a measurable performance regression.
+- General logging guidance: https://github.com/camunda/camunda/wiki/Logging
+
+## Templates
+
+- Processor: `zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateProcessor.java`
+- Behavior class: `zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java`
+- Registration: `zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java`
+
+## Canonical docs
+
+- `zeebe/engine/README.md` § "Do's and Don'ts" — full list of stream-processor invariants.
+- `docs/zeebe/developer_handbook.md` § "Authorization Checks in the Engine" — when and how to add authorization to a processor.
+- `docs/zeebe/engine_questions.md` — variable scoping, joining gateways, token semantics.
+

--- a/.claude/skills/engine-expert/processors.md
+++ b/.claude/skills/engine-expert/processors.md
@@ -17,10 +17,18 @@ Processors are where the engine's logic lives. They consume commands and produce
 - **Inter-partition command receivers must be idempotent.** Prefer reject-redundant-command (write a rejection, no state change) over re-emitting the same events.
 - **Take small steps.** Append follow-up commands rather than doing everything in one processing cycle. The single thread is shared with every other command on this partition.
 
+## Error and rejection messages
+
+- **Follow the format** `Expected [X], but got [Y] [in CONTEXT]`. Include execution context (partition ID, entity key, etc.) when it helps the user act on the failure.
+- **Rejection reasons use the same pattern** — they surface to the user, so write them as remediation guidance, not as debug output.
+- Full guidance: https://github.com/camunda/camunda/wiki/Error-Guidelines
+
 ## Logging
 
 - **Hot paths log at trace level only.** The engine processes thousands of commands per second; INFO/DEBUG on a hot path is a measurable performance regression.
-- General logging guidance: https://github.com/camunda/camunda/wiki/Logging
+- **Use SLF4J's parameterized formatting** (`log.info("X {}", arg)`), never `String.format`. SLF4J skips formatting when the level is disabled; `String.format` allocates regardless.
+- Levels: `TRACE` = component execution detail (granular loggers only); `DEBUG` = developer diagnostics; `INFO` = operator-facing events (leader changes, membership updates); `WARN` = expected, self-resolving errors that need monitoring (timeouts, transient unavailability); `ERROR` = critical failures requiring immediate attention.
+- Full guidance: https://github.com/camunda/camunda/wiki/Logging
 
 ## Templates
 

--- a/.claude/skills/engine-expert/processors.md
+++ b/.claude/skills/engine-expert/processors.md
@@ -31,6 +31,19 @@ Two escape hatches:
 
 Rule of thumb: if the value escapes the immediate read (passed to a helper that may itself read state, stored anywhere, or returned across another `get` on the same CF), copy it.
 
+## Non-transactional side effects
+
+State writes (`stateWriter.appendFollowUpEvent`, follow-up commands, response writes) are transactional — they roll back together if processing throws. **Inline side effects are not.** Direct calls to metrics (`metric.increment()`), post-commit hooks, or other external mutations execute immediately and are *not* undone when the transaction rolls back.
+
+Two asymmetries to remember:
+
+- **Forward** (already in `zeebe/engine/README.md` § *Side-effects are not guaranteed to be executed*): a side effect may not run — failover or commit failure can drop it. Don't put critical work in one.
+- **Inverse** (not in the README): a side effect that *did* run is not rolled back. If it executes before a later state write that throws, the state rolls back but the side effect stays — counters drift, sometimes negative.
+
+**Fix:** order matters. Inside a processor, do all state writes, follow-up commands, and response writes — and any helper calls that could throw — first. Run inline non-transactional side effects only after every potentially-throwing step has succeeded.
+
+Production example: `IncidentResolveProcessor.processRecord` called `incidentMetrics.incidentResolved()` before `publishIncidentRelatedJob(...)` and `attemptToContinueProcessProcessing(...)`, both of which can throw. On the throw path, the resolved-incident counter incremented while the state rolled back.
+
 ## Error and rejection messages
 
 - **Follow the format** `Expected [X], but got [Y] [in CONTEXT]`. Include execution context (partition ID, entity key, etc.) when it helps the user act on the failure.

--- a/.claude/skills/engine-expert/processors.md
+++ b/.claude/skills/engine-expert/processors.md
@@ -17,6 +17,20 @@ Processors are where the engine's logic lives. They consume commands and produce
 - **Inter-partition command receivers must be idempotent.** Prefer reject-redundant-command (write a rejection, no state change) over re-emitting the same events.
 - **Take small steps.** Append follow-up commands rather than doing everything in one processing cycle. The single thread is shared with every other command on this partition.
 
+## Reading state safely
+
+Values returned from `ColumnFamily.get(...)` — and from `*State` reads built on top of it — are backed by a **shared, mutable buffer owned by the column family**. Each column family holds a single `valueInstance` that gets re-wrapped on every read. There are two failure modes:
+
+- **Holding a value across another read of the same CF.** `final var a = cf.get(keyA); final var b = cf.get(keyB);` returns the same reference both times — `a` now also reads as B's data. Iteration (`forEach`, `whileTrue`) re-wraps the same instance on every step, so storing the value across iterations has the same effect.
+- **Caching a value past the immediate read** (e.g. into a `Map`, `List`, or field). Production incident: `DbFormState` cached the `persistedForm` returned from RocksDB, and form ids ended up pointing to the wrong form objects (INC-981, #16311).
+
+Two escape hatches:
+
+- `value.copyFrom(stateRead)` into an instance you own. See `ProcessInstanceMigrationCatchEventBehavior` for examples (`copy.copyFrom(timerInstance)`, `copySubscription.copyFrom(subscription)`).
+- `cf.get(key, valueSupplier)` allocates a fresh instance per call instead of returning the shared reference — useful when you'd otherwise immediately copy.
+
+Rule of thumb: if the value escapes the immediate read (passed to a helper that may itself read state, stored anywhere, or returned across another `get` on the same CF), copy it.
+
 ## Error and rejection messages
 
 - **Follow the format** `Expected [X], but got [Y] [in CONTEXT]`. Include execution context (partition ID, entity key, etc.) when it helps the user act on the failure.

--- a/.claude/skills/engine-expert/records.md
+++ b/.claude/skills/engine-expert/records.md
@@ -1,0 +1,36 @@
+# Records, Value Types, and Intents
+
+Records are the engine's data carriers. They flow through the log stream during processing and are exported to secondary storage (Elasticsearch / OpenSearch / RDBMS) for consumers (REST API, Operate, Tasklist, Optimize). The schema must therefore serve **both** the engine's processing needs **and** the consumers' read needs.
+
+## Iron rules
+
+- **Naming alignment is mandatory.** `ValueType.USER` ↔ `UserIntent` ↔ `UserRecord` ↔ `UserRecordValue`. Misalignment has slipped through before — block it on review.
+- **Schema serves both processing and exporting.** Exporters typically cannot read state before writing (rare exceptions only). So any aggregation or derived value the consumers need must be **computed in the processor and written into the event**. Schema must support both:
+  - the **input data** for state mutation (e.g., the increment requested by this command), and
+  - the **output data** consumers need (e.g., the resulting cumulative total).
+  - Concrete example: a counter record carries `incrementBy` (input from the command) **and** `totalAfter` (output computed by the processor and persisted in the event).
+- **SBE messages are extended, not changed in incompatible ways.** Adding fields is fine; reordering, retyping, or removing existing fields is not.
+- **Sensitive fields use `#sanitized()`** (e.g., `new IntegerProperty("token").sanitized()`) so they are excluded from logs and `toString()` while still being serialized to JSON for export.
+
+## Workflow
+
+Read `docs/zeebe/developer_handbook.md` before starting. The canonical step-by-step lives there:
+
+- For a new record/value type: § "How to create a new record" walks through the seven phases (protocol, protocol-impl, exporters, test setups, official docs, Camunda Process Test, supported value types).
+- For extending an existing record: § "How to extend an existing record" — the smaller four-step variant.
+
+The skill's role is to surface the iron rules above, not to replace the handbook.
+
+## Templates
+
+- `RecordValue` interface: `zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/UserRecordValue.java`
+- `RecordValue` implementation: `zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/user/UserRecord.java`
+- Intent: `zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/UserIntent.java`
+- Mapping: `zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java`
+- Serialization tests: `zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java` (extend with both a fully-populated case and a minimal/empty case)
+
+## Canonical docs
+
+- `docs/zeebe/developer_handbook.md` — new and extended record walkthroughs.
+- `zeebe/engine/README.md` § "Record values are data objects that are often reused across different records of the same value type" — when to introduce a sub-record-value type.
+

--- a/.claude/skills/engine-expert/scripts/check-released-applier.sh
+++ b/.claude/skills/engine-expert/scripts/check-released-applier.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Usage: check-released-applier.sh <path-to-applier-file>
+# Prints the first release tag containing this file, or "UNRELEASED" if none.
+# Exit code 0 = released, 1 = unreleased.
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <path-to-applier-file>" >&2
+  exit 2
+fi
+
+file="$1"
+for tag in $(git tag -l | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V); do
+  if git cat-file -e "$tag:$file" 2>/dev/null; then
+    echo "RELEASED (first seen in $tag)"
+    exit 0
+  fi
+done
+echo "UNRELEASED"
+exit 1

--- a/.claude/skills/engine-expert/scripts/check-released-applier.sh
+++ b/.claude/skills/engine-expert/scripts/check-released-applier.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Usage: check-released-applier.sh <path-to-applier-file>
-# Prints the first release tag containing this file, or "UNRELEASED" if none.
+# Prints 'RELEASED (first seen in <tag>)' if a release contains this file, or "UNRELEASED" if none.
 # Exit code 0 = released, 1 = unreleased.
 set -euo pipefail
 
@@ -10,7 +10,13 @@ if [[ $# -ne 1 ]]; then
 fi
 
 file="$1"
-for tag in $(git tag -l | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V); do
+
+# Filter to release tags only (X.Y.Z, no -rc/-alpha/etc.). The `|| true`
+# tolerates `grep` exiting 1 when no tags match, which would otherwise
+# abort the script under `set -o pipefail` and skip the UNRELEASED path.
+tags=$(git tag -l | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V || true)
+
+for tag in $tags; do
   if git cat-file -e "$tag:$file" 2>/dev/null; then
     echo "RELEASED (first seen in $tag)"
     exit 0

--- a/.claude/skills/engine-expert/scripts/check-released-applier.sh
+++ b/.claude/skills/engine-expert/scripts/check-released-applier.sh
@@ -11,6 +11,13 @@ fi
 
 file="$1"
 
+# Normalize to a repo-relative path; otherwise `git cat-file -e "$tag:$file"`
+# below silently misses every tag and falls through to UNRELEASED.
+file=$(git ls-files --full-name --error-unmatch -- "$file" 2>/dev/null) || {
+  echo "Path not tracked in git: $1" >&2
+  exit 2
+}
+
 # Filter to release tags only (X.Y.Z, no -rc/-alpha/etc.). The `|| true`
 # tolerates `grep` exiting 1 when no tags match, which would otherwise
 # abort the script under `set -o pipefail` and skip the UNRELEASED path.

--- a/.claude/skills/engine-expert/testing.md
+++ b/.claude/skills/engine-expert/testing.md
@@ -28,7 +28,9 @@ Use `ProcessingStateExtension`. Assert on state directly here — that's the uni
 
 Use `EngineRule`. Assert on appended records via `RecordingExporter` — never on state.
 
-- Template: `zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobCompleteAuthorizationTest.java`
+- Templates:
+  - **Per-class (default):** `zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/CreateUserTest.java` — uses `@ClassRule public static final EngineRule ENGINE`. Match this pattern unless tests genuinely cannot share engine state.
+  - **Per-test (exception):** `zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobCompleteAuthorizationTest.java` — uses an instance `@Rule EngineRule`. Useful reference for record assertions and test-client usage; only mirror the per-test isolation when siblings can't share state.
 - Internal test clients (`engine.job()`, `engine.user()`, `engine.authorization()`, etc.) are the entry points for submitting commands.
 - When adding a new feature, **extend the corresponding test client** rather than reaching into private engine internals. Template: `zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/JobClient.java`.
 

--- a/.claude/skills/engine-expert/testing.md
+++ b/.claude/skills/engine-expert/testing.md
@@ -1,0 +1,65 @@
+# Engine Testing
+
+The engine has two test entry points: `ProcessingStateExtension` (JUnit 5) for state and applier tests, and `EngineRule` (JUnit 4) for processor tests. Pick the smallest entry point that exercises what you're changing — `EngineRule` is significantly more expensive than `ProcessingStateExtension`.
+
+## Iron rules
+
+- **Always short-circuit `RecordingExporter`** with `.limit()`, `.getFirst()`, `.exists()`, etc. Otherwise the stream stays open and the test hangs.
+- **Verify behavior via appended records, not state.** In `EngineRule` tests, query the `RecordingExporter` to assert what the engine produced. Do **not** assert on state classes from an `EngineRule` test:
+  - State is an implementation detail; the appended records are the engine's actual output and the contract with consumers.
+  - State classes are not thread-safe; reading them from the test thread while the engine writes is unsafe.
+  - State-only assertions are appropriate in `ProcessingStateExtension` tests for state/applier behavior, not in `EngineRule` tests.
+- **Tests must be fast AND reliable.** Re-run any new or modified test **at least 3 times** before declaring it stable. Flaky tests will erode trust in the suite.
+- **`EngineRule` is expensive — default to per-class.** Use per-test isolation only when the test genuinely cannot share state with its siblings.
+- **Use `// given / // when / // then`** structure, AssertJ assertions, and Awaitility for async waiting (never `Thread.sleep`).
+- **Migrate JUnit 4 → 5** when modifying older tests; don't add new JUnit 4 tests outside `EngineRule`-based ones (which still require JUnit 4).
+
+## Patterns
+
+### State + applier tests (JUnit 5)
+
+Use `ProcessingStateExtension`. Assert on state directly here — that's the unit under test.
+
+- Templates:
+  - `zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/user/UserStateTest.java`
+  - `zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/TenantAppliersTest.java`
+
+### Processor tests (JUnit 4)
+
+Use `EngineRule`. Assert on appended records via `RecordingExporter` — never on state.
+
+- Template: `zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobCompleteAuthorizationTest.java`
+- Internal test clients (`engine.job()`, `engine.user()`, `engine.authorization()`, etc.) are the entry points for submitting commands.
+- When adding a new feature, **extend the corresponding test client** rather than reaching into private engine internals. Template: `zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/JobClient.java`.
+
+## Debugging
+
+- `CompactRecordLogger` output is the first thing to read on a failed test. Add `assert false` at the end of a passing test to dump records during exploration.
+- **If `CompactRecordLogger` omits a field that mattered to your investigation, that's a strong signal to extend the logger** for that record type. Future debugging benefits — your time is not the only time saved.
+- Source: `zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java`
+
+## Running tests locally
+
+Always scope to the test(s) you actually need — running the full engine module locally is slow and is what CI is for.
+
+```bash
+# Single class
+./mvnw verify -pl zeebe/engine -Dtest=MyTest \
+  -DskipTests=false -DskipITs -Dquickly
+
+# Multiple classes
+./mvnw verify -pl zeebe/engine -Dtest=MyTest1,MyTest2 \
+  -DskipTests=false -DskipITs -Dquickly
+
+# Glob pattern
+./mvnw verify -pl zeebe/engine -Dtest='*UserTest*' \
+  -DskipTests=false -DskipITs -Dquickly
+```
+
+`-Dquickly` skips checks (spotless, license) and other tests, which is what makes the run fast. Apply spotless separately via the format command in `SKILL.md` § "Local checks before commit". CI runs the comprehensive build.
+
+## Canonical docs
+
+- `docs/testing.md`, `docs/testing/unit.md` — repo-wide testing guidelines.
+- `zeebe/engine/README.md` § "Testing guidelines" — engine-specific test patterns and the `CompactRecordLogger` failure-output legend.
+

--- a/.codeowners
+++ b/.codeowners
@@ -192,6 +192,9 @@ mwnw*                       @camunda/monorepo-devops-team
 /zeebe/feel-tagged-parameters/ @camunda/core-features
 /zeebe/exporter-api/        @camunda/core-features
 
+# Engine-expert skill
+/.claude/skills/engine-expert/ @korthout @camunda/core-features
+
 # optimize / BI team
 /zeebe/exporter-filter/        @camunda/core-features
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -146,6 +146,9 @@
 # AI Assistant Instructions
 /CLAUDE.md  @camunda/orchestration-cluster
 
+# Engine-expert skill
+/.claude/skills/engine-expert/  @korthout @camunda/core-features
+
 # MCP gateway
 /gateways/gateway-mcp @camunda/connectors-agentic-ai
 


### PR DESCRIPTION
## Description

Adds a repo-checked-in Claude skill, `engine-expert`, that helps contributors (and Claude) make confident changes to the Zeebe workflow engine in `zeebe/engine/`. The skill is self-contained — no dependency on plugin-provided skills — so anyone who clones the repo gets it automatically.

The skill is shaped per Anthropic's "domain-specific organization" pattern: a single `SKILL.md` (description + iron rules + router) that points to four flat reference files for records, processors, event appliers, and tests, plus a small bash helper that detects whether an event applier or state class file has shipped in any release tag (used to decide modify-in-place vs. add-new-version).

Beyond what is already documented in `zeebe/engine/README.md` and `docs/zeebe/`, the skill surfaces silent-danger pitfalls that are easy to miss on review:

- state-class methods reachable from event appliers carry the same "don't change after release" rule (no golden file protects them);
- the key generator is rehydrated on replay by reading appended record keys, so a generated key must be used as the record key of at least one appended record (storing it only inside `RecordValue` is not enough);
- forward-port timing of new event applier versions across minor versions and release branches breaks the upgrade path if missed;
- `EngineRule` tests must assert on appended records via `RecordingExporter`, not on state classes (state is an implementation detail and not thread-safe to read from the test thread).

The skill is `Use when …`-triggered on the engine capabilities contributors actually work on (BPMN, DMN, jobs, identity, batch ops, variables, deployments, signals, messages, timers, multi-tenancy, authorization) — not on internal mechanisms — so it loads at the right moments without polluting unrelated sessions.

Follow-up (separate PRs): backport four skill-only insights into the canonical docs (forward-port timing, state-class rule, key-generator rehydration, no state assertions in `EngineRule`).

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

No related issues