### PR TITLE
build: create volume after mkdir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -128,11 +128,6 @@ ENV ROCKSDB_MUSL_LIBC=false
 
 WORKDIR ${ZB_HOME}
 EXPOSE 8080 26500 26501 26502
-VOLUME /tmp
-VOLUME ${ZB_HOME}/data
-VOLUME ${ZB_HOME}/logs
-VOLUME ${ZB_HOME}/documents
-VOLUME /driver-lib
 
 # Switch to root to allow setting up our own user
 USER root
@@ -146,6 +141,12 @@ RUN addgroup --gid 1001 camunda && \
     mkdir ${ZB_HOME}/documents && \
     chown -R 1001:0 ${ZB_HOME} && \
     chmod -R 0775 ${ZB_HOME}
+
+VOLUME /tmp
+VOLUME ${ZB_HOME}/data
+VOLUME ${ZB_HOME}/logs
+VOLUME ${ZB_HOME}/documents
+VOLUME /driver-lib
 
 COPY --from=jattach --chown=1001:0 /jattach /usr/local/bin/jattach
 COPY --link --chown=1001:0 zeebe/docker/utils/startup.sh /usr/local/bin/startup.sh

--- a/camunda.Dockerfile
+++ b/camunda.Dockerfile
@@ -127,11 +127,6 @@ ENV ROCKSDB_MUSL_LIBC=false
 
 WORKDIR ${CAMUNDA_HOME}
 EXPOSE 8080 26500 26501 26502
-VOLUME /tmp
-VOLUME ${CAMUNDA_HOME}/data
-VOLUME ${CAMUNDA_HOME}/logs
-VOLUME ${CAMUNDA_HOME}/documents
-VOLUME /driver-lib
 
 # Switch to root to allow setting up our own user
 USER root
@@ -145,6 +140,12 @@ RUN addgroup --gid 1001 camunda && \
     mkdir ${CAMUNDA_HOME}/documents && \
     chown -R 1001:0 ${CAMUNDA_HOME} && \
     chmod -R 0775 ${CAMUNDA_HOME}
+
+VOLUME /tmp
+VOLUME ${CAMUNDA_HOME}/data
+VOLUME ${CAMUNDA_HOME}/logs
+VOLUME ${CAMUNDA_HOME}/documents
+VOLUME /driver-lib
 
 COPY --from=jattach --chown=1001:0 /jattach /usr/local/bin/jattach
 COPY --from=dist --chown=1001:0 /camunda/camunda-zeebe ${CAMUNDA_HOME}


### PR DESCRIPTION
## Description
when VOLUME is used the corresponding directory is created as well. This makes the build fail on podman.

Declaring the volume after the folders are created with the right permissions fixes the issue

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

