### PR TITLE
fix: skip decision instance 400 validation tests for compat versions without the fix

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionInstanceSearchTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionInstanceSearchTest.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
 @CompatibilityTest
@@ -491,6 +492,10 @@ class DecisionInstanceSearchTest {
   }
 
   @Test
+  @DisabledIfSystemProperty(
+      named = "camunda.compatibility.test.version",
+      matches = "8\\.9\\.[01]",
+      disabledReason = "Validation returning 400 was introduced in 8.9.2")
   void shouldReturnBadRequestOnGetWhenIdIsInvalid() {
     final var decisionInstanceId = "invalidDecisionInstanceId";
     // when / then
@@ -503,6 +508,10 @@ class DecisionInstanceSearchTest {
   }
 
   @Test
+  @DisabledIfSystemProperty(
+      named = "camunda.compatibility.test.version",
+      matches = "8\\.9\\.[01]",
+      disabledReason = "Validation returning 400 was introduced in 8.9.2")
   void shouldReturn400ForInvalidDecisionInstance() {
     // when
     final var decisionInstanceId = "invalidDecisionInstanceId";


### PR DESCRIPTION
## Description

The compatibility test workflow tests newer clients against older server versions. The GET decision instance endpoint only returns 400 for invalid IDs since 8.9.2 (introduced in #50549), so these tests fail against 8.9.0 and 8.9.1 servers that return 404 instead.

Disable the two affected tests when running compatibility tests against those specific versions.

## Related issues

https://camunda.slack.com/archives/C0A2AGG2Q2E/p1777609842167509
