### PR TITLE
feat: expose static getProcessState tool in /mcp/processes server

### DIFF
--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/CamundaMcpToolSpecificationsAutoConfiguration.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/config/CamundaMcpToolSpecificationsAutoConfiguration.java
@@ -13,13 +13,18 @@ import io.camunda.gateway.mcp.config.schema.CamundaJsonSchemaGenerator;
 import io.camunda.gateway.mcp.config.server.ToolRepository;
 import io.camunda.gateway.mcp.config.tool.CamundaMcpTool;
 import io.camunda.gateway.mcp.config.tool.CamundaSyncStatelessMcpToolProvider;
+import io.camunda.gateway.mcp.tool.process.state.ProcessStateTools;
 import io.camunda.zeebe.util.Either;
 import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import org.jspecify.annotations.NonNull;
 import org.springframework.ai.util.json.JsonParser;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
@@ -56,19 +61,52 @@ public class CamundaMcpToolSpecificationsAutoConfiguration {
         .getToolSpecifications();
   }
 
+  /**
+   * Creates static tool specifications for the processes MCP server.
+   *
+   * <p>The processes server exposes a fixed set of helper tools alongside dynamic process
+   * definition tools. These static tools are always available regardless of which process
+   * definitions are deployed.
+   */
+  @Bean(name = "processesMcpStaticToolSpecifications")
+  public List<SyncToolSpecification> processesMcpStaticToolSpecifications(
+      final ObjectProvider<ProcessStateTools> processStateToolsProvider,
+      final CamundaJsonSchemaGenerator jsonSchemaGenerator) {
+    final ProcessStateTools processStateTools = processStateToolsProvider.getIfAvailable();
+    if (processStateTools == null) {
+      return List.of();
+    }
+    return new CamundaSyncStatelessMcpToolProvider(List.of(processStateTools), jsonSchemaGenerator)
+        .getToolSpecifications();
+  }
+
+  /**
+   * Default processes tool repository backed by the static tool specifications.
+   *
+   * <p>This default is replaced when a real implementation (e.g. one that also exposes deployed
+   * process definitions as tools) is present. Any overriding bean should inject {@code
+   * processesMcpStaticToolSpecifications} and include those specs to keep the static tools
+   * available.
+   */
   @Bean(name = "processesToolRepository")
   @ConditionalOnMissingBean(name = "processesToolRepository")
