### PR TITLE
feat: Add 'priority' field to JobRecord. Export via all Exporters

### DIFF
--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
@@ -115,4 +115,15 @@
     </createTable>
   </changeSet>
 
+  <changeSet id="add_job_priority_column" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="${prefix}JOB" columnName="PRIORITY"/>
+      </not>
+    </preConditions>
+    <addColumn tableName="${prefix}JOB">
+      <column name="PRIORITY" type="INTEGER"/>
+    </addColumn>
+  </changeSet>
+
 </databaseChangeLog>

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/JobEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/JobEntityMapper.java
@@ -26,6 +26,7 @@ public class JobEntityMapper {
         .kind(JobKind.valueOf(jobDbModel.kind().name()))
         .listenerEventType(ListenerEventType.valueOf(jobDbModel.listenerEventType().name()))
         .retries(jobDbModel.retries())
+        .priority(jobDbModel.priority())
         .isDenied(jobDbModel.isDenied())
         .deniedReason(jobDbModel.deniedReason())
         .hasFailedWithRetriesLeft(jobDbModel.hasFailedWithRetriesLeft())

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/JobDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/JobDbModel.java
@@ -30,6 +30,7 @@ public class JobDbModel implements Copyable<JobDbModel> {
   private JobKind kind;
   private ListenerEventType listenerEventType;
   private Integer retries;
+  private Integer priority;
   private Boolean isDenied;
   private String deniedReason;
   private Boolean hasFailedWithRetriesLeft = false;
@@ -62,6 +63,7 @@ public class JobDbModel implements Copyable<JobDbModel> {
       final JobKind kind,
       final ListenerEventType listenerEventType,
       final Integer retries,
+      final Integer priority,
       final Boolean isDenied,
       final String deniedReason,
       final boolean hasFailedWithRetriesLeft,
@@ -87,6 +89,7 @@ public class JobDbModel implements Copyable<JobDbModel> {
     this.kind = kind;
     this.listenerEventType = listenerEventType;
     this.retries = retries;
+    this.priority = priority;
     this.isDenied = isDenied;
     this.deniedReason = deniedReason;
     this.hasFailedWithRetriesLeft = hasFailedWithRetriesLeft;
@@ -128,6 +131,7 @@ public class JobDbModel implements Copyable<JobDbModel> {
         kind,
         listenerEventType,
         retries,
+        priority,
         isDenied,
         deniedReason,
         hasFailedWithRetriesLeft,
@@ -215,6 +219,14 @@ public class JobDbModel implements Copyable<JobDbModel> {
 
   public void retries(final Integer retries) {
     this.retries = retries;
+  }
+
+  public Integer priority() {
+    return priority;
+  }
+
+  public void priority(final Integer priority) {
+    this.priority = priority;
   }
 
   public Boolean isDenied() {
@@ -375,6 +387,7 @@ public class JobDbModel implements Copyable<JobDbModel> {
         .kind(kind)
         .listenerEventType(listenerEventType)
         .retries(retries)
+        .priority(priority)
         .isDenied(isDenied)
         .deniedReason(deniedReason)
         .hasFailedWithRetriesLeft(hasFailedWithRetriesLeft)
@@ -404,6 +417,7 @@ public class JobDbModel implements Copyable<JobDbModel> {
     private JobKind kind;
     private ListenerEventType listenerEventType;
     private Integer retries;
+    private Integer priority;
     private Boolean isDenied;
     private String deniedReason;
     private Boolean hasFailedWithRetriesLeft = false;
@@ -455,6 +469,11 @@ public class JobDbModel implements Copyable<JobDbModel> {
 
     public Builder retries(final Integer retries) {
       this.retries = retries;
+      return this;
+    }
+
+    public Builder priority(final Integer priority) {
+      this.priority = priority;
       return this;
     }
 
@@ -563,6 +582,7 @@ public class JobDbModel implements Copyable<JobDbModel> {
           kind,
           listenerEventType,
           retries,
+          priority,
           isDenied,
           deniedReason,
           hasFailedWithRetriesLeft,

--- a/db/rdbms/src/main/resources/mapper/JobMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/JobMapper.xml
@@ -40,6 +40,7 @@
         WORKER,
         STATE,
         RETRIES,
+        PRIORITY,
         ERROR_MESSAGE,
         ERROR_CODE,
         END_TIME,
@@ -234,6 +235,7 @@
     <result column="WORKER" property="worker" javaType="java.lang.String" />
     <result column="STATE" property="state" javaType="io.camunda.search.entities.JobEntity$JobState" />
     <result column="RETRIES" property="retries" javaType="java.lang.Integer" />
+    <result column="PRIORITY" property="priority" javaType="java.lang.Integer" />
     <result column="ERROR_MESSAGE" property="errorMessage" javaType="java.lang.String" />
     <result column="ERROR_CODE" property="errorCode" javaType="java.lang.String" />
     <result column="END_TIME" property="endTime" javaType="java.time.OffsetDateTime" />
@@ -252,12 +254,12 @@
 
   <insert id="insert" parameterType="io.camunda.db.rdbms.write.queue.BatchInsertDto">
     INSERT INTO ${prefix}JOB (JOB_KEY, PARTITION_ID, PROCESS_INSTANCE_KEY, ROOT_PROCESS_INSTANCE_KEY, ELEMENT_INSTANCE_KEY, PROCESS_DEFINITION_ID, PROCESS_DEFINITION_KEY,
-    TENANT_ID, TYPE, WORKER, STATE, RETRIES, ERROR_MESSAGE, ERROR_CODE, END_TIME, CUSTOM_HEADERS, KIND, ELEMENT_ID, IS_DENIED, DENIED_REASON, LISTENER_EVENT_TYPE,
+    TENANT_ID, TYPE, WORKER, STATE, RETRIES, PRIORITY, ERROR_MESSAGE, ERROR_CODE, END_TIME, CUSTOM_HEADERS, KIND, ELEMENT_ID, IS_DENIED, DENIED_REASON, LISTENER_EVENT_TYPE,
     DEADLINE, HAS_FAILED_WITH_RETRIES_LEFT, CREATION_TIME, LAST_UPDATE_TIME)
     VALUES
     <foreach collection="dbModels" item="job" separator=",">
       (#{job.jobKey}, #{job.partitionId}, #{job.processInstanceKey}, #{job.rootProcessInstanceKey}, #{job.elementInstanceKey}, #{job.processDefinitionId},
-      #{job.processDefinitionKey}, #{job.tenantId}, #{job.type}, #{job.worker}, #{job.state}, #{job.retries}, #{job.errorMessage}, #{job.errorCode}, #{job.endTime, jdbcType=TIMESTAMP}, #{job.serializedCustomHeaders}, #{job.kind}, #{job.elementId}, #{job.isDenied},
+      #{job.processDefinitionKey}, #{job.tenantId}, #{job.type}, #{job.worker}, #{job.state}, #{job.retries}, #{job.priority}, #{job.errorMessage}, #{job.errorCode}, #{job.endTime, jdbcType=TIMESTAMP}, #{job.serializedCustomHeaders}, #{job.kind}, #{job.elementId}, #{job.isDenied},
       #{job.deniedReason}, #{job.listenerEventType}, #{job.deadline, jdbcType=TIMESTAMP}, #{job.hasFailedWithRetriesLeft}, #{job.creationTime, jdbcType=TIMESTAMP}, #{job.lastUpdateTime, jdbcType=TIMESTAMP})
     </foreach>
   </insert>
@@ -266,10 +268,10 @@
     INSERT ALL
     <foreach collection="dbModels" item="job">
       INTO ${prefix}JOB (JOB_KEY, PARTITION_ID, PROCESS_INSTANCE_KEY, ROOT_PROCESS_INSTANCE_KEY, ELEMENT_INSTANCE_KEY, PROCESS_DEFINITION_ID, PROCESS_DEFINITION_KEY,
-      TENANT_ID, TYPE, WORKER, STATE, RETRIES, ERROR_MESSAGE, ERROR_CODE, END_TIME, CUSTOM_HEADERS, KIND, ELEMENT_ID, IS_DENIED, DENIED_REASON, LISTENER_EVENT_TYPE,
+      TENANT_ID, TYPE, WORKER, STATE, RETRIES, PRIORITY, ERROR_MESSAGE, ERROR_CODE, END_TIME, CUSTOM_HEADERS, KIND, ELEMENT_ID, IS_DENIED, DENIED_REASON, LISTENER_EVENT_TYPE,
       DEADLINE, HAS_FAILED_WITH_RETRIES_LEFT, CREATION_TIME, LAST_UPDATE_TIME)
       VALUES (#{job.jobKey}, #{job.partitionId}, #{job.processInstanceKey}, #{job.rootProcessInstanceKey}, #{job.elementInstanceKey}, #{job.processDefinitionId},
-      #{job.processDefinitionKey}, #{job.tenantId}, #{job.type}, #{job.worker}, #{job.state}, #{job.retries}, #{job.errorMessage}, #{job.errorCode}, #{job.endTime, jdbcType=TIMESTAMP}, #{job.serializedCustomHeaders}, #{job.kind}, #{job.elementId}, #{job.isDenied},
+      #{job.processDefinitionKey}, #{job.tenantId}, #{job.type}, #{job.worker}, #{job.state}, #{job.retries}, #{job.priority}, #{job.errorMessage}, #{job.errorCode}, #{job.endTime, jdbcType=TIMESTAMP}, #{job.serializedCustomHeaders}, #{job.kind}, #{job.elementId}, #{job.isDenied},
       #{job.deniedReason}, #{job.listenerEventType}, #{job.deadline, jdbcType=TIMESTAMP}, #{job.hasFailedWithRetriesLeft}, #{job.creationTime, jdbcType=TIMESTAMP}, #{job.lastUpdateTime, jdbcType=TIMESTAMP})
     </foreach>
     SELECT * FROM dual
@@ -284,6 +286,7 @@
       PROCESS_DEFINITION_KEY = #{processDefinitionKey},
       TENANT_ID = #{tenantId},
       RETRIES = #{retries},
+      PRIORITY = #{priority},
       STATE = #{state},
       TYPE = #{type},
       WORKER = #{worker},

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/JobEntityMapperTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/JobEntityMapperTest.java
@@ -35,6 +35,7 @@ public class JobEntityMapperTest {
             .kind(JobKind.BPMN_ELEMENT)
             .listenerEventType(ListenerEventType.START)
             .retries(3)
+            .priority(5)
             .isDenied(true)
             .deniedReason("testDeniedReason")
             .hasFailedWithRetriesLeft(false)
@@ -59,7 +60,7 @@ public class JobEntityMapperTest {
     // Then
     assertThat(entity)
         .usingRecursiveComparison()
-        .ignoringFields("deadline", "endTime", "customHeaders", "priority")
+        .ignoringFields("deadline", "endTime", "customHeaders")
         .isEqualTo(jobDbModel);
 
     assertThat(entity.deadline())
@@ -81,6 +82,7 @@ public class JobEntityMapperTest {
             .kind(JobKind.BPMN_ELEMENT)
             .listenerEventType(ListenerEventType.START)
             .retries(0)
+            .priority(null)
             .isDenied(false)
             .deniedReason(null)
             .hasFailedWithRetriesLeft(false)

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/JobEntityMapperTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/JobEntityMapperTest.java
@@ -59,7 +59,7 @@ public class JobEntityMapperTest {
     // Then
     assertThat(entity)
         .usingRecursiveComparison()
-        .ignoringFields("deadline", "endTime", "customHeaders")
+        .ignoringFields("deadline", "endTime", "customHeaders", "priority")
         .isEqualTo(jobDbModel);
 
     assertThat(entity.deadline())

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/JobFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/JobFixtures.java
@@ -40,6 +40,7 @@ public final class JobFixtures extends CommonFixtures {
             .endTime(NOW)
             .isDenied(false)
             .retries(1)
+            .priority(RANDOM.nextInt(-100, 101))
             .errorCode("error-code-" + generateRandomString(20))
             .deniedReason("denied-reason-" + generateRandomString(20))
             .listenerEventType(randomEnum(ListenerEventType.class))

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/job/JobIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/job/JobIT.java
@@ -331,6 +331,7 @@ public class JobIT {
             .kind(original.kind())
             .listenerEventType(original.listenerEventType())
             .retries(original.retries())
+            .priority(original.priority())
             .hasFailedWithRetriesLeft(original.hasFailedWithRetriesLeft())
             .processDefinitionId(original.processDefinitionId())
             .processDefinitionKey(original.processDefinitionKey())
@@ -357,6 +358,7 @@ public class JobIT {
     assertThat(stored.endTime())
         .isCloseTo(original.endTime(), new TemporalUnitWithinOffset(1, ChronoUnit.MILLIS));
     assertThat(stored.rootProcessInstanceKey()).isEqualTo(original.rootProcessInstanceKey());
+    assertThat(stored.priority()).isEqualTo(original.priority());
   }
 
   @TestTemplate

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/JobEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/JobEntityTransformer.java
@@ -26,6 +26,7 @@ public class JobEntityTransformer
         .kind(toJobKind(value.getJobKind()))
         .listenerEventType(toListenerEventType(value.getListenerEventType()))
         .retries(value.getRetries())
+        .priority(value.getPriority())
         .isDenied(value.isDenied())
         .deniedReason(value.getDeniedReason())
         .hasFailedWithRetriesLeft(value.isJobFailedWithRetriesLeft())

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/entity/JobEntityTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/entity/JobEntityTransformerTest.java
@@ -38,6 +38,7 @@ class JobEntityTransformerTest {
     when(entityValue.getJobKind()).thenReturn(JobKind.BPMN_ELEMENT.name());
     when(entityValue.getListenerEventType()).thenReturn(ListenerEventType.UNSPECIFIED.name());
     when(entityValue.getRetries()).thenReturn(3);
+    when(entityValue.getPriority()).thenReturn(0);
     when(entityValue.getBpmnProcessId()).thenReturn("process-def-1");
     when(entityValue.getProcessDefinitionKey()).thenReturn(1000L);
     when(entityValue.getProcessInstanceKey()).thenReturn(2000L);
@@ -45,6 +46,30 @@ class JobEntityTransformerTest {
     when(entityValue.getFlowNodeId()).thenReturn("element-1");
     when(entityValue.getCreationTime()).thenReturn(java.time.OffsetDateTime.now());
     when(entityValue.getLastUpdateTime()).thenReturn(java.time.OffsetDateTime.now());
+  }
+
+  @Test
+  void shouldMapPriority() {
+    // given
+    when(entityValue.getPriority()).thenReturn(75);
+
+    // when
+    final var transformed = transformer.apply(entityValue);
+
+    // then
+    assertThat(transformed.priority()).isEqualTo(75);
+  }
+
+  @Test
+  void shouldMapNullPriority() {
+    // given
+    when(entityValue.getPriority()).thenReturn(null);
+
+    // when
+    final var transformed = transformer.apply(entityValue);
+
+    // then
+    assertThat(transformed.priority()).isNull();
   }
 
   @Test

--- a/search/search-domain/src/main/java/io/camunda/search/entities/JobEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/JobEntity.java
@@ -25,6 +25,7 @@ public record JobEntity(
     JobKind kind,
     ListenerEventType listenerEventType,
     Integer retries,
+    @Nullable Integer priority,
     @Nullable Boolean isDenied,
     @Nullable String deniedReason,
     Boolean hasFailedWithRetriesLeft,
@@ -75,6 +76,7 @@ public record JobEntity(
     private @Nullable JobKind kind;
     private @Nullable ListenerEventType listenerEventType;
     private @Nullable Integer retries;
+    private @Nullable Integer priority;
     private @Nullable Boolean isDenied;
     private @Nullable String deniedReason;
     private @Nullable Boolean hasFailedWithRetriesLeft;
@@ -125,6 +127,11 @@ public record JobEntity(
 
     public Builder retries(final Integer retries) {
       this.retries = retries;
+      return this;
+    }
+
+    public Builder priority(final Integer priority) {
+      this.priority = priority;
       return this;
     }
 
@@ -224,6 +231,7 @@ public record JobEntity(
           kind,
           listenerEventType,
           retries,
+          priority,
           isDenied,
           deniedReason,
           hasFailedWithRetriesLeft,

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/JobTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/JobTemplate.java
@@ -32,6 +32,7 @@ public class JobTemplate extends AbstractTemplateDescriptor
   public static final String JOB_TYPE = "type";
   public static final String JOB_WORKER = "worker";
   public static final String RETRIES = "retries";
+  public static final String PRIORITY = "priority";
   public static final String JOB_STATE = "state";
   public static final String ERROR_MESSAGE = "errorMessage";
   public static final String ERROR_CODE = "errorCode";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/JobEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/JobEntity.java
@@ -44,6 +44,10 @@ public class JobEntity
   @BeforeVersion880 private String type;
   @BeforeVersion880 private String worker;
   @BeforeVersion880 private Integer retries;
+
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private Integer priority;
+
   @BeforeVersion880 private String state;
   @BeforeVersion880 private String errorMessage;
   @BeforeVersion880 private String errorCode;
@@ -161,6 +165,15 @@ public class JobEntity
 
   public JobEntity setRetries(final Integer retries) {
     this.retries = retries;
+    return this;
+  }
+
+  public Integer getPriority() {
+    return priority;
+  }
+
+  public JobEntity setPriority(final Integer priority) {
+    this.priority = priority;
     return this;
   }
 
@@ -323,6 +336,7 @@ public class JobEntity
         type,
         worker,
         retries,
+        priority,
         state,
         errorMessage,
         errorCode,
@@ -362,6 +376,7 @@ public class JobEntity
         && Objects.equals(type, jobEntity.type)
         && Objects.equals(worker, jobEntity.worker)
         && Objects.equals(retries, jobEntity.retries)
+        && Objects.equals(priority, jobEntity.priority)
         && Objects.equals(state, jobEntity.state)
         && Objects.equals(errorMessage, jobEntity.errorMessage)
         && Objects.equals(errorCode, jobEntity.errorCode)
@@ -404,6 +419,8 @@ public class JobEntity
         + '\''
         + ", retries="
         + retries
+        + ", priority="
+        + priority
         + ", state='"
         + state
         + '\''

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-job.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-job.json
@@ -40,6 +40,9 @@
       "retries": {
         "type": "integer"
       },
+      "priority": {
+        "type": "integer"
+      },
       "state": {
         "type": "keyword"
       },

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-job.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-job.json
@@ -40,6 +40,9 @@
       "retries": {
         "type": "integer"
       },
+      "priority": {
+        "type": "integer"
+      },
       "state": {
         "type": "keyword"
       },

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/JobHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/JobHandler.java
@@ -19,6 +19,7 @@ import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_FAI
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_STATE;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_WORKER;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.LAST_UPDATE_TIME;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.PRIORITY;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.PROCESS_DEFINITION_KEY;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.RETRIES;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.TIME;
@@ -100,6 +101,7 @@ public class JobHandler implements ExportHandler<JobEntity, JobRecordValue> {
         .setWorker(recordValue.getWorker())
         .setState(record.getIntent().name())
         .setRetries(recordValue.getRetries())
+        .setPriority(recordValue.getPriority())
         .setErrorMessage(recordValue.getErrorMessage())
         .setErrorCode(recordValue.getErrorCode())
         .setCustomHeaders(recordValue.getCustomHeaders())
@@ -160,6 +162,7 @@ public class JobHandler implements ExportHandler<JobEntity, JobRecordValue> {
     updateFields.put(JOB_WORKER, jobEntity.getWorker());
     updateFields.put(JOB_STATE, jobEntity.getState());
     updateFields.put(RETRIES, jobEntity.getRetries());
+    updateFields.put(PRIORITY, jobEntity.getPriority());
     updateFields.put(ERROR_MESSAGE, jobEntity.getErrorMessage());
     updateFields.put(ERROR_CODE, jobEntity.getErrorCode());
     updateFields.put(TIME, jobEntity.getEndTime());

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/JobHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/JobHandlerTest.java
@@ -19,6 +19,7 @@ import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_FAI
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_STATE;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.JOB_WORKER;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.LAST_UPDATE_TIME;
+import static io.camunda.webapps.schema.descriptors.template.JobTemplate.PRIORITY;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.PROCESS_DEFINITION_KEY;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.RETRIES;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.TIME;
@@ -149,6 +150,7 @@ final class JobHandlerTest {
     final String tenantId = "tenantId";
     final String jobType = "jobType";
     final int retries = 3;
+    final int priority = 77;
     final String jobWorker = "jobWorker";
     final String errorMessage = "someErrorMessage";
     final String errorCode = "errorCode";
@@ -165,6 +167,7 @@ final class JobHandlerTest {
             .withProcessDefinitionKey(processDefinitionKey)
             .withType(jobType)
             .withRetries(retries)
+            .withPriority(priority)
             .withWorker(jobWorker)
             .withCustomHeaders(Map.of("key", "val"))
             .withTenantId(tenantId)
@@ -202,6 +205,7 @@ final class JobHandlerTest {
     assertThat(entity.getJobKind()).isEqualTo(jobKind.name());
     assertThat(entity.getListenerEventType()).isEqualTo(jobListenerEventType.name());
     assertThat(entity.getRetries()).isEqualTo(retries);
+    assertThat(entity.getPriority()).isEqualTo(priority);
     assertThat(entity.getWorker()).isEqualTo(jobWorker);
     assertThat(entity.getCustomHeaders()).isEqualTo(Map.of("key", "val"));
     assertThat(entity.getState()).isEqualTo("CREATED");
@@ -260,6 +264,7 @@ final class JobHandlerTest {
     final String tenantId = "tenantId";
     final String jobType = "jobType";
     final int retries = 3;
+    final int priority = 88;
     final String jobWorker = "jobWorker";
     final String errorMessage = "someErrorMessage";
     final String errorCode = "errorCode";
@@ -278,6 +283,7 @@ final class JobHandlerTest {
             .withProcessDefinitionKey(processDefinitionKey)
             .withType(jobType)
             .withRetries(retries)
+            .withPriority(priority)
             .withWorker(jobWorker)
             .withCustomHeaders(Map.of("key", "val"))
             .withTenantId(tenantId)
@@ -320,6 +326,7 @@ final class JobHandlerTest {
     assertThat(entity.getJobKind()).isEqualTo(jobKind.name());
     assertThat(entity.getListenerEventType()).isEqualTo(jobListenerEventType.name());
     assertThat(entity.getRetries()).isEqualTo(retries);
+    assertThat(entity.getPriority()).isEqualTo(priority);
     assertThat(entity.getWorker()).isEqualTo(jobWorker);
     assertThat(entity.getCustomHeaders()).isEqualTo(Map.of("key", "val"));
     assertThat(entity.getState()).isEqualTo("COMPLETED");
@@ -400,11 +407,39 @@ final class JobHandlerTest {
   }
 
   @Test
+  void shouldSetPriorityWhenCompletingPreV810Entity() {
+    // given
+    final var entity = new JobEntity().setId("111");
+    assertThat(entity.getPriority()).isNull();
+
+    final var recordValue =
+        ImmutableJobRecordValue.builder()
+            .withJobKind(JobKind.BPMN_ELEMENT)
+            .withResult(ImmutableJobResultValue.builder().build())
+            .withPriority(10)
+            .build();
+    final Record<JobRecordValue> record =
+        factory.generateRecord(
+            ValueType.JOB,
+            r ->
+                r.withIntent(JobIntent.COMPLETED)
+                    .withValueType(ValueType.JOB)
+                    .withValue(recordValue));
+
+    // when
+    underTest.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getPriority()).isEqualTo(10);
+  }
+
+  @Test
   void shouldUpsertEntityOnFlush() {
     // given
     final String jobId = "111";
     final String expectedIndexName = JobTemplate.INDEX_NAME;
     final int retries = 3;
+    final int priority = 55;
     final String jobWorker = "jobWorker";
     final String errorMessage = "someErrorMessage";
     final String errorCode = "errorCode";
@@ -423,6 +458,7 @@ final class JobHandlerTest {
             .setWorker(jobWorker)
             .setState(state)
             .setRetries(retries)
+            .setPriority(priority)
             .setErrorMessage(errorMessage)
             .setErrorCode(errorCode)
             .setEndTime(endTime)
@@ -437,6 +473,7 @@ final class JobHandlerTest {
     expectedUpdateFields.put(JOB_WORKER, jobEntity.getWorker());
     expectedUpdateFields.put(JOB_STATE, jobEntity.getState());
     expectedUpdateFields.put(RETRIES, jobEntity.getRetries());
+    expectedUpdateFields.put(PRIORITY, jobEntity.getPriority());
     expectedUpdateFields.put(ERROR_MESSAGE, jobEntity.getErrorMessage());
     expectedUpdateFields.put(ERROR_CODE, jobEntity.getErrorCode());
     expectedUpdateFields.put(TIME, jobEntity.getEndTime());
@@ -465,6 +502,7 @@ final class JobHandlerTest {
     final String expectedIndexName = JobTemplate.INDEX_NAME;
     final String elementId = "elementId";
     final int retries = 2;
+    final int priority = 55;
     final String jobWorker = "jobWorker";
     final String errorMessage = "someErrorMessage";
     final String errorCode = "errorCode";
@@ -484,6 +522,7 @@ final class JobHandlerTest {
             .setWorker(jobWorker)
             .setState(state)
             .setRetries(retries)
+            .setPriority(priority)
             .setErrorMessage(errorMessage)
             .setErrorCode(errorCode)
             .setEndTime(endTime)
@@ -501,6 +540,7 @@ final class JobHandlerTest {
     expectedUpdateFields.put(JOB_WORKER, jobEntity.getWorker());
     expectedUpdateFields.put(JOB_STATE, jobEntity.getState());
     expectedUpdateFields.put(RETRIES, jobEntity.getRetries());
+    expectedUpdateFields.put(PRIORITY, jobEntity.getPriority());
     expectedUpdateFields.put(ERROR_MESSAGE, jobEntity.getErrorMessage());
     expectedUpdateFields.put(ERROR_CODE, jobEntity.getErrorCode());
     expectedUpdateFields.put(TIME, jobEntity.getEndTime());

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.exporter.dto.BulkIndexAction;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.util.SemanticVersion;
 import io.camunda.zeebe.util.VersionUtil;
 import java.io.IOException;
@@ -40,6 +41,7 @@ final class BulkIndexRequest {
           .addMixIn(Record.class, RecordSequenceMixin.class)
           .addMixIn(CommandDistributionRecordValue.class, CommandDistributionMixin.class)
           .addMixIn(EvaluatedDecisionValue.class, EvaluatedDecisionMixin.class)
+          .addMixIn(JobRecordValue.class, JobMixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);
 
   // The property of the ES record template to store the sequence of the record.
@@ -49,6 +51,7 @@ final class BulkIndexRequest {
   private static final String RECORD_DECISION_EVALUATION_INSTANCE_KEY_PROPERTY =
       "decisionEvaluationInstanceKey";
   private static final String AUTH_INFO_PROPERTY = "authInfo";
+  private static final String PRIORITY_PROPERTY = "priority";
   private final List<IndexOperation> operations = new ArrayList<>();
   private BulkIndexAction lastIndexedMetadata;
   private int memoryUsageBytes = 0;
@@ -162,4 +165,7 @@ final class BulkIndexRequest {
 
   @JsonIgnoreProperties({AUTH_INFO_PROPERTY})
   private static final class CommandDistributionMixin {}
+
+  @JsonIgnoreProperties({PRIORITY_PROPERTY})
+  private static final class JobMixin {}
 }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
@@ -68,6 +68,9 @@
                 "retries": {
                   "type": "long"
                 },
+                "priority": {
+                  "type": "integer"
+                },
                 "retryBackoff": {
                   "type": "long"
                 },

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
@@ -49,6 +49,9 @@
             "retries": {
               "type": "long"
             },
+            "priority": {
+              "type": "integer"
+            },
             "retryBackoff": {
               "type": "long"
             },

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.exporter.dto.BulkIndexAction;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.value.decision.DecisionEvaluationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.jackson.ZeebeProtocolModule;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
@@ -382,6 +383,57 @@ final class BulkIndexRequestTest {
           .describedAs(
               "Expect that decisionEvaluationInstanceKey is suppressed via @JsonIgnore on the impl class")
           .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexJobRecordWithoutPriorityOnPreviousVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.JOB,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(new JobRecord().setPriority(50)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("priority"))
+          .describedAs(
+              "Expect that job records are NOT serialized with priority on previous version")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexJobRecordWithPriorityOnCurrentVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.JOB,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(new JobRecord().setPriority(50)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("priority"))
+          .describedAs("Expect that job records are serialized with priority on current version")
+          .containsExactly(50);
     }
 
     private Record<?> deserializeSource(final IndexOperation operation) {

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.exporter.opensearch.dto.BulkIndexAction;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.util.SemanticVersion;
 import io.camunda.zeebe.util.VersionUtil;
 import jakarta.json.spi.JsonProvider;
@@ -47,6 +48,7 @@ final class BulkIndexRequest {
           .addMixIn(Record.class, RecordSequenceMixin.class)
           .addMixIn(CommandDistributionRecordValue.class, CommandDistributionMixin.class)
           .addMixIn(EvaluatedDecisionValue.class, EvaluatedDecisionMixin.class)
+          .addMixIn(JobRecordValue.class, JobMixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);
 
   // The property of the ES record template to store the sequence of the record.
@@ -56,6 +58,7 @@ final class BulkIndexRequest {
   private static final String RECORD_DECISION_EVALUATION_INSTANCE_KEY_PROPERTY =
       "decisionEvaluationInstanceKey";
   private static final String AUTH_INFO_PROPERTY = "authInfo";
+  private static final String PRIORITY_PROPERTY = "priority";
 
   private final List<BulkOperation> operations = new ArrayList<>();
 
@@ -185,4 +188,7 @@ final class BulkIndexRequest {
 
   @JsonIgnoreProperties({AUTH_INFO_PROPERTY})
   private static final class CommandDistributionMixin {}
+
+  @JsonIgnoreProperties({PRIORITY_PROPERTY})
+  private static final class JobMixin {}
 }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
@@ -74,6 +74,9 @@
                 "retries": {
                   "type": "long"
                 },
+                "priority": {
+                  "type": "integer"
+                },
                 "retryBackoff": {
                   "type": "long"
                 },

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-template.json
@@ -55,6 +55,9 @@
             "retries": {
               "type": "long"
             },
+            "priority": {
+              "type": "integer"
+            },
             "retryBackoff": {
               "type": "long"
             },

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.exporter.opensearch.dto.BulkIndexAction;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.value.decision.DecisionEvaluationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.jackson.ZeebeProtocolModule;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
@@ -396,6 +397,53 @@ final class BulkIndexRequestTest {
           .describedAs(
               "Expect that decisionEvaluationInstanceKey is suppressed via @JsonIgnore on the impl class")
           .isNull();
+    }
+
+    @Test
+    void shouldIndexJobRecordWithoutPriorityOnPreviousVersion() throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.JOB,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(new JobRecord().setPriority(50)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value.get("priority"))
+          .describedAs(
+              "Expect that job records are NOT serialized with priority on previous version")
+          .isNull();
+    }
+
+    @Test
+    void shouldIndexJobRecordWithPriorityOnCurrentVersion() throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.JOB,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(new JobRecord().setPriority(50)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations()).hasSize(1);
+      final Map<String, Object> value = getValueFromFirstOperation(request);
+      assertThat(value.get("priority"))
+          .describedAs("Expect that job records are serialized with priority on current version")
+          .isEqualTo(50);
     }
 
     private static Map<String, Object> getDocumentAsMap(final BulkOperation operation)

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/JobExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/JobExportHandler.java
@@ -74,6 +74,7 @@ public class JobExportHandler implements RdbmsExportHandler<JobRecordValue> {
             .worker(value.getWorker())
             .state(JobState.valueOf(record.getIntent().name()))
             .retries(value.getRetries())
+            .priority(value.getPriority())
             .errorMessage(value.getErrorMessage())
             .errorCode(value.getErrorCode())
             .customHeaders(value.getCustomHeaders())

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/JobExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/JobExportHandlerTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.db.rdbms.write.domain.JobDbModel;
+import io.camunda.db.rdbms.write.service.JobWriter;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.value.ImmutableJobRecordValue;
+import io.camunda.zeebe.protocol.record.value.JobKind;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class JobExportHandlerTest {
+
+  private static final Set<JobIntent> TEST_EXPORTABLE_INTENTS =
+      EnumSet.of(
+          JobIntent.CREATED,
+          JobIntent.COMPLETED,
+          JobIntent.TIMED_OUT,
+          JobIntent.FAILED,
+          JobIntent.RETRIES_UPDATED,
+          JobIntent.CANCELED,
+          JobIntent.ERROR_THROWN,
+          JobIntent.MIGRATED);
+  private final ProtocolFactory factory = new ProtocolFactory();
+  @Mock private JobWriter jobWriter;
+  @Captor private ArgumentCaptor<JobDbModel> jobDbModelCaptor;
+  private JobExportHandler handler;
+
+  private static Stream<JobIntent> exportableIntents() {
+    return TEST_EXPORTABLE_INTENTS.stream();
+  }
+
+  private static Stream<JobIntent> nonExportableIntents() {
+    return Stream.of(JobIntent.values()).filter(Predicate.not(TEST_EXPORTABLE_INTENTS::contains));
+  }
+
+  @BeforeEach
+  void setUp() {
+    handler = new JobExportHandler(jobWriter);
+  }
+
+  @ParameterizedTest(name = "Should export record with intent: {0}")
+  @MethodSource("exportableIntents")
+  void shouldExportRecord(final JobIntent intent) {
+    // given
+    final Record<JobRecordValue> record =
+        factory.generateRecord(ValueType.JOB, r -> r.withIntent(intent));
+
+    // when / then
+    assertThat(handler.canExport(record)).isTrue();
+  }
+
+  @ParameterizedTest(name = "Should not export record with unsupported intent: {0}")
+  @MethodSource("nonExportableIntents")
+  void shouldNotExportRecord(final JobIntent intent) {
+    // given
+    final Record<JobRecordValue> record =
+        factory.generateRecord(ValueType.JOB, r -> r.withIntent(intent));
+
+    // when / then
+    assertThat(handler.canExport(record)).isFalse();
+  }
+
+  @Test
+  void shouldMapProtocolDefaultPriorityAsZero() {
+    // given
+    final var recordValue =
+        ImmutableJobRecordValue.builder().withJobKind(JobKind.BPMN_ELEMENT).build();
+    final Record<JobRecordValue> record =
+        factory.generateRecord(
+            ValueType.JOB,
+            r ->
+                r.withIntent(JobIntent.CREATED)
+                    .withValueType(ValueType.JOB)
+                    .withValue(recordValue));
+
+    // when
+    handler.export(record);
+
+    // then
+    verify(jobWriter).create(jobDbModelCaptor.capture());
+    assertThat(jobDbModelCaptor.getValue().priority()).isZero();
+  }
+
+  @Test
+  void shouldMapPriorityOnCreate() {
+    // given
+    final var recordValue =
+        ImmutableJobRecordValue.builder()
+            .withJobKind(JobKind.BPMN_ELEMENT)
+            .withPriority(42)
+            .build();
+    final Record<JobRecordValue> record =
+        factory.generateRecord(
+            ValueType.JOB,
+            r ->
+                r.withIntent(JobIntent.CREATED)
+                    .withValueType(ValueType.JOB)
+                    .withValue(recordValue));
+
+    // when
+    handler.export(record);
+
+    // then
+    verify(jobWriter).create(jobDbModelCaptor.capture());
+    assertThat(jobDbModelCaptor.getValue().priority()).isEqualTo(42);
+  }
+
+  @Test
+  void shouldMapPriorityOnUpdate() {
+    // given
+    final var recordValue =
+        ImmutableJobRecordValue.builder()
+            .withJobKind(JobKind.BPMN_ELEMENT)
+            .withPriority(99)
+            .build();
+    final Record<JobRecordValue> record =
+        factory.generateRecord(
+            ValueType.JOB,
+            r ->
+                r.withIntent(JobIntent.RETRIES_UPDATED)
+                    .withValueType(ValueType.JOB)
+                    .withValue(recordValue));
+
+    // when
+    handler.export(record);
+
+    // then
+    verify(jobWriter).update(jobDbModelCaptor.capture());
+    assertThat(jobDbModelCaptor.getValue().priority()).isEqualTo(99);
+  }
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
@@ -53,6 +53,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   public static final DirectBuffer NO_HEADERS = new UnsafeBuffer(MsgPackHelper.EMTPY_OBJECT);
   public static final String RETRIES = "retries";
   public static final String TIMEOUT = "timeout";
+  public static final String PRIORITY = "priority";
   private static final String EMPTY_STRING = "";
   private static final String TYPE = "type";
   private static final String CUSTOM_HEADERS = "customHeaders";
@@ -87,6 +88,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
       new StringValue("isUserTaskMigration");
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
       new StringValue("rootProcessInstanceKey");
+  private static final StringValue PRIORITY_KEY = new StringValue(PRIORITY);
   private final StringProperty typeProp = new StringProperty(TYPE_KEY, EMPTY_STRING);
   private final StringProperty workerProp = new StringProperty(WORKER_KEY, EMPTY_STRING);
   private final LongProperty deadlineProp = new LongProperty(DEADLINE_KEY, -1);
@@ -129,9 +131,10 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
       new BooleanProperty(IS_JOB_TO_USERTASK_MIGRATION_KEY, false);
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
+  private final IntegerProperty priorityProp = new IntegerProperty(PRIORITY_KEY, 0);
 
   public JobRecord() {
-    super(24);
+    super(25);
     declareProperty(deadlineProp)
         .declareProperty(timeoutProp)
         .declareProperty(workerProp)
@@ -156,7 +159,8 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
         .declareProperty(resultProp)
         .declareProperty(tagsProp)
         .declareProperty(isJobToUserTaskMigrationProp)
-        .declareProperty(rootProcessInstanceKeyProp);
+        .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(priorityProp);
   }
 
   public void wrapWithoutVariables(final JobRecord record) {
@@ -186,6 +190,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
 
     setTags(record.getTags());
     rootProcessInstanceKeyProp.setValue(record.getRootProcessInstanceKey());
+    priorityProp.setValue(record.getPriority());
   }
 
   public void wrap(final JobRecord record) {
@@ -231,6 +236,11 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   @Override
   public int getRetries() {
     return retriesProp.getValue();
+  }
+
+  @Override
+  public int getPriority() {
+    return priorityProp.getValue();
   }
 
   @Override
@@ -426,6 +436,11 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
 
   public JobRecord setRetryBackoff(final long retryBackoff) {
     retryBackoffProp.setValue(retryBackoff);
+    return this;
+  }
+
+  public JobRecord setPriority(final int priority) {
+    priorityProp.setValue(priority);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -870,6 +870,7 @@ final class JsonSerializableToJsonTest {
                         "foo": "bar"
                       },
                       "retries": 3,
+                      "priority": 0,
                       "jobKind": "BPMN_ELEMENT",
                       "jobListenerEventType": "UNSPECIFIED",
                       "retryBackoff": 1002,
@@ -1035,7 +1036,8 @@ final class JsonSerializableToJsonTest {
                       .setResult(result)
                       .setTags(Set.of("tag1", "tag2"))
                       .setRootProcessInstanceKey(rootProcessInstanceKey)
-                      .setIsJobToUserTaskMigration(true);
+                      .setIsJobToUserTaskMigration(true)
+                      .setPriority(42);
 
               record.setCustomHeaders(wrapArray(MsgPackConverter.convertToMsgPack(customHeaders)));
               return record;
@@ -1054,6 +1056,7 @@ final class JsonSerializableToJsonTest {
                     "foo": "bar"
                   },
                   "retries": 12,
+                  "priority": 42,
                   "jobKind": "BPMN_ELEMENT",
                   "jobListenerEventType": "UNSPECIFIED",
                   "retryBackoff": 1003,
@@ -1131,6 +1134,7 @@ final class JsonSerializableToJsonTest {
                   "variables": {},
                   "worker": "",
                   "retries": -1,
+                  "priority": 0,
                   "jobKind": "BPMN_ELEMENT",
                   "jobListenerEventType": "UNSPECIFIED",
                   "retryBackoff": 0,
@@ -1193,6 +1197,7 @@ final class JsonSerializableToJsonTest {
                   "timeout": -1,
                   "worker": "",
                   "retries": -1,
+                  "priority": 0,
                   "jobKind": "BPMN_ELEMENT",
                   "jobListenerEventType": "UNSPECIFIED",
                   "retryBackoff": 0,

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/JobRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/JobRecord.golden
@@ -42,12 +42,12 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   public static final DirectBuffer NO_HEADERS = new UnsafeBuffer(MsgPackHelper.EMTPY_OBJECT);
   public static final String RETRIES = "retries";
   public static final String TIMEOUT = "timeout";
+  public static final String PRIORITY = "priority";
   private static final String EMPTY_STRING = "";
   private static final String TYPE = "type";
   private static final String CUSTOM_HEADERS = "customHeaders";
   private static final String VARIABLES = "variables";
   private static final String ERROR_MESSAGE = "errorMessage";
-
   // Static StringValue keys to avoid memory waste
   private static final StringValue TYPE_KEY = new StringValue(TYPE);
   private static final StringValue WORKER_KEY = new StringValue("worker");
@@ -77,6 +77,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
       new StringValue("isUserTaskMigration");
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
       new StringValue("rootProcessInstanceKey");
+  private static final StringValue PRIORITY_KEY = new StringValue(PRIORITY);
   private final StringProperty typeProp = new StringProperty(TYPE_KEY, EMPTY_STRING);
   private final StringProperty workerProp = new StringProperty(WORKER_KEY, EMPTY_STRING);
   private final LongProperty deadlineProp = new LongProperty(DEADLINE_KEY, -1);
@@ -119,9 +120,10 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
       new BooleanProperty(IS_JOB_TO_USERTASK_MIGRATION_KEY, false);
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
+  private final IntegerProperty priorityProp = new IntegerProperty(PRIORITY_KEY, 0);
 
   public JobRecord() {
-    super(24);
+    super(25);
     declareProperty(deadlineProp)
         .declareProperty(timeoutProp)
         .declareProperty(workerProp)
@@ -146,7 +148,8 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
         .declareProperty(resultProp)
         .declareProperty(tagsProp)
         .declareProperty(isJobToUserTaskMigrationProp)
-        .declareProperty(rootProcessInstanceKeyProp);
+        .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(priorityProp);
   }
 
   public void wrapWithoutVariables(final JobRecord record) {
@@ -176,6 +179,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
 
     setTags(record.getTags());
     rootProcessInstanceKeyProp.setValue(record.getRootProcessInstanceKey());
+    priorityProp.setValue(record.getPriority());
   }
 
   public void wrap(final JobRecord record) {
@@ -221,6 +225,11 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   @Override
   public int getRetries() {
     return retriesProp.getValue();
+  }
+
+  @Override
+  public int getPriority() {
+    return priorityProp.getValue();
   }
 
   @Override
@@ -421,6 +430,11 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
 
   public JobRecord setRetries(final int retries) {
     retriesProp.setValue(retries);
+    return this;
+  }
+
+  public JobRecord setPriority(final int priority) {
+    priorityProp.setValue(priority);
     return this;
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobRecordValue.java
@@ -57,6 +57,12 @@ public interface JobRecordValue
   int getRetries();
 
   /**
+   * @return the priority of this job; higher values activate first. Jobs with equal priority are
+   *     ordered by key ascending (creation order). Returns 0 if no priority is set (default).
+   */
+  int getPriority();
+
+  /**
    * @return the time of backoff in milliseconds. If backoff is disabled this method returns 0
    *     (default value).
    */

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -656,6 +656,7 @@ public class CompactRecordLogger {
     }
 
     result.append(" ").append(value.getRetries()).append(" retries,");
+    result.append(" priority '").append(value.getPriority()).append("',");
 
     if (!StringUtils.isEmpty(value.getErrorCode())) {
       result.append(" ").append(value.getErrorCode()).append(":").append(value.getErrorMessage());

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -656,7 +656,7 @@ public class CompactRecordLogger {
     }
 
     result.append(" ").append(value.getRetries()).append(" retries,");
-    result.append(" priority '").append(value.getPriority()).append("',");
+    result.append(" ").append(value.getPriority()).append(" priority,");
 
     if (!StringUtils.isEmpty(value.getErrorCode())) {
       result.append(" ").append(value.getErrorCode()).append(":").append(value.getErrorMessage());


### PR DESCRIPTION
## Description

* Adds the `priority` field of Jobs to `JobRecord` (https://github.com/camunda/camunda/issues/51845)
* Exports the new field via the Record (legacy) Exporters (https://github.com/camunda/camunda/issues/51845)
* Exports the new field via the Camunda Exporter (https://github.com/camunda/camunda/issues/51947)
* Exports the new field via the RDBMS Exporter (https://github.com/camunda/camunda/issues/51950)

See linked issues for more details.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes https://github.com/camunda/camunda/issues/51845, https://github.com/camunda/camunda/issues/51947, https://github.com/camunda/camunda/issues/51950
