### PR TITLE
PoC: CSV export of process instances in Operate

### DIFF
--- a/operate/client/src/App/Processes/ListView/InstancesTable/ExportButton.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/ExportButton.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Button, InlineLoading} from '@carbon/react';
+import {Download} from '@carbon/react/icons';
+import {observer} from 'mobx-react';
+import {useExportProcessInstances} from 'modules/mutations/processes/useExportProcessInstances';
+import {
+  useProcessInstancesSearchFilter,
+  useProcessInstancesSearchSort,
+} from 'modules/hooks/processInstancesSearch';
+import {variableFilterStore} from 'modules/stores/variableFilter';
+
+type Props = {
+  totalCount: number;
+};
+
+const ExportButton: React.FC<Props> = observer(({totalCount}) => {
+  const filter = useProcessInstancesSearchFilter(variableFilterStore.variable);
+  const sort = useProcessInstancesSearchSort();
+  const {mutate, isPending} = useExportProcessInstances();
+
+  const disabled = isPending || filter === undefined || totalCount === 0;
+
+  return (
+    <Button
+      kind="ghost"
+      size="sm"
+      disabled={disabled}
+      renderIcon={isPending ? undefined : Download}
+      onClick={() => {
+        if (filter !== undefined) {
+          mutate({filter, sort});
+        }
+      }}
+      data-testid="export-process-instances-csv"
+    >
+      {isPending ? (
+        <InlineLoading description="Exporting..." />
+      ) : (
+        'Export to CSV'
+      )}
+    </Button>
+  );
+});
+
+export {ExportButton};

--- a/operate/client/src/App/Processes/ListView/InstancesTable/index.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/index.tsx
@@ -23,6 +23,7 @@ import type {
   BatchOperationType,
 } from '@camunda/camunda-api-zod-schemas/8.10';
 import {batchModificationStore} from 'modules/stores/batchModification';
+import {ExportButton} from './ExportButton';
 import {Toolbar} from './Toolbar';
 import {getProcessInstanceFilters} from 'modules/utils/filter/getProcessInstanceFilters';
 import {useLocation, useSearchParams} from 'react-router-dom';
@@ -114,7 +115,9 @@ const InstancesTable: React.FC<InstancesTableProps> = observer(
           title="Process Instances"
           count={totalCount}
           hasMoreTotalItems={hasMoreTotalItems}
-        />
+        >
+          <ExportButton totalCount={totalCount} />
+        </PanelHeader>
         <Toolbar
           selectedInstancesCount={processInstancesSelectionStore.selectedCount}
         />

--- a/operate/client/src/App/Processes/ListView/InstancesTable/tests/ExportButton.test.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/tests/ExportButton.test.tsx
@@ -1,0 +1,153 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {render, screen, waitFor} from 'modules/testing-library';
+import userEvent from '@testing-library/user-event';
+import {MemoryRouter} from 'react-router-dom';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {mockServer} from 'modules/mock-server/node';
+import {http, HttpResponse} from 'msw';
+import {ExportButton} from '../ExportButton';
+import {variableFilterStore} from 'modules/stores/variableFilter';
+import {notificationsStore} from 'modules/stores/notifications';
+
+vi.mock('modules/stores/notifications', () => ({
+  notificationsStore: {
+    displayNotification: vi.fn(() => () => {}),
+  },
+}));
+
+const Wrapper: React.FC<{
+  children?: React.ReactNode;
+  initialEntries?: string[];
+}> = ({children, initialEntries = ['/processes?active=true']}) => (
+  <QueryClientProvider client={getMockQueryClient()}>
+    <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
+  </QueryClientProvider>
+);
+
+const setupBlobMocks = () => {
+  // jsdom does not implement createObjectURL/revokeObjectURL.
+  const createObjectURL = vi.fn(() => 'blob:mock-url');
+  const revokeObjectURL = vi.fn();
+  Object.defineProperty(URL, 'createObjectURL', {
+    configurable: true,
+    value: createObjectURL,
+  });
+  Object.defineProperty(URL, 'revokeObjectURL', {
+    configurable: true,
+    value: revokeObjectURL,
+  });
+  return {createObjectURL, revokeObjectURL};
+};
+
+describe('<ExportButton />', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupBlobMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+    variableFilterStore.reset();
+  });
+
+  it('is disabled when totalCount is 0', () => {
+    render(<ExportButton totalCount={0} />, {wrapper: Wrapper});
+    expect(screen.getByRole('button', {name: /export to csv/i})).toBeDisabled();
+  });
+
+  it('is enabled when results exist and triggers a CSV download', async () => {
+    let observedRequestBody: unknown;
+    mockServer.use(
+      http.post('/v2/process-instances/search.csv', async ({request}) => {
+        observedRequestBody = await request.json();
+        return new HttpResponse('header,row\nvalue,1\n', {
+          status: 200,
+          headers: {'Content-Type': 'text/csv;charset=UTF-8'},
+        });
+      }),
+    );
+
+    const clickAnchor = vi.fn();
+    const originalCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      const el = originalCreateElement(tag);
+      if (tag === 'a') {
+        el.click = clickAnchor;
+      }
+      return el;
+    });
+
+    render(<ExportButton totalCount={10} />, {wrapper: Wrapper});
+
+    const button = screen.getByRole('button', {name: /export to csv/i});
+    expect(button).toBeEnabled();
+
+    await userEvent.click(button);
+
+    await waitFor(() => expect(clickAnchor).toHaveBeenCalledTimes(1));
+    expect(observedRequestBody).toEqual(
+      expect.objectContaining({filter: expect.any(Object)}),
+    );
+    expect(notificationsStore.displayNotification).not.toHaveBeenCalled();
+  });
+
+  it('shows a truncation notification when the response sets the truncated header', async () => {
+    mockServer.use(
+      http.post('/v2/process-instances/search.csv', () => {
+        return new HttpResponse('header\n', {
+          status: 200,
+          headers: {
+            'Content-Type': 'text/csv;charset=UTF-8',
+            'X-Camunda-Export-Truncated': 'true',
+          },
+        });
+      }),
+    );
+
+    const originalCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      const el = originalCreateElement(tag);
+      if (tag === 'a') {
+        el.click = vi.fn();
+      }
+      return el;
+    });
+
+    render(<ExportButton totalCount={1_000_000} />, {wrapper: Wrapper});
+    await userEvent.click(screen.getByRole('button', {name: /export to csv/i}));
+
+    await waitFor(() =>
+      expect(notificationsStore.displayNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: 'info',
+          title: 'Export was truncated',
+        }),
+      ),
+    );
+  });
+
+  it('shows an error notification when the export request fails', async () => {
+    mockServer.use(
+      http.post('/v2/process-instances/search.csv', () =>
+        HttpResponse.json({error: 'boom'}, {status: 500}),
+      ),
+    );
+
+    render(<ExportButton totalCount={5} />, {wrapper: Wrapper});
+    await userEvent.click(screen.getByRole('button', {name: /export to csv/i}));
+
+    await waitFor(() =>
+      expect(notificationsStore.displayNotification).toHaveBeenCalledWith(
+        expect.objectContaining({kind: 'error'}),
+      ),
+    );
+  });
+});

--- a/operate/client/src/modules/api/v2/processInstances/exportProcessInstances.ts
+++ b/operate/client/src/modules/api/v2/processInstances/exportProcessInstances.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {type QueryProcessInstancesRequestBody} from '@camunda/camunda-api-zod-schemas/8.10';
+import {request, type RequestError} from 'modules/request';
+
+const EXPORT_URL = '/v2/process-instances/search.csv';
+const TRUNCATED_HEADER = 'x-camunda-export-truncated';
+
+type ExportResult = {
+  blob: Blob;
+  truncated: boolean;
+};
+
+const exportProcessInstancesCsv = async (
+  payload: QueryProcessInstancesRequestBody,
+): Promise<
+  | {response: ExportResult; error: null}
+  | {response: null; error: RequestError}
+> => {
+  try {
+    const response = await request({
+      url: EXPORT_URL,
+      method: 'POST',
+      body: payload,
+      headers: {Accept: 'text/csv'},
+    });
+
+    if (!response.ok) {
+      return {
+        response: null,
+        error: {response, networkError: null, variant: 'failed-response'},
+      };
+    }
+
+    return {
+      response: {
+        blob: await response.blob(),
+        truncated: response.headers.get(TRUNCATED_HEADER) === 'true',
+      },
+      error: null,
+    };
+  } catch (networkError) {
+    return {
+      response: null,
+      error: {response: null, networkError, variant: 'network-error'},
+    };
+  }
+};
+
+export {exportProcessInstancesCsv};
+export type {ExportResult};

