### PR TITLE
fix: prevent exporter state version conflict after restore

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
@@ -142,7 +142,8 @@ public final class ClusterConfigurationManagerService
             new ExporterStateInitializer(
                 staticConfiguration.partitionConfig().exporting().exporters().keySet(),
                 staticConfiguration.localMemberId(),
-                managerActor))
+                managerActor,
+                false))
         .andThen(new RoutingStateInitializer(staticConfiguration.partitionCount()));
     // This initializer does not set the cluster ID, as it is not required for non-coordinators.
     // Non-coordinators will receive the cluster ID from the coordinator via gossip.
@@ -167,7 +168,8 @@ public final class ClusterConfigurationManagerService
             new ExporterStateInitializer(
                 staticConfiguration.partitionConfig().exporting().exporters().keySet(),
                 staticConfiguration.localMemberId(),
-                managerActor))
+                managerActor,
+                true))
         .andThen(new RoutingStateInitializer(staticConfiguration.partitionCount()))
         .andThen(new ClusterIdInitializer(staticConfiguration.clusterId()));
   }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ExporterStateInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ExporterStateInitializer.java
@@ -37,14 +37,17 @@ public class ExporterStateInitializer implements ClusterConfigurationModifier {
   private final Set<String> configuredExporters;
   private final MemberId localMemberId;
   private final ConcurrencyControl executor;
+  private final boolean isCoordinator;
 
   public ExporterStateInitializer(
       final Set<String> configuredExporters,
       final MemberId localMemberId,
-      final ConcurrencyControl executor) {
+      final ConcurrencyControl executor,
+      final boolean isCoordinator) {
     this.configuredExporters = configuredExporters;
     this.localMemberId = localMemberId;
     this.executor = executor;
+    this.isCoordinator = isCoordinator;
   }
 
   @Override
@@ -52,10 +55,28 @@ public class ExporterStateInitializer implements ClusterConfigurationModifier {
     final ActorFuture<ClusterConfiguration> result = executor.createFuture();
     if (!configuration.hasMember(localMemberId)) {
       result.complete(configuration);
+    } else if (configuration.isAfterRestore()) {
+      if (isCoordinator) {
+        result.complete(updateExporterStateForAllMembers(configuration));
+      } else {
+        LOGGER.debug(
+            "Skipping exporter state initialization: post-restore pending UpdateRoutingState "
+                + "detected. Coordinator will handle initialization for all members.");
+        result.complete(configuration);
+      }
     } else {
       result.complete(configuration.updateMember(localMemberId, this::updateExporterState));
     }
     return result;
+  }
+
+  private ClusterConfiguration updateExporterStateForAllMembers(
+      final ClusterConfiguration configuration) {
+    ClusterConfiguration updated = configuration;
+    for (final var memberId : configuration.members().keySet()) {
+      updated = updated.updateMember(memberId, this::updateExporterState);
+    }
+    return updated;
   }
 
   private MemberState updateExporterState(final MemberState memberState) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterChangePlan.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterChangePlan.java
@@ -30,6 +30,8 @@ public record ClusterChangePlan(
     List<CompletedOperation> completedOperations,
     List<ClusterConfigurationChangeOperation> pendingOperations) {
 
+  private static final long RESTORE_CHANGE_ID = -2L;
+
   public ClusterChangePlan {
     completedOperations = List.copyOf(completedOperations);
     pendingOperations = List.copyOf(pendingOperations);
@@ -39,6 +41,15 @@ public record ClusterChangePlan(
       final long id, final List<ClusterConfigurationChangeOperation> operations) {
     return new ClusterChangePlan(
         id, 1, Status.IN_PROGRESS, Instant.now(), List.of(), List.copyOf(operations));
+  }
+
+  public static ClusterChangePlan initForRestore(
+      final List<ClusterConfigurationChangeOperation> operations) {
+    return init(RESTORE_CHANGE_ID, operations);
+  }
+
+  public boolean isRestore() {
+    return id == RESTORE_CHANGE_ID;
   }
 
   /** To be called when the first operation is completed. */

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfiguration.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.dynamic.config.state;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
 import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.UpdateRoutingState;
 import io.camunda.zeebe.dynamic.config.state.MemberState.State;
 import java.util.List;
 import java.util.Map;
@@ -248,6 +249,19 @@ public record ClusterConfiguration(
 
   public boolean hasPendingChanges() {
     return pendingChanges.isPresent() && pendingChanges.orElseThrow().hasPendingChanges();
+  }
+
+  /**
+   * Returns true if this configuration was produced by a restore: {@code pendingChanges} is
+   * present, marked as a restore plan, and contains exactly one pending operation which is an
+   * {@link UpdateRoutingState}.
+   */
+  public boolean isAfterRestore() {
+    return pendingChanges
+        .filter(ClusterChangePlan::isRestore)
+        .map(ClusterChangePlan::pendingOperations)
+        .filter(ops -> ops.size() == 1 && ops.get(0) instanceof UpdateRoutingState)
+        .isPresent();
   }
 
   /**

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationModifierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationModifierTest.java
@@ -10,7 +10,9 @@ package io.camunda.zeebe.dynamic.config;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.UpdateRoutingState;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
@@ -20,6 +22,7 @@ import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -30,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 final class ClusterConfigurationModifierTest {
 
@@ -78,7 +82,8 @@ final class ClusterConfigurationModifierTest {
     void shouldUpdateExporterConfig(final ExporterConfigParameter parameter) {
       // given
       final var exporterStateInitializer =
-          new ExporterStateInitializer(parameter.configuredExporters(), LOCAL_MEMBER_ID, executor);
+          new ExporterStateInitializer(
+              parameter.configuredExporters(), LOCAL_MEMBER_ID, executor, false);
 
       // when
       final var newConfiguration =
@@ -123,7 +128,7 @@ final class ClusterConfigurationModifierTest {
 
       // when
       final var newConfiguration =
-          new ExporterStateInitializer(Set.of("expA", "expB"), LOCAL_MEMBER_ID, executor)
+          new ExporterStateInitializer(Set.of("expA", "expB"), LOCAL_MEMBER_ID, executor, false)
               .modify(currentConfiguration)
               .join();
 
@@ -140,7 +145,7 @@ final class ClusterConfigurationModifierTest {
     void shouldNotUpdateMemberStateIfNoExporterChanges() {
       // when
       final var newConfiguration =
-          new ExporterStateInitializer(Set.of("expA", "expB"), LOCAL_MEMBER_ID, executor)
+          new ExporterStateInitializer(Set.of("expA", "expB"), LOCAL_MEMBER_ID, executor, false)
               .modify(withTwoEnabledExporters())
               .join();
 
@@ -316,6 +321,131 @@ final class ClusterConfigurationModifierTest {
           Named.of(
               "Disabled Exporter's Config is Removed",
               new ExporterConfigParameter(currentConfiguration, Set.of("expA"), initialConfig)));
+    }
+
+    @Test
+    void shouldUpdateAllMembersWhenCoordinatorAndPostRestore() {
+      // given
+      final var member1 = MemberId.from("1");
+      final var configWithPendingOp =
+          withRestorePendingChange(withTwoMembers(LOCAL_MEMBER_ID, member1), LOCAL_MEMBER_ID);
+
+      // when
+      final var result =
+          new ExporterStateInitializer(Set.of("expA"), LOCAL_MEMBER_ID, executor, true)
+              .modify(configWithPendingOp)
+              .join();
+
+      // then — expA was added for both members
+      ClusterConfigurationAssert.assertThatClusterTopology(result)
+          .member(LOCAL_MEMBER_ID)
+          .hasPartitionSatisfying(
+              1, p -> assertThat(p.config().exporting().exporters()).containsKey("expA"))
+          .describedAs("Local member is updated");
+      ClusterConfigurationAssert.assertThatClusterTopology(result)
+          .member(member1)
+          .hasPartitionSatisfying(
+              1, p -> assertThat(p.config().exporting().exporters()).containsKey("expA"))
+          .describedAs("Other member is updated");
+    }
+
+    @Test
+    void shouldSkipWhenNonCoordinatorAndPostRestore() {
+      // given
+      final var configWithPendingOp =
+          withRestorePendingChange(withTwoEnabledExporters(), LOCAL_MEMBER_ID);
+
+      // when
+      final var result =
+          new ExporterStateInitializer(
+                  Set.of("expA", "expB", "expC"), LOCAL_MEMBER_ID, executor, false)
+              .modify(configWithPendingOp)
+              .join();
+
+      // then — config is unchanged
+      assertThat(result)
+          .describedAs("Exporter state is not initialized")
+          .isEqualTo(configWithPendingOp);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldUpdateOnlyLocalMemberOnNormalRestart(final boolean isCoordinator) {
+      // given — two members, no pending changes
+      final var member1 = MemberId.from("1");
+      final var config = withTwoMembers(LOCAL_MEMBER_ID, member1);
+
+      // when — coordinator on normal restart (no pending UpdateRoutingState)
+      final var result =
+          new ExporterStateInitializer(Set.of("expA"), LOCAL_MEMBER_ID, executor, isCoordinator)
+              .modify(config)
+              .join();
+
+      // then — only local member is updated
+      ClusterConfigurationAssert.assertThatClusterTopology(result)
+          .member(LOCAL_MEMBER_ID)
+          .hasPartitionSatisfying(
+              1, p -> assertThat(p.config().exporting().exporters()).containsKey("expA"))
+          .describedAs("Local member is updated");
+      ClusterConfigurationAssert.assertThatClusterTopology(result)
+          .member(member1)
+          .hasPartitionSatisfying(
+              1, p -> assertThat(p.config().exporting().exporters()).doesNotContainKey("expA"))
+          .describedAs("Other member is not updated");
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldUpdateLocalMemberWhenNotPostRestoreWithPendingChanges(final boolean isCoordinator) {
+      // given — pending ops that are not post restore
+      final var member1 = MemberId.from("1");
+      final var config =
+          withTwoMembers(LOCAL_MEMBER_ID, member1)
+              .startConfigurationChange(
+                  List.of(new UpdateRoutingState(LOCAL_MEMBER_ID, Optional.empty())));
+
+      // when
+      final var result =
+          new ExporterStateInitializer(Set.of("expA"), LOCAL_MEMBER_ID, executor, isCoordinator)
+              .modify(config)
+              .join();
+
+      // then
+      assertThat(result).isNotEqualTo(config);
+      ClusterConfigurationAssert.assertThatClusterTopology(result)
+          .member(LOCAL_MEMBER_ID)
+          .hasPartitionSatisfying(
+              1, p -> assertThat(p.config().exporting().exporters()).containsKey("expA"));
+
+      // other member is not updated
+      ClusterConfigurationAssert.assertThatClusterTopology(result)
+          .member(member1)
+          .hasPartitionSatisfying(
+              1, p -> assertThat(p.config().exporting().exporters()).doesNotContainKey("expA"));
+    }
+
+    private static ClusterConfiguration withRestorePendingChange(
+        final ClusterConfiguration base, final MemberId coordinatorId) {
+      return new ClusterConfiguration(
+          base.version(),
+          base.members(),
+          base.lastChange(),
+          Optional.of(
+              ClusterChangePlan.initForRestore(
+                  List.of(new UpdateRoutingState(coordinatorId, Optional.empty())))),
+          base.routingState(),
+          base.clusterId(),
+          base.incarnationNumber());
+    }
+
+    private static ClusterConfiguration withTwoMembers(
+        final MemberId member0, final MemberId member1) {
+      final DynamicPartitionConfig config = DynamicPartitionConfig.init();
+      return ClusterConfiguration.init()
+          .addMember(
+              member0, MemberState.initializeAsActive(Map.of(1, PartitionState.active(1, config))))
+          .addMember(
+              member1, MemberState.initializeAsActive(Map.of(1, PartitionState.active(1, config))));
     }
 
     private static ClusterConfiguration withTwoEnabledExporters() {

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
@@ -282,8 +282,8 @@ public class RestoreManager implements CloseableSilently {
             base.members(),
             base.lastChange(),
             Optional.of(
-                ClusterChangePlan.init(
-                    1L, List.of(new UpdateRoutingState(coordinatorId, Optional.empty())))),
+                ClusterChangePlan.initForRestore(
+                    List.of(new UpdateRoutingState(coordinatorId, Optional.empty())))),
             base.routingState(),
             base.clusterId(),
             base.incarnationNumber());


### PR DESCRIPTION
## Problem                                                                                                
  
`S3NodeIdProviderRestoreAcceptanceIT` was flaky after backup restore. During restore, `RestoreManager`  writes a pending `UpdateRoutingState` operation into the persisted ClusterConfiguration to ensure the routing state is synced with the partition's state incase there was a scaling operation before backup. On the  subsequent broker restart, two concurrent updates raced: 
                                                         
  - Broker 0 (coordinator) applied UpdateRoutingState, advancing the global config to `{version=2,  member2{version=0}}`
  - Broker 2 ran `ExporterStateInitializer`, resulting in `{version=1,  member2{version=1}}`                                                        
  
When Broker 2 received Broker 0's gossip, `member2{version=0}` in the incoming config was lower than its local `member2{version=1}`, it is detected as a conflict because the global configuration is lower. This leads to shut down Broker 2. In production this is harmless (the broker restarts  and re-applies exporter state on top of the updated config), but the tests do not restart brokers automatically, so `awaitCompleteTopology` timed out.

## Fix
Eliminate the race by ensuring only one actor modifies the ClusterConfiguration in the post-restore  scenario:
                                                                                                         
  - The coordinator (ExporterStateInitializer with isCoordinator=true) detects the post-restore state and  applies exporter state initialization for all members, not just itself.
  - Non-coordinators detect the post-restore state and skip initialization entirely.    
  - Normal restarts (no pending UpdateRoutingState) are unaffected: each broker initializes only its own  member state as before.  
  
Since the initialization is done pre-gossip, the non-coordinator nodes would start with the right configuration for exporters.                                                                 
  
To reliably detect the post-restore state, `RestoreManage`r now marks the pending change with a sentinel plan ID (RESTORE_CHANGE_ID = 0, reserved for restore; all normal change IDs are > 0). `ClusterConfiguration.isAfterRestore()` checks for this sentinel ID together with a single pending `UpdateRoutingState` operation.

## Checklist

<!--- Please delete options that are not relevant. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #51929 
