### PR TITLE
fix: avoid double fetching process instance

### DIFF
--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/ProcessInstanceReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/ProcessInstanceReader.java
@@ -54,7 +54,12 @@ public class ProcessInstanceReader {
       final Long processInstanceKey) {
     final ProcessInstanceForListViewEntity processInstance =
         processStore.getProcessInstanceListViewByKey(processInstanceKey);
+    return getProcessInstanceWithOperationsByKey(processInstance);
+  }
 
+  public ListViewProcessInstanceDto getProcessInstanceWithOperationsByKey(
+      final ProcessInstanceForListViewEntity processInstance) {
+    final Long processInstanceKey = processInstance.getKey();
     final List<ProcessInstanceReferenceDto> callHierarchy =
         createCallHierarchy(processInstance.getTreePath(), String.valueOf(processInstanceKey));
 

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/ProcessInstanceRestService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/ProcessInstanceRestService.java
@@ -37,6 +37,7 @@ import io.camunda.operate.webapp.security.permission.PermissionsService;
 import io.camunda.operate.webapp.writer.BatchOperationWriter;
 import io.camunda.spring.utils.ConditionalOnRdbmsDisabled;
 import io.camunda.webapps.schema.entities.SequenceFlowEntity;
+import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
 import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
 import io.camunda.webapps.schema.entities.operation.OperationType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
@@ -139,8 +140,11 @@ public class ProcessInstanceRestService extends InternalAPIErrorController {
   @GetMapping("/{id}")
   public ListViewProcessInstanceDto queryProcessInstanceById(
       @PathVariable @ValidLongId final String id) {
-    checkIdentityReadPermission(Long.parseLong(id));
-    return processInstanceReader.getProcessInstanceWithOperationsByKey(Long.valueOf(id));
+    final Long key = Long.valueOf(id);
+    final ProcessInstanceForListViewEntity instance =
+        processInstanceReader.getProcessInstanceByKey(key);
+    checkIdentityPermission(instance.getBpmnProcessId(), key, PermissionType.READ_PROCESS_INSTANCE);
+    return processInstanceReader.getProcessInstanceWithOperationsByKey(instance);
   }
 
   @Operation(summary = "Get incidents by process instance id")
@@ -220,9 +224,15 @@ public class ProcessInstanceRestService extends InternalAPIErrorController {
 
   private void checkIdentityPermission(
       final Long processInstanceKey, final PermissionType permission) {
-    if (!permissionsService.hasPermissionForProcess(
+    checkIdentityPermission(
         processInstanceReader.getProcessInstanceByKey(processInstanceKey).getBpmnProcessId(),
-        permission)) {
+        processInstanceKey,
+        permission);
+  }
+
+  private void checkIdentityPermission(
+      final String bpmnProcessId, final Long processInstanceKey, final PermissionType permission) {
+    if (!permissionsService.hasPermissionForProcess(bpmnProcessId, permission)) {
       throw new NotAuthorizedException(
           String.format(
               "No %s permission for process instance %s", permission, processInstanceKey));

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/ProcessInstanceRestServiceTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/ProcessInstanceRestServiceTest.java
@@ -79,10 +79,11 @@ public class ProcessInstanceRestServiceTest {
     final String validId = "123";
     // when
     final ListViewProcessInstanceDto expectedDto = new ListViewProcessInstanceDto().setId("one id");
-    when(processInstanceReader.getProcessInstanceWithOperationsByKey(Long.valueOf(validId)))
+    final ProcessInstanceForListViewEntity entity =
+        new ProcessInstanceForListViewEntity().setKey(Long.valueOf(validId));
+    when(processInstanceReader.getProcessInstanceByKey(Long.valueOf(validId))).thenReturn(entity);
+    when(processInstanceReader.getProcessInstanceWithOperationsByKey(entity))
         .thenReturn(expectedDto);
-    when(processInstanceReader.getProcessInstanceByKey(Long.valueOf(validId)))
-        .thenReturn(new ProcessInstanceForListViewEntity());
     // then
     final ListViewProcessInstanceDto actualResult = underTest.queryProcessInstanceById(validId);
     assertThat(actualResult).isEqualTo(expectedDto);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

We currently fetch the process instance twice. This PR refactors the logic to avoid the second fetch

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #51291 
