### PR TITLE
fix: always pass allowOverride: false for task assignment

### DIFF
--- a/tasklist/client/src/modules/api/index.ts
+++ b/tasklist/client/src/modules/api/index.ts
@@ -125,7 +125,12 @@ const api = {
       },
     });
   },
-  assignTask: (params: Pick<UserTask, 'userTaskKey'> & {assignee: string}) => {
+  assignTask: (
+    params: Pick<UserTask, 'userTaskKey'> & {
+      assignee: string;
+      allowOverride: boolean;
+    },
+  ) => {
     const {userTaskKey, ...body} = params;
     return new Request(getFullURL(endpoints.assignTask.getUrl({userTaskKey})), {
       ...BASE_REQUEST_OPTIONS,

--- a/tasklist/client/src/pages/TaskDetailsLayout/AssignButton/index.tsx
+++ b/tasklist/client/src/pages/TaskDetailsLayout/AssignButton/index.tsx
@@ -81,6 +81,7 @@ const AssignButton: React.FC<Props> = ({
       const result = await assignTask({
         userTaskKey: id,
         assignee: currentUser,
+        allowOverride: false,
       });
 
       if (result === null) {


### PR DESCRIPTION
## Description

Always pass `allowOverride: false` for task assignment to override API default

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #51814
