### PR TITLE
build: remove unused rocksdb native library from docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,29 +85,29 @@ RUN mkdir camunda-zeebe && \
     tar xfvz zeebe.tar.gz --strip 1 -C camunda-zeebe
 
 ARG TARGETARCH
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
+# Slim the RocksDB JNI jar: keeps only the target-arch glibc .so, removing ~60 MB of unused native libs
+RUN \
+    # Map Docker TARGETARCH to the RocksDB native lib filename suffix
+    if [ "$TARGETARCH" = "amd64" ]; then \
       ROCKSDB_ARCH="linux64"; \
     elif [ "$TARGETARCH" = "arm64" ]; then \
       ROCKSDB_ARCH="linux-aarch64"; \
     else \
       echo "Unsupported architecture: $TARGETARCH" >&2 && exit 1; \
     fi && \
+    # Locate the jar (version-agnostic)
     ROCKSDB_JAR=$(find camunda-zeebe/lib -name 'rocksdbjni-*.jar' | head -1) && \
     UNPACK=$(mktemp -d) && \
-    OUTPUT=$(mktemp -d) && \
+    # Unpack, remove all native libs except the one we need, validate, repack
     unzip -q "$ROCKSDB_JAR" -d "$UNPACK" && \
-    find "$UNPACK" -type f ! \( -name '*.so' -o -name '*.jnilib' -o -name '*.dll' \) \
-      | while IFS= read -r f; do \
-          install -D "$f" "$OUTPUT/${f#"$UNPACK"/}"; \
-        done && \
-    install "$UNPACK/librocksdbjni-${ROCKSDB_ARCH}.so" \
-            "$OUTPUT/librocksdbjni-${ROCKSDB_ARCH}.so" && \
-    count=$(find "$OUTPUT" \( -name '*.so' -o -name '*.jnilib' -o -name '*.dll' \) | wc -l) && \
-    [ "$count" -eq 1 ] || \
-      { echo "Expected exactly 1 native lib, found $count" >&2; exit 1; } && \
+    find "$UNPACK" \( -name '*.so' -o -name '*.jnilib' -o -name '*.dll' \) \
+      ! -name "librocksdbjni-${ROCKSDB_ARCH}.so" -delete && \
+    # Verify only one shared lib is left
+    count=$(find "$UNPACK" \( -name '*.so' -o -name '*.jnilib' -o -name '*.dll' \) | wc -l) && \
+    [ "$count" -eq 1 ] || { echo "Expected exactly 1 native lib, found $count" >&2; exit 1; } && \
     rm "$ROCKSDB_JAR" && \
-    ( cd "$OUTPUT" && zip -qr "$OLDPWD/$ROCKSDB_JAR" . ) && \
-    rm -rf "$UNPACK" "$OUTPUT"
+    ( cd "$UNPACK" && zip -qr "$OLDPWD/$ROCKSDB_JAR" . ) && \
+    rm -rf "$UNPACK"
 
 
 ### Image containing the zeebe distribution ###

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,11 +71,43 @@ FROM ubuntu:noble AS distball
 # hadolint ignore=DL3002
 USER root
 WORKDIR /zeebe
