### PR TITLE
feat: add AppCDS to reduce container startup time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -173,7 +173,7 @@ VOLUME /driver-lib
 COPY --from=jattach --chown=1001:0 /jattach /usr/local/bin/jattach
 COPY --link --chown=1001:0 zeebe/docker/utils/startup.sh /usr/local/bin/startup.sh
 COPY --from=dist --chown=1001:0 /zeebe/camunda-zeebe ${ZB_HOME}
-COPY --from=cds-gen --chown=1001:0 /usr/local/zeebe/camunda.jsa ${ZB_HOME}/camunda.jsa
+COPY --from=cds-gen --chown=1001:0 /usr/local/camunda/camunda.jsa ${ZB_HOME}/camunda.jsa
 
 RUN ln -s /driver-lib ${ZB_HOME}/driver-lib
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -89,17 +89,17 @@ FROM base-${BASE} AS cds-gen
 # hadolint ignore=DL3002
 USER root
 
-# Copy to /usr/local/camunda so classpath entries match the runtime image exactly.
+# Copy to /usr/local/zeebe so classpath entries match the runtime image exactly.
 # CDS archives are path-sensitive: if the classpath differs at load time the archive is ignored.
-COPY --from=dist --chown=root:root /zeebe/camunda-zeebe /usr/local/camunda
+COPY --from=dist --chown=root:root /zeebe/camunda-zeebe /usr/local/zeebe
 
 # Run a training boot: classes are recorded into camunda.jsa on JVM exit.
 # spring.context.exit=onRefresh causes a clean exit right after context refresh.
 # camunda.data.secondary-storage.type=NONE disables all DB/ES connections.
 # || true: any remaining failures are acceptable;
 #          the archive is still written because -XX:ArchiveClassesAtExit fires on any exit.
-RUN JAVA_OPTS="-XX:ArchiveClassesAtExit=/usr/local/camunda/camunda.jsa" \
-       /usr/local/camunda/bin/camunda \
+RUN JAVA_OPTS="-XX:ArchiveClassesAtExit=/usr/local/zeebe/camunda.jsa" \
+       /usr/local/zeebe/bin/camunda \
          --spring.context.exit=onRefresh \
          "--camunda.data.secondary-storage.type=NONE" \
     || true
@@ -173,7 +173,7 @@ VOLUME /driver-lib
 COPY --from=jattach --chown=1001:0 /jattach /usr/local/bin/jattach
 COPY --link --chown=1001:0 zeebe/docker/utils/startup.sh /usr/local/bin/startup.sh
 COPY --from=dist --chown=1001:0 /zeebe/camunda-zeebe ${ZB_HOME}
-COPY --from=cds-gen --chown=1001:0 /usr/local/camunda/camunda.jsa ${ZB_HOME}/camunda.jsa
+COPY --from=cds-gen --chown=1001:0 /usr/local/zeebe/camunda.jsa ${ZB_HOME}/camunda.jsa
 
 RUN ln -s /driver-lib ${ZB_HOME}/driver-lib
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,19 +88,22 @@ FROM base-${BASE} AS cds-gen
 
 # hadolint ignore=DL3002
 USER root
-WORKDIR /zeebe
 
-COPY --from=dist --chown=root:root /zeebe/camunda-zeebe ./camunda-zeebe
+# Copy to /usr/local/zeebe so classpath entries match the runtime image exactly.
+# CDS archives are path-sensitive: if the classpath differs at load time the archive is ignored.
+COPY --from=dist --chown=root:root /zeebe/camunda-zeebe /usr/local/zeebe
 
 # Run a training boot: classes are recorded into camunda.jsa on JVM exit.
 # spring.context.exit=onRefresh causes a clean exit right after context refresh.
 # camunda.data.secondary-storage.type=NONE disables all DB/ES connections.
+# config/ is on the classpath but CDS rejects non-empty directories; empty it first.
 # || true: any remaining failures are acceptable;
 #          the archive is still written because -XX:ArchiveClassesAtExit fires on any exit.