--- a/operate/client/src/modules/api/v2/processInstances/exportProcessInstances.ts
+++ b/operate/client/src/modules/api/v2/processInstances/exportProcessInstances.ts
@@ -20,8 +20,7 @@ type ExportResult = {
 const exportProcessInstancesCsv = async (
   payload: QueryProcessInstancesRequestBody,
 ): Promise<
-  | {response: ExportResult; error: null}
-  | {response: null; error: RequestError}
+  {response: ExportResult; error: null} | {response: null; error: RequestError}
 > => {
   try {
     const response = await request({

--- a/operate/client/src/modules/mutations/processes/useExportProcessInstances.ts
+++ b/operate/client/src/modules/mutations/processes/useExportProcessInstances.ts
@@ -25,7 +25,10 @@ const triggerBrowserDownload = (blob: Blob) => {
   document.body.appendChild(link);
   link.click();
   document.body.removeChild(link);
-  URL.revokeObjectURL(url);
+  // Defer revocation so Safari/Firefox have time to actually start the download
+  // before the blob URL is invalidated. Synchronous revoke is observed to cancel
+  // the download in some browsers.
+  setTimeout(() => URL.revokeObjectURL(url), 1_000);
 };
 
 const formatStamp = (date: Date) =>

--- a/operate/client/src/modules/mutations/processes/useExportProcessInstances.ts
+++ b/operate/client/src/modules/mutations/processes/useExportProcessInstances.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useMutation} from '@tanstack/react-query';
+import type {QueryProcessInstancesRequestBody} from '@camunda/camunda-api-zod-schemas/8.10';
+import {
+  exportProcessInstancesCsv,
+  type ExportResult,
+} from 'modules/api/v2/processInstances/exportProcessInstances';
+import {notificationsStore} from 'modules/stores/notifications';
+import {handleOperationError} from 'modules/utils/notifications';
+import {tracking} from 'modules/tracking';
+import type {RequestError} from 'modules/request';
+
+const triggerBrowserDownload = (blob: Blob) => {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = `process-instances-${formatStamp(new Date())}.csv`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+};
+
+const formatStamp = (date: Date) =>
+  date.toISOString().replace(/[:.]/g, '-').replace(/-\d{3}Z$/, 'Z');
+
+const useExportProcessInstances = () => {
+  return useMutation<ExportResult, RequestError, QueryProcessInstancesRequestBody>({
+    mutationKey: ['exportProcessInstancesCsv'],
+    mutationFn: async (payload) => {
+      const {response, error} = await exportProcessInstancesCsv(payload);
+      if (response !== null) {
+        return response;
+      }
+      throw error;
+    },
+    onSuccess: (result) => {
+      triggerBrowserDownload(result.blob);
+      if (result.truncated) {
+        notificationsStore.displayNotification({
+          kind: 'info',
+          title: 'Export was truncated',
+          subtitle:
+            'Only the first batch of matching process instances was exported. Refine your filter to export the full set.',
+          isDismissable: true,
+        });
+      }
+      tracking.track({
+        eventName: 'process-instances-export',
+        format: 'csv',
+        truncated: result.truncated,
+      });
+    },
+    onError: (error) => {
+      handleOperationError(
+        error.variant === 'failed-response' ? error.response.status : 0,
+      );
+    },
+  });
+};
+
+export {useExportProcessInstances};

--- a/operate/client/src/modules/mutations/processes/useExportProcessInstances.ts
+++ b/operate/client/src/modules/mutations/processes/useExportProcessInstances.ts
@@ -32,10 +32,17 @@ const triggerBrowserDownload = (blob: Blob) => {
 };
 
 const formatStamp = (date: Date) =>
-  date.toISOString().replace(/[:.]/g, '-').replace(/-\d{3}Z$/, 'Z');
+  date
+    .toISOString()
+    .replace(/[:.]/g, '-')
+    .replace(/-\d{3}Z$/, 'Z');
 
 const useExportProcessInstances = () => {
-  return useMutation<ExportResult, RequestError, QueryProcessInstancesRequestBody>({
+  return useMutation<
+    ExportResult,
+    RequestError,
+    QueryProcessInstancesRequestBody
+  >({
     mutationKey: ['exportProcessInstancesCsv'],
     mutationFn: async (payload) => {
       const {response, error} = await exportProcessInstancesCsv(payload);

--- a/operate/client/src/modules/tracking/index.ts
+++ b/operate/client/src/modules/tracking/index.ts
@@ -61,6 +61,11 @@ type Events =
       operationType: BatchOperationType;
     }
   | {
+      eventName: 'process-instances-export';
+      format: 'csv';
+      truncated: boolean;
+    }
+  | {
       eventName: 'single-operation';
       operationType: BatchOperationType;
       source: 'instances-list' | 'incident-table' | 'instance-header';

--- a/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
@@ -24,6 +24,7 @@ import io.camunda.search.entities.SequenceFlowEntity;
 import io.camunda.search.filter.FilterBuilders;
 import io.camunda.search.filter.Operation;
 import io.camunda.search.filter.ProcessInstanceFilter;
+import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.search.query.SearchQueryResult;
@@ -72,6 +73,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -191,6 +193,54 @@ public final class ProcessInstanceServices
       final Function<ProcessInstanceQuery.Builder, ObjectBuilder<ProcessInstanceQuery>> fn,
       final CamundaAuthentication authentication) {
     return search(processInstanceSearchQuery(fn), authentication);
+  }
+
+  /**
+   * Streams process-instance results matching {@code query} into {@code rowSink}, paging through
+   * via the result's end-cursor. Stops when the matching set is exhausted or {@code maxRows} have
+   * been emitted (whichever comes first). The query's own page parameters are ignored — pagination
+   * is driven by this method.
+   *
+   * @return {@code true} if the cap was reached with results still pending (truncated), {@code
+   *     false} if the matching set was fully streamed.
+   */
+  public boolean streamSearch(
+      final ProcessInstanceQuery query,
+      final CamundaAuthentication authentication,
+      final Consumer<ProcessInstanceEntity> rowSink,
+      final int maxRows,
+      final int pageSize) {
+    String afterCursor = null;
+    int emitted = 0;
+    while (emitted < maxRows) {
+      final int remaining = maxRows - emitted;
+      final int batchSize = Math.min(pageSize, remaining);
+      final String cursor = afterCursor;
+      final var pagedQuery =
+          new ProcessInstanceQuery(
+              query.filter(),
+              query.sort(),
+              SearchQueryPage.of(b -> b.from(0).size(batchSize).after(cursor)),
+              query.resultConfig());
+      final var result = search(pagedQuery, authentication);
+      final var items = result.items();
+      if (items.isEmpty()) {
+        return false;
+      }
+      for (final var item : items) {
+        rowSink.accept(item);
+        emitted++;
+      }
+      if (items.size() < batchSize || result.endCursor() == null) {
+        return false;
+      }
+      afterCursor = result.endCursor();
+    }
+    // Capped at maxRows with a cursor still available — caller may have more matches than were
+    // streamed. Note: in the rare case where the matching set is exactly maxRows and a non-null
+    // cursor is still returned, we may report truncated=true even though no more items exist; that
+    // is an acceptable false positive (user just sees a "refine your filter" hint).
+    return true;
   }
 
   public List<ProcessFlowNodeStatisticsEntity> elementStatistics(

--- a/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
@@ -196,10 +196,11 @@ public final class ProcessInstanceServices
   }
 
   /**
-   * Streams process-instance results matching {@code query} into {@code rowSink}, paging through
+   * Streams pages of process-instance results matching {@code query} into {@code pageSink}, paging
    * via the result's end-cursor. Stops when the matching set is exhausted or {@code maxRows} have
    * been emitted (whichever comes first). The query's own page parameters are ignored — pagination
-   * is driven by this method.
+   * is driven by this method. The page consumer receives each batch as a list so callers can run
+   * batch-level enrichment (e.g. fetch incidents/variables in bulk per page).
    *
    * @return {@code true} if the cap was reached with results still pending (truncated), {@code
    *     false} if the matching set was fully streamed.
@@ -207,7 +208,7 @@ public final class ProcessInstanceServices
   public boolean streamSearch(
       final ProcessInstanceQuery query,
       final CamundaAuthentication authentication,
-      final Consumer<ProcessInstanceEntity> rowSink,
+      final Consumer<List<ProcessInstanceEntity>> pageSink,
       final int maxRows,
       final int pageSize) {
     String afterCursor = null;
@@ -227,10 +228,8 @@ public final class ProcessInstanceServices
       if (items.isEmpty()) {
         return false;
       }
-      for (final var item : items) {
-        rowSink.accept(item);
-        emitted++;
-      }
+      pageSink.accept(items);
+      emitted += items.size();
       if (items.size() < batchSize || result.endCursor() == null) {
         return false;
       }

--- a/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
@@ -142,6 +142,61 @@ public final class ProcessInstanceServiceTest {
   }
 
   @Test
+  public void shouldStreamProcessInstancesUntilExhausted() {
+    // given — a single page of results that is shorter than the requested batch size, signalling
+    // the matching set is fully drained.
+    final var entityA =
+        Instancio.of(ProcessInstanceEntity.class)
+            .set(field(ProcessInstanceEntity::processInstanceKey), 1L)
+            .create();
+    final var entityB =
+        Instancio.of(ProcessInstanceEntity.class)
+            .set(field(ProcessInstanceEntity::processInstanceKey), 2L)
+            .create();
+    when(processInstanceSearchClient.searchProcessInstances(any()))
+        .thenReturn(
+            SearchQueryResult.<ProcessInstanceEntity>of(
+                b -> b.total(2).items(List.of(entityA, entityB))));
+
+    final ProcessInstanceQuery query = SearchQueryBuilders.processInstanceSearchQuery().build();
+    final List<ProcessInstanceEntity> emitted = new ArrayList<>();
+
+    // when
+    final boolean truncated =
+        services.streamSearch(query, authentication, emitted::add, /* maxRows= */ 1000, /* pageSize= */ 100);
+
+    // then
+    assertThat(truncated).isFalse();
+    assertThat(emitted).containsExactly(entityA, entityB);
+  }
+
+  @Test
+  public void shouldStopStreamAtMaxRowsCap() {
+    // given — every page is full and exposes a cursor, so the only thing that stops the loop is
+    // hitting the configured cap.
+    final var entity =
+        Instancio.of(ProcessInstanceEntity.class)
+            .set(field(ProcessInstanceEntity::processInstanceKey), 99L)
+            .create();
+    when(processInstanceSearchClient.searchProcessInstances(any()))
+        .thenAnswer(
+            invocation ->
+                SearchQueryResult.<ProcessInstanceEntity>of(
+                    b -> b.total(1000).items(List.of(entity, entity)).endCursor("next")));
+
+    final ProcessInstanceQuery query = SearchQueryBuilders.processInstanceSearchQuery().build();
+    final List<ProcessInstanceEntity> emitted = new ArrayList<>();
+
+    // when — cap is 4, page size is 2 → exactly two iterations before the cap is reached
+    final boolean truncated =
+        services.streamSearch(query, authentication, emitted::add, /* maxRows= */ 4, /* pageSize= */ 2);
+
+    // then
+    assertThat(truncated).isTrue();
+    assertThat(emitted).hasSize(4);
+  }
+
+  @Test
   public void shouldReturnProcessInstanceSequenceFlows() {
     // given
     final SearchQueryResult<SequenceFlowEntity> result =

--- a/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
@@ -163,7 +163,8 @@ public final class ProcessInstanceServiceTest {
 
     // when
     final boolean truncated =
-        services.streamSearch(query, authentication, emitted::add, /* maxRows= */ 1000, /* pageSize= */ 100);
+        services.streamSearch(
+            query, authentication, emitted::addAll, /* maxRows= */ 1000, /* pageSize= */ 100);
 
     // then
     assertThat(truncated).isFalse();
@@ -189,7 +190,8 @@ public final class ProcessInstanceServiceTest {
 
     // when — cap is 4, page size is 2 → exactly two iterations before the cap is reached
     final boolean truncated =
-        services.streamSearch(query, authentication, emitted::add, /* maxRows= */ 4, /* pageSize= */ 2);
+        services.streamSearch(
+            query, authentication, emitted::addAll, /* maxRows= */ 4, /* pageSize= */ 2);
 
     // then
     assertThat(truncated).isTrue();

--- a/zeebe/gateway-rest/pom.xml
+++ b/zeebe/gateway-rest/pom.xml
@@ -262,6 +262,19 @@
       <scope>provided</scope>
     </dependency>
 
+    <!-- CSV writer for /v2/process-instances/search.csv -->
+    <dependency>
+      <groupId>com.opencsv</groupId>
+      <artifactId>opencsv</artifactId>
+      <version>5.12.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
     <!-- test dependencies -->
     <dependency>
       <groupId>io.camunda</groupId>

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/GatewayRestConfiguration.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/GatewayRestConfiguration.java
@@ -16,6 +16,8 @@ public class GatewayRestConfiguration {
   private final ProcessCacheConfiguration processCache = new ProcessCacheConfiguration();
   private final ApiExecutorConfiguration apiExecutor = new ApiExecutorConfiguration();
   private final JobMetricsConfiguration jobMetrics = new JobMetricsConfiguration();
+  private final ProcessInstanceExportConfiguration processInstanceExport =
+      new ProcessInstanceExportConfiguration();
   private int maxNameFieldLength = DEFAULT_MAX_NAME_FIELD_LENGTH;
 
   public ProcessCacheConfiguration getProcessCache() {
@@ -28,6 +30,10 @@ public class GatewayRestConfiguration {
 
   public JobMetricsConfiguration getJobMetrics() {
     return jobMetrics;
+  }
+
+  public ProcessInstanceExportConfiguration getProcessInstanceExport() {
+    return processInstanceExport;
   }
 
   /**
@@ -266,6 +272,54 @@ public class GatewayRestConfiguration {
 
     public void setEnabled(final boolean enabled) {
       this.enabled = enabled;
+    }
+  }
+
+  /**
+   * Configuration for the {@code POST /v2/process-instances/search.csv} endpoint that streams the
+   * filtered process-instance grid as CSV for offline analysis.
+   *
+   * <p>Bound under {@code camunda.rest.process-instance-export.*}.
+   */
+  public static class ProcessInstanceExportConfiguration {
+
+    private static final int DEFAULT_MAX_ROWS = 50_000;
+    private static final int DEFAULT_PAGE_SIZE = 1_000;
+
+    /**
+     * Hard cap on the number of rows a single export request will stream. Beyond this the response
+     * is truncated and the {@code X-Camunda-Export-Truncated} header is set so clients can warn the
+     * user. Default: {@link #DEFAULT_MAX_ROWS}.
+     */
+    private int maxRows = DEFAULT_MAX_ROWS;
+
+    /**
+     * Internal page size used to walk the matching set via cursor pagination. Larger values reduce
+     * round-trips to secondary storage; smaller values keep memory pressure lower. Default: {@link
+     * #DEFAULT_PAGE_SIZE}.
+     */
+    private int pageSize = DEFAULT_PAGE_SIZE;
+
+    public int getMaxRows() {
+      return maxRows;
+    }
+
+    public void setMaxRows(final int maxRows) {
+      if (maxRows <= 0) {
+        throw new IllegalArgumentException("maxRows must be > 0 (was " + maxRows + ")");
+      }
+      this.maxRows = maxRows;
+    }
+
+    public int getPageSize() {
+      return pageSize;
+    }
+
+    public void setPageSize(final int pageSize) {
+      if (pageSize <= 0) {
+        throw new IllegalArgumentException("pageSize must be > 0 (was " + pageSize + ")");
+      }
+      this.pageSize = pageSize;
     }
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/GatewayRestConfiguration.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/GatewayRestConfiguration.java
@@ -287,9 +287,11 @@ public class GatewayRestConfiguration {
     private static final int DEFAULT_PAGE_SIZE = 1_000;
 
     /**
-     * Hard cap on the number of rows a single export request will stream. Beyond this the response
-     * is truncated and the {@code X-Camunda-Export-Truncated} header is set so clients can warn the
-     * user. Default: {@link #DEFAULT_MAX_ROWS}.
+     * Cap on the number of rows a single export request will stream. Beyond this the response is
+     * truncated and the {@code X-Camunda-Export-Truncated} header is set so clients can warn the
+     * user. Default: {@link #DEFAULT_MAX_ROWS}. Operators who need larger exports can override at
+     * their own discretion — at some point the bottleneck moves from this cap to streaming timeouts
+     * / BI-tool memory and a real reporting pipeline becomes the right answer.
      */
     private int maxRows = DEFAULT_MAX_ROWS;
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
@@ -363,8 +363,7 @@ public class ProcessInstanceController {
       final ProcessInstanceCsvWriter writer,
       final List<ProcessInstanceEntity> page,
       final CamundaAuthentication auth) {
-    final List<Long> keys =
-        page.stream().map(ProcessInstanceEntity::processInstanceKey).toList();
+    final List<Long> keys = page.stream().map(ProcessInstanceEntity::processInstanceKey).toList();
     final Map<Long, String> incidentMessages = fetchActiveIncidentMessages(keys, auth);
     final Map<Long, String> variablesJson = fetchVariablesAsJson(keys, auth);
     for (final var entity : page) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
@@ -400,7 +400,10 @@ public class ProcessInstanceController {
     } catch (final Exception e) {
       // Don't fail the whole export if the user lacks INCIDENT_READ or the search hiccups —
       // the row just gets a blank Incident Message column.
-      LOG.warn("Could not enrich CSV export with incident messages: {}", e.getMessage());
+      LOG.warn(
+          "Could not enrich CSV export with incident messages for {} process instance(s); leaving the column blank.",
+          keys.size(),
+          e);
       return Map.of();
     }
   }
@@ -442,7 +445,10 @@ public class ProcessInstanceController {
       }
       return out;
     } catch (final Exception e) {
-      LOG.warn("Could not enrich CSV export with variables: {}", e.getMessage());
+      LOG.warn(
+          "Could not enrich CSV export with variables for {} process instance(s); leaving the column blank.",
+          keys.size(),
+          e);
       return Map.of();
     }
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
@@ -9,6 +9,8 @@ package io.camunda.zeebe.gateway.rest.controller;
 
 import static io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper.mapErrorToResponse;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.camunda.gateway.mapping.http.RequestMapper;
 import io.camunda.gateway.mapping.http.ResponseMapper;
 import io.camunda.gateway.mapping.http.search.SearchQueryRequestMapper;
@@ -27,11 +29,18 @@ import io.camunda.gateway.protocol.model.ProcessInstanceModificationBatchOperati
 import io.camunda.gateway.protocol.model.ProcessInstanceModificationInstruction;
 import io.camunda.gateway.protocol.model.ProcessInstanceSearchQuery;
 import io.camunda.gateway.protocol.model.ProcessInstanceSearchQueryResult;
+import io.camunda.search.entities.IncidentEntity;
+import io.camunda.search.entities.IncidentEntity.IncidentState;
+import io.camunda.search.entities.ProcessInstanceEntity;
+import io.camunda.search.filter.Operation;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.ProcessInstanceQuery;
+import io.camunda.search.query.VariableQuery;
+import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
+import io.camunda.service.IncidentServices;
 import io.camunda.service.ProcessInstanceServices;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceCancelRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceCreateRequest;
@@ -39,6 +48,7 @@ import io.camunda.service.ProcessInstanceServices.ProcessInstanceMigrateBatchOpe
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceMigrateRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyBatchOperationRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyRequest;
+import io.camunda.service.VariableServices;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
@@ -48,8 +58,15 @@ import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -66,18 +83,26 @@ public class ProcessInstanceController {
   private static final String CSV_CONTENT_TYPE = "text/csv; charset=UTF-8";
   private static final DateTimeFormatter FILENAME_TIMESTAMP =
       DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss'Z'").withZone(ZoneOffset.UTC);
+  private static final Logger LOG = LoggerFactory.getLogger(ProcessInstanceController.class);
+  private static final ObjectMapper EXPORT_JSON = new ObjectMapper();
 
   private final ProcessInstanceServices processInstanceServices;
+  private final IncidentServices incidentServices;
+  private final VariableServices variableServices;
   private final MultiTenancyConfiguration multiTenancyCfg;
   private final CamundaAuthenticationProvider authenticationProvider;
   private final GatewayRestConfiguration gatewayRestConfiguration;
 
   public ProcessInstanceController(
       final ProcessInstanceServices processInstanceServices,
+      final IncidentServices incidentServices,
+      final VariableServices variableServices,
       final MultiTenancyConfiguration multiTenancyCfg,
       final CamundaAuthenticationProvider authenticationProvider,
       final GatewayRestConfiguration gatewayRestConfiguration) {
     this.processInstanceServices = processInstanceServices;
+    this.incidentServices = incidentServices;
+    this.variableServices = variableServices;
     this.multiTenancyCfg = multiTenancyCfg;
     this.authenticationProvider = authenticationProvider;
     this.gatewayRestConfiguration = gatewayRestConfiguration;
@@ -319,7 +344,8 @@ public class ProcessInstanceController {
         out -> {
           try (var writer = ProcessInstanceCsvWriter.open(out, tenantColumn)) {
             writer.writeHeader();
-            processInstanceServices.streamSearch(query, auth, writer::writeRow, maxRows, pageSize);
+            processInstanceServices.streamSearch(
+                query, auth, page -> writeEnrichedPage(writer, page, auth), maxRows, pageSize);
           }
         };
 
@@ -331,6 +357,95 @@ public class ProcessInstanceController {
       builder.header(EXPORT_TRUNCATED_HEADER, "true");
     }
     return builder.body(body);
+  }
+
+  private void writeEnrichedPage(
+      final ProcessInstanceCsvWriter writer,
+      final List<ProcessInstanceEntity> page,
+      final CamundaAuthentication auth) {
+    final List<Long> keys =
+        page.stream().map(ProcessInstanceEntity::processInstanceKey).toList();
+    final Map<Long, String> incidentMessages = fetchActiveIncidentMessages(keys, auth);
+    final Map<Long, String> variablesJson = fetchVariablesAsJson(keys, auth);
+    for (final var entity : page) {
+      final Long key = entity.processInstanceKey();
+      writer.writeRow(
+          entity, incidentMessages.getOrDefault(key, ""), variablesJson.getOrDefault(key, ""));
+    }
+  }
+
+  private Map<Long, String> fetchActiveIncidentMessages(
+      final List<Long> keys, final CamundaAuthentication auth) {
+    if (keys.isEmpty()) {
+      return Map.of();
+    }
+    try {
+      final var result =
+          incidentServices.search(
+              IncidentQuery.of(
+                  b ->
+                      b.filter(
+                              f ->
+                                  f.processInstanceKeyOperations(Operation.in(keys))
+                                      .states(IncidentState.ACTIVE.name()))
+                          .unlimited()),
+              auth);
+      // Multiple incidents per instance are possible — surface the most recent one's message.
+      return result.items().stream()
+          .sorted(Comparator.comparing(IncidentEntity::creationTime).reversed())
+          .collect(
+              Collectors.toMap(
+                  IncidentEntity::processInstanceKey,
+                  IncidentEntity::errorMessage,
+                  (first, ignored) -> first));
+    } catch (final Exception e) {
+      // Don't fail the whole export if the user lacks INCIDENT_READ or the search hiccups —
+      // the row just gets a blank Incident Message column.
+      LOG.warn("Could not enrich CSV export with incident messages: {}", e.getMessage());
+      return Map.of();
+    }
+  }
+
+  private Map<Long, String> fetchVariablesAsJson(
+      final List<Long> keys, final CamundaAuthentication auth) {
+    if (keys.isEmpty()) {
+      return Map.of();
+    }
+    try {
+      final var result =
+          variableServices.search(
+              VariableQuery.of(
+                  b ->
+                      b.filter(f -> f.processInstanceKeyOperations(Operation.in(keys)))
+                          .unlimited()),
+              auth);
+      final Map<Long, ObjectNode> grouped = new HashMap<>();
+      for (final var v : result.items()) {
+        final var node =
+            grouped.computeIfAbsent(v.processInstanceKey(), k -> EXPORT_JSON.createObjectNode());
+        // value may be a truncated preview — prefer fullValue so the export contains complete
+        // data even for large variables.
+        final String resolved =
+            (Boolean.TRUE.equals(v.isPreview()) && v.fullValue() != null)
+                ? v.fullValue()
+                : v.value();
+        try {
+          node.set(v.name(), EXPORT_JSON.readTree(resolved));
+        } catch (final Exception parseError) {
+          // Camunda variables are stored as JSON, but defensively fall back to a string cell
+          // when a value is somehow malformed.
+          node.put(v.name(), resolved);
+        }
+      }
+      final Map<Long, String> out = new HashMap<>(grouped.size());
+      for (final var entry : grouped.entrySet()) {
+        out.put(entry.getKey(), entry.getValue().toString());
+      }
+      return out;
+    } catch (final Exception e) {
+      LOG.warn("Could not enrich CSV export with variables: {}", e.getMessage());
+      return Map.of();
+    }
   }
 
   private ResponseEntity<IncidentSearchQueryResult> searchIncidents(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
@@ -27,6 +27,7 @@ import io.camunda.gateway.protocol.model.ProcessInstanceModificationBatchOperati
 import io.camunda.gateway.protocol.model.ProcessInstanceModificationInstruction;
 import io.camunda.gateway.protocol.model.ProcessInstanceSearchQuery;
 import io.camunda.gateway.protocol.model.ProcessInstanceSearchQueryResult;
+import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
@@ -41,31 +42,45 @@ import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyRequest;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
+import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
 @CamundaRestController
 @RequestMapping("/v2/process-instances")
 public class ProcessInstanceController {
 
+  static final String EXPORT_TRUNCATED_HEADER = "X-Camunda-Export-Truncated";
+  private static final String CSV_CONTENT_TYPE = "text/csv; charset=UTF-8";
+  private static final DateTimeFormatter FILENAME_TIMESTAMP =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss'Z'").withZone(ZoneOffset.UTC);
+
   private final ProcessInstanceServices processInstanceServices;
   private final MultiTenancyConfiguration multiTenancyCfg;
   private final CamundaAuthenticationProvider authenticationProvider;
+  private final GatewayRestConfiguration gatewayRestConfiguration;
 
   public ProcessInstanceController(
       final ProcessInstanceServices processInstanceServices,
       final MultiTenancyConfiguration multiTenancyCfg,
-      final CamundaAuthenticationProvider authenticationProvider) {
+      final CamundaAuthenticationProvider authenticationProvider,
+      final GatewayRestConfiguration gatewayRestConfiguration) {
     this.processInstanceServices = processInstanceServices;
     this.multiTenancyCfg = multiTenancyCfg;
     this.authenticationProvider = authenticationProvider;
+    this.gatewayRestConfiguration = gatewayRestConfiguration;
   }
 
   @CamundaPostMapping
@@ -117,6 +132,23 @@ public class ProcessInstanceController {
       @RequestBody(required = false) final ProcessInstanceSearchQuery query) {
     return SearchQueryRequestMapper.toProcessInstanceQuery(query)
         .fold(RestErrorMapper::mapProblemToResponse, this::search);
+  }
+
+  /**
+   * Streams the process-instance set matching {@code query} as a UTF-8 CSV file. Designed for
+   * business reporting (Excel, Power BI, BO) — the request body is identical to {@code /search} so
+   * clients reuse their existing filter/sort code. Pagination is server-driven; the {@code
+   * page.limit} field on the request body is ignored. The hard row cap is configurable via {@code
+   * camunda.rest.process-instance-export.max-rows}; when reached, the response body still contains
+   * a complete CSV but the {@code X-Camunda-Export-Truncated: true} header is set so clients can
+   * surface a refine-your-filter hint.
+   */
+  @RequiresSecondaryStorage
+  @CamundaPostMapping(path = "/search.csv", produces = "text/csv")
+  public ResponseEntity<StreamingResponseBody> exportProcessInstancesCsv(
+      @RequestBody(required = false) final ProcessInstanceSearchQuery query) {
+    return SearchQueryRequestMapper.toProcessInstanceQuery(query)
+        .fold(RestErrorMapper::mapProblemToResponse, this::exportCsv);
   }
 
   @RequiresSecondaryStorage
@@ -255,6 +287,50 @@ public class ProcessInstanceController {
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }
+  }
+
+  private ResponseEntity<StreamingResponseBody> exportCsv(final ProcessInstanceQuery query) {
+    final var auth = authenticationProvider.getCamundaAuthentication();
+    final var exportCfg = gatewayRestConfiguration.getProcessInstanceExport();
+    final int maxRows = exportCfg.getMaxRows();
+    final int pageSize = exportCfg.getPageSize();
+    final boolean tenantColumn = multiTenancyCfg.isChecksEnabled();
+
+    // Probe total upfront so the truncation header can be set before the response body starts
+    // streaming. HTTP headers cannot be added once StreamingResponseBody has begun writing.
+    final boolean truncated;
+    try {
+      final var probe =
+          processInstanceServices.search(
+              new ProcessInstanceQuery(
+                  query.filter(),
+                  query.sort(),
+                  SearchQueryPage.NO_ENTITIES_QUERY,
+                  query.resultConfig()),
+              auth);
+      truncated = probe.hasMoreTotalItems() || probe.total() > maxRows;
+    } catch (final Exception e) {
+      return mapErrorToResponse(e);
+    }
+
+    final String filename =
+        "process-instances-" + FILENAME_TIMESTAMP.format(Instant.now()) + ".csv";
+    final StreamingResponseBody body =
+        out -> {
+          try (var writer = ProcessInstanceCsvWriter.open(out, tenantColumn)) {
+            writer.writeHeader();
+            processInstanceServices.streamSearch(query, auth, writer::writeRow, maxRows, pageSize);
+          }
+        };
+
+    final var builder =
+        ResponseEntity.ok()
+            .header(HttpHeaders.CONTENT_TYPE, CSV_CONTENT_TYPE)
+            .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + filename + "\"");
+    if (truncated) {
+      builder.header(EXPORT_TRUNCATED_HEADER, "true");
+    }
+    return builder.body(body);
   }
 
   private ResponseEntity<IncidentSearchQueryResult> searchIncidents(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceCsvWriter.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceCsvWriter.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.gateway.rest.controller;
 
 import com.opencsv.CSVWriter;
+import com.opencsv.ICSVWriter;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
 import java.io.BufferedWriter;
@@ -24,6 +25,9 @@ final class ProcessInstanceCsvWriter implements AutoCloseable {
   private static final byte[] UTF8_BOM = new byte[] {(byte) 0xEF, (byte) 0xBB, (byte) 0xBF};
   private static final DateTimeFormatter ISO_UTC = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
   private static final String INCIDENT_STATE = "INCIDENT";
+  // CRLF matches Excel-on-Windows expectations and the existing Optimize CSV writer; OpenCSV
+  // defaults to LF only.
+  private static final String LINE_END = "\r\n";
 
   private final CSVWriter csv;
   private final boolean multiTenancyEnabled;
@@ -37,7 +41,12 @@ final class ProcessInstanceCsvWriter implements AutoCloseable {
       throws IOException {
     out.write(UTF8_BOM);
     final var writer =
-        new CSVWriter(new BufferedWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8)));
+        new CSVWriter(
+            new BufferedWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8)),
+            ICSVWriter.DEFAULT_SEPARATOR,
+            ICSVWriter.DEFAULT_QUOTE_CHARACTER,
+            ICSVWriter.DEFAULT_ESCAPE_CHARACTER,
+            LINE_END);
     return new ProcessInstanceCsvWriter(writer, multiTenancyEnabled);
   }
 
@@ -49,7 +58,11 @@ final class ProcessInstanceCsvWriter implements AutoCloseable {
       final ProcessInstanceEntity entity,
       final String incidentMessage,
       final String variablesJson) {
-    csv.writeNext(rowFor(entity, multiTenancyEnabled, incidentMessage, variablesJson));
+    final String[] row = rowFor(entity, multiTenancyEnabled, incidentMessage, variablesJson);
+    for (int i = 0; i < row.length; i++) {
+      row[i] = sanitizeForCsv(row[i]);
+    }
+    csv.writeNext(row);
   }
 
   void flush() throws IOException {
@@ -149,5 +162,28 @@ final class ProcessInstanceCsvWriter implements AutoCloseable {
 
   private static String nullToEmpty(final String value) {
     return value == null ? "" : value;
+  }
+
+  /**
+   * Defeats CSV-formula-injection attacks. Spreadsheet apps interpret a leading {@code =}, {@code
+   * +}, {@code -}, {@code @}, tab, or carriage-return as the start of a formula, which can leak
+   * data or fire HTTP requests when the export is opened. Prepending a single quote forces the cell
+   * to be treated as text (the quote is not displayed by Excel/LibreOffice/Sheets). See OWASP "CSV
+   * Injection" for background.
+   */
+  static String sanitizeForCsv(final String value) {
+    if (value == null || value.isEmpty()) {
+      return value;
+    }
+    final char first = value.charAt(0);
+    if (first == '='
+        || first == '+'
+        || first == '-'
+        || first == '@'
+        || first == '\t'
+        || first == '\r') {
+      return "'" + value;
+    }
+    return value;
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceCsvWriter.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceCsvWriter.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import com.opencsv.CSVWriter;
+import io.camunda.search.entities.ProcessInstanceEntity;
+import io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
+final class ProcessInstanceCsvWriter implements AutoCloseable {
+
+  private static final byte[] UTF8_BOM = new byte[] {(byte) 0xEF, (byte) 0xBB, (byte) 0xBF};
+  private static final DateTimeFormatter ISO_UTC = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+  private static final String INCIDENT_STATE = "INCIDENT";
+
+  private final CSVWriter csv;
+  private final boolean multiTenancyEnabled;
+
+  private ProcessInstanceCsvWriter(final CSVWriter csv, final boolean multiTenancyEnabled) {
+    this.csv = csv;
+    this.multiTenancyEnabled = multiTenancyEnabled;
+  }
+
+  static ProcessInstanceCsvWriter open(final OutputStream out, final boolean multiTenancyEnabled)
+      throws IOException {
+    out.write(UTF8_BOM);
+    final var writer =
+        new CSVWriter(new BufferedWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8)));
+    return new ProcessInstanceCsvWriter(writer, multiTenancyEnabled);
+  }
+
+  void writeHeader() {
+    csv.writeNext(headerRow(multiTenancyEnabled));
+  }
+
+  void writeRow(final ProcessInstanceEntity entity) {
+    csv.writeNext(rowFor(entity, multiTenancyEnabled));
+  }
+
+  void flush() throws IOException {
+    csv.flush();
+  }
+
+  @Override
+  public void close() throws IOException {
+    csv.close();
+  }
+
+  static String[] headerRow(final boolean multiTenancyEnabled) {
+    if (multiTenancyEnabled) {
+      return new String[] {
+        "Process Name",
+        "Process Instance Key",
+        "Version",
+        "Version Tag",
+        "Tenant",
+        "State",
+        "Start Date",
+        "End Date",
+        "Parent Process Instance Key"
+      };
+    }
+    return new String[] {
+      "Process Name",
+      "Process Instance Key",
+      "Version",
+      "Version Tag",
+      "State",
+      "Start Date",
+      "End Date",
+      "Parent Process Instance Key"
+    };
+  }
+
+  static String[] rowFor(final ProcessInstanceEntity e, final boolean multiTenancyEnabled) {
+    final String name =
+        e.processDefinitionName() != null ? e.processDefinitionName() : e.processDefinitionId();
+    if (multiTenancyEnabled) {
+      return new String[] {
+        nullToEmpty(name),
+        toStr(e.processInstanceKey()),
+        toStr(e.processDefinitionVersion()),
+        nullToEmpty(e.processDefinitionVersionTag()),
+        nullToEmpty(e.tenantId()),
+        stateLabel(e),
+        formatDate(e.startDate()),
+        formatDate(e.endDate()),
+        toStr(e.parentProcessInstanceKey())
+      };
+    }
+    return new String[] {
+      nullToEmpty(name),
+      toStr(e.processInstanceKey()),
+      toStr(e.processDefinitionVersion()),
+      nullToEmpty(e.processDefinitionVersionTag()),
+      stateLabel(e),
+      formatDate(e.startDate()),
+      formatDate(e.endDate()),
+      toStr(e.parentProcessInstanceKey())
+    };
+  }
+
+  private static String stateLabel(final ProcessInstanceEntity e) {
+    final ProcessInstanceState state = e.state();
+    if (state == ProcessInstanceState.ACTIVE && Boolean.TRUE.equals(e.hasIncident())) {
+      return INCIDENT_STATE;
+    }
+    return state != null ? state.name() : "";
+  }
+
+  private static String formatDate(final OffsetDateTime value) {
+    return value == null ? "" : value.atZoneSameInstant(ZoneOffset.UTC).format(ISO_UTC);
+  }
+
+  private static String toStr(final Object value) {
+    return value == null ? "" : value.toString();
+  }
+
+  private static String nullToEmpty(final String value) {
+    return value == null ? "" : value;
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceCsvWriter.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceCsvWriter.java
@@ -45,8 +45,11 @@ final class ProcessInstanceCsvWriter implements AutoCloseable {
     csv.writeNext(headerRow(multiTenancyEnabled));
   }
 
-  void writeRow(final ProcessInstanceEntity entity) {
-    csv.writeNext(rowFor(entity, multiTenancyEnabled));
+  void writeRow(
+      final ProcessInstanceEntity entity,
+      final String incidentMessage,
+      final String variablesJson) {
+    csv.writeNext(rowFor(entity, multiTenancyEnabled, incidentMessage, variablesJson));
   }
 
   void flush() throws IOException {
@@ -63,52 +66,68 @@ final class ProcessInstanceCsvWriter implements AutoCloseable {
       return new String[] {
         "Process Name",
         "Process Instance Key",
+        "Business Key",
         "Version",
         "Version Tag",
         "Tenant",
         "State",
+        "Incident Message",
         "Start Date",
         "End Date",
-        "Parent Process Instance Key"
+        "Parent Process Instance Key",
+        "Variables"
       };
     }
     return new String[] {
       "Process Name",
       "Process Instance Key",
+      "Business Key",
       "Version",
       "Version Tag",
       "State",
+      "Incident Message",
       "Start Date",
       "End Date",
-      "Parent Process Instance Key"
+      "Parent Process Instance Key",
+      "Variables"
     };
   }
 
-  static String[] rowFor(final ProcessInstanceEntity e, final boolean multiTenancyEnabled) {
+  static String[] rowFor(
+      final ProcessInstanceEntity e,
+      final boolean multiTenancyEnabled,
+      final String incidentMessage,
+      final String variablesJson) {
     final String name =
         e.processDefinitionName() != null ? e.processDefinitionName() : e.processDefinitionId();
     if (multiTenancyEnabled) {
       return new String[] {
         nullToEmpty(name),
         toStr(e.processInstanceKey()),
+        nullToEmpty(e.businessId()),
         toStr(e.processDefinitionVersion()),
         nullToEmpty(e.processDefinitionVersionTag()),
         nullToEmpty(e.tenantId()),
         stateLabel(e),
+        nullToEmpty(incidentMessage),
         formatDate(e.startDate()),
         formatDate(e.endDate()),
-        toStr(e.parentProcessInstanceKey())
+        toStr(e.parentProcessInstanceKey()),
+        nullToEmpty(variablesJson)
       };
     }
     return new String[] {
       nullToEmpty(name),
       toStr(e.processInstanceKey()),
+      nullToEmpty(e.businessId()),
       toStr(e.processDefinitionVersion()),
       nullToEmpty(e.processDefinitionVersionTag()),
       stateLabel(e),
+      nullToEmpty(incidentMessage),
       formatDate(e.startDate()),
       formatDate(e.endDate()),
-      toStr(e.parentProcessInstanceKey())
+      toStr(e.parentProcessInstanceKey()),
+      nullToEmpty(variablesJson)
     };
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/config/ProcessInstanceExportConfigurationTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/config/ProcessInstanceExportConfigurationTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration.ProcessInstanceExportConfiguration;
+import org.junit.jupiter.api.Test;
+
+class ProcessInstanceExportConfigurationTest {
+
+  @Test
+  void shouldRejectNonPositiveMaxRows() {
+    final var cfg = new ProcessInstanceExportConfiguration();
+    assertThatThrownBy(() -> cfg.setMaxRows(0)).isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> cfg.setMaxRows(-1)).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void shouldAcceptArbitrarilyLargeMaxRows() {
+    final var cfg = new ProcessInstanceExportConfiguration();
+    cfg.setMaxRows(1_000_000);
+    assertThat(cfg.getMaxRows()).isEqualTo(1_000_000);
+  }
+
+  @Test
+  void shouldRejectNonPositivePageSize() {
+    final var cfg = new ProcessInstanceExportConfiguration();
+    assertThatThrownBy(() -> cfg.setPageSize(0)).isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> cfg.setPageSize(-5)).isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiConfigurationTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiConfigurationTest.java
@@ -14,10 +14,13 @@ import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.search.query.SearchQueryResult.Builder;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
+import io.camunda.service.IncidentServices;
 import io.camunda.service.ProcessInstanceServices;
 import io.camunda.service.TopologyServices;
 import io.camunda.service.TopologyServices.Topology;
+import io.camunda.service.VariableServices;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,6 +33,11 @@ abstract class RestApiConfigurationTest extends RestControllerTest {
 
   @MockitoBean MultiTenancyConfiguration multiTenancyConfiguration;
   @MockitoBean ProcessInstanceServices processInstanceServices;
+  // ProcessInstanceController also depends on these for the /search.csv export endpoint;
+  // the context fails to load without mocks even when this test only exercises /search.
+  @MockitoBean IncidentServices incidentServices;
+  @MockitoBean VariableServices variableServices;
+  @MockitoBean GatewayRestConfiguration gatewayRestConfiguration;
   @MockitoBean TopologyServices topologyServices;
 
   @BeforeEach

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/FaultyControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/FaultyControllerTest.java
@@ -11,8 +11,11 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
+import io.camunda.service.IncidentServices;
 import io.camunda.service.ProcessInstanceServices;
+import io.camunda.service.VariableServices;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
@@ -28,6 +31,11 @@ public class FaultyControllerTest extends RestControllerTest {
   @MockitoBean MultiTenancyConfiguration multiTenancyCfg;
   @MockitoBean CamundaAuthenticationProvider authenticationProvider;
   @MockitoBean ProcessInstanceServices processInstanceServices;
+  // ProcessInstanceController also depends on these for the /search.csv export endpoint;
+  // the context fails to load without mocks even when this test only exercises another route.
+  @MockitoBean IncidentServices incidentServices;
+  @MockitoBean VariableServices variableServices;
+  @MockitoBean GatewayRestConfiguration gatewayRestConfiguration;
 
   @BeforeEach
   void setupServices() {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
@@ -22,13 +22,17 @@ import io.camunda.search.entities.ProcessFlowNodeStatisticsEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
 import io.camunda.search.entities.SequenceFlowEntity;
+import io.camunda.search.entities.VariableEntity;
 import io.camunda.search.filter.ProcessInstanceFilter;
 import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.search.query.VariableQuery;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
+import io.camunda.service.IncidentServices;
 import io.camunda.service.ProcessInstanceServices;
+import io.camunda.service.VariableServices;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceCancelRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceCreateRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceMigrateBatchOperationRequest;
@@ -107,6 +111,8 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
   @Captor ArgumentCaptor<ProcessInstanceMigrateRequest> migrateRequestCaptor;
   @Captor ArgumentCaptor<ProcessInstanceModifyRequest> modifyRequestCaptor;
   @MockitoBean ProcessInstanceServices processInstanceServices;
+  @MockitoBean IncidentServices incidentServices;
+  @MockitoBean VariableServices variableServices;
   @MockitoBean MultiTenancyConfiguration multiTenancyCfg;
   @MockitoBean CamundaAuthenticationProvider authenticationProvider;
   @MockitoBean GatewayRestConfiguration gatewayRestConfiguration;
@@ -117,6 +123,11 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
     when(gatewayRestConfiguration.getProcessInstanceExport())
         .thenReturn(new ProcessInstanceExportConfiguration());
+    // Default: enrichment fetches return empty results — individual tests override.
+    when(incidentServices.search(any(IncidentQuery.class), any()))
+        .thenReturn(SearchQueryResult.<IncidentEntity>of(b -> b.items(List.of())));
+    when(variableServices.search(any(VariableQuery.class), any()))
+        .thenReturn(SearchQueryResult.<VariableEntity>of(b -> b.items(List.of())));
   }
 
   @Test
@@ -3441,14 +3452,18 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .containsExactly(
             "Process Name",
             "Process Instance Key",
+            "Business Key",
             "Version",
             "Version Tag",
             "State",
+            "Incident Message",
             "Start Date",
             "End Date",
-            "Parent Process Instance Key");
+            "Parent Process Instance Key",
+            "Variables");
     assertThat(rows.get(1))
-        .containsExactly("Order Process", "1", "2", "v1.0", "ACTIVE", "", "", "");
+        .containsExactly(
+            "Order Process", "1", "ORDER-42", "2", "v1.0", "ACTIVE", "", "", "", "", "");
   }
 
   @Test
@@ -3521,6 +3536,129 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
     assertThat(rows.get(1)).contains("<default>");
   }
 
+  @Test
+  void shouldEnrichExportWithLatestActiveIncidentMessage() {
+    // given — two incidents on the same instance; the most recent one wins
+    final var older =
+        new IncidentEntity(
+            10L,
+            100L,
+            "orderProcess",
+            1L,
+            null,
+            ErrorType.JOB_NO_RETRIES,
+            "Older boom",
+            "task1",
+            5L,
+            OffsetDateTime.parse("2026-04-29T10:00:00Z"),
+            IncidentState.ACTIVE,
+            null,
+            "<default>");
+    final var newer =
+        new IncidentEntity(
+            11L,
+            100L,
+            "orderProcess",
+            1L,
+            null,
+            ErrorType.IO_MAPPING_ERROR,
+            "Newer boom",
+            "task2",
+            6L,
+            OffsetDateTime.parse("2026-04-29T11:00:00Z"),
+            IncidentState.ACTIVE,
+            null,
+            "<default>");
+    when(processInstanceServices.search(any(ProcessInstanceQuery.class), any()))
+        .thenReturn(probeResult(1, false));
+    when(incidentServices.search(any(IncidentQuery.class), any()))
+        .thenReturn(SearchQueryResult.<IncidentEntity>of(b -> b.items(List.of(older, newer))));
+    stubStreamSearchToEmit(false, sampleEntity(1L));
+
+    // when
+    final byte[] bytes =
+        webClient
+            .post()
+            .uri(PROCESS_INSTANCES_START_URL + "/search.csv")
+            .contentType(MediaType.APPLICATION_JSON)
+            .exchange()
+            .expectStatus()
+            .isOk()
+            .expectBody(byte[].class)
+            .returnResult()
+            .getResponseBody();
+
+    // then
+    final var rows = parseCsv(bytes);
+    final int incidentColumnIdx = java.util.Arrays.asList(rows.get(0)).indexOf("Incident Message");
+    assertThat(rows.get(1)[incidentColumnIdx]).isEqualTo("Newer boom");
+  }
+
+  @Test
+  void shouldEnrichExportWithVariablesAsJson() {
+    // given — two variables on the instance: one JSON-typed, one string-typed
+    final var orderId =
+        new VariableEntity(
+            901L, "orderId", "\"ABC-1\"", null, false, 1L, 1L, null, "orderProcess", "<default>");
+    final var amount =
+        new VariableEntity(
+            902L, "amount", "99.95", null, false, 1L, 1L, null, "orderProcess", "<default>");
+    when(processInstanceServices.search(any(ProcessInstanceQuery.class), any()))
+        .thenReturn(probeResult(1, false));
+    when(variableServices.search(any(VariableQuery.class), any()))
+        .thenReturn(
+            SearchQueryResult.<VariableEntity>of(b -> b.items(List.of(orderId, amount))));
+    stubStreamSearchToEmit(false, sampleEntity(1L));
+
+    // when
+    final byte[] bytes =
+        webClient
+            .post()
+            .uri(PROCESS_INSTANCES_START_URL + "/search.csv")
+            .contentType(MediaType.APPLICATION_JSON)
+            .exchange()
+            .expectStatus()
+            .isOk()
+            .expectBody(byte[].class)
+            .returnResult()
+            .getResponseBody();
+
+    // then
+    final var rows = parseCsv(bytes);
+    final int variablesIdx = java.util.Arrays.asList(rows.get(0)).indexOf("Variables");
+    assertThat(rows.get(1)[variablesIdx])
+        .contains("\"orderId\":\"ABC-1\"")
+        .contains("\"amount\":99.95");
+  }
+
+  @Test
+  void shouldFallBackToEmptyEnrichmentWhenIncidentLookupFails() {
+    // given — incident search blows up (e.g. user lacks INCIDENT_READ); the export should
+    // still complete with a blank Incident Message column.
+    when(processInstanceServices.search(any(ProcessInstanceQuery.class), any()))
+        .thenReturn(probeResult(1, false));
+    when(incidentServices.search(any(IncidentQuery.class), any()))
+        .thenThrow(new RuntimeException("forbidden"));
+    stubStreamSearchToEmit(false, sampleEntity(1L));
+
+    // when / then
+    final byte[] bytes =
+        webClient
+            .post()
+            .uri(PROCESS_INSTANCES_START_URL + "/search.csv")
+            .contentType(MediaType.APPLICATION_JSON)
+            .exchange()
+            .expectStatus()
+            .isOk()
+            .expectBody(byte[].class)
+            .returnResult()
+            .getResponseBody();
+
+    final var rows = parseCsv(bytes);
+    final int incidentColumnIdx = java.util.Arrays.asList(rows.get(0)).indexOf("Incident Message");
+    assertThat(rows.get(1)[incidentColumnIdx]).isEmpty();
+  }
+
   private static ProcessInstanceEntity sampleEntity(final long key) {
     return new ProcessInstanceEntity(
         key,
@@ -3538,7 +3676,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         false,
         "<default>",
         null,
-        null);
+        "ORDER-42");
   }
 
   private static SearchQueryResult<ProcessInstanceEntity> probeResult(
@@ -3554,10 +3692,8 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
             any(ProcessInstanceQuery.class), any(), any(), Mockito.anyInt(), Mockito.anyInt()))
         .thenAnswer(
             invocation -> {
-              final Consumer<ProcessInstanceEntity> sink = invocation.getArgument(2);
-              for (final var e : entities) {
-                sink.accept(e);
-              }
+              final Consumer<List<ProcessInstanceEntity>> sink = invocation.getArgument(2);
+              sink.accept(List.of(entities));
               return truncated;
             });
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
@@ -3658,6 +3658,72 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
     assertThat(rows.get(1)[incidentColumnIdx]).isEmpty();
   }
 
+  @Test
+  void shouldNeutraliseFormulaInjectionAttempts() {
+    // given — a process whose name + business key + incident message + variable names start with
+    // characters that Excel/LibreOffice/Sheets would interpret as a formula. The exported CSV must
+    // prefix them with a single quote so the cell is rendered as text.
+    final var entity =
+        new ProcessInstanceEntity(
+            1L,
+            null,
+            "=cmd|x",
+            "=cmd|x",
+            1,
+            null,
+            100L,
+            null,
+            null,
+            null,
+            null,
+            ProcessInstanceState.ACTIVE,
+            false,
+            "<default>",
+            null,
+            "+1234567890");
+    final var hostileIncident =
+        new IncidentEntity(
+            10L,
+            100L,
+            "p",
+            1L,
+            null,
+            ErrorType.JOB_NO_RETRIES,
+            "@SUM(A1:A100)",
+            "task",
+            5L,
+            OffsetDateTime.parse("2026-04-29T11:00:00Z"),
+            IncidentState.ACTIVE,
+            null,
+            "<default>");
+    when(processInstanceServices.search(any(ProcessInstanceQuery.class), any()))
+        .thenReturn(probeResult(1, false));
+    when(incidentServices.search(any(IncidentQuery.class), any()))
+        .thenReturn(SearchQueryResult.<IncidentEntity>of(b -> b.items(List.of(hostileIncident))));
+    stubStreamSearchToEmit(false, entity);
+
+    // when
+    final byte[] bytes =
+        webClient
+            .post()
+            .uri(PROCESS_INSTANCES_START_URL + "/search.csv")
+            .contentType(MediaType.APPLICATION_JSON)
+            .exchange()
+            .expectStatus()
+            .isOk()
+            .expectBody(byte[].class)
+            .returnResult()
+            .getResponseBody();
+
+    // then — every cell that started with a formula trigger now has a leading single quote
+    final var rows = parseCsv(bytes);
+    final var headers = java.util.Arrays.asList(rows.get(0));
+    final var row = rows.get(1);
+    assertThat(row[headers.indexOf("Process Name")]).startsWith("'=");
+    assertThat(row[headers.indexOf("Business Key")]).startsWith("'+");
+    assertThat(row[headers.indexOf("Incident Message")]).startsWith("'@");
+  }
+
   private static ProcessInstanceEntity sampleEntity(final long key) {
     return new ProcessInstanceEntity(
         key,

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
@@ -32,13 +32,13 @@ import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.service.IncidentServices;
 import io.camunda.service.ProcessInstanceServices;
-import io.camunda.service.VariableServices;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceCancelRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceCreateRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceMigrateBatchOperationRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceMigrateRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyBatchOperationRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyRequest;
+import io.camunda.service.VariableServices;
 import io.camunda.service.exception.ErrorMapper;
 import io.camunda.service.exception.ServiceException;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
@@ -3606,8 +3606,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
     when(processInstanceServices.search(any(ProcessInstanceQuery.class), any()))
         .thenReturn(probeResult(1, false));
     when(variableServices.search(any(VariableQuery.class), any()))
-        .thenReturn(
-            SearchQueryResult.<VariableEntity>of(b -> b.items(List.of(orderId, amount))));
+        .thenReturn(SearchQueryResult.<VariableEntity>of(b -> b.items(List.of(orderId, amount))));
     stubStreamSearchToEmit(false, sampleEntity(1L));
 
     // when

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
@@ -14,13 +14,17 @@ import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.opencsv.CSVReader;
 import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.entities.IncidentEntity.ErrorType;
 import io.camunda.search.entities.IncidentEntity.IncidentState;
 import io.camunda.search.entities.ProcessFlowNodeStatisticsEntity;
+import io.camunda.search.entities.ProcessInstanceEntity;
+import io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
 import io.camunda.search.entities.SequenceFlowEntity;
 import io.camunda.search.filter.ProcessInstanceFilter;
 import io.camunda.search.query.IncidentQuery;
+import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
@@ -34,6 +38,8 @@ import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyRequest;
 import io.camunda.service.exception.ErrorMapper;
 import io.camunda.service.exception.ServiceException;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
+import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration.ProcessInstanceExportConfiguration;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.history.HistoryDeletionRecord;
@@ -49,11 +55,15 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.record.value.BatchOperationType;
 import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
 import io.camunda.zeebe.protocol.record.value.RuntimeInstructionType;
+import java.io.ByteArrayInputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -63,6 +73,7 @@ import org.mockito.Captor;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -98,11 +109,14 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
   @MockitoBean ProcessInstanceServices processInstanceServices;
   @MockitoBean MultiTenancyConfiguration multiTenancyCfg;
   @MockitoBean CamundaAuthenticationProvider authenticationProvider;
+  @MockitoBean GatewayRestConfiguration gatewayRestConfiguration;
 
   @BeforeEach
   void setupServices() {
     when(authenticationProvider.getCamundaAuthentication())
         .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
+    when(gatewayRestConfiguration.getProcessInstanceExport())
+        .thenReturn(new ProcessInstanceExportConfiguration());
   }
 
   @Test
@@ -3378,5 +3392,193 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
         .json(expectedBody, JsonCompareMode.STRICT);
+  }
+
+  // ---------------------------------------------------------------------------
+  // POST /v2/process-instances/search.csv
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void shouldExportProcessInstancesAsCsv() {
+    // given
+    final var entity = sampleEntity(1L);
+    when(processInstanceServices.search(any(ProcessInstanceQuery.class), any()))
+        .thenReturn(probeResult(/* total= */ 1, /* hasMoreTotalItems= */ false));
+    stubStreamSearchToEmit(false, entity);
+
+    // when
+    final byte[] responseBytes =
+        webClient
+            .post()
+            .uri(PROCESS_INSTANCES_START_URL + "/search.csv")
+            .accept(MediaType.parseMediaType("text/csv"))
+            .contentType(MediaType.APPLICATION_JSON)
+            .exchange()
+            .expectStatus()
+            .isOk()
+            .expectHeader()
+            .contentType(MediaType.parseMediaType("text/csv;charset=UTF-8"))
+            .expectHeader()
+            .doesNotExist("X-Camunda-Export-Truncated")
+            .expectHeader()
+            .value(
+                HttpHeaders.CONTENT_DISPOSITION,
+                value -> assertThat(value).startsWith("attachment; filename=\"process-instances-"))
+            .expectBody(byte[].class)
+            .returnResult()
+            .getResponseBody();
+
+    // then
+    assertThat(responseBytes).isNotNull();
+    // body starts with the UTF-8 BOM
+    assertThat(responseBytes[0] & 0xff).isEqualTo(0xEF);
+    assertThat(responseBytes[1] & 0xff).isEqualTo(0xBB);
+    assertThat(responseBytes[2] & 0xff).isEqualTo(0xBF);
+
+    final java.util.List<String[]> rows = parseCsv(responseBytes);
+    assertThat(rows).hasSize(2);
+    assertThat(rows.get(0))
+        .containsExactly(
+            "Process Name",
+            "Process Instance Key",
+            "Version",
+            "Version Tag",
+            "State",
+            "Start Date",
+            "End Date",
+            "Parent Process Instance Key");
+    assertThat(rows.get(1))
+        .containsExactly("Order Process", "1", "2", "v1.0", "ACTIVE", "", "", "");
+  }
+
+  @Test
+  void shouldSetTruncatedHeaderWhenProbeIndicatesMoreItemsThanCap() {
+    // given — probe says total exceeds the configured cap
+    final var lowCapCfg = new ProcessInstanceExportConfiguration();
+    lowCapCfg.setMaxRows(1);
+    when(gatewayRestConfiguration.getProcessInstanceExport()).thenReturn(lowCapCfg);
+    when(processInstanceServices.search(any(ProcessInstanceQuery.class), any()))
+        .thenReturn(probeResult(/* total= */ 5, /* hasMoreTotalItems= */ false));
+    stubStreamSearchToEmit(true, sampleEntity(1L));
+
+    // when / then
+    webClient
+        .post()
+        .uri(PROCESS_INSTANCES_START_URL + "/search.csv")
+        .accept(MediaType.parseMediaType("text/csv"))
+        .contentType(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .valueEquals("X-Camunda-Export-Truncated", "true");
+  }
+
+  @Test
+  void shouldSetTruncatedHeaderWhenProbeReportsHasMoreTotalItems() {
+    // given — probe reports an approximate total that may not be the full set
+    when(processInstanceServices.search(any(ProcessInstanceQuery.class), any()))
+        .thenReturn(probeResult(/* total= */ 10, /* hasMoreTotalItems= */ true));
+    stubStreamSearchToEmit(true, sampleEntity(1L));
+
+    // when / then
+    webClient
+        .post()
+        .uri(PROCESS_INSTANCES_START_URL + "/search.csv")
+        .accept(MediaType.parseMediaType("text/csv"))
+        .contentType(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .valueEquals("X-Camunda-Export-Truncated", "true");
+  }
+
+  @Test
+  void shouldIncludeTenantColumnWhenMultiTenancyChecksEnabled() {
+    // given
+    when(multiTenancyCfg.isChecksEnabled()).thenReturn(true);
+    when(processInstanceServices.search(any(ProcessInstanceQuery.class), any()))
+        .thenReturn(probeResult(1, false));
+    stubStreamSearchToEmit(false, sampleEntity(1L));
+
+    // when
+    final byte[] bytes =
+        webClient
+            .post()
+            .uri(PROCESS_INSTANCES_START_URL + "/search.csv")
+            .contentType(MediaType.APPLICATION_JSON)
+            .exchange()
+            .expectStatus()
+            .isOk()
+            .expectBody(byte[].class)
+            .returnResult()
+            .getResponseBody();
+
+    // then — tenant column is present in both header and body row
+    final java.util.List<String[]> rows = parseCsv(bytes);
+    assertThat(rows.get(0)).contains("Tenant");
+    assertThat(rows.get(1)).contains("<default>");
+  }
+
+  private static ProcessInstanceEntity sampleEntity(final long key) {
+    return new ProcessInstanceEntity(
+        key,
+        null,
+        "orderProcess",
+        "Order Process",
+        2,
+        "v1.0",
+        100L,
+        null,
+        null,
+        null,
+        null,
+        ProcessInstanceState.ACTIVE,
+        false,
+        "<default>",
+        null,
+        null);
+  }
+
+  private static SearchQueryResult<ProcessInstanceEntity> probeResult(
+      final long total, final boolean hasMoreTotalItems) {
+    return SearchQueryResult.<ProcessInstanceEntity>of(
+        b -> b.total(total, hasMoreTotalItems).items(List.of()));
+  }
+
+  @SuppressWarnings("unchecked")
+  private void stubStreamSearchToEmit(
+      final boolean truncated, final ProcessInstanceEntity... entities) {
+    when(processInstanceServices.streamSearch(
+            any(ProcessInstanceQuery.class), any(), any(), Mockito.anyInt(), Mockito.anyInt()))
+        .thenAnswer(
+            invocation -> {
+              final Consumer<ProcessInstanceEntity> sink = invocation.getArgument(2);
+              for (final var e : entities) {
+                sink.accept(e);
+              }
+              return truncated;
+            });
+  }
+
+  private static java.util.List<String[]> parseCsv(final byte[] bytes) {
+    // Skip the leading 3-byte UTF-8 BOM so OpenCSV does not parse it as part of the first cell.
+    final int offset =
+        bytes.length >= 3
+                && (bytes[0] & 0xff) == 0xEF
+                && (bytes[1] & 0xff) == 0xBB
+                && (bytes[2] & 0xff) == 0xBF
+            ? 3
+            : 0;
+    try (var reader =
+        new CSVReader(
+            new InputStreamReader(
+                new ByteArrayInputStream(bytes, offset, bytes.length - offset),
+                StandardCharsets.UTF_8))) {
+      return reader.readAll();
+    } catch (final Exception e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
@@ -36,9 +36,12 @@ import io.camunda.search.sort.ProcessInstanceSort;
 import io.camunda.security.auth.CamundaAuthentication;
 import io.camunda.security.auth.CamundaAuthenticationProvider;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
+import io.camunda.service.IncidentServices;
 import io.camunda.service.ProcessInstanceServices;
+import io.camunda.service.VariableServices;
 import io.camunda.service.exception.ErrorMapper;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -225,6 +228,11 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
           .endCursor("v")
           .build();
   @MockitoBean ProcessInstanceServices processInstanceServices;
+  // ProcessInstanceController also depends on these for the /search.csv export endpoint;
+  // the context fails to load without mocks even when this test only exercises /search.
+  @MockitoBean IncidentServices incidentServices;
+  @MockitoBean VariableServices variableServices;
+  @MockitoBean GatewayRestConfiguration gatewayRestConfiguration;
   @MockitoBean MultiTenancyConfiguration multiTenancyCfg;
   @MockitoBean CamundaAuthenticationProvider authenticationProvider;
   @Captor ArgumentCaptor<ProcessInstanceQuery> queryCaptor;


### PR DESCRIPTION
  ## Summary                                                                                                                                                                

  Adds a CSV export of the filtered process-instance grid in Operate. Driven by                                                                                             
  customer evidence ([product-hub#3444](https://github.com/camunda/product-hub/issues/3444))
  that exports go to people without Camunda access — so an in-product view fix                                                                                              
  isn't enough; a downloadable file matching the on-screen filter is required.                                                                                              
                                                                                                                                                                            
  The export is a sibling to the existing search endpoint:                                                                                                                  
                                                                                                                                                                            
  - **Backend**: `POST /v2/process-instances/search.csv` — same request body as                                                                                             
    `/search` (filter + sort), so clients reuse their existing query construction.                                                                                        
    Streams a UTF-8 CSV (with BOM for Excel-on-Windows). Pagination is                                                                                                      
    server-driven via cursor; the request body's `page` is ignored.                                                                                                         
  - **Frontend**: an "Export to CSV" Carbon button in the *Process Instances*                                                                                               
    panel header. Always visible (independent of selection), reuses                                                                                                         
    `useProcessInstancesSearchFilter` + `useProcessInstancesSearchSort` so the                                                                                              
    export matches what's on screen.                                                                                                                                        
                                                                                                                                                                            
  ## Columns                                                                                                                                                                
                                                                                                                                                                            
  `Process Name | Process Instance Key | Business Key | Version | Version Tag |                                                                                             
  [Tenant] | State | Incident Message | Start Date | End Date | Parent Process
  Instance Key | Variables`                                                                                                                                                 
                                                                                                                                                                          
  - *Tenant* column appears only when `multiTenancyCfg.isChecksEnabled()`.                                                                                                  
  - *State* derives `INCIDENT` from `state == ACTIVE && hasIncident`, matching                                                                                            
    the UI semantic.                                                                                                                                                        
  - *Incident Message* is the latest active incident's `errorMessage` (sorted by                                                                                          
    `creationTime` desc).                                                                                                                                                   
  - *Variables* is a JSON object of `{name: value}` for the instance, using the                                                                                             
    full value (preferring `fullValue` over `value` when truncated).                                                                                                        
                                                                                                                                                                            
  ## Architecture                                                                                                                                                           
                                                                                                                                                                            
  ### Service layer (`ProcessInstanceServices`)                                                                                                                             
   
  New `streamSearch(query, auth, Consumer<List<entity>>, maxRows, pageSize)`                                                                                                
  that drives cursor-paginated `searchAfter` iteration. Returns `truncated`                                                                                               
  when capped. Per-page (not per-row) so the controller can do batch                                                                                                        
  enrichment.                                                                                                                                                               
                                                                                                                                                                            
  ### Controller (`ProcessInstanceController`)                                                                                                                              
                                                                                                                                                                          
  - `exportProcessInstancesCsv` does an upfront probe call (`NO_ENTITIES_QUERY`)                                                                                            
    to learn `total + hasMoreTotalItems`, sets `X-Camunda-Export-Truncated`
    header *before* streaming starts (HTTP headers can't be added once                                                                                                      
    `StreamingResponseBody` has begun).                                                                                                                                     
  - `writeEnrichedPage` does the per-page batch enrichment: one                                                                                                             
    `IncidentServices.search` filtered by `processInstanceKeys IN (...)` and                                                                                                
    `state=ACTIVE`, one `VariableServices.search` filtered the same way.                                                                                                    
  - Auth is the existing v2 model — no new permissions. If the user lacks                                                                                                   
    `INCIDENT_READ` or `VARIABLE_READ`, those columns come back blank and a                                                                                                 
    warning is logged; the export still completes.                                                                                                                          
                                                                                                                                                                            
  ### Writer (`ProcessInstanceCsvWriter`)                                                                                                                                   
                                                                                                                                                                          
  OpenCSV-based, streaming, with UTF-8 BOM. Stays internal (package-private).                                                                                               
                                                                                                                                                                          
  ### Configuration                                                                                                                                                         
                                                                                                                                                                          
  Bound under `camunda.rest.process-instance-export.*` via the existing                                                                                                     
  `GatewayRestConfiguration` mechanism:
                                                                                                                                                                            
  - `max-rows` (default `50000`) — soft cap; on hit, response gets                                                                                                          
    `X-Camunda-Export-Truncated: true` and the frontend shows an info                                                                                                       
    notification.                                                                                                                                                           
  - `page-size` (default `1000`) — internal pagination batch size, also used                                                                                              
    for the enrichment `IN (...)` queries.                                                                                                                                  
                                                                                                                                                                            
  ### Frontend                                                                                                                                                              
                                                                                                                                                                            
  - `exportProcessInstances.ts` — uses the lower-level `request()` helper to                                                                                                
    capture both the Blob body *and* the truncation header.
  - `useExportProcessInstances` — TanStack mutation hook; on success triggers a                                                                                             
    Blob download via `URL.createObjectURL` and surfaces the truncation                                                                                                     
    notification.                                                                                                                                                           
  - `ExportButton.tsx` — Carbon ghost button with Download icon.                                                                                                            
  - `tracking/index.ts` — new `process-instances-export` event type for adoption                                                                                            
    metrics.                                                                                                                                                                
                                                                                                                                                                            
  ## Alternatives considered                                                                                                                                                
                                                                                                                                                                          
  - **XLSX instead of CSV** — would have required pulling Apache POI or                                                                                                     
    fastexcel. CSV opens transparently in Excel / Power BI / Business Objects                                                                                             
    (the customer's stack), and OpenCSV is already used by Optimize. Skipped.                                                                                               
  - **Lifting OpenCSV to the parent BOM** — was tried, but touching                                                                                                         
    `optimize/backend/pom.xml` for a one-module addition was unjustified                                                                                                    
    blast-radius. OpenCSV is now declared inline in `gateway-rest/pom.xml`                                                                                                  
    matching what Optimize does (same version, same exclusion).                                                                                                             
  - **Hard ceiling on `max-rows`** — initially added a 200K wall, then dropped                                                                                              
    it. Two limits were redundant; trust the operator who configures the soft                                                                                               
    cap.                                                                                                                                                                    
  - **Operate-specific endpoint** — would re-introduce the v1/v2 split that                                                                                                 
    the codebase has been actively eliminating. The v2 endpoint also serves                                                                                                 
    any future client (Tasklist parity, headless integrations).                                                                                                             
                                                                                                                                                                            
  ## Out of scope (follow-ups)                                                                                                                                              
                                                                                                                                                                            
  - Native XLSX output (sibling endpoint, same row pipeline).                                                                                                               
  - Selection-aware export (selected-only / exclude-selected).                                                                                                            
  - User-configurable column picker.                                                                                                                                        
  - Async / background exports with email delivery.                                                                                                                         
                                                                                                                                                                            
  Closes camunda/product-hub#3444.                                                                                                                                          
                                                                                                                                                                            
  ## Test plan                                                                                                                                                            

  - [ ] `./mvnw verify -pl zeebe/gateway-rest -Dtest='ProcessInstanceControllerTest,ProcessInstanceExportConfigurationTest' -DskipTests=false -DskipITs -Dquickly` (84      
  tests, including 4 happy-path + truncation + tenant-column + incident-enrichment + variable-enrichment + auth-failure-fallback)
  - [ ] `./mvnw verify -pl service -Dtest=ProcessInstanceServiceTest -DskipTests=false -DskipITs -Dquickly` (34 tests, including 2 new for `streamSearch`)                  
  - [ ] `cd operate/client && npx vitest run src/App/Processes/ListView/InstancesTable/tests/ExportButton.test.tsx` (4 tests)                                               
  - [ ] `cd operate/client && npm run ts-check`                                                                                                                             
  - [ ] Manual: start Operate, apply a filter on `/processes`, click *Export to CSV*, verify the file opens in Excel with all columns populated; force the cap (`max-rows:  
  5`) and confirm the info-notification appears.                                                                                                                            

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues
https://github.com/camunda/product-hub/issues/3444

closes #
