### PR TITLE
ci: use a different mirror for Maven binary

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -187,6 +187,15 @@ runs:
           "username": "${{ steps.secrets.outputs.ci-account-username }}",
           "password": "${{ steps.secrets.outputs.ci-account-password }}"
         }]
+      # Avoid rate limiting on repo.maven.apache.org by mirroring central via Google's
+      # public Maven Central mirror. Applies to all artifacts (deps, plugins, extensions, BOM).
+      CENTRAL_MAVEN_MIRROR: >-
+        [{
+          "id": "google-maven-central",
+          "name": "Google Maven Central Mirror",
+          "url": "https://maven-central.storage-download.googleapis.com/maven2",
+          "mirrorOf": "central"
+        }]
       EXTRA_MAVEN_MIRRORS: ${{ inputs.maven-mirrors }}
       EXTRA_MAVEN_SERVERS: ${{ inputs.maven-servers }}
     run: |
@@ -200,8 +209,9 @@ runs:
       mirrors=$(\
         jq -n \
         --argjson nexus_mirror "${CAMUNDA_NEXUS_MAVEN_MIRROR}" \
+        --argjson central_mirror "${CENTRAL_MAVEN_MIRROR}" \
         --argjson maven_mirrors "${EXTRA_MAVEN_MIRRORS}" \
-        '[ $nexus_mirror + $maven_mirrors | group_by(.id)[] | add ]'
+        '[ $nexus_mirror + $central_mirror + $maven_mirrors | group_by(.id)[] | add ]'
       )
       servers=$(\
         jq -n \

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,3 +1,4 @@
 wrapperVersion=3.3.4
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.14/apache-maven-3.9.14-bin.zip
+distributionUrl=https://maven-central.storage-download.googleapis.com/maven2/org/apache/maven/apache-maven/3.9.14/apache-maven-3.9.14-bin.zip
+distributionSha256Sum=55fadd669532a3205d5db95f490bf13971d8b0843526f407f29db0e61f074ab3

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -159,7 +159,7 @@
       </snapshots>
       <id>central</id>
       <name>Maven Central</name>
-      <url>https://repo.maven.apache.org/maven2</url>
+      <url>https://maven-central.storage-download.googleapis.com/maven2</url>
       <layout>default</layout>
     </repository>
 

--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -638,7 +638,7 @@
     <repository>
       <id>maven_central</id>
       <name>Maven Central</name>
-      <url>https://repo.maven.apache.org/maven2/</url>
+      <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
     </repository>
   </repositories>
 


### PR DESCRIPTION

## Description

<!-- Describe the goal and purpose of this PR. -->

Related: #inc-5345-job-ci-operate-unit-testsdatalayer-has-high-failure-rate-in-merge

Using a different URL for maven binary to avoid rate limiting.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
