### PR TITLE
ci: surface built image tag in GitHub Actions summary

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -261,8 +261,11 @@ jobs:
           ref: ${{ inputs.ref }}
       - name: Get image tag
         id: image-tag
+        if: ${{ inputs.orchestration-tag == '' && inputs.reuse-tag == '' }}
         run: |
-          echo "image-tag=${{ inputs.name }}-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          image_tag="${{ inputs.name }}-$(git rev-parse --short HEAD)"
+          echo "image-tag=${image_tag}" >> "$GITHUB_OUTPUT"
+          echo "**Built image tag:** \`${image_tag}\`" >> "$GITHUB_STEP_SUMMARY"
       - name: Validate Docker image tags exist
         if: ${{ inputs.orchestration-tag != '' || inputs.optimize-tag != '' || inputs.identity-tag != '' || inputs.connectors-tag != '' }}
         env:


### PR DESCRIPTION
## Summary

- When building from source, the computed image tag (`<name>-<short-sha>`) was only visible deep in the job logs, making it tedious to copy for reruns
- The `Get image tag` step now writes the tag to `$GITHUB_STEP_SUMMARY` so it's immediately visible at the top of the workflow run page
- Also added an `if` guard so the step only runs when neither `orchestration-tag` nor `reuse-tag` is provided — only when the tag is actually being computed

## Test plan

- [ ] Trigger the load test workflow from source (no `reuse-tag`/`orchestration-tag`) and confirm the tag appears in the summary
- [ ] Trigger with `reuse-tag` set and confirm the step is skipped and the workflow still deploys correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)