-RUN JAVA_OPTS="-XX:ArchiveClassesAtExit=/zeebe/camunda.jsa" \
-    ./camunda-zeebe/bin/camunda \
-      --spring.context.exit=onRefresh \
-      "--camunda.data.secondary-storage.type=NONE" \
+RUN find /usr/local/zeebe/config -mindepth 1 -delete \
+    && JAVA_OPTS="-XX:ArchiveClassesAtExit=/usr/local/zeebe/camunda.jsa" \
+       /usr/local/zeebe/bin/camunda \
+         --spring.context.exit=onRefresh \
+         "--camunda.data.secondary-storage.type=NONE" \
     || true
 
 ### Application Image ###
@@ -153,15 +156,15 @@ EXPOSE 8080 26500 26501 26502
 # Switch to root to allow setting up our own user
 USER root
 RUN addgroup --gid 1001 camunda && \
-    adduser -S -G camunda -u 1001 -h ${ZB_HOME} camunda && \
-    chmod g=u /etc/passwd && \
-    # These directories are to be mounted by users, eagerly creating them and setting ownership
-    # helps to avoid potential permission issues due to default volume ownership.
-    mkdir ${ZB_HOME}/data && \
-    mkdir ${ZB_HOME}/logs && \
-    mkdir ${ZB_HOME}/documents && \
-    chown -R 1001:0 ${ZB_HOME} && \
-    chmod -R 0775 ${ZB_HOME}
+  adduser -S -G camunda -u 1001 -h ${ZB_HOME} camunda && \
+  chmod g=u /etc/passwd && \
+  # These directories are to be mounted by users, eagerly creating them and setting ownership
+  # helps to avoid potential permission issues due to default volume ownership.
+  mkdir ${ZB_HOME}/data && \
+  mkdir ${ZB_HOME}/logs && \
+  mkdir ${ZB_HOME}/documents && \
+  chown -R 1001:0 ${ZB_HOME} && \
+  chmod -R 0775 ${ZB_HOME}
 
 VOLUME /tmp
 VOLUME ${ZB_HOME}/data
@@ -172,7 +175,7 @@ VOLUME /driver-lib
 COPY --from=jattach --chown=1001:0 /jattach /usr/local/bin/jattach
 COPY --link --chown=1001:0 zeebe/docker/utils/startup.sh /usr/local/bin/startup.sh
 COPY --from=dist --chown=1001:0 /zeebe/camunda-zeebe ${ZB_HOME}
-COPY --from=cds-gen --chown=1001:0 /zeebe/camunda.jsa ${ZB_HOME}/camunda.jsa
+COPY --from=cds-gen --chown=1001:0 /usr/local/zeebe/camunda.jsa ${ZB_HOME}/camunda.jsa
 
 RUN ln -s /driver-lib ${ZB_HOME}/driver-lib
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,6 +82,27 @@ RUN mkdir camunda-zeebe && \
 # hadolint ignore=DL3006
 FROM ${DIST} AS dist
 
+### AppCDS archive generation ###
+# hadolint ignore=DL3006
+FROM base-${BASE} AS cds-gen
+
+# hadolint ignore=DL3002
+USER root
+WORKDIR /zeebe
+
+COPY --from=dist --chown=root:root /zeebe/camunda-zeebe ./camunda-zeebe
+
+# Run a training boot: classes are recorded into camunda.jsa on JVM exit.
+# spring.context.exit=onRefresh causes a clean exit right after context refresh.
+# camunda.data.secondary-storage.type=NONE disables all DB/ES connections.
+# || true: any remaining failures are acceptable;
+#          the archive is still written because -XX:ArchiveClassesAtExit fires on any exit.
+RUN JAVA_OPTS="-XX:ArchiveClassesAtExit=/zeebe/camunda.jsa" \
+    ./camunda-zeebe/bin/camunda \
+      --spring.context.exit=onRefresh \
+      "--camunda.data.secondary-storage.type=NONE" \
+    || true
+
 ### Application Image ###
 # https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
 # hadolint ignore=DL3006
@@ -151,6 +172,7 @@ VOLUME /driver-lib
 COPY --from=jattach --chown=1001:0 /jattach /usr/local/bin/jattach
 COPY --link --chown=1001:0 zeebe/docker/utils/startup.sh /usr/local/bin/startup.sh
 COPY --from=dist --chown=1001:0 /zeebe/camunda-zeebe ${ZB_HOME}
+COPY --from=cds-gen --chown=1001:0 /zeebe/camunda.jsa ${ZB_HOME}/camunda.jsa
 
 RUN ln -s /driver-lib ${ZB_HOME}/driver-lib
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -89,19 +89,17 @@ FROM base-${BASE} AS cds-gen
 # hadolint ignore=DL3002
 USER root
 
