### PR TITLE
feat: cache /webapp/** static assets and resolve base-href via Thymeleaf

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -1121,7 +1121,8 @@ public class WebSecurityConfig {
                               "/tasklist/client-config.js",
                               "/tasklist/custom.css",
                               "/tasklist/favicon.ico",
-                              "/webapp/assets/**")
+                              "/webapp/assets/**",
+                              "/webapp/favicon.ico")
                           .permitAll()
                           .anyRequest()
                           .authenticated())

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -193,6 +193,7 @@ public class WebSecurityConfig {
           "/admin/**",
           "/operate/**",
           "/tasklist/**",
+          "/webapp/**",
           "/",
           "/sso-callback/**",
           "/oauth2/authorization/**",
@@ -1119,7 +1120,8 @@ public class WebSecurityConfig {
                               "/tasklist/assets/**",
                               "/tasklist/client-config.js",
                               "/tasklist/custom.css",
-                              "/tasklist/favicon.ico")
+                              "/tasklist/favicon.ico",
+                              "/webapp/assets/**")
                           .permitAll()
                           .anyRequest()
                           .authenticated())

--- a/webapp/client/apps/orchestration-cluster-webapp/index.prod.html
+++ b/webapp/client/apps/orchestration-cluster-webapp/index.prod.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+	<head>
+		<meta charset="utf-8" />
+		<base href="/" th:attr="href=${contextPath}" />
+		<link rel="icon" href="./favicon.ico" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#000000" />
+		<meta name="description" content="Camunda Orchestration Cluster web application" />
+		<title>Orchestration Cluster</title>
+	</head>
+	<body>
+		<noscript>You need to enable JavaScript to run this app.</noscript>
+		<div id="app"></div>
+		<script type="module" src="/src/main.tsx"></script>
+	</body>
+</html>

--- a/webapp/client/apps/orchestration-cluster-webapp/package.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev --port 3000",
-		"build": "vite build",
+		"build": "vite build && node ./renameProdIndex.mjs",
 		"typecheck": "tsc -p tsconfig.browser.json",
 		"extract-sbom": "vite build --mode sbom"
 	},

--- a/webapp/client/apps/orchestration-cluster-webapp/renameProdIndex.mjs
+++ b/webapp/client/apps/orchestration-cluster-webapp/renameProdIndex.mjs
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import fs from 'node:fs/promises';
+import path, {dirname} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const oldPath = path.join(
+	dirname(fileURLToPath(import.meta.url)),
+	'dist',
+	'index.prod.html',
+);
+const newPath = path.join(
+	dirname(fileURLToPath(import.meta.url)),
+	'dist',
+	'index.html',
+);
+
+fs.rename(oldPath, newPath, (err) => {
+	if (err) {
+		throw err;
+	}
+
+	console.log('Rename complete!');
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/renameProdIndex.mjs
+++ b/webapp/client/apps/orchestration-cluster-webapp/renameProdIndex.mjs
@@ -21,10 +21,5 @@ const newPath = path.join(
 	'index.html',
 );
 
-fs.rename(oldPath, newPath, (err) => {
-	if (err) {
-		throw err;
-	}
-
-	console.log('Rename complete!');
-});
+await fs.rename(oldPath, newPath);
+console.log('Rename complete!');

--- a/webapp/client/apps/orchestration-cluster-webapp/vite.config.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/vite.config.ts
@@ -22,6 +22,7 @@ const basePlugins: PluginOption[] = [
 ];
 
 const config = defineConfig(({mode}) => ({
+	base: mode === 'production' ? './' : undefined,
 	resolve: {tsconfigPaths: true},
 	plugins: mode === 'sbom' ? [...basePlugins, sbom()] : basePlugins,
 	server: {
@@ -47,6 +48,10 @@ const config = defineConfig(({mode}) => ({
 		rolldownOptions: {
 			output: {
 				postBanner: '/*! licenses: /assets/vendor.LICENSE.txt */',
+			},
+			input: {
+				index:
+					mode === 'visual-regression' ? './index.html' : './index.prod.html',
 			},
 		},
 	},

