### PR TITLE
deps: replace checker-qual with jspecify in process-test modules

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1951,6 +1951,7 @@
         <version>${version.gson}</version>
       </dependency>
 
+      <!-- no direct usages; kept here to pin the transitive version pulled in by gRPC and Guava -->
       <dependency>
         <groupId>org.checkerframework</groupId>
         <artifactId>checker-qual</artifactId>

--- a/testing/camunda-process-test-spring-boot-3/pom.xml
+++ b/testing/camunda-process-test-spring-boot-3/pom.xml
@@ -106,8 +106,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.checkerframework</groupId>
-      <artifactId>checker-qual</artifactId>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
     </dependency>
 
     <dependency>

--- a/testing/camunda-process-test-spring/pom.xml
+++ b/testing/camunda-process-test-spring/pom.xml
@@ -85,8 +85,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.checkerframework</groupId>
-      <artifactId>checker-qual</artifactId>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
     </dependency>
 
     <dependency>

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/proxy/AbstractInvocationHandler.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/proxy/AbstractInvocationHandler.java
@@ -21,7 +21,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.Arrays;
 import javax.annotation.CheckForNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jspecify.annotations.Nullable;
 
 public abstract class AbstractInvocationHandler<T> implements InvocationHandler {
 


### PR DESCRIPTION
## Summary

- Replaces direct `checker-qual` dependency with `jspecify` in `camunda-process-test-spring` and `camunda-process-test-spring-boot-3`
- Updates the single import site in `AbstractInvocationHandler.java` from `org.checkerframework.checker.nullness.qual.Nullable` to `org.jspecify.annotations.Nullable`
- Adds a comment in `parent/pom.xml` explaining that the `checker-qual` entry is kept only to pin the transitive version pulled in by gRPC and Guava

`jspecify` is already managed in the parent BOM and is the project-standard nullness annotation library.
