### PR TITLE
Document minor release freeze risk in event applier guide

### DIFF
--- a/docs/zeebe/event-applier-golden-files.md
+++ b/docs/zeebe/event-applier-golden-files.md
@@ -26,11 +26,11 @@ to safely update to the next minor version without any breaking changes in repla
 > code may already be frozen while patches of older minor versions continue to ship. If your new
 > event applier version makes it into a patch of an older minor but does not make it into the new
 > minor's initial release, the upgrade path from that patch to the new minor is broken. The new
-> minor will not know how to replay the new applier version, which is unrecoverable without an
-> ad-hoc patch.
+> minor is missing the corresponding event applier version registration and therefore cannot replay
+> events written with that version, which is unrecoverable without an ad-hoc patch.
 >
-> Either hold off on porting new event applier versions to stable branches during a minor code
-> freeze, or ensure your port is included in the minor release.
+> Either hold off on porting new event applier versions to stable branches during a minor release
+> code freeze, or ensure your port is included in the minor release.
 >
 > 💡 **Example:** This happened during the 8.9.0 release. `ProcessEvent.TRIGGERING` v2 was
 > backported to `stable/8.8` (released in 8.8.22) and to `stable/8.9`, but was not included in

--- a/docs/zeebe/event-applier-golden-files.md
+++ b/docs/zeebe/event-applier-golden-files.md
@@ -21,6 +21,21 @@ applier, register a new version. It's usually the safer choice and does not cost
 applier version in a minor version, add it to all newer minor versions as well. This allows users
 to safely update to the next minor version without any breaking changes in replay.
 
+> [!WARNING]
+> **Beware of minor release code freezes.** During the release of a new minor version, its source
+> code may already be frozen while patches of older minor versions continue to ship. If your new
+> event applier version makes it into a patch of an older minor but does not make it into the new
+> minor's initial release, the upgrade path from that patch to the new minor is broken. The new
+> minor will not know how to replay the new applier version, which is unrecoverable without an
+> ad-hoc patch.
+>
+> Either hold off on porting new event applier versions to stable branches during a minor code
+> freeze, or ensure your port is included in the minor release.
+>
+> 💡 **Example:** This happened during the 8.9.0 release. `ProcessEvent.TRIGGERING` v2 was
+> backported to `stable/8.8` (released in 8.8.22) and to `stable/8.9`, but was not included in
+> 8.9.0. Clusters updating from 8.8.22 to 8.9.0 hit dead partitions, unrecoverable until 8.9.1.
+
 ## Common cases
 
 The following scenarios where the test fails are common and should be straightforward to resolve.


### PR DESCRIPTION
## Description

Adds a warning admonition to `docs/zeebe/event-applier-golden-files.md` covering a timing trap that is not currently documented: during a minor code freeze, a new event applier version can land in a patch of the older minor but miss the new minor's initial release. When that happens, the upgrade path from that patch to the new minor is broken — the new minor cannot replay the new applier version, leaving partitions dead until an ad-hoc patch ships.

The doc now tells contributors to either hold off on porting new applier versions to stable branches during a minor code freeze, or to ensure the port lands in the minor release. The 8.9.0 incident with `ProcessEvent.TRIGGERING` v2 is included as a concrete example.

### Relation to #52071

[#52071](https://github.com/camunda/camunda/pull/52071) (Add `engine-expert` skill) explicitly calls out forward-port timing of new event applier versions as one of the silent-danger pitfalls that the skill surfaces *because the canonical docs don't cover it*, and lists "backport forward-port timing into canonical docs" as a follow-up. This PR is that follow-up. Once one of the two lands, the other should be adjusted: the skill in #52071 can drop the forward-port-timing pitfall from the "skill-only insights" list (or simply point at this doc), and this PR can drop the cross-reference.

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

- Incident channel: [#inc-zeebe-dead-partition-8-9](https://camunda.slack.com/archives/C0AV48RPUNL)
- Team report: [team-orchestration-cluster](https://camunda.slack.com/archives/C08F5RD5X8B/p1776783322722799)