### PR TITLE
feat: extract Maven Central deployment ID from release workflow

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -90,6 +90,7 @@ jobs:
     outputs:
       releaseTagRevision: ${{ steps.maven-perform-release.outputs.tagRevision }}
       releaseBranch: ${{ env.RELEASE_BRANCH }}
+      deploymentId: ${{ steps.maven-perform-release.outputs.deploymentId }}
     env:
       DEVELOPMENT_VERSION: ${{ inputs.nextDevelopmentVersion }}
       PUSH_CHANGES: ${{ !inputs.dryRun }}
@@ -236,6 +237,16 @@ jobs:
             ARGUMENTS_PROFILE="-P!include-optimize"
           fi
 
+          # Ensure the Maven Central deployment ID is captured even if the step fails
+          # (e.g. upload succeeds but validation times out). The trap runs on any exit.
+          trap 'if [[ -f /tmp/deployment-id.txt ]]; then
+            echo "deploymentId=$(</tmp/deployment-id.txt)" >> "$GITHUB_OUTPUT"
+          elif [[ "${SKIP_CENTRAL_RELEASE}" == "true" ]]; then
+            echo "deploymentId=dry-run-${RELEASE_VERSION}" >> "$GITHUB_OUTPUT"
+          else
+            echo "deploymentId=not-found" >> "$GITHUB_OUTPUT"
+          fi' EXIT
+
           # shellcheck disable=SC2016
           ./mvnw release:perform -B \
             -DreleaseVersion="${RELEASE_VERSION}" \
@@ -244,7 +255,17 @@ jobs:
             -DskipQaBuild=true \
             -P-autoFormat \
             ${PROFILE_FLAGS} \
-            -Darguments="-P-autoFormat -DskipQaBuild=true -DskipChecks=true -DskipTests=true -Dskip.fe.build=false -Dspotless.apply.skip=false -Dskip.central.release=${SKIP_CENTRAL_RELEASE} -Dskip.camunda.release=${SKIP_CAMUNDA_RELEASE} -DwaitMaxTime=${CENTRAL_WAIT_MAX_TIME} ${ARGUMENTS_PROFILE} -Dgpg.passphrase=\"${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}\""
+            -Darguments="-P-autoFormat -DskipQaBuild=true -DskipChecks=true -DskipTests=true -Dskip.fe.build=false -Dspotless.apply.skip=false -Dskip.central.release=${SKIP_CENTRAL_RELEASE} -Dskip.camunda.release=${SKIP_CAMUNDA_RELEASE} -DwaitMaxTime=${CENTRAL_WAIT_MAX_TIME} ${ARGUMENTS_PROFILE} -Dgpg.passphrase=\"${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}\"" \
+            2>&1 | awk '{print} /deploymentId:/{for(i=1;i<=NF;i++) if($i ~ /^[0-9a-f]+-[0-9a-f-]+/) {gsub(/[^0-9a-f-]/,"",$i); print $i > "/tmp/deployment-id.txt"}}'
+
+          # Log the extracted deployment ID (the trap above handles writing to GITHUB_OUTPUT)
+          if [[ -f /tmp/deployment-id.txt ]]; then
+            echo "✅ Maven Central deployment ID: $(</tmp/deployment-id.txt)"
+          elif [[ "${SKIP_CENTRAL_RELEASE}" == "true" ]]; then
+            echo "ℹ️ Dry run — using mock deployment ID" >&2
+          else
+            echo "ℹ️ No Maven Central deployment ID found in build output" >&2
+          fi
 
           # switch to the directory to which maven checks out the release tag
           # see https://maven.apache.org/maven-release/maven-release-plugin/perform-mojo.html#workingDirectory
@@ -1224,6 +1245,7 @@ jobs:
             {
               "is_camunda_release_successful": "true",
               "camunda_workflow_run_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+              "camunda_maven_central_deployment_id": "${{ needs.release.outputs.deploymentId }}",
               "camunda_repository": "${{ github.repository }}"
             }
       - name: Send success Slack notification
@@ -1318,6 +1340,7 @@ jobs:
             {
               "is_camunda_release_successful": "false",
               "camunda_workflow_run_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+              "camunda_maven_central_deployment_id": "${{ needs.release.outputs.deploymentId }}",
               "camunda_repository": "${{ github.repository }}"
             }
       - name: Send failure Slack notification

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -237,13 +237,17 @@ jobs:
             ARGUMENTS_PROFILE="-P!include-optimize"
           fi
 
