### PR TITLE
feat: support process/element context in evaluateExpression client co…

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/command/EvaluateExpressionCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/EvaluateExpressionCommandStep1.java
@@ -19,7 +19,20 @@ import io.camunda.client.api.response.EvaluateExpressionResponse;
 import java.io.InputStream;
 import java.util.Map;
 
-/** Command to evaluate an expression. */
+/**
+ * Command to evaluate a FEEL expression.
+ *
+ * <p>The expression can optionally be evaluated in the variable scope of a process instance (via
+ * {@link EvaluateExpressionCommandStep2#processInstanceKey(long)}) or an element instance (via
+ * {@link EvaluateExpressionCommandStep2#elementInstanceKey(long)}). These two options are mutually
+ * exclusive: setting both on the same builder causes {@link EvaluateExpressionCommandStep2#send()}
+ * to fail with an {@link IllegalStateException}. If neither is set, the expression is evaluated
+ * against tenant-scoped cluster variables and the request-body variables only.
+ *
+ * <p>When variables passed via {@link EvaluateExpressionCommandStep2#variables(Map)} share a key
+ * with engine variables resolved from the process or element context, the value from {@code
+ * variables} takes precedence for the current evaluation.
+ */
 public interface EvaluateExpressionCommandStep1 {
 
   /**
@@ -85,5 +98,42 @@ public interface EvaluateExpressionCommandStep1 {
      */
     @Override
     EvaluateExpressionCommandStep2 variable(String key, Object value);
+
+    /**
+     * Evaluate the expression in the variable scope of the given process instance. Engine variables
+     * visible at the process-instance scope are exposed to the expression in addition to the
+     * request-body variables and tenant-scoped cluster variables.
+     *
+     * <p>When a key is present both in the request-body {@code variables} and in the engine
+     * variable scope, the value from {@code variables} takes precedence for this evaluation only.
+     *
+     * <p>Mutually exclusive with {@link #elementInstanceKey(long)}: setting both on the same
+     * builder causes {@link #send()} to fail with an {@link IllegalStateException}.
+     *
+     * @param processInstanceKey the key of the process instance whose variable scope is exposed to
+     *     the expression
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    EvaluateExpressionCommandStep2 processInstanceKey(long processInstanceKey);
+
+    /**
+     * Evaluate the expression in the variable scope of the given element instance. Engine variables
+     * visible at the element-instance scope (including parent scopes up to the process instance)
+     * are exposed to the expression in addition to the request-body variables and tenant-scoped
+     * cluster variables.
+     *
+     * <p>When a key is present both in the request-body {@code variables} and in the engine
+     * variable scope, the value from {@code variables} takes precedence for this evaluation only.
+     *
+     * <p>Mutually exclusive with {@link #processInstanceKey(long)}: setting both on the same
+     * builder causes {@link #send()} to fail with an {@link IllegalStateException}.
+     *
+     * @param elementInstanceKey the key of the element instance whose variable scope is exposed to
+     *     the expression
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    EvaluateExpressionCommandStep2 elementInstanceKey(long elementInstanceKey);
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/EvaluateExpressionCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/EvaluateExpressionCommandStep1.java
@@ -22,16 +22,14 @@ import java.util.Map;
 /**
  * Command to evaluate a FEEL expression.
  *
- * <p>The expression can optionally be evaluated in the variable scope of a process instance (via
- * {@link EvaluateExpressionCommandStep2#processInstanceKey(long)}) or an element instance (via
- * {@link EvaluateExpressionCommandStep2#elementInstanceKey(long)}). These two options are mutually
- * exclusive: setting both on the same builder causes {@link EvaluateExpressionCommandStep2#send()}
- * to fail with an {@link IllegalStateException}. If neither is set, the expression is evaluated
- * against tenant-scoped cluster variables and the request-body variables only.
+ * <p>The expression can optionally be evaluated in the variable scope of a process or element
+ * instance via {@link EvaluateExpressionCommandStep2#scopeKey(long)}. If no scope key is set, the
+ * expression is evaluated against tenant-scoped cluster variables and the request-body variables
+ * only.
  *
  * <p>When variables passed via {@link EvaluateExpressionCommandStep2#variables(Map)} share a key
- * with engine variables resolved from the process or element context, the value from {@code
- * variables} takes precedence for the current evaluation.
+ * with engine variables resolved from the scope, the value from {@code variables} takes precedence
+ * for the current evaluation.
  */
 public interface EvaluateExpressionCommandStep1 {
 
@@ -100,40 +98,18 @@ public interface EvaluateExpressionCommandStep1 {
     EvaluateExpressionCommandStep2 variable(String key, Object value);
 
     /**
-     * Evaluate the expression in the variable scope of the given process instance. Engine variables
-     * visible at the process-instance scope are exposed to the expression in addition to the
+     * Evaluate the expression in the variable scope of the given process or element instance.
+     * Engine variables visible at this scope are exposed to the expression in addition to the
      * request-body variables and tenant-scoped cluster variables.
      *
      * <p>When a key is present both in the request-body {@code variables} and in the engine
      * variable scope, the value from {@code variables} takes precedence for this evaluation only.
      *
-     * <p>Mutually exclusive with {@link #elementInstanceKey(long)}: setting both on the same
-     * builder causes {@link #send()} to fail with an {@link IllegalStateException}.
-     *
-     * @param processInstanceKey the key of the process instance whose variable scope is exposed to
-     *     the expression
+     * @param scopeKey the key of the process or element instance scope whose variables are exposed
+     *     to the expression
      * @return the builder for this command. Call {@link #send()} to complete the command and send
      *     it to the broker.
      */
-    EvaluateExpressionCommandStep2 processInstanceKey(long processInstanceKey);
-
-    /**
-     * Evaluate the expression in the variable scope of the given element instance. Engine variables
-     * visible at the element-instance scope (including parent scopes up to the process instance)
-     * are exposed to the expression in addition to the request-body variables and tenant-scoped
-     * cluster variables.
-     *
-     * <p>When a key is present both in the request-body {@code variables} and in the engine
-     * variable scope, the value from {@code variables} takes precedence for this evaluation only.
-     *
-     * <p>Mutually exclusive with {@link #processInstanceKey(long)}: setting both on the same
-     * builder causes {@link #send()} to fail with an {@link IllegalStateException}.
-     *
-     * @param elementInstanceKey the key of the element instance whose variable scope is exposed to
-     *     the expression
-     * @return the builder for this command. Call {@link #send()} to complete the command and send
-     *     it to the broker.
-     */
-    EvaluateExpressionCommandStep2 elementInstanceKey(long elementInstanceKey);
+    EvaluateExpressionCommandStep2 scopeKey(long scopeKey);
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/EvaluateExpressionCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/EvaluateExpressionCommandImpl.java
@@ -25,6 +25,7 @@ import io.camunda.client.api.response.EvaluateExpressionResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.response.EvaluateExpressionResponseImpl;
+import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.client.protocol.rest.ExpressionEvaluationRequest;
 import io.camunda.client.protocol.rest.ExpressionEvaluationResult;
 import java.time.Duration;
@@ -70,6 +71,18 @@ public class EvaluateExpressionCommandImpl
   }
 
   @Override
+  public EvaluateExpressionCommandStep2 processInstanceKey(final long processInstanceKey) {
+    request.setProcessInstanceKey(ParseUtil.keyToString(processInstanceKey));
+    return this;
+  }
+
+  @Override
+  public EvaluateExpressionCommandStep2 elementInstanceKey(final long elementInstanceKey) {
+    request.setElementInstanceKey(ParseUtil.keyToString(elementInstanceKey));
+    return this;
+  }
+
+  @Override
   public FinalCommandStep<EvaluateExpressionResponse> requestTimeout(
       final Duration requestTimeout) {
     httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
@@ -78,6 +91,11 @@ public class EvaluateExpressionCommandImpl
 
   @Override
   public CamundaFuture<EvaluateExpressionResponse> send() {
+    if (request.getProcessInstanceKey() != null && request.getElementInstanceKey() != null) {
+      throw new IllegalStateException(
+          "Expected to evaluate expression with either processInstanceKey or elementInstanceKey, "
+              + "but both were set. These fields are mutually exclusive.");
+    }
     final HttpCamundaFuture<EvaluateExpressionResponse> result = new HttpCamundaFuture<>();
     httpClient.post(
         "/expression/evaluation",

--- a/clients/java/src/main/java/io/camunda/client/impl/command/EvaluateExpressionCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/EvaluateExpressionCommandImpl.java
@@ -71,14 +71,8 @@ public class EvaluateExpressionCommandImpl
   }
 
   @Override
-  public EvaluateExpressionCommandStep2 processInstanceKey(final long processInstanceKey) {
-    request.setProcessInstanceKey(ParseUtil.keyToString(processInstanceKey));
-    return this;
-  }
-
-  @Override
-  public EvaluateExpressionCommandStep2 elementInstanceKey(final long elementInstanceKey) {
-    request.setElementInstanceKey(ParseUtil.keyToString(elementInstanceKey));
+  public EvaluateExpressionCommandStep2 scopeKey(final long scopeKey) {
+    request.setScopeKey(ParseUtil.keyToString(scopeKey));
     return this;
   }
 
@@ -91,11 +85,6 @@ public class EvaluateExpressionCommandImpl
 
   @Override
   public CamundaFuture<EvaluateExpressionResponse> send() {
-    if (request.getProcessInstanceKey() != null && request.getElementInstanceKey() != null) {
-      throw new IllegalStateException(
-          "Expected to evaluate expression with either processInstanceKey or elementInstanceKey, "
-              + "but both were set. These fields are mutually exclusive.");
-    }
     final HttpCamundaFuture<EvaluateExpressionResponse> result = new HttpCamundaFuture<>();
     httpClient.post(
         "/expression/evaluation",

--- a/clients/java/src/test/java/io/camunda/client/expression/EvaluateExpressionTest.java
+++ b/clients/java/src/test/java/io/camunda/client/expression/EvaluateExpressionTest.java
@@ -240,4 +240,161 @@ public final class EvaluateExpressionTest extends ClientRestTest {
         .extracting(EvaluationWarning::getMessage)
         .containsExactly("Warning 1", "Warning 2");
   }
+
+  @Test
+  void shouldEvaluateExpressionWithProcessInstanceKey() {
+    // given
+    final String expression = "=x + y";
+    final long processInstanceKey = 1234567890L;
+    gatewayService.onExpressionEvaluationRequest(
+        new ExpressionEvaluationResult().expression(expression).result(30));
+
+    // when
+    client
+        .newEvaluateExpressionCommand()
+        .expression(expression)
+        .processInstanceKey(processInstanceKey)
+        .send()
+        .join();
+
+    // then
+    assertThat(RestGatewayService.getLastRequest())
+        .hasMethod(RequestMethod.POST)
+        .hasUrl(RestGatewayPaths.getExpressionEvaluationUrl())
+        .extractingBody(ExpressionEvaluationRequest.class)
+        .isEqualTo(
+            new ExpressionEvaluationRequest()
+                .expression(expression)
+                .tenantId("<default>")
+                .processInstanceKey(String.valueOf(processInstanceKey)));
+  }
+
+  @Test
+  void shouldEvaluateExpressionWithElementInstanceKey() {
+    // given
+    final String expression = "=x + y";
+    final long elementInstanceKey = 9876543210L;
+    gatewayService.onExpressionEvaluationRequest(
+        new ExpressionEvaluationResult().expression(expression).result(30));
+
+    // when
+    client
+        .newEvaluateExpressionCommand()
+        .expression(expression)
+        .elementInstanceKey(elementInstanceKey)
+        .send()
+        .join();
+
+    // then
+    assertThat(RestGatewayService.getLastRequest())
+        .hasMethod(RequestMethod.POST)
+        .hasUrl(RestGatewayPaths.getExpressionEvaluationUrl())
+        .extractingBody(ExpressionEvaluationRequest.class)
+        .isEqualTo(
+            new ExpressionEvaluationRequest()
+                .expression(expression)
+                .tenantId("<default>")
+                .elementInstanceKey(String.valueOf(elementInstanceKey)));
+  }
+
+  @Test
+  void shouldEvaluateExpressionWithProcessInstanceKeyAndVariables() {
+    // given
+    final String expression = "=x + y";
+    final long processInstanceKey = 1234567890L;
+    final Map<String, Object> variables = variablesMap("x", 10, "y", 20);
+    gatewayService.onExpressionEvaluationRequest(
+        new ExpressionEvaluationResult().expression(expression).result(30));
+
+    // when
+    client
+        .newEvaluateExpressionCommand()
+        .expression(expression)
+        .processInstanceKey(processInstanceKey)
+        .variables(variables)
+        .send()
+        .join();
+
+    // then
+    assertThat(RestGatewayService.getLastRequest())
+        .hasMethod(RequestMethod.POST)
+        .hasUrl(RestGatewayPaths.getExpressionEvaluationUrl())
+        .extractingBody(ExpressionEvaluationRequest.class)
+        .isEqualTo(
+            new ExpressionEvaluationRequest()
+                .expression(expression)
+                .tenantId("<default>")
+                .processInstanceKey(String.valueOf(processInstanceKey))
+                .variables(variables));
+  }
+
+  @Test
+  void shouldRejectBothProcessInstanceKeyAndElementInstanceKey() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newEvaluateExpressionCommand()
+                    .expression("=x + y")
+                    .processInstanceKey(1L)
+                    .elementInstanceKey(2L)
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("processInstanceKey")
+        .hasMessageContaining("elementInstanceKey")
+        .hasMessageContaining("mutually exclusive");
+  }
+
+  @Test
+  void shouldReceiveExpressionEvaluationResultWithProcessInstanceKey() {
+    // given
+    final String expression = "=x + y";
+    final Object resultValue = 30;
+    gatewayService.onExpressionEvaluationRequest(
+        new ExpressionEvaluationResult()
+            .expression(expression)
+            .result(resultValue)
+            .warnings(Collections.emptyList()));
+
+    // when
+    final EvaluateExpressionResponse response =
+        client
+            .newEvaluateExpressionCommand()
+            .expression(expression)
+            .processInstanceKey(1234567890L)
+            .send()
+            .join();
+
+    // then
+    assertThat(response.getExpression()).isEqualTo(expression);
+    assertThat(response.getResult()).isEqualTo(resultValue);
+    assertThat(response.getWarnings()).isEmpty();
+  }
+
+  @Test
+  void shouldReceiveExpressionEvaluationResultWithElementInstanceKey() {
+    // given
+    final String expression = "=x + y";
+    final Object resultValue = 30;
+    gatewayService.onExpressionEvaluationRequest(
+        new ExpressionEvaluationResult()
+            .expression(expression)
+            .result(resultValue)
+            .warnings(Collections.emptyList()));
+
+    // when
+    final EvaluateExpressionResponse response =
+        client
+            .newEvaluateExpressionCommand()
+            .expression(expression)
+            .elementInstanceKey(9876543210L)
+            .send()
+            .join();
+
+    // then
+    assertThat(response.getExpression()).isEqualTo(expression);
+    assertThat(response.getResult()).isEqualTo(resultValue);
+    assertThat(response.getWarnings()).isEmpty();
+  }
 }

--- a/clients/java/src/test/java/io/camunda/client/expression/EvaluateExpressionTest.java
+++ b/clients/java/src/test/java/io/camunda/client/expression/EvaluateExpressionTest.java
@@ -39,11 +39,10 @@ import org.junit.jupiter.api.Test;
 
 public final class EvaluateExpressionTest extends ClientRestTest {
 
-  private static Map<String, Object> variablesMap(
-      final String k1, final Object v1, final String k2, final Object v2) {
+  private static Map<String, Object> variablesMap() {
     final Map<String, Object> map = new HashMap<>();
-    map.put(k1, v1);
-    map.put(k2, v2);
+    map.put("x", 10);
+    map.put("y", 20);
     return map;
   }
 
@@ -88,7 +87,7 @@ public final class EvaluateExpressionTest extends ClientRestTest {
   void shouldEvaluateExpressionWithVariablesAsMap() {
     // given
     final String expression = "=x + y";
-    final Map<String, Object> variables = variablesMap("x", 10, "y", 20);
+    final Map<String, Object> variables = variablesMap();
     gatewayService.onExpressionEvaluationRequest(
         new ExpressionEvaluationResult().expression(expression).result(30));
 
@@ -132,7 +131,7 @@ public final class EvaluateExpressionTest extends ClientRestTest {
             new ExpressionEvaluationRequest()
                 .expression(expression)
                 .tenantId("<default>")
-                .variables(variablesMap("x", 10, "y", 20)));
+                .variables(variablesMap()));
   }
 
   @Test
@@ -160,7 +159,7 @@ public final class EvaluateExpressionTest extends ClientRestTest {
             new ExpressionEvaluationRequest()
                 .expression(expression)
                 .tenantId("<default>")
-                .variables(variablesMap("x", 10, "y", 20)));
+                .variables(variablesMap()));
   }
 
   @Test
@@ -242,20 +241,15 @@ public final class EvaluateExpressionTest extends ClientRestTest {
   }
 
   @Test
-  void shouldEvaluateExpressionWithProcessInstanceKey() {
+  void shouldEvaluateExpressionWithScopeKey() {
     // given
     final String expression = "=x + y";
-    final long processInstanceKey = 1234567890L;
+    final long scopeKey = 1234567890L;
     gatewayService.onExpressionEvaluationRequest(
         new ExpressionEvaluationResult().expression(expression).result(30));
 
     // when
-    client
-        .newEvaluateExpressionCommand()
-        .expression(expression)
-        .processInstanceKey(processInstanceKey)
-        .send()
-        .join();
+    client.newEvaluateExpressionCommand().expression(expression).scopeKey(scopeKey).send().join();
 
     // then
     assertThat(RestGatewayService.getLastRequest())
@@ -266,14 +260,15 @@ public final class EvaluateExpressionTest extends ClientRestTest {
             new ExpressionEvaluationRequest()
                 .expression(expression)
                 .tenantId("<default>")
-                .processInstanceKey(String.valueOf(processInstanceKey)));
+                .scopeKey(String.valueOf(scopeKey)));
   }
 
   @Test
-  void shouldEvaluateExpressionWithElementInstanceKey() {
+  void shouldEvaluateExpressionWithScopeKeyAndVariables() {
     // given
     final String expression = "=x + y";
-    final long elementInstanceKey = 9876543210L;
+    final long scopeKey = 9876543210L;
+    final Map<String, Object> variables = variablesMap();
     gatewayService.onExpressionEvaluationRequest(
         new ExpressionEvaluationResult().expression(expression).result(30));
 
@@ -281,36 +276,7 @@ public final class EvaluateExpressionTest extends ClientRestTest {
     client
         .newEvaluateExpressionCommand()
         .expression(expression)
-        .elementInstanceKey(elementInstanceKey)
-        .send()
-        .join();
-
-    // then
-    assertThat(RestGatewayService.getLastRequest())
-        .hasMethod(RequestMethod.POST)
-        .hasUrl(RestGatewayPaths.getExpressionEvaluationUrl())
-        .extractingBody(ExpressionEvaluationRequest.class)
-        .isEqualTo(
-            new ExpressionEvaluationRequest()
-                .expression(expression)
-                .tenantId("<default>")
-                .elementInstanceKey(String.valueOf(elementInstanceKey)));
-  }
-
-  @Test
-  void shouldEvaluateExpressionWithProcessInstanceKeyAndVariables() {
-    // given
-    final String expression = "=x + y";
-    final long processInstanceKey = 1234567890L;
-    final Map<String, Object> variables = variablesMap("x", 10, "y", 20);
-    gatewayService.onExpressionEvaluationRequest(
-        new ExpressionEvaluationResult().expression(expression).result(30));
-
-    // when
-    client
-        .newEvaluateExpressionCommand()
-        .expression(expression)
-        .processInstanceKey(processInstanceKey)
+        .scopeKey(scopeKey)
         .variables(variables)
         .send()
         .join();
@@ -324,30 +290,12 @@ public final class EvaluateExpressionTest extends ClientRestTest {
             new ExpressionEvaluationRequest()
                 .expression(expression)
                 .tenantId("<default>")
-                .processInstanceKey(String.valueOf(processInstanceKey))
+                .scopeKey(String.valueOf(scopeKey))
                 .variables(variables));
   }
 
   @Test
-  void shouldRejectBothProcessInstanceKeyAndElementInstanceKey() {
-    // when / then
-    assertThatThrownBy(
-            () ->
-                client
-                    .newEvaluateExpressionCommand()
-                    .expression("=x + y")
-                    .processInstanceKey(1L)
-                    .elementInstanceKey(2L)
-                    .send()
-                    .join())
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("processInstanceKey")
-        .hasMessageContaining("elementInstanceKey")
-        .hasMessageContaining("mutually exclusive");
-  }
-
-  @Test
-  void shouldReceiveExpressionEvaluationResultWithProcessInstanceKey() {
+  void shouldReceiveExpressionEvaluationResultWithScopeKey() {
     // given
     final String expression = "=x + y";
     final Object resultValue = 30;
@@ -362,33 +310,7 @@ public final class EvaluateExpressionTest extends ClientRestTest {
         client
             .newEvaluateExpressionCommand()
             .expression(expression)
-            .processInstanceKey(1234567890L)
-            .send()
-            .join();
-
-    // then
-    assertThat(response.getExpression()).isEqualTo(expression);
-    assertThat(response.getResult()).isEqualTo(resultValue);
-    assertThat(response.getWarnings()).isEmpty();
-  }
-
-  @Test
-  void shouldReceiveExpressionEvaluationResultWithElementInstanceKey() {
-    // given
-    final String expression = "=x + y";
-    final Object resultValue = 30;
-    gatewayService.onExpressionEvaluationRequest(
-        new ExpressionEvaluationResult()
-            .expression(expression)
-            .result(resultValue)
-            .warnings(Collections.emptyList()));
-
-    // when
-    final EvaluateExpressionResponse response =
-        client
-            .newEvaluateExpressionCommand()
-            .expression(expression)
-            .elementInstanceKey(9876543210L)
+            .scopeKey(1234567890L)
             .send()
             .join();
 


### PR DESCRIPTION
This pull request extends the Java client’s expression evaluation command to support evaluating FEEL expressions within the context of a specific process instance or element instance. It introduces mutually exclusive options for specifying the variable scope, ensures correct behavior with validation, and adds comprehensive tests for these new features.

**API Enhancements:**

* Added `processInstanceKey(long)` and `elementInstanceKey(long)` methods to `EvaluateExpressionCommandStep2`, allowing expressions to be evaluated in the context of a specific process or element instance. These options are mutually exclusive and provide clear documentation on precedence and behavior. [[1]](diffhunk://#diff-0d32235aa725848b37c094466f0dfe090c7563d141f84d96dc95297e80ccc067L22-R35) [[2]](diffhunk://#diff-0d32235aa725848b37c094466f0dfe090c7563d141f84d96dc95297e80ccc067R101-R137)

**Implementation Updates:**

* Implemented the new methods in `EvaluateExpressionCommandImpl`, ensuring the correct setting of keys and enforcing mutual exclusivity by throwing an `IllegalStateException` if both are set. [[1]](diffhunk://#diff-97dca16b20f7c717b253ce42e338d59c841b1ce180a5320827d311123faacd36R28) [[2]](diffhunk://#diff-97dca16b20f7c717b253ce42e338d59c841b1ce180a5320827d311123faacd36R73-R84) [[3]](diffhunk://#diff-97dca16b20f7c717b253ce42e338d59c841b1ce180a5320827d311123faacd36R94-R98)

**Testing Improvements:**

* Added comprehensive tests in `EvaluateExpressionTest` to verify evaluation with `processInstanceKey`, `elementInstanceKey`, their interaction with variables, and correct rejection when both keys are set. Also verifies that the result is returned as expected for each scope.

closes https://github.com/camunda/camunda/issues/51991