--- a/webapp/server/pom.xml
+++ b/webapp/server/pom.xml
@@ -67,6 +67,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-webmvc</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
     </dependency>
@@ -95,6 +100,54 @@
       <artifactId>mockito-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-resttestclient</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-restclient</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -107,6 +160,9 @@
             <!-- webapp-webjar ships static resources (META-INF/resources/webapp/*) consumed at
                  runtime by Spring Boot's resource handler; no compile-time class references. -->
             <dependency>io.camunda:webapp-webjar</dependency>
+            <dependency>org.springframework.boot:spring-boot-starter-test</dependency>
+            <dependency>org.springframework.boot:spring-boot-starter-web</dependency>
+            <dependency>org.springframework.boot:spring-boot-restclient</dependency>
           </usedDependencies>
         </configuration>
       </plugin>

--- a/webapp/server/pom.xml
+++ b/webapp/server/pom.xml
@@ -26,7 +26,6 @@
       <artifactId>camunda-spring-utils</artifactId>
     </dependency>
 
-    <!-- Static resources (FE webjar). Only used at runtime; not referenced at compile time. -->
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>webapp-webjar</artifactId>
@@ -157,8 +156,6 @@
         <artifactId>maven-dependency-plugin</artifactId>
         <configuration>
           <usedDependencies>
-            <!-- webapp-webjar ships static resources (META-INF/resources/webapp/*) consumed at
-                 runtime by Spring Boot's resource handler; no compile-time class references. -->
             <dependency>io.camunda:webapp-webjar</dependency>
             <dependency>org.springframework.boot:spring-boot-starter-test</dependency>
             <dependency>org.springframework.boot:spring-boot-starter-web</dependency>

--- a/webapp/server/src/main/java/io/camunda/webapp/WebappWebMvcConfig.java
+++ b/webapp/server/src/main/java/io/camunda/webapp/WebappWebMvcConfig.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapp;
+
+import io.camunda.spring.utils.ConditionalOnWebappUiEnabled;
+import java.time.Duration;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.CacheControl;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * Static-resource configuration for the unified BFF webapp. Maps {@code /webapp/assets/**} to the
+ * webjar-packaged FE bundle ({@code classpath:/META-INF/resources/webapp/assets/}) and applies
+ * forever-caching headers.
+ *
+ * <p>Forever-caching is safe because the FE build emits hash-suffixed filenames (cache-busting via
+ * filename change). The shell {@code index.html} is intentionally NOT covered here: it is served
+ * via {@link io.camunda.webapp.controllers.WebappIndexController} and inherits the no-cache headers
+ * applied by the Spring Security filter chain, so a redeploy with a new bundle hash is picked up on
+ * the next reload.
+ *
+ * <p>Active under the {@code tmp-webapp} profile (via {@link
+ * io.camunda.webapp.WebappModuleConfiguration}'s component scan) and gated identically to {@link
+ * io.camunda.webapp.controllers.WebappIndexController} for symmetry.
+ */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnWebappUiEnabled("tmp-webapp")
+public class WebappWebMvcConfig implements WebMvcConfigurer {
+
+  static final String ASSETS_PATH_PATTERN = "/webapp/assets/**";
+  static final String ASSETS_CLASSPATH_LOCATION = "classpath:/META-INF/resources/webapp/assets/";
+  static final Duration ASSETS_CACHE_MAX_AGE = Duration.ofDays(365);
+
+  @Override
+  public void addResourceHandlers(final ResourceHandlerRegistry registry) {
+    registry
+        .addResourceHandler(ASSETS_PATH_PATTERN)
+        .addResourceLocations(ASSETS_CLASSPATH_LOCATION)
+        .setCacheControl(CacheControl.maxAge(ASSETS_CACHE_MAX_AGE).cachePublic().immutable());
+  }
+}

--- a/webapp/server/src/test/java/io/camunda/webapp/WebappCacheHeadersIT.java
+++ b/webapp/server/src/test/java/io/camunda/webapp/WebappCacheHeadersIT.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.webapptest.TestWebappApplication;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.resttestclient.TestRestTemplate;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * Verifies that static assets under {@code /webapp/assets/**} are served with forever-caching
+ * headers, while non-asset paths under {@code /webapp/} are not handled by the resource handler.
+ */
+@SpringBootTest(classes = TestWebappApplication.class, webEnvironment = WebEnvironment.RANDOM_PORT)
+@AutoConfigureTestRestTemplate
+@ActiveProfiles("tmp-webapp")
+class WebappCacheHeadersIT {
+
+  @Autowired private TestRestTemplate restTemplate;
+
+  @Test
+  void shouldServeWebappAssetsWithImmutableForeverCacheHeader() {
+    // when
+    final ResponseEntity<String> response =
+        restTemplate.getForEntity("/webapp/assets/test-asset.js", String.class);
+
+    // then
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getHeaders().getCacheControl())
+        .as("forever-cache header on /webapp/assets/**")
+        .isEqualTo("max-age=31536000, public, immutable");
+  }
+
+  @Test
+  void shouldNotServeUnknownAssetsAsStaticResources() {
+    // when — ensures the resource handler does not silently 200 on missing files
+    final ResponseEntity<String> response =
+        restTemplate.getForEntity("/webapp/assets/does-not-exist.js", String.class);
+
+    // then
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+  }
+}

--- a/webapp/server/src/test/java/io/camunda/webapp/WebappCacheHeadersIT.java
+++ b/webapp/server/src/test/java/io/camunda/webapp/WebappCacheHeadersIT.java
@@ -22,7 +22,8 @@ import org.springframework.test.context.ActiveProfiles;
 
 /**
  * Verifies that static assets under {@code /webapp/assets/**} are served with forever-caching
- * headers, while non-asset paths under {@code /webapp/} are not handled by the resource handler.
+ * headers and that requests for non-existent assets return 404 rather than being silently resolved
+ * by the resource handler.
  */
 @SpringBootTest(classes = TestWebappApplication.class, webEnvironment = WebEnvironment.RANDOM_PORT)
 @AutoConfigureTestRestTemplate

--- a/webapp/server/src/test/java/io/camunda/webapptest/TestWebappApplication.java
+++ b/webapp/server/src/test/java/io/camunda/webapptest/TestWebappApplication.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapptest;
+
+import io.camunda.webapp.WebappModuleConfiguration;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Minimal Spring Boot bootstrap used by integration tests in this module (e.g., {@code
+ * WebappCacheHeadersIT}).
+ */
+@SpringBootConfiguration
+@EnableAutoConfiguration
+@Import(WebappModuleConfiguration.class)
+public class TestWebappApplication {}

--- a/webapp/server/src/test/resources/META-INF/resources/webapp/assets/test-asset.js
+++ b/webapp/server/src/test/resources/META-INF/resources/webapp/assets/test-asset.js
@@ -1,0 +1,2 @@
+// test asset fixture for WebappCacheHeadersIT
+console.log("test asset");


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Sets up forever-caching for the orchestration-cluster-webapp's hashed assets and renders the SPA shell with a Thymeleaf-resolved `<base href>` so the browser fetches assets from the correct path.

* `webapp-server`: new `WebMvcConfigurer` mapping `/webapp/assets/**` to the webjar's classpath location with `Cache-Control: max-age=31536000, public, immutable` (+ ITs).
* `authentication`: register `/webapp/**` in `WEBAPP_PATHS` and permit `/webapp/assets/**` in the OIDC profile.
* `orchestration-cluster-webapp`: add `index.prod.html` (Thymeleaf-tagged) + `renameProdIndex.mjs` post-build step, mirroring the pattern in `tasklist/client`. Set Vite `base: './'` in production so emitted asset URLs resolve against `<base href>`.

Smoke-verified end-to-end: `/webapp/index.html` renders the shell with `<base href="/webapp/">`, and the browser fetches hashed assets from `/webapp/assets/...` with the long-lived cache headers.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #51311
