### PR TITLE
feat: add integration tests for PIK and EIK expression evaluation res…

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ExpressionAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ExpressionAuthorizationIT.java
@@ -7,13 +7,20 @@
  */
 package io.camunda.it.auth;
 
+import static io.camunda.client.api.search.enums.PermissionType.CREATE;
+import static io.camunda.client.api.search.enums.PermissionType.CREATE_PROCESS_INSTANCE;
 import static io.camunda.client.api.search.enums.PermissionType.EVALUATE;
+import static io.camunda.client.api.search.enums.PermissionType.READ_PROCESS_DEFINITION;
+import static io.camunda.client.api.search.enums.PermissionType.READ_PROCESS_INSTANCE;
 import static io.camunda.client.api.search.enums.ResourceType.EXPRESSION;
+import static io.camunda.client.api.search.enums.ResourceType.PROCESS_DEFINITION;
+import static io.camunda.client.api.search.enums.ResourceType.RESOURCE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.search.enums.ElementInstanceState;
 import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.Permissions;
 import io.camunda.qa.util.auth.TestUser;
@@ -21,7 +28,10 @@ import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.time.Duration;
 import java.util.List;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
@@ -35,6 +45,16 @@ class ExpressionAuthorizationIT {
 
   private static final String AUTHORIZED_USER = "authorizedUser";
   private static final String UNAUTHORIZED_USER = "unauthorizedUser";
+  private static final String ADMIN_USER = "adminUser";
+  private static final String SCOPE_AUTHORIZED_USER = "scopeAuthorizedUser";
+  private static final String SCOPE_UNAUTHORIZED_USER = "scopeUnauthorizedUser";
+
+  private static final String PROCESS_ID = "service_tasks_v1";
+  private static final String OTHER_PROCESS_ID = "service_tasks_v2";
+  private static final String TASK_ELEMENT_ID = "taskA";
+
+  private static long processInstanceKey;
+  private static long elementInstanceKey;
 
   @UserDefinition
   private static final TestUser AUTHORIZED_USER_DEF =
@@ -46,6 +66,92 @@ class ExpressionAuthorizationIT {
   @UserDefinition
   private static final TestUser UNAUTHORIZED_USER_DEF =
       new TestUser(UNAUTHORIZED_USER, "password", List.of());
+
+  @UserDefinition
+  private static final TestUser ADMIN_USER_DEF =
+      new TestUser(
+          ADMIN_USER,
+          "password",
+          List.of(
+              new Permissions(RESOURCE, CREATE, List.of("*")),
+              new Permissions(PROCESS_DEFINITION, CREATE_PROCESS_INSTANCE, List.of("*")),
+              new Permissions(PROCESS_DEFINITION, READ_PROCESS_DEFINITION, List.of("*")),
+              new Permissions(PROCESS_DEFINITION, READ_PROCESS_INSTANCE, List.of("*"))));
+
+  /** Has EVALUATE + READ_PROCESS_INSTANCE on every process definition. */
+  @UserDefinition
+  private static final TestUser SCOPE_AUTHORIZED_USER_DEF =
+      new TestUser(
+          SCOPE_AUTHORIZED_USER,
+          "password",
+          List.of(
+              new Permissions(EXPRESSION, EVALUATE, List.of("*")),
+              new Permissions(PROCESS_DEFINITION, READ_PROCESS_INSTANCE, List.of("*"))));
+
+  /**
+   * Has EVALUATE + READ_PROCESS_INSTANCE only on {@link #OTHER_PROCESS_ID}, not on the process
+   * definition the test instance belongs to. Used to verify the authorization is scoped per
+   * bpmnProcessId.
+   */
+  @UserDefinition
+  private static final TestUser SCOPE_UNAUTHORIZED_USER_DEF =
+      new TestUser(
+          SCOPE_UNAUTHORIZED_USER,
+          "password",
+          List.of(
+              new Permissions(EXPRESSION, EVALUATE, List.of("*")),
+              new Permissions(
+                  PROCESS_DEFINITION, READ_PROCESS_INSTANCE, List.of(OTHER_PROCESS_ID))));
+
+  @BeforeAll
+  static void setUp(@Authenticated(ADMIN_USER) final CamundaClient adminClient) {
+    adminClient
+        .newDeployResourceCommand()
+        .addResourceFromClasspath("process/" + PROCESS_ID + ".bpmn")
+        .send()
+        .join();
+
+    processInstanceKey =
+        adminClient
+            .newCreateInstanceCommand()
+            .bpmnProcessId(PROCESS_ID)
+            .latestVersion()
+            .send()
+            .join()
+            .getProcessInstanceKey();
+
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(
+                        adminClient
+                            .newElementInstanceSearchRequest()
+                            .filter(
+                                f ->
+                                    f.processInstanceKey(processInstanceKey)
+                                        .elementId(TASK_ELEMENT_ID)
+                                        .state(ElementInstanceState.ACTIVE))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(1));
+
+    elementInstanceKey =
+        adminClient
+            .newElementInstanceSearchRequest()
+            .filter(
+                f ->
+                    f.processInstanceKey(processInstanceKey)
+                        .elementId(TASK_ELEMENT_ID)
+                        .state(ElementInstanceState.ACTIVE))
+            .send()
+            .join()
+            .items()
+            .getFirst()
+            .getElementInstanceKey();
+  }
 
   @Test
   void shouldEvaluateExpressionWithEvaluatePermission(
@@ -66,6 +172,93 @@ class ExpressionAuthorizationIT {
     assertThatExceptionOfType(ProblemException.class)
         .isThrownBy(
             () -> userClient.newEvaluateExpressionCommand().expression("=1 + 2").send().join())
+        .withMessageContaining("403");
+  }
+
+  // ============ PROCESS / ELEMENT INSTANCE CONTEXT AUTHORIZATION ============
+
+  @Test
+  void shouldEvaluateExpressionWithProcessInstanceKeyWhenAuthorized(
+      @Authenticated(SCOPE_AUTHORIZED_USER) final CamundaClient userClient) {
+    // when
+    final var response =
+        userClient
+            .newEvaluateExpressionCommand()
+            .expression("=1 + 2")
+            .processInstanceKey(processInstanceKey)
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getResult()).isEqualTo(3);
+  }
+
+  @Test
+  void shouldEvaluateExpressionWithElementInstanceKeyWhenAuthorized(
+      @Authenticated(SCOPE_AUTHORIZED_USER) final CamundaClient userClient) {
+    // when
+    final var response =
+        userClient
+            .newEvaluateExpressionCommand()
+            .expression("=1 + 2")
+            .elementInstanceKey(elementInstanceKey)
+            .send()
+            .join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getResult()).isEqualTo(3);
+  }
+
+  @Test
+  void shouldRejectEvaluateExpressionWithProcessInstanceKeyWithoutReadProcessInstance(
+      @Authenticated(AUTHORIZED_USER) final CamundaClient userClient) {
+    // given - AUTHORIZED_USER has EVALUATE but no READ_PROCESS_INSTANCE
+    // when / then
+    assertThatExceptionOfType(ProblemException.class)
+        .isThrownBy(
+            () ->
+                userClient
+                    .newEvaluateExpressionCommand()
+                    .expression("=1 + 2")
+                    .processInstanceKey(processInstanceKey)
+                    .send()
+                    .join())
+        .withMessageContaining("403");
+  }
+
+  @Test
+  void shouldRejectEvaluateExpressionWithElementInstanceKeyWithoutReadProcessInstance(
+      @Authenticated(AUTHORIZED_USER) final CamundaClient userClient) {
+    // given - AUTHORIZED_USER has EVALUATE but no READ_PROCESS_INSTANCE
+    // when / then
+    assertThatExceptionOfType(ProblemException.class)
+        .isThrownBy(
+            () ->
+                userClient
+                    .newEvaluateExpressionCommand()
+                    .expression("=1 + 2")
+                    .elementInstanceKey(elementInstanceKey)
+                    .send()
+                    .join())
+        .withMessageContaining("403");
+  }
+
+  @Test
+  void shouldRejectEvaluateExpressionWithProcessInstanceKeyWhenScopedToDifferentProcess(
+      @Authenticated(SCOPE_UNAUTHORIZED_USER) final CamundaClient userClient) {
+    // given - SCOPE_UNAUTHORIZED_USER has READ_PROCESS_INSTANCE only on a different bpmnProcessId
+    // when / then
+    assertThatExceptionOfType(ProblemException.class)
+        .isThrownBy(
+            () ->
+                userClient
+                    .newEvaluateExpressionCommand()
+                    .expression("=1 + 2")
+                    .processInstanceKey(processInstanceKey)
+                    .send()
+                    .join())
         .withMessageContaining("403");
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ExpressionAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ExpressionAuthorizationIT.java
@@ -175,17 +175,17 @@ class ExpressionAuthorizationIT {
         .withMessageContaining("403");
   }
 
-  // ============ PROCESS / ELEMENT INSTANCE CONTEXT AUTHORIZATION ============
+  // ============ SCOPE CONTEXT AUTHORIZATION ============
 
   @Test
-  void shouldEvaluateExpressionWithProcessInstanceKeyWhenAuthorized(
+  void shouldEvaluateExpressionWithProcessInstanceScopeKeyWhenAuthorized(
       @Authenticated(SCOPE_AUTHORIZED_USER) final CamundaClient userClient) {
     // when
     final var response =
         userClient
             .newEvaluateExpressionCommand()
             .expression("=1 + 2")
-            .processInstanceKey(processInstanceKey)
+            .scopeKey(processInstanceKey)
             .send()
             .join();
 
@@ -195,14 +195,14 @@ class ExpressionAuthorizationIT {
   }
 
   @Test
-  void shouldEvaluateExpressionWithElementInstanceKeyWhenAuthorized(
+  void shouldEvaluateExpressionWithElementInstanceScopeKeyWhenAuthorized(
       @Authenticated(SCOPE_AUTHORIZED_USER) final CamundaClient userClient) {
     // when
     final var response =
         userClient
             .newEvaluateExpressionCommand()
             .expression("=1 + 2")
-            .elementInstanceKey(elementInstanceKey)
+            .scopeKey(elementInstanceKey)
             .send()
             .join();
 
@@ -212,7 +212,7 @@ class ExpressionAuthorizationIT {
   }
 
   @Test
-  void shouldRejectEvaluateExpressionWithProcessInstanceKeyWithoutReadProcessInstance(
+  void shouldRejectEvaluateExpressionWithProcessInstanceScopeKeyWithoutReadProcessInstance(
       @Authenticated(AUTHORIZED_USER) final CamundaClient userClient) {
     // given - AUTHORIZED_USER has EVALUATE but no READ_PROCESS_INSTANCE
     // when / then
@@ -222,14 +222,14 @@ class ExpressionAuthorizationIT {
                 userClient
                     .newEvaluateExpressionCommand()
                     .expression("=1 + 2")
-                    .processInstanceKey(processInstanceKey)
+                    .scopeKey(processInstanceKey)
                     .send()
                     .join())
         .withMessageContaining("403");
   }
 
   @Test
-  void shouldRejectEvaluateExpressionWithElementInstanceKeyWithoutReadProcessInstance(
+  void shouldRejectEvaluateExpressionWithElementInstanceScopeKeyWithoutReadProcessInstance(
       @Authenticated(AUTHORIZED_USER) final CamundaClient userClient) {
     // given - AUTHORIZED_USER has EVALUATE but no READ_PROCESS_INSTANCE
     // when / then
@@ -239,14 +239,14 @@ class ExpressionAuthorizationIT {
                 userClient
                     .newEvaluateExpressionCommand()
                     .expression("=1 + 2")
-                    .elementInstanceKey(elementInstanceKey)
+                    .scopeKey(elementInstanceKey)
                     .send()
                     .join())
         .withMessageContaining("403");
   }
 
   @Test
-  void shouldRejectEvaluateExpressionWithProcessInstanceKeyWhenScopedToDifferentProcess(
+  void shouldRejectEvaluateExpressionWithProcessInstanceScopeKeyWhenScopedToDifferentProcess(
       @Authenticated(SCOPE_UNAUTHORIZED_USER) final CamundaClient userClient) {
     // given - SCOPE_UNAUTHORIZED_USER has READ_PROCESS_INSTANCE only on a different bpmnProcessId
     // when / then
@@ -256,7 +256,7 @@ class ExpressionAuthorizationIT {
                 userClient
                     .newEvaluateExpressionCommand()
                     .expression("=1 + 2")
-                    .processInstanceKey(processInstanceKey)
+                    .scopeKey(processInstanceKey)
                     .send()
                     .join())
         .withMessageContaining("403");

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ExpressionEvaluationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ExpressionEvaluationIT.java
@@ -15,15 +15,20 @@ import io.camunda.client.api.command.ClientHttpException;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.response.EvaluateExpressionResponse;
 import io.camunda.client.api.response.EvaluationWarning;
+import io.camunda.client.api.search.enums.ElementInstanceState;
+import io.camunda.client.api.search.response.ElementInstance;
 import io.camunda.qa.util.cluster.TestCamundaApplication;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.assertj.core.api.InstanceOfAssertFactories;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 
 @MultiDbTest
@@ -890,4 +895,244 @@ public class ExpressionEvaluationIT {
         .extracting(ClientHttpException::code)
         .isEqualTo(500);
   }
+
+  // ============ PROCESS / ELEMENT INSTANCE CONTEXT TESTS ============
+
+  @Test
+  void shouldEvaluateExpressionInProcessInstanceContext() {
+    // given
+    final ProcessAndElement instance = deployAndStart(Map.of("x", 10, "y", 20));
+
+    // when
+    final EvaluateExpressionResponse response =
+        camundaClient
+            .newEvaluateExpressionCommand()
+            .expression("=x + y")
+            .processInstanceKey(instance.processInstanceKey)
+            .send()
+            .join();
+
+    // then
+    assertThat(response.getResult()).isEqualTo(30);
+    assertThat(response.getWarnings()).isEmpty();
+  }
+
+  @Test
+  void shouldEvaluateExpressionInElementInstanceContext() {
+    // given
+    final ProcessAndElement instance = deployAndStart(Map.of("x", 10, "y", 20));
+
+    // when
+    final EvaluateExpressionResponse response =
+        camundaClient
+            .newEvaluateExpressionCommand()
+            .expression("=x + y")
+            .elementInstanceKey(instance.elementInstanceKey)
+            .send()
+            .join();
+
+    // then - element instance inherits from the process instance scope
+    assertThat(response.getResult()).isEqualTo(30);
+    assertThat(response.getWarnings()).isEmpty();
+  }
+
+  @Test
+  void shouldRejectWhenBothProcessInstanceKeyAndElementInstanceKeyAreSet() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                camundaClient
+                    .newEvaluateExpressionCommand()
+                    .expression("=1")
+                    .processInstanceKey(1L)
+                    .elementInstanceKey(2L)
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("processInstanceKey")
+        .hasMessageContaining("elementInstanceKey")
+        .hasMessageContaining("mutually exclusive");
+  }
+
+  @Test
+  void shouldReturnNullWhenProcessVariableNotInScope() {
+    // given - process started without any variables, so x is not in scope
+    final ProcessAndElement instance = deployAndStart(Map.of());
+
+    // when
+    final EvaluateExpressionResponse response =
+        camundaClient
+            .newEvaluateExpressionCommand()
+            .expression("=x")
+            .processInstanceKey(instance.processInstanceKey)
+            .send()
+            .join();
+
+    // then
+    assertThat(response.getResult()).isNull();
+    assertThat(response.getWarnings())
+        .extracting(EvaluationWarning::getMessage)
+        .anySatisfy(message -> assertThat(message).contains("No variable found with name 'x'"));
+  }
+
+  // ---- precedence: same variable name at process and element scope ----
+
+  @Test
+  void shouldReadProcessLevelVariableWhenUsingProcessInstanceKey() {
+    // given - process-level x=10, element-local x=99 (shadows only the element scope)
+    final ProcessAndElement instance = deployAndStart(Map.of("x", 10));
+    setLocalVariable(instance.elementInstanceKey, "x", 99);
+
+    // when - asking with processInstanceKey resolves at the process root scope
+    final EvaluateExpressionResponse response =
+        camundaClient
+            .newEvaluateExpressionCommand()
+            .expression("=x")
+            .processInstanceKey(instance.processInstanceKey)
+            .send()
+            .join();
+
+    // then - process-level value wins because the element-local var is not visible at root
+    assertThat(response.getResult()).isEqualTo(10);
+    assertThat(response.getWarnings()).isEmpty();
+  }
+
+  @Test
+  void shouldReadElementLevelVariableWhenUsingElementInstanceKey() {
+    // given - same setup as above: process-level x=10, element-local x=99
+    final ProcessAndElement instance = deployAndStart(Map.of("x", 10));
+    setLocalVariable(instance.elementInstanceKey, "x", 99);
+
+    // when - asking with elementInstanceKey resolves starting at the element scope
+    final EvaluateExpressionResponse response =
+        camundaClient
+            .newEvaluateExpressionCommand()
+            .expression("=x")
+            .elementInstanceKey(instance.elementInstanceKey)
+            .send()
+            .join();
+
+    // then - element-local value shadows the process-level value
+    assertThat(response.getResult()).isEqualTo(99);
+    assertThat(response.getWarnings()).isEmpty();
+  }
+
+  // ---- precedence: request-body variables override engine variables ----
+
+  @Test
+  void shouldOverrideProcessVariableWithRequestVariableInProcessContext() {
+    // given - process-level x=10
+    final ProcessAndElement instance = deployAndStart(Map.of("x", 10));
+
+    // when - request-body variable x=999 is supplied alongside processInstanceKey
+    final EvaluateExpressionResponse response =
+        camundaClient
+            .newEvaluateExpressionCommand()
+            .expression("=x")
+            .processInstanceKey(instance.processInstanceKey)
+            .variable("x", 999)
+            .send()
+            .join();
+
+    // then - request-body value takes precedence over the engine variable
+    assertThat(response.getResult()).isEqualTo(999);
+  }
+
+  @Test
+  void shouldOverrideElementVariableWithRequestVariableInElementContext() {
+    // given - process-level x=10, element-local x=99
+    final ProcessAndElement instance = deployAndStart(Map.of("x", 10));
+    setLocalVariable(instance.elementInstanceKey, "x", 99);
+
+    // when - request-body variable x=999 is supplied alongside elementInstanceKey
+    final EvaluateExpressionResponse response =
+        camundaClient
+            .newEvaluateExpressionCommand()
+            .expression("=x")
+            .elementInstanceKey(instance.elementInstanceKey)
+            .variable("x", 999)
+            .send()
+            .join();
+
+    // then - request-body value takes precedence over both engine scopes
+    assertThat(response.getResult()).isEqualTo(999);
+  }
+
+  // ============ HELPERS ============
+
+  private ProcessAndElement deployAndStart(final Map<String, Object> processVariables) {
+    final String processId = "expr_proc_" + UUID.randomUUID().toString().replace("-", "");
+    final String taskId = "wait_task";
+    final BpmnModelInstance model =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .serviceTask(taskId, t -> t.zeebeJobType("expr-eval-it-noop"))
+            .endEvent()
+            .done();
+
+    camundaClient
+        .newDeployResourceCommand()
+        .addProcessModel(model, processId + ".bpmn")
+        .send()
+        .join();
+
+    final long processInstanceKey =
+        camundaClient
+            .newCreateInstanceCommand()
+            .bpmnProcessId(processId)
+            .latestVersion()
+            .variables(processVariables)
+            .send()
+            .join()
+            .getProcessInstanceKey();
+
+    final long elementInstanceKey = waitForActiveElementInstance(processInstanceKey, taskId);
+    return new ProcessAndElement(processInstanceKey, elementInstanceKey);
+  }
+
+  private long waitForActiveElementInstance(final long processInstanceKey, final String elementId) {
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newElementInstanceSearchRequest()
+                            .filter(
+                                f ->
+                                    f.processInstanceKey(processInstanceKey)
+                                        .elementId(elementId)
+                                        .state(ElementInstanceState.ACTIVE))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(1));
+
+    final ElementInstance element =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .filter(
+                f ->
+                    f.processInstanceKey(processInstanceKey)
+                        .elementId(elementId)
+                        .state(ElementInstanceState.ACTIVE))
+            .send()
+            .join()
+            .items()
+            .getFirst();
+    return element.getElementInstanceKey();
+  }
+
+  private void setLocalVariable(
+      final long elementInstanceKey, final String key, final Object value) {
+    camundaClient
+        .newSetVariablesCommand(elementInstanceKey)
+        .variables(Map.of(key, value))
+        .local(true)
+        .send()
+        .join();
+  }
+
+  private record ProcessAndElement(long processInstanceKey, long elementInstanceKey) {}
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ExpressionEvaluationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ExpressionEvaluationIT.java
@@ -896,10 +896,10 @@ public class ExpressionEvaluationIT {
         .isEqualTo(500);
   }
 
-  // ============ PROCESS / ELEMENT INSTANCE CONTEXT TESTS ============
+  // ============ SCOPE CONTEXT TESTS ============
 
   @Test
-  void shouldEvaluateExpressionInProcessInstanceContext() {
+  void shouldEvaluateExpressionWithProcessInstanceScopeKey() {
     // given
     final ProcessAndElement instance = deployAndStart(Map.of("x", 10, "y", 20));
 
@@ -908,7 +908,7 @@ public class ExpressionEvaluationIT {
         camundaClient
             .newEvaluateExpressionCommand()
             .expression("=x + y")
-            .processInstanceKey(instance.processInstanceKey)
+            .scopeKey(instance.processInstanceKey)
             .send()
             .join();
 
@@ -918,7 +918,7 @@ public class ExpressionEvaluationIT {
   }
 
   @Test
-  void shouldEvaluateExpressionInElementInstanceContext() {
+  void shouldEvaluateExpressionWithElementInstanceScopeKey() {
     // given
     final ProcessAndElement instance = deployAndStart(Map.of("x", 10, "y", 20));
 
@@ -927,31 +927,13 @@ public class ExpressionEvaluationIT {
         camundaClient
             .newEvaluateExpressionCommand()
             .expression("=x + y")
-            .elementInstanceKey(instance.elementInstanceKey)
+            .scopeKey(instance.elementInstanceKey)
             .send()
             .join();
 
     // then - element instance inherits from the process instance scope
     assertThat(response.getResult()).isEqualTo(30);
     assertThat(response.getWarnings()).isEmpty();
-  }
-
-  @Test
-  void shouldRejectWhenBothProcessInstanceKeyAndElementInstanceKeyAreSet() {
-    // when / then
-    assertThatThrownBy(
-            () ->
-                camundaClient
-                    .newEvaluateExpressionCommand()
-                    .expression("=1")
-                    .processInstanceKey(1L)
-                    .elementInstanceKey(2L)
-                    .send()
-                    .join())
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("processInstanceKey")
-        .hasMessageContaining("elementInstanceKey")
-        .hasMessageContaining("mutually exclusive");
   }
 
   @Test
@@ -964,7 +946,7 @@ public class ExpressionEvaluationIT {
         camundaClient
             .newEvaluateExpressionCommand()
             .expression("=x")
-            .processInstanceKey(instance.processInstanceKey)
+            .scopeKey(instance.processInstanceKey)
             .send()
             .join();
 
@@ -978,17 +960,17 @@ public class ExpressionEvaluationIT {
   // ---- precedence: same variable name at process and element scope ----
 
   @Test
-  void shouldReadProcessLevelVariableWhenUsingProcessInstanceKey() {
+  void shouldReadProcessLevelVariableWhenUsingProcessInstanceScopeKey() {
     // given - process-level x=10, element-local x=99 (shadows only the element scope)
     final ProcessAndElement instance = deployAndStart(Map.of("x", 10));
     setLocalVariable(instance.elementInstanceKey, "x", 99);
 
-    // when - asking with processInstanceKey resolves at the process root scope
+    // when - asking with process instance scope key resolves at the process root scope
     final EvaluateExpressionResponse response =
         camundaClient
             .newEvaluateExpressionCommand()
             .expression("=x")
-            .processInstanceKey(instance.processInstanceKey)
+            .scopeKey(instance.processInstanceKey)
             .send()
             .join();
 
@@ -998,17 +980,17 @@ public class ExpressionEvaluationIT {
   }
 
   @Test
-  void shouldReadElementLevelVariableWhenUsingElementInstanceKey() {
+  void shouldReadElementLevelVariableWhenUsingElementInstanceScopeKey() {
     // given - same setup as above: process-level x=10, element-local x=99
     final ProcessAndElement instance = deployAndStart(Map.of("x", 10));
     setLocalVariable(instance.elementInstanceKey, "x", 99);
 
-    // when - asking with elementInstanceKey resolves starting at the element scope
+    // when - asking with element instance scope key resolves starting at the element scope
     final EvaluateExpressionResponse response =
         camundaClient
             .newEvaluateExpressionCommand()
             .expression("=x")
-            .elementInstanceKey(instance.elementInstanceKey)
+            .scopeKey(instance.elementInstanceKey)
             .send()
             .join();
 
@@ -1024,12 +1006,12 @@ public class ExpressionEvaluationIT {
     // given - process-level x=10
     final ProcessAndElement instance = deployAndStart(Map.of("x", 10));
 
-    // when - request-body variable x=999 is supplied alongside processInstanceKey
+    // when - request-body variable x=999 is supplied alongside a process instance scope key
     final EvaluateExpressionResponse response =
         camundaClient
             .newEvaluateExpressionCommand()
             .expression("=x")
-            .processInstanceKey(instance.processInstanceKey)
+            .scopeKey(instance.processInstanceKey)
             .variable("x", 999)
             .send()
             .join();
@@ -1044,12 +1026,12 @@ public class ExpressionEvaluationIT {
     final ProcessAndElement instance = deployAndStart(Map.of("x", 10));
     setLocalVariable(instance.elementInstanceKey, "x", 99);
 
-    // when - request-body variable x=999 is supplied alongside elementInstanceKey
+    // when - request-body variable x=999 is supplied alongside an element instance scope key
     final EvaluateExpressionResponse response =
         camundaClient
             .newEvaluateExpressionCommand()
             .expression("=x")
-            .elementInstanceKey(instance.elementInstanceKey)
+            .scopeKey(instance.elementInstanceKey)
             .variable("x", 999)
             .send()
             .join();


### PR DESCRIPTION
This pull request enhances the expression evaluation feature in the acceptance test suite by adding comprehensive tests for evaluating expressions within process and element instance contexts, as well as introducing fine-grained authorization checks for these scenarios. The changes ensure that expression evaluation respects variable scoping (process, element, and request-body), enforces correct authorization, and handles edge cases such as variable shadowing and mutually exclusive context parameters.

**Expression Evaluation Context and Variable Scoping:**

* Added tests to verify that expressions can be evaluated in the context of a specific process instance or element instance, ensuring correct variable resolution and scoping behavior. This includes checks for variable shadowing, request-body variable precedence, and handling of missing variables.

* Implemented helper methods (`deployAndStart`, `waitForActiveElementInstance`, `setLocalVariable`) to streamline test setup for process and element instance context scenarios.

**Authorization and Access Control:**

* Introduced new user definitions and permissions to test authorization logic for expression evaluation in process/element contexts, including both authorized and unauthorized scenarios. Added tests to ensure that users require both `EVALUATE` and `READ_PROCESS_INSTANCE` permissions to evaluate expressions with process or element instance keys, and that permissions are correctly scoped to the process definition. [[1]](diffhunk://#diff-37035bcaadfa94b00b5a63064bac673889ce61316bd80c3096c33e0d6e418d42R48-R57) [[2]](diffhunk://#diff-37035bcaadfa94b00b5a63064bac673889ce61316bd80c3096c33e0d6e418d42R70-R155) [[3]](diffhunk://#diff-37035bcaadfa94b00b5a63064bac673889ce61316bd80c3096c33e0d6e418d42R177-R263)

**Edge Case Handling:**

* Added tests to verify that providing both `processInstanceKey` and `elementInstanceKey` in a single expression evaluation request results in a clear error, enforcing mutual exclusivity of these parameters.

* Added tests to confirm that evaluating an expression when a process variable is not in scope returns `null` and produces an appropriate warning.

**Test Infrastructure Improvements:**

* Updated imports and constants to support new test scenarios and user definitions, including additional permissions, resource types, and utility classes for process/element instance handling. [[1]](diffhunk://#diff-37035bcaadfa94b00b5a63064bac673889ce61316bd80c3096c33e0d6e418d42R10-R34) [[2]](diffhunk://#diff-8c9297c113232c05d8dc4862407fb8e46c736431d1a173056163ed0f554f179bR18-R31)

These changes significantly improve the robustness and coverage of expression evaluation and authorization logic in the test suite, ensuring correct behavior in complex real-world scenarios.

related to https://github.com/camunda/camunda/issues/51991