### PR TITLE
fix: listen to GROUP records only on partition 1

### DIFF
--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -194,6 +194,14 @@ public class RdbmsExporterWrapper implements Exporter {
               rdbmsWriters.getDecisionRequirementsWriter(),
               cacheRegistry.decisionRequirementsCache()));
       builder.withHandler(ValueType.FORM, new FormExportHandler(rdbmsWriters.getFormWriter()));
+      builder.withHandler(
+          ValueType.CLUSTER_VARIABLE,
+          new ClusterVariableExportHandler(rdbmsWriters.getClusterVariableWriter()));
+      builder.withHandler(
+          ValueType.GLOBAL_LISTENER,
+          new GlobalListenerExportHandler(rdbmsWriters.getGlobalListenerWriter()));
+      builder.withHandler(
+          ValueType.RESOURCE, new ResourceExportHandler(rdbmsWriters.getResourceWriter()));
     }
 
     builder.withHandler(
@@ -227,9 +235,6 @@ public class RdbmsExporterWrapper implements Exporter {
     builder.withHandler(
         ValueType.VARIABLE, new VariableExportHandler(rdbmsWriters.getVariableWriter()));
     builder.withHandler(
-        ValueType.CLUSTER_VARIABLE,
-        new ClusterVariableExportHandler(rdbmsWriters.getClusterVariableWriter()));
-    builder.withHandler(
         ValueType.USER_TASK,
         new UserTaskExportHandler(rdbmsWriters.getUserTaskWriter(), cacheRegistry.processCache()));
     builder.withHandler(ValueType.JOB, new JobExportHandler(rdbmsWriters.getJobWriter()));
@@ -262,11 +267,6 @@ public class RdbmsExporterWrapper implements Exporter {
     builder.withHandler(
         ValueType.JOB_METRICS_BATCH,
         new JobMetricsBatchExportHandler(rdbmsWriters.getJobMetricsBatchWriter()));
-    builder.withHandler(
-        ValueType.GLOBAL_LISTENER,
-        new GlobalListenerExportHandler(rdbmsWriters.getGlobalListenerWriter()));
-    builder.withHandler(
-        ValueType.RESOURCE, new ResourceExportHandler(rdbmsWriters.getResourceWriter()));
 
     if (config.getAuditLog().isEnabled()) {
       registerAuditLogHandlers(rdbmsWriters, builder, config, partitionId);

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -179,6 +179,7 @@ public class RdbmsExporterWrapper implements Exporter {
           ValueType.TENANT, new TenantExportHandler(rdbmsWriters.getTenantWriter()));
       builder.withHandler(ValueType.ROLE, new RoleExportHandler(rdbmsWriters.getRoleWriter()));
       builder.withHandler(ValueType.USER, new UserExportHandler(rdbmsWriters.getUserWriter()));
+      builder.withHandler(ValueType.GROUP, new GroupExportHandler(rdbmsWriters.getGroupWriter()));
       builder.withHandler(
           ValueType.AUTHORIZATION,
           new AuthorizationExportHandler(rdbmsWriters.getAuthorizationWriter()));
@@ -198,7 +199,6 @@ public class RdbmsExporterWrapper implements Exporter {
     builder.withHandler(
         ValueType.DECISION_EVALUATION,
         new DecisionInstanceExportHandler(rdbmsWriters.getDecisionInstanceWriter()));
-    builder.withHandler(ValueType.GROUP, new GroupExportHandler(rdbmsWriters.getGroupWriter()));
     builder.withHandler(
         ValueType.INCIDENT,
         new IncidentExportHandler(

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterWrapperTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterWrapperTest.java
@@ -208,6 +208,15 @@ class RdbmsExporterWrapperTest {
     assertThat(registeredHandlers)
         .as("Should register FORM handler on partition 1")
         .containsKey(ValueType.FORM);
+    assertThat(registeredHandlers)
+        .as("Should register CLUSTER_VARIABLE handler on partition 1")
+        .containsKey(ValueType.CLUSTER_VARIABLE);
+    assertThat(registeredHandlers)
+        .as("Should register RESOURCE handler on partition 1")
+        .containsKey(ValueType.RESOURCE);
+    assertThat(registeredHandlers)
+        .as("Should register GLOBAL_LISTENER handler on partition 1")
+        .containsKey(ValueType.GLOBAL_LISTENER);
   }
 
   @Test
@@ -265,6 +274,15 @@ class RdbmsExporterWrapperTest {
     assertThat(registeredHandlers)
         .as("Should not register FORM handler on partition 2")
         .doesNotContainKey(ValueType.FORM);
+    assertThat(registeredHandlers)
+        .as("Should not register CLUSTER_VARIABLE handler on partition 1")
+        .doesNotContainKey(ValueType.CLUSTER_VARIABLE);
+    assertThat(registeredHandlers)
+        .as("Should not register RESOURCE handler on partition 1")
+        .doesNotContainKey(ValueType.RESOURCE);
+    assertThat(registeredHandlers)
+        .as("Should not register GLOBAL_LISTENER handler on partition 1")
+        .doesNotContainKey(ValueType.GLOBAL_LISTENER);
   }
 
   private void assertAuditLogExportPresent(

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterWrapperTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterWrapperTest.java
@@ -194,6 +194,9 @@ class RdbmsExporterWrapperTest {
         .as("Should register USER handler on partition 1")
         .containsKey(ValueType.USER);
     assertThat(registeredHandlers)
+        .as("Should register GROUP handler on partition 1")
+        .containsKey(ValueType.GROUP);
+    assertThat(registeredHandlers)
         .as("Should register AUTHORIZATION handler on partition 1")
         .containsKey(ValueType.AUTHORIZATION);
     assertThat(registeredHandlers)
@@ -247,6 +250,9 @@ class RdbmsExporterWrapperTest {
     assertThat(registeredHandlers)
         .as("Should not register USER handler on partition 2")
         .doesNotContainKey(ValueType.USER);
+    assertThat(registeredHandlers)
+        .as("Should not register GROUP handler on partition 2")
+        .doesNotContainKey(ValueType.GROUP);
     assertThat(registeredHandlers)
         .as("Should not register AUTHORIZATION handler on partition 2")
         .doesNotContainKey(ValueType.AUTHORIZATION);


### PR DESCRIPTION
## Description

Fix: Listen to GROUP records only on partition 1. Everything else would lead to looping PK violation exceptions on all but one partitions.
