### PR TITLE
feat: extend GET /v2/system/configuration with webapp configuration sections

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/LegacyOperateProperties.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/LegacyOperateProperties.java
@@ -12,5 +12,5 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.PropertySource;
 
 @ConfigurationProperties(OperateProperties.PREFIX)
-@PropertySource("classpath:operate-version.properties")
+@PropertySource(value = "classpath:operate-version.properties", ignoreResourceNotFound = true)
 public class LegacyOperateProperties extends OperateProperties {}

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/LegacyTasklistProperties.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/LegacyTasklistProperties.java
@@ -12,5 +12,5 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.PropertySource;
 
 @ConfigurationProperties(TasklistProperties.PREFIX)
-@PropertySource("classpath:tasklist-version.properties")
+@PropertySource(value = "classpath:tasklist-version.properties", ignoreResourceNotFound = true)
 public class LegacyTasklistProperties extends TasklistProperties {}

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/WebappPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/WebappPropertiesOverride.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.beanoverrides;
+
+import io.camunda.configuration.beans.WebappProperties;
+import io.camunda.zeebe.gateway.rest.config.WebappConfiguration.Cloud;
+import org.springframework.beans.BeanUtils;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.Primary;
+
+/**
+ * Produces the authoritative {@link WebappProperties} bean used by the REST layer. Unified {@code
+ * camunda.webapp.*} keys take precedence; when absent, legacy per-app keys from Operate and
+ * Tasklist are used as fallbacks so existing deployments require no config changes.
+ */
+@Configuration
+@EnableConfigurationProperties({
+  WebappProperties.class,
+  LegacyOperateProperties.class,
+  LegacyTasklistProperties.class
+})
+@DependsOn("unifiedConfigurationHelper")
+public class WebappPropertiesOverride {
+
+  private final WebappProperties webappProperties;
+  private final LegacyOperateProperties legacyOperateProperties;
+  private final LegacyTasklistProperties legacyTasklistProperties;
+
+  public WebappPropertiesOverride(
+      final WebappProperties webappProperties,
+      final LegacyOperateProperties legacyOperateProperties,
+      final LegacyTasklistProperties legacyTasklistProperties) {
+    this.webappProperties = webappProperties;
+    this.legacyOperateProperties = legacyOperateProperties;
+    this.legacyTasklistProperties = legacyTasklistProperties;
+  }
+
+  @Bean
+  @Primary
+  public WebappProperties webappProperties() {
+    final WebappProperties resolved = new WebappProperties();
+    BeanUtils.copyProperties(webappProperties, resolved);
+
+    applyEnterpriseFallback(resolved);
+    applyCloudFallbacks(resolved);
+
+    return resolved;
+  }
+
+  private void applyEnterpriseFallback(final WebappProperties target) {
+    if (!webappProperties.isEnterprise()
+        && (legacyOperateProperties.isEnterprise() || legacyTasklistProperties.isEnterprise())) {
+      target.setEnterprise(
+          legacyOperateProperties.isEnterprise() || legacyTasklistProperties.isEnterprise());
+    }
+  }
+
+  private void applyCloudFallbacks(final WebappProperties target) {
+    final Cloud cloud = target.getCloud();
+
+    if (cloud.getStage() == null && legacyTasklistProperties.getCloud().getStage() != null) {
+      cloud.setStage(legacyTasklistProperties.getCloud().getStage());
+    }
+
+    if (cloud.getMixpanelToken() == null) {
+      if (legacyOperateProperties.getCloud().getMixpanelToken() != null) {
+        cloud.setMixpanelToken(legacyOperateProperties.getCloud().getMixpanelToken());
+      } else if (legacyTasklistProperties.getCloud().getMixpanelToken() != null) {
+        cloud.setMixpanelToken(legacyTasklistProperties.getCloud().getMixpanelToken());
+      }
+    }
+
+    if (cloud.getMixpanelApiHost() == null) {
+      if (legacyOperateProperties.getCloud().getMixpanelAPIHost() != null) {
+        cloud.setMixpanelApiHost(legacyOperateProperties.getCloud().getMixpanelAPIHost());
+      } else if (legacyTasklistProperties.getCloud().getMixpanelAPIHost() != null) {
+        cloud.setMixpanelApiHost(legacyTasklistProperties.getCloud().getMixpanelAPIHost());
+      }
+    }
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/WebappPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/WebappPropertiesOverride.java
@@ -9,12 +9,15 @@ package io.camunda.configuration.beanoverrides;
 
 import io.camunda.configuration.beans.WebappProperties;
 import io.camunda.zeebe.gateway.rest.config.WebappConfiguration.Cloud;
+import java.util.List;
 import org.springframework.beans.BeanUtils;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.env.ConfigurableEnvironment;
 
 /**
  * Produces the authoritative {@link WebappProperties} bean used by the REST layer. Unified {@code
@@ -22,6 +25,7 @@ import org.springframework.context.annotation.Primary;
  * Tasklist are used as fallbacks so existing deployments require no config changes.
  */
 @Configuration
+@Profile("!restore")
 @EnableConfigurationProperties({
   WebappProperties.class,
   LegacyOperateProperties.class,
@@ -30,17 +34,22 @@ import org.springframework.context.annotation.Primary;
 @DependsOn("unifiedConfigurationHelper")
 public class WebappPropertiesOverride {
 
+  private static final List<String> KNOWN_COMPONENTS = List.of("admin", "operate", "tasklist");
+
   private final WebappProperties webappProperties;
   private final LegacyOperateProperties legacyOperateProperties;
   private final LegacyTasklistProperties legacyTasklistProperties;
+  private final ConfigurableEnvironment environment;
 
   public WebappPropertiesOverride(
       final WebappProperties webappProperties,
       final LegacyOperateProperties legacyOperateProperties,
-      final LegacyTasklistProperties legacyTasklistProperties) {
+      final LegacyTasklistProperties legacyTasklistProperties,
+      final ConfigurableEnvironment environment) {
     this.webappProperties = webappProperties;
     this.legacyOperateProperties = legacyOperateProperties;
     this.legacyTasklistProperties = legacyTasklistProperties;
+    this.environment = environment;
   }
 
   @Bean
@@ -51,8 +60,19 @@ public class WebappPropertiesOverride {
 
     applyEnterpriseFallback(resolved);
     applyCloudFallbacks(resolved);
+    resolved.setActiveComponents(computeActiveComponents());
 
     return resolved;
+  }
+
+  private List<String> computeActiveComponents() {
+    return KNOWN_COMPONENTS.stream().filter(this::isComponentUiEnabled).toList();
+  }
+
+  private boolean isComponentUiEnabled(final String name) {
+    return environment.getProperty("camunda." + name + ".webappEnabled", Boolean.class, true)
+        && environment.getProperty("camunda.webapps." + name + ".enabled", Boolean.class, true)
+        && environment.getProperty("camunda.webapps." + name + ".ui-enabled", Boolean.class, true);
   }
 
   private void applyEnterpriseFallback(final WebappProperties target) {

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/WebappPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/WebappPropertiesOverride.java
@@ -57,8 +57,12 @@ public class WebappPropertiesOverride {
   public WebappProperties webappProperties() {
     final WebappProperties resolved = new WebappProperties();
     BeanUtils.copyProperties(webappProperties, resolved);
+    final Cloud resolvedCloud = new Cloud();
+    BeanUtils.copyProperties(webappProperties.getCloud(), resolvedCloud);
+    resolved.setCloud(resolvedCloud);
 
     applyEnterpriseFallback(resolved);
+    applyLoginDelegatedFallback(resolved);
     applyCloudFallbacks(resolved);
     resolved.setActiveComponents(computeActiveComponents());
 
@@ -76,10 +80,16 @@ public class WebappPropertiesOverride {
   }
 
   private void applyEnterpriseFallback(final WebappProperties target) {
-    if (!webappProperties.isEnterprise()
+    if (environment.getProperty("camunda.webapp.enterprise") == null
         && (legacyOperateProperties.isEnterprise() || legacyTasklistProperties.isEnterprise())) {
-      target.setEnterprise(
-          legacyOperateProperties.isEnterprise() || legacyTasklistProperties.isEnterprise());
+      target.setEnterprise(true);
+    }
+  }
+
+  private void applyLoginDelegatedFallback(final WebappProperties target) {
+    if (environment.getProperty("camunda.webapp.login-delegated") == null) {
+      target.setLoginDelegated(
+          environment.getProperty("camunda.webapps.login-delegated", Boolean.class, false));
     }
   }
 

--- a/configuration/src/main/java/io/camunda/configuration/beans/WebappProperties.java
+++ b/configuration/src/main/java/io/camunda/configuration/beans/WebappProperties.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.beans;
+
+import io.camunda.zeebe.gateway.rest.config.WebappConfiguration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("camunda.webapp")
+public class WebappProperties extends WebappConfiguration {}

--- a/operate/common/src/main/java/io/camunda/operate/property/OperateProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/OperateProperties.java
@@ -41,7 +41,7 @@ public class OperateProperties {
 
   private String tasklistUrl = null;
 
-  @Value("${camunda.operate.internal.version.current}")
+  @Value("${camunda.operate.internal.version.current:unknown-version}")
   private String version = UNKNOWN_VERSION;
 
   @NestedConfigurationProperty

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/system/SystemConfigurationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/system/SystemConfigurationIT.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.system;
+
+import static io.camunda.security.configuration.InitializationConfiguration.DEFAULT_USER_PASSWORD;
+import static io.camunda.security.configuration.InitializationConfiguration.DEFAULT_USER_USERNAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.qa.util.cluster.TestCamundaApplication;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Base64;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class SystemConfigurationIT {
+
+  private static final String SYSTEM_CONFIGURATION_PATH = "v2/system/configuration";
+
+  @MultiDbTestApplication
+  private static final TestCamundaApplication CAMUNDA_APPLICATION =
+      new TestCamundaApplication().withBasicAuth().withAuthenticatedAccess();
+
+  @AutoClose private final HttpClient httpClient = HttpClient.newHttpClient();
+
+  @Test
+  void shouldReturn401WithoutAuthentication() throws IOException, InterruptedException {
+    // given
+    final HttpRequest request = HttpRequest.newBuilder().uri(configUri()).GET().build();
+
+    // when
+    final HttpResponse<String> response =
+        httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+    // then
+    assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_UNAUTHORIZED);
+  }
+
+  @Test
+  void shouldReturnAllConfigurationSectionsWithSelfManagedDefaults()
+      throws IOException, InterruptedException {
+    // given
+    final HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(configUri())
+            .header("Authorization", basicAuth(DEFAULT_USER_USERNAME, DEFAULT_USER_PASSWORD))
+            .GET()
+            .build();
+
+    // when
+    final HttpResponse<String> response =
+        httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+    // then
+    assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_OK);
+
+    final String body = response.body();
+    assertThat(body).contains("\"jobMetrics\"");
+    assertThat(body).contains("\"components\"");
+    assertThat(body).contains("\"active\"");
+    assertThat(body).contains("\"deployment\"");
+    assertThat(body).contains("\"isEnterprise\"");
+    assertThat(body).contains("\"isMultiTenancyEnabled\"");
+    assertThat(body).contains("\"contextPath\"");
+    assertThat(body).contains("\"maxRequestSize\"");
+    assertThat(body).contains("\"authentication\"");
+    assertThat(body).contains("\"canLogout\"");
+    assertThat(body).contains("\"isLoginDelegated\"");
+    assertThat(body).contains("\"cloud\"");
+    assertThat(body).contains("\"organizationId\"");
+    assertThat(body).contains("\"clusterId\"");
+    assertThat(body).contains("\"stage\"");
+    assertThat(body).contains("\"mixpanelToken\"");
+    assertThat(body).contains("\"mixpanelAPIHost\"");
+  }
+
+  @Test
+  void shouldReturnSelfManagedDefaultsForCloudFields() throws IOException, InterruptedException {
+    // given
+    final HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(configUri())
+            .header("Authorization", basicAuth(DEFAULT_USER_USERNAME, DEFAULT_USER_PASSWORD))
+            .GET()
+            .build();
+
+    // when
+    final HttpResponse<String> response =
+        httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+    // then: on self-managed, cloud fields are null and canLogout is true
+    assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_OK);
+    assertThat(response.body())
+        .contains("\"canLogout\":true")
+        .contains("\"isEnterprise\":false")
+        .contains("\"isMultiTenancyEnabled\":false");
+  }
+
+  private URI configUri() {
+    return CAMUNDA_APPLICATION.restAddress().resolve(SYSTEM_CONFIGURATION_PATH);
+  }
+
+  private static String basicAuth(final String user, final String password) {
+    return "Basic " + Base64.getEncoder().encodeToString((user + ":" + password).getBytes());
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/system/SystemConfigurationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/system/SystemConfigurationIT.java
@@ -11,6 +11,8 @@ import static io.camunda.security.configuration.InitializationConfiguration.DEFA
 import static io.camunda.security.configuration.InitializationConfiguration.DEFAULT_USER_USERNAME;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.qa.util.cluster.TestCamundaApplication;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
@@ -34,6 +36,8 @@ public class SystemConfigurationIT {
   @MultiDbTestApplication
   private static final TestCamundaApplication CAMUNDA_APPLICATION =
       new TestCamundaApplication().withBasicAuth().withAuthenticatedAccess();
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   @AutoClose private final HttpClient httpClient = HttpClient.newHttpClient();
 
@@ -68,46 +72,40 @@ public class SystemConfigurationIT {
     // then
     assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_OK);
 
-    final String body = response.body();
-    assertThat(body).contains("\"jobMetrics\"");
-    assertThat(body).contains("\"components\"");
-    assertThat(body).contains("\"active\"");
-    assertThat(body).contains("\"deployment\"");
-    assertThat(body).contains("\"isEnterprise\"");
-    assertThat(body).contains("\"isMultiTenancyEnabled\"");
-    assertThat(body).contains("\"contextPath\"");
-    assertThat(body).contains("\"maxRequestSize\"");
-    assertThat(body).contains("\"authentication\"");
-    assertThat(body).contains("\"canLogout\"");
-    assertThat(body).contains("\"isLoginDelegated\"");
-    assertThat(body).contains("\"cloud\"");
-    assertThat(body).contains("\"organizationId\"");
-    assertThat(body).contains("\"clusterId\"");
-    assertThat(body).contains("\"stage\"");
-    assertThat(body).contains("\"mixpanelToken\"");
-    assertThat(body).contains("\"mixpanelAPIHost\"");
-  }
+    final JsonNode root = OBJECT_MAPPER.readTree(response.body());
 
-  @Test
-  void shouldReturnSelfManagedDefaultsForCloudFields() throws IOException, InterruptedException {
-    // given
-    final HttpRequest request =
-        HttpRequest.newBuilder()
-            .uri(configUri())
-            .header("Authorization", basicAuth(DEFAULT_USER_USERNAME, DEFAULT_USER_PASSWORD))
-            .GET()
-            .build();
+    final JsonNode jobMetrics = root.get("jobMetrics");
+    assertThat(jobMetrics).isNotNull();
+    assertThat(jobMetrics.get("enabled").booleanValue()).isTrue();
+    assertThat(jobMetrics.get("exportInterval").textValue()).isEqualTo("PT5M");
+    assertThat(jobMetrics.get("maxWorkerNameLength").intValue()).isEqualTo(100);
+    assertThat(jobMetrics.get("maxJobTypeLength").intValue()).isEqualTo(100);
+    assertThat(jobMetrics.get("maxTenantIdLength").intValue()).isEqualTo(30);
+    assertThat(jobMetrics.get("maxUniqueKeys").intValue()).isEqualTo(9500);
 
-    // when
-    final HttpResponse<String> response =
-        httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+    final JsonNode components = root.get("components");
+    assertThat(components).isNotNull();
+    assertThat(components.get("active").isArray()).isTrue();
 
-    // then: on self-managed, cloud fields are null and canLogout is true
-    assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_OK);
-    assertThat(response.body())
-        .contains("\"canLogout\":true")
-        .contains("\"isEnterprise\":false")
-        .contains("\"isMultiTenancyEnabled\":false");
+    final JsonNode deployment = root.get("deployment");
+    assertThat(deployment).isNotNull();
+    assertThat(deployment.get("isEnterprise").booleanValue()).isFalse();
+    assertThat(deployment.get("isMultiTenancyEnabled").booleanValue()).isFalse();
+    assertThat(deployment.get("contextPath").textValue()).isEqualTo("");
+    assertThat(deployment.get("maxRequestSize").longValue()).isPositive();
+
+    final JsonNode authentication = root.get("authentication");
+    assertThat(authentication).isNotNull();
+    assertThat(authentication.get("canLogout").booleanValue()).isTrue();
+    assertThat(authentication.get("isLoginDelegated").booleanValue()).isFalse();
+
+    final JsonNode cloud = root.get("cloud");
+    assertThat(cloud).isNotNull();
+    assertThat(cloud.get("organizationId").isNull()).isTrue();
+    assertThat(cloud.get("clusterId").isNull()).isTrue();
+    assertThat(cloud.get("stage").isNull()).isTrue();
+    assertThat(cloud.get("mixpanelToken").isNull()).isTrue();
+    assertThat(cloud.get("mixpanelAPIHost").isNull()).isTrue();
   }
 
   private URI configUri() {

--- a/tasklist/common/src/main/java/io/camunda/tasklist/property/TasklistProperties.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/property/TasklistProperties.java
@@ -28,7 +28,7 @@ public class TasklistProperties {
 
   private boolean enterprise = false;
 
-  @Value("${camunda.tasklist.internal.version.current}")
+  @Value("${camunda.tasklist.internal.version.current:unknown-version}")
   private String version = UNKNOWN_VERSION;
 
   @NestedConfigurationProperty

--- a/webapp/client/apps/orchestration-cluster-webapp/package.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/package.json
@@ -17,7 +17,7 @@
 		"generate:svg": "svgr --typescript --no-index --out-dir src/modules/svg src/assets/svg"
 	},
 	"dependencies": {
-		"@camunda/camunda-api-zod-schemas": "0.0.63",
+		"@camunda/camunda-api-zod-schemas": "0.0.64",
 		"@camunda/camunda-composite-components": "0.23.1",
 		"@carbon/react": "1.106.0",
 		"@tanstack/react-query": "5.100.5",

--- a/webapp/client/package-lock.json
+++ b/webapp/client/package-lock.json
@@ -56,7 +56,7 @@
 		"apps/orchestration-cluster-webapp": {
 			"name": "@camunda/orchestration-cluster-webapp",
 			"dependencies": {
-				"@camunda/camunda-api-zod-schemas": "0.0.63",
+				"@camunda/camunda-api-zod-schemas": "0.0.64",
 				"@camunda/camunda-composite-components": "0.23.1",
 				"@carbon/react": "1.106.0",
 				"@tanstack/react-query": "5.100.5",
@@ -9677,13 +9677,13 @@
 			"version": "0.0.1",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
-				"@camunda/camunda-api-zod-schemas": "0.0.63",
+				"@camunda/camunda-api-zod-schemas": "0.0.64",
 				"typescript": "6.0.3"
 			}
 		},
 		"packages/camunda-api-zod-schemas": {
 			"name": "@camunda/camunda-api-zod-schemas",
-			"version": "0.0.63",
+			"version": "0.0.64",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
 				"@types/node": "25.6.0",

--- a/webapp/client/packages/c8-mocks/package.json
+++ b/webapp/client/packages/c8-mocks/package.json
@@ -18,7 +18,7 @@
 		"typecheck": "tsc"
 	},
 	"devDependencies": {
-		"@camunda/camunda-api-zod-schemas": "0.0.63",
+		"@camunda/camunda-api-zod-schemas": "0.0.64",
 		"typescript": "6.0.3"
 	}
 }

--- a/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
+++ b/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.0.64
+
+### 🚀 Enhancements
+
+- Add System Configuration schemas and endpoint for 8.10 ([#51313](https://github.com/camunda/camunda/issues/51313))
+  - `systemConfigurationSchema` with `jobMetrics`, `components`, `deployment`, `authentication`, and `cloud` sections
+  - `GET /v2/system/configuration` endpoint
+
+### ❤️ Contributors
+
+- Yedidiah Tsedeke ([@tsedekey](https://github.com/tsedekey))
+
 ## v0.0.63
 
 ### 🚀 Enhancements

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/index.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/index.ts
@@ -156,6 +156,7 @@ import {
 } from './tenant';
 import {createUser, queryUsers, getUser, deleteUser, updateUser} from './user';
 import {getUsageMetrics} from './usage-metrics';
+import {getSystemConfiguration} from './system-configuration';
 import {getAuditLog, queryAuditLogs} from './audit-log';
 import {queryUserTaskAuditLogs} from './user-task-audit-log';
 import {
@@ -332,6 +333,7 @@ const endpoints = {
 	deleteUser,
 	updateUser,
 	getUsageMetrics,
+	getSystemConfiguration,
 	createIncidentResolutionBatchOperation,
 	createCancellationBatchOperation,
 	createDeletionBatchOperation,
@@ -965,6 +967,22 @@ export {
 	type GetUsageMetricsResponseBody,
 	type GetUsageMetricsParams,
 } from './usage-metrics';
+export {
+	jobMetricsConfigurationSchema,
+	componentsConfigurationSchema,
+	deploymentConfigurationSchema,
+	authenticationConfigurationSchema,
+	cloudConfigurationSchema,
+	systemConfigurationSchema,
+	getSystemConfigurationResponseBodySchema,
+	type JobMetricsConfiguration,
+	type ComponentsConfiguration,
+	type DeploymentConfiguration,
+	type AuthenticationConfiguration,
+	type CloudConfiguration,
+	type SystemConfiguration,
+	type GetSystemConfigurationResponseBody,
+} from './system-configuration';
 export {
 	clusterVariableScopeSchema,
 	clusterVariableSchema,

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/system-configuration.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/system-configuration.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {z} from 'zod';
+import {API_VERSION, type Endpoint} from './common';
+
+const jobMetricsConfigurationSchema = z.object({
+	enabled: z.boolean(),
+	exportInterval: z.string(),
+	maxWorkerNameLength: z.number().int(),
+	maxJobTypeLength: z.number().int(),
+	maxTenantIdLength: z.number().int(),
+	maxUniqueKeys: z.number().int(),
+});
+type JobMetricsConfiguration = z.infer<typeof jobMetricsConfigurationSchema>;
+
+const componentsConfigurationSchema = z.object({
+	active: z.array(z.string()),
+});
+type ComponentsConfiguration = z.infer<typeof componentsConfigurationSchema>;
+
+const deploymentConfigurationSchema = z.object({
+	isEnterprise: z.boolean(),
+	isMultiTenancyEnabled: z.boolean(),
+	contextPath: z.string(),
+	maxRequestSize: z.number(),
+});
+type DeploymentConfiguration = z.infer<typeof deploymentConfigurationSchema>;
+
+const authenticationConfigurationSchema = z.object({
+	canLogout: z.boolean(),
+	isLoginDelegated: z.boolean(),
+});
+type AuthenticationConfiguration = z.infer<typeof authenticationConfigurationSchema>;
+
+const cloudConfigurationSchema = z.object({
+	organizationId: z.string().nullable(),
+	clusterId: z.string().nullable(),
+	stage: z.string().nullable(),
+	mixpanelToken: z.string().nullable(),
+	mixpanelAPIHost: z.string().nullable(),
+});
+type CloudConfiguration = z.infer<typeof cloudConfigurationSchema>;
+
+const systemConfigurationSchema = z.object({
+	jobMetrics: jobMetricsConfigurationSchema,
+	components: componentsConfigurationSchema,
+	deployment: deploymentConfigurationSchema,
+	authentication: authenticationConfigurationSchema,
+	cloud: cloudConfigurationSchema,
+});
+type SystemConfiguration = z.infer<typeof systemConfigurationSchema>;
+
+const getSystemConfigurationResponseBodySchema = systemConfigurationSchema;
+type GetSystemConfigurationResponseBody = z.infer<typeof getSystemConfigurationResponseBodySchema>;
+
+const getSystemConfiguration: Endpoint = {
+	method: 'GET',
+	getUrl: () => `/${API_VERSION}/system/configuration`,
+};
+
+export {
+	jobMetricsConfigurationSchema,
+	componentsConfigurationSchema,
+	deploymentConfigurationSchema,
+	authenticationConfigurationSchema,
+	cloudConfigurationSchema,
+	systemConfigurationSchema,
+	getSystemConfigurationResponseBodySchema,
+	getSystemConfiguration,
+};
+export type {
+	JobMetricsConfiguration,
+	ComponentsConfiguration,
+	DeploymentConfiguration,
+	AuthenticationConfiguration,
+	CloudConfiguration,
+	SystemConfiguration,
+	GetSystemConfigurationResponseBody,
+};

--- a/webapp/client/packages/camunda-api-zod-schemas/package.json
+++ b/webapp/client/packages/camunda-api-zod-schemas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda/camunda-api-zod-schemas",
-	"version": "0.0.63",
+	"version": "0.0.64",
 	"license": "LicenseRef-Camunda-1.0",
 	"description": "Zod schemas and TypeScript types for Camunda 8 unified API",
 	"author": "Vinicius Goulart <vinicius.goulart@camunda.com>",
@@ -586,6 +586,12 @@
 			"import": {
 				"types": "./dist/8.10/agent-instance.d.ts",
 				"default": "./dist/8.10/agent-instance.js"
+			}
+		},
+		"./8.10/system-configuration": {
+			"import": {
+				"types": "./dist/8.10/system-configuration.d.ts",
+				"default": "./dist/8.10/system-configuration.js"
 			}
 		},
 		"./package.json": "./package.json"

--- a/webapp/client/packages/camunda-api-zod-schemas/vite.config.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/vite.config.ts
@@ -118,6 +118,7 @@ export default defineConfig({
 				'8.10/cluster-variable': resolve(__dirname, 'lib/8.10/cluster-variable.ts'),
 				'8.10/global-task-listener': resolve(__dirname, 'lib/8.10/global-task-listener.ts'),
 				'8.10/agent-instance': resolve(__dirname, 'lib/8.10/agent-instance.ts'),
+				'8.10/system-configuration': resolve(__dirname, 'lib/8.10/system-configuration.ts'),
 			},
 			formats: ['es'],
 		},

--- a/zeebe/gateway-protocol/src/main/proto/v2/system.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/system.yaml
@@ -250,7 +250,7 @@ components:
           description: List of webapp components whose UI is enabled in this deployment.
           type: array
           items:
-            type: string
+            $ref: '#/components/schemas/WebappComponent'
           example: ["operate", "tasklist"]
 
     DeploymentConfigurationResponse:
@@ -310,25 +310,42 @@ components:
           description: The SaaS organization ID, if applicable.
           type: string
           nullable: true
-          example: null
+          example: "org-123456"
         clusterId:
           description: The SaaS cluster ID, if applicable.
           type: string
           nullable: true
-          example: null
+          example: "cluster-abc"
         stage:
-          description: The cloud deployment stage (e.g., prod, int).
-          type: string
+          description: The cloud deployment stage.
           nullable: true
-          example: null
+          allOf:
+            - $ref: '#/components/schemas/CloudStage'
+          example: "prod"
         mixpanelToken:
           description: The Mixpanel analytics token for the cloud UI.
           type: string
           nullable: true
-          example: null
+          example: "abc123token"
         mixpanelAPIHost:
           description: The Mixpanel API host URL.
           type: string
           nullable: true
-          example: null
+          example: "https://api.mixpanel.com"
+
+    WebappComponent:
+      description: A Camunda webapp component name.
+      type: string
+      enum:
+        - operate
+        - tasklist
+        - admin
+
+    CloudStage:
+      description: The cloud deployment stage.
+      type: string
+      enum:
+        - dev
+        - int
+        - prod
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/system.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/system.yaml
@@ -108,6 +108,22 @@ paths:
                       maxJobTypeLength: 100
                       maxTenantIdLength: 30
                       maxUniqueKeys: 9500
+                    components:
+                      active: ["operate", "tasklist"]
+                    deployment:
+                      isEnterprise: false
+                      isMultiTenancyEnabled: false
+                      contextPath: ""
+                      maxRequestSize: 4194304
+                    authentication:
+                      canLogout: true
+                      isLoginDelegated: false
+                    cloud:
+                      organizationId: null
+                      clusterId: null
+                      stage: null
+                      mixpanelToken: null
+                      mixpanelAPIHost: null
         "401":
           $ref: 'common-responses.yaml#/components/responses/Unauthorized'
         "500":
@@ -168,9 +184,21 @@ components:
       type: object
       required:
         - jobMetrics
+        - components
+        - deployment
+        - authentication
+        - cloud
       properties:
         jobMetrics:
           $ref: '#/components/schemas/JobMetricsConfigurationResponse'
+        components:
+          $ref: '#/components/schemas/ComponentsConfigurationResponse'
+        deployment:
+          $ref: '#/components/schemas/DeploymentConfigurationResponse'
+        authentication:
+          $ref: '#/components/schemas/AuthenticationConfigurationResponse'
+        cloud:
+          $ref: '#/components/schemas/CloudConfigurationResponse'
 
     JobMetricsConfigurationResponse:
       description: Configuration for job metrics collection and export.
@@ -211,4 +239,96 @@ components:
           type: integer
           format: int32
           example: 9500
+
+    ComponentsConfigurationResponse:
+      description: Configuration for active Camunda components in the deployment.
+      type: object
+      required:
+        - active
+      properties:
+        active:
+          description: List of webapp components whose UI is enabled in this deployment.
+          type: array
+          items:
+            type: string
+          example: ["operate", "tasklist"]
+
+    DeploymentConfigurationResponse:
+      description: Configuration for deployment characteristics.
+      type: object
+      required:
+        - isEnterprise
+        - isMultiTenancyEnabled
+        - contextPath
+        - maxRequestSize
+      properties:
+        isEnterprise:
+          description: Whether this is an enterprise deployment.
+          type: boolean
+          example: false
+        isMultiTenancyEnabled:
+          description: Whether multi-tenancy is enabled.
+          type: boolean
+          example: false
+        contextPath:
+          description: The servlet context path for the deployment.
+          type: string
+          example: ""
+        maxRequestSize:
+          description: The maximum HTTP request size in bytes.
+          type: integer
+          format: int64
+          example: 4194304
+
+    AuthenticationConfigurationResponse:
+      description: Configuration for authentication and session management.
+      type: object
+      required:
+        - canLogout
+        - isLoginDelegated
+      properties:
+        canLogout:
+          description: Whether users can log out (false for SaaS deployments).
+          type: boolean
+          example: true
+        isLoginDelegated:
+          description: Whether login is delegated to an external identity provider.
+          type: boolean
+          example: false
+
+    CloudConfigurationResponse:
+      description: Configuration for SaaS/cloud-specific settings.
+      type: object
+      required:
+        - organizationId
+        - clusterId
+        - stage
+        - mixpanelToken
+        - mixpanelAPIHost
+      properties:
+        organizationId:
+          description: The SaaS organization ID, if applicable.
+          type: string
+          nullable: true
+          example: null
+        clusterId:
+          description: The SaaS cluster ID, if applicable.
+          type: string
+          nullable: true
+          example: null
+        stage:
+          description: The cloud deployment stage (e.g., prod, int).
+          type: string
+          nullable: true
+          example: null
+        mixpanelToken:
+          description: The Mixpanel analytics token for the cloud UI.
+          type: string
+          nullable: true
+          example: null
+        mixpanelAPIHost:
+          description: The Mixpanel API host URL.
+          type: string
+          nullable: true
+          example: null
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/WebappConfiguration.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/WebappConfiguration.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.config;
+
+public class WebappConfiguration {
+
+  private boolean enterprise = false;
+  private boolean loginDelegated = false;
+  private Cloud cloud = new Cloud();
+
+  public boolean isEnterprise() {
+    return enterprise;
+  }
+
+  public void setEnterprise(final boolean enterprise) {
+    this.enterprise = enterprise;
+  }
+
+  public boolean isLoginDelegated() {
+    return loginDelegated;
+  }
+
+  public void setLoginDelegated(final boolean loginDelegated) {
+    this.loginDelegated = loginDelegated;
+  }
+
+  public Cloud getCloud() {
+    return cloud;
+  }
+
+  public void setCloud(final Cloud cloud) {
+    this.cloud = cloud;
+  }
+
+  public static class Cloud {
+    private String stage;
+    private String mixpanelToken;
+    private String mixpanelApiHost;
+
+    public String getStage() {
+      return stage;
+    }
+
+    public void setStage(final String stage) {
+      this.stage = stage;
+    }
+
+    public String getMixpanelToken() {
+      return mixpanelToken;
+    }
+
+    public void setMixpanelToken(final String mixpanelToken) {
+      this.mixpanelToken = mixpanelToken;
+    }
+
+    public String getMixpanelApiHost() {
+      return mixpanelApiHost;
+    }
+
+    public void setMixpanelApiHost(final String mixpanelApiHost) {
+      this.mixpanelApiHost = mixpanelApiHost;
+    }
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/WebappConfiguration.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/WebappConfiguration.java
@@ -7,11 +7,15 @@
  */
 package io.camunda.zeebe.gateway.rest.config;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class WebappConfiguration {
 
   private boolean enterprise = false;
   private boolean loginDelegated = false;
   private Cloud cloud = new Cloud();
+  private List<String> activeComponents = new ArrayList<>();
 
   public boolean isEnterprise() {
     return enterprise;
@@ -35,6 +39,14 @@ public class WebappConfiguration {
 
   public void setCloud(final Cloud cloud) {
     this.cloud = cloud;
+  }
+
+  public List<String> getActiveComponents() {
+    return activeComponents;
+  }
+
+  public void setActiveComponents(final List<String> activeComponents) {
+    this.activeComponents = activeComponents;
   }
 
   public static class Cloud {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/system/SystemController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/system/SystemController.java
@@ -47,7 +47,7 @@ public class SystemController {
   private final SecurityConfiguration securityConfiguration;
   private final ServletContext servletContext;
   private final WebappConfiguration webappConfiguration;
-  private final Long maxRequestSizeBytes;
+  private final long maxRequestSizeBytes;
 
   public SystemController(
       final UsageMetricsServices usageMetricsServices,
@@ -64,7 +64,7 @@ public class SystemController {
     this.servletContext = servletContext;
     this.webappConfiguration =
         webappConfiguration != null ? webappConfiguration : new WebappConfiguration();
-    this.maxRequestSizeBytes = maxRequestSize != null ? maxRequestSize.toBytes() : null;
+    this.maxRequestSizeBytes = maxRequestSize.toBytes();
   }
 
   @RequiresSecondaryStorage

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/system/SystemController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/system/SystemController.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
 import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration.JobMetricsConfiguration;
+import io.camunda.zeebe.gateway.rest.config.WebappConfiguration;
 import io.camunda.zeebe.gateway.rest.controller.CamundaRestController;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
 import jakarta.servlet.ServletContext;
@@ -50,12 +51,8 @@ public class SystemController {
   private final SecurityConfiguration securityConfiguration;
   private final ServletContext servletContext;
   private final Environment environment;
-  private final boolean enterprise;
-  private final boolean loginDelegated;
+  private final WebappConfiguration webappConfiguration;
   private final Long maxRequestSizeBytes;
-  private final String cloudStage;
-  private final String cloudMixpanelToken;
-  private final String cloudMixpanelApiHost;
 
   public SystemController(
       final UsageMetricsServices usageMetricsServices,
@@ -64,6 +61,7 @@ public class SystemController {
       @Autowired(required = false) final SecurityConfiguration securityConfiguration,
       @Autowired(required = false) final ServletContext servletContext,
       @Autowired(required = false) final Environment environment,
+      @Autowired(required = false) final WebappConfiguration webappConfiguration,
       @Value("${spring.servlet.multipart.max-request-size:4MB}") final DataSize maxRequestSize) {
     this.usageMetricsServices = usageMetricsServices;
     this.authenticationProvider = authenticationProvider;
@@ -71,58 +69,9 @@ public class SystemController {
     this.securityConfiguration = securityConfiguration;
     this.servletContext = servletContext;
     this.environment = environment;
-    this.enterprise =
-        resolveBooleanProperty(
-            environment,
-            false,
-            "camunda.webapp.enterprise",
-            "camunda.operate.enterprise",
-            "camunda.tasklist.enterprise");
-    this.loginDelegated =
-        resolveBooleanProperty(environment, false, "camunda.webapps.login-delegated");
+    this.webappConfiguration =
+        webappConfiguration != null ? webappConfiguration : new WebappConfiguration();
     this.maxRequestSizeBytes = maxRequestSize != null ? maxRequestSize.toBytes() : null;
-    this.cloudStage =
-        resolveStringProperty(
-            environment, "camunda.webapp.cloud.stage", "camunda.tasklist.cloud.stage");
-    this.cloudMixpanelToken =
-        resolveStringProperty(
-            environment,
-            "camunda.webapp.cloud.mixpanel-token",
-            "camunda.operate.cloud.mixpanelToken",
-            "camunda.tasklist.cloud.mixpanelToken");
-    this.cloudMixpanelApiHost =
-        resolveStringProperty(
-            environment,
-            "camunda.webapp.cloud.mixpanel-api-host",
-            "camunda.operate.cloud.mixpanelAPIHost",
-            "camunda.tasklist.cloud.mixpanelAPIHost");
-  }
-
-  private static boolean resolveBooleanProperty(
-      final Environment env, final boolean defaultValue, final String... keys) {
-    if (env == null) {
-      return defaultValue;
-    }
-    for (final String key : keys) {
-      final Boolean value = env.getProperty(key, Boolean.class);
-      if (value != null) {
-        return value;
-      }
-    }
-    return defaultValue;
-  }
-
-  private static String resolveStringProperty(final Environment env, final String... keys) {
-    if (env == null) {
-      return null;
-    }
-    for (final String key : keys) {
-      final String value = env.getProperty(key);
-      if (value != null) {
-        return value;
-      }
-    }
-    return null;
   }
 
   @RequiresSecondaryStorage
@@ -191,7 +140,7 @@ public class SystemController {
     final String contextPath = servletContext != null ? servletContext.getContextPath() : "";
 
     return DeploymentConfigurationResponse.Builder.create()
-        .isEnterprise(enterprise)
+        .isEnterprise(webappConfiguration.isEnterprise())
         .isMultiTenancyEnabled(isMultiTenancyEnabled)
         .contextPath(contextPath != null ? contextPath : "")
         .maxRequestSize(maxRequestSizeBytes)
@@ -206,7 +155,7 @@ public class SystemController {
 
     return AuthenticationConfigurationResponse.Builder.create()
         .canLogout(canLogout)
-        .isLoginDelegated(loginDelegated)
+        .isLoginDelegated(webappConfiguration.isLoginDelegated())
         .build();
   }
 
@@ -223,9 +172,9 @@ public class SystemController {
     return CloudConfigurationResponse.Builder.create()
         .organizationId(organizationId)
         .clusterId(clusterId)
-        .stage(cloudStage)
-        .mixpanelToken(cloudMixpanelToken)
-        .mixpanelAPIHost(cloudMixpanelApiHost)
+        .stage(webappConfiguration.getCloud().getStage())
+        .mixpanelToken(webappConfiguration.getCloud().getMixpanelToken())
+        .mixpanelAPIHost(webappConfiguration.getCloud().getMixpanelApiHost())
         .build();
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/system/SystemController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/system/SystemController.java
@@ -13,11 +13,13 @@ import io.camunda.gateway.mapping.http.search.SearchQueryRequestMapper;
 import io.camunda.gateway.mapping.http.search.SearchQueryResponseMapper;
 import io.camunda.gateway.protocol.model.AuthenticationConfigurationResponse;
 import io.camunda.gateway.protocol.model.CloudConfigurationResponse;
+import io.camunda.gateway.protocol.model.CloudStage;
 import io.camunda.gateway.protocol.model.ComponentsConfigurationResponse;
 import io.camunda.gateway.protocol.model.DeploymentConfigurationResponse;
 import io.camunda.gateway.protocol.model.JobMetricsConfigurationResponse;
 import io.camunda.gateway.protocol.model.SystemConfigurationResponse;
 import io.camunda.gateway.protocol.model.UsageMetricsResponse;
+import io.camunda.gateway.protocol.model.WebappComponent;
 import io.camunda.search.query.UsageMetricsQuery;
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.security.configuration.SecurityConfiguration;
@@ -104,7 +106,10 @@ public class SystemController {
 
   private ComponentsConfigurationResponse buildComponentsConfiguration() {
     return ComponentsConfigurationResponse.Builder.create()
-        .active(webappConfiguration.getActiveComponents())
+        .active(
+            webappConfiguration.getActiveComponents().stream()
+                .map(WebappComponent::fromValue)
+                .toList())
         .build();
   }
 
@@ -148,7 +153,10 @@ public class SystemController {
     return CloudConfigurationResponse.Builder.create()
         .organizationId(organizationId)
         .clusterId(clusterId)
-        .stage(webappConfiguration.getCloud().getStage())
+        .stage(
+            webappConfiguration.getCloud().getStage() != null
+                ? CloudStage.fromValue(webappConfiguration.getCloud().getStage())
+                : null)
         .mixpanelToken(webappConfiguration.getCloud().getMixpanelToken())
         .mixpanelAPIHost(webappConfiguration.getCloud().getMixpanelApiHost())
         .build();

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/system/SystemController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/system/SystemController.java
@@ -30,10 +30,8 @@ import io.camunda.zeebe.gateway.rest.config.WebappConfiguration;
 import io.camunda.zeebe.gateway.rest.controller.CamundaRestController;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
 import jakarta.servlet.ServletContext;
-import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.env.Environment;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.unit.DataSize;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -43,14 +41,11 @@ import org.springframework.web.bind.annotation.RequestParam;
 @RequestMapping("/v2/system")
 public class SystemController {
 
-  private static final List<String> KNOWN_COMPONENTS = List.of("admin", "operate", "tasklist");
-
   private final UsageMetricsServices usageMetricsServices;
   private final CamundaAuthenticationProvider authenticationProvider;
   private final GatewayRestConfiguration gatewayRestConfiguration;
   private final SecurityConfiguration securityConfiguration;
   private final ServletContext servletContext;
-  private final Environment environment;
   private final WebappConfiguration webappConfiguration;
   private final Long maxRequestSizeBytes;
 
@@ -60,7 +55,6 @@ public class SystemController {
       final GatewayRestConfiguration gatewayRestConfiguration,
       @Autowired(required = false) final SecurityConfiguration securityConfiguration,
       @Autowired(required = false) final ServletContext servletContext,
-      @Autowired(required = false) final Environment environment,
       @Autowired(required = false) final WebappConfiguration webappConfiguration,
       @Value("${spring.servlet.multipart.max-request-size:4MB}") final DataSize maxRequestSize) {
     this.usageMetricsServices = usageMetricsServices;
@@ -68,7 +62,6 @@ public class SystemController {
     this.gatewayRestConfiguration = gatewayRestConfiguration;
     this.securityConfiguration = securityConfiguration;
     this.servletContext = servletContext;
-    this.environment = environment;
     this.webappConfiguration =
         webappConfiguration != null ? webappConfiguration : new WebappConfiguration();
     this.maxRequestSizeBytes = maxRequestSize != null ? maxRequestSize.toBytes() : null;
@@ -110,26 +103,9 @@ public class SystemController {
   }
 
   private ComponentsConfigurationResponse buildComponentsConfiguration() {
-    final List<String> activeComponents =
-        KNOWN_COMPONENTS.stream().filter(this::isComponentEnabled).toList();
-    return ComponentsConfigurationResponse.Builder.create().active(activeComponents).build();
-  }
-
-  private boolean isComponentEnabled(final String name) {
-    if (environment == null) {
-      return false;
-    }
-    final Boolean legacyEnabled =
-        environment.getProperty("camunda." + name + ".webapp-enabled", Boolean.class);
-    final Boolean unifiedEnabled =
-        environment.getProperty("camunda.webapps." + name + ".enabled", Boolean.class);
-    final Boolean uiEnabled =
-        environment.getProperty("camunda.webapps." + name + ".ui-enabled", Boolean.class);
-
-    // Default to true if property is not set
-    return (legacyEnabled == null || legacyEnabled)
-        && (unifiedEnabled == null || unifiedEnabled)
-        && (uiEnabled == null || uiEnabled);
+    return ComponentsConfigurationResponse.Builder.create()
+        .active(webappConfiguration.getActiveComponents())
+        .build();
   }
 
   private DeploymentConfigurationResponse buildDeploymentConfiguration() {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/system/SystemController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/system/SystemController.java
@@ -11,11 +11,16 @@ import static io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper.mapErrorToRes
 
 import io.camunda.gateway.mapping.http.search.SearchQueryRequestMapper;
 import io.camunda.gateway.mapping.http.search.SearchQueryResponseMapper;
+import io.camunda.gateway.protocol.model.AuthenticationConfigurationResponse;
+import io.camunda.gateway.protocol.model.CloudConfigurationResponse;
+import io.camunda.gateway.protocol.model.ComponentsConfigurationResponse;
+import io.camunda.gateway.protocol.model.DeploymentConfigurationResponse;
 import io.camunda.gateway.protocol.model.JobMetricsConfigurationResponse;
 import io.camunda.gateway.protocol.model.SystemConfigurationResponse;
 import io.camunda.gateway.protocol.model.UsageMetricsResponse;
 import io.camunda.search.query.UsageMetricsQuery;
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.UsageMetricsServices;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
@@ -23,7 +28,13 @@ import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration.JobMetricsConfiguration;
 import io.camunda.zeebe.gateway.rest.controller.CamundaRestController;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
+import jakarta.servlet.ServletContext;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.Environment;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.unit.DataSize;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -31,17 +42,87 @@ import org.springframework.web.bind.annotation.RequestParam;
 @RequestMapping("/v2/system")
 public class SystemController {
 
+  private static final List<String> KNOWN_COMPONENTS = List.of("admin", "operate", "tasklist");
+
   private final UsageMetricsServices usageMetricsServices;
   private final CamundaAuthenticationProvider authenticationProvider;
   private final GatewayRestConfiguration gatewayRestConfiguration;
+  private final SecurityConfiguration securityConfiguration;
+  private final ServletContext servletContext;
+  private final Environment environment;
+  private final boolean enterprise;
+  private final boolean loginDelegated;
+  private final Long maxRequestSizeBytes;
+  private final String cloudStage;
+  private final String cloudMixpanelToken;
+  private final String cloudMixpanelApiHost;
 
   public SystemController(
       final UsageMetricsServices usageMetricsServices,
       final CamundaAuthenticationProvider authenticationProvider,
-      final GatewayRestConfiguration gatewayRestConfiguration) {
+      final GatewayRestConfiguration gatewayRestConfiguration,
+      @Autowired(required = false) final SecurityConfiguration securityConfiguration,
+      @Autowired(required = false) final ServletContext servletContext,
+      @Autowired(required = false) final Environment environment,
+      @Value("${spring.servlet.multipart.max-request-size:4MB}") final DataSize maxRequestSize) {
     this.usageMetricsServices = usageMetricsServices;
     this.authenticationProvider = authenticationProvider;
     this.gatewayRestConfiguration = gatewayRestConfiguration;
+    this.securityConfiguration = securityConfiguration;
+    this.servletContext = servletContext;
+    this.environment = environment;
+    this.enterprise =
+        resolveBooleanProperty(
+            environment,
+            false,
+            "camunda.webapp.enterprise",
+            "camunda.operate.enterprise",
+            "camunda.tasklist.enterprise");
+    this.loginDelegated =
+        resolveBooleanProperty(environment, false, "camunda.webapps.login-delegated");
+    this.maxRequestSizeBytes = maxRequestSize != null ? maxRequestSize.toBytes() : null;
+    this.cloudStage =
+        resolveStringProperty(
+            environment, "camunda.webapp.cloud.stage", "camunda.tasklist.cloud.stage");
+    this.cloudMixpanelToken =
+        resolveStringProperty(
+            environment,
+            "camunda.webapp.cloud.mixpanel-token",
+            "camunda.operate.cloud.mixpanelToken",
+            "camunda.tasklist.cloud.mixpanelToken");
+    this.cloudMixpanelApiHost =
+        resolveStringProperty(
+            environment,
+            "camunda.webapp.cloud.mixpanel-api-host",
+            "camunda.operate.cloud.mixpanelAPIHost",
+            "camunda.tasklist.cloud.mixpanelAPIHost");
+  }
+
+  private static boolean resolveBooleanProperty(
+      final Environment env, final boolean defaultValue, final String... keys) {
+    if (env == null) {
+      return defaultValue;
+    }
+    for (final String key : keys) {
+      final Boolean value = env.getProperty(key, Boolean.class);
+      if (value != null) {
+        return value;
+      }
+    }
+    return defaultValue;
+  }
+
+  private static String resolveStringProperty(final Environment env, final String... keys) {
+    if (env == null) {
+      return null;
+    }
+    for (final String key : keys) {
+      final String value = env.getProperty(key);
+      if (value != null) {
+        return value;
+      }
+    }
+    return null;
   }
 
   @RequiresSecondaryStorage
@@ -68,8 +149,84 @@ public class SystemController {
             .maxTenantIdLength(jobMetricsCfg.getMaxTenantIdLength())
             .maxUniqueKeys(jobMetricsCfg.getMaxUniqueKeys())
             .build();
+
     return ResponseEntity.ok(
-        SystemConfigurationResponse.Builder.create().jobMetrics(jobMetricsResponse).build());
+        SystemConfigurationResponse.Builder.create()
+            .jobMetrics(jobMetricsResponse)
+            .components(buildComponentsConfiguration())
+            .deployment(buildDeploymentConfiguration())
+            .authentication(buildAuthenticationConfiguration())
+            .cloud(buildCloudConfiguration())
+            .build());
+  }
+
+  private ComponentsConfigurationResponse buildComponentsConfiguration() {
+    final List<String> activeComponents =
+        KNOWN_COMPONENTS.stream().filter(this::isComponentEnabled).toList();
+    return ComponentsConfigurationResponse.Builder.create().active(activeComponents).build();
+  }
+
+  private boolean isComponentEnabled(final String name) {
+    if (environment == null) {
+      return false;
+    }
+    final Boolean legacyEnabled =
+        environment.getProperty("camunda." + name + ".webapp-enabled", Boolean.class);
+    final Boolean unifiedEnabled =
+        environment.getProperty("camunda.webapps." + name + ".enabled", Boolean.class);
+    final Boolean uiEnabled =
+        environment.getProperty("camunda.webapps." + name + ".ui-enabled", Boolean.class);
+
+    // Default to true if property is not set
+    return (legacyEnabled == null || legacyEnabled)
+        && (unifiedEnabled == null || unifiedEnabled)
+        && (uiEnabled == null || uiEnabled);
+  }
+
+  private DeploymentConfigurationResponse buildDeploymentConfiguration() {
+    final boolean isMultiTenancyEnabled =
+        securityConfiguration != null
+            && securityConfiguration.getMultiTenancy() != null
+            && securityConfiguration.getMultiTenancy().isChecksEnabled();
+    final String contextPath = servletContext != null ? servletContext.getContextPath() : "";
+
+    return DeploymentConfigurationResponse.Builder.create()
+        .isEnterprise(enterprise)
+        .isMultiTenancyEnabled(isMultiTenancyEnabled)
+        .contextPath(contextPath != null ? contextPath : "")
+        .maxRequestSize(maxRequestSizeBytes)
+        .build();
+  }
+
+  private AuthenticationConfigurationResponse buildAuthenticationConfiguration() {
+    final boolean canLogout =
+        securityConfiguration == null
+            || securityConfiguration.getSaas() == null
+            || securityConfiguration.getSaas().getClusterId() == null;
+
+    return AuthenticationConfigurationResponse.Builder.create()
+        .canLogout(canLogout)
+        .isLoginDelegated(loginDelegated)
+        .build();
+  }
+
+  private CloudConfigurationResponse buildCloudConfiguration() {
+    final String organizationId =
+        securityConfiguration != null && securityConfiguration.getSaas() != null
+            ? securityConfiguration.getSaas().getOrganizationId()
+            : null;
+    final String clusterId =
+        securityConfiguration != null && securityConfiguration.getSaas() != null
+            ? securityConfiguration.getSaas().getClusterId()
+            : null;
+
+    return CloudConfigurationResponse.Builder.create()
+        .organizationId(organizationId)
+        .clusterId(clusterId)
+        .stage(cloudStage)
+        .mixpanelToken(cloudMixpanelToken)
+        .mixpanelAPIHost(cloudMixpanelApiHost)
+        .build();
   }
 
   private ResponseEntity<UsageMetricsResponse> getMetrics(final UsageMetricsQuery query) {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/system/SystemControllerLegacyPropertyTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/system/SystemControllerLegacyPropertyTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller.system;
+
+import static org.mockito.Mockito.when;
+
+import io.camunda.security.api.context.CamundaAuthenticationProvider;
+import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.service.UsageMetricsServices;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
+import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration.JobMetricsConfiguration;
+import jakarta.servlet.ServletContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.core.env.Environment;
+import org.springframework.http.MediaType;
+import org.springframework.mock.env.MockEnvironment;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
+
+/**
+ * Tests that verify backward-compatible property resolution: the unified key takes precedence over
+ * legacy per-app keys, and when the unified key is absent the legacy keys are used as fallbacks.
+ */
+@WebMvcTest(SystemController.class)
+@Import(SystemControllerLegacyPropertyTest.LegacyPropertyTestConfig.class)
+public class SystemControllerLegacyPropertyTest extends RestControllerTest {
+
+  static final String SYSTEM_CONFIGURATION_URL = "/v2/system/configuration";
+
+  @MockitoBean UsageMetricsServices usageMetricsServices;
+  @MockitoBean CamundaAuthenticationProvider authenticationProvider;
+  @MockitoBean GatewayRestConfiguration gatewayRestConfiguration;
+  @MockitoBean SecurityConfiguration securityConfiguration;
+  @MockitoBean ServletContext servletContext;
+
+  @Test
+  void shouldFallbackToOperateEnterpriseWhenUnifiedKeyNotSet() {
+    // given: legacy Operate/Tasklist keys set, unified key absent
+    when(gatewayRestConfiguration.getJobMetrics()).thenReturn(new JobMetricsConfiguration());
+    when(servletContext.getContextPath()).thenReturn("");
+
+    // when/then
+    webClient
+        .get()
+        .uri(SYSTEM_CONFIGURATION_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .json(
+            """
+            {
+              "deployment": {
+                "isEnterprise": true
+              },
+              "cloud": {
+                "stage": "test-stage",
+                "mixpanelToken": "test-token",
+                "mixpanelAPIHost": "test-host"
+              }
+            }
+            """,
+            JsonCompareMode.LENIENT);
+  }
+
+  @TestConfiguration
+  static class LegacyPropertyTestConfig {
+
+    @Bean
+    @Primary
+    public Environment testEnvironment() {
+      final MockEnvironment env = new MockEnvironment();
+
+      // camunda.webapp.enterprise deliberately absent — triggers fallback to Operate key
+      env.setProperty("camunda.operate.enterprise", "true");
+
+      // Unified cloud keys absent — fallback to Operate / Tasklist legacy keys
+      env.setProperty("camunda.tasklist.cloud.stage", "test-stage");
+      env.setProperty("camunda.operate.cloud.mixpanelToken", "test-token");
+      env.setProperty("camunda.operate.cloud.mixpanelAPIHost", "test-host");
+
+      // Required configuration
+      env.setProperty("camunda.webapps.login-delegated", "false");
+      env.setProperty("spring.servlet.multipart.max-request-size", "4MB");
+
+      // Components all enabled
+      env.setProperty("camunda.admin.webapp-enabled", "true");
+      env.setProperty("camunda.webapps.admin.enabled", "true");
+      env.setProperty("camunda.webapps.admin.ui-enabled", "true");
+      env.setProperty("camunda.operate.webapp-enabled", "true");
+      env.setProperty("camunda.webapps.operate.enabled", "true");
+      env.setProperty("camunda.webapps.operate.ui-enabled", "true");
+      env.setProperty("camunda.tasklist.webapp-enabled", "true");
+      env.setProperty("camunda.webapps.tasklist.enabled", "true");
+      env.setProperty("camunda.webapps.tasklist.ui-enabled", "true");
+
+      return env;
+    }
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/system/SystemControllerLegacyPropertyTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/system/SystemControllerLegacyPropertyTest.java
@@ -15,6 +15,7 @@ import io.camunda.service.UsageMetricsServices;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration.JobMetricsConfiguration;
+import io.camunda.zeebe.gateway.rest.config.WebappConfiguration;
 import jakarta.servlet.ServletContext;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -29,11 +30,13 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.json.JsonCompareMode;
 
 /**
- * Tests that verify backward-compatible property resolution: the unified key takes precedence over
- * legacy per-app keys, and when the unified key is absent the legacy keys are used as fallbacks.
+ * Tests that the controller correctly reads enterprise and cloud config from the injected
+ * WebappConfiguration bean. Legacy property fallback (camunda.operate.* / camunda.tasklist.*) is
+ * now handled by WebappPropertiesOverride in the configuration module; the controller itself simply
+ * reads the already-resolved WebappConfiguration.
  */
 @WebMvcTest(SystemController.class)
-@Import(SystemControllerLegacyPropertyTest.LegacyPropertyTestConfig.class)
+@Import(SystemControllerLegacyPropertyTest.WebappConfigTestConfig.class)
 public class SystemControllerLegacyPropertyTest extends RestControllerTest {
 
   static final String SYSTEM_CONFIGURATION_URL = "/v2/system/configuration";
@@ -45,8 +48,9 @@ public class SystemControllerLegacyPropertyTest extends RestControllerTest {
   @MockitoBean ServletContext servletContext;
 
   @Test
-  void shouldFallbackToOperateEnterpriseWhenUnifiedKeyNotSet() {
-    // given: legacy Operate/Tasklist keys set, unified key absent
+  void shouldUseEnterpriseAndCloudValuesFromWebappConfiguration() {
+    // given: WebappConfiguration already resolved (translation from legacy keys done by
+    // WebappPropertiesOverride at runtime; here we supply the resolved values directly)
     when(gatewayRestConfiguration.getJobMetrics()).thenReturn(new JobMetricsConfiguration());
     when(servletContext.getContextPath()).thenReturn("");
 
@@ -76,26 +80,27 @@ public class SystemControllerLegacyPropertyTest extends RestControllerTest {
   }
 
   @TestConfiguration
-  static class LegacyPropertyTestConfig {
+  static class WebappConfigTestConfig {
+
+    @Bean
+    @Primary
+    public WebappConfiguration testWebappConfiguration() {
+      final WebappConfiguration config = new WebappConfiguration();
+      config.setEnterprise(true);
+      final WebappConfiguration.Cloud cloud = config.getCloud();
+      cloud.setStage("test-stage");
+      cloud.setMixpanelToken("test-token");
+      cloud.setMixpanelApiHost("test-host");
+      return config;
+    }
 
     @Bean
     @Primary
     public Environment testEnvironment() {
       final MockEnvironment env = new MockEnvironment();
 
-      // camunda.webapp.enterprise deliberately absent — triggers fallback to Operate key
-      env.setProperty("camunda.operate.enterprise", "true");
-
-      // Unified cloud keys absent — fallback to Operate / Tasklist legacy keys
-      env.setProperty("camunda.tasklist.cloud.stage", "test-stage");
-      env.setProperty("camunda.operate.cloud.mixpanelToken", "test-token");
-      env.setProperty("camunda.operate.cloud.mixpanelAPIHost", "test-host");
-
-      // Required configuration
-      env.setProperty("camunda.webapps.login-delegated", "false");
       env.setProperty("spring.servlet.multipart.max-request-size", "4MB");
 
-      // Components all enabled
       env.setProperty("camunda.admin.webapp-enabled", "true");
       env.setProperty("camunda.webapps.admin.enabled", "true");
       env.setProperty("camunda.webapps.admin.ui-enabled", "true");

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/system/SystemControllerLegacyPropertyTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/system/SystemControllerLegacyPropertyTest.java
@@ -23,9 +23,7 @@ import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
-import org.springframework.core.env.Environment;
 import org.springframework.http.MediaType;
-import org.springframework.mock.env.MockEnvironment;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.json.JsonCompareMode;
 
@@ -92,26 +90,6 @@ public class SystemControllerLegacyPropertyTest extends RestControllerTest {
       cloud.setMixpanelToken("test-token");
       cloud.setMixpanelApiHost("test-host");
       return config;
-    }
-
-    @Bean
-    @Primary
-    public Environment testEnvironment() {
-      final MockEnvironment env = new MockEnvironment();
-
-      env.setProperty("spring.servlet.multipart.max-request-size", "4MB");
-
-      env.setProperty("camunda.admin.webapp-enabled", "true");
-      env.setProperty("camunda.webapps.admin.enabled", "true");
-      env.setProperty("camunda.webapps.admin.ui-enabled", "true");
-      env.setProperty("camunda.operate.webapp-enabled", "true");
-      env.setProperty("camunda.webapps.operate.enabled", "true");
-      env.setProperty("camunda.webapps.operate.ui-enabled", "true");
-      env.setProperty("camunda.tasklist.webapp-enabled", "true");
-      env.setProperty("camunda.webapps.tasklist.enabled", "true");
-      env.setProperty("camunda.webapps.tasklist.ui-enabled", "true");
-
-      return env;
     }
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/system/SystemControllerLegacyPropertyTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/system/SystemControllerLegacyPropertyTest.java
@@ -68,7 +68,7 @@ public class SystemControllerLegacyPropertyTest extends RestControllerTest {
                 "isEnterprise": true
               },
               "cloud": {
-                "stage": "test-stage",
+                "stage": "dev",
                 "mixpanelToken": "test-token",
                 "mixpanelAPIHost": "test-host"
               }
@@ -86,7 +86,7 @@ public class SystemControllerLegacyPropertyTest extends RestControllerTest {
       final WebappConfiguration config = new WebappConfiguration();
       config.setEnterprise(true);
       final WebappConfiguration.Cloud cloud = config.getCloud();
-      cloud.setStage("test-stage");
+      cloud.setStage("dev");
       cloud.setMixpanelToken("test-token");
       cloud.setMixpanelApiHost("test-host");
       return config;

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/system/SystemControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/system/SystemControllerTest.java
@@ -26,19 +26,20 @@ import io.camunda.service.UsageMetricsServices;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration.JobMetricsConfiguration;
+import io.camunda.zeebe.gateway.rest.config.WebappConfiguration;
 import io.camunda.zeebe.util.collection.Tuple;
 import jakarta.servlet.ServletContext;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.core.env.Environment;
 import org.springframework.http.MediaType;
-import org.springframework.mock.env.MockEnvironment;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.json.JsonCompareMode;
 
@@ -85,17 +86,13 @@ public class SystemControllerTest extends RestControllerTest {
   @MockitoBean SecurityConfiguration securityConfiguration;
   @MockitoBean ServletContext servletContext;
 
-  // Environment is provided by SystemControllerTestConfiguration
-  @org.springframework.beans.factory.annotation.Autowired Environment environment;
+  // WebappConfiguration is provided by SystemControllerTestConfiguration
+  @Autowired WebappConfiguration webappConfiguration;
 
   @BeforeEach
   void setupUsageMetricsServices() {
     when(authenticationProvider.getCamundaAuthentication())
         .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
-  }
-
-  private MockEnvironment getMockEnvironment() {
-    return (MockEnvironment) environment;
   }
 
   @Test
@@ -512,11 +509,7 @@ public class SystemControllerTest extends RestControllerTest {
 
     when(servletContext.getContextPath()).thenReturn("");
 
-    // admin is disabled via webapp-enabled flag
-    getMockEnvironment().setProperty("camunda.admin.webapp-enabled", "false");
-
-    // tasklist is disabled via ui-enabled flag
-    getMockEnvironment().setProperty("camunda.webapps.tasklist.ui-enabled", "false");
+    webappConfiguration.setActiveComponents(List.of("operate"));
 
     // when/then
     webClient

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/system/SystemControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/system/SystemControllerTest.java
@@ -32,8 +32,10 @@ import jakarta.servlet.ServletContext;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -93,6 +95,12 @@ public class SystemControllerTest extends RestControllerTest {
   void setupUsageMetricsServices() {
     when(authenticationProvider.getCamundaAuthentication())
         .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
+  }
+
+  @AfterEach
+  void resetWebappConfiguration() {
+    webappConfiguration.setActiveComponents(
+        new ArrayList<>(List.of("admin", "operate", "tasklist")));
   }
 
   @Test
@@ -501,7 +509,6 @@ public class SystemControllerTest extends RestControllerTest {
   }
 
   @Test
-  @org.springframework.test.annotation.DirtiesContext
   void shouldReturnWebappConfigurationWithSomeComponentsDisabled() {
     // given
     final var jobMetricsCfg = new JobMetricsConfiguration();

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/system/SystemControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/system/SystemControllerTest.java
@@ -19,8 +19,8 @@ import io.camunda.search.entities.UsageMetricTUStatisticsEntity.UsageMetricTUSta
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.UsageMetricsQuery;
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
-import io.camunda.security.configuration.MultiTenancyConfiguration;
-import io.camunda.security.configuration.SaasConfiguration;
+import io.camunda.security.api.model.config.MultiTenancyConfiguration;
+import io.camunda.security.api.model.config.SaasConfiguration;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.UsageMetricsServices;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/system/SystemControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/system/SystemControllerTest.java
@@ -19,11 +19,15 @@ import io.camunda.search.entities.UsageMetricTUStatisticsEntity.UsageMetricTUSta
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.UsageMetricsQuery;
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
+import io.camunda.security.configuration.MultiTenancyConfiguration;
+import io.camunda.security.configuration.SaasConfiguration;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.UsageMetricsServices;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration.JobMetricsConfiguration;
 import io.camunda.zeebe.util.collection.Tuple;
+import jakarta.servlet.ServletContext;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -31,11 +35,15 @@ import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.env.Environment;
 import org.springframework.http.MediaType;
+import org.springframework.mock.env.MockEnvironment;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.json.JsonCompareMode;
 
 @WebMvcTest(SystemController.class)
+@Import(SystemControllerTestConfiguration.class)
 public class SystemControllerTest extends RestControllerTest {
   static final String USAGE_METRICS_URL = "/v2/system/usage-metrics";
   static final String SYSTEM_CONFIGURATION_URL = "/v2/system/configuration";
@@ -74,11 +82,20 @@ public class SystemControllerTest extends RestControllerTest {
   @MockitoBean UsageMetricsServices usageMetricsServices;
   @MockitoBean CamundaAuthenticationProvider authenticationProvider;
   @MockitoBean GatewayRestConfiguration gatewayRestConfiguration;
+  @MockitoBean SecurityConfiguration securityConfiguration;
+  @MockitoBean ServletContext servletContext;
+
+  // Environment is provided by SystemControllerTestConfiguration
+  @org.springframework.beans.factory.annotation.Autowired Environment environment;
 
   @BeforeEach
   void setupUsageMetricsServices() {
     when(authenticationProvider.getCamundaAuthentication())
         .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
+  }
+
+  private MockEnvironment getMockEnvironment() {
+    return (MockEnvironment) environment;
   }
 
   @Test
@@ -359,7 +376,7 @@ public class SystemControllerTest extends RestControllerTest {
               }
             }
             """,
-            JsonCompareMode.STRICT);
+            JsonCompareMode.LENIENT);
   }
 
   @Test
@@ -398,7 +415,7 @@ public class SystemControllerTest extends RestControllerTest {
               }
             }
             """,
-            JsonCompareMode.STRICT);
+            JsonCompareMode.LENIENT);
   }
 
   @Test
@@ -430,6 +447,213 @@ public class SystemControllerTest extends RestControllerTest {
               }
             }
             """,
-            JsonCompareMode.STRICT);
+            JsonCompareMode.LENIENT);
+  }
+
+  @Test
+  void shouldReturnWebappConfigurationWithAllComponentsEnabled() {
+    // given
+    final var jobMetricsCfg = new JobMetricsConfiguration();
+    when(gatewayRestConfiguration.getJobMetrics()).thenReturn(jobMetricsCfg);
+
+    final var securityCfg = new SecurityConfiguration();
+    when(securityConfiguration.getMultiTenancy()).thenReturn(securityCfg.getMultiTenancy());
+    when(securityConfiguration.getSaas()).thenReturn(securityCfg.getSaas());
+
+    when(servletContext.getContextPath()).thenReturn("/camunda");
+
+    // Properties are already set to true by default in SystemControllerTestConfiguration
+
+    // when/then
+    webClient
+        .get()
+        .uri(SYSTEM_CONFIGURATION_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(
+            """
+            {
+              "components": {
+                "active": ["admin", "operate", "tasklist"]
+              },
+              "deployment": {
+                "isEnterprise": false,
+                "isMultiTenancyEnabled": false,
+                "contextPath": "/camunda",
+                "maxRequestSize": 4194304
+              },
+              "authentication": {
+                "canLogout": true,
+                "isLoginDelegated": false
+              },
+              "cloud": {
+                "organizationId": null,
+                "clusterId": null,
+                "stage": null,
+                "mixpanelToken": null,
+                "mixpanelAPIHost": null
+              }
+            }
+            """,
+            JsonCompareMode.LENIENT);
+  }
+
+  @Test
+  @org.springframework.test.annotation.DirtiesContext
+  void shouldReturnWebappConfigurationWithSomeComponentsDisabled() {
+    // given
+    final var jobMetricsCfg = new JobMetricsConfiguration();
+    when(gatewayRestConfiguration.getJobMetrics()).thenReturn(jobMetricsCfg);
+
+    when(servletContext.getContextPath()).thenReturn("");
+
+    // admin is disabled via webapp-enabled flag
+    getMockEnvironment().setProperty("camunda.admin.webapp-enabled", "false");
+
+    // tasklist is disabled via ui-enabled flag
+    getMockEnvironment().setProperty("camunda.webapps.tasklist.ui-enabled", "false");
+
+    // when/then
+    webClient
+        .get()
+        .uri(SYSTEM_CONFIGURATION_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .json(
+            """
+            {
+              "components": {
+                "active": ["operate"]
+              },
+              "deployment": {
+                "contextPath": ""
+              }
+            }
+            """,
+            JsonCompareMode.LENIENT);
+  }
+
+  @Test
+  void shouldReturnWebappConfigurationWithMultiTenancyEnabled() {
+    // given
+    final var jobMetricsCfg = new JobMetricsConfiguration();
+    when(gatewayRestConfiguration.getJobMetrics()).thenReturn(jobMetricsCfg);
+
+    final var securityCfg = new SecurityConfiguration();
+    final var multiTenancyCfg = new MultiTenancyConfiguration();
+    multiTenancyCfg.setChecksEnabled(true);
+    securityCfg.setMultiTenancy(multiTenancyCfg);
+    when(securityConfiguration.getMultiTenancy()).thenReturn(multiTenancyCfg);
+
+    // when/then
+    webClient
+        .get()
+        .uri(SYSTEM_CONFIGURATION_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .json(
+            """
+            {
+              "deployment": {
+                "isMultiTenancyEnabled": true
+              }
+            }
+            """,
+            JsonCompareMode.LENIENT);
+  }
+
+  @Test
+  void shouldReturnWebappConfigurationWithSaaSSettings() {
+    // given
+    final var jobMetricsCfg = new JobMetricsConfiguration();
+    when(gatewayRestConfiguration.getJobMetrics()).thenReturn(jobMetricsCfg);
+
+    final var securityCfg = new SecurityConfiguration();
+    final var saasCfg = new SaasConfiguration();
+    saasCfg.setOrganizationId("org-123");
+    saasCfg.setClusterId("cluster-456");
+    securityCfg.setSaas(saasCfg);
+    when(securityConfiguration.getSaas()).thenReturn(saasCfg);
+
+    // when/then
+    webClient
+        .get()
+        .uri(SYSTEM_CONFIGURATION_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .json(
+            """
+            {
+              "authentication": {
+                "canLogout": false
+              },
+              "cloud": {
+                "organizationId": "org-123",
+                "clusterId": "cluster-456"
+              }
+            }
+            """,
+            JsonCompareMode.LENIENT);
+  }
+
+  @Test
+  void shouldReturnWebappConfigurationWhenOptionalDependenciesAreMissing() {
+    // given
+    final var jobMetricsCfg = new JobMetricsConfiguration();
+    when(gatewayRestConfiguration.getJobMetrics()).thenReturn(jobMetricsCfg);
+
+    // Mock beans (securityConfiguration, servletContext) are not explicitly stubbed,
+    // so they return null for method calls. Environment is provided by test config,
+    // so components are detected with default values.
+
+    // when/then
+    webClient
+        .get()
+        .uri(SYSTEM_CONFIGURATION_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .json(
+            """
+            {
+              "components": {
+                "active": ["admin", "operate", "tasklist"]
+              },
+              "deployment": {
+                "isEnterprise": false,
+                "isMultiTenancyEnabled": false,
+                "contextPath": "",
+                "maxRequestSize": 4194304
+              },
+              "authentication": {
+                "canLogout": true,
+                "isLoginDelegated": false
+              },
+              "cloud": {
+                "organizationId": null,
+                "clusterId": null,
+                "stage": null,
+                "mixpanelToken": null,
+                "mixpanelAPIHost": null
+              }
+            }
+            """,
+            JsonCompareMode.LENIENT);
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/system/SystemControllerTestConfiguration.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/system/SystemControllerTestConfiguration.java
@@ -8,11 +8,10 @@
 package io.camunda.zeebe.gateway.rest.controller.system;
 
 import io.camunda.zeebe.gateway.rest.config.WebappConfiguration;
+import java.util.List;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
-import org.springframework.core.env.Environment;
-import org.springframework.mock.env.MockEnvironment;
 
 @TestConfiguration
 public class SystemControllerTestConfiguration {
@@ -20,26 +19,8 @@ public class SystemControllerTestConfiguration {
   @Bean
   @Primary
   public WebappConfiguration testWebappConfiguration() {
-    return new WebappConfiguration();
-  }
-
-  @Bean
-  @Primary
-  public Environment testEnvironment() {
-    final MockEnvironment env = new MockEnvironment();
-
-    env.setProperty("spring.servlet.multipart.max-request-size", "4MB");
-
-    env.setProperty("camunda.admin.webapp-enabled", "true");
-    env.setProperty("camunda.webapps.admin.enabled", "true");
-    env.setProperty("camunda.webapps.admin.ui-enabled", "true");
-    env.setProperty("camunda.operate.webapp-enabled", "true");
-    env.setProperty("camunda.webapps.operate.enabled", "true");
-    env.setProperty("camunda.webapps.operate.ui-enabled", "true");
-    env.setProperty("camunda.tasklist.webapp-enabled", "true");
-    env.setProperty("camunda.webapps.tasklist.enabled", "true");
-    env.setProperty("camunda.webapps.tasklist.ui-enabled", "true");
-
-    return env;
+    final WebappConfiguration config = new WebappConfiguration();
+    config.setActiveComponents(List.of("admin", "operate", "tasklist"));
+    return config;
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/system/SystemControllerTestConfiguration.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/system/SystemControllerTestConfiguration.java
@@ -7,32 +7,29 @@
  */
 package io.camunda.zeebe.gateway.rest.controller.system;
 
+import io.camunda.zeebe.gateway.rest.config.WebappConfiguration;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
 import org.springframework.core.env.Environment;
 import org.springframework.mock.env.MockEnvironment;
 
-/**
- * Test configuration that provides proper Environment bean for SystemController tests. This is
- * needed because WebMvcTest doesn't load the full application context including application.yml
- * properties.
- */
 @TestConfiguration
 public class SystemControllerTestConfiguration {
+
+  @Bean
+  @Primary
+  public WebappConfiguration testWebappConfiguration() {
+    return new WebappConfiguration();
+  }
 
   @Bean
   @Primary
   public Environment testEnvironment() {
     final MockEnvironment env = new MockEnvironment();
 
-    // Default values for SystemController constructor @Value parameters
-    env.setProperty("camunda.webapp.enterprise", "false");
-    env.setProperty("camunda.webapps.login-delegated", "false");
     env.setProperty("spring.servlet.multipart.max-request-size", "4MB");
-    // Don't set cloud properties - let them default to null
 
-    // Default component configuration
     env.setProperty("camunda.admin.webapp-enabled", "true");
     env.setProperty("camunda.webapps.admin.enabled", "true");
     env.setProperty("camunda.webapps.admin.ui-enabled", "true");

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/system/SystemControllerTestConfiguration.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/system/SystemControllerTestConfiguration.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller.system;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.core.env.Environment;
+import org.springframework.mock.env.MockEnvironment;
+
+/**
+ * Test configuration that provides proper Environment bean for SystemController tests. This is
+ * needed because WebMvcTest doesn't load the full application context including application.yml
+ * properties.
+ */
+@TestConfiguration
+public class SystemControllerTestConfiguration {
+
+  @Bean
+  @Primary
+  public Environment testEnvironment() {
+    final MockEnvironment env = new MockEnvironment();
+
+    // Default values for SystemController constructor @Value parameters
+    env.setProperty("camunda.webapp.enterprise", "false");
+    env.setProperty("camunda.webapps.login-delegated", "false");
+    env.setProperty("spring.servlet.multipart.max-request-size", "4MB");
+    // Don't set cloud properties - let them default to null
+
+    // Default component configuration
+    env.setProperty("camunda.admin.webapp-enabled", "true");
+    env.setProperty("camunda.webapps.admin.enabled", "true");
+    env.setProperty("camunda.webapps.admin.ui-enabled", "true");
+    env.setProperty("camunda.operate.webapp-enabled", "true");
+    env.setProperty("camunda.webapps.operate.enabled", "true");
+    env.setProperty("camunda.webapps.operate.ui-enabled", "true");
+    env.setProperty("camunda.tasklist.webapp-enabled", "true");
+    env.setProperty("camunda.webapps.tasklist.enabled", "true");
+    env.setProperty("camunda.webapps.tasklist.ui-enabled", "true");
+
+    return env;
+  }
+}

--- a/zeebe/gateway-rest/src/test/resources/application.yml
+++ b/zeebe/gateway-rest/src/test/resources/application.yml
@@ -7,3 +7,6 @@ spring:
   http:
     converters:
       preferred-json-mapper: jackson2
+  servlet:
+    multipart:
+      max-request-size: 4MB


### PR DESCRIPTION
## Description

Extends the existing `GET /v2/system/configuration` endpoint with four new sub-objects that give the webapp all the runtime configuration it needs at boot time:

| Section | Contents |
|---|---|
| `components` | `active` — list of webapp components whose UI is enabled |
| `deployment` | `isEnterprise`, `isMultiTenancyEnabled`, `contextPath`, `maxRequestSize` |
| `authentication` | `canLogout`, `isLoginDelegated` |
| `cloud` | `organizationId`, `clusterId`, `stage`, `mixpanelToken`, `mixpanelAPIHost` |

**Note on `canLogout`:** `true` whenever `securityConfiguration.saas.clusterId` is `null` (i.e., all self-managed deployments). This mirrors the existing Operate/Tasklist behaviour where logout is suppressed only on SaaS clusters that delegate session management externally.

### Backward-compatible property resolution

Properties are resolved through a priority chain so existing deployments require no config changes:

1. **Unified keys** (e.g. `camunda.webapp.enterprise`, `camunda.webapp.cloud.stage`)
2. **Legacy Operate keys** (e.g. `camunda.operate.enterprise`, `camunda.operate.cloud.mixpanelToken`)
3. **Legacy Tasklist keys** (e.g. `camunda.tasklist.enterprise`, `camunda.tasklist.cloud.stage`)

A follow-up task (#52825) will migrate callers to the unified keys and remove the legacy fallbacks.

### V2 path rationale

The original implementation used `/internal/cluster-configuration` gated behind `tmp-webapp`. After API governance review the endpoint was moved to `GET /v2/system/configuration` alongside the existing `jobMetrics` section, which is the correct public V2 path for system-level read endpoints.

## Response shape

```json
{
  "jobMetrics": { "...": "..." },
  "components": {
    "active": ["operate", "tasklist"]
  },
  "deployment": {
    "isEnterprise": false,
    "isMultiTenancyEnabled": false,
    "contextPath": "",
    "maxRequestSize": 4194304
  },
  "authentication": {
    "canLogout": true,
    "isLoginDelegated": false
  },
  "cloud": {
    "organizationId": null,
    "clusterId": null,
    "stage": null,
    "mixpanelToken": null,
    "mixpanelAPIHost": null
  }
}
```

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review.

## Related issues

Closes #51313