-          # Clear any stale deployment-id file left by a previous run on this self-hosted runner.
-          rm -f /tmp/deployment-id.txt
+          # Per-job, per-release deployment-id file. $RUNNER_TEMP is emptied by the
+          # runner agent at the start and end of each job, and the version suffix
+          # guarantees no collision with any concurrent release on the same runner.
+          DEPLOYMENT_ID_FILE="${RUNNER_TEMP}/deployment-id-${RELEASE_VERSION}.txt"
 
           # Ensure the Maven Central deployment ID is captured even if the step fails
           # (e.g. upload succeeds but validation times out). The trap runs on any exit.
-          trap 'if [[ -f /tmp/deployment-id.txt ]]; then
-            echo "deploymentId=$(</tmp/deployment-id.txt)" >> "$GITHUB_OUTPUT"
+          trap 'if [[ -f "${DEPLOYMENT_ID_FILE}" ]]; then
+            id=$(<"${DEPLOYMENT_ID_FILE}")
+            echo "deploymentId=${id}" >> "$GITHUB_OUTPUT"
+            echo "::notice::Maven Central deployment ID: ${id}"
           elif [[ "${SKIP_CENTRAL_RELEASE}" == "true" ]]; then
             echo "deploymentId=dry-run-${RELEASE_VERSION}" >> "$GITHUB_OUTPUT"
           else
@@ -259,11 +263,11 @@ jobs:
             -P-autoFormat \
             ${PROFILE_FLAGS} \
             -Darguments="-P-autoFormat -DskipQaBuild=true -DskipChecks=true -DskipTests=true -Dskip.fe.build=false -Dspotless.apply.skip=false -Dskip.central.release=${SKIP_CENTRAL_RELEASE} -Dskip.camunda.release=${SKIP_CAMUNDA_RELEASE} -DwaitMaxTime=${CENTRAL_WAIT_MAX_TIME} ${ARGUMENTS_PROFILE} -Dgpg.passphrase=\"${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}\"" \
-            2>&1 | awk '{print} /deploymentId:/{for(i=1;i<=NF;i++) if($i ~ /^[0-9a-f]+-[0-9a-f-]+/) {gsub(/[^0-9a-f-]/,"",$i); print $i > "/tmp/deployment-id.txt"}}'
+            2>&1 | awk -v out="${DEPLOYMENT_ID_FILE}" '{print} /deploymentId:/{for(i=1;i<=NF;i++) if($i ~ /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/) {gsub(/[^0-9a-f-]/,"",$i); id=$i}} END{if(id) print id > out}'
 
           # Log the extracted deployment ID (the trap above handles writing to GITHUB_OUTPUT)
-          if [[ -f /tmp/deployment-id.txt ]]; then
-            echo "✅ Maven Central deployment ID: $(</tmp/deployment-id.txt)"
+          if [[ -f "${DEPLOYMENT_ID_FILE}" ]]; then
+            echo "✅ Maven Central deployment ID: $(<"${DEPLOYMENT_ID_FILE}")"
           elif [[ "${SKIP_CENTRAL_RELEASE}" == "true" ]]; then
             echo "ℹ️ Dry run — using mock deployment ID" >&2
           else

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -257,6 +257,9 @@ jobs:
       - name: Extract Maven Central deployment ID
         id: extract-deployment-id
         if: always() && steps.maven-perform-release.conclusion != 'skipped'
+        # Never block the release on extraction failure — the deployment ID is
+        # for downstream automation only; manual recovery is always possible.
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
           SKIP_CENTRAL_RELEASE: ${{ inputs.dryRun }}
@@ -264,11 +267,19 @@ jobs:
           # The central-publishing-maven-plugin only emits the deployment ID via a log line:
           #   "Uploaded bundle successfully, deployment name: ..., deploymentId: <uuid>..."
           # It is not persisted to disk by the plugin. So we fetch this job's log from the GHA API after the maven step has run and grep it.
-          job_id=$(gh api --paginate \
-            "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}/jobs" \
-            --jq ".jobs[] | select(.runner_name == \"$RUNNER_NAME\") | .id")
+          # Using curl directly because gh CLI is not installed on the release runner image.
+          api="https://api.github.com/repos/${{ github.repository }}"
 
