### PR TITLE
Allow hiding configuration property values from logs

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/ActorIdleStrategy.java
+++ b/configuration/src/main/java/io/camunda/configuration/ActorIdleStrategy.java
@@ -32,7 +32,7 @@ public class ActorIdleStrategy {
       Duration.ofNanos(ActorSchedulerBuilder.DEFAULT_MAX_PARK_PERIOD_NS);
 
   public long getMaxSpins() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".max-spins",
         maxSpins,
         Long.class,
@@ -45,7 +45,7 @@ public class ActorIdleStrategy {
   }
 
   public long getMaxYields() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".max-yields",
         maxYields,
         Long.class,
@@ -58,7 +58,7 @@ public class ActorIdleStrategy {
   }
 
   public Duration getMinParkPeriod() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".min-park-period",
         minParkPeriod,
         Duration.class,
@@ -71,7 +71,7 @@ public class ActorIdleStrategy {
   }
 
   public Duration getMaxParkPeriod() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".max-park-period",
         maxParkPeriod,
         Duration.class,

--- a/configuration/src/main/java/io/camunda/configuration/Azure.java
+++ b/configuration/src/main/java/io/camunda/configuration/Azure.java
@@ -117,7 +117,7 @@ public class Azure {
   }
 
   public String getAccountKey() {
-    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
+    return UnifiedConfigurationHelper.validateSensitiveLegacyConfigurationWithOrdering(
         PREFIX + ".account-key",
         accountKey,
         String.class,
@@ -130,7 +130,7 @@ public class Azure {
   }
 
   public String getConnectionString() {
-    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
+    return UnifiedConfigurationHelper.validateSensitiveLegacyConfigurationWithOrdering(
         PREFIX + ".connection-string",
         connectionString,
         String.class,

--- a/configuration/src/main/java/io/camunda/configuration/Azure.java
+++ b/configuration/src/main/java/io/camunda/configuration/Azure.java
@@ -91,7 +91,7 @@ public class Azure {
   @NestedConfigurationProperty private SasToken sasToken = new SasToken();
 
   public String getEndpoint() {
-    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrderingUnsafe(
         PREFIX + ".endpoint",
         endpoint,
         String.class,
@@ -104,7 +104,7 @@ public class Azure {
   }
 
   public String getAccountName() {
-    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrderingUnsafe(
         PREFIX + ".account-name",
         accountName,
         String.class,
@@ -143,7 +143,7 @@ public class Azure {
   }
 
   public String getBasePath() {
-    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrderingUnsafe(
         PREFIX + ".base-path",
         basePath,
         String.class,
@@ -156,7 +156,7 @@ public class Azure {
   }
 
   public boolean isCreateContainer() {
-    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrderingUnsafe(
         PREFIX + ".create-container",
         createContainer,
         Boolean.class,

--- a/configuration/src/main/java/io/camunda/configuration/BatchOperation.java
+++ b/configuration/src/main/java/io/camunda/configuration/BatchOperation.java
@@ -33,7 +33,7 @@ public class BatchOperation {
   }
 
   public boolean isExportItemsOnCreation() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         prefix() + ".export-items-on-creation",
         exportItemsOnCreation,
         Boolean.class,

--- a/configuration/src/main/java/io/camunda/configuration/Bulk.java
+++ b/configuration/src/main/java/io/camunda/configuration/Bulk.java
@@ -36,7 +36,7 @@ public class Bulk {
   public Duration getDelay() {
     final var delayInt = Math.toIntExact(delay.toSeconds());
     final var result =
-        UnifiedConfigurationHelper.validateLegacyConfiguration(
+        UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
             prefix + ".delay",
             delayInt,
             Integer.class,
@@ -50,7 +50,7 @@ public class Bulk {
   }
 
   public int getSize() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         prefix + ".size",
         size,
         Integer.class,
@@ -65,7 +65,7 @@ public class Bulk {
   public DataSize getMemoryLimit() {
     final var memoryLimitInt = Math.toIntExact(memoryLimit.toMegabytes());
     final var result =
-        UnifiedConfigurationHelper.validateLegacyConfiguration(
+        UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
             prefix + ".memory-limit",
             memoryLimitInt,
             Integer.class,

--- a/configuration/src/main/java/io/camunda/configuration/Cache.java
+++ b/configuration/src/main/java/io/camunda/configuration/Cache.java
@@ -27,7 +27,7 @@ public class Cache {
   }
 
   public int getMaxSize() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         prefix + ".max-size",
         maxSize,
         Integer.class,

--- a/configuration/src/main/java/io/camunda/configuration/Cluster.java
+++ b/configuration/src/main/java/io/camunda/configuration/Cluster.java
@@ -185,7 +185,7 @@ public class Cluster implements Cloneable {
   }
 
   public List<String> getInitialContactPoints() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         UNIFIED_INITIAL_CONTACT_POINTS_PROPERTY,
         initialContactPoints,
         ResolvableType.forClassWithGenerics(List.class, String.class),
@@ -206,7 +206,7 @@ public class Cluster implements Cloneable {
   }
 
   public int getPartitionCount() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".partition-count",
         partitionCount,
         Integer.class,
@@ -219,7 +219,7 @@ public class Cluster implements Cloneable {
   }
 
   public int getReplicationFactor() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".replication-factor",
         replicationFactor,
         Integer.class,
@@ -232,7 +232,7 @@ public class Cluster implements Cloneable {
   }
 
   public int getSize() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".size",
         size,
         Integer.class,
@@ -253,7 +253,7 @@ public class Cluster implements Cloneable {
   }
 
   public String getName() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".name",
         name,
         String.class,
@@ -266,7 +266,7 @@ public class Cluster implements Cloneable {
   }
 
   public String getClusterId() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".cluster-id",
         clusterId,
         String.class,
@@ -279,7 +279,7 @@ public class Cluster implements Cloneable {
   }
 
   public String getGatewayId() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".gateway-id",
         gatewayId,
         String.class,
@@ -300,7 +300,7 @@ public class Cluster implements Cloneable {
   }
 
   public CompressionAlgorithm getCompressionAlgorithm() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".compression-algorithm",
         compressionAlgorithm,
         CompressionAlgorithm.class,

--- a/configuration/src/main/java/io/camunda/configuration/CommandApi.java
+++ b/configuration/src/main/java/io/camunda/configuration/CommandApi.java
@@ -45,7 +45,7 @@ public class CommandApi {
   private Integer advertisedPort;
 
   public String getHost() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".host",
         host,
         String.class,
@@ -58,7 +58,7 @@ public class CommandApi {
   }
 
   public Integer getPort() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".port",
         port,
         Integer.class,
@@ -71,7 +71,7 @@ public class CommandApi {
   }
 
   public String getAdvertisedHost() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".advertised-host",
         advertisedHost,
         String.class,
@@ -84,7 +84,7 @@ public class CommandApi {
   }
 
   public Integer getAdvertisedPort() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".advertised-port",
         advertisedPort,
         Integer.class,

--- a/configuration/src/main/java/io/camunda/configuration/Data.java
+++ b/configuration/src/main/java/io/camunda/configuration/Data.java
@@ -57,7 +57,7 @@ public class Data {
   }
 
   public Duration getSnapshotPeriod() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".snapshot-period",
         snapshotPeriod,
         Duration.class,

--- a/configuration/src/main/java/io/camunda/configuration/Disk.java
+++ b/configuration/src/main/java/io/camunda/configuration/Disk.java
@@ -42,7 +42,7 @@ public class Disk {
   }
 
   public boolean isMonitoringEnabled() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".monitoring-enabled",
         monitoringEnabled,
         Boolean.class,
@@ -55,7 +55,7 @@ public class Disk {
   }
 
   public Duration getMonitoringInterval() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".monitoring-interval",
         monitoringInterval,
         Duration.class,

--- a/configuration/src/main/java/io/camunda/configuration/Distribution.java
+++ b/configuration/src/main/java/io/camunda/configuration/Distribution.java
@@ -35,7 +35,7 @@ public class Distribution {
   private Duration redistributionInterval = DEFAULT_COMMAND_REDISTRIBUTION_INTERVAL;
 
   public Duration getMaxBackoffDuration() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".max-backoff-duration",
         maxBackoffDuration,
         Duration.class,
@@ -48,7 +48,7 @@ public class Distribution {
   }
 
   public Duration getRedistributionInterval() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".redistribution-interval",
         redistributionInterval,
         Duration.class,

--- a/configuration/src/main/java/io/camunda/configuration/DocumentBasedHistory.java
+++ b/configuration/src/main/java/io/camunda/configuration/DocumentBasedHistory.java
@@ -94,7 +94,7 @@ public class DocumentBasedHistory {
   }
 
   public boolean isProcessInstanceEnabled() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         prefix + ".process-instance-enabled",
         processInstanceEnabled,
         Boolean.class,
@@ -107,7 +107,7 @@ public class DocumentBasedHistory {
   }
 
   public ProcessInstanceRetentionMode getProcessInstanceRetentionMode() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         prefix + ".process-instance-retention-mode",
         processInstanceRetentionMode,
         ProcessInstanceRetentionMode.class,
@@ -133,7 +133,7 @@ public class DocumentBasedHistory {
   }
 
   public String getElsRolloverDateFormat() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         prefix + ".els-rollover-date-format",
         elsRolloverDateFormat,
         String.class,
@@ -146,7 +146,7 @@ public class DocumentBasedHistory {
   }
 
   public String getRolloverInterval() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         prefix + ".rollover-interval",
         rolloverInterval,
         String.class,
@@ -159,7 +159,7 @@ public class DocumentBasedHistory {
   }
 
   public int getRolloverBatchSize() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         prefix + ".rollover-batch-size",
         rolloverBatchSize,
         Integer.class,
@@ -180,7 +180,7 @@ public class DocumentBasedHistory {
   }
 
   public String getWaitPeriodBeforeArchiving() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         prefix + ".wait-period-before-archiving",
         waitPeriodBeforeArchiving,
         String.class,
@@ -193,7 +193,7 @@ public class DocumentBasedHistory {
   }
 
   public Duration getDelayBetweenRuns() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         prefix + ".delay-between-runs",
         delayBetweenRuns,
         Duration.class,
@@ -206,7 +206,7 @@ public class DocumentBasedHistory {
   }
 
   public Duration getMaxDelayBetweenRuns() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         prefix + ".max-delay-between-runs",
         maxDelayBetweenRuns,
         Duration.class,
@@ -219,7 +219,7 @@ public class DocumentBasedHistory {
   }
 
   public String getPolicyName() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         prefix + ".policy-name",
         policyName,
         String.class,

--- a/configuration/src/main/java/io/camunda/configuration/DocumentBasedSecondaryStorageBackup.java
+++ b/configuration/src/main/java/io/camunda/configuration/DocumentBasedSecondaryStorageBackup.java
@@ -67,7 +67,7 @@ public class DocumentBasedSecondaryStorageBackup implements Cloneable {
   }
 
   public String getRepositoryName() {
-    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrderingUnsafe(
         prefix + ".repository-name",
         repositoryName,
         String.class,
@@ -80,7 +80,7 @@ public class DocumentBasedSecondaryStorageBackup implements Cloneable {
   }
 
   public int getSnapshotTimeout() {
-    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrderingUnsafe(
         prefix + ".snapshot-timeout",
         snapshotTimeout,
         Integer.class,
@@ -98,7 +98,7 @@ public class DocumentBasedSecondaryStorageBackup implements Cloneable {
     // due to type difference. Test legacy with old unified config key first and then against the
     // updated unified config key.
     final long legacyIncompleteCheckTimeout =
-        UnifiedConfigurationHelper.validateLegacyConfiguration(
+        UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
             // Old unified config key kept for backwards compatibility
             "camunda.data.backup.incomplete-check-timeout",
             incompleteCheckTimeout.getSeconds(),
@@ -107,7 +107,7 @@ public class DocumentBasedSecondaryStorageBackup implements Cloneable {
             LEGACY_OPERATE_INCOMPLETE_CHECK_TIMEOUT_IN_SECONDS);
 
     final Duration incompleteCheckTimeoutInDuration =
-        UnifiedConfigurationHelper.validateLegacyConfiguration(
+        UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
             prefix + ".incomplete-check-timeout",
             incompleteCheckTimeout,
             Duration.class,

--- a/configuration/src/main/java/io/camunda/configuration/DocumentBasedSecondaryStorageDatabase.java
+++ b/configuration/src/main/java/io/camunda/configuration/DocumentBasedSecondaryStorageDatabase.java
@@ -128,7 +128,7 @@ public abstract class DocumentBasedSecondaryStorageDatabase
 
   @Override
   public String getPassword() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateSensitiveLegacyConfiguration(
         prefix() + ".password",
         super.getPassword(),
         String.class,

--- a/configuration/src/main/java/io/camunda/configuration/DocumentBasedSecondaryStorageDatabase.java
+++ b/configuration/src/main/java/io/camunda/configuration/DocumentBasedSecondaryStorageDatabase.java
@@ -102,7 +102,7 @@ public abstract class DocumentBasedSecondaryStorageDatabase
   @Override
   public String getUrl() {
     validateUrlConfiguration();
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         prefix() + ".url",
         super.getUrl(),
         String.class,
@@ -118,7 +118,7 @@ public abstract class DocumentBasedSecondaryStorageDatabase
 
   @Override
   public String getUsername() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         prefix() + ".username",
         super.getUsername(),
         String.class,
@@ -167,7 +167,7 @@ public abstract class DocumentBasedSecondaryStorageDatabase
   }
 
   public boolean isCreateSchema() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         prefix() + ".create-schema",
         createSchema,
         Boolean.class,
@@ -244,7 +244,7 @@ public abstract class DocumentBasedSecondaryStorageDatabase
   }
 
   public String getClusterName() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         prefix() + ".cluster-name",
         clusterName,
         String.class,
@@ -257,7 +257,7 @@ public abstract class DocumentBasedSecondaryStorageDatabase
   }
 
   public String getIndexPrefix() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         prefix() + ".index-prefix",
         indexPrefix,
         String.class,
@@ -270,7 +270,7 @@ public abstract class DocumentBasedSecondaryStorageDatabase
   }
 
   public int getNumberOfShards() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         prefix() + ".number-of-shards",
         numberOfShards,
         Integer.class,
@@ -299,7 +299,7 @@ public abstract class DocumentBasedSecondaryStorageDatabase
   }
 
   public String getDateFormat() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         prefix() + ".date-format",
         dateFormat,
         String.class,
@@ -313,7 +313,7 @@ public abstract class DocumentBasedSecondaryStorageDatabase
 
   public Duration getSocketTimeout() {
     final var socketTimeout =
-        UnifiedConfigurationHelper.validateLegacyConfiguration(
+        UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
             prefix() + ".socket-timeout",
             this.socketTimeout != null ? Math.toIntExact(this.socketTimeout.toMillis()) : null,
             Integer.class,
@@ -328,7 +328,7 @@ public abstract class DocumentBasedSecondaryStorageDatabase
 
   public Duration getConnectionTimeout() {
     final var connectionTimeoutInt =
-        UnifiedConfigurationHelper.validateLegacyConfiguration(
+        UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
             prefix() + ".connection-timeout",
             connectionTimeout != null ? Math.toIntExact(connectionTimeout.toMillis()) : null,
             Integer.class,
@@ -342,7 +342,7 @@ public abstract class DocumentBasedSecondaryStorageDatabase
   }
 
   public int getNumberOfReplicas() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         prefix() + ".number-of-replicas",
         numberOfReplicas,
         Integer.class,
@@ -363,7 +363,7 @@ public abstract class DocumentBasedSecondaryStorageDatabase
   }
 
   public int getVariableSizeThreshold() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         prefix() + ".variable-size-threshold",
         variableSizeThreshold,
         Integer.class,
@@ -376,7 +376,7 @@ public abstract class DocumentBasedSecondaryStorageDatabase
   }
 
   public Map<String, Integer> getNumberOfReplicasPerIndex() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         prefix() + ".number-of-replicas-per-index",
         numberOfReplicasPerIndex,
         ResolvableType.forClassWithGenerics(Map.class, String.class, Integer.class),
@@ -389,7 +389,7 @@ public abstract class DocumentBasedSecondaryStorageDatabase
   }
 
   public Map<String, Integer> getNumberOfShardsPerIndex() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         prefix() + ".number-of-shards-per-index",
         numberOfShardsPerIndex,
         ResolvableType.forClassWithGenerics(Map.class, String.class, Integer.class),
@@ -410,7 +410,7 @@ public abstract class DocumentBasedSecondaryStorageDatabase
   }
 
   public Integer getTemplatePriority() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         prefix() + ".template-priority",
         templatePriority,
         Integer.class,

--- a/configuration/src/main/java/io/camunda/configuration/EngineBatchOperation.java
+++ b/configuration/src/main/java/io/camunda/configuration/EngineBatchOperation.java
@@ -162,7 +162,7 @@ public class EngineBatchOperation {
   private int queryRetryBackoffFactor = DEFAULT_BATCH_OPERATION_QUERY_RETRY_BACKOFF_FACTOR;
 
   public Duration getSchedulerInterval() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".scheduler-interval",
         schedulerInterval,
         Duration.class,
@@ -175,7 +175,7 @@ public class EngineBatchOperation {
   }
 
   public int getChunkSize() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".chunk-size",
         chunkSize,
         Integer.class,
@@ -188,7 +188,7 @@ public class EngineBatchOperation {
   }
 
   public int getQueryPageSize() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".query-page-size",
         queryPageSize,
         Integer.class,
@@ -201,7 +201,7 @@ public class EngineBatchOperation {
   }
 
   public int getQueryInClauseSize() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".query-in-clause-size",
         queryInClauseSize,
         Integer.class,
@@ -214,7 +214,7 @@ public class EngineBatchOperation {
   }
 
   public int getQueryRetryMax() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".query-retry-max",
         queryRetryMax,
         Integer.class,
@@ -227,7 +227,7 @@ public class EngineBatchOperation {
   }
 
   public Duration getQueryRetryInitialDelay() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".query-retry-initial-delay",
         queryRetryInitialDelay,
         Duration.class,
@@ -240,7 +240,7 @@ public class EngineBatchOperation {
   }
 
   public Duration getQueryRetryMaxDelay() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".query-retry-max-delay",
         queryRetryMaxDelay,
         Duration.class,
@@ -253,7 +253,7 @@ public class EngineBatchOperation {
   }
 
   public int getQueryRetryBackoffFactor() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".query-retry-backoff-factor",
         queryRetryBackoffFactor,
         Integer.class,

--- a/configuration/src/main/java/io/camunda/configuration/Executor.java
+++ b/configuration/src/main/java/io/camunda/configuration/Executor.java
@@ -69,7 +69,7 @@ public class Executor {
   private int queueCapacity = 64;
 
   public int getCorePoolSizeMultiplier() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".core-pool-size-multiplier",
         corePoolSizeMultiplier,
         Integer.class,
@@ -82,7 +82,7 @@ public class Executor {
   }
 
   public int getMaxPoolSizeMultiplier() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".max-pool-size-multiplier",
         maxPoolSizeMultiplier,
         Integer.class,
@@ -96,7 +96,7 @@ public class Executor {
 
   public Duration getKeepAlive() {
     final Long currentKeepAliveSeconds =
-        UnifiedConfigurationHelper.validateLegacyConfiguration(
+        UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
             PREFIX + ".keep-alive",
             keepAlive.getSeconds(),
             Long.class,
@@ -110,7 +110,7 @@ public class Executor {
   }
 
   public int getQueueCapacity() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".queue-capacity",
         queueCapacity,
         Integer.class,

--- a/configuration/src/main/java/io/camunda/configuration/Export.java
+++ b/configuration/src/main/java/io/camunda/configuration/Export.java
@@ -41,7 +41,7 @@ public class Export {
   private Map<Integer, Set<Long>> skipRecords = Map.of();
 
   public Duration getDistributionInterval() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".distribution-interval",
         distributionInterval,
         Duration.class,

--- a/configuration/src/main/java/io/camunda/configuration/Expression.java
+++ b/configuration/src/main/java/io/camunda/configuration/Expression.java
@@ -34,7 +34,7 @@ public class Expression {
   private Duration timeout = EngineConfiguration.DEFAULT_EXPRESSION_EVALUATION_TIMEOUT;
 
   public Duration getTimeout() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".timeout",
         timeout,
         Duration.class,

--- a/configuration/src/main/java/io/camunda/configuration/Filesystem.java
+++ b/configuration/src/main/java/io/camunda/configuration/Filesystem.java
@@ -24,7 +24,7 @@ public class Filesystem {
   private String basePath;
 
   public String getBasePath() {
-    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrderingUnsafe(
         PREFIX + ".base-path",
         basePath,
         String.class,

--- a/configuration/src/main/java/io/camunda/configuration/FreeSpace.java
+++ b/configuration/src/main/java/io/camunda/configuration/FreeSpace.java
@@ -35,7 +35,7 @@ public class FreeSpace {
   private DataSize replication = DataSize.ofGigabytes(1);
 
   public DataSize getProcessing() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".processing",
         processing,
         DataSize.class,
@@ -48,7 +48,7 @@ public class FreeSpace {
   }
 
   public DataSize getReplication() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".replication",
         replication,
         DataSize.class,

--- a/configuration/src/main/java/io/camunda/configuration/Gcs.java
+++ b/configuration/src/main/java/io/camunda/configuration/Gcs.java
@@ -68,7 +68,7 @@ public class Gcs {
   private int bufferSize = 2 * 1024 * 1024;
 
   public String getBucketName() {
-    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrderingUnsafe(
         PREFIX + ".bucket-name",
         bucketName,
         String.class,
@@ -81,7 +81,7 @@ public class Gcs {
   }
 
   public String getBasePath() {
-    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrderingUnsafe(
         PREFIX + ".base-path",
         basePath,
         String.class,
@@ -94,7 +94,7 @@ public class Gcs {
   }
 
   public String getHost() {
-    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrderingUnsafe(
         PREFIX + ".host",
         host,
         String.class,
@@ -107,7 +107,7 @@ public class Gcs {
   }
 
   public GcsBackupStoreAuth getAuth() {
-    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrderingUnsafe(
         PREFIX + ".auth",
         auth,
         GcsBackupStoreAuth.class,

--- a/configuration/src/main/java/io/camunda/configuration/Grpc.java
+++ b/configuration/src/main/java/io/camunda/configuration/Grpc.java
@@ -58,7 +58,7 @@ public class Grpc implements Cloneable {
   private int managementThreads = DEFAULT_MANAGEMENT_THREADS;
 
   public String getAddress() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".address",
         address,
         String.class,
@@ -71,7 +71,7 @@ public class Grpc implements Cloneable {
   }
 
   public int getPort() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".port",
         port,
         Integer.class,
@@ -84,7 +84,7 @@ public class Grpc implements Cloneable {
   }
 
   public Duration getMinKeepAliveInterval() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".min-keep-alive-interval",
         minKeepAliveInterval,
         Duration.class,
@@ -105,7 +105,7 @@ public class Grpc implements Cloneable {
   }
 
   public int getManagementThreads() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".management-threads",
         managementThreads,
         Integer.class,

--- a/configuration/src/main/java/io/camunda/configuration/IncidentNotifier.java
+++ b/configuration/src/main/java/io/camunda/configuration/IncidentNotifier.java
@@ -84,7 +84,7 @@ public class IncidentNotifier {
   }
 
   public String getM2mClientSecret() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateSensitiveLegacyConfiguration(
         prefix() + ".m2m-client-secret",
         m2mClientSecret,
         String.class,

--- a/configuration/src/main/java/io/camunda/configuration/IncidentNotifier.java
+++ b/configuration/src/main/java/io/camunda/configuration/IncidentNotifier.java
@@ -32,7 +32,7 @@ public class IncidentNotifier {
   }
 
   public String getWebhook() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         prefix() + ".webhook",
         webhook,
         String.class,
@@ -45,7 +45,7 @@ public class IncidentNotifier {
   }
 
   public String getAuth0Domain() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         prefix() + ".auth0-domain",
         auth0Domain,
         String.class,
@@ -58,7 +58,7 @@ public class IncidentNotifier {
   }
 
   public String getAuth0Protocol() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         prefix() + ".auth0-protocol",
         auth0Protocol,
         String.class,
@@ -71,7 +71,7 @@ public class IncidentNotifier {
   }
 
   public String getM2mClientId() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         prefix() + ".m2m-client-id",
         m2mClientId,
         String.class,
@@ -97,7 +97,7 @@ public class IncidentNotifier {
   }
 
   public String getM2mAudience() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         prefix() + ".m2m-audience",
         m2mAudience,
         String.class,

--- a/configuration/src/main/java/io/camunda/configuration/InternalApi.java
+++ b/configuration/src/main/java/io/camunda/configuration/InternalApi.java
@@ -60,7 +60,7 @@ public class InternalApi implements Cloneable {
   private Integer advertisedPort;
 
   public String getHost() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".host",
         host,
         String.class,
@@ -73,7 +73,7 @@ public class InternalApi implements Cloneable {
   }
 
   public Integer getPort() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".port",
         port,
         Integer.class,
@@ -86,7 +86,7 @@ public class InternalApi implements Cloneable {
   }
 
   public String getAdvertisedHost() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".advertised-host",
         advertisedHost,
         String.class,
@@ -99,7 +99,7 @@ public class InternalApi implements Cloneable {
   }
 
   public Integer getAdvertisedPort() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".advertised-port",
         advertisedPort,
         Integer.class,

--- a/configuration/src/main/java/io/camunda/configuration/JobMetricsConfig.java
+++ b/configuration/src/main/java/io/camunda/configuration/JobMetricsConfig.java
@@ -58,7 +58,7 @@ public class JobMetricsConfig {
   private boolean enabled = DEFAULT_ENABLED;
 
   public Duration getExportInterval() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".export-interval",
         exportInterval,
         Duration.class,
@@ -71,7 +71,7 @@ public class JobMetricsConfig {
   }
 
   public int getMaxWorkerNameLength() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".max-worker-name-length",
         maxWorkerNameLength,
         Integer.class,
@@ -84,7 +84,7 @@ public class JobMetricsConfig {
   }
 
   public int getMaxJobTypeLength() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".max-job-type-length",
         maxJobTypeLength,
         Integer.class,
@@ -97,7 +97,7 @@ public class JobMetricsConfig {
   }
 
   public int getMaxTenantIdLength() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".max-tenant-id-length",
         maxTenantIdLength,
         Integer.class,
@@ -110,7 +110,7 @@ public class JobMetricsConfig {
   }
 
   public int getMaxUniqueKeys() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".max-unique-keys",
         maxUniqueKeys,
         Integer.class,
@@ -123,7 +123,7 @@ public class JobMetricsConfig {
   }
 
   public boolean isEnabled() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".enabled",
         enabled,
         Boolean.class,

--- a/configuration/src/main/java/io/camunda/configuration/KeyStore.java
+++ b/configuration/src/main/java/io/camunda/configuration/KeyStore.java
@@ -40,7 +40,7 @@ public class KeyStore implements Cloneable {
   private String password;
 
   public File getFilePath() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         prefix + ".file-path",
         filePath,
         File.class,

--- a/configuration/src/main/java/io/camunda/configuration/KeyStore.java
+++ b/configuration/src/main/java/io/camunda/configuration/KeyStore.java
@@ -53,7 +53,7 @@ public class KeyStore implements Cloneable {
   }
 
   public String getPassword() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateSensitiveLegacyConfiguration(
         prefix + ".password",
         password,
         String.class,

--- a/configuration/src/main/java/io/camunda/configuration/Limit.java
+++ b/configuration/src/main/java/io/camunda/configuration/Limit.java
@@ -122,7 +122,7 @@ public class Limit {
   @NestedConfigurationProperty private final LegacyVegas legacyVegas = new LegacyVegas();
 
   public boolean isEnabled() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".enabled",
         enabled,
         Boolean.class,
@@ -135,7 +135,7 @@ public class Limit {
   }
 
   public boolean isWindowed() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".windowed",
         windowed,
         Boolean.class,
@@ -148,7 +148,7 @@ public class Limit {
   }
 
   public String getAlgorithm() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".algorithm",
         algorithm,
         String.class,
@@ -186,7 +186,7 @@ public class Limit {
 
   // Legacy property getters for backward compatibility validation
   public Duration getAimdRequestTimeout() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".aimd.request-timeout",
         aimd.getRequestTimeout(),
         Duration.class,
@@ -195,7 +195,7 @@ public class Limit {
   }
 
   public int getAimdInitialLimit() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".aimd.initial-limit",
         aimd.getInitialLimit(),
         Integer.class,
@@ -204,7 +204,7 @@ public class Limit {
   }
 
   public int getAimdMinLimit() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".aimd.min-limit",
         aimd.getMinLimit(),
         Integer.class,
@@ -213,7 +213,7 @@ public class Limit {
   }
 
   public int getAimdMaxLimit() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".aimd.max-limit",
         aimd.getMaxLimit(),
         Integer.class,
@@ -222,7 +222,7 @@ public class Limit {
   }
 
   public double getAimdBackoffRatio() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".aimd.backoff-ratio",
         aimd.getBackoffRatio(),
         Double.class,
@@ -231,7 +231,7 @@ public class Limit {
   }
 
   public int getFixedLimit() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".fixed.limit",
         fixed.getLimit(),
         Integer.class,
@@ -240,7 +240,7 @@ public class Limit {
   }
 
   public int getVegasAlpha() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".vegas.alpha",
         vegas.getAlpha(),
         Integer.class,
@@ -249,7 +249,7 @@ public class Limit {
   }
 
   public int getVegasBeta() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".vegas.beta",
         vegas.getBeta(),
         Integer.class,
@@ -258,7 +258,7 @@ public class Limit {
   }
 
   public int getVegasInitialLimit() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".vegas.initial-limit",
         vegas.getInitialLimit(),
         Integer.class,
@@ -267,7 +267,7 @@ public class Limit {
   }
 
   public int getGradientMinLimit() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".gradient.min-limit",
         gradient.getMinLimit(),
         Integer.class,
@@ -276,7 +276,7 @@ public class Limit {
   }
 
   public int getGradientInitialLimit() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".gradient.initial-limit",
         gradient.getInitialLimit(),
         Integer.class,
@@ -285,7 +285,7 @@ public class Limit {
   }
 
   public double getGradientRttTolerance() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".gradient.rtt-tolerance",
         gradient.getRttTolerance(),
         Double.class,
@@ -294,7 +294,7 @@ public class Limit {
   }
 
   public int getGradient2MinLimit() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".gradient2.min-limit",
         gradient2.getMinLimit(),
         Integer.class,
@@ -303,7 +303,7 @@ public class Limit {
   }
 
   public int getGradient2InitialLimit() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".gradient2.initial-limit",
         gradient2.getInitialLimit(),
         Integer.class,
@@ -312,7 +312,7 @@ public class Limit {
   }
 
   public double getGradient2RttTolerance() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".gradient2.rtt-tolerance",
         gradient2.getRttTolerance(),
         Double.class,
@@ -321,7 +321,7 @@ public class Limit {
   }
 
   public int getGradient2LongWindow() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".gradient2.long-window",
         gradient2.getLongWindow(),
         Integer.class,
@@ -330,7 +330,7 @@ public class Limit {
   }
 
   public int getLegacyVegasInitialLimit() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".legacy-vegas.initial-limit",
         legacyVegas.getInitialLimit(),
         Integer.class,
@@ -339,7 +339,7 @@ public class Limit {
   }
 
   public int getLegacyVegasMaxConcurrency() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".legacy-vegas.max-concurrency",
         legacyVegas.getMaxConcurrency(),
         Integer.class,
@@ -348,7 +348,7 @@ public class Limit {
   }
 
   public double getLegacyVegasAlphaLimit() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".legacy-vegas.alpha-limit",
         legacyVegas.getAlphaLimit(),
         Double.class,
@@ -357,7 +357,7 @@ public class Limit {
   }
 
   public double getLegacyVegasBetaLimit() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".legacy-vegas.beta-limit",
         legacyVegas.getBetaLimit(),
         Double.class,

--- a/configuration/src/main/java/io/camunda/configuration/LogStream.java
+++ b/configuration/src/main/java/io/camunda/configuration/LogStream.java
@@ -34,7 +34,7 @@ public class LogStream {
   private DataSize logSegmentSize = DataSize.ofMegabytes(128);
 
   public int getLogIndexDensity() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".log-index-density",
         logIndexDensity,
         Integer.class,
@@ -47,7 +47,7 @@ public class LogStream {
   }
 
   public DataSize getLogSegmentSize() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".log-segment-size",
         logSegmentSize,
         DataSize.class,

--- a/configuration/src/main/java/io/camunda/configuration/LongPolling.java
+++ b/configuration/src/main/java/io/camunda/configuration/LongPolling.java
@@ -48,7 +48,7 @@ public class LongPolling implements Cloneable {
       ConfigurationDefaults.DEFAULT_LONG_POLLING_EMPTY_RESPONSE_THRESHOLD;
 
   public boolean isEnabled() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".enabled",
         enabled,
         Boolean.class,
@@ -61,7 +61,7 @@ public class LongPolling implements Cloneable {
   }
 
   public long getTimeout() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".timeout",
         timeout,
         Long.class,
@@ -74,7 +74,7 @@ public class LongPolling implements Cloneable {
   }
 
   public long getProbeTimeout() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".probe-timeout",
         probeTimeout,
         Long.class,
@@ -87,7 +87,7 @@ public class LongPolling implements Cloneable {
   }
 
   public int getMinEmptyResponses() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".min-empty-responses",
         minEmptyResponses,
         Integer.class,

--- a/configuration/src/main/java/io/camunda/configuration/Membership.java
+++ b/configuration/src/main/java/io/camunda/configuration/Membership.java
@@ -84,7 +84,7 @@ public class Membership implements Cloneable {
   private Duration syncInterval = Duration.ofMillis(10_000);
 
   public boolean isBroadcastUpdates() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".broadcast-updates",
         broadcastUpdates,
         Boolean.class,
@@ -97,7 +97,7 @@ public class Membership implements Cloneable {
   }
 
   public boolean isBroadcastDisputes() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".broadcast-disputes",
         broadcastDisputes,
         Boolean.class,
@@ -110,7 +110,7 @@ public class Membership implements Cloneable {
   }
 
   public boolean isNotifySuspect() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".notify-suspect",
         notifySuspect,
         Boolean.class,
@@ -123,7 +123,7 @@ public class Membership implements Cloneable {
   }
 
   public Duration getGossipInterval() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".gossip-interval",
         gossipInterval,
         Duration.class,
@@ -136,7 +136,7 @@ public class Membership implements Cloneable {
   }
 
   public int getGossipFanout() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".gossip-fanout",
         gossipFanout,
         Integer.class,
@@ -149,7 +149,7 @@ public class Membership implements Cloneable {
   }
 
   public Duration getProbeInterval() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".probe-interval",
         probeInterval,
         Duration.class,
@@ -162,7 +162,7 @@ public class Membership implements Cloneable {
   }
 
   public Duration getProbeTimeout() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".probe-timeout",
         probeTimeout,
         Duration.class,
@@ -175,7 +175,7 @@ public class Membership implements Cloneable {
   }
 
   public int getSuspectProbes() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".suspect-probes",
         suspectProbes,
         Integer.class,
@@ -188,7 +188,7 @@ public class Membership implements Cloneable {
   }
 
   public Duration getFailureTimeout() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".failure-timeout",
         failureTimeout,
         Duration.class,
@@ -201,7 +201,7 @@ public class Membership implements Cloneable {
   }
 
   public Duration getSyncInterval() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".sync-interval",
         syncInterval,
         Duration.class,

--- a/configuration/src/main/java/io/camunda/configuration/Metadata.java
+++ b/configuration/src/main/java/io/camunda/configuration/Metadata.java
@@ -40,7 +40,7 @@ public class Metadata {
   private int gossipFanout = ClusterConfigurationGossiperConfig.DEFAULT_GOSSIP_FANOUT;
 
   public Duration getSyncDelay() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".sync-delay", syncDelay, Duration.class, SUPPORTED, LEGACY_SYNC_DELAY_PROPERTIES);
   }
 
@@ -49,7 +49,7 @@ public class Metadata {
   }
 
   public Duration getSyncRequestTimeout() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".sync-request-timeout",
         syncRequestTimeout,
         Duration.class,
@@ -62,7 +62,7 @@ public class Metadata {
   }
 
   public int getGossipFanout() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".gossip-fanout",
         gossipFanout,
         Integer.class,

--- a/configuration/src/main/java/io/camunda/configuration/Metrics.java
+++ b/configuration/src/main/java/io/camunda/configuration/Metrics.java
@@ -30,7 +30,7 @@ public class Metrics {
   @NestedConfigurationProperty private JobMetricsConfig jobMetrics = new JobMetricsConfig();
 
   public boolean isActor() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".actor",
         actor,
         Boolean.class,
@@ -43,7 +43,7 @@ public class Metrics {
   }
 
   public boolean isEnableExporterExecutionMetrics() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".enable-exporter-execution-metrics",
         enableExporterExecutionMetrics,
         Boolean.class,

--- a/configuration/src/main/java/io/camunda/configuration/Monitoring.java
+++ b/configuration/src/main/java/io/camunda/configuration/Monitoring.java
@@ -31,7 +31,7 @@ public class Monitoring {
   }
 
   public boolean isJfr() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".jfr",
         isJfr,
         Boolean.class,

--- a/configuration/src/main/java/io/camunda/configuration/Network.java
+++ b/configuration/src/main/java/io/camunda/configuration/Network.java
@@ -92,7 +92,7 @@ public class Network implements Cloneable {
   @NestedConfigurationProperty private CommandApi commandApi = new CommandApi();
 
   public String getHost() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".host",
         host,
         String.class,
@@ -105,7 +105,7 @@ public class Network implements Cloneable {
   }
 
   public String getAdvertisedHost() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".advertised-host",
         advertisedHost,
         String.class,
@@ -118,7 +118,7 @@ public class Network implements Cloneable {
   }
 
   public int getPortOffset() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".port-offset",
         portOffset,
         Integer.class,
@@ -131,7 +131,7 @@ public class Network implements Cloneable {
   }
 
   public DataSize getMaxMessageSize() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".max-message-size",
         maxMessageSize,
         DataSize.class,
@@ -144,7 +144,7 @@ public class Network implements Cloneable {
   }
 
   public DataSize getSocketSendBuffer() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".socket-send-buffer",
         socketSendBuffer,
         DataSize.class,
@@ -157,7 +157,7 @@ public class Network implements Cloneable {
   }
 
   public DataSize getSocketReceiveBuffer() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".socket-receive-buffer",
         socketReceiveBuffer,
         DataSize.class,
@@ -170,7 +170,7 @@ public class Network implements Cloneable {
   }
 
   public Duration getHeartbeatTimeout() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".heartbeat-timeout",
         heartbeatTimeout,
         Duration.class,
@@ -183,7 +183,7 @@ public class Network implements Cloneable {
   }
 
   public Duration getHeartbeatInterval() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".heartbeat-interval",
         heartbeatInterval,
         Duration.class,

--- a/configuration/src/main/java/io/camunda/configuration/NodeIdProvider.java
+++ b/configuration/src/main/java/io/camunda/configuration/NodeIdProvider.java
@@ -270,7 +270,7 @@ public class NodeIdProvider {
     private int nodeId;
 
     public int getNodeId() {
-      return UnifiedConfigurationHelper.validateLegacyConfiguration(
+      return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
           Cluster.PREFIX + ".node-id",
           nodeId,
           Integer.class,

--- a/configuration/src/main/java/io/camunda/configuration/Opensearch.java
+++ b/configuration/src/main/java/io/camunda/configuration/Opensearch.java
@@ -20,7 +20,7 @@ public class Opensearch extends DocumentBasedSecondaryStorageDatabase {
   }
 
   public boolean isAwsEnabled() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         "camunda.data.secondary-storage.opensearch.aws-enabled",
         awsEnabled,
         Boolean.class,

--- a/configuration/src/main/java/io/camunda/configuration/Partitioning.java
+++ b/configuration/src/main/java/io/camunda/configuration/Partitioning.java
@@ -44,7 +44,7 @@ public class Partitioning {
   }
 
   public Scheme getScheme() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".scheme",
         scheme,
         Scheme.class,

--- a/configuration/src/main/java/io/camunda/configuration/PostExport.java
+++ b/configuration/src/main/java/io/camunda/configuration/PostExport.java
@@ -42,7 +42,7 @@ public class PostExport {
   }
 
   public int getBatchSize() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         prefix + ".batch-size",
         batchSize,
         Integer.class,
@@ -55,7 +55,7 @@ public class PostExport {
   }
 
   public Duration getDelayBetweenRuns() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         prefix + ".delay-between-runs",
         delayBetweenRuns,
         Duration.class,
@@ -68,7 +68,7 @@ public class PostExport {
   }
 
   public Duration getMaxDelayBetweenRuns() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         prefix + ".max-delay-between-runs",
         maxDelayBetweenRuns,
         Duration.class,
@@ -81,7 +81,7 @@ public class PostExport {
   }
 
   public boolean isIgnoreMissingData() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         prefix + ".ignore-missing-data",
         ignoreMissingData,
         Boolean.class,

--- a/configuration/src/main/java/io/camunda/configuration/PrimaryStorage.java
+++ b/configuration/src/main/java/io/camunda/configuration/PrimaryStorage.java
@@ -58,7 +58,7 @@ public class PrimaryStorage {
   @NestedConfigurationProperty private PrimaryStorageBackup backup = new PrimaryStorageBackup();
 
   public String getDirectory() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".directory",
         directory,
         String.class,
@@ -71,7 +71,7 @@ public class PrimaryStorage {
   }
 
   public String getRuntimeDirectory() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".runtime-directory",
         runtimeDirectory,
         String.class,

--- a/configuration/src/main/java/io/camunda/configuration/PrimaryStorageBackup.java
+++ b/configuration/src/main/java/io/camunda/configuration/PrimaryStorageBackup.java
@@ -94,7 +94,7 @@ public class PrimaryStorageBackup implements Cloneable {
   }
 
   public BackupStoreType getStore() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".store",
         store,
         BackupStoreType.class,
@@ -107,7 +107,7 @@ public class PrimaryStorageBackup implements Cloneable {
   }
 
   public boolean isContinuous() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".continuous",
         continuous,
         Boolean.class,

--- a/configuration/src/main/java/io/camunda/configuration/ProcessCache.java
+++ b/configuration/src/main/java/io/camunda/configuration/ProcessCache.java
@@ -25,7 +25,7 @@ public class ProcessCache {
   private Duration expirationIdle = Duration.ofMillis(0);
 
   public int getMaxSize() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".max-size",
         maxSize,
         Integer.class,
@@ -39,7 +39,7 @@ public class ProcessCache {
 
   public Duration getExpirationIdle() {
     final Long currentExpirationIdle =
-        UnifiedConfigurationHelper.validateLegacyConfiguration(
+        UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
             PREFIX + ".expiration-idle",
             expirationIdle.toMillis(),
             Long.class,

--- a/configuration/src/main/java/io/camunda/configuration/ProcessInstanceCreation.java
+++ b/configuration/src/main/java/io/camunda/configuration/ProcessInstanceCreation.java
@@ -30,7 +30,7 @@ public class ProcessInstanceCreation {
   private boolean businessIdUniquenessEnabled = DEFAULT_BUSINESS_ID_UNIQUENESS_ENABLED;
 
   public boolean isBusinessIdUniquenessEnabled() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".business-id-uniqueness-enabled",
         businessIdUniquenessEnabled,
         Boolean.class,

--- a/configuration/src/main/java/io/camunda/configuration/Processing.java
+++ b/configuration/src/main/java/io/camunda/configuration/Processing.java
@@ -177,7 +177,7 @@ public class Processing {
   private int maxRecoverableRetries = DEFAULT_MAX_RECOVERABLE_RETRIES;
 
   public Integer getMaxCommandsInBatch() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".max-commands-in-batch",
         maxCommandsInBatch,
         Integer.class,
@@ -190,7 +190,7 @@ public class Processing {
   }
 
   public boolean isEnableAsyncScheduledTasks() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".enable-async-scheduled-tasks",
         enableAsyncScheduledTasks,
         Boolean.class,
@@ -203,7 +203,7 @@ public class Processing {
   }
 
   public Duration getScheduledTasksCheckInterval() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".scheduled-tasks-check-interval",
         scheduledTasksCheckInterval,
         Duration.class,
@@ -216,7 +216,7 @@ public class Processing {
   }
 
   public Set<Long> getSkipPositions() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".skip-positions",
         skipPositions,
         ResolvableType.forClassWithGenerics(Set.class, Long.class),
@@ -237,7 +237,7 @@ public class Processing {
   }
 
   public boolean isEnablePreconditionsCheck() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".enable-preconditions-check",
         enablePreconditionsCheck,
         Boolean.class,
@@ -250,7 +250,7 @@ public class Processing {
   }
 
   public boolean isEnableForeignKeyChecks() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".enable-foreign-key-checks",
         enableForeignKeyChecks,
         Boolean.class,
@@ -263,7 +263,7 @@ public class Processing {
   }
 
   public boolean isEnableYieldingDueDateChecker() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".enable-yielding-duedate-checker",
         enableYieldingDueDateChecker,
         Boolean.class,
@@ -276,7 +276,7 @@ public class Processing {
   }
 
   public boolean isEnableAsyncMessageTtlChecker() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".enable-async-message-ttl-checker",
         enableAsyncMessageTtlChecker,
         Boolean.class,
@@ -289,7 +289,7 @@ public class Processing {
   }
 
   public boolean isEnableAsyncTimerDuedateChecker() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".enable-async-timer-duedate-checker",
         enableAsyncTimerDuedateChecker,
         Boolean.class,
@@ -302,7 +302,7 @@ public class Processing {
   }
 
   public boolean isEnableStraightthroughProcessingLoopDetector() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".enable-straightthrough-processing-loop-detector",
         enableStraightthroughProcessingLoopDetector,
         Boolean.class,
@@ -316,7 +316,7 @@ public class Processing {
   }
 
   public boolean isEnableMessageBodyOnExpired() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".enable-message-body-on-expired",
         enableMessageBodyOnExpired,
         Boolean.class,

--- a/configuration/src/main/java/io/camunda/configuration/Raft.java
+++ b/configuration/src/main/java/io/camunda/configuration/Raft.java
@@ -189,7 +189,7 @@ public class Raft {
   private PreAllocationStrategy segmentPreallocationStrategy = PreAllocationStrategy.POSIX_OR_FILL;
 
   public Duration getHeartbeatInterval() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".heartbeat-interval",
         heartbeatInterval,
         Duration.class,
@@ -202,7 +202,7 @@ public class Raft {
   }
 
   public Duration getElectionTimeout() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".election-timeout",
         electionTimeout,
         Duration.class,
@@ -215,7 +215,7 @@ public class Raft {
   }
 
   public boolean isPriorityElectionEnabled() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".priority-election-enabled",
         priorityElectionEnabled,
         Boolean.class,
@@ -228,7 +228,7 @@ public class Raft {
   }
 
   public boolean isFlushEnabled() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".flush-enabled",
         flushEnabled,
         Boolean.class,
@@ -241,7 +241,7 @@ public class Raft {
   }
 
   public Duration getFlushDelay() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".flush-delay",
         flushDelay,
         Duration.class,
@@ -254,7 +254,7 @@ public class Raft {
   }
 
   public int getMaxAppendsPerFollower() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".max-appends-per-follower",
         maxAppendsPerFollower,
         Integer.class,
@@ -267,7 +267,7 @@ public class Raft {
   }
 
   public DataSize getMaxAppendBatchSize() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".max-append-batch-size",
         maxAppendBatchSize,
         DataSize.class,
@@ -280,7 +280,7 @@ public class Raft {
   }
 
   public Duration getRequestTimeout() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".request-timeout",
         requestTimeout,
         Duration.class,
@@ -293,7 +293,7 @@ public class Raft {
   }
 
   public Duration getSnapshotRequestTimeout() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".snapshot-request-timeout",
         snapshotRequestTimeout,
         Duration.class,
@@ -306,7 +306,7 @@ public class Raft {
   }
 
   public DataSize getSnapshotChunkSize() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".snapshot-chunk-size",
         snapshotChunkSize,
         DataSize.class,
@@ -319,7 +319,7 @@ public class Raft {
   }
 
   public Duration getConfigurationChangeTimeout() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".configuration-change-timeout",
         configurationChangeTimeout,
         Duration.class,
@@ -332,7 +332,7 @@ public class Raft {
   }
 
   public Duration getMaxQuorumResponseTimeout() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".max-quorum-response-timeout",
         maxQuorumResponseTimeout,
         Duration.class,
@@ -345,7 +345,7 @@ public class Raft {
   }
 
   public int getMinStepDownFailureCount() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".min-step-down-failure-count",
         minStepDownFailureCount,
         Integer.class,
@@ -358,7 +358,7 @@ public class Raft {
   }
 
   public int getPreferSnapshotReplicationThreshold() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".prefer-snapshot-replication-threshold",
         preferSnapshotReplicationThreshold,
         Integer.class,
@@ -371,7 +371,7 @@ public class Raft {
   }
 
   public boolean isPreallocateSegmentFiles() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".preallocate-segment-files",
         preallocateSegmentFiles,
         Boolean.class,
@@ -387,7 +387,7 @@ public class Raft {
     if (!isPreallocateSegmentFiles()) {
       return PreAllocationStrategy.NOOP;
     }
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".segment-preallocation-strategy",
         segmentPreallocationStrategy,
         PreAllocationStrategy.class,

--- a/configuration/src/main/java/io/camunda/configuration/Restore.java
+++ b/configuration/src/main/java/io/camunda/configuration/Restore.java
@@ -26,7 +26,7 @@ public class Restore {
       List.of("lost+found", VersionedDirectoryLayout.DIRECTORY_INITIALIZED_FILE);
 
   public boolean isValidateConfig() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".validate-config",
         validateConfig,
         Boolean.class,
@@ -39,7 +39,7 @@ public class Restore {
   }
 
   public List<String> getIgnoreFilesInTarget() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".ignore-files-in-target",
         ignoreFilesInTarget,
         List.class,

--- a/configuration/src/main/java/io/camunda/configuration/Retention.java
+++ b/configuration/src/main/java/io/camunda/configuration/Retention.java
@@ -30,7 +30,7 @@ public class Retention {
   private String minimumAge = "30d";
 
   public boolean isEnabled() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".enabled",
         enabled,
         Boolean.class,
@@ -43,7 +43,7 @@ public class Retention {
   }
 
   public String getMinimumAge() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".minimum-age",
         minimumAge,
         String.class,

--- a/configuration/src/main/java/io/camunda/configuration/RocksDb.java
+++ b/configuration/src/main/java/io/camunda/configuration/RocksDb.java
@@ -145,7 +145,7 @@ public class RocksDb {
   }
 
   public boolean isStatisticsEnabled() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".statistics-enabled",
         statisticsEnabled,
         Boolean.class,
@@ -158,7 +158,7 @@ public class RocksDb {
   }
 
   public AccessMetricsKind getAccessMetrics() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".access-metrics",
         accessMetrics,
         AccessMetricsKind.class,
@@ -171,7 +171,7 @@ public class RocksDb {
   }
 
   public DataSize getMemoryLimit() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".memory-limit",
         memoryLimit,
         DataSize.class,
@@ -200,7 +200,7 @@ public class RocksDb {
   }
 
   public int getMaxOpenFiles() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".max-open-files",
         maxOpenFiles,
         Integer.class,
@@ -213,7 +213,7 @@ public class RocksDb {
   }
 
   public int getMaxWriteBufferNumber() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".max-write-buffer-number",
         maxWriteBufferNumber,
         Integer.class,
@@ -226,7 +226,7 @@ public class RocksDb {
   }
 
   public int getMinWriteBufferNumberToMerge() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".min-write-buffer-number-to-merge",
         minWriteBufferNumberToMerge,
         Integer.class,
@@ -239,7 +239,7 @@ public class RocksDb {
   }
 
   public int getIoRateBytesPerSecond() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".io-rate-bytes-per-second",
         ioRateBytesPerSecond,
         Integer.class,
@@ -252,7 +252,7 @@ public class RocksDb {
   }
 
   public boolean isWalDisabled() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".wal-disabled",
         walDisabled,
         Boolean.class,
@@ -265,7 +265,7 @@ public class RocksDb {
   }
 
   public boolean isSstPartitioningEnabled() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".sst-partitioning-enabled",
         sstPartitioningEnabled,
         Boolean.class,

--- a/configuration/src/main/java/io/camunda/configuration/S3.java
+++ b/configuration/src/main/java/io/camunda/configuration/S3.java
@@ -167,7 +167,7 @@ public class S3 {
   private String basePath;
 
   public String getBucketName() {
-    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrderingUnsafe(
         PREFIX + ".bucket-name",
         bucketName,
         String.class,
@@ -180,7 +180,7 @@ public class S3 {
   }
 
   public String getEndpoint() {
-    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrderingUnsafe(
         PREFIX + ".endpoint",
         endpoint,
         String.class,
@@ -193,7 +193,7 @@ public class S3 {
   }
 
   public String getRegion() {
-    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrderingUnsafe(
         PREFIX + ".region",
         region,
         String.class,
@@ -206,7 +206,7 @@ public class S3 {
   }
 
   public String getAccessKey() {
-    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrderingUnsafe(
         PREFIX + ".access-key",
         accessKey,
         String.class,
@@ -232,7 +232,7 @@ public class S3 {
   }
 
   public Duration getApiCallTimeout() {
-    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrderingUnsafe(
         PREFIX + ".api-call-timeout",
         apiCallTimeout,
         Duration.class,
@@ -245,7 +245,7 @@ public class S3 {
   }
 
   public boolean isForcePathStyleAccess() {
-    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrderingUnsafe(
         PREFIX + ".force-path-style-access",
         forcePathStyleAccess,
         Boolean.class,
@@ -258,7 +258,7 @@ public class S3 {
   }
 
   public String getCompression() {
-    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrderingUnsafe(
         PREFIX + ".compression",
         compression,
         String.class,
@@ -271,7 +271,7 @@ public class S3 {
   }
 
   public int getMaxConcurrentConnections() {
-    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrderingUnsafe(
         PREFIX + ".max-concurrent-connections",
         maxConcurrentConnections,
         Integer.class,
@@ -284,7 +284,7 @@ public class S3 {
   }
 
   public Duration getConnectionAcquisitionTimeout() {
-    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrderingUnsafe(
         PREFIX + ".connection-acquisition-timeout",
         connectionAcquisitionTimeout,
         Duration.class,
@@ -297,7 +297,7 @@ public class S3 {
   }
 
   public boolean isSupportLegacyMd5() {
-    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrderingUnsafe(
         PREFIX + ".support-legacy-md5",
         supportLegacyMd5,
         Boolean.class,
@@ -310,7 +310,7 @@ public class S3 {
   }
 
   public String getBasePath() {
-    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrderingUnsafe(
         PREFIX + ".base-path",
         basePath,
         String.class,

--- a/configuration/src/main/java/io/camunda/configuration/S3.java
+++ b/configuration/src/main/java/io/camunda/configuration/S3.java
@@ -219,7 +219,7 @@ public class S3 {
   }
 
   public String getSecretKey() {
-    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
+    return UnifiedConfigurationHelper.validateSensitiveLegacyConfigurationWithOrdering(
         PREFIX + ".secret-key",
         secretKey,
         String.class,

--- a/configuration/src/main/java/io/camunda/configuration/SasToken.java
+++ b/configuration/src/main/java/io/camunda/configuration/SasToken.java
@@ -52,7 +52,7 @@ public class SasToken {
   }
 
   public String getValue() {
-    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
+    return UnifiedConfigurationHelper.validateSensitiveLegacyConfigurationWithOrdering(
         PREFIX + ".value",
         value,
         String.class,

--- a/configuration/src/main/java/io/camunda/configuration/SasToken.java
+++ b/configuration/src/main/java/io/camunda/configuration/SasToken.java
@@ -39,7 +39,7 @@ public class SasToken {
   }
 
   public SasTokenType getType() {
-    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrderingUnsafe(
         PREFIX + ".type",
         type,
         SasTokenType.class,

--- a/configuration/src/main/java/io/camunda/configuration/SecondaryStorage.java
+++ b/configuration/src/main/java/io/camunda/configuration/SecondaryStorage.java
@@ -64,7 +64,7 @@ public class SecondaryStorage {
   }
 
   public SecondaryStorageType getType() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".type",
         type,
         SecondaryStorageType.class,

--- a/configuration/src/main/java/io/camunda/configuration/SecondaryStorageSecurity.java
+++ b/configuration/src/main/java/io/camunda/configuration/SecondaryStorageSecurity.java
@@ -31,7 +31,7 @@ public class SecondaryStorageSecurity {
   }
 
   public boolean isEnabled() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         prefix() + ".enabled",
         enabled,
         Boolean.class,
@@ -44,7 +44,7 @@ public class SecondaryStorageSecurity {
   }
 
   public String getCertificatePath() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         prefix() + ".certificate-path",
         certificatePath,
         String.class,
@@ -57,7 +57,7 @@ public class SecondaryStorageSecurity {
   }
 
   public boolean isVerifyHostname() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         prefix() + ".verify-hostname",
         verifyHostname,
         Boolean.class,
@@ -70,7 +70,7 @@ public class SecondaryStorageSecurity {
   }
 
   public boolean isSelfSigned() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         prefix() + ".self-signed",
         selfSigned,
         Boolean.class,

--- a/configuration/src/main/java/io/camunda/configuration/Ssl.java
+++ b/configuration/src/main/java/io/camunda/configuration/Ssl.java
@@ -46,7 +46,7 @@ public class Ssl implements Cloneable {
   @NestedConfigurationProperty private KeyStore keyStore = new KeyStore();
 
   public boolean isEnabled() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".enabled",
         enabled,
         Boolean.class,
@@ -59,7 +59,7 @@ public class Ssl implements Cloneable {
   }
 
   public File getCertificate() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".certificate",
         certificate,
         File.class,
@@ -72,7 +72,7 @@ public class Ssl implements Cloneable {
   }
 
   public File getCertificatePrivateKey() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".certificate-private-key",
         certificatePrivateKey,
         File.class,

--- a/configuration/src/main/java/io/camunda/configuration/System.java
+++ b/configuration/src/main/java/io/camunda/configuration/System.java
@@ -46,7 +46,7 @@ public class System {
   @NestedConfigurationProperty private Restore restore = new Restore();
 
   public int getCpuThreadCount() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".cpu-thread-count",
         cpuThreadCount,
         Integer.class,
@@ -59,7 +59,7 @@ public class System {
   }
 
   public int getIoThreadCount() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".io-thread-count",
         ioThreadCount,
         Integer.class,
@@ -72,7 +72,7 @@ public class System {
   }
 
   public boolean getClockControlled() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".clock-controlled",
         clockControlled,
         Boolean.class,

--- a/configuration/src/main/java/io/camunda/configuration/Throttle.java
+++ b/configuration/src/main/java/io/camunda/configuration/Throttle.java
@@ -44,7 +44,7 @@ public class Throttle {
   private Duration resolution = DEFAULT_RESOLUTION;
 
   public boolean isEnabled() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".enabled",
         enabled,
         Boolean.class,
@@ -57,7 +57,7 @@ public class Throttle {
   }
 
   public int getAcceptableBacklog() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".acceptable-backlog",
         acceptableBacklog,
         Integer.class,
@@ -70,7 +70,7 @@ public class Throttle {
   }
 
   public int getMinimumLimit() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".minimum-limit",
         minimumLimit,
         Integer.class,
@@ -83,7 +83,7 @@ public class Throttle {
   }
 
   public Duration getResolution() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".resolution",
         resolution,
         Duration.class,

--- a/configuration/src/main/java/io/camunda/configuration/TlsCluster.java
+++ b/configuration/src/main/java/io/camunda/configuration/TlsCluster.java
@@ -52,7 +52,7 @@ public class TlsCluster implements Cloneable {
   @NestedConfigurationProperty private KeyStore keyStore = new KeyStore();
 
   public boolean isEnabled() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".enabled",
         enabled,
         Boolean.class,
@@ -65,7 +65,7 @@ public class TlsCluster implements Cloneable {
   }
 
   public File getCertificateChainPath() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".certificate-chain-path",
         certificateChainPath,
         File.class,
@@ -78,7 +78,7 @@ public class TlsCluster implements Cloneable {
   }
 
   public File getCertificatePrivateKeyPath() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".certificate-private-key-path",
         certificatePrivateKeyPath,
         File.class,

--- a/configuration/src/main/java/io/camunda/configuration/UnifiedConfigurationHelper.java
+++ b/configuration/src/main/java/io/camunda/configuration/UnifiedConfigurationHelper.java
@@ -46,27 +46,132 @@ public class UnifiedConfigurationHelper {
     UnifiedConfigurationHelper.environment = environment;
   }
 
-  public static <T> T validateLegacyConfiguration(
+  /**
+   * Validates the legacy configuration properties based on the provided backward compatibility mode
+   * and returns the appropriate value. This method could potentially log the value of the
+   * properties (both unified configuration ones and legacy one), so it is not safe to use for
+   * sensitive data. Use {@link #validateSensitiveLegacyConfiguration} instead in that case.
+   *
+   * @param newProperty the new unified configuration property name
+   * @param newValue the new unified configuration property value
+   * @param expectedType the expected type of the configuration property
+   * @param backwardsCompatibilityMode the backward compatibility mode to apply when validating the
+   *     legacy properties
+   * @param legacyProperties the set of legacy configuration property names to validate
+   * @return the value to use for the configuration property
+   * @throws UnifiedConfigurationException if the legacy configuration is not valid according to the
+   *     backward compatibility mode
+   */
+  public static <T> T validateLegacyConfigurationUnsafe(
       final String newProperty,
       final T newValue,
       final Class<T> expectedType,
       final BackwardsCompatibilityMode backwardsCompatibilityMode,
       final Set<String> legacyProperties) {
+    return validateLegacyConfiguration(
+        newProperty, newValue, expectedType, backwardsCompatibilityMode, legacyProperties, false);
+  }
+
+  /**
+   * Validates the legacy configuration properties based on the provided backward compatibility mode
+   * and returns the appropriate value. This method could potentially log the value of the
+   * properties (both unified configuration ones and legacy one), so it is not safe to use for
+   * sensitive data. Use {@link #validateSensitiveLegacyConfiguration} instead in that case.
+   *
+   * @param newProperty the new unified configuration property name
+   * @param newValue the new unified configuration property value
+   * @param expectedType the expected type of the configuration property
+   * @param backwardsCompatibilityMode the backward compatibility mode to apply when validating the
+   *     legacy properties
+   * @param legacyProperties the set of legacy configuration property names to validate
+   * @return the value to use for the configuration property
+   * @throws UnifiedConfigurationException if the legacy configuration is not valid according to the
+   *     backward compatibility mode
+   */
+  public static <T> T validateLegacyConfigurationUnsafe(
+      final String newProperty,
+      final T newValue,
+      final ResolvableType expectedType,
+      final BackwardsCompatibilityMode backwardsCompatibilityMode,
+      final Set<String> legacyProperties) {
+    return validateLegacyConfiguration(
+        newProperty, newValue, expectedType, backwardsCompatibilityMode, legacyProperties, false);
+  }
+
+  /**
+   * Validates the legacy configuration properties based on the provided backward compatibility mode
+   * and returns the appropriate value. This method will not log the value of the properties, so it
+   * is safe to use for sensitive data.
+   *
+   * @param newProperty the new unified configuration property name
+   * @param newValue the new unified configuration property value
+   * @param expectedType the expected type of the configuration property
+   * @param backwardsCompatibilityMode the backward compatibility mode to apply when validating the
+   *     legacy properties
+   * @param legacyProperties the set of legacy configuration property names to validate
+   * @return the value to use for the configuration property
+   * @throws UnifiedConfigurationException if the legacy configuration is not valid according to the
+   *     backward compatibility mode
+   */
+  public static <T> T validateSensitiveLegacyConfiguration(
+      final String newProperty,
+      final T newValue,
+      final Class<T> expectedType,
+      final BackwardsCompatibilityMode backwardsCompatibilityMode,
+      final Set<String> legacyProperties) {
+    return validateLegacyConfiguration(
+        newProperty, newValue, expectedType, backwardsCompatibilityMode, legacyProperties, true);
+  }
+
+  /**
+   * Validates the legacy configuration properties based on the provided backward compatibility mode
+   * and returns the appropriate value. This method will not log the value of the properties, so it
+   * is safe to use for sensitive data.
+   *
+   * @param newProperty the new unified configuration property name
+   * @param newValue the new unified configuration property value
+   * @param expectedType the expected type of the configuration property
+   * @param backwardsCompatibilityMode the backward compatibility mode to apply when validating the
+   *     legacy properties
+   * @param legacyProperties the set of legacy configuration property names to validate
+   * @return the value to use for the configuration property
+   * @throws UnifiedConfigurationException if the legacy configuration is not valid according to the
+   *     backward compatibility mode
+   */
+  public static <T> T validateSensitiveLegacyConfiguration(
+      final String newProperty,
+      final T newValue,
+      final ResolvableType expectedType,
+      final BackwardsCompatibilityMode backwardsCompatibilityMode,
+      final Set<String> legacyProperties) {
+    return validateLegacyConfiguration(
+        newProperty, newValue, expectedType, backwardsCompatibilityMode, legacyProperties, true);
+  }
+
+  private static <T> T validateLegacyConfiguration(
+      final String newProperty,
+      final T newValue,
+      final Class<T> expectedType,
+      final BackwardsCompatibilityMode backwardsCompatibilityMode,
+      final Set<String> legacyProperties,
+      final boolean isSensitiveData) {
 
     return UnifiedConfigurationHelper.validateLegacyConfiguration(
         newProperty,
         newValue,
         ResolvableType.forClass(expectedType),
         backwardsCompatibilityMode,
-        legacyProperties);
+        legacyProperties,
+        isSensitiveData);
   }
 
-  public static <T> T validateLegacyConfiguration(
+  private static <T> T validateLegacyConfiguration(
       final String newProperty,
       final T newValue,
       final ResolvableType expectedType,
       final BackwardsCompatibilityMode backwardsCompatibilityMode,
-      final Set<String> legacyProperties) {
+      final Set<String> legacyProperties,
+      final boolean isSensitiveData) {
 
     // If the environment is not set, it is assumed that the helper is used
     // in a non-Spring context, and the validation of backward compatibility
@@ -89,39 +194,160 @@ public class UnifiedConfigurationHelper {
       case NOT_SUPPORTED ->
           backwardsCompatibilityNotSupported(legacyProperties, newProperty, newValue, expectedType);
       case SUPPORTED_ONLY_IF_VALUES_MATCH -> {
-        final T legacyValue = getLegacyValue(legacyProperties, expectedType);
+        final T legacyValue = getLegacyValue(legacyProperties, expectedType, isSensitiveData);
         yield backwardsCompatibilitySupportedOnlyIfValuesMatch(
-            legacyProperties, legacyValue, newProperty, newValue, expectedType);
+            legacyProperties, legacyValue, newProperty, newValue, expectedType, isSensitiveData);
       }
       case SUPPORTED -> {
-        final T legacyValue = getLegacyValue(legacyProperties, expectedType);
+        final T legacyValue = getLegacyValue(legacyProperties, expectedType, isSensitiveData);
         yield backwardsCompatibilitySupported(
             legacyProperties, legacyValue, newProperty, newValue, expectedType);
       }
     };
   }
 
-  public static <T> T validateLegacyConfigurationWithOrdering(
+  /**
+   * Validates the legacy configuration properties based on the provided backward compatibility mode
+   * and returns the appropriate value. Multiple sets of legacy configuration properties can be
+   * provided. The value of the properties in each set must be unique (ignoring unset properties),
+   * while properties in different sets can be different with the last set value being considered
+   * for the configuration. This method could potentially log the value of the properties (both
+   * unified configuration ones and legacy one), so it is not safe to use for sensitive data. Use
+   * {@link #validateSensitiveLegacyConfigurationWithOrdering} instead in that case.
+   *
+   * @param newProperty the new unified configuration property name
+   * @param newValue the new unified configuration property value
+   * @param expectedType the expected type of the configuration property
+   * @param backwardsCompatibilityMode the backward compatibility mode to apply when validating the
+   *     legacy properties
+   * @param legacyProperties ordered set of subsets of legacy configuration property names to
+   *     validate
+   * @return the value to use for the configuration property
+   * @throws UnifiedConfigurationException if the legacy configuration is not valid according to the
+   *     backward compatibility mode
+   */
+  public static <T> T validateLegacyConfigurationWithOrderingUnsafe(
       final String newProperty,
       final T newValue,
       final Class<T> expectedType,
       final BackwardsCompatibilityMode backwardsCompatibilityMode,
       final Set<Set<String>> legacyProperties) {
+    return validateLegacyConfigurationWithOrdering(
+        newProperty, newValue, expectedType, backwardsCompatibilityMode, legacyProperties, false);
+  }
+
+  /**
+   * Validates the legacy configuration properties based on the provided backward compatibility mode
+   * and returns the appropriate value. Multiple sets of legacy configuration properties can be
+   * provided. The value of the properties in each set must be unique (ignoring unset properties),
+   * while properties in different sets can be different with the last set value being considered
+   * for the configuration. This method could potentially log the value of the properties (both
+   * unified configuration ones and legacy one), so it is not safe to use for sensitive data. Use
+   * {@link #validateSensitiveLegacyConfigurationWithOrdering} instead in that case.
+   *
+   * @param newProperty the new unified configuration property name
+   * @param newValue the new unified configuration property value
+   * @param expectedType the expected type of the configuration property
+   * @param backwardsCompatibilityMode the backward compatibility mode to apply when validating the
+   *     legacy properties
+   * @param legacyProperties ordered set of subsets of legacy configuration property names to
+   *     validate
+   * @return the value to use for the configuration property
+   * @throws UnifiedConfigurationException if the legacy configuration is not valid according to the
+   *     backward compatibility mode
+   */
+  public static <T> T validateLegacyConfigurationWithOrderingUnsafe(
+      final String newProperty,
+      final T newValue,
+      final ResolvableType expectedType,
+      final BackwardsCompatibilityMode backwardsCompatibilityMode,
+      final Set<Set<String>> legacyProperties) {
+    return validateLegacyConfigurationWithOrdering(
+        newProperty, newValue, expectedType, backwardsCompatibilityMode, legacyProperties, false);
+  }
+
+  /**
+   * Validates the legacy configuration properties based on the provided backward compatibility mode
+   * and returns the appropriate value. Multiple sets of legacy configuration properties can be
+   * provided. The value of the properties in each set must be unique (ignoring unset properties),
+   * while properties in different sets can be different with the last set value being considered
+   * for the configuration. This method will not log the value of the properties, so it is safe to
+   * use for sensitive data.
+   *
+   * @param newProperty the new unified configuration property name
+   * @param newValue the new unified configuration property value
+   * @param expectedType the expected type of the configuration property
+   * @param backwardsCompatibilityMode the backward compatibility mode to apply when validating the
+   *     legacy properties
+   * @param legacyProperties ordered set of subsets of legacy configuration property names to
+   *     validate
+   * @return the value to use for the configuration property
+   * @throws UnifiedConfigurationException if the legacy configuration is not valid according to the
+   *     backward compatibility mode
+   */
+  public static <T> T validateSensitiveLegacyConfigurationWithOrdering(
+      final String newProperty,
+      final T newValue,
+      final Class<T> expectedType,
+      final BackwardsCompatibilityMode backwardsCompatibilityMode,
+      final Set<Set<String>> legacyProperties) {
+    return validateLegacyConfigurationWithOrdering(
+        newProperty, newValue, expectedType, backwardsCompatibilityMode, legacyProperties, true);
+  }
+
+  /**
+   * Validates the legacy configuration properties based on the provided backward compatibility mode
+   * and returns the appropriate value. Multiple sets of legacy configuration properties can be
+   * provided. The value of the properties in each set must be unique (ignoring unset properties),
+   * while properties in different sets can be different with the last set value being considered
+   * for the configuration. This method will not log the value of the properties, so it is safe to
+   * use for sensitive data.
+   *
+   * @param newProperty the new unified configuration property name
+   * @param newValue the new unified configuration property value
+   * @param expectedType the expected type of the configuration property
+   * @param backwardsCompatibilityMode the backward compatibility mode to apply when validating the
+   *     legacy properties
+   * @param legacyProperties ordered set of subsets of legacy configuration property names to
+   *     validate
+   * @return the value to use for the configuration property
+   * @throws UnifiedConfigurationException if the legacy configuration is not valid according to the
+   *     backward compatibility mode
+   */
+  public static <T> T validateSensitiveLegacyConfigurationWithOrdering(
+      final String newProperty,
+      final T newValue,
+      final ResolvableType expectedType,
+      final BackwardsCompatibilityMode backwardsCompatibilityMode,
+      final Set<Set<String>> legacyProperties) {
+    return validateLegacyConfigurationWithOrdering(
+        newProperty, newValue, expectedType, backwardsCompatibilityMode, legacyProperties, true);
+  }
+
+  private static <T> T validateLegacyConfigurationWithOrdering(
+      final String newProperty,
+      final T newValue,
+      final Class<T> expectedType,
+      final BackwardsCompatibilityMode backwardsCompatibilityMode,
+      final Set<Set<String>> legacyProperties,
+      final boolean isSensitiveData) {
 
     return UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
         newProperty,
         newValue,
         ResolvableType.forClass(expectedType),
         backwardsCompatibilityMode,
-        legacyProperties);
+        legacyProperties,
+        isSensitiveData);
   }
 
-  public static <T> T validateLegacyConfigurationWithOrdering(
+  private static <T> T validateLegacyConfigurationWithOrdering(
       final String newProperty,
       final T newValue,
       final ResolvableType expectedType,
       final BackwardsCompatibilityMode backwardsCompatibilityMode,
-      final Set<Set<String>> legacyProperties) {
+      final Set<Set<String>> legacyProperties,
+      final boolean isSensitiveData) {
 
     // If the environment is not set, it is assumed that the helper is used
     // in a non-Spring context, and the validation of backward compatibility
@@ -148,7 +374,7 @@ public class UnifiedConfigurationHelper {
           throw new UnifiedConfigurationException(
               "backwardsCompatibilityMode cannot be SUPPORTED_ONLY_IF_VALUES_MATCH when using ordered properties");
       case SUPPORTED -> {
-        final T legacyValue = getLegacyValueNested(legacyProperties, expectedType);
+        final T legacyValue = getLegacyValueNested(legacyProperties, expectedType, isSensitiveData);
         yield backwardsCompatibilitySupportedInOrderedProperties(
             legacyProperties, legacyValue, newProperty, newValue, expectedType);
       }
@@ -156,22 +382,26 @@ public class UnifiedConfigurationHelper {
   }
 
   private static <T> T getLegacyValue(
-      final Set<String> legacyProperties, final ResolvableType expectedType) {
-    final var legacyConfigurationValues = new HashMap<String, T>();
+      final Set<String> legacyProperties,
+      final ResolvableType expectedType,
+      final boolean isSensitiveData) {
+    final var legacyConfigurationDisplayValues = new HashMap<String, String>();
+    final var legacyValues = new HashSet<T>();
 
     for (final String legacyProperty : legacyProperties) {
       final T legacyValue = parseLegacyValue(legacyProperty, expectedType);
+      final String legacyDisplayValue = displayValue(legacyValue, isSensitiveData);
 
-      LOGGER.trace("Parsing legacy property '{}' -> '{}'", legacyProperty, legacyValue);
+      LOGGER.trace("Parsing legacy property '{}' -> {}", legacyProperty, legacyDisplayValue);
       if (legacyValue != null) {
-        legacyConfigurationValues.put(legacyProperty, legacyValue);
-        LOGGER.trace("Parsed actual value: '{}'", legacyValue);
+        legacyConfigurationDisplayValues.put(legacyProperty, legacyDisplayValue);
+        legacyValues.add(legacyValue);
+        LOGGER.trace("Parsed actual value: {}", legacyDisplayValue);
       } else {
         LOGGER.trace("Parsed null object");
       }
     }
 
-    final Set<T> legacyValues = new HashSet<>(legacyConfigurationValues.values());
     if (legacyValues.isEmpty()) {
       return null;
     }
@@ -179,24 +409,28 @@ public class UnifiedConfigurationHelper {
     if (legacyValues.size() > 1) {
       throw new UnifiedConfigurationException(
           String.format(
-              "Ambiguous legacy configuration. Legacy properties: %s", legacyConfigurationValues));
+              "Ambiguous legacy configuration. Legacy properties: %s",
+              legacyConfigurationDisplayValues));
     }
 
     return legacyValues.iterator().next();
   }
 
   private static <T> T getLegacyValueNested(
-      final Set<Set<String>> legacyProperties, final ResolvableType expectedType) {
+      final Set<Set<String>> legacyProperties,
+      final ResolvableType expectedType,
+      final boolean isSensitiveData) {
     final var legacyConfigurationValues = new HashMap<String, T>();
 
     for (final Set<String> legacyProperty : legacyProperties) {
       for (final String prop : legacyProperty) {
         final T legacyValue = parseLegacyValue(prop, expectedType);
+        final String legacyDisplayValue = displayValue(legacyValue, isSensitiveData);
 
-        LOGGER.trace("Parsing legacy property '{}' -> '{}'", prop, legacyValue);
+        LOGGER.trace("Parsing legacy property '{}' -> {}", prop, legacyDisplayValue);
         if (legacyValue != null) {
           legacyConfigurationValues.put(prop, legacyValue);
-          LOGGER.trace("Parsed actual value: '{}'", legacyValue);
+          LOGGER.trace("Parsed actual value: {}", legacyDisplayValue);
         } else {
           LOGGER.trace("Parsed null object");
         }
@@ -220,7 +454,9 @@ public class UnifiedConfigurationHelper {
                 "Ambiguous legacy configuration. Legacy properties: %s",
                 legacyConfigurationValues.entrySet().stream()
                     .filter(e -> legacyPropertySet.contains(e.getKey()))
-                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))));
+                    .collect(
+                        Collectors.toMap(
+                            Map.Entry::getKey, e -> displayValue(e.getValue(), isSensitiveData)))));
       }
 
       legacyValues.addAll(setValues);
@@ -233,7 +469,11 @@ public class UnifiedConfigurationHelper {
     if (legacyValues.size() > legacyProperties.size()) {
       throw new UnifiedConfigurationException(
           String.format(
-              "Ambiguous legacy configuration. Legacy properties: %s", legacyConfigurationValues));
+              "Ambiguous legacy configuration. Legacy properties: %s",
+              legacyConfigurationValues.entrySet().stream()
+                  .collect(
+                      Collectors.toMap(
+                          Map.Entry::getKey, e -> displayValue(e.getValue(), isSensitiveData)))));
     }
 
     return legacyValues.stream().reduce((first, second) -> second).orElse(null);
@@ -279,7 +519,8 @@ public class UnifiedConfigurationHelper {
       final T legacyValue,
       final String newProperty,
       final T newValue,
-      final ResolvableType expectedType) {
+      final ResolvableType expectedType,
+      final boolean isSensitiveData) {
     final boolean legacyPresent = legacyConfigPresent(legacyProperties, expectedType);
 
     final String warningMessage =
@@ -312,7 +553,10 @@ public class UnifiedConfigurationHelper {
       final String errorMessage =
           String.format(
               "Ambiguous configuration. The value %s=%s conflicts with the values '%s' from the legacy properties %s",
-              newProperty, newValue, legacyValue, String.join(", ", legacyProperties));
+              newProperty,
+              displayValue(newValue, isSensitiveData),
+              displayValue(legacyValue, isSensitiveData),
+              String.join(", ", legacyProperties));
       throw new UnifiedConfigurationException(errorMessage);
     }
   }
@@ -557,6 +801,10 @@ public class UnifiedConfigurationHelper {
       final Map<String, Object> args) {
     return new io.camunda.zeebe.broker.exporter.context.ExporterConfiguration("rdbms", args)
         .instantiate(io.camunda.exporter.rdbms.ExporterConfiguration.class);
+  }
+
+  private static <T> String displayValue(final T value, final boolean isSensitiveData) {
+    return isSensitiveData ? "*****" : value != null ? value.toString() : "<null>";
   }
 
   /* Setters used by tests to inject the mock objects */

--- a/configuration/src/main/java/io/camunda/configuration/Upgrade.java
+++ b/configuration/src/main/java/io/camunda/configuration/Upgrade.java
@@ -27,7 +27,7 @@ public class Upgrade {
   private boolean enableVersionCheck = ExperimentalCfg.DEFAULT_VERSION_CHECK_ENABLED;
 
   public boolean getEnableVersionCheck() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".enable-version-check",
         enableVersionCheck,
         Boolean.class,

--- a/configuration/src/main/java/io/camunda/configuration/Write.java
+++ b/configuration/src/main/java/io/camunda/configuration/Write.java
@@ -40,7 +40,7 @@ public class Write {
   @NestedConfigurationProperty private Throttle throttle = new Throttle();
 
   public boolean isEnabled() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".enabled",
         enabled,
         Boolean.class,
@@ -53,7 +53,7 @@ public class Write {
   }
 
   public int getLimit() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".limit",
         limit,
         Integer.class,
@@ -66,7 +66,7 @@ public class Write {
   }
 
   public Duration getRampUp() {
-    return UnifiedConfigurationHelper.validateLegacyConfiguration(
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".ramp-up",
         rampUp,
         Duration.class,

--- a/configuration/src/test/java/io/camunda/configuration/UnifiedConfigurationHelperIT.java
+++ b/configuration/src/test/java/io/camunda/configuration/UnifiedConfigurationHelperIT.java
@@ -32,7 +32,7 @@ class UnifiedConfigurationHelperIT {
     @Test
     void shouldReturnListFromNewWhenNewConfigUsesMultilineListSyntax() {
       final List<String> list =
-          UnifiedConfigurationHelper.validateLegacyConfiguration(
+          UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
               "new" + ".multilinelistsyntax",
               List.of("newItem1", "newItem2"),
               ResolvableType.forClassWithGenerics(List.class, String.class),
@@ -44,7 +44,7 @@ class UnifiedConfigurationHelperIT {
     @Test
     void shouldReturnListFromNewWhenNewConfigUsesInlineListSyntax() {
       final List<String> list =
-          UnifiedConfigurationHelper.validateLegacyConfiguration(
+          UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
               "new" + ".inlinelistsyntax",
               List.of("newItem3", "newItem4"),
               ResolvableType.forClassWithGenerics(List.class, String.class),
@@ -56,7 +56,7 @@ class UnifiedConfigurationHelperIT {
     @Test
     void shouldReturnListFromNewWhenNewConfigUsesInlineListSyntaxWithoutQuotes() {
       final List<String> list =
-          UnifiedConfigurationHelper.validateLegacyConfiguration(
+          UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
               "new" + ".inlinelistsyntaxwithoutqoutes",
               List.of("newItem7", "newItem8"),
               ResolvableType.forClassWithGenerics(List.class, String.class),
@@ -68,7 +68,7 @@ class UnifiedConfigurationHelperIT {
     @Test
     void shouldReturnListFromNewWhenNewConfigUsesCommaSeparatedString() {
       final List<String> list =
-          UnifiedConfigurationHelper.validateLegacyConfiguration(
+          UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
               "new" + ".commaseparatedstring",
               List.of("newItem5", "newItem6"),
               ResolvableType.forClassWithGenerics(List.class, String.class),
@@ -81,7 +81,7 @@ class UnifiedConfigurationHelperIT {
     void shouldReturnMapFromNewWhenNewConfigUsesMultilineMapSyntax() {
       final var expectedMap = Map.of("k1new", 1, "k2new", 2, "k3new", 3);
       final Map<String, Integer> map =
-          UnifiedConfigurationHelper.validateLegacyConfiguration(
+          UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
               "new" + ".multilinemapsyntax",
               expectedMap,
               ResolvableType.forClassWithGenerics(Map.class, String.class, Integer.class),
@@ -94,7 +94,7 @@ class UnifiedConfigurationHelperIT {
     void shouldReturnMapFromNewWhenNewConfigUsesInlineMapSyntax() {
       final var expectedMap = Map.of("k4new", 4, "k5new", 5, "k6new", 6);
       final Map<String, Integer> map =
-          UnifiedConfigurationHelper.validateLegacyConfiguration(
+          UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
               "new" + ".inlinemapsyntax",
               expectedMap,
               ResolvableType.forClassWithGenerics(Map.class, String.class, Integer.class),
@@ -107,7 +107,7 @@ class UnifiedConfigurationHelperIT {
     void shouldReturnMapFromNewWhenNewConfigUsesSinglelineMapSyntax() {
       final var expectedMap = Map.of("k7new", 7, "k8new", 8, "k9new", 9);
       final Map<String, Integer> map =
-          UnifiedConfigurationHelper.validateLegacyConfiguration(
+          UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
               "new" + ".singlelinemapsyntax",
               expectedMap,
               ResolvableType.forClassWithGenerics(Map.class, String.class, Integer.class),
@@ -122,7 +122,7 @@ class UnifiedConfigurationHelperIT {
     @Test
     void shouldReturnListFromLegacyWhenLegacyConfigUsesMultilineListSyntax() {
       final List<String> list =
-          UnifiedConfigurationHelper.validateLegacyConfiguration(
+          UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
               "foo" + ".bar",
               Collections.emptyList(),
               ResolvableType.forClassWithGenerics(List.class, String.class),
@@ -134,7 +134,7 @@ class UnifiedConfigurationHelperIT {
     @Test
     void shouldReturnListFromLegacyWhenLegacyConfigUsesInlineListSyntax() {
       final List<String> list =
-          UnifiedConfigurationHelper.validateLegacyConfiguration(
+          UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
               "foo" + ".bar",
               Collections.emptyList(),
               ResolvableType.forClassWithGenerics(List.class, String.class),
@@ -146,7 +146,7 @@ class UnifiedConfigurationHelperIT {
     @Test
     void shouldReturnListFromLegacyWhenLegacyConfigUsesInlineListSyntaxWithoutQuotes() {
       final List<String> list =
-          UnifiedConfigurationHelper.validateLegacyConfiguration(
+          UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
               "foo" + ".bar",
               Collections.emptyList(),
               ResolvableType.forClassWithGenerics(List.class, String.class),
@@ -158,7 +158,7 @@ class UnifiedConfigurationHelperIT {
     @Test
     void shouldReturnListFromLegacyWhenLegacyConfigUsesCommaSeparatedString() {
       final List<String> list =
-          UnifiedConfigurationHelper.validateLegacyConfiguration(
+          UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
               "foo" + ".bar",
               Collections.emptyList(),
               ResolvableType.forClassWithGenerics(List.class, String.class),
@@ -170,7 +170,7 @@ class UnifiedConfigurationHelperIT {
     @Test
     void shouldReturnDurationListFromLegacyWhenLegacyConfigUsesMultilineListSyntax() {
       final List<Duration> list =
-          UnifiedConfigurationHelper.validateLegacyConfiguration(
+          UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
               "foo" + ".bar",
               Collections.emptyList(),
               ResolvableType.forClassWithGenerics(List.class, Duration.class),
@@ -184,7 +184,7 @@ class UnifiedConfigurationHelperIT {
     @Test
     void shouldReturnDurationListFromLegacyWhenLegacyConfigUsesInlineListSyntax() {
       final List<Duration> list =
-          UnifiedConfigurationHelper.validateLegacyConfiguration(
+          UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
               "foo" + ".bar",
               Collections.emptyList(),
               ResolvableType.forClassWithGenerics(List.class, Duration.class),
@@ -198,7 +198,7 @@ class UnifiedConfigurationHelperIT {
     @Test
     void shouldReturnDurationListFromLegacyWhenLegacyConfigUsesCommaSeparatedString() {
       final List<Duration> list =
-          UnifiedConfigurationHelper.validateLegacyConfiguration(
+          UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
               "foo" + ".bar",
               Collections.emptyList(),
               ResolvableType.forClassWithGenerics(List.class, Duration.class),
@@ -212,7 +212,7 @@ class UnifiedConfigurationHelperIT {
     @Test
     void shouldReturnDataSizeListFromLegacyWhenLegacyConfigUsesMultilineListSyntax() {
       final List<DataSize> list =
-          UnifiedConfigurationHelper.validateLegacyConfiguration(
+          UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
               "foo" + ".bar",
               Collections.emptyList(),
               ResolvableType.forClassWithGenerics(List.class, DataSize.class),
@@ -226,7 +226,7 @@ class UnifiedConfigurationHelperIT {
     @Test
     void shouldReturnDataSizeListFromLegacyWhenLegacyConfigUsesInlineListSyntax() {
       final List<DataSize> list =
-          UnifiedConfigurationHelper.validateLegacyConfiguration(
+          UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
               "foo" + ".bar",
               Collections.emptyList(),
               ResolvableType.forClassWithGenerics(List.class, DataSize.class),
@@ -240,7 +240,7 @@ class UnifiedConfigurationHelperIT {
     @Test
     void shouldReturnDataSizeListFromLegacyWhenLegacyConfigUsesCommaSeparatedString() {
       final List<DataSize> list =
-          UnifiedConfigurationHelper.validateLegacyConfiguration(
+          UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
               "foo" + ".bar",
               Collections.emptyList(),
               ResolvableType.forClassWithGenerics(List.class, DataSize.class),
@@ -254,7 +254,7 @@ class UnifiedConfigurationHelperIT {
     @Test
     void shouldReturnMapFromLegacyWhenLegacyConfigUsesMultilineMapSyntax() {
       final Map<String, Integer> map =
-          UnifiedConfigurationHelper.validateLegacyConfiguration(
+          UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
               "foo" + ".bar",
               Collections.emptyMap(),
               ResolvableType.forClassWithGenerics(Map.class, String.class, Integer.class),
@@ -267,7 +267,7 @@ class UnifiedConfigurationHelperIT {
     @Test
     void shouldReturnMapFromLegacyWhenLegacyConfigUsesInlineMapSyntax() {
       final Map<String, Integer> map =
-          UnifiedConfigurationHelper.validateLegacyConfiguration(
+          UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
               "foo" + ".bar",
               Collections.emptyMap(),
               ResolvableType.forClassWithGenerics(Map.class, String.class, Integer.class),
@@ -280,7 +280,7 @@ class UnifiedConfigurationHelperIT {
     @Test
     void shouldReturnMapFromLegacyWhenLegacyConfigUsesSinglelineMapSyntax() {
       final Map<String, Integer> map =
-          UnifiedConfigurationHelper.validateLegacyConfiguration(
+          UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
               "foo" + ".bar",
               Collections.emptyMap(),
               ResolvableType.forClassWithGenerics(Map.class, String.class, Integer.class),
@@ -296,7 +296,7 @@ class UnifiedConfigurationHelperIT {
     @Test
     void shouldReturnListFromNewWhenNewConfigUsesMultilineListSyntax() {
       final List<String> list =
-          UnifiedConfigurationHelper.validateLegacyConfiguration(
+          UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
               "new" + ".multilinelistsyntax",
               List.of("newItem1", "newItem2"),
               ResolvableType.forClassWithGenerics(List.class, String.class),
@@ -308,7 +308,7 @@ class UnifiedConfigurationHelperIT {
     @Test
     void shouldReturnListFromNewWhenNewConfigUsesInlineListSyntax() {
       final List<String> list =
-          UnifiedConfigurationHelper.validateLegacyConfiguration(
+          UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
               "new" + ".inlinelistsyntax",
               List.of("newItem3", "newItem4"),
               ResolvableType.forClassWithGenerics(List.class, String.class),
@@ -320,7 +320,7 @@ class UnifiedConfigurationHelperIT {
     @Test
     void shouldReturnListFromNewWhenNewConfigUsesInlineListSyntaxWithoutQuotes() {
       final List<String> list =
-          UnifiedConfigurationHelper.validateLegacyConfiguration(
+          UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
               "new" + ".inlinelistsyntaxwithoutqoutes",
               List.of("newItem7", "newItem8"),
               ResolvableType.forClassWithGenerics(List.class, String.class),
@@ -332,7 +332,7 @@ class UnifiedConfigurationHelperIT {
     @Test
     void shouldReturnListFromNewWhenNewConfigUsesCommaSeparatedString() {
       final List<String> list =
-          UnifiedConfigurationHelper.validateLegacyConfiguration(
+          UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
               "new" + ".commaseparatedstring",
               List.of("newItem5", "newItem6"),
               ResolvableType.forClassWithGenerics(List.class, String.class),
@@ -345,7 +345,7 @@ class UnifiedConfigurationHelperIT {
     void shouldReturnMapFromNewWhenNewConfigUsesMultilineMapSyntax() {
       final var expectedMap = Map.of("k1new", 1, "k2new", 2, "k3new", 3);
       final Map<String, Integer> map =
-          UnifiedConfigurationHelper.validateLegacyConfiguration(
+          UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
               "new" + ".multilinemapsyntax",
               expectedMap,
               ResolvableType.forClassWithGenerics(Map.class, String.class, Integer.class),
@@ -358,7 +358,7 @@ class UnifiedConfigurationHelperIT {
     void shouldReturnMapFromNewWhenNewConfigUsesInlineMapSyntax() {
       final var expectedMap = Map.of("k4new", 4, "k5new", 5, "k6new", 6);
       final Map<String, Integer> map =
-          UnifiedConfigurationHelper.validateLegacyConfiguration(
+          UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
               "new" + ".inlinemapsyntax",
               expectedMap,
               ResolvableType.forClassWithGenerics(Map.class, String.class, Integer.class),
@@ -371,7 +371,7 @@ class UnifiedConfigurationHelperIT {
     void shouldReturnMapFromNewWhenNewConfigUsesSinglelineMapSyntax() {
       final var expectedMap = Map.of("k7new", 7, "k8new", 8, "k9new", 9);
       final Map<String, Integer> map =
-          UnifiedConfigurationHelper.validateLegacyConfiguration(
+          UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
               "new" + ".singlelinemapsyntax",
               expectedMap,
               ResolvableType.forClassWithGenerics(Map.class, String.class, Integer.class),

--- a/configuration/src/test/java/io/camunda/configuration/UnifiedConfigurationHelperTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/UnifiedConfigurationHelperTest.java
@@ -59,7 +59,7 @@ class UnifiedConfigurationHelperTest {
     setPropertyValues("legacy.prop1", "matchingValue");
 
     final String result =
-        UnifiedConfigurationHelper.validateLegacyConfiguration(
+        UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
             NEW_PROPERTY, newValue, String.class, mode, SINGLE_LEGACY_PROPERTY);
 
     // then
@@ -82,7 +82,7 @@ class UnifiedConfigurationHelperTest {
     assertThatExceptionOfType(UnifiedConfigurationException.class)
         .isThrownBy(
             () ->
-                UnifiedConfigurationHelper.validateLegacyConfiguration(
+                UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
                     NEW_PROPERTY, newValue, String.class, mode, MULTIPLE_LEGACY_PROPERTIES))
         .withMessageContaining("Ambiguous legacy configuration")
         .withMessageContaining("legacy.prop1=legacyValue1")
@@ -104,7 +104,7 @@ class UnifiedConfigurationHelperTest {
     assertThatExceptionOfType(UnifiedConfigurationException.class)
         .isThrownBy(
             () ->
-                UnifiedConfigurationHelper.validateLegacyConfiguration(
+                UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
                     NEW_PROPERTY, newValue, String.class, mode, MULTIPLE_LEGACY_PROPERTIES))
         .withMessageContaining("Ambiguous configuration");
   }
@@ -120,7 +120,7 @@ class UnifiedConfigurationHelperTest {
 
     // then
     final String result =
-        UnifiedConfigurationHelper.validateLegacyConfiguration(
+        UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
             NEW_PROPERTY, newValue, String.class, mode, SINGLE_LEGACY_PROPERTY);
     assertThat(result).isEqualTo("legacyValue1");
   }
@@ -138,7 +138,7 @@ class UnifiedConfigurationHelperTest {
 
     // then
     final String result =
-        UnifiedConfigurationHelper.validateLegacyConfiguration(
+        UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
             NEW_PROPERTY, newValue, String.class, mode, MULTIPLE_LEGACY_PROPERTIES);
     assertThat(result).isEqualTo("defaultValue");
   }
@@ -156,7 +156,7 @@ class UnifiedConfigurationHelperTest {
 
     // then
     final String result =
-        UnifiedConfigurationHelper.validateLegacyConfiguration(
+        UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
             NEW_PROPERTY, sameValue, String.class, mode, MULTIPLE_LEGACY_PROPERTIES);
     assertThat(result).isEqualTo(sameValue);
   }
@@ -176,7 +176,7 @@ class UnifiedConfigurationHelperTest {
     assertThatExceptionOfType(UnifiedConfigurationException.class)
         .isThrownBy(
             () ->
-                UnifiedConfigurationHelper.validateLegacyConfiguration(
+                UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
                     NEW_PROPERTY, newValue, String.class, mode, MULTIPLE_LEGACY_PROPERTIES))
         .withMessageContaining("Ambiguous configuration");
   }
@@ -192,7 +192,7 @@ class UnifiedConfigurationHelperTest {
 
     // then
     final String result =
-        UnifiedConfigurationHelper.validateLegacyConfiguration(
+        UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
             NEW_PROPERTY, newValue, String.class, mode, MULTIPLE_LEGACY_PROPERTIES);
     assertThat(result).isEqualTo(newValue);
   }
@@ -208,7 +208,7 @@ class UnifiedConfigurationHelperTest {
     assertThatExceptionOfType(UnifiedConfigurationException.class)
         .isThrownBy(
             () ->
-                UnifiedConfigurationHelper.validateLegacyConfiguration(
+                UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
                     newProperty, newValue, String.class, mode, SINGLE_LEGACY_PROPERTY))
         .withMessageContaining("cannot be null");
   }
@@ -227,7 +227,7 @@ class UnifiedConfigurationHelperTest {
     assertThatExceptionOfType(UnifiedConfigurationException.class)
         .isThrownBy(
             () ->
-                UnifiedConfigurationHelper.validateLegacyConfiguration(
+                UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
                     NEW_PROPERTY, newValue, String.class, mode, MULTIPLE_LEGACY_PROPERTIES))
         .withMessageContaining(
             "The following legacy configuration properties are no longer supported")
@@ -241,7 +241,7 @@ class UnifiedConfigurationHelperTest {
     final BackwardsCompatibilityMode mode = SUPPORTED;
 
     final String expected =
-        UnifiedConfigurationHelper.validateLegacyConfiguration(
+        UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
             NEW_PROPERTY, defaultValue, String.class, mode, MULTIPLE_LEGACY_PROPERTIES);
     assertThat(expected).isEqualTo(defaultValue);
   }
@@ -257,7 +257,7 @@ class UnifiedConfigurationHelperTest {
 
     final String expected = "legacyValue";
     final String actual =
-        UnifiedConfigurationHelper.validateLegacyConfiguration(
+        UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
             NEW_PROPERTY, defaultValue, String.class, mode, SINGLE_LEGACY_PROPERTY);
     assertThat(actual).isEqualTo(expected);
   }
@@ -280,7 +280,7 @@ class UnifiedConfigurationHelperTest {
 
       final String expected = "newValue";
       final String actual =
-          UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
+          UnifiedConfigurationHelper.validateLegacyConfigurationWithOrderingUnsafe(
               NEW_PROPERTY, defaultValue, String.class, mode, LEGACY_ORDERED_PROPERTIES);
       assertThat(actual).isEqualTo(expected);
     }
@@ -299,7 +299,7 @@ class UnifiedConfigurationHelperTest {
 
       final String expected = "legacyValue3";
       final String actual =
-          UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
+          UnifiedConfigurationHelper.validateLegacyConfigurationWithOrderingUnsafe(
               NEW_PROPERTY, defaultValue, String.class, mode, LEGACY_ORDERED_PROPERTIES);
       assertThat(actual).isEqualTo(expected);
     }
@@ -317,7 +317,7 @@ class UnifiedConfigurationHelperTest {
 
       final String expected = "legacyValue2";
       final String actual =
-          UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
+          UnifiedConfigurationHelper.validateLegacyConfigurationWithOrderingUnsafe(
               NEW_PROPERTY, defaultValue, String.class, mode, LEGACY_ORDERED_PROPERTIES);
       assertThat(actual).isEqualTo(expected);
     }
@@ -333,7 +333,7 @@ class UnifiedConfigurationHelperTest {
 
       final String expected = "legacyValue";
       final String actual =
-          UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
+          UnifiedConfigurationHelper.validateLegacyConfigurationWithOrderingUnsafe(
               NEW_PROPERTY, defaultValue, String.class, mode, LEGACY_ORDERED_PROPERTIES);
       assertThat(actual).isEqualTo(expected);
     }
@@ -352,7 +352,7 @@ class UnifiedConfigurationHelperTest {
 
       final String expected = "newValue";
       final String actual =
-          UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
+          UnifiedConfigurationHelper.validateLegacyConfigurationWithOrderingUnsafe(
               NEW_PROPERTY, defaultValue, String.class, mode, LEGACY_ORDERED_PROPERTIES);
       assertThat(actual).isEqualTo(expected);
     }
@@ -370,7 +370,7 @@ class UnifiedConfigurationHelperTest {
 
       final String expected = "newValue";
       final String actual =
-          UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
+          UnifiedConfigurationHelper.validateLegacyConfigurationWithOrderingUnsafe(
               NEW_PROPERTY, defaultValue, String.class, mode, LEGACY_ORDERED_PROPERTIES);
       assertThat(actual).isEqualTo(expected);
     }
@@ -387,7 +387,7 @@ class UnifiedConfigurationHelperTest {
 
       final String expected = "newValue";
       final String actual =
-          UnifiedConfigurationHelper.validateLegacyConfigurationWithOrdering(
+          UnifiedConfigurationHelper.validateLegacyConfigurationWithOrderingUnsafe(
               NEW_PROPERTY, defaultValue, String.class, mode, LEGACY_ORDERED_PROPERTIES);
       assertThat(actual).isEqualTo(expected);
     }


### PR DESCRIPTION
## Description

This pull request updates the configuration classes to use "unsafe" or "sensitive" variants of legacy configuration validation helper methods. The main goal is to ensure that configuration values are handled with the appropriate level of safety, especially for sensitive information such as credentials.

The existing `validateLegacyConfiguration(…, boolean isSensitiveData)` signature is replaced
with two explicit public method families:

- `validateNonSensitiveLegacyConfiguration` / `validateNonSensitiveLegacyConfigurationWithOrdering`
- `validateSensitiveLegacyConfiguration` / `validateSensitiveLegacyConfigurationWithOrdering`

This means every caller must consciously choose the correct variant.

All existing callers (60 files) are updated to the non-sensitive variant in this commit.

Seven credential-returning getters are switched from the non-sensitive to the sensitive variant.
Their values are now masked as `*****` in any log or error output:

| Class | Getter | Property |
|-------|--------|----------|
| `Azure` | `getAccountKey()` | `…azure.account-key` |
| `Azure` | `getConnectionString()` | `…azure.connection-string` |
| `DocumentBasedSecondaryStorageDatabase` | `getPassword()` | `…<db>.password` |
| `IncidentNotifier` | `getM2mClientSecret()` | `…incident-notifier.m2m-client-secret` |
| `KeyStore` | `getPassword()` | `…keystore.password` |
| `S3` | `getSecretKey()` | `…s3.secret-key` |
| `SasToken` | `getValue()` | `…sas-token.value` |

## Checklist

<!--- Please delete options that are not relevant. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #52256 
