### PR TITLE
build: compute minor version from current version in migration IT

### DIFF
--- a/identity/client/package-lock.json
+++ b/identity/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "identity-frontend",
-  "version": "8.9.0-SNAPSHOT",
+  "version": "8.9.3-SNAPSHOT",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "identity-frontend",
-      "version": "8.9.0-SNAPSHOT",
+      "version": "8.9.3-SNAPSHOT",
       "dependencies": {
         "@camunda/camunda-api-zod-schemas": "0.0.56",
         "@camunda/camunda-composite-components": "0.22.6",

--- a/identity/client/package.json
+++ b/identity/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "identity-frontend",
   "private": true,
-  "version": "8.9.0-SNAPSHOT",
+  "version": "8.9.3-SNAPSHOT",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/operate/client/package-lock.json
+++ b/operate/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "camunda-operate",
-  "version": "8.9.0-SNAPSHOT",
+  "version": "8.9.3-SNAPSHOT",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "camunda-operate",
-      "version": "8.9.0-SNAPSHOT",
+      "version": "8.9.3-SNAPSHOT",
       "dependencies": {
         "@axe-core/playwright": "4.11.1",
         "@bpmn-io/element-template-icon-renderer": "1.0.0",

--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "camunda-operate",
-  "version": "8.9.0-SNAPSHOT",
+  "version": "8.9.3-SNAPSHOT",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -673,7 +673,7 @@
               <value>${version.identity}</value>
             </property>
           </systemProperties>
-          <excludedGroups>rdbms, multi-db-test, compatibility-test, nightly</excludedGroups>
+          <excludedGroups>rdbms, multi-db-test, compatibility-test, nightly, dl-nightly</excludedGroups>
         </configuration>
         <dependencies>
           <dependency>
@@ -699,6 +699,22 @@
   </build>
 
   <profiles>
+    <profile>
+      <id>dl-nightly</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration combine.self="override">
+              <groups>dl-nightly</groups>
+              <excludedGroups/>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
     <profile>
       <id>rdbms</id>
       <build>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/schema/ElasticsearchExporterMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/schema/ElasticsearchExporterMigrationIT.java
@@ -46,14 +46,14 @@ class ElasticsearchExporterMigrationIT {
   private static final String HTTP_PREFIX = "http://";
   private static final String ES_NETWORK_ALIAS = "test-elasticsearch";
 
-  private static Network network;
-  private static ElasticsearchContainer esContainer;
-  private static RestClientTransport transport;
-  private static ElasticsearchClient esClient;
-  private static RestClient restClient;
-  private static ExporterMigrationTestHelper testHelper;
-
   @TempDir private static Path dataDir;
+
+  private Network network;
+  private ElasticsearchContainer esContainer;
+  private RestClientTransport transport;
+  private ElasticsearchClient esClient;
+  private RestClient restClient;
+  private ExporterMigrationTestHelper testHelper;
 
   @BeforeEach
   void setUp() {
@@ -108,7 +108,7 @@ class ElasticsearchExporterMigrationIT {
 
   @ParameterizedTest(name = "Migrate from {0} to current version")
   @MethodSource("io.camunda.it.schema.ExporterMigrationTestHelper#fetchAllPatchesFromPreviousMinor")
-  @Tag("nightly")
+  @Tag("dl-nightly")
   @Timeout(value = 10, unit = TimeUnit.MINUTES)
   void shouldCompleteUpgradeWithBacklogAndExportAllRecordsAgainstReleasePatches(
       final String version) throws Exception {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/schema/ExporterMigrationTestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/schema/ExporterMigrationTestHelper.java
@@ -60,13 +60,13 @@ public class ExporterMigrationTestHelper {
   private static final String DEPLOYMENT_INDEX = "zeebe-record_deployment_*";
   private static final String ZEEBE_RECORD_INDEXES = "zeebe-record*";
 
-  private static final String PREVIOUS_VERSION_MINOR =
-      getMinorVersion(VersionUtil.getPreviousVersion());
-  private static final String CURRENT_VERSION_MINOR = getMinorVersion(VersionUtil.getVersion());
+  private static final String CURRENT_MINOR_VERSION = getCurrentMinorVersion();
+  private static final String PREVIOUS_MINOR_VERSION =
+      getPreviousMinorVersion(CURRENT_MINOR_VERSION);
   private static final String API_URL =
       String.format(
           "https://hub.docker.com/v2/repositories/camunda/camunda/tags?page_size=%d&name=%s",
-          100, PREVIOUS_VERSION_MINOR);
+          100, PREVIOUS_MINOR_VERSION);
 
   private static final String PROCESS_ID = "migration-test";
   private static final String JOB_TYPE = "test-job";
@@ -296,7 +296,7 @@ public class ExporterMigrationTestHelper {
           .join(30, TimeUnit.SECONDS);
     } finally {
       // ---- Phase 3: Stop previous version, extract volume to host ----
-      log.info("Phase 3: Stopping Camunda " + PREVIOUS_VERSION_MINOR + " and extracting volume");
+      log.info("Phase 3: Stopping Camunda " + version + " and extracting volume");
       camundaPrevious.stop();
     }
 
@@ -333,7 +333,7 @@ public class ExporterMigrationTestHelper {
     // ---- Phase 4: Start current version in-JVM, resume exporter, create instance #4 ----
     log.info(
         "Phase 4: Starting Camunda {} (in-JVM) with working dir: {}",
-        CURRENT_VERSION_MINOR,
+        CURRENT_MINOR_VERSION,
         workingDir);
     assertThat(Files.exists(workingDir.resolve("data")))
         .as("data directory should exist after extraction")
@@ -360,11 +360,11 @@ public class ExporterMigrationTestHelper {
 
     try {
       brokerCurrent.start().await(TestHealthProbe.READY, Duration.ofMinutes(3));
-      log.info("Camunda " + CURRENT_VERSION_MINOR + " broker started");
+      log.info("Camunda " + CURRENT_MINOR_VERSION + " broker started");
 
       // Resume exporter
       ExportingActuator.of(brokerCurrent).resume();
-      log.info("Resumed exporter on " + CURRENT_VERSION_MINOR);
+      log.info("Resumed exporter on " + CURRENT_MINOR_VERSION);
 
       try (final CamundaClient clientCurrent =
           brokerCurrent.newClientBuilder().preferRestOverGrpc(false).build()) {
@@ -372,7 +372,7 @@ public class ExporterMigrationTestHelper {
         // previous version
         // may not be immediately available after log replay
         final var instanceKey4 = new long[1];
-        Awaitility.await("create instance #4 on " + CURRENT_VERSION_MINOR)
+        Awaitility.await("create instance #4 on " + CURRENT_MINOR_VERSION)
             .atMost(Duration.ofSeconds(60))
             .pollInterval(Duration.ofSeconds(2))
             .ignoreExceptions()
@@ -383,7 +383,7 @@ public class ExporterMigrationTestHelper {
                   return true;
                 });
         instanceKeys.add(instanceKey4[0]);
-        log.info("Created instance #4 on {}: {}", CURRENT_VERSION_MINOR, instanceKey4[0]);
+        log.info("Created instance #4 on {}: {}", CURRENT_MINOR_VERSION, instanceKey4[0]);
 
         // ---- Phase 5: Complete all remaining jobs ----
         log.info("Phase 5: Completing remaining jobs");
@@ -527,11 +527,6 @@ public class ExporterMigrationTestHelper {
     return Integer.compare(patch1, patch2);
   }
 
-  public static String getMinorVersion(final String version) {
-    final String[] components = version.split("\\.");
-    return components[0] + "." + components[1];
-  }
-
   public static List<String> fetchLatestPatchFromPreviousMinor()
       throws IOException, InterruptedException {
     final List<String> allVersions = fetchAllPatchesFromPreviousMinor();
@@ -575,7 +570,7 @@ public class ExporterMigrationTestHelper {
 
     final List<String> allVersions = new ArrayList<>();
     for (final String tag : allTags) {
-      if (!tag.startsWith(PREVIOUS_VERSION_MINOR)) {
+      if (!tag.startsWith(PREVIOUS_MINOR_VERSION)) {
         continue;
       }
 
@@ -594,16 +589,41 @@ public class ExporterMigrationTestHelper {
     }
 
     if (allVersions.isEmpty()) {
-      throw new NoSuchElementException("No release images found for " + PREVIOUS_VERSION_MINOR);
+      throw new NoSuchElementException("No release images found for " + PREVIOUS_MINOR_VERSION);
     }
 
     allVersions.sort(ExporterMigrationTestHelper::comparePatches);
 
-    final String snapshotVersion = PREVIOUS_VERSION_MINOR + "-SNAPSHOT";
+    final String snapshotVersion = PREVIOUS_MINOR_VERSION + "-SNAPSHOT";
     if (allTags.contains(snapshotVersion)) {
       allVersions.add(snapshotVersion);
     }
 
     return allVersions;
+  }
+
+  private static String getCurrentMinorVersion() {
+    final String currentVersion = VersionUtil.getVersion();
+    if ("development".equalsIgnoreCase(currentVersion)) {
+      throw new RuntimeException("Current version cannot be determined");
+    }
+
+    final String[] components = currentVersion.split("\\.");
+    if (components.length < 2) {
+      throw new RuntimeException("Current version has invalid format: " + currentVersion);
+    }
+
+    return String.format("%s.%s", components[0], components[1]);
+  }
+
+  private static String getPreviousMinorVersion(final String currentMinorVersion) {
+    final String[] components = currentMinorVersion.split("\\.");
+    final int minor = Integer.parseInt(components[1]);
+    if (minor == 0) {
+      throw new RuntimeException(
+          "previous minor version cannot be determined from " + currentMinorVersion);
+    }
+
+    return String.format("%s.%s", components[0], String.valueOf(minor - 1));
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/schema/OpensearchExporterMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/schema/OpensearchExporterMigrationIT.java
@@ -13,8 +13,8 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.core5.http.HttpHost;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
@@ -33,18 +33,17 @@ public class OpensearchExporterMigrationIT {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(OpensearchExporterMigrationIT.class);
   private static final String OS_NETWORK_ALIAS = "test-opensearch";
-  private static final String HTTP_PREFIX = "http://";
-
-  private static Network network;
-  private static OpenSearchContainer osContainer;
-  private static ApacheHttpClient5Transport transport;
-  private static OpenSearchClient osClient;
-  private static ExporterMigrationTestHelper testHelper;
 
   @TempDir private static Path dataDir;
 
-  @BeforeAll
-  static void setUp() {
+  private Network network;
+  private OpenSearchContainer osContainer;
+  private ApacheHttpClient5Transport transport;
+  private OpenSearchClient osClient;
+  private ExporterMigrationTestHelper testHelper;
+
+  @BeforeEach
+  void setUp() {
     network = Network.newNetwork();
 
     osContainer =
@@ -84,8 +83,8 @@ public class OpensearchExporterMigrationIT {
             osClient, OS_NETWORK_ALIAS, network, osContainer.getHttpHostAddress(), dataDir, LOGGER);
   }
 
-  @AfterAll
-  static void tearDown() throws Exception {
+  @AfterEach
+  void tearDown() throws Exception {
     if (transport != null) {
       transport.close();
     }
@@ -108,7 +107,7 @@ public class OpensearchExporterMigrationIT {
 
   @ParameterizedTest(name = "Migrate from {0} to current version")
   @MethodSource("io.camunda.it.schema.ExporterMigrationTestHelper#fetchAllPatchesFromPreviousMinor")
-  @Tag("nightly")
+  @Tag("dl-nightly")
   @Timeout(value = 10, unit = TimeUnit.MINUTES)
   void shouldCompleteUpgradeWithBacklogAndExportAllRecordsAgainstReleasePatches(
       final String version) throws Exception {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
In runs like this:
https://github.com/camunda/camunda/actions/runs/25115162344/job/73605623903

when the current version is `8.9.something`, the previous minor version is expected to be `8.8`.
This is not currently achieved by VersionUtil.getPreviousVersion(), so this PR is implementing it the way the tests expect it.

This has been working as expected in this run:
https://github.com/camunda/camunda/actions/runs/25119091947/job/73614432598?pr=50510

Screenshots:

<img width="1337" height="648" alt="image" src="https://github.com/user-attachments/assets/10c7c41c-5ad3-47b6-bf30-179efa9461cd" />

<img width="1272" height="589" alt="image" src="https://github.com/user-attachments/assets/b0339207-8789-477b-9308-0defb816ed6a" />

In addition to this, the acceptance tests's POM has been slightly changed so that:
* data layer nightly tests are not executed in other PRs
* data layer nightly tests are executed only when the `dl-nightly` profile is activated with the verify command

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
