### PR TITLE
build: default load tests to gRPC instead of REST

### DIFF
--- a/.github/workflows/camunda-daily-load-tests.yml
+++ b/.github/workflows/camunda-daily-load-tests.yml
@@ -74,23 +74,23 @@ jobs:
       scenario: max
       build-frontend: true
 
-  setup-max-grpc-load-test:
-    name: Setup max gRPC load test
+  setup-max-rest-load-test:
+    name: Setup max rest load test
     needs:
       - benchmark-data
     uses: ./.github/workflows/camunda-load-test.yml
     secrets: inherit
     with:
-      name: ${{ needs.benchmark-data.outputs.benchmark }}-grpc
+      name: ${{ needs.benchmark-data.outputs.benchmark }}-rest
       ttl: 1
       scenario: max
       build-frontend: true
-      load-test-load: --set global.preferRest.enabled=false
+      load-test-load: --set global.preferRest.enabled=true
 
   notify:
     name: Notify on failure
     runs-on: ubuntu-latest
-    needs: [ setup-max-load-test, setup-max-grpc-load-test ]
+    needs: [ setup-max-load-test, setup-max-rest-load-test ]
     if: failure()
     timeout-minutes: 5
     permissions: { }

--- a/.github/workflows/camunda-daily-load-tests.yml
+++ b/.github/workflows/camunda-daily-load-tests.yml
@@ -75,7 +75,7 @@ jobs:
       build-frontend: true
 
   setup-max-rest-load-test:
-    name: Setup max rest load test
+    name: Setup max REST load test
     needs:
       - benchmark-data
     uses: ./.github/workflows/camunda-load-test.yml

--- a/load-tests/load-test-values.yaml
+++ b/load-tests/load-test-values.yaml
@@ -8,7 +8,7 @@ global:
       - name: harbor-registry
 
   preferRest:
-    enabled: true
+    enabled: false
 
   nodeSelector:
     component: benchmark-n2-standard-4


### PR DESCRIPTION
## Description
Set `global.preferRest.enabled` to false in `load-tests/load-test-values.yaml` so load tests target the gRPC gateway by default.

gRPC is currently more stable and faster than REST in our load runs. Switching the default back to gRPC gives the REST path headroom to stabilise.


## Checklist

<!--- Please delete options that are not relevant. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [x] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #https://camunda.slack.com/archives/C0A22S6M4TF/p1777541742704089?thread_ts=1777536249.257729&cid=C0A22S6M4TF