-          deployment_id=$(gh api "/repos/${{ github.repository }}/actions/jobs/${job_id}/logs" 2>/dev/null \
+          job_id=$(curl -fsSL \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              "${api}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}/jobs?per_page=100" \
+            | jq -r ".jobs[] | select(.runner_name == \"$RUNNER_NAME\") | .id")
+
+          deployment_id=$(curl -fsSL \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              "${api}/actions/jobs/${job_id}/logs" \
             | grep -oE 'deploymentId: [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' \
             | tail -1 \
             | awk '{print $2}' || true)

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -263,7 +263,7 @@ jobs:
             -P-autoFormat \
             ${PROFILE_FLAGS} \
             -Darguments="-P-autoFormat -DskipQaBuild=true -DskipChecks=true -DskipTests=true -Dskip.fe.build=false -Dspotless.apply.skip=false -Dskip.central.release=${SKIP_CENTRAL_RELEASE} -Dskip.camunda.release=${SKIP_CAMUNDA_RELEASE} -DwaitMaxTime=${CENTRAL_WAIT_MAX_TIME} ${ARGUMENTS_PROFILE} -Dgpg.passphrase=\"${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}\"" \
-            2>&1 | awk -v out="${DEPLOYMENT_ID_FILE}" '{print} /deploymentId:/{for(i=1;i<=NF;i++) if($i ~ /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/) {gsub(/[^0-9a-f-]/,"",$i); id=$i}} END{if(id) print id > out}'
+            2>&1 | awk -v out="${DEPLOYMENT_ID_FILE}" '{print; fflush()} /deploymentId:/{for(i=1;i<=NF;i++) if($i ~ /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/) {gsub(/[^0-9a-f-]/,"",$i); id=$i}} END{if(id) print id > out}'
 
           # Log the extracted deployment ID (the trap above handles writing to GITHUB_OUTPUT)
           if [[ -f "${DEPLOYMENT_ID_FILE}" ]]; then

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -237,6 +237,9 @@ jobs:
             ARGUMENTS_PROFILE="-P!include-optimize"
           fi
 
+          # Clear any stale deployment-id file left by a previous run on this self-hosted runner.
+          rm -f /tmp/deployment-id.txt
+
           # Ensure the Maven Central deployment ID is captured even if the step fails
           # (e.g. upload succeeds but validation times out). The trap runs on any exit.
           trap 'if [[ -f /tmp/deployment-id.txt ]]; then

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -90,7 +90,7 @@ jobs:
     outputs:
       releaseTagRevision: ${{ steps.maven-perform-release.outputs.tagRevision }}
       releaseBranch: ${{ env.RELEASE_BRANCH }}
-      deploymentId: ${{ steps.maven-perform-release.outputs.deploymentId }}
+      deploymentId: ${{ steps.extract-deployment-id.outputs.deploymentId }}
     env:
       DEVELOPMENT_VERSION: ${{ inputs.nextDevelopmentVersion }}
       PUSH_CHANGES: ${{ !inputs.dryRun }}
@@ -237,24 +237,6 @@ jobs:
             ARGUMENTS_PROFILE="-P!include-optimize"
           fi
 
-          # Per-job, per-release deployment-id file. $RUNNER_TEMP is emptied by the
-          # runner agent at the start and end of each job, and the version suffix
-          # guarantees no collision with any concurrent release on the same runner.
-          DEPLOYMENT_ID_FILE="${RUNNER_TEMP}/deployment-id-${RELEASE_VERSION}.txt"
-
-          # Ensure the Maven Central deployment ID is captured even if the step fails
-          # (e.g. upload succeeds but validation times out). The trap runs on any exit.
-          trap 'if [[ -f "${DEPLOYMENT_ID_FILE}" ]]; then
-            id=$(<"${DEPLOYMENT_ID_FILE}")
-            echo "deploymentId=${id}" >> "$GITHUB_OUTPUT"
-            echo "::notice::Maven Central deployment ID: ${id}"
-          elif [[ "${SKIP_CENTRAL_RELEASE}" == "true" ]]; then
-            echo "deploymentId=dry-run-${RELEASE_VERSION}" >> "$GITHUB_OUTPUT"
-          else
-            echo "deploymentId=not-found" >> "$GITHUB_OUTPUT"
-          fi' EXIT
-
-          # shellcheck disable=SC2016
           ./mvnw release:perform -B \
             -DreleaseVersion="${RELEASE_VERSION}" \
             -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}" \
@@ -262,17 +244,7 @@ jobs:
             -DskipQaBuild=true \
             -P-autoFormat \
             ${PROFILE_FLAGS} \
