### PR TITLE
fix: add x-semantic-provider annotations

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/authorizations.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/authorizations.yaml
@@ -354,6 +354,8 @@ components:
             $ref: '#/components/schemas/AuthorizationResult'
 
     AuthorizationCreateResult:
+      x-semantic-provider: 
+        - authorizationKey
       type: object
       properties:
         authorizationKey:

--- a/zeebe/gateway-protocol/src/main/proto/v2/authorizations.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/authorizations.yaml
@@ -354,7 +354,7 @@ components:
             $ref: '#/components/schemas/AuthorizationResult'
 
     AuthorizationCreateResult:
-      x-semantic-provider: 
+      x-semantic-provider:
         - authorizationKey
       type: object
       properties:

--- a/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
@@ -318,8 +318,6 @@ components:
             $ref: '#/components/schemas/BatchOperationResponse'
 
     BatchOperationResponse:
-      x-semantic-provider:
-        - batchOperationKey
       required:
         - batchOperationKey
         - batchOperationType

--- a/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
@@ -231,6 +231,8 @@ components:
         - batchOperationKey
         - batchOperationType
       description: The created batch operation.
+      x-semantic-provider:
+        - batchOperationKey
       type: object
       properties:
         batchOperationKey:
@@ -316,6 +318,8 @@ components:
             $ref: '#/components/schemas/BatchOperationResponse'
 
     BatchOperationResponse:
+      x-semantic-provider:
+        - batchOperationKey
       required:
         - batchOperationKey
         - batchOperationType

--- a/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
@@ -314,6 +314,10 @@ components:
       x-semantic-provider:
         - decisionDefinitionKey
         - decisionRequirementsKey
+        - decisionDefinitionId
+        - decisionRequirementsId
+        - name
+        - version
       required:
         - decisionDefinitionId
         - decisionDefinitionKey

--- a/zeebe/gateway-protocol/src/main/proto/v2/documents.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/documents.yaml
@@ -280,6 +280,8 @@ paths:
 components:
   schemas:
     DocumentReference:
+      x-semantic-provider:
+        - documentId
       type: object
       required:
         - camunda.document.type

--- a/zeebe/gateway-protocol/src/main/proto/v2/global-listeners.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/global-listeners.yaml
@@ -260,6 +260,8 @@ components:
 
     # CRUD Responses
     GlobalTaskListenerResult:
+      x-semantic-provider:
+        - id
       type: object
       required:
         - id

--- a/zeebe/gateway-protocol/src/main/proto/v2/global-listeners.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/global-listeners.yaml
@@ -260,8 +260,6 @@ components:
 
     # CRUD Responses
     GlobalTaskListenerResult:
-      x-semantic-provider:
-        - id
       type: object
       required:
         - id

--- a/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
@@ -183,6 +183,8 @@ components:
       description: |
         The message key of the correlated message, as well as the first process instance key it
         correlated with.
+      x-semantic-provider:
+        - messageKey
       type: object
       required:
         - tenantId
@@ -237,6 +239,8 @@ components:
 
     MessagePublicationResult:
       description: The message key of the published message.
+      x-semantic-provider:
+        - messageKey
       type: object
       required:
         - tenantId


### PR DESCRIPTION
## Description

Adds x-semantic-provider annotations to various response schemas. This supports automated test generation in https://github.com/camunda/api-test-generator. Relates to https://github.com/camunda/camunda/issues/52169

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
