### PR TITLE
fix(8.8): route Optimize historyCleanup config into environment-config.yaml

### DIFF
--- a/load-tests/camunda-platform-values.yaml
+++ b/load-tests/camunda-platform-values.yaml
@@ -75,13 +75,45 @@ identity:
 optimize:
   enabled: true
   fullnameOverride: optimize # we override the names for simplicity of the deployment
-  extraConfiguration:
-    application.yml: |
-      historyCleanup:
-        cronTrigger: '*/30 * * * *'
-        ttl: 'P1D'
-        processDataCleanup:
-          enabled: true
+  # Optimize reads historyCleanup only from environment-config.yaml (its custom config loader),
+  # not from application.yml via spring.config.import. We therefore override the full
+  # environment-config.yaml via `configuration` so the cleanup block is in the correct file.
+  # ES host/port use Optimize's ${VAR:default} placeholder syntax so they stay dynamic at
+  # runtime (the deployment sets OPTIMIZE_ELASTICSEARCH_HOST / OPTIMIZE_ELASTICSEARCH_HTTP_PORT).
+  configuration: |
+    zeebe:
+      enabled: true
+      partitionCount: 3
+      name: "zeebe-record"
+    es:
+      connection:
+        nodes:
+          - host: "${OPTIMIZE_ELASTICSEARCH_HOST:localhost}"
+            httpPort: ${OPTIMIZE_ELASTICSEARCH_HTTP_PORT:9200}
+    spring:
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+      profiles:
+        active: "ccsm"
+    security:
+      auth:
+        cookie:
+          same-site:
+            enabled: false
+        ccsm:
+          redirectRootUrl: "http://localhost:8083"
+    api:
+      audience: "optimize-api"
+      jwtSetUri: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/certs"
+
+    ## Configure Optimize data cleanup
+    historyCleanup:
+      cronTrigger: '*/30 * * * *'
+      ttl: 'P1D'
+      processDataCleanup:
+        enabled: true
   env:
     # https://docs.camunda.io/docs/self-managed/components/optimize/configuration/logging/#google-stackdriver-json-logging
     - name: OPTIMIZE_LOG_APPENDER


### PR DESCRIPTION
Optimize's custom ConfigurationService reads historyCleanup settings only from environment-config.yaml (its default config locations). The spring.config.import mechanism used to inject application.yml is unreliable in older Optimize versions (bugs fixed in 8.9+, issues #47472/#47473) and was silently ignored, causing the cleanup scheduler to initialize with the service-config defaults (processDataCleanup disabled) and immediately stop.

Switch from extraConfiguration.application.yml to optimize.configuration, which directly replaces the environment-config.yaml ConfigMap key. The full environment config is reproduced here so no connectivity settings are lost; ES host/port retain the ${VAR:default} placeholder syntax so they remain dynamic at runtime (resolved by Optimize's ConfigurationParser from the pod env vars set by the Helm deployment).

* Initially from https://github.com/camunda/camunda/pull/51818
* Should be documented by https://github.com/camunda/camunda/issues/52187
* cf. https://app.incident.io/camunda/incidents/5337

Rendering diff after applying this change:

```diff
diff --git a/templates/optimize/configmap.yaml b/templates/optimize/configmap.yaml
index 66c3af2..552f835 100644
--- a/templates/optimize/configmap.yaml
+++ b/templates/optimize/configmap.yaml
@@ -17,7 +17,6 @@ metadata:
 apiVersion: v1
 data:
   environment-config.yaml: |
-
     zeebe:
       enabled: true
       partitionCount: 3
@@ -25,9 +24,8 @@ data:
     es:
       connection:
         nodes:
-          - host: "c8-optimize-cleanup-88-elasticsearch"
-            httpPort: 9200
-
+          - host: "${OPTIMIZE_ELASTICSEARCH_HOST:localhost}"
+            httpPort: ${OPTIMIZE_ELASTICSEARCH_HTTP_PORT:9200}
     spring:
       servlet:
         multipart:
@@ -35,7 +33,6 @@ data:
           max-request-size: "10MB"
       profiles:
         active: "ccsm"
-
     security:
       auth:
         cookie:
@@ -46,6 +43,11 @@ data:
     api:
       audience: "optimize-api"
       jwtSetUri: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/certs"
+    historyCleanup:
+      cronTrigger: '0 1 * * *'
+      ttl: 'P1D'
+      processDataCleanup:
+        enabled: true
   application-ccsm.yaml: |
     camunda:
       identity:
@@ -53,9 +55,3 @@ data:
         audience: "optimize-api"
         issuer: "http://localhost:18080/auth/realms/camunda-platform"
         issuerBackendUrl: "http://keycloak/auth/realms/camunda-platform"
-  application.yml: |
-    historyCleanup:
-      cronTrigger: '0 1 * * *'
-      ttl: 'P1D'
-      processDataCleanup:
-        enabled: true
diff --git a/templates/optimize/deployment.yaml b/templates/optimize/deployment.yaml
index e930391..4f87c21 100644
--- a/templates/optimize/deployment.yaml
+++ b/templates/optimize/deployment.yaml
@@ -43,7 +43,7 @@ spec:
         app.kubernetes.io/component: optimize
         app.kubernetes.io/version: "8.8.8"
       annotations:
-        checksum/config: bac1ca46b9b784ce2ab5673e29ea0934e56c858c1353bda3b4771f1affa1c880
+        checksum/config: 5b2b42f6a2aa4e764e93870c769e849b54d040a683b46e4fb4036c00011760b2
     spec:
       imagePullSecrets:
         - name: harbor-registry
@@ -85,9 +85,6 @@ spec:
             - mountPath: /optimize/config/application-ccsm.yaml
               subPath: application-ccsm.yaml
               name: environment-config
-            - name: environment-config
-              mountPath: /optimize/config/application.yml
-              subPath: application.yml
       containers:
         - name: optimize
           image: camunda/optimize:8.8.8
@@ -161,9 +158,6 @@ spec:
             - mountPath: /optimize/config/application-ccsm.yaml
               subPath: application-ccsm.yaml
               name: environment-config
-            - name: environment-config
-              mountPath: /optimize/config/application.yml
-              subPath: application.yml
       volumes:
         - name: tmp
           emptyDir: {}
```

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

* https://github.com/camunda/camunda/issues/52187