+
+# Install tools before COPY so this layer is cached independently of the distball
+# hadolint ignore=DL3008
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends unzip zip && \
+    rm -rf /var/lib/apt/lists/*
+
 ARG DISTBALL="dist/target/camunda-zeebe-*.tar.gz"
 COPY --link ${DISTBALL} zeebe.tar.gz
 
 RUN mkdir camunda-zeebe && \
     tar xfvz zeebe.tar.gz --strip 1 -C camunda-zeebe
+
+ARG TARGETARCH
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+      ROCKSDB_ARCH="linux64"; \
+    elif [ "$TARGETARCH" = "arm64" ]; then \
+      ROCKSDB_ARCH="linux-aarch64"; \
+    else \
+      echo "Unsupported architecture: $TARGETARCH" >&2 && exit 1; \
+    fi && \
+    ROCKSDB_JAR=$(find camunda-zeebe/lib -name 'rocksdbjni-*.jar' | head -1) && \
+    UNPACK=$(mktemp -d) && \
+    OUTPUT=$(mktemp -d) && \
+    unzip -q "$ROCKSDB_JAR" -d "$UNPACK" && \
+    find "$UNPACK" -type f ! \( -name '*.so' -o -name '*.jnilib' -o -name '*.dll' \) \
+      | while IFS= read -r f; do \
+          install -D "$f" "$OUTPUT/${f#"$UNPACK"/}"; \
+        done && \
+    install "$UNPACK/librocksdbjni-${ROCKSDB_ARCH}.so" \
+            "$OUTPUT/librocksdbjni-${ROCKSDB_ARCH}.so" && \
+    count=$(find "$OUTPUT" \( -name '*.so' -o -name '*.jnilib' -o -name '*.dll' \) | wc -l) && \
+    [ "$count" -eq 1 ] || \
+      { echo "Expected exactly 1 native lib, found $count" >&2; exit 1; } && \
+    rm "$ROCKSDB_JAR" && \
+    ( cd "$OUTPUT" && zip -qr "$OLDPWD/$ROCKSDB_JAR" . ) && \
+    rm -rf "$UNPACK" "$OUTPUT"
 
 
 ### Image containing the zeebe distribution ###

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,7 @@ FROM ubuntu:noble AS distball
 # hadolint ignore=DL3002
 USER root
 WORKDIR /zeebe
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install tools before COPY so this layer is cached independently of the distball
 # hadolint ignore=DL3008
@@ -86,6 +87,7 @@ RUN mkdir camunda-zeebe && \
 
 ARG TARGETARCH
 # Slim the RocksDB JNI jar: keeps only the target-arch glibc .so, removing ~60 MB of unused native libs
+# hadolint ignore=DL3003
 RUN \
     # Map Docker TARGETARCH to the RocksDB native lib filename suffix
     if [ "$TARGETARCH" = "amd64" ]; then \

--- a/camunda.Dockerfile
+++ b/camunda.Dockerfile
@@ -71,6 +71,7 @@ FROM ubuntu:noble AS distball
 # hadolint ignore=DL3002
 USER root
 WORKDIR /camunda
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install tools before COPY so this layer is cached independently of the distball
 # hadolint ignore=DL3008
@@ -86,6 +87,7 @@ RUN mkdir camunda-zeebe && \
 
 ARG TARGETARCH
 # Slim the RocksDB JNI jar: keeps only the target-arch glibc .so, removing ~60 MB of unused native libs
+# hadolint ignore=DL3003
 RUN \
     # Map Docker TARGETARCH to the RocksDB native lib filename suffix
     if [ "$TARGETARCH" = "amd64" ]; then \

--- a/camunda.Dockerfile
+++ b/camunda.Dockerfile
@@ -71,11 +71,43 @@ FROM ubuntu:noble AS distball
 # hadolint ignore=DL3002
 USER root
 WORKDIR /camunda
+
+# Install tools before COPY so this layer is cached independently of the distball
+# hadolint ignore=DL3008
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends unzip zip && \
+    rm -rf /var/lib/apt/lists/*
+
 ARG DISTBALL="dist/target/camunda-zeebe-*.tar.gz"
 COPY --link ${DISTBALL} camunda.tar.gz
 
 RUN mkdir camunda-zeebe && \
     tar xfvz camunda.tar.gz --strip 1 -C camunda-zeebe
+
+ARG TARGETARCH
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+      ROCKSDB_ARCH="linux64"; \
+    elif [ "$TARGETARCH" = "arm64" ]; then \
+      ROCKSDB_ARCH="linux-aarch64"; \
+    else \
+      echo "Unsupported architecture: $TARGETARCH" >&2 && exit 1; \
+    fi && \
+    ROCKSDB_JAR=$(find camunda-zeebe/lib -name 'rocksdbjni-*.jar' | head -1) && \
+    UNPACK=$(mktemp -d) && \
+    OUTPUT=$(mktemp -d) && \
+    unzip -q "$ROCKSDB_JAR" -d "$UNPACK" && \
+    find "$UNPACK" -type f ! \( -name '*.so' -o -name '*.jnilib' -o -name '*.dll' \) \
+      | while IFS= read -r f; do \
+          install -D "$f" "$OUTPUT/${f#"$UNPACK"/}"; \
+        done && \
+    install "$UNPACK/librocksdbjni-${ROCKSDB_ARCH}.so" \
+            "$OUTPUT/librocksdbjni-${ROCKSDB_ARCH}.so" && \
+    count=$(find "$OUTPUT" \( -name '*.so' -o -name '*.jnilib' -o -name '*.dll' \) | wc -l) && \
+    [ "$count" -eq 1 ] || \
+      { echo "Expected exactly 1 native lib, found $count" >&2; exit 1; } && \
+    rm "$ROCKSDB_JAR" && \
+    ( cd "$OUTPUT" && zip -qr "$OLDPWD/$ROCKSDB_JAR" . ) && \
+    rm -rf "$UNPACK" "$OUTPUT"
 
 
 ### Image containing the camunda distribution ###

--- a/camunda.Dockerfile
+++ b/camunda.Dockerfile
@@ -85,29 +85,29 @@ RUN mkdir camunda-zeebe && \
     tar xfvz camunda.tar.gz --strip 1 -C camunda-zeebe
 
 ARG TARGETARCH
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
+# Slim the RocksDB JNI jar: keeps only the target-arch glibc .so, removing ~60 MB of unused native libs
+RUN \
+    # Map Docker TARGETARCH to the RocksDB native lib filename suffix
+    if [ "$TARGETARCH" = "amd64" ]; then \
       ROCKSDB_ARCH="linux64"; \
     elif [ "$TARGETARCH" = "arm64" ]; then \
       ROCKSDB_ARCH="linux-aarch64"; \
     else \
       echo "Unsupported architecture: $TARGETARCH" >&2 && exit 1; \
     fi && \
+    # Locate the jar (version-agnostic)
     ROCKSDB_JAR=$(find camunda-zeebe/lib -name 'rocksdbjni-*.jar' | head -1) && \
     UNPACK=$(mktemp -d) && \
-    OUTPUT=$(mktemp -d) && \
+    # Unpack, remove all native libs except the one we need, validate, repack
     unzip -q "$ROCKSDB_JAR" -d "$UNPACK" && \
-    find "$UNPACK" -type f ! \( -name '*.so' -o -name '*.jnilib' -o -name '*.dll' \) \
-      | while IFS= read -r f; do \
-          install -D "$f" "$OUTPUT/${f#"$UNPACK"/}"; \
-        done && \
-    install "$UNPACK/librocksdbjni-${ROCKSDB_ARCH}.so" \
-            "$OUTPUT/librocksdbjni-${ROCKSDB_ARCH}.so" && \
-    count=$(find "$OUTPUT" \( -name '*.so' -o -name '*.jnilib' -o -name '*.dll' \) | wc -l) && \
-    [ "$count" -eq 1 ] || \
-      { echo "Expected exactly 1 native lib, found $count" >&2; exit 1; } && \
+    find "$UNPACK" \( -name '*.so' -o -name '*.jnilib' -o -name '*.dll' \) \
+      ! -name "librocksdbjni-${ROCKSDB_ARCH}.so" -delete && \
+    # Verify only shared lib is left
+    count=$(find "$UNPACK" \( -name '*.so' -o -name '*.jnilib' -o -name '*.dll' \) | wc -l) && \
+    [ "$count" -eq 1 ] || { echo "Expected exactly 1 native lib, found $count" >&2; exit 1; } && \
     rm "$ROCKSDB_JAR" && \
-    ( cd "$OUTPUT" && zip -qr "$OLDPWD/$ROCKSDB_JAR" . ) && \
-    rm -rf "$UNPACK" "$OUTPUT"
+    ( cd "$UNPACK" && zip -qr "$OLDPWD/$ROCKSDB_JAR" . ) && \
+    rm -rf "$UNPACK"
 
 
 ### Image containing the camunda distribution ###


### PR DESCRIPTION
## Description
Adds a build stage where we unpack the rocksdb-jni jar and remove the native libraries for the architecture we dont' need.
The jar contains (14 native libs total):
-  Linux glibc: x86_64, aarch64, i386, ppc64le, s390x, riscv64
-  Linux musl (Alpine): x86_64, aarch64, i386, ppc64le, s390x
- macOS: x86_64, arm64
- Windows: x86_64

To identify the arch we are currently building, `$TARGETARCH` is used

For each docker image we just need one: linux-{amd64,aarch64}.
We remove all the other libs and keep only the one we require.
We verify that the lib required is included before zipping.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

