### PR TITLE
fix: remove redundant wildcard prefix from search

### DIFF
--- a/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
@@ -514,7 +514,7 @@ public final class ProcessInstanceServices
             b ->
                 b.filter(
                         query.filter().toBuilder()
-                            .treePathOperations(Operation.like("*" + treePath + "*"))
+                            .treePathOperations(Operation.like(treePath + "*"))
                             .build())
                     .page(query.page())
                     .sort(query.sort())),

--- a/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
@@ -496,7 +496,7 @@ public final class ProcessInstanceServiceTest {
     verify(incidentServices).search(incidentQueryCaptor.capture(), any());
     final var incidentQuery = incidentQueryCaptor.getValue();
     assertThat(incidentQuery.filter().treePathOperations())
-        .containsExactly(Operation.like("*" + processInstance.treePath() + "*"));
+        .containsExactly(Operation.like(processInstance.treePath() + "*"));
     assertThat(incidentQuery.page()).isEqualTo(query.page());
     assertThat(incidentQuery.sort()).isEqualTo(query.sort());
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Removes a redundant wildcard prefix for the tree path search, which we expect was less performant.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #51289 
