### PR TITLE
fix: set job poller log to ERROR

### DIFF
--- a/load-tests/load-tester/src/main/resources/application.yaml
+++ b/load-tests/load-tester/src/main/resources/application.yaml
@@ -10,6 +10,7 @@ server:
 logging:
   level:
     root: ${LOG_LEVEL:WARN}
+    io.camunda.client.job.poller: ERROR
     # Apache HC5 (used by CamundaClient's REST transport) logs every 503 retry
     # at INFO, flooding starter/worker pod logs under benchmark load when
     # LOG_LEVEL=INFO. Pin this package to WARN; override with


### PR DESCRIPTION
## Description

 * Job poller causes a lot of noisy logs when node is unavailable or RESOURCE_EXHAUSTED Turning off logging for it is the most appropriate right now

[Example alert](https://console.cloud.google.com/monitoring/alerting/alerts/0.o7876roe9bmu?channelType=slack&project=camunda-benchmark)

<img width="2015" height="615" alt="2026-04-29_16-57" src="https://github.com/user-attachments/assets/d409e006-6ecc-403e-88e2-db6f92242584" />



## Related issues

related https://github.com/camunda/camunda/issues/52134
