### PR TITLE
fix: remove public form from mock data

### DIFF
--- a/tasklist/data-generator/src/main/resources/startedByLinkedForm.bpmn
+++ b/tasklist/data-generator/src/main/resources/startedByLinkedForm.bpmn
@@ -40,9 +40,6 @@
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:extensionElements>
         <zeebe:formDefinition formId="Form_0mik7px" />
-        <zeebe:properties>
-          <zeebe:property name="publicAccess" value="true" />
-        </zeebe:properties>
       </bpmn:extensionElements>
       <bpmn:outgoing>Flow_15vkolf</bpmn:outgoing>
     </bpmn:startEvent>

--- a/tasklist/data-generator/src/main/resources/subscribeFormProcess.bpmn
+++ b/tasklist/data-generator/src/main/resources/subscribeFormProcess.bpmn
@@ -53,9 +53,6 @@
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:extensionElements>
         <zeebe:formDefinition formKey="camunda-forms:bpmn:subscribeForm" />
-        <zeebe:properties>
-          <zeebe:property name="publicAccess" value="true" />
-        </zeebe:properties>
       </bpmn:extensionElements>
       <bpmn:outgoing>Flow_15vkolf</bpmn:outgoing>
     </bpmn:startEvent>

--- a/tasklist/data-generator/src/main/resources/travelSearchProcess.bpmn
+++ b/tasklist/data-generator/src/main/resources/travelSearchProcess.bpmn
@@ -71,9 +71,6 @@
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:extensionElements>
         <zeebe:formDefinition formKey="camunda-forms:bpmn:travelForm" />
-        <zeebe:properties>
-          <zeebe:property name="publicAccess" value="true" />
-        </zeebe:properties>
       </bpmn:extensionElements>
       <bpmn:outgoing>Flow_15vkolf</bpmn:outgoing>
     </bpmn:startEvent>

--- a/tasklist/qa/integration-tests/src/test/resources/startedByFormProcess.bpmn
+++ b/tasklist/qa/integration-tests/src/test/resources/startedByFormProcess.bpmn
@@ -72,9 +72,6 @@
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:extensionElements>
         <zeebe:formDefinition formKey="camunda-forms:bpmn:testForm" />
-        <zeebe:properties>
-          <zeebe:property name="publicAccess" value="true" />
-        </zeebe:properties>
       </bpmn:extensionElements>
       <bpmn:outgoing>Flow_15vkolf</bpmn:outgoing>
     </bpmn:startEvent>

--- a/tasklist/qa/integration-tests/src/test/resources/startedByLinkedForm.bpmn
+++ b/tasklist/qa/integration-tests/src/test/resources/startedByLinkedForm.bpmn
@@ -73,9 +73,6 @@
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:extensionElements>
         <zeebe:formDefinition formId="Form_0mik7px" />
-        <zeebe:properties>
-          <zeebe:property name="publicAccess" value="true" />
-        </zeebe:properties>
       </bpmn:extensionElements>
       <bpmn:outgoing>Flow_15vkolf</bpmn:outgoing>
     </bpmn:startEvent>

--- a/tasklist/qa/integration-tests/src/test/resources/subscribeFormProcess.bpmn
+++ b/tasklist/qa/integration-tests/src/test/resources/subscribeFormProcess.bpmn
@@ -74,9 +74,6 @@
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:extensionElements>
         <zeebe:formDefinition formKey="camunda-forms:bpmn:subscribeForm" />
-        <zeebe:properties>
-          <zeebe:property name="publicAccess" value="true" />
-        </zeebe:properties>
       </bpmn:extensionElements>
       <bpmn:outgoing>Flow_15vkolf</bpmn:outgoing>
     </bpmn:startEvent>

--- a/tasklist/qa/integration-tests/src/test/resources/travelSearchProcess.bpmn
+++ b/tasklist/qa/integration-tests/src/test/resources/travelSearchProcess.bpmn
@@ -71,9 +71,6 @@
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:extensionElements>
         <zeebe:formDefinition formKey="camunda-forms:bpmn:travelForm" />
-        <zeebe:properties>
-          <zeebe:property name="publicAccess" value="true" />
-        </zeebe:properties>
       </bpmn:extensionElements>
       <bpmn:outgoing>Flow_15vkolf</bpmn:outgoing>
     </bpmn:startEvent>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Public start forms are not supported and since https://github.com/camunda/camunda/pull/51563 the engine refuses deployments with it

This PR fixes the mock data that still had it