### PR TITLE
test: fix flaky E2E tests in stable/8.8 nightly run

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessMigrationModePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessMigrationModePage.ts
@@ -116,7 +116,7 @@ export class OperateProcessMigrationModePage {
     mappings: Array<{label: string | RegExp; targetValue: string}>,
   ): Promise<void> {
     for (const {label, targetValue} of mappings) {
-      await expect(this.page.getByLabel(label)).toHaveValue(targetValue);
+      await expect(this.page.getByLabel(label)).toHaveValue(targetValue, {timeout: 30000});
     }
   }
 
@@ -140,3 +140,4 @@ export class OperateProcessMigrationModePage {
     );
   }
 }
+

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskDetailsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskDetailsPage.ts
@@ -365,7 +365,7 @@ class TaskDetailsPage {
           const inputValue = await input.inputValue();
           expect(inputValue).toContain(expectedValue);
         } else {
-          await expect(input).toHaveValue(expectedValue);
+          await expect(input).toHaveValue(expectedValue, {timeout: 30000});
         }
       },
       onFailure: async () => {
@@ -417,3 +417,4 @@ class TaskDetailsPage {
 }
 
 export {TaskDetailsPage};
+

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/TasklistProcessesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/TasklistProcessesPage.ts
@@ -59,7 +59,10 @@ class TasklistProcessesPage {
 
   async clickStartProcessSubButton(): Promise<void> {
     await this.startProcessSubButton.click();
+    // Wait for the process start modal to close before callers navigate away
+    await this.page.locator('.cds--modal-container').waitFor({state: 'hidden', timeout: 10000}).catch(() => {});
   }
 }
 
 export {TasklistProcessesPage};
+

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -146,7 +146,7 @@ test.describe.serial('Process Instance Migration', () => {
         .toBe(sourceVersion);
 
       await expect(operateProcessesPage.resultsText.first()).toBeVisible({
-        timeout: 30000,
+        timeout: 60000,
       });
     });
 
@@ -335,7 +335,7 @@ test.describe.serial('Process Instance Migration', () => {
       await operateFiltersPanelPage.selectVersion(targetVersion);
 
       await expect(operateProcessesPage.resultsText.first()).toBeVisible({
-        timeout: 30000,
+        timeout: 60000,
       });
 
       await operateOperationPanelPage.expandOperationIdField();
@@ -363,7 +363,7 @@ test.describe.serial('Process Instance Migration', () => {
       await operateFiltersPanelPage.selectVersion(targetVersion);
 
       await expect(operateProcessesPage.resultsText.first()).toBeVisible({
-        timeout: 30000,
+        timeout: 60000,
       });
     });
 
@@ -392,7 +392,7 @@ test.describe.serial('Process Instance Migration', () => {
       await operateFiltersPanelPage.selectVersion(targetVersion);
 
       await expect(operateProcessesPage.resultsText.first()).toBeVisible({
-        timeout: 30000,
+        timeout: 60000,
       });
     });
 
@@ -428,7 +428,7 @@ test.describe.serial('Process Instance Migration', () => {
       await operateFiltersPanelPage.selectVersion(sourceVersion);
 
       await expect(operateProcessesPage.resultsText.first()).toBeVisible({
-        timeout: 30000,
+        timeout: 60000,
       });
     });
 
@@ -633,7 +633,7 @@ test.describe.serial('Process Instance Migration', () => {
       await operateFiltersPanelPage.selectVersion(targetVersion);
 
       await expect(operateProcessesPage.resultsText.first()).toBeVisible({
-        timeout: 30000,
+        timeout: 60000,
       });
 
       await operateProcessesPage.clickProcessInstanceLink();
@@ -679,7 +679,7 @@ test.describe.serial('Process Instance Migration', () => {
       await operateFiltersPanelPage.selectVersion(targetVersion);
 
       await expect(operateProcessesPage.resultsText.first()).toBeVisible({
-        timeout: 30000,
+        timeout: 60000,
       });
 
       await operateProcessesPage.clickProcessInstanceLink();
@@ -740,7 +740,7 @@ test.describe.serial('Process Instance Migration', () => {
       await operateFiltersPanelPage.selectVersion(targetVersion);
 
       await expect(operateProcessesPage.resultsText.first()).toBeVisible({
-        timeout: 30000,
+        timeout: 60000,
       });
 
       await operateProcessesPage.clickProcessInstanceLink();
@@ -969,7 +969,7 @@ test.describe('Parallel job-based user task migration', () => {
 
       await operateFiltersPanelPage.selectVersion(sourceVersion);
       await expect(operateProcessesPage.resultsText.first()).toBeVisible({
-        timeout: 30000,
+        timeout: 60000,
       });
     });
 
@@ -1130,3 +1130,4 @@ test.describe('Parallel job-based user task migration', () => {
     });
   });
 });
+


### PR DESCRIPTION
## Summary

Fixes 4 flaky failures from nightly run https://github.com/camunda/camunda/actions/runs/25197711215 (stable/8.8, both v1 and v2 jobs).

### Failures and root causes

| Test | Job | Root cause |
|------|-----|------------|
| `Process Instance Migration > Auto mapping migration` | v2 | `resultsText.first()` 30 s timeout too short — filter + version selection can take longer under CI load |
| `Parallel job-based user task migration > Migrate parallel job-based user tasks to Camunda user tasks` | v2 | `verifyFlowNodeMappings` used default 10 s action timeout on `toHaveValue`; auto-mapping populates selects asynchronously after version switch |
| `task details page > task completion with form from assigned to me filter` | v2 | `assertFieldValue` used default 10 s action timeout on `toHaveValue`; completed-task form renders fields asynchronously (Address* rendered after Name*) |
| `process page > complete process with start node having deployed form` | v1 | `clickStartProcessSubButton` didn't wait for the Carbon modal to close; modal still intercepted pointer events when `clickTasksTab` ran immediately after |

### Changes

- **`processInstanceMigration.spec.ts`** — raise all `resultsText.first()` visibility timeouts from 30 s → 60 s (9 occurrences, same pattern).
- **`OperateProcessMigrationModePage.ts`** — add `{timeout: 30000}` to `toHaveValue` in `verifyFlowNodeMappings` so Playwright waits up to 30 s for async auto-mapping to populate selects.
- **`TaskDetailsPage.ts`** — add `{timeout: 30000}` to `toHaveValue` in `assertFieldValue` so completed-task form data has time to render.
- **`TasklistProcessesPage.ts`** — after `clickStartProcessSubButton`, wait for `.cds--modal-container` to reach `hidden` state (with a graceful catch so tests without a modal don't fail).

## Test plan

- [ ] Re-run `tests/operate/processInstanceMigration.spec.ts` against a local cluster or trigger the nightly
- [ ] Re-run `tests/tasklist/task-details.spec.ts` (`task completion with form from assigned to me filter`)
- [ ] Re-run `tests/tasklist/processes-page.spec.ts` v1 (`complete process with start node having deployed form`)
- [ ] Verify no regressions in other tests that use `verifyFlowNodeMappings`, `assertFieldValue`, or `clickStartProcessSubButton`

Nightly run that surfaced this: https://github.com/camunda/camunda/actions/runs/25197711215