### PR TITLE
fix: forbid partition transitions from lower terms

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionImpl.java
@@ -124,6 +124,22 @@ public final class PartitionTransitionImpl implements PartitionTransition {
       ongoingTransitionFuture = currentTransitionFuture;
 
       final var ongoingTransition = currentTransition;
+
+      // A lower-term transition is stale and must not preempt a higher-term one. This can happen
+      // during bootstrap when toInactive(0) is queued after a Raft role change to FOLLOWER(1)
+      // has already started, because context.getCurrentTerm() is still 0 at that point.
+      if (term < ongoingTransition.term()) {
+        LOG.info(
+            "Ignoring stale transition to {} on term {} (current transition to {} on term {} has higher term)",
+            role,
+            term,
+            ongoingTransition.role(),
+            ongoingTransition.term());
+        nextTransitionFuture.completeExceptionally(
+            new PartitionTransition.CancelledPartitionTransition());
+        return;
+      }
+
       if (!ongoingTransition.isCompleted()) {
         LOG.info(
             "Cancelling transition {} in favor of next transition {}",

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionProcess.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionProcess.java
@@ -191,6 +191,14 @@ final class PartitionTransitionProcess {
     return completed;
   }
 
+  long term() {
+    return term;
+  }
+
+  Role role() {
+    return role;
+  }
+
   @Override
   public String toString() {
     return "PartitionTransitionProcess{"

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionImplTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionImplTest.java
@@ -337,6 +337,37 @@ class PartitionTransitionImplTest {
         .isSameAs(testException);
   }
 
+  @Test
+  void shouldIgnoreStaleTransitionWithLowerTerm() {
+    // given - first transition is paused mid-flight at term 1
+    final var step = new WaitingTransitionStep(TEST_CONCURRENCY_CONTROL);
+    when(mockStep2.transitionTo(any(), anyLong(), any()))
+        .thenReturn(TEST_CONCURRENCY_CONTROL.completedFuture(null));
+
+    final var sut = new PartitionTransitionImpl(of(step, mockStep2));
+    sut.setConcurrencyControl(TEST_CONCURRENCY_CONTROL);
+    sut.updateTransitionContext(mockContext);
+
+    final var firstTransitionFuture = sut.transitionTo(1L, Role.FOLLOWER);
+
+    // when - a stale toInactive(0) arrives while FOLLOWER(1) is still running
+    final var staleTransitionFuture = sut.transitionTo(0L, Role.INACTIVE);
+
+    // then - stale transition is immediately cancelled without touching the running one
+    assertThat(staleTransitionFuture.isCompletedExceptionally()).isTrue();
+    assertThat(staleTransitionFuture.getException())
+        .isInstanceOf(CancelledPartitionTransition.class);
+
+    // unblock the first transition and verify it completes successfully
+    step.unblock();
+    await().until(firstTransitionFuture::isDone);
+    assertThat(firstTransitionFuture.isCompletedExceptionally()).isFalse();
+
+    // stale transition steps must never have been invoked
+    verify(mockStep2, never()).transitionTo(mockContext, 0L, Role.INACTIVE);
+    verify(mockStep2, never()).prepareTransition(mockContext, 0L, Role.INACTIVE);
+  }
+
   @Test // regression test for #8044
   void shouldCloseAllCreatedInstancesOfStreamProcessor() {
     // given


### PR DESCRIPTION
## Description
When investigating a flaky test case of ScaleUpPartitionsTest I ran into a situation with the following log (extracted):
```
Cancelling transition
  PartitionTransitionProcess{term=1, role=FOLLOWER,
cancelRequested=false, completed=false}}
in favor of next transition
  PartitionTransitionProcess{term=0, role=INACTIVE,
cancelRequested=false, completed=false}
```
which clearly should not happen.
<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

relates #51932