### PR TITLE
refactor: run cron every 30 min

### DIFF
--- a/load-tests/camunda-platform-values.yaml
+++ b/load-tests/camunda-platform-values.yaml
@@ -85,7 +85,7 @@ optimize:
     - file: application.yml
       content: |
         historyCleanup:
-          cronTrigger: '0 1 * * *'
+          cronTrigger: '*/30 * * * *'
           ttl: 'P1D'
           processDataCleanup:
             enabled: true


### PR DESCRIPTION
## Description

 * Update cronTrigger for historyCleanup to run every 30 mins

Part of https://github.com/camunda/camunda/pull/51818 - we realized we want to run the cron more often to be able to clean up data early as possible after TTL was reached
<!-- Describe the goal and purpose of this PR. -->

## Related issues


Related to https://app.slack.com/client/T0PM0P1SA/C0B03ER9LNB we realized data is not cleaned up - cron job is running once a day and accumulated data for one day. We should run cron more often to have smaller chunks to clean up.


