### PR TITLE
feat: add MVF base components

### DIFF
--- a/operate/client/src/App/Processes/ListView/Filters/OptionalFiltersFormGroup.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/OptionalFiltersFormGroup.tsx
@@ -37,6 +37,9 @@ import {
   FieldContainer,
 } from 'modules/components/FiltersPanel/styled';
 import {Variable} from './VariableField';
+import {VariableFilter} from './VariablesFilter';
+import {variableFilterStore} from 'modules/stores/variableFilter';
+import {MULTI_VARIABLE_FILTER} from 'modules/feature-flags';
 
 type OptionalFilter =
   | 'variable'
@@ -70,8 +73,8 @@ const OPTIONAL_FILTER_FIELDS: Record<
   }
 > = {
   variable: {
-    keys: ['variableName', 'variableValues'],
-    label: 'Variable',
+    keys: MULTI_VARIABLE_FILTER ? [] : ['variableName', 'variableValues'],
+    label: MULTI_VARIABLE_FILTER ? 'Variables' : 'Variable',
   },
   processInstanceKey: {
     keys: ['processInstanceKey'],
@@ -196,6 +199,9 @@ const OptionalFiltersFormGroup: React.FC<Props> = observer(
               {(() => {
                 switch (filter) {
                   case 'variable':
+                    if (MULTI_VARIABLE_FILTER) {
+                      return <VariableFilter />;
+                    }
                     return <Variable />;
                   case 'startDateRange':
                     return (
@@ -296,6 +302,10 @@ const OptionalFiltersFormGroup: React.FC<Props> = observer(
                         (visibleFilter) => visibleFilter !== filter,
                       ),
                     );
+
+                    if (filter === 'variable' && MULTI_VARIABLE_FILTER) {
+                      variableFilterStore.setConditions([]);
+                    }
 
                     OPTIONAL_FILTER_FIELDS[filter].keys.forEach((key) => {
                       form.change(key, undefined);

--- a/operate/client/src/App/Processes/ListView/Filters/OptionalFiltersFormGroup.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/OptionalFiltersFormGroup.tsx
@@ -140,6 +140,8 @@ const OptionalFiltersFormGroup: React.FC<Props> = observer(
   ({visibleFilters, onVisibleFilterChange}) => {
     const location = useLocation() as LocationType;
     const form = useForm();
+    const hasActiveVariableFilters =
+      MULTI_VARIABLE_FILTER && variableFilterStore.hasActiveFilters;
 
     useEffect(() => {
       const filters = getProcessInstanceFilters(location.search);
@@ -158,11 +160,17 @@ const OptionalFiltersFormGroup: React.FC<Props> = observer(
               ...('endDateFrom' in filters && 'endDateTo' in filters
                 ? ['endDateRange']
                 : []),
+              ...(hasActiveVariableFilters ? ['variable'] : []),
             ] as OptionalFilter[]),
           ]),
         );
       });
-    }, [location.state, location.search, onVisibleFilterChange]);
+    }, [
+      location.state,
+      location.search,
+      onVisibleFilterChange,
+      hasActiveVariableFilters,
+    ]);
 
     const [isStartDateRangeModalOpen, setIsStartDateRangeModalOpen] =
       useState<boolean>(false);
@@ -303,10 +311,6 @@ const OptionalFiltersFormGroup: React.FC<Props> = observer(
                       ),
                     );
 
-                    if (filter === 'variable' && MULTI_VARIABLE_FILTER) {
-                      variableFilterStore.setConditions([]);
-                    }
-
                     OPTIONAL_FILTER_FIELDS[filter].keys.forEach((key) => {
                       form.change(key, undefined);
                       if (key === 'errorMessage') {
@@ -314,6 +318,11 @@ const OptionalFiltersFormGroup: React.FC<Props> = observer(
                         form.change('incidentErrorHashCode', undefined);
                       }
                     });
+
+                    if (filter === 'variable' && MULTI_VARIABLE_FILTER) {
+                      variableFilterStore.setConditions([]);
+                    }
+
                     form.submit();
                   }}
                 >

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterModal.test.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterModal.test.tsx
@@ -1,0 +1,219 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {render, screen} from 'modules/testing-library';
+import {VariableFilterModal} from './VariableFilterModal';
+import type {VariableCondition} from 'modules/stores/variableFilter';
+
+const renderModal = (
+  props: Partial<{
+    isOpen: boolean;
+    initialConditions: VariableCondition[];
+    onApply: (c: VariableCondition[]) => void;
+    onClose: () => void;
+  }> = {},
+) => {
+  return render(
+    <VariableFilterModal
+      isOpen={props.isOpen ?? true}
+      initialConditions={props.initialConditions ?? []}
+      onApply={props.onApply ?? vi.fn()}
+      onClose={props.onClose ?? vi.fn()}
+    />,
+  );
+};
+
+describe('<VariableFilterModal />', () => {
+  it('should render one empty row when no initial conditions', () => {
+    renderModal();
+
+    expect(screen.getAllByPlaceholderText('Variable name')).toHaveLength(1);
+  });
+
+  it('should render rows for each initial condition', () => {
+    const conditions: VariableCondition[] = [
+      {name: 'status', operator: 'equals', value: '"active"'},
+      {name: 'count', operator: 'notEqual', value: '0'},
+    ];
+    renderModal({initialConditions: conditions});
+
+    const nameInputs = screen.getAllByPlaceholderText('Variable name');
+    expect(nameInputs).toHaveLength(2);
+    expect(nameInputs[0]!).toHaveValue('status');
+    expect(nameInputs[1]!).toHaveValue('count');
+  });
+
+  it('should disable Apply button when all rows are empty', () => {
+    renderModal();
+
+    expect(screen.getByRole('button', {name: 'Apply'})).toBeDisabled();
+  });
+
+  it('should enable Apply button when at least one row is valid', async () => {
+    const {user} = renderModal();
+
+    await user.type(
+      screen.getAllByPlaceholderText('Variable name')[0]!,
+      'myVar',
+    );
+    await user.type(
+      screen.getAllByPlaceholderText('value in JSON format')[0]!,
+      '"hello"',
+    );
+
+    expect(screen.getByRole('button', {name: 'Apply'})).toBeEnabled();
+  });
+
+  it('should add a new row when Add condition is clicked', async () => {
+    const {user} = renderModal();
+
+    await user.click(screen.getByRole('button', {name: 'Add condition'}));
+
+    expect(screen.getAllByPlaceholderText('Variable name')).toHaveLength(2);
+  });
+
+  it('should disable Add condition button at MAX_CONDITIONS rows', async () => {
+    const conditions: VariableCondition[] = Array.from({length: 5}, (_, i) => ({
+      name: `var${i}`,
+      operator: 'equals' as const,
+      value: `"val${i}"`,
+    }));
+    renderModal({initialConditions: conditions});
+
+    expect(screen.getByRole('button', {name: 'Add condition'})).toBeDisabled();
+  });
+
+  it('should call onApply with valid conditions stripped of id', async () => {
+    const onApply = vi.fn();
+    const {user} = renderModal({onApply});
+
+    await user.type(
+      screen.getAllByPlaceholderText('Variable name')[0]!,
+      'status',
+    );
+    await user.type(
+      screen.getAllByPlaceholderText('value in JSON format')[0]!,
+      '"active"',
+    );
+    await user.click(screen.getByRole('button', {name: 'Apply'}));
+
+    expect(onApply).toHaveBeenCalledOnce();
+    const applied = onApply.mock.calls[0]![0] as VariableCondition[];
+    expect(applied).toHaveLength(1);
+    expect(applied[0]).toEqual({
+      name: 'status',
+      operator: 'equals',
+      value: '"active"',
+    });
+    expect(applied[0]).not.toHaveProperty('id');
+  });
+
+  it('should call onClose when Cancel is clicked', async () => {
+    const onClose = vi.fn();
+    const {user} = renderModal({onClose});
+
+    await user.click(screen.getByRole('button', {name: 'Cancel'}));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should filter out invalid (nameless) conditions on Apply', async () => {
+    const onApply = vi.fn();
+    const conditions: VariableCondition[] = [
+      {name: 'status', operator: 'equals', value: '"active"'},
+    ];
+    const {user} = renderModal({initialConditions: conditions, onApply});
+
+    await user.click(screen.getByRole('button', {name: 'Add condition'}));
+
+    await user.click(screen.getByRole('button', {name: 'Apply'}));
+
+    const applied = onApply.mock.calls[0]![0] as VariableCondition[];
+    expect(applied).toHaveLength(1);
+    expect(applied[0]!.name).toBe('status');
+  });
+
+  it('should accept exists operator without value as valid', async () => {
+    const onApply = vi.fn();
+    const {user} = renderModal({onApply});
+
+    await user.type(
+      screen.getAllByPlaceholderText('Variable name')[0]!,
+      'myVar',
+    );
+
+    await user.click(screen.getByRole('combobox', {name: 'Operator'}));
+    await user.click(screen.getByText('exists'));
+
+    await user.click(screen.getByRole('button', {name: 'Apply'}));
+
+    const applied = onApply.mock.calls[0]![0] as VariableCondition[];
+    expect(applied).toHaveLength(1);
+    expect(applied[0]).toEqual({name: 'myVar', operator: 'exists', value: ''});
+  });
+
+  it('should accept doesNotExist operator without value as valid', async () => {
+    const onApply = vi.fn();
+    const {user} = renderModal({onApply});
+
+    await user.type(
+      screen.getAllByPlaceholderText('Variable name')[0]!,
+      'myVar',
+    );
+
+    await user.click(screen.getByRole('combobox', {name: 'Operator'}));
+    await user.click(screen.getByText('does not exist'));
+
+    await user.click(screen.getByRole('button', {name: 'Apply'}));
+
+    const applied = onApply.mock.calls[0]![0] as VariableCondition[];
+    expect(applied).toHaveLength(1);
+    expect(applied[0]).toEqual({
+      name: 'myVar',
+      operator: 'doesNotExist',
+      value: '',
+    });
+  });
+
+  it('should hide value field when operator is changed to exists', async () => {
+    const {user} = renderModal();
+
+    await user.click(screen.getByRole('combobox', {name: 'Operator'}));
+    await user.click(screen.getByText('exists'));
+
+    expect(
+      screen.queryByPlaceholderText('value in JSON format'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should remove a row when its delete button is clicked', async () => {
+    const conditions: VariableCondition[] = [
+      {name: 'status', operator: 'equals', value: '"active"'},
+      {name: 'count', operator: 'notEqual', value: '0'},
+    ];
+    const {user} = renderModal({initialConditions: conditions});
+
+    expect(screen.getAllByPlaceholderText('Variable name')).toHaveLength(2);
+
+    const deleteButtons = screen.getAllByRole('button', {
+      name: 'Remove condition',
+    });
+    await user.click(deleteButtons[0]!);
+
+    const remaining = screen.getAllByPlaceholderText('Variable name');
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]!).toHaveValue('count');
+  });
+
+  it('should initialize with one empty row when opened with no initial conditions', () => {
+    renderModal({isOpen: true, initialConditions: []});
+
+    expect(screen.getAllByPlaceholderText('Variable name')).toHaveLength(1);
+    expect(screen.getAllByPlaceholderText('Variable name')[0]!).toHaveValue('');
+  });
+});

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterModal.test.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterModal.test.tsx
@@ -48,23 +48,8 @@ describe('<VariableFilterModal />', () => {
     expect(nameInputs[1]!).toHaveValue('count');
   });
 
-  it('should disable Apply button when all rows are empty', () => {
+  it('should always enable Apply button', () => {
     renderModal();
-
-    expect(screen.getByRole('button', {name: 'Apply'})).toBeDisabled();
-  });
-
-  it('should enable Apply button when at least one row is valid', async () => {
-    const {user} = renderModal();
-
-    await user.type(
-      screen.getAllByPlaceholderText('Variable name')[0]!,
-      'myVar',
-    );
-    await user.type(
-      screen.getAllByPlaceholderText('value in JSON format')[0]!,
-      '"hello"',
-    );
 
     expect(screen.getByRole('button', {name: 'Apply'})).toBeEnabled();
   });
@@ -120,22 +105,6 @@ describe('<VariableFilterModal />', () => {
     await user.click(screen.getByRole('button', {name: 'Cancel'}));
 
     expect(onClose).toHaveBeenCalledTimes(1);
-  });
-
-  it('should filter out invalid (nameless) conditions on Apply', async () => {
-    const onApply = vi.fn();
-    const conditions: VariableCondition[] = [
-      {name: 'status', operator: 'equals', value: '"active"'},
-    ];
-    const {user} = renderModal({initialConditions: conditions, onApply});
-
-    await user.click(screen.getByRole('button', {name: 'Add condition'}));
-
-    await user.click(screen.getByRole('button', {name: 'Apply'}));
-
-    const applied = onApply.mock.calls[0]![0] as VariableCondition[];
-    expect(applied).toHaveLength(1);
-    expect(applied[0]!.name).toBe('status');
   });
 
   it('should accept exists operator without value as valid', async () => {
@@ -215,5 +184,141 @@ describe('<VariableFilterModal />', () => {
 
     expect(screen.getAllByPlaceholderText('Variable name')).toHaveLength(1);
     expect(screen.getAllByPlaceholderText('Variable name')[0]!).toHaveValue('');
+  });
+
+  it('should show name error and keep modal open when name is empty on Apply', async () => {
+    const onApply = vi.fn();
+    const {user} = renderModal({onApply});
+
+    await user.click(screen.getByRole('button', {name: 'Apply'}));
+
+    expect(screen.getByText('Variable name is required')).toBeInTheDocument();
+    expect(onApply).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole('dialog', {name: 'Filter by Variable'}),
+    ).toBeInTheDocument();
+  });
+
+  it('should show JSON error when value is not valid JSON on Apply', async () => {
+    const onApply = vi.fn();
+    const {user} = renderModal({onApply});
+
+    await user.type(
+      screen.getAllByPlaceholderText('Variable name')[0]!,
+      'myVar',
+    );
+    await user.type(
+      screen.getAllByPlaceholderText('value in JSON format')[0]!,
+      'not-json',
+    );
+    await user.click(screen.getByRole('button', {name: 'Apply'}));
+
+    expect(screen.getByText('Value must be valid JSON')).toBeInTheDocument();
+    expect(onApply).not.toHaveBeenCalled();
+  });
+
+  it('should not show JSON error for contains operator', async () => {
+    const onApply = vi.fn();
+    const {user} = renderModal({onApply});
+
+    await user.type(
+      screen.getAllByPlaceholderText('Variable name')[0]!,
+      'myVar',
+    );
+    await user.click(screen.getByRole('combobox', {name: 'Operator'}));
+    await user.click(screen.getByText('contains'));
+    await user.type(
+      screen.getAllByPlaceholderText('search text')[0]!,
+      'active',
+    );
+
+    await user.click(screen.getByRole('button', {name: 'Apply'}));
+
+    expect(
+      screen.queryByText('Value must be valid JSON'),
+    ).not.toBeInTheDocument();
+    expect(onApply).toHaveBeenCalledOnce();
+  });
+
+  it('should clear error on blur after correcting the field', async () => {
+    const {user} = renderModal();
+
+    await user.click(screen.getByRole('button', {name: 'Apply'}));
+    expect(screen.getByText('Variable name is required')).toBeInTheDocument();
+
+    await user.type(
+      screen.getAllByPlaceholderText('Variable name')[0]!,
+      'myVar',
+    );
+    await user.tab();
+
+    expect(
+      screen.queryByText('Variable name is required'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should not re-validate on blur if row was never submitted with an error', async () => {
+    const {user} = renderModal();
+
+    await user.click(screen.getAllByPlaceholderText('Variable name')[0]!);
+    await user.tab();
+
+    expect(
+      screen.queryByText('Variable name is required'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should clear errors when a row is deleted', async () => {
+    const {user} = renderModal();
+
+    await user.click(screen.getByRole('button', {name: 'Add condition'}));
+    await user.click(screen.getByRole('button', {name: 'Apply'}));
+
+    expect(screen.getAllByText('Variable name is required')).toHaveLength(2);
+
+    const deleteButtons = screen.getAllByRole('button', {
+      name: 'Remove condition',
+    });
+    await user.click(deleteButtons[0]!);
+
+    expect(screen.getAllByText('Variable name is required')).toHaveLength(1);
+  });
+
+  it('should re-validate immediately when operator changes on a previously-failed row', async () => {
+    const onApply = vi.fn();
+    const {user} = renderModal({onApply});
+
+    await user.type(
+      screen.getAllByPlaceholderText('Variable name')[0]!,
+      'myVar',
+    );
+    await user.click(screen.getByRole('button', {name: 'Apply'}));
+    expect(screen.getByText('Value is required')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('combobox', {name: 'Operator'}));
+    await user.click(screen.getByText('exists'));
+
+    expect(screen.queryByText('Value is required')).not.toBeInTheDocument();
+  });
+
+  it('should apply successfully when all conditions are valid', async () => {
+    const onApply = vi.fn();
+    const {user} = renderModal({onApply});
+
+    await user.type(
+      screen.getAllByPlaceholderText('Variable name')[0]!,
+      'status',
+    );
+    await user.type(
+      screen.getAllByPlaceholderText('value in JSON format')[0]!,
+      '"active"',
+    );
+    await user.click(screen.getByRole('button', {name: 'Apply'}));
+
+    expect(onApply).toHaveBeenCalledOnce();
+    expect(
+      screen.queryByText('Variable name is required'),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText('Value is required')).not.toBeInTheDocument();
   });
 });

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterModal.test.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterModal.test.tsx
@@ -10,27 +10,20 @@ import {render, screen} from 'modules/testing-library';
 import {VariableFilterModal} from './VariableFilterModal';
 import type {VariableCondition} from 'modules/stores/variableFilter';
 
-const renderModal = (
-  props: Partial<{
-    isOpen: boolean;
-    initialConditions: VariableCondition[];
-    onApply: (c: VariableCondition[]) => void;
-    onClose: () => void;
-  }> = {},
-) => {
-  return render(
-    <VariableFilterModal
-      isOpen={props.isOpen ?? true}
-      initialConditions={props.initialConditions ?? []}
-      onApply={props.onApply ?? vi.fn()}
-      onClose={props.onClose ?? vi.fn()}
-    />,
-  );
+const baseMockProps = {
+  isOpen: true,
+  initialConditions: [] as VariableCondition[],
+  onApply: vi.fn(),
+  onClose: vi.fn(),
 };
 
 describe('<VariableFilterModal />', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('should render one empty row when no initial conditions', () => {
-    renderModal();
+    render(<VariableFilterModal {...baseMockProps} />);
 
     expect(screen.getAllByPlaceholderText('Variable name')).toHaveLength(1);
   });
@@ -40,7 +33,9 @@ describe('<VariableFilterModal />', () => {
       {name: 'status', operator: 'equals', value: '"active"'},
       {name: 'count', operator: 'notEqual', value: '0'},
     ];
-    renderModal({initialConditions: conditions});
+    render(
+      <VariableFilterModal {...baseMockProps} initialConditions={conditions} />,
+    );
 
     const nameInputs = screen.getAllByPlaceholderText('Variable name');
     expect(nameInputs).toHaveLength(2);
@@ -49,33 +44,37 @@ describe('<VariableFilterModal />', () => {
   });
 
   it('should always enable Apply button', () => {
-    renderModal();
+    render(<VariableFilterModal {...baseMockProps} />);
 
     expect(screen.getByRole('button', {name: 'Apply'})).toBeEnabled();
   });
 
   it('should add a new row when Add condition is clicked', async () => {
-    const {user} = renderModal();
+    const {user} = render(<VariableFilterModal {...baseMockProps} />);
 
     await user.click(screen.getByRole('button', {name: 'Add condition'}));
 
     expect(screen.getAllByPlaceholderText('Variable name')).toHaveLength(2);
   });
 
-  it('should disable Add condition button at MAX_CONDITIONS rows', async () => {
+  it('should disable Add condition button when condition limit is reached', async () => {
     const conditions: VariableCondition[] = Array.from({length: 5}, (_, i) => ({
       name: `var${i}`,
       operator: 'equals' as const,
       value: `"val${i}"`,
     }));
-    renderModal({initialConditions: conditions});
+    render(
+      <VariableFilterModal {...baseMockProps} initialConditions={conditions} />,
+    );
 
     expect(screen.getByRole('button', {name: 'Add condition'})).toBeDisabled();
   });
 
   it('should call onApply with valid conditions stripped of id', async () => {
     const onApply = vi.fn();
-    const {user} = renderModal({onApply});
+    const {user} = render(
+      <VariableFilterModal {...baseMockProps} onApply={onApply} />,
+    );
 
     await user.type(
       screen.getAllByPlaceholderText('Variable name')[0]!,
@@ -87,20 +86,16 @@ describe('<VariableFilterModal />', () => {
     );
     await user.click(screen.getByRole('button', {name: 'Apply'}));
 
-    expect(onApply).toHaveBeenCalledOnce();
-    const applied = onApply.mock.calls[0]![0] as VariableCondition[];
-    expect(applied).toHaveLength(1);
-    expect(applied[0]).toEqual({
-      name: 'status',
-      operator: 'equals',
-      value: '"active"',
-    });
-    expect(applied[0]).not.toHaveProperty('id');
+    expect(onApply).toHaveBeenCalledWith([
+      {name: 'status', operator: 'equals', value: '"active"'},
+    ]);
   });
 
   it('should call onClose when Cancel is clicked', async () => {
     const onClose = vi.fn();
-    const {user} = renderModal({onClose});
+    const {user} = render(
+      <VariableFilterModal {...baseMockProps} onClose={onClose} />,
+    );
 
     await user.click(screen.getByRole('button', {name: 'Cancel'}));
 
@@ -109,7 +104,9 @@ describe('<VariableFilterModal />', () => {
 
   it('should accept exists operator without value as valid', async () => {
     const onApply = vi.fn();
-    const {user} = renderModal({onApply});
+    const {user} = render(
+      <VariableFilterModal {...baseMockProps} onApply={onApply} />,
+    );
 
     await user.type(
       screen.getAllByPlaceholderText('Variable name')[0]!,
@@ -121,14 +118,16 @@ describe('<VariableFilterModal />', () => {
 
     await user.click(screen.getByRole('button', {name: 'Apply'}));
 
-    const applied = onApply.mock.calls[0]![0] as VariableCondition[];
-    expect(applied).toHaveLength(1);
-    expect(applied[0]).toEqual({name: 'myVar', operator: 'exists', value: ''});
+    expect(onApply).toHaveBeenCalledWith([
+      {name: 'myVar', operator: 'exists', value: ''},
+    ]);
   });
 
-  it('should accept doesNotExist operator without value as valid', async () => {
+  it('should accept "does not exist" operator without value as valid', async () => {
     const onApply = vi.fn();
-    const {user} = renderModal({onApply});
+    const {user} = render(
+      <VariableFilterModal {...baseMockProps} onApply={onApply} />,
+    );
 
     await user.type(
       screen.getAllByPlaceholderText('Variable name')[0]!,
@@ -140,17 +139,13 @@ describe('<VariableFilterModal />', () => {
 
     await user.click(screen.getByRole('button', {name: 'Apply'}));
 
-    const applied = onApply.mock.calls[0]![0] as VariableCondition[];
-    expect(applied).toHaveLength(1);
-    expect(applied[0]).toEqual({
-      name: 'myVar',
-      operator: 'doesNotExist',
-      value: '',
-    });
+    expect(onApply).toHaveBeenCalledWith([
+      {name: 'myVar', operator: 'doesNotExist', value: ''},
+    ]);
   });
 
   it('should hide value field when operator is changed to exists', async () => {
-    const {user} = renderModal();
+    const {user} = render(<VariableFilterModal {...baseMockProps} />);
 
     await user.click(screen.getByRole('combobox', {name: 'Operator'}));
     await user.click(screen.getByText('exists'));
@@ -165,7 +160,9 @@ describe('<VariableFilterModal />', () => {
       {name: 'status', operator: 'equals', value: '"active"'},
       {name: 'count', operator: 'notEqual', value: '0'},
     ];
-    const {user} = renderModal({initialConditions: conditions});
+    const {user} = render(
+      <VariableFilterModal {...baseMockProps} initialConditions={conditions} />,
+    );
 
     expect(screen.getAllByPlaceholderText('Variable name')).toHaveLength(2);
 
@@ -180,7 +177,13 @@ describe('<VariableFilterModal />', () => {
   });
 
   it('should initialize with one empty row when opened with no initial conditions', () => {
-    renderModal({isOpen: true, initialConditions: []});
+    render(
+      <VariableFilterModal
+        {...baseMockProps}
+        isOpen={true}
+        initialConditions={[]}
+      />,
+    );
 
     expect(screen.getAllByPlaceholderText('Variable name')).toHaveLength(1);
     expect(screen.getAllByPlaceholderText('Variable name')[0]!).toHaveValue('');
@@ -188,7 +191,9 @@ describe('<VariableFilterModal />', () => {
 
   it('should show name error and keep modal open when name is empty on Apply', async () => {
     const onApply = vi.fn();
-    const {user} = renderModal({onApply});
+    const {user} = render(
+      <VariableFilterModal {...baseMockProps} onApply={onApply} />,
+    );
 
     await user.click(screen.getByRole('button', {name: 'Apply'}));
 
@@ -201,7 +206,9 @@ describe('<VariableFilterModal />', () => {
 
   it('should show JSON error when value is not valid JSON on Apply', async () => {
     const onApply = vi.fn();
-    const {user} = renderModal({onApply});
+    const {user} = render(
+      <VariableFilterModal {...baseMockProps} onApply={onApply} />,
+    );
 
     await user.type(
       screen.getAllByPlaceholderText('Variable name')[0]!,
@@ -219,7 +226,9 @@ describe('<VariableFilterModal />', () => {
 
   it('should not show JSON error for contains operator', async () => {
     const onApply = vi.fn();
-    const {user} = renderModal({onApply});
+    const {user} = render(
+      <VariableFilterModal {...baseMockProps} onApply={onApply} />,
+    );
 
     await user.type(
       screen.getAllByPlaceholderText('Variable name')[0]!,
@@ -241,7 +250,7 @@ describe('<VariableFilterModal />', () => {
   });
 
   it('should clear error when user starts typing after a failed submit', async () => {
-    const {user} = renderModal();
+    const {user} = render(<VariableFilterModal {...baseMockProps} />);
 
     await user.click(screen.getByRole('button', {name: 'Apply'}));
     expect(screen.getByText('Variable name is required')).toBeInTheDocument();
@@ -257,7 +266,7 @@ describe('<VariableFilterModal />', () => {
   });
 
   it('should not show errors before a submit attempt', async () => {
-    const {user} = renderModal();
+    const {user} = render(<VariableFilterModal {...baseMockProps} />);
 
     await user.click(screen.getAllByPlaceholderText('Variable name')[0]!);
     await user.tab();
@@ -268,7 +277,7 @@ describe('<VariableFilterModal />', () => {
   });
 
   it('should clear errors when a row is deleted', async () => {
-    const {user} = renderModal();
+    const {user} = render(<VariableFilterModal {...baseMockProps} />);
 
     await user.click(screen.getByRole('button', {name: 'Add condition'}));
     await user.click(screen.getByRole('button', {name: 'Apply'}));
@@ -285,7 +294,9 @@ describe('<VariableFilterModal />', () => {
 
   it('should re-validate immediately when operator changes on a previously-failed row', async () => {
     const onApply = vi.fn();
-    const {user} = renderModal({onApply});
+    const {user} = render(
+      <VariableFilterModal {...baseMockProps} onApply={onApply} />,
+    );
 
     await user.type(
       screen.getAllByPlaceholderText('Variable name')[0]!,
@@ -302,7 +313,9 @@ describe('<VariableFilterModal />', () => {
 
   it('should apply successfully when all conditions are valid', async () => {
     const onApply = vi.fn();
-    const {user} = renderModal({onApply});
+    const {user} = render(
+      <VariableFilterModal {...baseMockProps} onApply={onApply} />,
+    );
 
     await user.type(
       screen.getAllByPlaceholderText('Variable name')[0]!,

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterModal.test.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterModal.test.tsx
@@ -240,7 +240,7 @@ describe('<VariableFilterModal />', () => {
     expect(onApply).toHaveBeenCalledOnce();
   });
 
-  it('should clear error on blur after correcting the field', async () => {
+  it('should clear error when user starts typing after a failed submit', async () => {
     const {user} = renderModal();
 
     await user.click(screen.getByRole('button', {name: 'Apply'}));
@@ -250,14 +250,13 @@ describe('<VariableFilterModal />', () => {
       screen.getAllByPlaceholderText('Variable name')[0]!,
       'myVar',
     );
-    await user.tab();
 
     expect(
       screen.queryByText('Variable name is required'),
     ).not.toBeInTheDocument();
   });
 
-  it('should not re-validate on blur if row was never submitted with an error', async () => {
+  it('should not show errors before a submit attempt', async () => {
     const {user} = renderModal();
 
     await user.click(screen.getAllByPlaceholderText('Variable name')[0]!);

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterModal.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterModal.tsx
@@ -1,0 +1,124 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useState} from 'react';
+import {Button, Stack} from '@carbon/react';
+import {Add} from '@carbon/react/icons';
+import {VariableFilterRow} from './VariableFilterRow';
+import type {VariableCondition} from 'modules/stores/variableFilter';
+import {type DraftCondition, MAX_CONDITIONS} from './constants';
+import {Modal, FilterRowsContainer, Description} from './styled';
+
+type Props = {
+  isOpen: boolean;
+  initialConditions: VariableCondition[];
+  onApply: (conditions: VariableCondition[]) => void;
+  onClose: () => void;
+};
+
+const createDraft = (): DraftCondition => ({
+  id: crypto.randomUUID(),
+  name: '',
+  operator: 'equals',
+  value: '',
+});
+
+const isConditionValid = (c: DraftCondition): boolean => {
+  if (!c.name.trim()) {
+    return false;
+  }
+  if (c.operator === 'exists' || c.operator === 'doesNotExist') {
+    return true;
+  }
+  return c.value.trim() !== '';
+};
+
+const VariableFilterModal: React.FC<Props> = ({
+  isOpen,
+  initialConditions,
+  onApply,
+  onClose,
+}) => {
+  const [draftConditions, setDraftConditions] = useState<DraftCondition[]>(
+    () =>
+      initialConditions.length > 0
+        ? initialConditions.map((c) => ({...c, id: crypto.randomUUID()}))
+        : [createDraft()],
+  );
+
+  const handleAddCondition = () => {
+    if (draftConditions.length >= MAX_CONDITIONS) {
+      return;
+    }
+    setDraftConditions((prev) => [...prev, createDraft()]);
+  };
+
+  const handleConditionChange = (updated: DraftCondition) => {
+    setDraftConditions((prev) =>
+      prev.map((c) => (c.id === updated.id ? updated : c)),
+    );
+  };
+
+  const handleConditionDelete = (id: string) => {
+    setDraftConditions((prev) => prev.filter((c) => c.id !== id));
+  };
+
+  const handleApply = () => {
+    const valid = draftConditions
+      .filter(isConditionValid)
+      .map(({id: _id, ...rest}) => rest);
+    onApply(valid);
+  };
+
+  const isApplyDisabled = !draftConditions.some(isConditionValid);
+
+  return (
+    <Modal
+      open={isOpen}
+      modalHeading="Filter by Variable"
+      primaryButtonText="Apply"
+      secondaryButtonText="Cancel"
+      onRequestSubmit={handleApply}
+      onRequestClose={onClose}
+      onSecondarySubmit={onClose}
+      primaryButtonDisabled={isApplyDisabled}
+      preventCloseOnClickOutside
+      size="md"
+    >
+      <Stack gap={5}>
+        <Description>
+          Define one or more conditions to filter process instances by variable
+          values. All conditions are combined with AND logic.
+        </Description>
+        <FilterRowsContainer gap={4}>
+          {draftConditions.map((condition, index) => (
+            <VariableFilterRow
+              key={condition.id}
+              condition={condition}
+              onChange={handleConditionChange}
+              onDelete={() => handleConditionDelete(condition.id)}
+              isDeleteHidden={draftConditions.length === 1}
+              rowIndex={index}
+            />
+          ))}
+        </FilterRowsContainer>
+        <Button
+          kind="ghost"
+          size="sm"
+          renderIcon={Add}
+          disabled={draftConditions.length >= MAX_CONDITIONS}
+          onClick={handleAddCondition}
+        >
+          Add condition
+        </Button>
+      </Stack>
+    </Modal>
+  );
+};
+
+export {VariableFilterModal};

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterModal.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterModal.tsx
@@ -11,8 +11,14 @@ import {Button, Stack} from '@carbon/react';
 import {Add} from '@carbon/react/icons';
 import {VariableFilterRow} from './VariableFilterRow';
 import type {VariableCondition} from 'modules/stores/variableFilter';
-import {type DraftCondition, MAX_CONDITIONS} from './constants';
-import {Modal, FilterRowsContainer, Description} from './styled';
+import {
+  type DraftCondition,
+  type RowErrors,
+  MAX_CONDITIONS,
+  validateCondition,
+  hasErrors,
+} from './constants';
+import {Modal, Description} from './styled';
 
 type Props = {
   isOpen: boolean;
@@ -28,16 +34,6 @@ const createDraft = (): DraftCondition => ({
   value: '',
 });
 
-const isConditionValid = (c: DraftCondition): boolean => {
-  if (!c.name.trim()) {
-    return false;
-  }
-  if (c.operator === 'exists' || c.operator === 'doesNotExist') {
-    return true;
-  }
-  return c.value.trim() !== '';
-};
-
 const VariableFilterModal: React.FC<Props> = ({
   isOpen,
   initialConditions,
@@ -50,6 +46,10 @@ const VariableFilterModal: React.FC<Props> = ({
         ? initialConditions.map((c) => ({...c, id: crypto.randomUUID()}))
         : [createDraft()],
   );
+  const [rowErrors, setRowErrors] = useState<Record<string, RowErrors>>({});
+  const [failedOnLastSubmit, setFailedOnLastSubmit] = useState<Set<string>>(
+    new Set(),
+  );
 
   const handleAddCondition = () => {
     if (draftConditions.length >= MAX_CONDITIONS) {
@@ -60,22 +60,64 @@ const VariableFilterModal: React.FC<Props> = ({
 
   const handleConditionChange = (updated: DraftCondition) => {
     setDraftConditions((prev) =>
-      prev.map((c) => (c.id === updated.id ? updated : c)),
+      prev.map((condition) =>
+        condition.id === updated.id ? updated : condition,
+      ),
     );
+    if (failedOnLastSubmit.has(updated.id)) {
+      const errors = validateCondition(updated);
+      setRowErrors((prev) => ({...prev, [updated.id]: errors}));
+    }
   };
 
   const handleConditionDelete = (id: string) => {
-    setDraftConditions((prev) => prev.filter((c) => c.id !== id));
+    setDraftConditions((prev) =>
+      prev.filter((condition) => condition.id !== id),
+    );
+    setRowErrors((prev) => {
+      const next = {...prev};
+      delete next[id];
+      return next;
+    });
+    setFailedOnLastSubmit((prev) => {
+      const next = new Set(prev);
+      next.delete(id);
+      return next;
+    });
   };
 
   const handleApply = () => {
-    const valid = draftConditions
-      .filter(isConditionValid)
-      .map(({id: _id, ...rest}) => rest);
-    onApply(valid);
+    const newErrors: Record<string, RowErrors> = {};
+    const newFailed = new Set<string>();
+
+    for (const condition of draftConditions) {
+      const errors = validateCondition(condition);
+      if (hasErrors(errors)) {
+        newErrors[condition.id] = errors;
+        newFailed.add(condition.id);
+      }
+    }
+
+    if (Object.keys(newErrors).length > 0) {
+      setRowErrors(newErrors);
+      setFailedOnLastSubmit(newFailed);
+      return;
+    }
+
+    onApply(draftConditions.map(({id: _id, ...rest}) => rest));
   };
 
-  const isApplyDisabled = !draftConditions.some(isConditionValid);
+  const handleFieldBlur = (id: string) => {
+    if (!failedOnLastSubmit.has(id)) {
+      return;
+    }
+    const condition = draftConditions.find((condition) => condition.id === id);
+    if (!condition) {
+      return;
+    }
+    const errors = validateCondition(condition);
+    setRowErrors((prev) => ({...prev, [id]: errors}));
+  };
 
   return (
     <Modal
@@ -86,7 +128,6 @@ const VariableFilterModal: React.FC<Props> = ({
       onRequestSubmit={handleApply}
       onRequestClose={onClose}
       onSecondarySubmit={onClose}
-      primaryButtonDisabled={isApplyDisabled}
       preventCloseOnClickOutside
       size="md"
     >
@@ -95,7 +136,7 @@ const VariableFilterModal: React.FC<Props> = ({
           Define one or more conditions to filter process instances by variable
           values. All conditions are combined with AND logic.
         </Description>
-        <FilterRowsContainer gap={4}>
+        <Stack gap={4}>
           {draftConditions.map((condition, index) => (
             <VariableFilterRow
               key={condition.id}
@@ -104,9 +145,11 @@ const VariableFilterModal: React.FC<Props> = ({
               onDelete={() => handleConditionDelete(condition.id)}
               isDeleteHidden={draftConditions.length === 1}
               rowIndex={index}
+              errors={rowErrors[condition.id] ?? {}}
+              onBlur={() => handleFieldBlur(condition.id)}
             />
           ))}
-        </FilterRowsContainer>
+        </Stack>
         <Button
           kind="ghost"
           size="sm"

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterModal.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterModal.tsx
@@ -9,6 +9,9 @@
 import {useState} from 'react';
 import {Button, Stack} from '@carbon/react';
 import {Add} from '@carbon/react/icons';
+import {Form} from 'react-final-form';
+import {FieldArray} from 'react-final-form-arrays';
+import arrayMutators from 'final-form-arrays';
 import {VariableFilterRow} from './VariableFilterRow';
 import type {VariableCondition} from 'modules/stores/variableFilter';
 import {
@@ -27,6 +30,10 @@ type Props = {
   onClose: () => void;
 };
 
+type FormValues = {
+  conditions: DraftCondition[];
+};
+
 const createDraft = (): DraftCondition => ({
   id: crypto.randomUUID(),
   name: '',
@@ -40,127 +47,83 @@ const VariableFilterModal: React.FC<Props> = ({
   onApply,
   onClose,
 }) => {
-  const [draftConditions, setDraftConditions] = useState<DraftCondition[]>(
-    () =>
-      initialConditions.length > 0
-        ? initialConditions.map((c) => ({...c, id: crypto.randomUUID()}))
-        : [createDraft()],
-  );
-  const [rowErrors, setRowErrors] = useState<Record<string, RowErrors>>({});
-  const [failedOnLastSubmit, setFailedOnLastSubmit] = useState<Set<string>>(
-    new Set(),
+  const [initialDraftConditions] = useState<DraftCondition[]>(() =>
+    initialConditions.length > 0
+      ? initialConditions.map((c) => ({...c, id: crypto.randomUUID()}))
+      : [createDraft()],
   );
 
-  const handleAddCondition = () => {
-    if (draftConditions.length >= MAX_CONDITIONS) {
-      return;
+  const handleSubmit = (
+    values: FormValues,
+  ): {conditions: RowErrors[]} | undefined => {
+    const conditionErrors = values.conditions.map(validateCondition);
+    if (conditionErrors.some(hasErrors)) {
+      return {conditions: conditionErrors};
     }
-    setDraftConditions((prev) => [...prev, createDraft()]);
-  };
-
-  const handleConditionChange = (updated: DraftCondition) => {
-    setDraftConditions((prev) =>
-      prev.map((condition) =>
-        condition.id === updated.id ? updated : condition,
+    onApply(
+      values.conditions.map(
+        ({id: _id, operator, name, value}): VariableCondition => {
+          if (operator === 'exists' || operator === 'doesNotExist') {
+            return {name, operator, value: ''};
+          }
+          return {name, operator, value: value ?? ''};
+        },
       ),
     );
-    if (failedOnLastSubmit.has(updated.id)) {
-      const errors = validateCondition(updated);
-      setRowErrors((prev) => ({...prev, [updated.id]: errors}));
-    }
-  };
-
-  const handleConditionDelete = (id: string) => {
-    setDraftConditions((prev) =>
-      prev.filter((condition) => condition.id !== id),
-    );
-    setRowErrors((prev) => {
-      const next = {...prev};
-      delete next[id];
-      return next;
-    });
-    setFailedOnLastSubmit((prev) => {
-      const next = new Set(prev);
-      next.delete(id);
-      return next;
-    });
-  };
-
-  const handleApply = () => {
-    const newErrors: Record<string, RowErrors> = {};
-    const newFailed = new Set<string>();
-
-    for (const condition of draftConditions) {
-      const errors = validateCondition(condition);
-      if (hasErrors(errors)) {
-        newErrors[condition.id] = errors;
-        newFailed.add(condition.id);
-      }
-    }
-
-    if (Object.keys(newErrors).length > 0) {
-      setRowErrors(newErrors);
-      setFailedOnLastSubmit(newFailed);
-      return;
-    }
-
-    onApply(draftConditions.map(({id: _id, ...rest}) => rest));
-  };
-
-  const handleFieldBlur = (id: string) => {
-    if (!failedOnLastSubmit.has(id)) {
-      return;
-    }
-    const condition = draftConditions.find((condition) => condition.id === id);
-    if (!condition) {
-      return;
-    }
-    const errors = validateCondition(condition);
-    setRowErrors((prev) => ({...prev, [id]: errors}));
+    return undefined;
   };
 
   return (
-    <Modal
-      open={isOpen}
-      modalHeading="Filter by Variable"
-      primaryButtonText="Apply"
-      secondaryButtonText="Cancel"
-      onRequestSubmit={handleApply}
-      onRequestClose={onClose}
-      onSecondarySubmit={onClose}
-      preventCloseOnClickOutside
-      size="md"
+    <Form<FormValues>
+      onSubmit={handleSubmit}
+      initialValues={{conditions: initialDraftConditions}}
+      mutators={{...arrayMutators}}
     >
-      <Stack gap={5}>
-        <Description>
-          Define one or more conditions to filter process instances by variable
-          values. All conditions are combined with AND logic.
-        </Description>
-        <Stack gap={4}>
-          {draftConditions.map((condition, index) => (
-            <VariableFilterRow
-              key={condition.id}
-              condition={condition}
-              onChange={handleConditionChange}
-              onDelete={() => handleConditionDelete(condition.id)}
-              isDeleteHidden={draftConditions.length === 1}
-              rowIndex={index}
-              errors={rowErrors[condition.id] ?? {}}
-              onBlur={() => handleFieldBlur(condition.id)}
-            />
-          ))}
-        </Stack>
-        <Button
-          kind="ghost"
-          size="sm"
-          renderIcon={Add}
-          disabled={draftConditions.length >= MAX_CONDITIONS}
-          onClick={handleAddCondition}
+      {({handleSubmit: submitForm}) => (
+        <Modal
+          open={isOpen}
+          modalHeading="Filter by Variable"
+          primaryButtonText="Apply"
+          secondaryButtonText="Cancel"
+          onRequestSubmit={submitForm}
+          onRequestClose={onClose}
+          onSecondarySubmit={onClose}
+          preventCloseOnClickOutside
+          size="md"
         >
-          Add condition
-        </Button>
-      </Stack>
-    </Modal>
+          <Stack gap={5}>
+            <Description>
+              Define one or more conditions to filter process instances by
+              variable values. All conditions are combined with AND logic.
+            </Description>
+            <FieldArray<DraftCondition> name="conditions">
+              {({fields}) => (
+                <Stack gap={4}>
+                  {fields.map((fieldName, index) => (
+                    <VariableFilterRow
+                      key={fieldName}
+                      fieldName={fieldName}
+                      rowIndex={index}
+                      onDelete={() => fields.remove(index)}
+                      isDeleteHidden={fields.length === 1}
+                    />
+                  ))}
+                  <Button
+                    kind="ghost"
+                    size="sm"
+                    renderIcon={Add}
+                    disabled={(fields.length ?? 0) >= MAX_CONDITIONS}
+                    onClick={() => fields.push(createDraft())}
+                  >
+                    Add condition
+                  </Button>
+                </Stack>
+              )}
+            </FieldArray>
+          </Stack>
+        </Modal>
+      )}
+    </Form>
   );
 };
 

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterModal.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterModal.tsx
@@ -7,21 +7,59 @@
  */
 
 import {useState} from 'react';
-import {Button, Stack} from '@carbon/react';
+import {Button, Modal, Stack} from '@carbon/react';
 import {Add} from '@carbon/react/icons';
 import {Form} from 'react-final-form';
 import {FieldArray} from 'react-final-form-arrays';
 import arrayMutators from 'final-form-arrays';
+import {isValidJSON} from 'modules/utils';
 import {VariableFilterRow} from './VariableFilterRow';
 import type {VariableCondition} from 'modules/stores/variableFilter';
-import {
-  type DraftCondition,
-  type RowErrors,
-  MAX_CONDITIONS,
-  validateCondition,
-  hasErrors,
-} from './constants';
-import {Modal, Description} from './styled';
+import type {DraftCondition} from './constants';
+import {Description, ModalContent} from './styled';
+
+const MAX_CONDITIONS = 5;
+
+type RowErrors = {
+  name?: string;
+  value?: string;
+};
+
+const validateCondition = (condition: DraftCondition): RowErrors => {
+  const errors: RowErrors = {};
+
+  if (!condition.name.trim()) {
+    errors.name = 'Variable name is required';
+  }
+
+  if (
+    condition.operator !== 'exists' &&
+    condition.operator !== 'doesNotExist'
+  ) {
+    if (!condition.value.trim()) {
+      errors.value = 'Value is required';
+    } else if (condition.operator === 'oneOf') {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(condition.value);
+      } catch {
+        // handled below
+      }
+      if (!Array.isArray(parsed)) {
+        errors.value = 'Value must be a JSON array (e.g. ["val1", "val2"])';
+      }
+    } else if (
+      condition.operator !== 'contains' &&
+      !isValidJSON(condition.value)
+    ) {
+      errors.value = 'Value must be valid JSON';
+    }
+  }
+
+  return errors;
+};
+
+const hasErrors = (errors: RowErrors) => Object.keys(errors).length > 0;
 
 type Props = {
   isOpen: boolean;
@@ -91,36 +129,38 @@ const VariableFilterModal: React.FC<Props> = ({
           preventCloseOnClickOutside
           size="md"
         >
-          <Stack gap={5}>
-            <Description>
-              Define one or more conditions to filter process instances by
-              variable values. All conditions are combined with AND logic.
-            </Description>
-            <FieldArray<DraftCondition> name="conditions">
-              {({fields}) => (
-                <Stack gap={4}>
-                  {fields.map((fieldName, index) => (
-                    <VariableFilterRow
-                      key={fieldName}
-                      fieldName={fieldName}
-                      rowIndex={index}
-                      onDelete={() => fields.remove(index)}
-                      isDeleteHidden={fields.length === 1}
-                    />
-                  ))}
-                  <Button
-                    kind="ghost"
-                    size="sm"
-                    renderIcon={Add}
-                    disabled={(fields.length ?? 0) >= MAX_CONDITIONS}
-                    onClick={() => fields.push(createDraft())}
-                  >
-                    Add condition
-                  </Button>
-                </Stack>
-              )}
-            </FieldArray>
-          </Stack>
+          <ModalContent>
+            <Stack gap={5}>
+              <Description>
+                Define one or more conditions to filter process instances by
+                variable values. All conditions are combined with AND logic.
+              </Description>
+              <FieldArray<DraftCondition> name="conditions">
+                {({fields}) => (
+                  <Stack gap={4}>
+                    {fields.map((fieldName, index) => (
+                      <VariableFilterRow
+                        key={fieldName}
+                        fieldName={fieldName}
+                        rowIndex={index}
+                        onDelete={() => fields.remove(index)}
+                        isDeleteHidden={fields.length === 1}
+                      />
+                    ))}
+                    <Button
+                      kind="ghost"
+                      size="sm"
+                      renderIcon={Add}
+                      disabled={(fields.length ?? 0) >= MAX_CONDITIONS}
+                      onClick={() => fields.push(createDraft())}
+                    >
+                      Add condition
+                    </Button>
+                  </Stack>
+                )}
+              </FieldArray>
+            </Stack>
+          </ModalContent>
         </Modal>
       )}
     </Form>

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterModal.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterModal.tsx
@@ -73,7 +73,6 @@ type FormValues = {
 };
 
 const createDraft = (): DraftCondition => ({
-  id: crypto.randomUUID(),
   name: '',
   operator: 'equals',
   value: '',
@@ -87,7 +86,7 @@ const VariableFilterModal: React.FC<Props> = ({
 }) => {
   const [initialDraftConditions] = useState<DraftCondition[]>(() =>
     initialConditions.length > 0
-      ? initialConditions.map((c) => ({...c, id: crypto.randomUUID()}))
+      ? initialConditions.map((c) => ({...c}))
       : [createDraft()],
   );
 
@@ -99,14 +98,12 @@ const VariableFilterModal: React.FC<Props> = ({
       return {conditions: conditionErrors};
     }
     onApply(
-      values.conditions.map(
-        ({id: _id, operator, name, value}): VariableCondition => {
-          if (operator === 'exists' || operator === 'doesNotExist') {
-            return {name, operator, value: ''};
-          }
-          return {name, operator, value: value ?? ''};
-        },
-      ),
+      values.conditions.map(({operator, name, value}): VariableCondition => {
+        if (operator === 'exists' || operator === 'doesNotExist') {
+          return {name, operator, value: ''};
+        }
+        return {name, operator, value: value ?? ''};
+      }),
     );
     return undefined;
   };

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterRow.test.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterRow.test.tsx
@@ -1,0 +1,146 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {render, screen} from 'modules/testing-library';
+import {VariableFilterRow} from './VariableFilterRow';
+import type {DraftCondition} from './constants';
+
+const makeCondition = (
+  overrides: Partial<DraftCondition> = {},
+): DraftCondition => ({
+  id: 'test-id',
+  name: '',
+  operator: 'equals',
+  value: '',
+  ...overrides,
+});
+
+describe('<VariableFilterRow />', () => {
+  it('should render name and value inputs and operator dropdown', () => {
+    render(
+      <VariableFilterRow
+        condition={makeCondition()}
+        onChange={vi.fn()}
+        onDelete={vi.fn()}
+        isDeleteHidden={true}
+        rowIndex={0}
+      />,
+    );
+
+    expect(
+      screen.getByTestId('variable-filter-name-test-id'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('variable-filter-operator-test-id'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('variable-filter-value-test-id'),
+    ).toBeInTheDocument();
+  });
+
+  it('should hide value field when operator does not require value', () => {
+    render(
+      <VariableFilterRow
+        condition={makeCondition({operator: 'exists'})}
+        onChange={vi.fn()}
+        onDelete={vi.fn()}
+        isDeleteHidden={true}
+        rowIndex={0}
+      />,
+    );
+
+    expect(
+      screen.queryByTestId('variable-filter-value-test-id'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should visually hide delete button when isDeleteHidden is true', () => {
+    render(
+      <VariableFilterRow
+        condition={makeCondition()}
+        onChange={vi.fn()}
+        onDelete={vi.fn()}
+        isDeleteHidden={true}
+        rowIndex={0}
+      />,
+    );
+
+    expect(screen.getByTestId('delete-variable-filter-test-id')).toHaveStyle({
+      visibility: 'hidden',
+    });
+  });
+
+  it('should show delete button when isDeleteHidden is false', () => {
+    render(
+      <VariableFilterRow
+        condition={makeCondition()}
+        onChange={vi.fn()}
+        onDelete={vi.fn()}
+        isDeleteHidden={false}
+        rowIndex={0}
+      />,
+    );
+
+    expect(screen.getByTestId('delete-variable-filter-test-id')).toHaveStyle({
+      visibility: 'visible',
+    });
+  });
+
+  it('should call onChange with updated name when name input changes', async () => {
+    const onChange = vi.fn();
+    const {user} = render(
+      <VariableFilterRow
+        condition={makeCondition()}
+        onChange={onChange}
+        onDelete={vi.fn()}
+        isDeleteHidden={true}
+        rowIndex={0}
+      />,
+    );
+
+    await user.type(screen.getByTestId('variable-filter-name-test-id'), 'x');
+
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({name: 'x'}));
+  });
+
+  it('should call onChange with updated value when value input changes', async () => {
+    const onChange = vi.fn();
+    const {user} = render(
+      <VariableFilterRow
+        condition={makeCondition({name: 'status'})}
+        onChange={onChange}
+        onDelete={vi.fn()}
+        isDeleteHidden={true}
+        rowIndex={0}
+      />,
+    );
+
+    await user.type(screen.getByTestId('variable-filter-value-test-id'), 'v');
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({value: 'v'}),
+    );
+  });
+
+  it('should call onDelete when delete button is clicked', async () => {
+    const onDelete = vi.fn();
+    const {user} = render(
+      <VariableFilterRow
+        condition={makeCondition()}
+        onChange={vi.fn()}
+        onDelete={onDelete}
+        isDeleteHidden={false}
+        rowIndex={0}
+      />,
+    );
+
+    await user.click(screen.getByTestId('delete-variable-filter-test-id'));
+
+    expect(onDelete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterRow.test.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterRow.test.tsx
@@ -7,37 +7,54 @@
  */
 
 import {render, screen} from 'modules/testing-library';
+import {Form} from 'react-final-form';
+import arrayMutators from 'final-form-arrays';
+import {FieldArray} from 'react-final-form-arrays';
 import {VariableFilterRow} from './VariableFilterRow';
 import type {DraftCondition} from './constants';
 
-const makeCondition = (
-  overrides: Partial<DraftCondition> = {},
-): DraftCondition => ({
-  id: 'test-id',
-  name: '',
-  operator: 'equals',
-  value: '',
-  ...overrides,
-});
+type RowFormValues = {conditions: DraftCondition[]};
 
-let defaultRowProps: {errors: object; onBlur: () => void};
+const renderRow = (
+  condition: Partial<DraftCondition> = {},
+  props: {onDelete?: () => void; isDeleteHidden?: boolean} = {},
+) => {
+  const draft: DraftCondition = {
+    id: 'test-id',
+    name: '',
+    operator: 'equals',
+    value: '',
+    ...condition,
+  };
 
-beforeEach(() => {
-  defaultRowProps = {errors: {}, onBlur: vi.fn()};
-});
+  return render(
+    <Form<RowFormValues>
+      onSubmit={vi.fn()}
+      initialValues={{conditions: [draft]}}
+      mutators={{...arrayMutators}}
+    >
+      {() => (
+        <FieldArray name="conditions">
+          {({fields}) =>
+            fields.map((fieldName, index) => (
+              <VariableFilterRow
+                key={fieldName}
+                fieldName={fieldName}
+                rowIndex={index}
+                onDelete={props.onDelete ?? vi.fn()}
+                isDeleteHidden={props.isDeleteHidden ?? true}
+              />
+            ))
+          }
+        </FieldArray>
+      )}
+    </Form>,
+  );
+};
 
 describe('<VariableFilterRow />', () => {
   it('should render name and value inputs and operator dropdown', () => {
-    render(
-      <VariableFilterRow
-        condition={makeCondition()}
-        onChange={vi.fn()}
-        onDelete={vi.fn()}
-        isDeleteHidden={true}
-        rowIndex={0}
-        {...defaultRowProps}
-      />,
-    );
+    renderRow();
 
     expect(
       screen.getByTestId('variable-filter-name-test-id'),
@@ -51,16 +68,7 @@ describe('<VariableFilterRow />', () => {
   });
 
   it('should hide value field when operator does not require value', () => {
-    render(
-      <VariableFilterRow
-        condition={makeCondition({operator: 'exists'})}
-        onChange={vi.fn()}
-        onDelete={vi.fn()}
-        isDeleteHidden={true}
-        rowIndex={0}
-        {...defaultRowProps}
-      />,
-    );
+    renderRow({operator: 'exists'});
 
     expect(
       screen.queryByTestId('variable-filter-value-test-id'),
@@ -68,16 +76,7 @@ describe('<VariableFilterRow />', () => {
   });
 
   it('should visually hide delete button when isDeleteHidden is true', () => {
-    render(
-      <VariableFilterRow
-        condition={makeCondition()}
-        onChange={vi.fn()}
-        onDelete={vi.fn()}
-        isDeleteHidden={true}
-        rowIndex={0}
-        {...defaultRowProps}
-      />,
-    );
+    renderRow({}, {isDeleteHidden: true});
 
     expect(screen.getByTestId('delete-variable-filter-test-id')).toHaveStyle({
       visibility: 'hidden',
@@ -85,151 +84,59 @@ describe('<VariableFilterRow />', () => {
   });
 
   it('should show delete button when isDeleteHidden is false', () => {
-    render(
-      <VariableFilterRow
-        condition={makeCondition()}
-        onChange={vi.fn()}
-        onDelete={vi.fn()}
-        isDeleteHidden={false}
-        rowIndex={0}
-        {...defaultRowProps}
-      />,
-    );
+    renderRow({}, {isDeleteHidden: false});
 
     expect(screen.getByTestId('delete-variable-filter-test-id')).toHaveStyle({
       visibility: 'visible',
     });
   });
 
-  it('should call onChange with updated name when name input changes', async () => {
-    const onChange = vi.fn();
-    const {user} = render(
-      <VariableFilterRow
-        condition={makeCondition()}
-        onChange={onChange}
-        onDelete={vi.fn()}
-        isDeleteHidden={true}
-        rowIndex={0}
-        {...defaultRowProps}
-      />,
-    );
+  it('should update name input when user types', async () => {
+    const {user} = renderRow();
 
     await user.type(screen.getByTestId('variable-filter-name-test-id'), 'x');
 
-    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({name: 'x'}));
+    expect(screen.getByTestId('variable-filter-name-test-id')).toHaveValue('x');
   });
 
-  it('should call onChange with updated value when value input changes', async () => {
-    const onChange = vi.fn();
-    const {user} = render(
-      <VariableFilterRow
-        condition={makeCondition({name: 'status'})}
-        onChange={onChange}
-        onDelete={vi.fn()}
-        isDeleteHidden={true}
-        rowIndex={0}
-        {...defaultRowProps}
-      />,
-    );
+  it('should update value input when user types', async () => {
+    const {user} = renderRow({name: 'status'});
 
     await user.type(screen.getByTestId('variable-filter-value-test-id'), 'v');
 
-    expect(onChange).toHaveBeenCalledWith(
-      expect.objectContaining({value: 'v'}),
+    expect(screen.getByTestId('variable-filter-value-test-id')).toHaveValue(
+      'v',
     );
   });
 
   it('should call onDelete when delete button is clicked', async () => {
     const onDelete = vi.fn();
-    const {user} = render(
-      <VariableFilterRow
-        condition={makeCondition()}
-        onChange={vi.fn()}
-        onDelete={onDelete}
-        isDeleteHidden={false}
-        rowIndex={0}
-        {...defaultRowProps}
-      />,
-    );
+    const {user} = renderRow({}, {onDelete, isDeleteHidden: false});
 
     await user.click(screen.getByTestId('delete-variable-filter-test-id'));
 
     expect(onDelete).toHaveBeenCalledTimes(1);
   });
 
-  it('should show name error when name error is provided', () => {
-    render(
-      <VariableFilterRow
-        condition={makeCondition()}
-        onChange={vi.fn()}
-        onDelete={vi.fn()}
-        isDeleteHidden={true}
-        rowIndex={0}
-        errors={{name: 'Variable name is required'}}
-        onBlur={vi.fn()}
-      />,
-    );
+  it('should hide value field after switching to exists operator', async () => {
+    const {user} = renderRow();
 
-    expect(screen.getByText('Variable name is required')).toBeInTheDocument();
-    expect(screen.getByTestId('variable-filter-name-test-id')).toHaveAttribute(
-      'aria-invalid',
-      'true',
-    );
+    await user.click(screen.getByRole('combobox', {name: 'Operator'}));
+    await user.click(screen.getByText('exists'));
+
+    expect(
+      screen.queryByTestId('variable-filter-value-test-id'),
+    ).not.toBeInTheDocument();
   });
 
-  it('should show value error when value error is provided', () => {
-    render(
-      <VariableFilterRow
-        condition={makeCondition({name: 'status'})}
-        onChange={vi.fn()}
-        onDelete={vi.fn()}
-        isDeleteHidden={true}
-        rowIndex={0}
-        errors={{value: 'Value must be valid JSON'}}
-        onBlur={vi.fn()}
-      />,
-    );
+  it('should show value field after switching back from exists to equals', async () => {
+    const {user} = renderRow({operator: 'exists'});
 
-    expect(screen.getByText('Value must be valid JSON')).toBeInTheDocument();
-  });
+    await user.click(screen.getByRole('combobox', {name: 'Operator'}));
+    await user.click(screen.getByText('equals'));
 
-  it('should call onBlur when name field loses focus', async () => {
-    const onBlur = vi.fn();
-    const {user} = render(
-      <VariableFilterRow
-        condition={makeCondition()}
-        onChange={vi.fn()}
-        onDelete={vi.fn()}
-        isDeleteHidden={true}
-        rowIndex={0}
-        errors={{}}
-        onBlur={onBlur}
-      />,
-    );
-
-    await user.click(screen.getByTestId('variable-filter-name-test-id'));
-    await user.tab();
-
-    expect(onBlur).toHaveBeenCalledTimes(1);
-  });
-
-  it('should call onBlur when value field loses focus', async () => {
-    const onBlur = vi.fn();
-    const {user} = render(
-      <VariableFilterRow
-        condition={makeCondition({name: 'status'})}
-        onChange={vi.fn()}
-        onDelete={vi.fn()}
-        isDeleteHidden={true}
-        rowIndex={0}
-        errors={{}}
-        onBlur={onBlur}
-      />,
-    );
-
-    await user.click(screen.getByTestId('variable-filter-value-test-id'));
-    await user.tab();
-
-    expect(onBlur).toHaveBeenCalledTimes(1);
+    expect(
+      screen.getByTestId('variable-filter-value-test-id'),
+    ).toBeInTheDocument();
   });
 });

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterRow.test.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterRow.test.tsx
@@ -15,10 +15,7 @@ import type {DraftCondition} from './constants';
 
 type RowFormValues = {conditions: DraftCondition[]};
 
-const renderRow = (
-  condition: Partial<DraftCondition> = {},
-  props: {onDelete?: () => void; isDeleteHidden?: boolean} = {},
-) => {
+const getWrapper = (condition: Partial<DraftCondition> = {}) => {
   const draft: DraftCondition = {
     id: 'test-id',
     name: '',
@@ -27,34 +24,30 @@ const renderRow = (
     ...condition,
   };
 
-  return render(
+  const Wrapper: React.FC<{children: React.ReactNode}> = ({children}) => (
     <Form<RowFormValues>
       onSubmit={vi.fn()}
       initialValues={{conditions: [draft]}}
       mutators={{...arrayMutators}}
     >
-      {() => (
-        <FieldArray name="conditions">
-          {({fields}) =>
-            fields.map((fieldName, index) => (
-              <VariableFilterRow
-                key={fieldName}
-                fieldName={fieldName}
-                rowIndex={index}
-                onDelete={props.onDelete ?? vi.fn()}
-                isDeleteHidden={props.isDeleteHidden ?? true}
-              />
-            ))
-          }
-        </FieldArray>
-      )}
-    </Form>,
+      {() => <FieldArray name="conditions">{() => children}</FieldArray>}
+    </Form>
   );
+
+  return Wrapper;
 };
 
 describe('<VariableFilterRow />', () => {
   it('should render name and value inputs and operator dropdown', () => {
-    renderRow();
+    render(
+      <VariableFilterRow
+        fieldName="conditions[0]"
+        rowIndex={0}
+        onDelete={vi.fn()}
+        isDeleteHidden={true}
+      />,
+      {wrapper: getWrapper()},
+    );
 
     expect(
       screen.getByTestId('variable-filter-name-test-id'),
@@ -68,7 +61,15 @@ describe('<VariableFilterRow />', () => {
   });
 
   it('should hide value field when operator does not require value', () => {
-    renderRow({operator: 'exists'});
+    render(
+      <VariableFilterRow
+        fieldName="conditions[0]"
+        rowIndex={0}
+        onDelete={vi.fn()}
+        isDeleteHidden={true}
+      />,
+      {wrapper: getWrapper({operator: 'exists'})},
+    );
 
     expect(
       screen.queryByTestId('variable-filter-value-test-id'),
@@ -76,7 +77,15 @@ describe('<VariableFilterRow />', () => {
   });
 
   it('should visually hide delete button when isDeleteHidden is true', () => {
-    renderRow({}, {isDeleteHidden: true});
+    render(
+      <VariableFilterRow
+        fieldName="conditions[0]"
+        rowIndex={0}
+        onDelete={vi.fn()}
+        isDeleteHidden={true}
+      />,
+      {wrapper: getWrapper()},
+    );
 
     expect(screen.getByTestId('delete-variable-filter-test-id')).toHaveStyle({
       visibility: 'hidden',
@@ -84,7 +93,15 @@ describe('<VariableFilterRow />', () => {
   });
 
   it('should show delete button when isDeleteHidden is false', () => {
-    renderRow({}, {isDeleteHidden: false});
+    render(
+      <VariableFilterRow
+        fieldName="conditions[0]"
+        rowIndex={0}
+        onDelete={vi.fn()}
+        isDeleteHidden={false}
+      />,
+      {wrapper: getWrapper()},
+    );
 
     expect(screen.getByTestId('delete-variable-filter-test-id')).toHaveStyle({
       visibility: 'visible',
@@ -92,7 +109,15 @@ describe('<VariableFilterRow />', () => {
   });
 
   it('should update name input when user types', async () => {
-    const {user} = renderRow();
+    const {user} = render(
+      <VariableFilterRow
+        fieldName="conditions[0]"
+        rowIndex={0}
+        onDelete={vi.fn()}
+        isDeleteHidden={true}
+      />,
+      {wrapper: getWrapper()},
+    );
 
     await user.type(screen.getByTestId('variable-filter-name-test-id'), 'x');
 
@@ -100,7 +125,15 @@ describe('<VariableFilterRow />', () => {
   });
 
   it('should update value input when user types', async () => {
-    const {user} = renderRow({name: 'status'});
+    const {user} = render(
+      <VariableFilterRow
+        fieldName="conditions[0]"
+        rowIndex={0}
+        onDelete={vi.fn()}
+        isDeleteHidden={true}
+      />,
+      {wrapper: getWrapper({name: 'status'})},
+    );
 
     await user.type(screen.getByTestId('variable-filter-value-test-id'), 'v');
 
@@ -111,7 +144,15 @@ describe('<VariableFilterRow />', () => {
 
   it('should call onDelete when delete button is clicked', async () => {
     const onDelete = vi.fn();
-    const {user} = renderRow({}, {onDelete, isDeleteHidden: false});
+    const {user} = render(
+      <VariableFilterRow
+        fieldName="conditions[0]"
+        rowIndex={0}
+        onDelete={onDelete}
+        isDeleteHidden={false}
+      />,
+      {wrapper: getWrapper()},
+    );
 
     await user.click(screen.getByTestId('delete-variable-filter-test-id'));
 
@@ -119,7 +160,15 @@ describe('<VariableFilterRow />', () => {
   });
 
   it('should hide value field after switching to exists operator', async () => {
-    const {user} = renderRow();
+    const {user} = render(
+      <VariableFilterRow
+        fieldName="conditions[0]"
+        rowIndex={0}
+        onDelete={vi.fn()}
+        isDeleteHidden={true}
+      />,
+      {wrapper: getWrapper()},
+    );
 
     await user.click(screen.getByRole('combobox', {name: 'Operator'}));
     await user.click(screen.getByText('exists'));
@@ -130,7 +179,15 @@ describe('<VariableFilterRow />', () => {
   });
 
   it('should show value field after switching back from exists to equals', async () => {
-    const {user} = renderRow({operator: 'exists'});
+    const {user} = render(
+      <VariableFilterRow
+        fieldName="conditions[0]"
+        rowIndex={0}
+        onDelete={vi.fn()}
+        isDeleteHidden={true}
+      />,
+      {wrapper: getWrapper({operator: 'exists'})},
+    );
 
     await user.click(screen.getByRole('combobox', {name: 'Operator'}));
     await user.click(screen.getByText('equals'));

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterRow.test.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterRow.test.tsx
@@ -20,6 +20,12 @@ const makeCondition = (
   ...overrides,
 });
 
+let defaultRowProps: {errors: object; onBlur: () => void};
+
+beforeEach(() => {
+  defaultRowProps = {errors: {}, onBlur: vi.fn()};
+});
+
 describe('<VariableFilterRow />', () => {
   it('should render name and value inputs and operator dropdown', () => {
     render(
@@ -29,6 +35,7 @@ describe('<VariableFilterRow />', () => {
         onDelete={vi.fn()}
         isDeleteHidden={true}
         rowIndex={0}
+        {...defaultRowProps}
       />,
     );
 
@@ -51,6 +58,7 @@ describe('<VariableFilterRow />', () => {
         onDelete={vi.fn()}
         isDeleteHidden={true}
         rowIndex={0}
+        {...defaultRowProps}
       />,
     );
 
@@ -67,6 +75,7 @@ describe('<VariableFilterRow />', () => {
         onDelete={vi.fn()}
         isDeleteHidden={true}
         rowIndex={0}
+        {...defaultRowProps}
       />,
     );
 
@@ -83,6 +92,7 @@ describe('<VariableFilterRow />', () => {
         onDelete={vi.fn()}
         isDeleteHidden={false}
         rowIndex={0}
+        {...defaultRowProps}
       />,
     );
 
@@ -100,6 +110,7 @@ describe('<VariableFilterRow />', () => {
         onDelete={vi.fn()}
         isDeleteHidden={true}
         rowIndex={0}
+        {...defaultRowProps}
       />,
     );
 
@@ -117,6 +128,7 @@ describe('<VariableFilterRow />', () => {
         onDelete={vi.fn()}
         isDeleteHidden={true}
         rowIndex={0}
+        {...defaultRowProps}
       />,
     );
 
@@ -136,11 +148,88 @@ describe('<VariableFilterRow />', () => {
         onDelete={onDelete}
         isDeleteHidden={false}
         rowIndex={0}
+        {...defaultRowProps}
       />,
     );
 
     await user.click(screen.getByTestId('delete-variable-filter-test-id'));
 
     expect(onDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it('should show name error when name error is provided', () => {
+    render(
+      <VariableFilterRow
+        condition={makeCondition()}
+        onChange={vi.fn()}
+        onDelete={vi.fn()}
+        isDeleteHidden={true}
+        rowIndex={0}
+        errors={{name: 'Variable name is required'}}
+        onBlur={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Variable name is required')).toBeInTheDocument();
+    expect(screen.getByTestId('variable-filter-name-test-id')).toHaveAttribute(
+      'aria-invalid',
+      'true',
+    );
+  });
+
+  it('should show value error when value error is provided', () => {
+    render(
+      <VariableFilterRow
+        condition={makeCondition({name: 'status'})}
+        onChange={vi.fn()}
+        onDelete={vi.fn()}
+        isDeleteHidden={true}
+        rowIndex={0}
+        errors={{value: 'Value must be valid JSON'}}
+        onBlur={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Value must be valid JSON')).toBeInTheDocument();
+  });
+
+  it('should call onBlur when name field loses focus', async () => {
+    const onBlur = vi.fn();
+    const {user} = render(
+      <VariableFilterRow
+        condition={makeCondition()}
+        onChange={vi.fn()}
+        onDelete={vi.fn()}
+        isDeleteHidden={true}
+        rowIndex={0}
+        errors={{}}
+        onBlur={onBlur}
+      />,
+    );
+
+    await user.click(screen.getByTestId('variable-filter-name-test-id'));
+    await user.tab();
+
+    expect(onBlur).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call onBlur when value field loses focus', async () => {
+    const onBlur = vi.fn();
+    const {user} = render(
+      <VariableFilterRow
+        condition={makeCondition({name: 'status'})}
+        onChange={vi.fn()}
+        onDelete={vi.fn()}
+        isDeleteHidden={true}
+        rowIndex={0}
+        errors={{}}
+        onBlur={onBlur}
+      />,
+    );
+
+    await user.click(screen.getByTestId('variable-filter-value-test-id'));
+    await user.tab();
+
+    expect(onBlur).toHaveBeenCalledTimes(1);
   });
 });

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterRow.test.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterRow.test.tsx
@@ -17,7 +17,6 @@ type RowFormValues = {conditions: DraftCondition[]};
 
 const getWrapper = (condition: Partial<DraftCondition> = {}) => {
   const draft: DraftCondition = {
-    id: 'test-id',
     name: '',
     operator: 'equals',
     value: '',
@@ -49,15 +48,11 @@ describe('<VariableFilterRow />', () => {
       {wrapper: getWrapper()},
     );
 
+    expect(screen.getByTestId('variable-filter-name-0')).toBeInTheDocument();
     expect(
-      screen.getByTestId('variable-filter-name-test-id'),
+      screen.getByTestId('variable-filter-operator-0'),
     ).toBeInTheDocument();
-    expect(
-      screen.getByTestId('variable-filter-operator-test-id'),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByTestId('variable-filter-value-test-id'),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId('variable-filter-value-0')).toBeInTheDocument();
   });
 
   it('should hide value field when operator does not require value', () => {
@@ -72,7 +67,7 @@ describe('<VariableFilterRow />', () => {
     );
 
     expect(
-      screen.queryByTestId('variable-filter-value-test-id'),
+      screen.queryByTestId('variable-filter-value-0'),
     ).not.toBeInTheDocument();
   });
 
@@ -87,7 +82,7 @@ describe('<VariableFilterRow />', () => {
       {wrapper: getWrapper()},
     );
 
-    expect(screen.getByTestId('delete-variable-filter-test-id')).toHaveStyle({
+    expect(screen.getByTestId('delete-variable-filter-0')).toHaveStyle({
       visibility: 'hidden',
     });
   });
@@ -103,7 +98,7 @@ describe('<VariableFilterRow />', () => {
       {wrapper: getWrapper()},
     );
 
-    expect(screen.getByTestId('delete-variable-filter-test-id')).toHaveStyle({
+    expect(screen.getByTestId('delete-variable-filter-0')).toHaveStyle({
       visibility: 'visible',
     });
   });
@@ -119,9 +114,9 @@ describe('<VariableFilterRow />', () => {
       {wrapper: getWrapper()},
     );
 
-    await user.type(screen.getByTestId('variable-filter-name-test-id'), 'x');
+    await user.type(screen.getByTestId('variable-filter-name-0'), 'x');
 
-    expect(screen.getByTestId('variable-filter-name-test-id')).toHaveValue('x');
+    expect(screen.getByTestId('variable-filter-name-0')).toHaveValue('x');
   });
 
   it('should update value input when user types', async () => {
@@ -135,11 +130,9 @@ describe('<VariableFilterRow />', () => {
       {wrapper: getWrapper({name: 'status'})},
     );
 
-    await user.type(screen.getByTestId('variable-filter-value-test-id'), 'v');
+    await user.type(screen.getByTestId('variable-filter-value-0'), 'v');
 
-    expect(screen.getByTestId('variable-filter-value-test-id')).toHaveValue(
-      'v',
-    );
+    expect(screen.getByTestId('variable-filter-value-0')).toHaveValue('v');
   });
 
   it('should call onDelete when delete button is clicked', async () => {
@@ -154,7 +147,7 @@ describe('<VariableFilterRow />', () => {
       {wrapper: getWrapper()},
     );
 
-    await user.click(screen.getByTestId('delete-variable-filter-test-id'));
+    await user.click(screen.getByTestId('delete-variable-filter-0'));
 
     expect(onDelete).toHaveBeenCalledTimes(1);
   });
@@ -174,7 +167,7 @@ describe('<VariableFilterRow />', () => {
     await user.click(screen.getByText('exists'));
 
     expect(
-      screen.queryByTestId('variable-filter-value-test-id'),
+      screen.queryByTestId('variable-filter-value-0'),
     ).not.toBeInTheDocument();
   });
 
@@ -192,8 +185,6 @@ describe('<VariableFilterRow />', () => {
     await user.click(screen.getByRole('combobox', {name: 'Operator'}));
     await user.click(screen.getByText('equals'));
 
-    expect(
-      screen.getByTestId('variable-filter-value-test-id'),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId('variable-filter-value-0')).toBeInTheDocument();
   });
 });

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterRow.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterRow.tsx
@@ -10,7 +10,7 @@ import {useState} from 'react';
 import {Dropdown, TextInput} from '@carbon/react';
 import {Close, Maximize} from '@carbon/react/icons';
 import {createPortal} from 'react-dom';
-import {useField} from 'react-final-form';
+import {Field, useField, useForm} from 'react-final-form';
 import {JSONEditorModal} from 'modules/components/JSONEditorModal';
 import {IconTextInput} from 'modules/components/IconInput';
 import {useFieldError} from 'modules/hooks/useFieldError';
@@ -43,18 +43,14 @@ const VariableFilterRow: React.FC<Props> = ({
   rowIndex,
 }) => {
   const [isJsonEditorOpen, setIsJsonEditorOpen] = useState(false);
+  const form = useForm();
 
-  const {input: nameInput} = useField<string>(`${fieldName}.name`, {
-    subscription: {value: true},
-  });
-  const {input: operatorInput} = useField<VariableFilterOperator>(
-    `${fieldName}.operator`,
-    {subscription: {value: true}},
-  );
-  const {input: valueInput} = useField<string>(`${fieldName}.value`, {
-    subscription: {value: true},
-  });
-  const {input: idInput} = useField<string>(`${fieldName}.id`, {
+  const {
+    input: {value: fieldId},
+  } = useField<string>(`${fieldName}.id`, {subscription: {value: true}});
+  const {
+    input: {value: operatorValue},
+  } = useField<VariableFilterOperator>(`${fieldName}.operator`, {
     subscription: {value: true},
   });
 
@@ -62,7 +58,7 @@ const VariableFilterRow: React.FC<Props> = ({
   const valueError = useFieldError(`${fieldName}.value`);
 
   const selectedOperator = VARIABLE_FILTER_OPERATORS.find(
-    (op) => op.id === operatorInput.value,
+    (op) => op.id === operatorValue,
   );
   const isValueRequired = selectedOperator?.requiresValue ?? true;
 
@@ -70,32 +66,33 @@ const VariableFilterRow: React.FC<Props> = ({
     selectedItem: (typeof VARIABLE_FILTER_OPERATORS)[number] | null,
   ) => {
     const newOperator: VariableFilterOperator = selectedItem?.id ?? 'equals';
-    const requiresValue = selectedItem?.requiresValue ?? true;
-    operatorInput.onChange(newOperator);
-    if (!requiresValue) {
-      valueInput.onChange('');
+    form.change(`${fieldName}.operator`, newOperator);
+    if (!selectedItem?.requiresValue) {
+      form.change(`${fieldName}.value`, '');
     }
   };
-
-  const fieldId = idInput.value;
 
   return (
     <>
       <FilterRow>
-        <TextInput
-          id={`variable-name-${fieldId}`}
-          labelText="Name"
-          hideLabel
-          placeholder="Variable name"
-          value={nameInput.value}
-          onChange={nameInput.onChange}
-          onBlur={nameInput.onBlur}
-          invalid={nameError !== undefined}
-          invalidText={nameError}
-          size="sm"
-          autoComplete="off"
-          data-testid={`variable-filter-name-${fieldId}`}
-        />
+        <Field name={`${fieldName}.name`} subscription={{value: true}}>
+          {({input}) => (
+            <TextInput
+              id={`variable-name-${fieldId}`}
+              labelText="Name"
+              hideLabel
+              placeholder="Variable name"
+              value={input.value}
+              onChange={input.onChange}
+              onBlur={input.onBlur}
+              invalid={nameError !== undefined}
+              invalidText={nameError}
+              size="sm"
+              autoComplete="off"
+              data-testid={`variable-filter-name-${fieldId}`}
+            />
+          )}
+        </Field>
         <Dropdown
           id={`variable-operator-${fieldId}`}
           titleText="Operator"
@@ -111,22 +108,42 @@ const VariableFilterRow: React.FC<Props> = ({
         />
         <ValueFieldContainer>
           {isValueRequired && (
-            <IconTextInput
-              id={`variable-value-${fieldId}`}
-              labelText="Value"
-              hideLabel
-              placeholder={getValuePlaceholder(operatorInput.value)}
-              value={valueInput.value}
-              onChange={valueInput.onChange}
-              onBlur={valueInput.onBlur}
-              invalid={valueError !== undefined}
-              invalidText={valueError}
-              size="sm"
-              Icon={Maximize}
-              buttonLabel="Open JSON editor"
-              onIconClick={() => setIsJsonEditorOpen(true)}
-              data-testid={`variable-filter-value-${fieldId}`}
-            />
+            <Field name={`${fieldName}.value`} subscription={{value: true}}>
+              {({input}) => (
+                <>
+                  <IconTextInput
+                    id={`variable-value-${fieldId}`}
+                    labelText="Value"
+                    hideLabel
+                    placeholder={getValuePlaceholder(operatorValue)}
+                    value={input.value}
+                    onChange={input.onChange}
+                    onBlur={input.onBlur}
+                    invalid={valueError !== undefined}
+                    invalidText={valueError}
+                    size="sm"
+                    Icon={Maximize}
+                    buttonLabel="Open JSON editor"
+                    onIconClick={() => setIsJsonEditorOpen(true)}
+                    data-testid={`variable-filter-value-${fieldId}`}
+                  />
+                  {isJsonEditorOpen &&
+                    createPortal(
+                      <JSONEditorModal
+                        isVisible={isJsonEditorOpen}
+                        title="Edit Variable Value"
+                        value={input.value}
+                        onClose={() => setIsJsonEditorOpen(false)}
+                        onApply={(value) => {
+                          input.onChange(value ?? '');
+                          setIsJsonEditorOpen(false);
+                        }}
+                      />,
+                      document.body,
+                    )}
+                </>
+              )}
+            </Field>
           )}
         </ValueFieldContainer>
         <DeleteButton
@@ -141,21 +158,6 @@ const VariableFilterRow: React.FC<Props> = ({
           <Close />
         </DeleteButton>
       </FilterRow>
-
-      {isJsonEditorOpen &&
-        createPortal(
-          <JSONEditorModal
-            isVisible={isJsonEditorOpen}
-            title="Edit Variable Value"
-            value={valueInput.value}
-            onClose={() => setIsJsonEditorOpen(false)}
-            onApply={(value) => {
-              valueInput.onChange(value ?? '');
-              setIsJsonEditorOpen(false);
-            }}
-          />,
-          document.body,
-        )}
     </>
   );
 };

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterRow.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterRow.tsx
@@ -13,7 +13,11 @@ import {createPortal} from 'react-dom';
 import {JSONEditorModal} from 'modules/components/JSONEditorModal';
 import {IconTextInput} from 'modules/components/IconInput';
 import type {VariableFilterOperator} from 'modules/stores/variableFilter';
-import {type DraftCondition, VARIABLE_FILTER_OPERATORS} from './constants';
+import {
+  type DraftCondition,
+  type RowErrors,
+  VARIABLE_FILTER_OPERATORS,
+} from './constants';
 import {
   FilterRow,
   ConditionDropdownContainer,
@@ -27,6 +31,8 @@ type Props = {
   onDelete: () => void;
   isDeleteHidden: boolean;
   rowIndex: number;
+  errors: RowErrors;
+  onBlur: () => void;
 };
 
 const getValuePlaceholder = (operator: VariableFilterOperator): string => {
@@ -46,6 +52,8 @@ const VariableFilterRow: React.FC<Props> = ({
   onDelete,
   isDeleteHidden,
   rowIndex,
+  errors,
+  onBlur,
 }) => {
   const [isJsonEditorOpen, setIsJsonEditorOpen] = useState(false);
 
@@ -89,6 +97,9 @@ const VariableFilterRow: React.FC<Props> = ({
           placeholder="Variable name"
           value={condition.name}
           onChange={handleNameChange}
+          onBlur={onBlur}
+          invalid={!!errors.name}
+          invalidText={errors.name}
           size="sm"
           autoComplete="off"
           data-testid={`variable-filter-name-${condition.id}`}
@@ -117,6 +128,9 @@ const VariableFilterRow: React.FC<Props> = ({
               placeholder={getValuePlaceholder(condition.operator)}
               value={condition.value}
               onChange={handleValueChange}
+              onBlur={onBlur}
+              invalid={!!errors.value}
+              invalidText={errors.value}
               size="sm"
               Icon={Maximize}
               buttonLabel="Open JSON editor"

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterRow.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterRow.tsx
@@ -10,29 +10,19 @@ import {useState} from 'react';
 import {Dropdown, TextInput} from '@carbon/react';
 import {Close, Maximize} from '@carbon/react/icons';
 import {createPortal} from 'react-dom';
+import {useField} from 'react-final-form';
 import {JSONEditorModal} from 'modules/components/JSONEditorModal';
 import {IconTextInput} from 'modules/components/IconInput';
+import {useFieldError} from 'modules/hooks/useFieldError';
 import type {VariableFilterOperator} from 'modules/stores/variableFilter';
-import {
-  type DraftCondition,
-  type RowErrors,
-  VARIABLE_FILTER_OPERATORS,
-} from './constants';
-import {
-  FilterRow,
-  ConditionDropdownContainer,
-  ValueFieldContainer,
-  DeleteButton,
-} from './styled';
+import {VARIABLE_FILTER_OPERATORS} from './constants';
+import {FilterRow, ValueFieldContainer, DeleteButton} from './styled';
 
 type Props = {
-  condition: DraftCondition;
-  onChange: (condition: DraftCondition) => void;
+  fieldName: string;
   onDelete: () => void;
   isDeleteHidden: boolean;
   rowIndex: number;
-  errors: RowErrors;
-  onBlur: () => void;
 };
 
 const getValuePlaceholder = (operator: VariableFilterOperator): string => {
@@ -47,95 +37,95 @@ const getValuePlaceholder = (operator: VariableFilterOperator): string => {
 };
 
 const VariableFilterRow: React.FC<Props> = ({
-  condition,
-  onChange,
+  fieldName,
   onDelete,
   isDeleteHidden,
   rowIndex,
-  errors,
-  onBlur,
 }) => {
   const [isJsonEditorOpen, setIsJsonEditorOpen] = useState(false);
 
+  const {input: nameInput} = useField<string>(`${fieldName}.name`, {
+    subscription: {value: true},
+  });
+  const {input: operatorInput} = useField<VariableFilterOperator>(
+    `${fieldName}.operator`,
+    {subscription: {value: true}},
+  );
+  const {input: valueInput} = useField<string>(`${fieldName}.value`, {
+    subscription: {value: true},
+  });
+  const {input: idInput} = useField<string>(`${fieldName}.id`, {
+    subscription: {value: true},
+  });
+
+  const nameError = useFieldError(`${fieldName}.name`);
+  const valueError = useFieldError(`${fieldName}.value`);
+
   const selectedOperator = VARIABLE_FILTER_OPERATORS.find(
-    (op) => op.id === condition.operator,
+    (op) => op.id === operatorInput.value,
   );
   const isValueRequired = selectedOperator?.requiresValue ?? true;
-
-  const handleNameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    onChange({...condition, name: event.target.value});
-  };
 
   const handleOperatorChange = (
     selectedItem: (typeof VARIABLE_FILTER_OPERATORS)[number] | null,
   ) => {
     const newOperator: VariableFilterOperator = selectedItem?.id ?? 'equals';
     const requiresValue = selectedItem?.requiresValue ?? true;
-    onChange({
-      ...condition,
-      operator: newOperator,
-      value: requiresValue ? condition.value : '',
-    });
+    operatorInput.onChange(newOperator);
+    if (!requiresValue) {
+      valueInput.onChange('');
+    }
   };
 
-  const handleValueChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    onChange({...condition, value: event.target.value});
-  };
-
-  const handleJsonEditorApply = (value: string | undefined) => {
-    onChange({...condition, value: value ?? ''});
-    setIsJsonEditorOpen(false);
-  };
+  const fieldId = idInput.value;
 
   return (
     <>
       <FilterRow>
         <TextInput
-          id={`variable-name-${condition.id}`}
+          id={`variable-name-${fieldId}`}
           labelText="Name"
           hideLabel
           placeholder="Variable name"
-          value={condition.name}
-          onChange={handleNameChange}
-          onBlur={onBlur}
-          invalid={!!errors.name}
-          invalidText={errors.name}
+          value={nameInput.value}
+          onChange={nameInput.onChange}
+          onBlur={nameInput.onBlur}
+          invalid={nameError !== undefined}
+          invalidText={nameError}
           size="sm"
           autoComplete="off"
-          data-testid={`variable-filter-name-${condition.id}`}
+          data-testid={`variable-filter-name-${fieldId}`}
         />
-        <ConditionDropdownContainer>
-          <Dropdown
-            id={`variable-operator-${condition.id}`}
-            titleText="Operator"
-            hideLabel
-            label="Select condition"
-            items={VARIABLE_FILTER_OPERATORS}
-            itemToString={(item) => item?.label ?? ''}
-            selectedItem={selectedOperator ?? null}
-            onChange={({selectedItem}) => handleOperatorChange(selectedItem)}
-            size="sm"
-            direction={rowIndex < 2 ? 'bottom' : 'top'}
-            data-testid={`variable-filter-operator-${condition.id}`}
-          />
-        </ConditionDropdownContainer>
+        <Dropdown
+          id={`variable-operator-${fieldId}`}
+          titleText="Operator"
+          hideLabel
+          label="Select condition"
+          items={VARIABLE_FILTER_OPERATORS}
+          itemToString={(item) => item?.label ?? ''}
+          selectedItem={selectedOperator ?? null}
+          onChange={({selectedItem}) => handleOperatorChange(selectedItem)}
+          size="sm"
+          direction={rowIndex < 2 ? 'bottom' : 'top'}
+          data-testid={`variable-filter-operator-${fieldId}`}
+        />
         <ValueFieldContainer>
           {isValueRequired && (
             <IconTextInput
-              id={`variable-value-${condition.id}`}
+              id={`variable-value-${fieldId}`}
               labelText="Value"
               hideLabel
-              placeholder={getValuePlaceholder(condition.operator)}
-              value={condition.value}
-              onChange={handleValueChange}
-              onBlur={onBlur}
-              invalid={!!errors.value}
-              invalidText={errors.value}
+              placeholder={getValuePlaceholder(operatorInput.value)}
+              value={valueInput.value}
+              onChange={valueInput.onChange}
+              onBlur={valueInput.onBlur}
+              invalid={valueError !== undefined}
+              invalidText={valueError}
               size="sm"
               Icon={Maximize}
               buttonLabel="Open JSON editor"
               onIconClick={() => setIsJsonEditorOpen(true)}
-              data-testid={`variable-filter-value-${condition.id}`}
+              data-testid={`variable-filter-value-${fieldId}`}
             />
           )}
         </ValueFieldContainer>
@@ -145,7 +135,7 @@ const VariableFilterRow: React.FC<Props> = ({
           label="Remove condition"
           align="top-right"
           onClick={onDelete}
-          data-testid={`delete-variable-filter-${condition.id}`}
+          data-testid={`delete-variable-filter-${fieldId}`}
           $hidden={isDeleteHidden}
         >
           <Close />
@@ -157,9 +147,12 @@ const VariableFilterRow: React.FC<Props> = ({
           <JSONEditorModal
             isVisible={isJsonEditorOpen}
             title="Edit Variable Value"
-            value={condition.value}
+            value={valueInput.value}
             onClose={() => setIsJsonEditorOpen(false)}
-            onApply={handleJsonEditorApply}
+            onApply={(value) => {
+              valueInput.onChange(value ?? '');
+              setIsJsonEditorOpen(false);
+            }}
           />,
           document.body,
         )}

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterRow.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterRow.tsx
@@ -1,0 +1,156 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useState} from 'react';
+import {Dropdown, TextInput} from '@carbon/react';
+import {Close, Maximize} from '@carbon/react/icons';
+import {createPortal} from 'react-dom';
+import {JSONEditorModal} from 'modules/components/JSONEditorModal';
+import {IconTextInput} from 'modules/components/IconInput';
+import type {VariableFilterOperator} from 'modules/stores/variableFilter';
+import {type DraftCondition, VARIABLE_FILTER_OPERATORS} from './constants';
+import {
+  FilterRow,
+  ConditionDropdownContainer,
+  ValueFieldContainer,
+  DeleteButton,
+} from './styled';
+
+type Props = {
+  condition: DraftCondition;
+  onChange: (condition: DraftCondition) => void;
+  onDelete: () => void;
+  isDeleteHidden: boolean;
+  rowIndex: number;
+};
+
+const getValuePlaceholder = (operator: VariableFilterOperator): string => {
+  switch (operator) {
+    case 'contains':
+      return 'search text';
+    case 'oneOf':
+      return '["val1", "val2"]';
+    default:
+      return 'value in JSON format';
+  }
+};
+
+const VariableFilterRow: React.FC<Props> = ({
+  condition,
+  onChange,
+  onDelete,
+  isDeleteHidden,
+  rowIndex,
+}) => {
+  const [isJsonEditorOpen, setIsJsonEditorOpen] = useState(false);
+
+  const selectedOperator = VARIABLE_FILTER_OPERATORS.find(
+    (op) => op.id === condition.operator,
+  );
+  const isValueRequired = selectedOperator?.requiresValue ?? true;
+
+  const handleNameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    onChange({...condition, name: event.target.value});
+  };
+
+  const handleOperatorChange = (
+    selectedItem: (typeof VARIABLE_FILTER_OPERATORS)[number] | null,
+  ) => {
+    const newOperator: VariableFilterOperator = selectedItem?.id ?? 'equals';
+    const requiresValue = selectedItem?.requiresValue ?? true;
+    onChange({
+      ...condition,
+      operator: newOperator,
+      value: requiresValue ? condition.value : '',
+    });
+  };
+
+  const handleValueChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    onChange({...condition, value: event.target.value});
+  };
+
+  const handleJsonEditorApply = (value: string | undefined) => {
+    onChange({...condition, value: value ?? ''});
+    setIsJsonEditorOpen(false);
+  };
+
+  return (
+    <>
+      <FilterRow>
+        <TextInput
+          id={`variable-name-${condition.id}`}
+          labelText="Name"
+          hideLabel
+          placeholder="Variable name"
+          value={condition.name}
+          onChange={handleNameChange}
+          size="sm"
+          autoComplete="off"
+          data-testid={`variable-filter-name-${condition.id}`}
+        />
+        <ConditionDropdownContainer>
+          <Dropdown
+            id={`variable-operator-${condition.id}`}
+            titleText="Operator"
+            hideLabel
+            label="Select condition"
+            items={VARIABLE_FILTER_OPERATORS}
+            itemToString={(item) => item?.label ?? ''}
+            selectedItem={selectedOperator ?? null}
+            onChange={({selectedItem}) => handleOperatorChange(selectedItem)}
+            size="sm"
+            direction={rowIndex < 2 ? 'bottom' : 'top'}
+            data-testid={`variable-filter-operator-${condition.id}`}
+          />
+        </ConditionDropdownContainer>
+        <ValueFieldContainer>
+          {isValueRequired && (
+            <IconTextInput
+              id={`variable-value-${condition.id}`}
+              labelText="Value"
+              hideLabel
+              placeholder={getValuePlaceholder(condition.operator)}
+              value={condition.value}
+              onChange={handleValueChange}
+              size="sm"
+              Icon={Maximize}
+              buttonLabel="Open JSON editor"
+              onIconClick={() => setIsJsonEditorOpen(true)}
+              data-testid={`variable-filter-value-${condition.id}`}
+            />
+          )}
+        </ValueFieldContainer>
+        <DeleteButton
+          kind="ghost"
+          size="sm"
+          label="Remove condition"
+          align="top-right"
+          onClick={onDelete}
+          data-testid={`delete-variable-filter-${condition.id}`}
+          $hidden={isDeleteHidden}
+        >
+          <Close />
+        </DeleteButton>
+      </FilterRow>
+
+      {isJsonEditorOpen &&
+        createPortal(
+          <JSONEditorModal
+            isVisible={isJsonEditorOpen}
+            title="Edit Variable Value"
+            value={condition.value}
+            onClose={() => setIsJsonEditorOpen(false)}
+            onApply={handleJsonEditorApply}
+          />,
+          document.body,
+        )}
+    </>
+  );
+};
+
+export {VariableFilterRow};

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterRow.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterRow.tsx
@@ -10,10 +10,9 @@ import {useState} from 'react';
 import {Dropdown, TextInput} from '@carbon/react';
 import {Close, Maximize} from '@carbon/react/icons';
 import {createPortal} from 'react-dom';
-import {Field, useField, useForm} from 'react-final-form';
+import {Field, useForm} from 'react-final-form';
 import {JSONEditorModal} from 'modules/components/JSONEditorModal';
 import {IconTextInput} from 'modules/components/IconInput';
-import {useFieldError} from 'modules/hooks/useFieldError';
 import type {VariableFilterOperator} from 'modules/stores/variableFilter';
 import {VARIABLE_FILTER_OPERATORS} from './constants';
 import {FilterRow, ValueFieldContainer, DeleteButton} from './styled';
@@ -45,120 +44,141 @@ const VariableFilterRow: React.FC<Props> = ({
   const [isJsonEditorOpen, setIsJsonEditorOpen] = useState(false);
   const form = useForm();
 
-  const {
-    input: {value: fieldId},
-  } = useField<string>(`${fieldName}.id`, {subscription: {value: true}});
-  const {
-    input: {value: operatorValue},
-  } = useField<VariableFilterOperator>(`${fieldName}.operator`, {
-    subscription: {value: true},
-  });
-
-  const nameError = useFieldError(`${fieldName}.name`);
-  const valueError = useFieldError(`${fieldName}.value`);
-
-  const selectedOperator = VARIABLE_FILTER_OPERATORS.find(
-    (op) => op.id === operatorValue,
-  );
-  const isValueRequired = selectedOperator?.requiresValue ?? true;
-
-  const handleOperatorChange = (
-    selectedItem: (typeof VARIABLE_FILTER_OPERATORS)[number] | null,
-  ) => {
-    const newOperator: VariableFilterOperator = selectedItem?.id ?? 'equals';
-    form.change(`${fieldName}.operator`, newOperator);
-    if (!selectedItem?.requiresValue) {
-      form.change(`${fieldName}.value`, '');
-    }
-  };
-
   return (
-    <>
-      <FilterRow>
-        <Field name={`${fieldName}.name`} subscription={{value: true}}>
-          {({input}) => (
-            <TextInput
-              id={`variable-name-${fieldId}`}
-              labelText="Name"
-              hideLabel
-              placeholder="Variable name"
-              value={input.value}
-              onChange={input.onChange}
-              onBlur={input.onBlur}
-              invalid={nameError !== undefined}
-              invalidText={nameError}
-              size="sm"
-              autoComplete="off"
-              data-testid={`variable-filter-name-${fieldId}`}
-            />
-          )}
-        </Field>
-        <Dropdown
-          id={`variable-operator-${fieldId}`}
-          titleText="Operator"
-          hideLabel
-          label="Select condition"
-          items={VARIABLE_FILTER_OPERATORS}
-          itemToString={(item) => item?.label ?? ''}
-          selectedItem={selectedOperator ?? null}
-          onChange={({selectedItem}) => handleOperatorChange(selectedItem)}
-          size="sm"
-          direction={rowIndex < 2 ? 'bottom' : 'top'}
-          data-testid={`variable-filter-operator-${fieldId}`}
-        />
-        <ValueFieldContainer>
-          {isValueRequired && (
-            <Field name={`${fieldName}.value`} subscription={{value: true}}>
-              {({input}) => (
-                <>
-                  <IconTextInput
-                    id={`variable-value-${fieldId}`}
-                    labelText="Value"
-                    hideLabel
-                    placeholder={getValuePlaceholder(operatorValue)}
-                    value={input.value}
-                    onChange={input.onChange}
-                    onBlur={input.onBlur}
-                    invalid={valueError !== undefined}
-                    invalidText={valueError}
-                    size="sm"
-                    Icon={Maximize}
-                    buttonLabel="Open JSON editor"
-                    onIconClick={() => setIsJsonEditorOpen(true)}
-                    data-testid={`variable-filter-value-${fieldId}`}
-                  />
-                  {isJsonEditorOpen &&
-                    createPortal(
-                      <JSONEditorModal
-                        isVisible={isJsonEditorOpen}
-                        title="Edit Variable Value"
-                        value={input.value}
-                        onClose={() => setIsJsonEditorOpen(false)}
-                        onApply={(value) => {
-                          input.onChange(value ?? '');
-                          setIsJsonEditorOpen(false);
-                        }}
-                      />,
-                      document.body,
+    <FilterRow>
+      <Field
+        name={`${fieldName}.name`}
+        subscription={{
+          value: true,
+          submitError: true,
+          dirtySinceLastSubmit: true,
+        }}
+      >
+        {({input, meta}) => (
+          <TextInput
+            id={input.name}
+            name={input.name}
+            labelText="Name"
+            hideLabel
+            placeholder="Variable name"
+            value={input.value}
+            onChange={input.onChange}
+            onBlur={input.onBlur}
+            invalid={
+              !meta.dirtySinceLastSubmit && meta.submitError !== undefined
+            }
+            invalidText={
+              meta.dirtySinceLastSubmit ? undefined : meta.submitError
+            }
+            size="sm"
+            autoComplete="off"
+            data-testid={`variable-filter-name-${rowIndex}`}
+          />
+        )}
+      </Field>
+      <Field<VariableFilterOperator>
+        name={`${fieldName}.operator`}
+        subscription={{value: true}}
+      >
+        {({input: operatorInput}) => {
+          const selectedOperator = VARIABLE_FILTER_OPERATORS.find(
+            (op) => op.id === operatorInput.value,
+          );
+          const isValueRequired = selectedOperator?.requiresValue ?? true;
+
+          return (
+            <>
+              <Dropdown
+                id={operatorInput.name}
+                titleText="Operator"
+                hideLabel
+                label="Select condition"
+                items={VARIABLE_FILTER_OPERATORS}
+                itemToString={(item) => item?.label ?? ''}
+                selectedItem={selectedOperator ?? null}
+                onChange={({selectedItem}) => {
+                  const newOperator: VariableFilterOperator =
+                    selectedItem?.id ?? 'equals';
+                  operatorInput.onChange(newOperator);
+                  if (!selectedItem?.requiresValue) {
+                    form.change(`${fieldName}.value`, '');
+                  }
+                }}
+                size="sm"
+                direction={rowIndex < 2 ? 'bottom' : 'top'}
+                data-testid={`variable-filter-operator-${rowIndex}`}
+              />
+              <ValueFieldContainer>
+                {isValueRequired && (
+                  <Field
+                    name={`${fieldName}.value`}
+                    subscription={{
+                      value: true,
+                      submitError: true,
+                      dirtySinceLastSubmit: true,
+                    }}
+                  >
+                    {({input, meta}) => (
+                      <>
+                        <IconTextInput
+                          id={input.name}
+                          name={input.name}
+                          labelText="Value"
+                          hideLabel
+                          placeholder={getValuePlaceholder(operatorInput.value)}
+                          value={input.value}
+                          onChange={input.onChange}
+                          onBlur={input.onBlur}
+                          invalid={
+                            !meta.dirtySinceLastSubmit &&
+                            meta.submitError !== undefined
+                          }
+                          invalidText={
+                            meta.dirtySinceLastSubmit
+                              ? undefined
+                              : meta.submitError
+                          }
+                          size="sm"
+                          Icon={Maximize}
+                          buttonLabel="Open JSON editor"
+                          onIconClick={() => setIsJsonEditorOpen(true)}
+                          data-testid={`variable-filter-value-${rowIndex}`}
+                        />
+                        {isJsonEditorOpen &&
+                          createPortal(
+                            <JSONEditorModal
+                              isVisible={isJsonEditorOpen}
+                              title="Edit Variable Value"
+                              value={input.value}
+                              onClose={() => setIsJsonEditorOpen(false)}
+                              onApply={(value) => {
+                                input.onChange(value ?? '');
+                                setIsJsonEditorOpen(false);
+                              }}
+                            />,
+                            document.body,
+                          )}
+                      </>
                     )}
-                </>
-              )}
-            </Field>
-          )}
-        </ValueFieldContainer>
-        <DeleteButton
-          kind="ghost"
-          size="sm"
-          label="Remove condition"
-          align="top-right"
-          onClick={onDelete}
-          data-testid={`delete-variable-filter-${fieldId}`}
-          $hidden={isDeleteHidden}
-        >
-          <Close />
-        </DeleteButton>
-      </FilterRow>
-    </>
+                  </Field>
+                )}
+              </ValueFieldContainer>
+            </>
+          );
+        }}
+      </Field>
+      <DeleteButton
+        kind="ghost"
+        size="sm"
+        label="Remove condition"
+        align="top-right"
+        onClick={onDelete}
+        data-testid={`delete-variable-filter-${rowIndex}`}
+        $hidden={isDeleteHidden}
+      >
+        <Close />
+      </DeleteButton>
+    </FilterRow>
   );
 };
 

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/constants.ts
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/constants.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {VariableFilterOperator} from 'modules/stores/variableFilter';
+
+type OperatorConfig = {
+  id: VariableFilterOperator;
+  label: string;
+  requiresValue: boolean;
+};
+
+const VARIABLE_FILTER_OPERATORS: OperatorConfig[] = [
+  {id: 'equals', label: 'equals', requiresValue: true},
+  {id: 'notEqual', label: 'not equal', requiresValue: true},
+  {id: 'contains', label: 'contains', requiresValue: true},
+  {id: 'oneOf', label: 'is one of', requiresValue: true},
+  {id: 'exists', label: 'exists', requiresValue: false},
+  {id: 'doesNotExist', label: 'does not exist', requiresValue: false},
+];
+
+const MAX_CONDITIONS = 5;
+
+type DraftCondition = {
+  id: string;
+  name: string;
+  operator: VariableFilterOperator;
+  value: string;
+};
+
+export {MAX_CONDITIONS, VARIABLE_FILTER_OPERATORS, type DraftCondition};

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/constants.ts
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/constants.ts
@@ -6,7 +6,6 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {isValidJSON} from 'modules/utils';
 import type {VariableFilterOperator} from 'modules/stores/variableFilter';
 
 type OperatorConfig = {
@@ -24,8 +23,6 @@ const VARIABLE_FILTER_OPERATORS: OperatorConfig[] = [
   {id: 'doesNotExist', label: 'does not exist', requiresValue: false},
 ];
 
-const MAX_CONDITIONS = 5;
-
 type DraftCondition = {
   id: string;
   name: string;
@@ -33,52 +30,4 @@ type DraftCondition = {
   value: string;
 };
 
-type RowErrors = {
-  name?: string;
-  value?: string;
-};
-
-const validateCondition = (condition: DraftCondition): RowErrors => {
-  const errors: RowErrors = {};
-
-  if (!condition.name.trim()) {
-    errors.name = 'Variable name is required';
-  }
-
-  if (
-    condition.operator !== 'exists' &&
-    condition.operator !== 'doesNotExist'
-  ) {
-    if (!condition.value.trim()) {
-      errors.value = 'Value is required';
-    } else if (condition.operator === 'oneOf') {
-      let parsed: unknown;
-      try {
-        parsed = JSON.parse(condition.value);
-      } catch {
-        // handled below
-      }
-      if (!Array.isArray(parsed)) {
-        errors.value = 'Value must be a JSON array (e.g. ["val1", "val2"])';
-      }
-    } else if (
-      condition.operator !== 'contains' &&
-      !isValidJSON(condition.value)
-    ) {
-      errors.value = 'Value must be valid JSON';
-    }
-  }
-
-  return errors;
-};
-
-const hasErrors = (errors: RowErrors) => Object.keys(errors).length > 0;
-
-export {
-  MAX_CONDITIONS,
-  VARIABLE_FILTER_OPERATORS,
-  validateCondition,
-  hasErrors,
-  type DraftCondition,
-  type RowErrors,
-};
+export {VARIABLE_FILTER_OPERATORS, type DraftCondition};

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/constants.ts
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/constants.ts
@@ -6,6 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import {isValidJSON} from 'modules/utils';
 import type {VariableFilterOperator} from 'modules/stores/variableFilter';
 
 type OperatorConfig = {
@@ -32,4 +33,42 @@ type DraftCondition = {
   value: string;
 };
 
-export {MAX_CONDITIONS, VARIABLE_FILTER_OPERATORS, type DraftCondition};
+type RowErrors = {
+  name?: string;
+  value?: string;
+};
+
+const validateCondition = (condition: DraftCondition): RowErrors => {
+  const errors: RowErrors = {};
+
+  if (!condition.name.trim()) {
+    errors.name = 'Variable name is required';
+  }
+
+  if (
+    condition.operator !== 'exists' &&
+    condition.operator !== 'doesNotExist'
+  ) {
+    if (!condition.value.trim()) {
+      errors.value = 'Value is required';
+    } else if (
+      condition.operator !== 'contains' &&
+      !isValidJSON(condition.value)
+    ) {
+      errors.value = 'Value must be valid JSON';
+    }
+  }
+
+  return errors;
+};
+
+const hasErrors = (errors: RowErrors) => Object.keys(errors).length > 0;
+
+export {
+  MAX_CONDITIONS,
+  VARIABLE_FILTER_OPERATORS,
+  validateCondition,
+  hasErrors,
+  type DraftCondition,
+  type RowErrors,
+};

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/constants.ts
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/constants.ts
@@ -51,6 +51,16 @@ const validateCondition = (condition: DraftCondition): RowErrors => {
   ) {
     if (!condition.value.trim()) {
       errors.value = 'Value is required';
+    } else if (condition.operator === 'oneOf') {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(condition.value);
+      } catch {
+        // handled below
+      }
+      if (!Array.isArray(parsed)) {
+        errors.value = 'Value must be a JSON array (e.g. ["val1", "val2"])';
+      }
     } else if (
       condition.operator !== 'contains' &&
       !isValidJSON(condition.value)

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/constants.ts
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/constants.ts
@@ -24,7 +24,6 @@ const VARIABLE_FILTER_OPERATORS: OperatorConfig[] = [
 ];
 
 type DraftCondition = {
-  id: string;
   name: string;
   operator: VariableFilterOperator;
   value: string;

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/index.test.tsx
@@ -10,11 +10,10 @@ import {render, screen} from 'modules/testing-library';
 import {VariableFilter} from '.';
 import {variableFilterStore} from 'modules/stores/variableFilter';
 
-beforeEach(() => {
-  variableFilterStore.reset();
-});
-
 describe('<VariableFilter />', () => {
+  beforeEach(() => {
+    variableFilterStore.reset();
+  });
   it('should show "Add conditions" label when no conditions are set', () => {
     render(<VariableFilter />);
 
@@ -65,7 +64,7 @@ describe('<VariableFilter />', () => {
     ).toBeInTheDocument();
   });
 
-  it('should update store on apply', async () => {
+  it('should update conditions on apply', async () => {
     const {user} = render(<VariableFilter />);
 
     await user.click(screen.getByRole('button', {name: 'Add conditions'}));
@@ -89,7 +88,7 @@ describe('<VariableFilter />', () => {
     ).toBeInTheDocument();
   });
 
-  it('should not update store on cancel', async () => {
+  it('should not update conditions on cancel', async () => {
     const {user} = render(<VariableFilter />);
 
     await user.click(screen.getByRole('button', {name: 'Add conditions'}));

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/index.test.tsx
@@ -1,0 +1,116 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {render, screen} from 'modules/testing-library';
+import {VariableFilter} from '.';
+import {variableFilterStore} from 'modules/stores/variableFilter';
+
+beforeEach(() => {
+  variableFilterStore.reset();
+});
+
+describe('<VariableFilter />', () => {
+  it('should show "Add conditions" label when no conditions are set', () => {
+    render(<VariableFilter />);
+
+    expect(
+      screen.getByRole('button', {name: 'Add conditions'}),
+    ).toBeInTheDocument();
+  });
+
+  it('should show "Edit conditions" label when conditions exist', () => {
+    variableFilterStore.setConditions([
+      {name: 'status', operator: 'equals', value: '"active"'},
+    ]);
+
+    render(<VariableFilter />);
+
+    expect(
+      screen.getByRole('button', {name: 'Edit conditions'}),
+    ).toBeInTheDocument();
+  });
+
+  it('should render condition summary labels when conditions exist', () => {
+    variableFilterStore.setConditions([
+      {name: 'status', operator: 'equals', value: '"active"'},
+      {name: 'retries', operator: 'exists', value: ''},
+    ]);
+
+    render(<VariableFilter />);
+
+    expect(screen.getByText('status equals "active"')).toBeInTheDocument();
+    expect(screen.getByText('retries exists')).toBeInTheDocument();
+  });
+
+  it('should not render condition list when no conditions are set', () => {
+    render(<VariableFilter />);
+
+    expect(
+      screen.queryByRole('list', {name: 'Active variable filters'}),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should open the modal when the button is clicked', async () => {
+    const {user} = render(<VariableFilter />);
+
+    await user.click(screen.getByRole('button', {name: 'Add conditions'}));
+
+    expect(
+      screen.getByRole('dialog', {name: 'Filter by Variable'}),
+    ).toBeInTheDocument();
+  });
+
+  it('should update store on apply', async () => {
+    const {user} = render(<VariableFilter />);
+
+    await user.click(screen.getByRole('button', {name: 'Add conditions'}));
+
+    await user.type(
+      screen.getAllByPlaceholderText('Variable name')[0]!,
+      'status',
+    );
+    await user.type(
+      screen.getAllByPlaceholderText('value in JSON format')[0]!,
+      '"active"',
+    );
+
+    await user.click(screen.getByRole('button', {name: 'Apply'}));
+
+    expect(variableFilterStore.conditions).toEqual([
+      {name: 'status', operator: 'equals', value: '"active"'},
+    ]);
+    expect(
+      screen.getByRole('button', {name: 'Edit conditions'}),
+    ).toBeInTheDocument();
+  });
+
+  it('should not update store on cancel', async () => {
+    const {user} = render(<VariableFilter />);
+
+    await user.click(screen.getByRole('button', {name: 'Add conditions'}));
+    await user.click(screen.getByRole('button', {name: 'Cancel'}));
+
+    expect(variableFilterStore.conditions).toHaveLength(0);
+    expect(
+      screen.getByRole('button', {name: 'Add conditions'}),
+    ).toBeInTheDocument();
+  });
+
+  it('should reset draft rows when modal is reopened after adding unsaved rows', async () => {
+    const {user} = render(<VariableFilter />);
+
+    await user.click(screen.getByRole('button', {name: 'Add conditions'}));
+    await user.click(screen.getByRole('button', {name: 'Add condition'}));
+    expect(screen.getAllByPlaceholderText('Variable name')).toHaveLength(2);
+
+    await user.click(screen.getByRole('button', {name: 'Cancel'}));
+    await user.click(screen.getByRole('button', {name: 'Add conditions'}));
+
+    expect(screen.getAllByPlaceholderText('Variable name')).toHaveLength(1);
+  });
+});

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/index.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/index.tsx
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useState} from 'react';
+import {observer} from 'mobx-react';
+import {Button} from '@carbon/react';
+import {Edit} from '@carbon/react/icons';
+import {Title} from 'modules/components/FiltersPanel/styled';
+import {
+  variableFilterStore,
+  type VariableCondition,
+} from 'modules/stores/variableFilter';
+import {VARIABLE_FILTER_OPERATORS} from './constants';
+import {VariableFilterModal} from './VariableFilterModal';
+import {ConditionList, ConditionItem} from './styled';
+
+const getConditionLabel = (condition: VariableCondition): string => {
+  const config = VARIABLE_FILTER_OPERATORS.find(
+    (op) => op.id === condition.operator,
+  );
+  return config?.requiresValue
+    ? `${condition.name} ${config.label} ${condition.value}`
+    : `${condition.name} ${config?.label ?? condition.operator}`;
+};
+
+const VariableFilter: React.FC = observer(() => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const {conditions} = variableFilterStore;
+
+  const handleApply = (newConditions: VariableCondition[]) => {
+    variableFilterStore.setConditions(newConditions);
+    setIsModalOpen(false);
+  };
+
+  return (
+    <>
+      <Title>Variables</Title>
+      {conditions.length > 0 && (
+        <ConditionList aria-label="Active variable filters">
+          {conditions.map((condition) => (
+            <ConditionItem
+              key={`${condition.name}-${condition.operator}-${condition.value}`}
+            >
+              {getConditionLabel(condition)}
+            </ConditionItem>
+          ))}
+        </ConditionList>
+      )}
+      <Button
+        kind="ghost"
+        size="sm"
+        renderIcon={Edit}
+        onClick={() => setIsModalOpen(true)}
+        data-testid="open-variable-filter-modal"
+      >
+        {conditions.length === 0 ? 'Add conditions' : 'Edit conditions'}
+      </Button>
+
+      <VariableFilterModal
+        key={isModalOpen ? 'open' : 'closed'}
+        isOpen={isModalOpen}
+        initialConditions={conditions}
+        onApply={handleApply}
+        onClose={() => setIsModalOpen(false)}
+      />
+    </>
+  );
+});
+
+export {VariableFilter};

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/styled.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/styled.tsx
@@ -7,13 +7,11 @@
  */
 
 import styled from 'styled-components';
-import {IconButton as BaseIconButton, Modal as BaseModal} from '@carbon/react';
+import {IconButton as BaseIconButton} from '@carbon/react';
 import {styles} from '@carbon/elements';
 
-const Modal = styled(BaseModal)`
-  .cds--modal-content {
-    min-height: 350px;
-  }
+const ModalContent = styled.div`
+  min-height: 350px;
 `;
 
 const Description = styled.p`
@@ -48,7 +46,7 @@ const ConditionItem = styled.li`
 `;
 
 export {
-  Modal,
+  ModalContent,
   Description,
   FilterRow,
   ValueFieldContainer,

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/styled.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/styled.tsx
@@ -28,10 +28,6 @@ const FilterRow = styled.div`
   align-items: start;
 `;
 
-const ConditionDropdownContainer = styled.div`
-  width: 170px;
-`;
-
 const ValueFieldContainer = styled.div`
   position: relative;
 `;
@@ -55,7 +51,6 @@ export {
   Modal,
   Description,
   FilterRow,
-  ConditionDropdownContainer,
   ValueFieldContainer,
   DeleteButton,
   ConditionList,

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/styled.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/styled.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled from 'styled-components';
+import {
+  Stack,
+  IconButton as BaseIconButton,
+  Modal as BaseModal,
+} from '@carbon/react';
+import {styles} from '@carbon/elements';
+
+const Modal = styled(BaseModal)`
+  .cds--modal-content {
+    min-height: 350px;
+  }
+`;
+
+const Description = styled.p`
+  margin: 0;
+  ${styles.bodyShort01};
+`;
+
+const FilterRowsContainer = styled(Stack)``;
+
+const FilterRow = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 170px 1fr auto;
+  gap: var(--cds-spacing-05);
+  align-items: end;
+`;
+
+const ConditionDropdownContainer = styled.div`
+  width: 170px;
+`;
+
+const ValueFieldContainer = styled.div`
+  position: relative;
+`;
+
+const DeleteButton = styled(BaseIconButton)<{$hidden?: boolean}>`
+  flex-shrink: 0;
+  visibility: ${({$hidden}) => ($hidden ? 'hidden' : 'visible')};
+`;
+
+const ConditionList = styled.ul`
+  margin: 0;
+  padding: 0;
+  list-style: none;
+`;
+
+const ConditionItem = styled.li`
+  ${styles.bodyShort01};
+`;
+
+export {
+  Modal,
+  Description,
+  FilterRowsContainer,
+  FilterRow,
+  ConditionDropdownContainer,
+  ValueFieldContainer,
+  DeleteButton,
+  ConditionList,
+  ConditionItem,
+};

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/styled.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/styled.tsx
@@ -7,11 +7,7 @@
  */
 
 import styled from 'styled-components';
-import {
-  Stack,
-  IconButton as BaseIconButton,
-  Modal as BaseModal,
-} from '@carbon/react';
+import {IconButton as BaseIconButton, Modal as BaseModal} from '@carbon/react';
 import {styles} from '@carbon/elements';
 
 const Modal = styled(BaseModal)`
@@ -25,13 +21,11 @@ const Description = styled.p`
   ${styles.bodyShort01};
 `;
 
-const FilterRowsContainer = styled(Stack)``;
-
 const FilterRow = styled.div`
   display: grid;
   grid-template-columns: 1fr 170px 1fr auto;
   gap: var(--cds-spacing-05);
-  align-items: end;
+  align-items: start;
 `;
 
 const ConditionDropdownContainer = styled.div`
@@ -60,7 +54,6 @@ const ConditionItem = styled.li`
 export {
   Modal,
   Description,
-  FilterRowsContainer,
   FilterRow,
   ConditionDropdownContainer,
   ValueFieldContainer,

--- a/operate/client/src/App/Processes/ListView/Filters/index.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/index.tsx
@@ -40,6 +40,7 @@ import {
 import {TenantField} from 'modules/components/TenantField';
 import {batchModificationStore} from 'modules/stores/batchModification';
 import {variableFilterStore} from 'modules/stores/variableFilter';
+import {MULTI_VARIABLE_FILTER} from 'modules/feature-flags';
 import {useNavigate, useSearchParams} from 'react-router-dom';
 import {
   getDefinitionIdentifier,
@@ -106,10 +107,17 @@ const Filters: React.FC = observer(() => {
           <FiltersPanel
             localStorageKey="isFiltersCollapsed"
             isResetButtonDisabled={
-              (isEqual(initialValues, values) && visibleFilters.length === 0) ||
+              (isEqual(initialValues, values) &&
+                visibleFilters.length === 0 &&
+                !(
+                  MULTI_VARIABLE_FILTER && variableFilterStore.hasActiveFilters
+                )) ||
               isBatchModificationEnabled
             }
             onResetClick={() => {
+              if (MULTI_VARIABLE_FILTER) {
+                variableFilterStore.setConditions([]);
+              }
               form.reset();
               navigate({
                 search: updateProcessInstancesFilterSearchString(

--- a/operate/client/src/modules/feature-flags.ts
+++ b/operate/client/src/modules/feature-flags.ts
@@ -6,4 +6,6 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-export {};
+const MULTI_VARIABLE_FILTER = false;
+
+export {MULTI_VARIABLE_FILTER};

--- a/operate/client/src/modules/stores/variableFilter.ts
+++ b/operate/client/src/modules/stores/variableFilter.ts
@@ -61,7 +61,9 @@ class VariableFilter {
   }
 
   reset = () => {
-    this.state = {...DEFAULT_STATE};
+    this.state.variable = DEFAULT_STATE.variable;
+    this.state.isInMultipleMode = DEFAULT_STATE.isInMultipleMode;
+    this.state.conditions = DEFAULT_STATE.conditions;
     sessionStorage.removeItem(SESSION_STORAGE_KEY);
   };
 

--- a/operate/client/src/modules/stores/variableFilter.ts
+++ b/operate/client/src/modules/stores/variableFilter.ts
@@ -7,7 +7,7 @@
  */
 
 import isEqual from 'lodash/isEqual';
-import {makeAutoObservable, type IReactionDisposer} from 'mobx';
+import {makeAutoObservable, runInAction} from 'mobx';
 import {getValidVariableValues} from 'modules/utils/filter/getValidVariableValues';
 
 type Variable = {
@@ -15,26 +15,54 @@ type Variable = {
   values: string;
 };
 
+type VariableFilterOperator =
+  | 'equals'
+  | 'notEqual'
+  | 'contains'
+  | 'oneOf'
+  | 'exists'
+  | 'doesNotExist';
+
+type VariableCondition = {
+  name: string;
+  operator: VariableFilterOperator;
+  value: string;
+};
+
 type State = {
   variable?: Variable;
   isInMultipleMode: boolean;
+  conditions: VariableCondition[];
 };
 
 const DEFAULT_STATE: State = {
   variable: undefined,
   isInMultipleMode: false,
+  conditions: [],
 };
+
+const SESSION_STORAGE_KEY = 'operate.variableFilter.conditions';
 
 class VariableFilter {
   state: State = {...DEFAULT_STATE};
-  disposer: IReactionDisposer | null = null;
 
   constructor() {
     makeAutoObservable(this);
+    const stored = sessionStorage.getItem(SESSION_STORAGE_KEY);
+    if (stored) {
+      try {
+        runInAction(() => {
+          this.state.conditions = JSON.parse(stored) as VariableCondition[];
+        });
+      } catch {
+        //TODO check if this can be removed after a while, added just to be safe in case of invalid data in session storage
+      }
+    }
   }
 
   reset = () => {
     this.state = {...DEFAULT_STATE};
+    sessionStorage.removeItem(SESSION_STORAGE_KEY);
   };
 
   setVariable = (variable?: Variable) => {
@@ -47,8 +75,27 @@ class VariableFilter {
     this.state.isInMultipleMode = isInMultipleMode;
   };
 
+  setConditions = (conditions: VariableCondition[]) => {
+    if (!isEqual(this.state.conditions, conditions)) {
+      this.state.conditions = conditions;
+      if (conditions.length === 0) {
+        sessionStorage.removeItem(SESSION_STORAGE_KEY);
+      } else {
+        sessionStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(conditions));
+      }
+    }
+  };
+
   get variable() {
     return this.state.variable;
+  }
+
+  get conditions() {
+    return this.state.conditions;
+  }
+
+  get hasActiveFilters() {
+    return this.state.conditions.length > 0;
   }
 
   get variableWithValidatedValues() {
@@ -68,5 +115,7 @@ class VariableFilter {
   }
 }
 
-export const variableFilterStore = new VariableFilter();
-export type {Variable};
+const variableFilterStore = new VariableFilter();
+
+export {variableFilterStore};
+export type {Variable, VariableFilterOperator, VariableCondition};

--- a/operate/client/src/modules/stores/variableFilter.ts
+++ b/operate/client/src/modules/stores/variableFilter.ts
@@ -23,11 +23,21 @@ type VariableFilterOperator =
   | 'exists'
   | 'doesNotExist';
 
-type VariableCondition = {
+type VariableConditionWithValue = {
   name: string;
-  operator: VariableFilterOperator;
+  operator: 'equals' | 'notEqual' | 'contains' | 'oneOf';
   value: string;
 };
+
+type VariableConditionWithoutValue = {
+  name: string;
+  operator: 'exists' | 'doesNotExist';
+  value: '';
+};
+
+type VariableCondition =
+  | VariableConditionWithValue
+  | VariableConditionWithoutValue;
 
 type State = {
   variable?: Variable;
@@ -61,9 +71,7 @@ class VariableFilter {
   }
 
   reset = () => {
-    this.state.variable = DEFAULT_STATE.variable;
-    this.state.isInMultipleMode = DEFAULT_STATE.isInMultipleMode;
-    this.state.conditions = DEFAULT_STATE.conditions;
+    this.state = {...DEFAULT_STATE};
     sessionStorage.removeItem(SESSION_STORAGE_KEY);
   };
 


### PR DESCRIPTION
## Description

 - Adds base components for multi-variable filtering, based on [PoC](https://github.com/camunda/camunda/pull/44465/changes).
 - Adds field validation for MVF filter
- Adds a feature flag for MVF functionality

Out of scope                                                                                                                                                                                           
Search wiring is tracked separately in #51810. The store is populated and session-persisted but does not yet affect the `/process-instances/search` query


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #51800, #51802
