### PR TITLE
fix(tests): isolate job activation by process instance to prevent cross-test contamination

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-completion-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-completion-api-tests.spec.ts
@@ -45,6 +45,7 @@ test.describe('Job Completion API Tests', () => {
     const jobKey = await activateJobToObtainAValidJobKey(
       request,
       'jobApiTaskType',
+      state['processInstanceKey'] as string,
     );
 
     const completeRes = await request.post(
@@ -99,6 +100,7 @@ test.describe('Job Completion API Tests', () => {
       localState['jobKey'] = await activateJobToObtainAValidJobKey(
         request,
         'jobApiTaskType',
+        state['processInstanceKey'] as string,
       );
     });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-error-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-error-api-tests.spec.ts
@@ -21,10 +21,8 @@ import {
 
 /* eslint-disable playwright/expect-expect */
 test.describe('Job Error API Tests', () => {
-  const {beforeAll, beforeEach, afterEach} = setupProcessInstanceForTests(
-    'job_api_process',
-    'jobApiProcess',
-  );
+  const {beforeAll, beforeEach, afterEach, state} =
+    setupProcessInstanceForTests('job_api_process', 'jobApiProcess');
   test.beforeAll(beforeAll);
   test.beforeEach(beforeEach);
   test.afterEach(afterEach);
@@ -33,6 +31,7 @@ test.describe('Job Error API Tests', () => {
     const jobKey = await activateJobToObtainAValidJobKey(
       request,
       'jobApiTaskType',
+      state['processInstanceKey'] as string,
     );
 
     const errorRes = await request.post(buildUrl(`/jobs/${jobKey}/error`), {
@@ -82,6 +81,7 @@ test.describe('Job Error API Tests', () => {
       localState['jobKey'] = await activateJobToObtainAValidJobKey(
         request,
         'jobApiTaskType',
+        state['processInstanceKey'] as string,
       );
     });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-failure-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-failure-api-tests.spec.ts
@@ -21,10 +21,8 @@ import {
 
 /* eslint-disable playwright/expect-expect */
 test.describe('Job Fail API Tests', () => {
-  const {beforeAll, beforeEach, afterEach} = setupProcessInstanceForTests(
-    'job_api_process',
-    'jobApiProcess',
-  );
+  const {beforeAll, beforeEach, afterEach, state} =
+    setupProcessInstanceForTests('job_api_process', 'jobApiProcess');
   test.beforeAll(beforeAll);
   test.beforeEach(beforeEach);
   test.afterEach(afterEach);
@@ -33,6 +31,7 @@ test.describe('Job Fail API Tests', () => {
     const jobKey = await activateJobToObtainAValidJobKey(
       request,
       'jobApiTaskType',
+      state['processInstanceKey'] as string,
     );
 
     // Now fail the job
@@ -82,6 +81,7 @@ test.describe('Job Fail API Tests', () => {
       localState['jobKey'] = await activateJobToObtainAValidJobKey(
         request,
         'jobApiTaskType',
+        state['processInstanceKey'] as string,
       );
     });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-update-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-update-api-tests.spec.ts
@@ -21,10 +21,8 @@ import {
 
 /* eslint-disable playwright/expect-expect */
 test.describe('Job Update API Tests', () => {
-  const {beforeAll, beforeEach, afterEach} = setupProcessInstanceForTests(
-    'job_api_process',
-    'jobApiProcess',
-  );
+  const {beforeAll, beforeEach, afterEach, state} =
+    setupProcessInstanceForTests('job_api_process', 'jobApiProcess');
   test.beforeAll(beforeAll);
   test.beforeEach(beforeEach);
   test.afterEach(afterEach);
@@ -33,6 +31,7 @@ test.describe('Job Update API Tests', () => {
     const jobKey = await activateJobToObtainAValidJobKey(
       request,
       'jobApiTaskType',
+      state['processInstanceKey'] as string,
     );
 
     await test.step('PATCH update the job', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/job-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/job-requestHelpers.ts
@@ -17,27 +17,68 @@ import { validateResponse } from 'json-body-assertions';
 export async function activateJobToObtainAValidJobKey(
   request: APIRequestContext,
   jobType: string,
+  processInstanceKey?: string,
 ): Promise<number> {
-  const activateRes = await request.post(buildUrl('/jobs/activation'), {
-    headers: jsonHeaders(),
-    data: {
-      type: jobType,
-      timeout: 10000,
-      maxJobsToActivate: 1,
-    },
-  });
-  await assertStatusCode(activateRes, 200);
-  await validateResponse(
-    {
-      path: '/jobs/activation',
-      method: 'POST',
-      status: '200',
-    },
-    activateRes,
-  );
-  const activateJson = await activateRes.json();
-  expect(activateJson.jobs.length).toBe(1);
-  return activateJson.jobs[0].jobKey;
+  const result: Record<string, number> = {};
+  await expect(async () => {
+    // When filtering by processInstanceKey, grab a large batch so this worker
+    // can claim all available jobs of this type at once.  Releasing wrong jobs
+    // one-by-one with maxJobsToActivate:1 causes a livelock: every parallel
+    // worker grabs a wrong job, releases it back, and the jobs cycle endlessly
+    // between workers until the 30 s toPass timeout expires.  With a large
+    // batch, one worker claims everything, keeps its own job, and releases the
+    // rest; subsequent workers serialize naturally on the released pool.
+    const maxJobsToActivate = processInstanceKey !== undefined ? 50 : 1;
+    const activateRes = await request.post(buildUrl('/jobs/activation'), {
+      headers: jsonHeaders(),
+      data: {
+        type: jobType,
+        timeout: 30000,
+        maxJobsToActivate,
+      },
+    });
+    await assertStatusCode(activateRes, 200);
+    await validateResponse(
+      {
+        path: '/jobs/activation',
+        method: 'POST',
+        status: '200',
+      },
+      activateRes,
+    );
+    const activateJson = await activateRes.json();
+
+    if (processInstanceKey !== undefined) {
+      // Release every job that doesn't belong to our process instance so other
+      // workers can pick them up.  Do this unconditionally — even if our job
+      // isn't in the list — so we never hold foreign jobs locked on a retry.
+      for (const job of activateJson.jobs as Array<{
+        processInstanceKey: string | number;
+        jobKey: number;
+      }>) {
+        if (String(job.processInstanceKey) !== String(processInstanceKey)) {
+          await request.post(buildUrl(`/jobs/${job.jobKey}/failure`), {
+            headers: jsonHeaders(),
+            data: {retries: 1, errorMessage: 'Released by wrong worker'},
+          });
+        }
+      }
+      const myJob = (
+        activateJson.jobs as Array<{
+          processInstanceKey: string | number;
+          jobKey: number;
+        }>
+      ).find(
+        (j) => String(j.processInstanceKey) === String(processInstanceKey),
+      );
+      expect(myJob).toBeDefined();
+      result.jobKey = myJob!.jobKey;
+    } else {
+      expect(activateJson.jobs.length).toBe(1);
+      result.jobKey = activateJson.jobs[0].jobKey;
+    }
+  }).toPass(defaultAssertionOptions);
+  return result.jobKey;
 }
 
 export async function searchJobKey(


### PR DESCRIPTION
## Summary

- Parallel test files sharing `jobApiTaskType` jobs race against each other during activation, causing 404 errors when one test activates a job from another test's (subsequently-cancelled) process instance
- `activateJobToObtainAValidJobKey` now accepts an optional `processInstanceKey` and uses `maxJobsToActivate: 50` to grab all available jobs of that type at once, keeps the one matching the caller's process instance, and releases all others
- Using `maxJobsToActivate: 1` with release-and-retry caused a livelock: all parallel workers grab wrong jobs, release them back, and jobs cycle endlessly until the 30 s timeout — the large-batch approach serializes workers naturally
- All four `job_api_process`-based test files updated to pass their `state['processInstanceKey']`

## Root cause

From nightly run [#25198024005](https://github.com/camunda/camunda/actions/runs/25198024005):
```
404: Command 'FAIL' rejected: Expected to fail job with key '...', but no such job was found
404: Command 'UPDATE' rejected: Expected to update job with key '...', but no such job was found
```

`job-failure-api-tests.spec.ts` and `job-update-api-tests.spec.ts` (and siblings) all use `job_api_process.bpmn` with job type `jobApiTaskType` and run in different Playwright workers. Each worker's `activateJobToObtainAValidJobKey` would sometimes pick up a job belonging to another worker's process instance. When that process instance was cancelled by `afterEach`, the already-activated job disappeared, causing 404 on the subsequent fail/update/error call.

## Test plan
- [ ] On-demand CI run green for all job API tests

## On-demand CI runs
- [#25218998926](https://github.com/camunda/camunda/actions/runs/25218998926) — livelock fix (current)
: warning one test failed will check with another PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)