### PR TITLE
fix: do not run multiple queries at the same time

### DIFF
--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/metrics/ProcessInstanceStartMeter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/metrics/ProcessInstanceStartMeter.java
@@ -55,16 +55,33 @@ public class ProcessInstanceStartMeter implements AutoCloseable {
 
   /** Starts the periodic checking for process instance availability. */
   public void start() {
-    piCheckExecutorService.scheduleAtFixedRate(
+    scheduleCheck(availabilityCheckInterval.toMillis());
+  }
+
+  private void scheduleCheck(final long delay) {
+    final var scheduleTime = System.nanoTime();
+    piCheckExecutorService.schedule(
         () -> {
           try {
             checkForProcessInstances();
           } catch (final Exception e) {
             LOG.error("Failed to check process instances. Will retry...", e);
+          } finally {
+            // We only schedule another check AFTER the previous is done
+            // This is to avoid multiple queries running at the same time, with quering the same
+            // data. Especially if the response takes longer than our schedule interval there is no
+            // point in running again in between.
+            // If responses are slow - we will time out the active instances eventually
+            final var elapsedTime = scheduleTime - System.nanoTime();
+            final var nextDelay =
+                TimeUnit.NANOSECONDS.toMillis(elapsedTime) > availabilityCheckInterval.toMillis()
+                    ? 0
+                    : availabilityCheckInterval.toMillis()
+                        - TimeUnit.NANOSECONDS.toMillis(elapsedTime);
+            scheduleCheck(nextDelay);
           }
         },
-        availabilityCheckInterval.toMillis(),
-        availabilityCheckInterval.toMillis(),
+        delay,
         TimeUnit.MILLISECONDS);
   }
 

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/metrics/ProcessInstanceStartMeter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/metrics/ProcessInstanceStartMeter.java
@@ -121,15 +121,13 @@ public class ProcessInstanceStartMeter implements AutoCloseable {
               final long duration = endQueryTime - startQueryTime;
               dataAvailabilityQueryDurationTimer.record(duration, TimeUnit.NANOSECONDS);
 
-              if (error != null) {
+              if (error == null) {
+                LOG.debug("Available process instances items: {}", availableInstances.size());
+                processAvailableInstances(availableInstances);
+              } else {
                 LOG.error("Error while checking for available process instances", error);
-                cleanUpStaleInstances();
-                rescheduleCheck(duration);
-                return;
               }
 
-              LOG.debug("Available process instances items: {}", availableInstances.size());
-              processAvailableInstances(availableInstances);
               cleanUpStaleInstances();
               rescheduleCheck(duration);
             },

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/metrics/ProcessInstanceStartMeter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/metrics/ProcessInstanceStartMeter.java
@@ -65,6 +65,7 @@ public class ProcessInstanceStartMeter implements AutoCloseable {
             checkForProcessInstances();
           } catch (final Exception e) {
             LOG.error("Failed to check process instances. Will retry...", e);
+            rescheduleCheck(0);
           }
         },
         delay,
@@ -106,6 +107,7 @@ public class ProcessInstanceStartMeter implements AutoCloseable {
   private void checkForProcessInstances() {
     if (startedInstances.isEmpty()) {
       LOG.debug("No instances awaiting, skip check for process instances.");
+      rescheduleCheck(0);
       return;
     }
 

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/metrics/ProcessInstanceStartMeter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/metrics/ProcessInstanceStartMeter.java
@@ -59,30 +59,38 @@ public class ProcessInstanceStartMeter implements AutoCloseable {
   }
 
   private void scheduleCheck(final long delay) {
-    final var scheduleTime = System.nanoTime();
     piCheckExecutorService.schedule(
         () -> {
           try {
             checkForProcessInstances();
           } catch (final Exception e) {
             LOG.error("Failed to check process instances. Will retry...", e);
-          } finally {
-            // We only schedule another check AFTER the previous is done
-            // This is to avoid multiple queries running at the same time, with quering the same
-            // data. Especially if the response takes longer than our schedule interval there is no
-            // point in running again in between.
-            // If responses are slow - we will time out the active instances eventually
-            final var elapsedTime = scheduleTime - System.nanoTime();
-            final var nextDelay =
-                TimeUnit.NANOSECONDS.toMillis(elapsedTime) > availabilityCheckInterval.toMillis()
-                    ? 0
-                    : availabilityCheckInterval.toMillis()
-                        - TimeUnit.NANOSECONDS.toMillis(elapsedTime);
-            scheduleCheck(nextDelay);
           }
         },
         delay,
         TimeUnit.MILLISECONDS);
+  }
+
+  /**
+   * Reschedule the process instance check with a delay computed based on the elapsed time, which is
+   * recorded for the previous query duration (in nanoseconds).
+   *
+   * <p>If the query already took longer then the check interval, we immediately retrigger the
+   * check.
+   *
+   * @param elapsedTime the elapsed time (duration) of the previous query in nanosecond
+   */
+  private void rescheduleCheck(final long elapsedTime) {
+    // We only reschedule another check AFTER the previous is done
+    // This is to avoid multiple queries running at the same time, with quering the same
+    // data. Especially if the response takes longer than our schedule interval there is no
+    // point in running again in between.
+    // If responses are slow - we will time out the active instances eventually
+    final var nextDelay =
+        TimeUnit.NANOSECONDS.toMillis(elapsedTime) > availabilityCheckInterval.toMillis()
+            ? 0
+            : availabilityCheckInterval.toMillis() - TimeUnit.NANOSECONDS.toMillis(elapsedTime);
+    scheduleCheck(nextDelay);
   }
 
   /** Stops the periodic checking for process instance availability. */
@@ -108,18 +116,20 @@ public class ProcessInstanceStartMeter implements AutoCloseable {
         .whenCompleteAsync(
             (availableInstances, error) -> {
               final var endQueryTime = clock.getNanos();
-              dataAvailabilityQueryDurationTimer.record(
-                  endQueryTime - startQueryTime, TimeUnit.NANOSECONDS);
+              final long duration = endQueryTime - startQueryTime;
+              dataAvailabilityQueryDurationTimer.record(duration, TimeUnit.NANOSECONDS);
 
               if (error != null) {
                 LOG.error("Error while checking for available process instances", error);
                 cleanUpStaleInstances();
+                rescheduleCheck(duration);
                 return;
               }
 
               LOG.debug("Available process instances items: {}", availableInstances.size());
               processAvailableInstances(availableInstances);
               cleanUpStaleInstances();
+              rescheduleCheck(duration);
             },
             piCheckExecutorService);
   }


### PR DESCRIPTION
## Description

 * Data availability was running in parallel; if the response took longer, this could cause unnecessary overhead, especially because the same PIs were requested
  * It would also give no benefit, as responses would take time and return the same values
  * We should wait for the response and then retry, and timeout the instances that are overdue


I think this was causing unnecessary overhead - also overload in certain scenarios like the max load test, where responses take longer, or with REST and the realistic workload.

In addition, it could cause a stream of logs to time out, as parallel requests were running and couldn't be completed in time see [related alert](https://camunda.slack.com/archives/C0ANMGS3D4Y/p1777388653568749)

> [!IMPORTANT]
>
> Influenced by https://github.com/camunda/camunda/pull/51508 and @lilspikey work. Thanks for this 🙇🏼 


