### PR TITLE
feat: refactor the record for simplication, readability

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/ExpressionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/ExpressionBehavior.java
@@ -42,15 +42,15 @@ public class ExpressionBehavior {
    *
    * <ol>
    *   <li>Variables provided in the record body.
-   *   <li>Process/element instance variables visible from the record's scope (the element-instance
-   *       key if set, otherwise the process-instance key), walked up the scope tree.
+   *   <li>Process/element instance variables visible from the record's scope, walked up the scope
+   *       tree.
    *   <li>Tenant-scoped cluster variables.
    *   <li>Global cluster variables.
    * </ol>
    */
   public Either<Rejection, ExpressionRecord> resolveExpression(
       final Expression expression, final ExpressionRecord expressionRecord) {
-    final long scopeKey = resolveScopeKey(expressionRecord);
+    final long scopeKey = expressionRecord.getScopeKey();
     final var variables = expressionRecord.getVariables();
     final var bodyContext =
         variables == null
@@ -70,13 +70,6 @@ public class ExpressionBehavior {
         .mapLeft(this::mapEvaluationFailure)
         .flatMap(this::rejectIfEvaluationFailed)
         .map(evaluationResult -> mapSuccess(evaluationResult, expressionRecord));
-  }
-
-  private static long resolveScopeKey(final ExpressionRecord record) {
-    if (record.getElementInstanceKey() >= 0) {
-      return record.getElementInstanceKey();
-    }
-    return record.getProcessInstanceKey();
   }
 
   private Either<Rejection, EvaluationResult> rejectIfEvaluationFailed(
@@ -101,8 +94,7 @@ public class ExpressionBehavior {
         .setTenantId(expressionRecord.getTenantId())
         .setExpression(expressionRecord.getExpression())
         .setVariables(expressionRecord.getVariablesBuffer())
-        .setProcessInstanceKey(expressionRecord.getProcessInstanceKey())
-        .setElementInstanceKey(expressionRecord.getElementInstanceKey())
+        .setScopeKey(expressionRecord.getScopeKey())
         .setWarnings(
             evaluationResult.getWarnings().stream().map(EvaluationWarning::getMessage).toList())
         .setResultValue(evaluationResult.toBuffer());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/ExpressionValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/ExpressionValidator.java
@@ -24,16 +24,9 @@ public final class ExpressionValidator {
   private static final String ERROR_MESSAGE_EMPTY_EXPRESSION = "No expression provided";
   private static final String ERROR_MESSAGE_BLANK_EXPRESSION =
       "The expression must not be blank or empty";
-  private static final String ERROR_MESSAGE_BOTH_KEYS_PROVIDED =
-      "Either 'processInstanceKey' or 'elementInstanceKey' must be provided, not both";
-  private static final String ERROR_MESSAGE_PROCESS_INSTANCE_NOT_FOUND =
-      "No process instance found with key '%d'";
-  private static final String ERROR_MESSAGE_ELEMENT_INSTANCE_NOT_FOUND =
-      "No element instance found with key '%d'";
-  private static final String ERROR_MESSAGE_TENANT_MISMATCH_PROCESS_INSTANCE =
-      "No process instance found with key '%d' for tenant '%s'";
-  private static final String ERROR_MESSAGE_TENANT_MISMATCH_ELEMENT_INSTANCE =
-      "No element instance found with key '%d' for tenant '%s'";
+  private static final String ERROR_MESSAGE_SCOPE_NOT_FOUND = "No scope found with key '%d'";
+  private static final String ERROR_MESSAGE_TENANT_MISMATCH_SCOPE =
+      "No scope found with key '%d' for tenant '%s'";
 
   private final ExpressionLanguage expressionLanguage;
   private final ElementInstanceState elementInstanceState;
@@ -49,11 +42,37 @@ public final class ExpressionValidator {
     final var record = command.getValue();
     return parseValidExpression(record)
         .flatMap(
-            expression ->
-                validateScope(record)
-                    .map(
-                        resolvedInstance ->
-                            new ValidatedCommand(expression, record, resolvedInstance)));
+            expr -> resolveScope(record).map(scope -> new ValidatedCommand(expr, record, scope)));
+  }
+
+  private Either<Rejection, Optional<ResolvedInstance>> resolveScope(
+      final ExpressionRecord record) {
+    final long scopeKey = record.getScopeKey();
+    return isSet(scopeKey)
+        ? validateInstance(record, scopeKey).map(Optional::of)
+        : Either.right(Optional.empty());
+  }
+
+  private Either<Rejection, ResolvedInstance> validateInstance(
+      final ExpressionRecord record, final long scopeKey) {
+
+    final var instance = elementInstanceState.getInstance(scopeKey);
+    if (instance == null) {
+      return reject(RejectionType.NOT_FOUND, ERROR_MESSAGE_SCOPE_NOT_FOUND.formatted(scopeKey));
+    }
+
+    final var value = instance.getValue();
+    if (tenantMismatch(record.getTenantId(), value.getTenantId())) {
+      return reject(
+          RejectionType.NOT_FOUND,
+          ERROR_MESSAGE_TENANT_MISMATCH_SCOPE.formatted(scopeKey, record.getTenantId()));
+    }
+
+    return Either.right(new ResolvedInstance(value.getTenantId(), value.getBpmnProcessId()));
+  }
+
+  private static boolean tenantMismatch(final String provided, final String actual) {
+    return provided != null && !provided.isEmpty() && !provided.equals(actual);
   }
 
   /** Combines text-level validation and FEEL parsing — they always travel together. */
@@ -76,58 +95,6 @@ public final class ExpressionValidator {
     return Either.right(expression);
   }
 
-  /**
-   * Identifies the (optional) scope and, if present, validates that the caller's tenant owns it.
-   * Returns {@code Optional.empty()} when no scope was supplied — this is a valid state, not an
-   * error.
-   */
-  private Either<Rejection, Optional<ResolvedInstance>> validateScope(
-      final ExpressionRecord record) {
-    final boolean hasProcessInstanceKey = isSet(record.getProcessInstanceKey());
-    final boolean hasElementInstanceKey = isSet(record.getElementInstanceKey());
-
-    // Mutually exclusive — supplying both is a client-side error.
-    if (hasProcessInstanceKey && hasElementInstanceKey) {
-      return reject(RejectionType.INVALID_ARGUMENT, ERROR_MESSAGE_BOTH_KEYS_PROVIDED);
-    }
-
-    // Neither set → evaluation runs without an instance scope.
-    if (!hasProcessInstanceKey && !hasElementInstanceKey) {
-      return Either.right(Optional.empty());
-    }
-
-    final var target =
-        hasElementInstanceKey
-            ? ScopeTarget.elementInstance(record.getElementInstanceKey())
-            : ScopeTarget.processInstance(record.getProcessInstanceKey());
-
-    return validateInstance(record, target).map(Optional::of);
-  }
-
-  private Either<Rejection, ResolvedInstance> validateInstance(
-      final ExpressionRecord record, final ScopeTarget target) {
-    final var instance = elementInstanceState.getInstance(target.key());
-
-    // Unknown key → 404 rather than leaking details about what exists.
-    if (instance == null) {
-      return reject(RejectionType.NOT_FOUND, target.notFoundMessage());
-    }
-
-    final var providedTenantId = record.getTenantId();
-    final var actualTenantId = instance.getValue().getTenantId();
-
-    // Tenant mismatch is also reported as not-found so we don't confirm the instance
-    // exists under a different tenant.
-    if (providedTenantId != null
-        && !providedTenantId.isEmpty()
-        && !providedTenantId.equals(actualTenantId)) {
-      return reject(RejectionType.NOT_FOUND, target.tenantMismatchMessage(providedTenantId));
-    }
-
-    return Either.right(
-        new ResolvedInstance(actualTenantId, instance.getValue().getBpmnProcessId()));
-  }
-
   private static boolean isSet(final long key) {
     return key != UNSET_KEY;
   }
@@ -146,45 +113,4 @@ public final class ExpressionValidator {
    * (tenant inference, authorization checks) without a second state lookup.
    */
   public record ResolvedInstance(String tenantId, String bpmnProcessId) {}
-
-  private record ProcessInstanceScopeTarget(long key) implements ScopeTarget {
-    @Override
-    public String notFoundMessage() {
-      return ERROR_MESSAGE_PROCESS_INSTANCE_NOT_FOUND.formatted(key);
-    }
-
-    @Override
-    public String tenantMismatchMessage(final String tenantId) {
-      return ERROR_MESSAGE_TENANT_MISMATCH_PROCESS_INSTANCE.formatted(key, tenantId);
-    }
-  }
-
-  private record ElementInstanceScopeTarget(long key) implements ScopeTarget {
-    @Override
-    public String notFoundMessage() {
-      return ERROR_MESSAGE_ELEMENT_INSTANCE_NOT_FOUND.formatted(key);
-    }
-
-    @Override
-    public String tenantMismatchMessage(final String tenantId) {
-      return ERROR_MESSAGE_TENANT_MISMATCH_ELEMENT_INSTANCE.formatted(key, tenantId);
-    }
-  }
-
-  private sealed interface ScopeTarget
-      permits ProcessInstanceScopeTarget, ElementInstanceScopeTarget {
-    long key();
-
-    String notFoundMessage();
-
-    String tenantMismatchMessage(String tenantId);
-
-    static ScopeTarget processInstance(final long key) {
-      return new ProcessInstanceScopeTarget(key);
-    }
-
-    static ScopeTarget elementInstance(final long key) {
-      return new ElementInstanceScopeTarget(key);
-    }
-  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/ResolveExpressionAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/ResolveExpressionAuthorizationTest.java
@@ -138,7 +138,7 @@ public class ResolveExpressionAuthorizationTest {
     engine
         .expression()
         .withExpression(EXPRESSION)
-        .withProcessInstanceKey(processInstanceKey)
+        .withScopeKey(processInstanceKey)
         .resolve(user.getUsername());
 
     // then
@@ -181,7 +181,7 @@ public class ResolveExpressionAuthorizationTest {
     engine
         .expression()
         .withExpression(EXPRESSION)
-        .withElementInstanceKey(elementInstanceKey)
+        .withScopeKey(elementInstanceKey)
         .resolve(user.getUsername());
 
     // then
@@ -218,7 +218,7 @@ public class ResolveExpressionAuthorizationTest {
     engine
         .expression()
         .withExpression(EXPRESSION)
-        .withProcessInstanceKey(processInstanceKey)
+        .withScopeKey(processInstanceKey)
         .resolve(user.getUsername());
 
     // then
@@ -244,7 +244,7 @@ public class ResolveExpressionAuthorizationTest {
         engine
             .expression()
             .withExpression(EXPRESSION)
-            .withProcessInstanceKey(processInstanceKey)
+            .withScopeKey(processInstanceKey)
             .expectRejection()
             .resolve(user.getUsername());
 
@@ -275,7 +275,7 @@ public class ResolveExpressionAuthorizationTest {
         engine
             .expression()
             .withExpression(EXPRESSION)
-            .withElementInstanceKey(elementInstanceKey)
+            .withScopeKey(elementInstanceKey)
             .expectRejection()
             .resolve(user.getUsername());
 
@@ -306,7 +306,7 @@ public class ResolveExpressionAuthorizationTest {
         engine
             .expression()
             .withExpression(EXPRESSION)
-            .withProcessInstanceKey(processInstanceKey)
+            .withScopeKey(processInstanceKey)
             .expectRejection()
             .resolve(user.getUsername());
 
@@ -350,7 +350,7 @@ public class ResolveExpressionAuthorizationTest {
         engine
             .expression()
             .withExpression(EXPRESSION)
-            .withProcessInstanceKey(processAInstanceKey)
+            .withScopeKey(processAInstanceKey)
             .expectRejection()
             .resolve(user.getUsername());
 
@@ -391,7 +391,7 @@ public class ResolveExpressionAuthorizationTest {
         engine
             .expression()
             .withExpression(EXPRESSION)
-            .withElementInstanceKey(elementInstanceKey)
+            .withScopeKey(elementInstanceKey)
             .expectRejection()
             .resolve(user.getUsername());
 
@@ -426,7 +426,7 @@ public class ResolveExpressionAuthorizationTest {
         engine
             .expression()
             .withExpression(EXPRESSION)
-            .withProcessInstanceKey(processInstanceKey)
+            .withScopeKey(processInstanceKey)
             .expectRejection()
             .resolve(user.getUsername());
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/ResolveFeelExpressionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/ResolveFeelExpressionTest.java
@@ -896,23 +896,71 @@ public class ResolveFeelExpressionTest {
   }
 
   @Test
-  public void shouldRejectWhenBothProcessInstanceKeyAndElementInstanceKeyProvided() {
+  public void shouldWriteProcessInstanceKeyAsScopeKeyOnEvaluatedRecord() {
+    // given
+    ENGINE_RULE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("processScopeKey")
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType("test"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    final var processInstanceKey =
+        ENGINE_RULE.processInstance().ofBpmnProcessId("processScopeKey").create();
+
     // when
     final var record =
         ENGINE_RULE
             .expression()
             .withExpression("=1")
-            .withProcessInstanceKey(1L)
-            .withElementInstanceKey(2L)
-            .expectRejection()
+            .withProcessInstanceKey(processInstanceKey)
             .resolve();
 
     // then
     Assertions.assertThat(record)
-        .hasIntent(ExpressionIntent.EVALUATE)
-        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
-    assertThat(record.getRejectionReason())
-        .contains("Either 'processInstanceKey' or 'elementInstanceKey' must be provided, not both");
+        .hasIntent(ExpressionIntent.EVALUATED)
+        .hasRecordType(RecordType.EVENT);
+    assertThat(record.getValue().getScopeKey()).isEqualTo(processInstanceKey);
+  }
+
+  @Test
+  public void shouldWriteElementInstanceKeyAsScopeKeyOnEvaluatedRecord() {
+    // given
+    ENGINE_RULE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("elementScopeKey")
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType("test"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    final var processInstanceKey =
+        ENGINE_RULE.processInstance().ofBpmnProcessId("elementScopeKey").create();
+    final var elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .getFirst()
+            .getKey();
+
+    // when
+    final var record =
+        ENGINE_RULE
+            .expression()
+            .withExpression("=1")
+            .withElementInstanceKey(elementInstanceKey)
+            .resolve();
+
+    // then
+    Assertions.assertThat(record)
+        .hasIntent(ExpressionIntent.EVALUATED)
+        .hasRecordType(RecordType.EVENT);
+    assertThat(record.getValue().getScopeKey()).isEqualTo(elementInstanceKey);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/ResolveFeelExpressionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/ResolveFeelExpressionTest.java
@@ -748,7 +748,7 @@ public class ResolveFeelExpressionTest {
         ENGINE_RULE
             .expression()
             .withExpression("=myVar")
-            .withProcessInstanceKey(processInstanceKey)
+            .withScopeKey(processInstanceKey)
             .resolve();
 
     // then
@@ -790,7 +790,7 @@ public class ResolveFeelExpressionTest {
         ENGINE_RULE
             .expression()
             .withExpression("=elemVar")
-            .withElementInstanceKey(elementInstanceKey)
+            .withScopeKey(elementInstanceKey)
             .resolve();
 
     // then
@@ -837,7 +837,7 @@ public class ResolveFeelExpressionTest {
         ENGINE_RULE
             .expression()
             .withExpression("=catchVar")
-            .withElementInstanceKey(elementInstanceKey)
+            .withScopeKey(elementInstanceKey)
             .resolve();
 
     // then
@@ -885,7 +885,7 @@ public class ResolveFeelExpressionTest {
         ENGINE_RULE
             .expression()
             .withExpression("=boundaryVar")
-            .withElementInstanceKey(elementInstanceKey)
+            .withScopeKey(elementInstanceKey)
             .resolve();
 
     // then
@@ -913,11 +913,7 @@ public class ResolveFeelExpressionTest {
 
     // when
     final var record =
-        ENGINE_RULE
-            .expression()
-            .withExpression("=1")
-            .withProcessInstanceKey(processInstanceKey)
-            .resolve();
+        ENGINE_RULE.expression().withExpression("=1").withScopeKey(processInstanceKey).resolve();
 
     // then
     Assertions.assertThat(record)
@@ -950,11 +946,7 @@ public class ResolveFeelExpressionTest {
 
     // when
     final var record =
-        ENGINE_RULE
-            .expression()
-            .withExpression("=1")
-            .withElementInstanceKey(elementInstanceKey)
-            .resolve();
+        ENGINE_RULE.expression().withExpression("=1").withScopeKey(elementInstanceKey).resolve();
 
     // then
     Assertions.assertThat(record)
@@ -970,7 +962,7 @@ public class ResolveFeelExpressionTest {
         ENGINE_RULE
             .expression()
             .withExpression("=1")
-            .withProcessInstanceKey(999999L)
+            .withScopeKey(999999L)
             .expectRejection()
             .resolve();
 
@@ -988,7 +980,7 @@ public class ResolveFeelExpressionTest {
         ENGINE_RULE
             .expression()
             .withExpression("=1")
-            .withElementInstanceKey(999999L)
+            .withScopeKey(999999L)
             .expectRejection()
             .resolve();
 
@@ -1024,7 +1016,7 @@ public class ResolveFeelExpressionTest {
         ENGINE_RULE
             .expression()
             .withExpression("=score")
-            .withProcessInstanceKey(processInstanceKey)
+            .withScopeKey(processInstanceKey)
             .withVariables(Map.of("score", 99))
             .resolve();
 
@@ -1077,7 +1069,7 @@ public class ResolveFeelExpressionTest {
         ENGINE_RULE
             .expression()
             .withExpression("=score")
-            .withElementInstanceKey(elementInstanceKey)
+            .withScopeKey(elementInstanceKey)
             .resolve();
 
     // then - element-scope variable shadows the process-scope one
@@ -1114,7 +1106,7 @@ public class ResolveFeelExpressionTest {
         ENGINE_RULE
             .expression()
             .withExpression("=score")
-            .withProcessInstanceKey(processInstanceKey)
+            .withScopeKey(processInstanceKey)
             .resolve();
 
     // then - process instance variable wins over cluster variable
@@ -1145,7 +1137,7 @@ public class ResolveFeelExpressionTest {
         ENGINE_RULE
             .expression()
             .withExpression("=1")
-            .withProcessInstanceKey(processInstanceKey)
+            .withScopeKey(processInstanceKey)
             .withTenantId("wrong-tenant")
             .expectRejection()
             .resolve();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/ResolveFeelExpressionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/ResolveFeelExpressionTest.java
@@ -956,25 +956,7 @@ public class ResolveFeelExpressionTest {
   }
 
   @Test
-  public void shouldRejectWhenProcessInstanceKeyNotFound() {
-    // when
-    final var record =
-        ENGINE_RULE
-            .expression()
-            .withExpression("=1")
-            .withScopeKey(999999L)
-            .expectRejection()
-            .resolve();
-
-    // then
-    Assertions.assertThat(record)
-        .hasIntent(ExpressionIntent.EVALUATE)
-        .hasRejectionType(RejectionType.NOT_FOUND);
-    assertThat(record.getRejectionReason()).contains("999999");
-  }
-
-  @Test
-  public void shouldRejectWhenElementInstanceKeyNotFound() {
+  public void shouldRejectWhenScopeKeyNotFound() {
     // when
     final var record =
         ENGINE_RULE

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ExpressionClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ExpressionClient.java
@@ -62,12 +62,7 @@ public final class ExpressionClient {
     return this;
   }
 
-  public ExpressionClient withProcessInstanceKey(final long key) {
-    expressionRecord.setScopeKey(key);
-    return this;
-  }
-
-  public ExpressionClient withElementInstanceKey(final long key) {
+  public ExpressionClient withScopeKey(final long key) {
     expressionRecord.setScopeKey(key);
     return this;
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ExpressionClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ExpressionClient.java
@@ -63,12 +63,12 @@ public final class ExpressionClient {
   }
 
   public ExpressionClient withProcessInstanceKey(final long key) {
-    expressionRecord.setProcessInstanceKey(key);
+    expressionRecord.setScopeKey(key);
     return this;
   }
 
   public ExpressionClient withElementInstanceKey(final long key) {
-    expressionRecord.setElementInstanceKey(key);
+    expressionRecord.setScopeKey(key);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/expression/ExpressionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/expression/ExpressionRecord.java
@@ -32,8 +32,7 @@ public class ExpressionRecord extends UnifiedRecordValue implements ExpressionRe
   private static final StringValue WARNINGS_KEY = new StringValue("warnings");
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
   private static final StringValue VARIABLES_KEY = new StringValue("variables");
-  private static final StringValue PROCESS_INSTANCE_KEY_KEY = new StringValue("processInstanceKey");
-  private static final StringValue ELEMENT_INSTANCE_KEY_KEY = new StringValue("elementInstanceKey");
+  private static final StringValue SCOPE_KEY_KEY = new StringValue("scopeKey");
 
   private final StringProperty expressionProp = new StringProperty(EXPRESSION_KEY);
 
@@ -46,21 +45,16 @@ public class ExpressionRecord extends UnifiedRecordValue implements ExpressionRe
 
   private final DocumentProperty variablesProp = new DocumentProperty(VARIABLES_KEY);
 
-  private final LongProperty processInstanceKeyProp =
-      new LongProperty(PROCESS_INSTANCE_KEY_KEY, -1L);
-
-  private final LongProperty elementInstanceKeyProp =
-      new LongProperty(ELEMENT_INSTANCE_KEY_KEY, -1L);
+  private final LongProperty scopeKeyProp = new LongProperty(SCOPE_KEY_KEY, -1L);
 
   public ExpressionRecord() {
-    super(7);
+    super(6);
     declareProperty(expressionProp)
         .declareProperty(resultValueProp)
         .declareProperty(warningsProp)
         .declareProperty(tenantIdProp)
         .declareProperty(variablesProp)
-        .declareProperty(processInstanceKeyProp)
-        .declareProperty(elementInstanceKeyProp);
+        .declareProperty(scopeKeyProp);
   }
 
   @Override
@@ -125,22 +119,12 @@ public class ExpressionRecord extends UnifiedRecordValue implements ExpressionRe
   }
 
   @Override
-  public long getProcessInstanceKey() {
-    return processInstanceKeyProp.getValue();
+  public long getScopeKey() {
+    return scopeKeyProp.getValue();
   }
 
-  public ExpressionRecord setProcessInstanceKey(final long processInstanceKey) {
-    processInstanceKeyProp.setValue(processInstanceKey);
-    return this;
-  }
-
-  @Override
-  public long getElementInstanceKey() {
-    return elementInstanceKeyProp.getValue();
-  }
-
-  public ExpressionRecord setElementInstanceKey(final long elementInstanceKey) {
-    elementInstanceKeyProp.setValue(elementInstanceKey);
+  public ExpressionRecord setScopeKey(final long scopeKey) {
+    scopeKeyProp.setValue(scopeKey);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -652,8 +652,7 @@ final class JsonSerializableToJsonTest {
               record
                   .setExpression("=10 + 5")
                   .setResultValue(wrapString("15"))
-                  .setProcessInstanceKey(1)
-                  .setElementInstanceKey(2)
+                  .setScopeKey(1)
                   .setTenantId("test-tenant")
                   .setWarnings(List.of("warning1", "warning2"))
                   .setVariables(VARIABLES_MSGPACK);
@@ -664,8 +663,7 @@ final class JsonSerializableToJsonTest {
                   "tenantId":"test-tenant",
                   "expression":"=10 + 5",
                   "resultValue":49,
-                  "processInstanceKey":1,
-                  "elementInstanceKey":2,
+                  "scopeKey":1,
                   "warnings":["warning1","warning2"],
                   "variables":{
                     "foo":"bar"

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ExpressionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ExpressionRecord.golden
@@ -32,8 +32,7 @@ public class ExpressionRecord extends UnifiedRecordValue implements ExpressionRe
   private static final StringValue WARNINGS_KEY = new StringValue("warnings");
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
   private static final StringValue VARIABLES_KEY = new StringValue("variables");
-  private static final StringValue PROCESS_INSTANCE_KEY_KEY = new StringValue("processInstanceKey");
-  private static final StringValue ELEMENT_INSTANCE_KEY_KEY = new StringValue("elementInstanceKey");
+  private static final StringValue SCOPE_KEY_KEY = new StringValue("scopeKey");
 
   private final StringProperty expressionProp = new StringProperty(EXPRESSION_KEY);
 
@@ -46,21 +45,16 @@ public class ExpressionRecord extends UnifiedRecordValue implements ExpressionRe
 
   private final DocumentProperty variablesProp = new DocumentProperty(VARIABLES_KEY);
 
-  private final LongProperty processInstanceKeyProp =
-      new LongProperty(PROCESS_INSTANCE_KEY_KEY, -1L);
-
-  private final LongProperty elementInstanceKeyProp =
-      new LongProperty(ELEMENT_INSTANCE_KEY_KEY, -1L);
+  private final LongProperty scopeKeyProp = new LongProperty(SCOPE_KEY_KEY, -1L);
 
   public ExpressionRecord() {
-    super(7);
+    super(6);
     declareProperty(expressionProp)
         .declareProperty(resultValueProp)
         .declareProperty(warningsProp)
         .declareProperty(tenantIdProp)
         .declareProperty(variablesProp)
-        .declareProperty(processInstanceKeyProp)
-        .declareProperty(elementInstanceKeyProp);
+        .declareProperty(scopeKeyProp);
   }
 
   @Override
@@ -125,22 +119,12 @@ public class ExpressionRecord extends UnifiedRecordValue implements ExpressionRe
   }
 
   @Override
-  public long getProcessInstanceKey() {
-    return processInstanceKeyProp.getValue();
+  public long getScopeKey() {
+    return scopeKeyProp.getValue();
   }
 
-  public ExpressionRecord setProcessInstanceKey(final long processInstanceKey) {
-    processInstanceKeyProp.setValue(processInstanceKey);
-    return this;
-  }
-
-  @Override
-  public long getElementInstanceKey() {
-    return elementInstanceKeyProp.getValue();
-  }
-
-  public ExpressionRecord setElementInstanceKey(final long elementInstanceKey) {
-    elementInstanceKeyProp.setValue(elementInstanceKey);
+  public ExpressionRecord setScopeKey(final long scopeKey) {
+    scopeKeyProp.setValue(scopeKey);
     return this;
   }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ExpressionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ExpressionRecordValue.java
@@ -67,16 +67,10 @@ public interface ExpressionRecordValue extends RecordValue, TenantOwned, RecordV
   List<String> getWarnings();
 
   /**
-   * Returns the process instance key that provides context for this expression evaluation.
+   * Returns the process or element instance key that provides context for this expression
+   * evaluation.
    *
-   * @return the process instance key, or {@code -1} if not set
+   * @return the scope key, or {@code -1} if not set
    */
-  long getProcessInstanceKey();
-
-  /**
-   * Returns the element instance key that provides context for this expression evaluation.
-   *
-   * @return the element instance key, or {@code -1} if not set
-   */
-  long getElementInstanceKey();
+  long getScopeKey();
 }


### PR DESCRIPTION
This pull request refactors how expression evaluation scope is handled in the engine, simplifying the model by replacing the separate `processInstanceKey` and `elementInstanceKey` fields with a single `scopeKey` field. This change impacts the core engine logic, validation, protocol definitions, and tests, streamlining how scope is represented and validated throughout the codebase.

**Core engine and validation logic:**

- Replaced logic to resolve and validate scope: Instead of handling both `processInstanceKey` and `elementInstanceKey` (and enforcing mutual exclusivity), the code now uses a single `scopeKey` field for both purposes. Validation and error messages have been updated accordingly, and related helper classes/interfaces have been removed. [[1]](diffhunk://#diff-c6d82e0870f71d9798727b0d26d19ceb6f287762dbd8802544df520d8c65a0b0L45-R53) [[2]](diffhunk://#diff-7126ce3b818a3d8cb058bbb6eaa269884bdb7de442085b1862df3216c97bd673L52-R75) [[3]](diffhunk://#diff-7126ce3b818a3d8cb058bbb6eaa269884bdb7de442085b1862df3216c97bd673L79-L130) [[4]](diffhunk://#diff-7126ce3b818a3d8cb058bbb6eaa269884bdb7de442085b1862df3216c97bd673L149-L189)

**Protocol and record changes:**

- Updated `ExpressionRecord` and protocol interfaces to use `scopeKey`: The protocol implementation and interface now only define `scopeKey`, removing `processInstanceKey` and `elementInstanceKey`. Serialization, deserialization, and related constants have been updated. [[1]](diffhunk://#diff-3d08a38bc0b2a89f16bda1a82bff65dbc471e4b4553c56f8d3c01fa476fcec61L35-R35) [[2]](diffhunk://#diff-3d08a38bc0b2a89f16bda1a82bff65dbc471e4b4553c56f8d3c01fa476fcec61L49-R57) [[3]](diffhunk://#diff-3d08a38bc0b2a89f16bda1a82bff65dbc471e4b4553c56f8d3c01fa476fcec61L128-R127) [[4]](diffhunk://#diff-0f2d62386dd9fbb5df5894f3e91a28416961fb21fe336c9e5a0f889db89d0c5eL70-R75)

**Test and test utility updates:**

- Refactored tests and test clients to use `scopeKey`: All tests and test utilities that previously set or checked `processInstanceKey` or `elementInstanceKey` have been updated to use `scopeKey` instead. New tests ensure the correct value is set in evaluated records. [[1]](diffhunk://#diff-2668e3f6f2cbd0470e35a4b189897b4cbe661cceab7b9a5f7a5de0ef425ddb7bL899-R963) [[2]](diffhunk://#diff-0aab348bc98bba10bfca45d76e9d2de41891db137f3094aa6b78b2364c3d008fL66-R71) [[3]](diffhunk://#diff-5d17d6d0e390c53620a41eb516f809bb926fc5a139fa42c8c8e2802539d16b76L655-R655) [[4]](diffhunk://#diff-5d17d6d0e390c53620a41eb516f809bb926fc5a139fa42c8c8e2802539d16b76L667-R666)

These changes simplify the handling of scope in expression evaluation, reducing ambiguity and potential errors, and making the codebase easier to maintain.