-# Copy to /usr/local/zeebe so classpath entries match the runtime image exactly.
+# Copy to /usr/local/camunda so classpath entries match the runtime image exactly.
 # CDS archives are path-sensitive: if the classpath differs at load time the archive is ignored.
-COPY --from=dist --chown=root:root /zeebe/camunda-zeebe /usr/local/zeebe
+COPY --from=dist --chown=root:root /zeebe/camunda-zeebe /usr/local/camunda
 
 # Run a training boot: classes are recorded into camunda.jsa on JVM exit.
 # spring.context.exit=onRefresh causes a clean exit right after context refresh.
 # camunda.data.secondary-storage.type=NONE disables all DB/ES connections.
-# config/ is on the classpath but CDS rejects non-empty directories; empty it first.
 # || true: any remaining failures are acceptable;
 #          the archive is still written because -XX:ArchiveClassesAtExit fires on any exit.
-RUN find /usr/local/zeebe/config -mindepth 1 -delete \
-    && JAVA_OPTS="-XX:ArchiveClassesAtExit=/usr/local/zeebe/camunda.jsa" \
-       /usr/local/zeebe/bin/camunda \
+RUN JAVA_OPTS="-XX:ArchiveClassesAtExit=/usr/local/camunda/camunda.jsa" \
+       /usr/local/camunda/bin/camunda \
          --spring.context.exit=onRefresh \
          "--camunda.data.secondary-storage.type=NONE" \
     || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ ARG BASE="hardened"
 # set to "build" to build zeebe from scratch instead of using a distball
 ARG DIST="distball"
 
+ARG ZB_HOME=/usr/local/zeebe
+
 ### Base Application Image ###
 # hadolint ignore=DL3006
 FROM ${BASE_IMAGE}@${BASE_DIGEST} AS base-hardened
@@ -85,21 +87,22 @@ FROM ${DIST} AS dist
 ### AppCDS archive generation ###
 # hadolint ignore=DL3006
 FROM base-${BASE} AS cds-gen
+ARG ZB_HOME
 
 # hadolint ignore=DL3002
 USER root
 
-# Copy to /usr/local/zeebe so classpath entries match the runtime image exactly.
+# Copy to ${ZB_HOME} so classpath entries match the runtime image exactly.
 # CDS archives are path-sensitive: if the classpath differs at load time the archive is ignored.
-COPY --from=dist --chown=root:root /zeebe/camunda-zeebe /usr/local/zeebe
+COPY --from=dist --chown=root:root /zeebe/camunda-zeebe ${ZB_HOME}
 
 # Run a training boot: classes are recorded into camunda.jsa on JVM exit.
 # spring.context.exit=onRefresh causes a clean exit right after context refresh.
 # camunda.data.secondary-storage.type=NONE disables all DB/ES connections.
 # || true: any remaining failures are acceptable;
 #          the archive is still written because -XX:ArchiveClassesAtExit fires on any exit.
-RUN JAVA_OPTS="-XX:ArchiveClassesAtExit=/usr/local/zeebe/camunda.jsa" \
-       /usr/local/zeebe/bin/camunda \
+RUN JAVA_OPTS="-XX:ArchiveClassesAtExit=${ZB_HOME}/camunda.jsa" \
+       ${ZB_HOME}/bin/camunda \
          --spring.context.exit=onRefresh \
          "--camunda.data.secondary-storage.type=NONE" \
     || true
@@ -140,9 +143,10 @@ LABEL io.openshift.non-scalable="false"
 LABEL io.openshift.min-memory="512Mi"
 LABEL io.openshift.min-cpu="1"
 
-ENV ZB_HOME=/usr/local/zeebe \
-    ZEEBE_STANDALONE_GATEWAY=false \
-    ZEEBE_RESTORE=false
+ARG ZB_HOME
+ENV ZB_HOME=${ZB_HOME} \
+  ZEEBE_STANDALONE_GATEWAY=false \
+  ZEEBE_RESTORE=false
 ENV PATH="${ZB_HOME}/bin:${PATH}"
 # Disable RocksDB runtime check for musl, which launches `ldd` as a shell process
 # We know there's no need to check for musl on this image