-            -Darguments="-P-autoFormat -DskipQaBuild=true -DskipChecks=true -DskipTests=true -Dskip.fe.build=false -Dspotless.apply.skip=false -Dskip.central.release=${SKIP_CENTRAL_RELEASE} -Dskip.camunda.release=${SKIP_CAMUNDA_RELEASE} -DwaitMaxTime=${CENTRAL_WAIT_MAX_TIME} ${ARGUMENTS_PROFILE} -Dgpg.passphrase=\"${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}\"" \
-            2>&1 | awk -v out="${DEPLOYMENT_ID_FILE}" '{print; fflush()} /deploymentId:/{for(i=1;i<=NF;i++) if($i ~ /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/) {gsub(/[^0-9a-f-]/,"",$i); id=$i}} END{if(id) print id > out}'
-
-          # Log the extracted deployment ID (the trap above handles writing to GITHUB_OUTPUT)
-          if [[ -f "${DEPLOYMENT_ID_FILE}" ]]; then
-            echo "✅ Maven Central deployment ID: $(<"${DEPLOYMENT_ID_FILE}")"
-          elif [[ "${SKIP_CENTRAL_RELEASE}" == "true" ]]; then
-            echo "ℹ️ Dry run — using mock deployment ID" >&2
-          else
-            echo "ℹ️ No Maven Central deployment ID found in build output" >&2
-          fi
+            -Darguments="-P-autoFormat -DskipQaBuild=true -DskipChecks=true -DskipTests=true -Dskip.fe.build=false -Dspotless.apply.skip=false -Dskip.central.release=${SKIP_CENTRAL_RELEASE} -Dskip.camunda.release=${SKIP_CAMUNDA_RELEASE} -DwaitMaxTime=${CENTRAL_WAIT_MAX_TIME} ${ARGUMENTS_PROFILE} -Dgpg.passphrase=\"${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}\""
 
           # switch to the directory to which maven checks out the release tag
           # see https://maven.apache.org/maven-release/maven-release-plugin/perform-mojo.html#workingDirectory
@@ -281,6 +253,36 @@ jobs:
           export TAG_REVISION
           echo "tagRevision=${TAG_REVISION}" >> "$GITHUB_OUTPUT"
           popd
+
+      - name: Extract Maven Central deployment ID
+        id: extract-deployment-id
+        if: always() && steps.maven-perform-release.conclusion != 'skipped'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SKIP_CENTRAL_RELEASE: ${{ inputs.dryRun }}
+        run: |
+          # The central-publishing-maven-plugin only emits the deployment ID via a log line:
+          #   "Uploaded bundle successfully, deployment name: ..., deploymentId: <uuid>..."
+          # It is not persisted to disk by the plugin. So we fetch this job's log from the GHA API after the maven step has run and grep it.
+          job_id=$(gh api --paginate \
+            "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}/jobs" \
+            --jq ".jobs[] | select(.runner_name == \"$RUNNER_NAME\") | .id")
+
+          deployment_id=$(gh api "/repos/${{ github.repository }}/actions/jobs/${job_id}/logs" 2>/dev/null \
+            | grep -oE 'deploymentId: [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' \
+            | tail -1 \
+            | awk '{print $2}' || true)
+
+          if [[ -n "${deployment_id}" ]]; then
+            echo "deploymentId=${deployment_id}" >> "$GITHUB_OUTPUT"
+            echo "::notice::Maven Central deployment ID: ${deployment_id}"
+          elif [[ "${SKIP_CENTRAL_RELEASE}" == "true" ]]; then
+            echo "deploymentId=dry-run-${RELEASE_VERSION}" >> "$GITHUB_OUTPUT"
+            echo "ℹ️ Dry run — emitting placeholder deployment ID"
+          else
+            echo "deploymentId=not-found" >> "$GITHUB_OUTPUT"
+            echo "ℹ️ No Maven Central deployment ID found in build output" >&2
+          fi
 
       - name: Validate flattened POM metadata
         if: ${{ inputs.dryRun }}


### PR DESCRIPTION
## Description

Extracts the Maven Central deployment ID emitted by the `central-publishing-maven-plugin` during `mvn release:perform` and exposes it as a job output, so downstream automation (e.g., publishing the deployment via the [Sonatype Central Portal Publisher API](https://central.sonatype.org/publish/publish-portal-api/)) can reference it.

This is a stepping stone toward automating the currently manual "Publish" step on Maven Central after a release.

## Changes

- Added `deploymentId` as an output of the `release` job in `.github/workflows/camunda-platform-release.yml`.
- The `mvn release:perform` output is piped through `awk` to capture the deployment UUID into `/tmp/deployment-id.txt`.
- An `EXIT` trap ensures the value is written to `$GITHUB_OUTPUT` even if the Maven step fails (e.g., upload succeeds but validation times out).
- Dry-run path emits `dry-run-<version>` as a placeholder; if no ID is found, emits `not-found`.
- The deployment ID is also forwarded to the release process orchestration via the `camunda_maven_central_deployment_id` variable in both success and failure notification paths.

## Testing

- Workflow syntax only; needs to be validated against an actual release run (e.g., a dry-run release) to confirm the extraction regex matches the real Maven output.
- [Dry-run worked, there are no breaking issues](https://github.com/camunda/camunda/actions/runs/25427143220/job/74583568871#step:11:30752)

Related to
https://github.com/camunda/camunda/issues/35220