-  public ToolRepository processesToolRepository() {
+  public ToolRepository processesToolRepository(
+      @Qualifier("processesMcpStaticToolSpecifications")
+          final List<SyncToolSpecification> staticToolSpecs) {
+    final Map<String, SyncToolSpecification> toolMap =
+        staticToolSpecs.stream()
+            .collect(Collectors.toMap(spec -> spec.tool().name(), spec -> spec));
     return new ToolRepository() {
       @Override
       public @NonNull List<Tool> getTools(@NonNull final McpTransportContext transportContext) {
-        return List.of();
+        return toolMap.values().stream().map(SyncToolSpecification::tool).toList();
       }
 
       @Override
       public @NonNull Either<String, SyncToolSpecification> findTool(
           @NonNull final McpTransportContext transportContext, @NonNull final String toolName) {
-        return Either.left("Not implemented yet");
+        final var spec = toolMap.get(toolName);
+        return spec != null ? Either.right(spec) : Either.left("Tool not found: " + toolName);
       }
     };
   }

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/process/state/ProcessStateResult.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/process/state/ProcessStateResult.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.gateway.mcp.tool.process.state;
+
+import io.camunda.gateway.protocol.model.ElementInstanceResult;
+import io.camunda.gateway.protocol.model.ProcessInstanceResult;
+import io.camunda.gateway.protocol.model.VariableSearchResult;
+import java.util.List;
+
+/**
+ * Combined result for {@link ProcessStateTools#getProcessState}. Aggregates the process instance
+ * state, its current variables, and active element instances into a single response.
+ */
+public record ProcessStateResult(
+    ProcessInstanceResult processInstance,
+    List<VariableSearchResult> variables,
+    List<ElementInstanceResult> activeElementInstances) {}

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/process/state/ProcessStateTools.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/process/state/ProcessStateTools.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.gateway.mcp.tool.process.state;
+
+import static io.camunda.gateway.mcp.tool.ToolDescriptions.EVENTUAL_CONSISTENCY_NOTE;
+import static io.camunda.gateway.mcp.tool.ToolDescriptions.PROCESS_INSTANCE_KEY_NOT_NULL_MESSAGE;
+import static io.camunda.gateway.mcp.tool.ToolDescriptions.PROCESS_INSTANCE_KEY_POSITIVE_MESSAGE;
+
+import io.camunda.gateway.mapping.http.search.SearchQueryResponseMapper;
+import io.camunda.gateway.mcp.config.tool.CamundaMcpTool;
+import io.camunda.gateway.mcp.mapper.CallToolResultMapper;
+import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeState;
+import io.camunda.search.query.FlowNodeInstanceQuery;
+import io.camunda.search.query.VariableQuery;
+import io.camunda.security.auth.CamundaAuthenticationProvider;
+import io.camunda.service.ElementInstanceServices;
+import io.camunda.service.ProcessInstanceServices;
+import io.camunda.service.VariableServices;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import org.springframework.ai.mcp.annotation.McpTool.McpAnnotations;
+import org.springframework.ai.mcp.annotation.McpToolParam;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+@Component
+@Validated
+public class ProcessStateTools {
+
+  private final ProcessInstanceServices processInstanceServices;
+  private final VariableServices variableServices;
+  private final ElementInstanceServices elementInstanceServices;
+  private final CamundaAuthenticationProvider authenticationProvider;
+
+  public ProcessStateTools(
+      final ProcessInstanceServices processInstanceServices,
+      final VariableServices variableServices,
+      final ElementInstanceServices elementInstanceServices,
+      final CamundaAuthenticationProvider authenticationProvider) {
+    this.processInstanceServices = processInstanceServices;
+    this.variableServices = variableServices;
+    this.elementInstanceServices = elementInstanceServices;
+    this.authenticationProvider = authenticationProvider;
+  }
+
+  @CamundaMcpTool(
+      description =
+          "Get the current state of a process instance by its key. Returns the process state, "
+              + "current variables, active element instances, and incident status. "
+              + EVENTUAL_CONSISTENCY_NOTE,
+      annotations = @McpAnnotations(readOnlyHint = true))
+  public CallToolResult getProcessState(
+      @McpToolParam(
+              description =
+                  "The assigned key of the process instance, which acts as a unique identifier for this process instance.")
+          @NotNull(message = PROCESS_INSTANCE_KEY_NOT_NULL_MESSAGE)
+          @Positive(message = PROCESS_INSTANCE_KEY_POSITIVE_MESSAGE)
+          final Long processInstanceKey) {
+    try {
+      final var auth = authenticationProvider.getCamundaAuthentication();
+      final var processInstance = processInstanceServices.getByKey(processInstanceKey, auth);
+      final var variables = variableServices.search(variablesQuery(processInstanceKey), auth);
+      final var activeElements =
+          elementInstanceServices.search(activeElementInstancesQuery(processInstanceKey), auth);
+
+      return CallToolResultMapper.from(
+          new ProcessStateResult(
+              SearchQueryResponseMapper.toProcessInstance(processInstance),
+              SearchQueryResponseMapper.toVariableSearchQueryResponse(variables, false).getItems(),
+              SearchQueryResponseMapper.toElementInstanceSearchQueryResponse(activeElements)
+                  .getItems()));
+    } catch (final Exception e) {
+      return CallToolResultMapper.mapErrorToResult(e);
+    }
+  }
+
+  private static VariableQuery variablesQuery(final Long processInstanceKey) {
+    return VariableQuery.of(b -> b.filter(f -> f.processInstanceKeys(processInstanceKey)));
+  }
+
+  private static FlowNodeInstanceQuery activeElementInstancesQuery(final Long processInstanceKey) {
+    return FlowNodeInstanceQuery.of(
+        b ->
+            b.filter(
+                f ->
+                    f.processInstanceKeys(processInstanceKey).states(FlowNodeState.ACTIVE.name())));
+  }
+}

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/ToolsSchemaRegressionTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/ToolsSchemaRegressionTest.java
@@ -12,10 +12,12 @@ import io.camunda.gateway.mcp.tool.cluster.ClusterTools;
 import io.camunda.gateway.mcp.tool.incident.IncidentTools;
 import io.camunda.gateway.mcp.tool.process.definition.ProcessDefinitionTools;
 import io.camunda.gateway.mcp.tool.process.instance.ProcessInstanceTools;
+import io.camunda.gateway.mcp.tool.process.state.ProcessStateTools;
 import io.camunda.gateway.mcp.tool.usertask.UserTaskTools;
 import io.camunda.gateway.mcp.tool.variable.VariableTools;
 import io.camunda.gateway.protocol.model.JobActivationResult;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
+import io.camunda.service.ElementInstanceServices;
 import io.camunda.service.IncidentServices;
 import io.camunda.service.JobServices;
 import io.camunda.service.ProcessDefinitionServices;
@@ -56,6 +58,7 @@ import tools.jackson.databind.node.ObjectNode;
       IncidentTools.class,
       ProcessDefinitionTools.class,
       ProcessInstanceTools.class,
+      ProcessStateTools.class,
       UserTaskTools.class,
       VariableTools.class
     })
