### PR TITLE
fix: do not re-enable CONFIG_NOT_FOUND exporters absent from application config

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ExporterStateInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ExporterStateInitializer.java
@@ -101,7 +101,7 @@ public class ExporterStateInitializer implements ClusterConfigurationModifier {
     // Re-enable exporters whose configuration is added back to the application properties.
     final var configReaddedExporters =
         exportersInConfig.entrySet().stream()
-            .filter(entry -> exportersInConfig.containsKey(entry.getKey()))
+            .filter(entry -> configuredExporters.contains(entry.getKey()))
             .filter(entry -> entry.getValue().state().equals(State.CONFIG_NOT_FOUND))
             .toList();
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationModifierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationModifierTest.java
@@ -154,7 +154,8 @@ final class ClusterConfigurationModifierTest {
           enabledExporterRemoved(),
           exporterAddedAndRemoved(),
           disabledExporterConfigRemoved(),
-          exporterReadded());
+          exporterReadded(),
+          configNotFoundExporterNotReadded());
     }
 
     private static Arguments exporterAddedAndRemoved() {
@@ -257,6 +258,35 @@ final class ClusterConfigurationModifierTest {
               "Exporters Readded",
               new ExporterConfigParameter(
                   currentConfiguration, Set.of("expA", "expC"), expectedConfig)));
+    }
+
+    private static Arguments configNotFoundExporterNotReadded() {
+      final var initialConfig =
+          new DynamicPartitionConfig(
+              new ExportingConfig(
+                  ExportingState.EXPORTING,
+                  Map.of(
+                      "expA",
+                      new ExporterState(0, State.ENABLED, Optional.empty()),
+                      "expC",
+                      new ExporterState(1, State.CONFIG_NOT_FOUND, Optional.empty()))));
+
+      final ClusterConfiguration currentConfiguration =
+          ClusterConfiguration.init()
+              .addMember(
+                  LOCAL_MEMBER_ID,
+                  MemberState.initializeAsActive(
+                      Map.of(
+                          1,
+                          PartitionState.active(1, initialConfig),
+                          2,
+                          PartitionState.active(2, initialConfig))));
+
+      // expC is still absent from the application config — it must stay CONFIG_NOT_FOUND
+      return Arguments.of(
+          Named.of(
+              "CONFIG_NOT_FOUND Exporter Not Readded",
+              new ExporterConfigParameter(currentConfiguration, Set.of("expA"), initialConfig)));
     }
 
     private static Arguments disabledExporterConfigRemoved() {


### PR DESCRIPTION
## Description

When an exporter is removed from the application config, it is correctly marked as `CONFIG_NOT_FOUND` in the dynamic config file to avoid data loss. However, on the next restart, `ExporterStateInitializer` was re-enabling it unconditionally, causing it to flip-flop between `CONFIG_NOT_FOUND` and `ENABLED` on every restart.

The root cause was a tautological filter in `ExporterStateInitializer.updateExporterStateInPartition`:

```java
// Before (always true — iterates the same map it checks):
.filter(entry -> exportersInConfig.containsKey(entry.getKey()))

// After (checks the application config set):
.filter(entry -> configuredExporters.contains(entry.getKey()))
```

## Changes

- Fixed the one-line bug in `ExporterStateInitializer`
- Added regression test case `CONFIG_NOT_FOUND Exporter Not Readded` covering the scenario where a `CONFIG_NOT_FOUND` exporter is absent from the application config and must remain `CONFIG_NOT_FOUND`

Closes #52260

## Test plan

- [ ] `ClusterConfigurationModifierTest` — 9/9 passing, including the new regression test