@@ -173,7 +177,7 @@ VOLUME /driver-lib
 COPY --from=jattach --chown=1001:0 /jattach /usr/local/bin/jattach
 COPY --link --chown=1001:0 zeebe/docker/utils/startup.sh /usr/local/bin/startup.sh
 COPY --from=dist --chown=1001:0 /zeebe/camunda-zeebe ${ZB_HOME}
-COPY --from=cds-gen --chown=1001:0 /usr/local/zeebe/camunda.jsa ${ZB_HOME}/camunda.jsa
+COPY --from=cds-gen --chown=1001:0 ${ZB_HOME}/camunda.jsa ${ZB_HOME}/camunda.jsa
 
 RUN ln -s /driver-lib ${ZB_HOME}/driver-lib
 

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -919,10 +919,11 @@
           <copyConfigurationDirectory>true</copyConfigurationDirectory>
           <extraJvmArguments>-XX:+ExitOnOutOfMemoryError
             -Dfile.encoding=UTF-8 -Xshare:auto
+            -Dlog4j2.configurationFile=$BASEDIR/config/log4j2.xml
             ${jvm.module.opens}</extraJvmArguments>
           <!-- This will be added to the classpath as /urs/local/camunda/driver-lib/* -->
           <endorsedDir>driver-lib</endorsedDir>
-          <includeConfigurationDirectoryInClasspath>true</includeConfigurationDirectoryInClasspath>
+          <includeConfigurationDirectoryInClasspath>false</includeConfigurationDirectoryInClasspath>
           <platforms>
             <platform>windows</platform>
             <platform>unix</platform>

--- a/zeebe/docker/utils/startup.sh
+++ b/zeebe/docker/utils/startup.sh
@@ -1,5 +1,12 @@
 #!/bin/sh -xeu
 
+# Load AppCDS archive if present (generated at image build time).
+CDS_ARCHIVE="${ZB_HOME:-/usr/local/zeebe}/camunda.jsa"
+if [ -f "${CDS_ARCHIVE}" ]; then
+  JAVA_OPTS="${JAVA_OPTS:-} -XX:SharedArchiveFile=${CDS_ARCHIVE}"
+  export JAVA_OPTS
+fi
+
 if [ "$ZEEBE_STANDALONE_GATEWAY" = "true" ]; then
     exec /usr/local/zeebe/bin/gateway
 elif [ "$ZEEBE_RESTORE" = "true" ]; then


### PR DESCRIPTION
## Summary

- Adds a `cds-gen` Docker multi-stage build stage that runs a training boot of the application, recording all loaded JVM classes into a `.jsa` archive via `-XX:ArchiveClassesAtExit`
- Removes `config/` from the appassembler classpath (required by AppCDS — non-empty directories cannot be on the classpath at archive creation time) and points log4j2 to its config file via `-Dlog4j2.configurationFile=$BASEDIR/config/log4j2.xml`
- The archive is copied into the final image and loaded at startup via `-XX:SharedArchiveFile` in `startup.sh` when present
- `ZB_HOME` is defined as a global `ARG` in the Dockerfile and inherited by both `cds-gen` and `app` stages, ensuring the classpath paths recorded in the archive always match the runtime paths exactly (CDS archives are path-sensitive and will not load if the classpath differs

Inspired by comments in PR #13706

## How it works

1. `cds-gen` stage copies the distribution to `${ZB_HOME}` (matching the runtime path exactly — CDS is classpath-path-sensitive), then runs `bin/camunda` with `spring.context.exit=onRefresh` and `camunda.data.secondary-storage.type=NONE` to load all Spring/Camunda classes without connecting to any external service
2. The `.jsa` archive is written on JVM exit regardless of exit code
3. At runtime, `startup.sh` detects the archive and prepends `-XX:SharedArchiveFile` to `JAVA_OPTS` before exec-ing the broker/gateway/restore scripts

## Test plan

- [ ] `just install -pl dist -am` then `just docker` — build succeeds
- [ ] Run image with `-Xlog:cds=warning` — no "directory is not empty" warnings, archive loads silently
- [ ] Verify log4j2 output is correctly formatted (confirms `log4j2.xml` is found via the system property)
- [ ] Measure wall-clock time to first log line with and without `-Xshare:off` override to confirm improvement