@@ -74,6 +77,7 @@ class ToolsSchemaRegressionTest extends OperationalToolsTest {
   @MockitoBean private ProcessInstanceServices processInstanceServices;
   @MockitoBean private UserTaskServices userTaskServices;
   @MockitoBean private VariableServices variableServices;
+  @MockitoBean private ElementInstanceServices elementInstanceServices;
   @MockitoBean private MultiTenancyConfiguration multiTenancyConfiguration;
 
   @TestFactory

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/state/ProcessStateToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/state/ProcessStateToolsTest.java
@@ -1,0 +1,360 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.gateway.mcp.tool.process.state;
+
+import static io.camunda.gateway.mcp.tool.CallToolResultAssertions.assertTextContentFallback;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.gateway.mcp.OperationalToolsTest;
+import io.camunda.gateway.protocol.model.ElementInstanceResult;
+import io.camunda.gateway.protocol.model.ElementInstanceStateEnum;
+import io.camunda.gateway.protocol.model.ProcessInstanceResult;
+import io.camunda.gateway.protocol.model.ProcessInstanceStateEnum;
+import io.camunda.gateway.protocol.model.VariableSearchResult;
+import io.camunda.search.entities.FlowNodeInstanceEntity;
+import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeState;
+import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeType;
+import io.camunda.search.entities.ProcessInstanceEntity;
+import io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
+import io.camunda.search.entities.VariableEntity;
+import io.camunda.search.filter.FlowNodeInstanceFilter;
+import io.camunda.search.filter.VariableFilter;
+import io.camunda.search.query.FlowNodeInstanceQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.search.query.SearchQueryResult.Builder;
+import io.camunda.search.query.VariableQuery;
+import io.camunda.service.ElementInstanceServices;
+import io.camunda.service.ProcessInstanceServices;
+import io.camunda.service.VariableServices;
+import io.camunda.service.exception.ServiceException;
+import io.camunda.service.exception.ServiceException.Status;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import java.time.OffsetDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import tools.jackson.databind.json.JsonMapper;
+
+@ExtendWith(MockitoExtension.class)
+@ContextConfiguration(classes = {ProcessStateTools.class})
+class ProcessStateToolsTest extends OperationalToolsTest {
+
+  static final ProcessInstanceEntity PROCESS_INSTANCE_ENTITY =
+      new ProcessInstanceEntity(
+          123L,
+          null,
+          "demoProcess",
+          "Demo Process",
+          5,
+          "v5",
+          789L,
+          333L,
+          777L,
+          OffsetDateTime.parse("2024-01-01T00:00:00Z"),
+          null,
+          ProcessInstanceState.ACTIVE,
+          true,
+          "tenant",
+          "PI_123",
+          Set.of("tag1"),
+          null);
+
+  static final VariableEntity VARIABLE_ENTITY =
+      new VariableEntity(
+          456L,
+          "orderId",
+          "\"order-99\"",
+          "\"order-99\"",
+          false,
+          123L,
+          123L,
+          null,
+          "demoProcess",
+          "tenant");
+
+  static final FlowNodeInstanceEntity ELEMENT_INSTANCE_ENTITY =
+      new FlowNodeInstanceEntity(
+          999L,
+          123L,
+          null,
+          789L,
+          OffsetDateTime.parse("2024-01-01T01:00:00Z"),
+          null,
+          "serviceTask_1",
+          "Process Order",
+          null,
+          FlowNodeType.SERVICE_TASK,
+          FlowNodeState.ACTIVE,
+          false,
+          null,
+          "demoProcess",
+          "tenant",
+          null);
+
+  static final SearchQueryResult<VariableEntity> VARIABLE_SEARCH_RESULT =
+      new Builder<VariableEntity>().total(1L).items(List.of(VARIABLE_ENTITY)).build();
+
+  static final SearchQueryResult<FlowNodeInstanceEntity> ELEMENT_INSTANCE_SEARCH_RESULT =
+      new Builder<FlowNodeInstanceEntity>()
+          .total(1L)
+          .items(List.of(ELEMENT_INSTANCE_ENTITY))
+          .build();
+
+  @MockitoBean private ProcessInstanceServices processInstanceServices;
+  @MockitoBean private VariableServices variableServices;
+  @MockitoBean private ElementInstanceServices elementInstanceServices;
+
+  @Autowired private JsonMapper objectMapper;
+
+  @Captor private ArgumentCaptor<VariableQuery> variableQueryCaptor;
+  @Captor private ArgumentCaptor<FlowNodeInstanceQuery> elementQueryCaptor;
+
+  private void assertExampleResult(final ProcessStateResult result) {
+    assertExampleProcessInstance(result.processInstance());
+    assertExampleVariable(result.variables().getFirst());
+    assertExampleElementInstance(result.activeElementInstances().getFirst());
+  }
+
+  private void assertExampleProcessInstance(final ProcessInstanceResult processInstance) {
+    assertThat(processInstance.getProcessInstanceKey()).isEqualTo("123");
+    assertThat(processInstance.getProcessDefinitionId()).isEqualTo("demoProcess");
+    assertThat(processInstance.getState()).isEqualTo(ProcessInstanceStateEnum.ACTIVE);
+    assertThat(processInstance.getHasIncident()).isTrue();
+  }
+
+  private void assertExampleVariable(final VariableSearchResult variable) {
+    assertThat(variable.getVariableKey()).isEqualTo("456");
+    assertThat(variable.getName()).isEqualTo("orderId");
+    assertThat(variable.getValue()).isEqualTo("\"order-99\"");
+    assertThat(variable.getProcessInstanceKey()).isEqualTo("123");
+    assertThat(variable.getTenantId()).isEqualTo("tenant");
+  }
+
+  private void assertExampleElementInstance(final ElementInstanceResult elementInstance) {
+    assertThat(elementInstance.getElementInstanceKey()).isEqualTo("999");
+    assertThat(elementInstance.getProcessInstanceKey()).isEqualTo("123");
+    assertThat(elementInstance.getElementId()).isEqualTo("serviceTask_1");
+    assertThat(elementInstance.getElementName()).isEqualTo("Process Order");
+    assertThat(elementInstance.getState()).isEqualTo(ElementInstanceStateEnum.ACTIVE);
+  }
+
+  @Nested
+  class GetProcessState {
+
+    @Test
+    void shouldGetProcessStateByKey() {
+      // given
+      when(processInstanceServices.getByKey(any(), any())).thenReturn(PROCESS_INSTANCE_ENTITY);
+      when(variableServices.search(any(VariableQuery.class), any()))
+          .thenReturn(VARIABLE_SEARCH_RESULT);
+      when(elementInstanceServices.search(any(FlowNodeInstanceQuery.class), any()))
+          .thenReturn(ELEMENT_INSTANCE_SEARCH_RESULT);
+
+      // when
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder()
+                  .name("getProcessState")
+                  .arguments(Map.of("processInstanceKey", 123L))
+                  .build());
+
+      // then
+      assertThat(result.isError()).isFalse();
+      assertThat(result.structuredContent()).isNotNull();
+
+      final var processStateResult =
+          objectMapper.convertValue(result.structuredContent(), ProcessStateResult.class);
+      assertExampleResult(processStateResult);
+
+      verify(processInstanceServices).getByKey(eq(123L), any());
+
+      assertTextContentFallback(result);
+    }
+
+    @Test
+    void shouldQueryVariablesByProcessInstanceKey() {
+      // given
+      when(processInstanceServices.getByKey(any(), any())).thenReturn(PROCESS_INSTANCE_ENTITY);
+      when(variableServices.search(any(VariableQuery.class), any()))
+          .thenReturn(VARIABLE_SEARCH_RESULT);
+      when(elementInstanceServices.search(any(FlowNodeInstanceQuery.class), any()))
+          .thenReturn(ELEMENT_INSTANCE_SEARCH_RESULT);
+
+      // when
+      mcpClient.callTool(
+          CallToolRequest.builder()
+              .name("getProcessState")
+              .arguments(Map.of("processInstanceKey", 123L))
+              .build());
+
+      // then
+      verify(variableServices).search(variableQueryCaptor.capture(), any());
+      final VariableFilter capturedFilter = variableQueryCaptor.getValue().filter();
+      assertThat(capturedFilter.processInstanceKeyOperations()).hasSize(1);
+    }
+
+    @Test
+    void shouldQueryActiveElementInstancesByProcessInstanceKey() {
+      // given
+      when(processInstanceServices.getByKey(any(), any())).thenReturn(PROCESS_INSTANCE_ENTITY);
+      when(variableServices.search(any(VariableQuery.class), any()))
+          .thenReturn(VARIABLE_SEARCH_RESULT);
+      when(elementInstanceServices.search(any(FlowNodeInstanceQuery.class), any()))
+          .thenReturn(ELEMENT_INSTANCE_SEARCH_RESULT);
+
+      // when
+      mcpClient.callTool(
+          CallToolRequest.builder()
+              .name("getProcessState")
+              .arguments(Map.of("processInstanceKey", 123L))
+              .build());
+
+      // then
+      verify(elementInstanceServices).search(elementQueryCaptor.capture(), any());
+      final FlowNodeInstanceFilter capturedFilter = elementQueryCaptor.getValue().filter();
+      assertThat(capturedFilter.processInstanceKeys()).containsExactly(123L);
+      assertThat(capturedFilter.stateOperations()).hasSize(1);
+    }
+
+    @Test
+    void shouldReturnEmptyListsWhenNoVariablesOrElementInstances() {
+      // given
+      when(processInstanceServices.getByKey(any(), any())).thenReturn(PROCESS_INSTANCE_ENTITY);
+      when(variableServices.search(any(VariableQuery.class), any()))
+          .thenReturn(new Builder<VariableEntity>().total(0L).items(List.of()).build());
+      when(elementInstanceServices.search(any(FlowNodeInstanceQuery.class), any()))
+          .thenReturn(new Builder<FlowNodeInstanceEntity>().total(0L).items(List.of()).build());
+
+      // when
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder()
+                  .name("getProcessState")
+                  .arguments(Map.of("processInstanceKey", 123L))
+                  .build());
+
+      // then
+      assertThat(result.isError()).isFalse();
+      final var processStateResult =
+          objectMapper.convertValue(result.structuredContent(), ProcessStateResult.class);
+      assertThat(processStateResult.variables()).isEmpty();
+      assertThat(processStateResult.activeElementInstances()).isEmpty();
+    }
+
+    @Test
+    void shouldFailGetProcessStateOnProcessInstanceNotFound() {
+      // given
+      when(processInstanceServices.getByKey(any(), any()))
+          .thenThrow(new ServiceException("Expected failure", Status.NOT_FOUND));
+
+      // when
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder()
+                  .name("getProcessState")
+                  .arguments(Map.of("processInstanceKey", 123L))
+                  .build());
+
+      // then
+      assertThat(result.isError()).isTrue();
+      assertThat(result.structuredContent()).isNotNull();
+
+      final var problemDetail =
+          objectMapper.convertValue(result.structuredContent(), ProblemDetail.class);
+      assertThat(problemDetail.getDetail()).isEqualTo("Expected failure");
+      assertThat(problemDetail.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
+      assertThat(problemDetail.getTitle()).isEqualTo("NOT_FOUND");
+
+      assertTextContentFallback(result);
+    }
+
+    @Test
+    void shouldFailGetProcessStateOnMissingKey() {
+      // when
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder().name("getProcessState").arguments(Map.of()).build());
+
+      // then
+      assertThat(result.isError()).isTrue();
+      assertThat(result.structuredContent()).isNull();
+      assertThat(result.content())
+          .hasSize(1)
+          .first()
+          .isInstanceOfSatisfying(
+              TextContent.class,
+              textContent ->
+                  assertThat(textContent.text())
+                      .isEqualTo("processInstanceKey: Process instance key must not be null."));
+    }
+
+    @Test
+    void shouldFailGetProcessStateOnNullKey() {
+      // when
+      final var arguments = new HashMap<String, Object>();
+      arguments.put("processInstanceKey", null);
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder().name("getProcessState").arguments(arguments).build());
+
+      // then
+      assertThat(result.isError()).isTrue();
+      assertThat(result.structuredContent()).isNull();
+      assertThat(result.content())
+          .hasSize(1)
+          .first()
+          .isInstanceOfSatisfying(
+              TextContent.class,
+              textContent ->
+                  assertThat(textContent.text())
+                      .isEqualTo("processInstanceKey: Process instance key must not be null."));
+    }
+
+    @Test
+    void shouldFailGetProcessStateOnInvalidKey() {
+      // when
+      final CallToolResult result =
+          mcpClient.callTool(
+              CallToolRequest.builder()
+                  .name("getProcessState")
+                  .arguments(Map.of("processInstanceKey", -3L))
+                  .build());
+
+      // then
+      assertThat(result.isError()).isTrue();
+      assertThat(result.structuredContent()).isNull();
+      assertThat(result.content())
+          .hasSize(1)
+          .first()
+          .isInstanceOfSatisfying(
+              TextContent.class,
+              textContent ->
+                  assertThat(textContent.text())
+                      .isEqualTo(
+                          "processInstanceKey: Process instance key must be a positive number."));
+    }
+  }
+}

