### PR TITLE
Skip backport workflow when PR has no backport labels

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -13,14 +13,17 @@ jobs:
   backport:
     name: Create backport PRs
     runs-on: ubuntu-latest
-    # Only run when pull request is merged
+    # Only run when pull request is merged and carries at least one `backport ` label
     # or when a comment starting with `/backport` is created by someone other than a bot:
     # - https://github.com/backport-action bot user (user id: 97796249)
     # - Monorepo DevOps Automation GitHub App bot user (user id: 248077375)
+    # The label check uses toJSON + contains to match any label whose name starts with
+    # `backport ` (the leading `"` anchors the match to the start of a label name).
     if: >
       (
         github.event_name == 'pull_request' &&
-        github.event.pull_request.merged
+        github.event.pull_request.merged &&
+        contains(toJSON(github.event.pull_request.labels.*.name), '"backport ')
       ) || (
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&


### PR DESCRIPTION
## Description

The backport workflow currently triggers `korthout/backport-action` on every merged PR. When a PR carries no `backport ` labels, the action correctly determines there are no target branches and exits — but the workflow still consumes CI minutes, generates a GitHub App token via Vault, and (since #51994) posts a no-op summary comment on the merged PR.

This change adds a label check at the trigger layer so the workflow is skipped entirely when a merged PR has zero `backport ` labels.

The `/backport` issue_comment trigger is intentionally left unchanged: it can add labels and re-run, or pass targets directly via the comment body. Restricting it on labels would break that flow.

The label check uses `contains(toJSON(...labels.*.name), '"backport ')` because GitHub Actions expressions have no native "any element starts with" predicate. `toJSON` serialises the names array as `["label-a","label-b"]`, and the leading double-quote in the needle anchors the match to a label boundary so it matches names beginning with `backport ` and not labels that merely contain that substring.

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #52115
