### PR TITLE
fix: fix RDBMS replay positions

### DIFF
--- a/zeebe/exporter-test/src/main/java/io/camunda/zeebe/exporter/test/ExporterTestController.java
+++ b/zeebe/exporter-test/src/main/java/io/camunda/zeebe/exporter/test/ExporterTestController.java
@@ -80,8 +80,8 @@ public final class ExporterTestController implements Controller {
   }
 
   @Override
-  public boolean requestReplay(final long fromPosition) {
-    this.position.set(fromPosition - 1);
+  public boolean requestReplay(final long lastExportedPosition) {
+    position.set(lastExportedPosition);
     exporterMetadata.set(Optional.empty());
     return true;
   }

--- a/zeebe/exporter-test/src/test/java/io/camunda/zeebe/exporter/test/ExporterTestControllerTest.java
+++ b/zeebe/exporter-test/src/test/java/io/camunda/zeebe/exporter/test/ExporterTestControllerTest.java
@@ -53,10 +53,10 @@ final class ExporterTestControllerTest {
     // when - request replay from position 5
     final boolean result = controller.requestReplay(5);
 
-    // then - position should be reset to fromPosition - 1 = 4, and result indicates success
+    // then - position should be reset to lastExportedPosition = 5, and result indicates success
     assertThat(result).isTrue();
-    assertThat(controller.getPosition()).isEqualTo(4);
-    assertThat(controller.getLastExportedRecordPosition()).isEqualTo(4);
+    assertThat(controller.getPosition()).isEqualTo(5);
+    assertThat(controller.getLastExportedRecordPosition()).isEqualTo(5);
   }
 
   @Test

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
@@ -117,10 +117,10 @@ public final class RdbmsExporter {
             partitionId,
             lastPosition,
             exporterRdbmsPosition.lastExportedPosition(),
-            exporterRdbmsPosition.lastExportedPosition() + 1);
+            exporterRdbmsPosition.lastExportedPosition());
         lastPosition = exporterRdbmsPosition.lastExportedPosition();
         final boolean replayInitiated =
-            controller.requestReplay(exporterRdbmsPosition.lastExportedPosition() + 1);
+            controller.requestReplay(exporterRdbmsPosition.lastExportedPosition());
         if (!replayInitiated) {
           throw new ExporterException(
               String.format(

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterTest.java
@@ -478,8 +478,8 @@ class RdbmsExporterTest {
     // when
     exporter.open(controller);
 
-    // then - requestReplay should be called with rdbmsPosition + 1
-    verify(controller).requestReplay(rdbmsPosition + 1);
+    // then - requestReplay should be called with rdbmsPosition
+    verify(controller).requestReplay(rdbmsPosition);
   }
 
   @Test


### PR DESCRIPTION
## Description

Fix leftovers, Copilot found when I backported the replay feature to `8.9`.

I changed the target position argument to be the last exported position (committed) and not the next wanted position. This was not done in all locations.