--- a/gateways/gateway-mcp/src/test/resources/schema/tools-schema-snapshot.json
+++ b/gateways/gateway-mcp/src/test/resources/schema/tools-schema-snapshot.json
@@ -1113,6 +1113,27 @@
       "annotations": {
         "readOnlyHint": true
       }
+    },
+    {
+      "name": "getProcessState",
+      "title": "getProcessState",
+      "description": "Get the current state of a process instance by its key. Returns the process state, current variables, active element instances, and incident status. Note: Results are eventually consistent and may not immediately reflect recent changes.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "processInstanceKey": {
+            "type": "integer",
+            "format": "int64",
+            "description": "The assigned key of the process instance, which acts as a unique identifier for this process instance."
+          }
+        },
+        "required": [
+          "processInstanceKey"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": true
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds a `getProcessState` tool to both the `/mcp/cluster` and `/mcp/processes` MCP servers
- The tool accepts a `processInstanceKey` and returns the combined state: process instance status, current variables, and active element instances in a single call
- On the cluster server it's registered via `@CamundaMcpTool` scanning; on the processes server via a new `processesMcpStaticToolSpecifications` bean that the default `processesToolRepository` delegates to
- `ObjectProvider<ProcessStateTools>` is used in the static specs bean so that test contexts without `ProcessStateTools` still produce a valid (empty) tool repository instead of a startup failure

## Test plan

- [ ] `ProcessStateToolsTest` — 8 unit tests covering the happy path, query filters, empty results, and validation errors
- [ ] `ToolsSchemaRegressionTest` — schema snapshot updated to include `getProcessState`
- [ ] All `ProcessesMcpServer*` tests pass (empty/static/dynamic/failing repository variants)
- [ ] All other cluster tool tests (`ClusterToolsTest`, `IncidentToolsTest`, `UserTaskToolsTest`, `VariableToolsTest`) unaffected

https://claude.ai/code/session_01AbmvxSEGqLBK8KwAFjJE8f

---
_Generated by [Claude Code](https://claude.ai/code/session_01AbmvxSEGqLBK8KwAFjJE8f)_