### PR TITLE
docs: update links in mono repo documentation

### DIFF
--- a/docs/monorepo-docs/release.md
+++ b/docs/monorepo-docs/release.md
@@ -4,7 +4,7 @@ This document will become a knowledge base around the [C8 monorepo](https://gith
 
 ## Scope & Goal
 
-The goal of the C8 monorepo release process is to produce artifacts for patch, alpha and minor version releases of Camunda 8 components like Zeebe and (on 8.6+) most C8 webapps for SaaS and Self-Managed usage in a timely fashion. This includes [the ZPT (zeebe-process-test) project](https://github.com/camunda/zeebe-process-test).
+The goal of the C8 monorepo release process is to produce artifacts for patch, alpha and minor version releases of Camunda 8 components like Zeebe and (on 8.6+) most C8 webapps for SaaS and Self-Managed usage in a timely fashion. This includes [the ZPT (zeebe-process-test) project](https://github.com/camunda/zeebe-process-test) for 8.7-8.9.  Optimize is released separately for 8.7.
 
 It also involves automated and manual QA activities on release candidate builds to ensure bug-free artifacts on the final artifacts, e.g. certain benchmarks for Zeebe and interactive tests for C8 webapps.
 

--- a/docs/monorepo-docs/release.md
+++ b/docs/monorepo-docs/release.md
@@ -58,7 +58,7 @@ Components that depend on the C8 monorepo releases:
 
 ### Artifacts
 
-* [Maven Central](https://mvnrepository.com/artifact/io.camunda)
+* [Maven Central](https://central.sonatype.com/search?q=camunda&sort=published)
 * DockerHub:
   * [Zeebe](https://hub.docker.com/r/camunda/zeebe/)
   * [Operate](https://hub.docker.com/r/camunda/operate/)
@@ -256,8 +256,6 @@ For visibility and prioritization there is the (internal) [Monorepo Release proj
 For CI-related issues in the release process, also see our [CI & Automation documentation](./ci.md#issue-tracking).
 
 ## DRIs
-
-_This section is subject to change in_ [_#28528_](https://github.com/camunda/camunda/issues/28528)_._
 
 ### Release Manager
 

--- a/docs/monorepo-docs/release.md
+++ b/docs/monorepo-docs/release.md
@@ -4,7 +4,7 @@ This document will become a knowledge base around the [C8 monorepo](https://gith
 
 ## Scope & Goal
 
-The goal of the C8 monorepo release process is to produce artifacts for patch, alpha and minor version releases of Camunda 8 components like Zeebe and (on 8.6+) most C8 webapps for SaaS and Self-Managed usage in a timely fashion. This includes [the ZPT (zeebe-process-test) project](https://github.com/camunda/zeebe-process-test). Optimize is released separately for 8.6 to 8.8 (at least).
+The goal of the C8 monorepo release process is to produce artifacts for patch, alpha and minor version releases of Camunda 8 components like Zeebe and (on 8.6+) most C8 webapps for SaaS and Self-Managed usage in a timely fashion. This includes [the ZPT (zeebe-process-test) project](https://github.com/camunda/zeebe-process-test).
 
 It also involves automated and manual QA activities on release candidate builds to ensure bug-free artifacts on the final artifacts, e.g. certain benchmarks for Zeebe and interactive tests for C8 webapps.
 

--- a/monorepo-docs-site/docusaurus.config.js
+++ b/monorepo-docs-site/docusaurus.config.js
@@ -62,8 +62,8 @@ const config = {
           sidebarPath: require.resolve('./sidebars.js'),
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
-          editUrl:
-            'https://github.com/camunda/camunda/tree/main/docs/monorepo-docs/',
+          editUrl: (/** @type {{docPath: string}} */ {docPath}) =>
+            `https://github.com/camunda/camunda/edit/main/docs/monorepo-docs/${docPath}`,
         },
         blog: false,
         theme: {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
* update editUrl function for dynamic documentation editing links
* remove outdated note about Optimize release timeline in release process documentation
* update Maven Central link in release documentation to the official one

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #
