### PR TITLE
feat: add Spectral lint rules for x-semantic-establishes / x-semantic-requires

### DIFF
--- a/zeebe/gateway-protocol/.spectral.yaml
+++ b/zeebe/gateway-protocol/.spectral.yaml
@@ -11,6 +11,7 @@ functions:
   - verifyResponsePropertiesRequired
   - verifyDeprecatedEnumMembers
   - verifyAddedInVersion
+  - verifySemanticKindsRegistered
 functionsDir: ./spectral-functions
 rules:
   # Tag validation
@@ -158,3 +159,82 @@ rules:
     message: "{{error}}"
     then:
       function: verifyAddedInVersion
+
+  # ── x-semantic-establishes / x-semantic-requires (camunda/camunda#52272) ──
+  # Three rules:
+  #   1. Schema-shape lint for x-semantic-establishes (operation-level).
+  #   2. Schema-shape lint for x-semantic-requires (operation-level).
+  #   3. Cross-document check: every kind: must be in semantic-kinds.json,
+  #      and every required kind must be established somewhere.
+  # The first two use Spectral's built-in `schema` function (no custom code);
+  # the third uses verifySemanticKindsRegistered.
+
+  semantic-establishes-shape:
+    description: "`x-semantic-establishes` must conform to the documented schema."
+    severity: error
+    given: $.paths[*][get,put,post,patch,delete].x-semantic-establishes
+    then:
+      function: schema
+      functionOptions:
+        schema:
+          type: object
+          required: [kind, identifiedBy]
+          additionalProperties: false
+          properties:
+            kind:
+              type: string
+              pattern: "^[A-Z][A-Za-z0-9]+$"
+              description: PascalCase singular noun. The symbolic name of the established thing, not of the operation.
+            shape:
+              type: string
+              enum: [entity, edge]
+              description: Optional discriminator. Defaults to `entity`. Use `edge` for membership-style relationships observable only via member-list search.
+            identifiedBy:
+              type: array
+              minItems: 1
+              description: Ordered tuple of identifying members. Length 1 for single-key entities, length ≥ 2 for composite-key entities and edges.
+              items:
+                type: object
+                required: [in, name, semanticType]
+                additionalProperties: false
+                properties:
+                  in: { type: string, enum: [body, path, query, header] }
+                  name: { type: string, minLength: 1 }
+                  semanticType:
+                    type: string
+                    pattern: "^[A-Z][A-Za-z0-9]+$"
+
+  semantic-requires-shape:
+    description: "`x-semantic-requires` must conform to the documented schema."
+    severity: error
+    given: $.paths[*][get,put,post,patch,delete].x-semantic-requires
+    then:
+      function: schema
+      functionOptions:
+        schema:
+          type: object
+          required: [kind, bind]
+          additionalProperties: false
+          properties:
+            kind:
+              type: string
+              pattern: "^[A-Z][A-Za-z0-9]+$"
+            bind:
+              type: object
+              minProperties: 1
+              description: Maps members of the established tuple to local parameters of the consumer.
+              additionalProperties:
+                type: object
+                required: [from, name]
+                additionalProperties: false
+                properties:
+                  from: { type: string, enum: [body, path, query, header] }
+                  name: { type: string, minLength: 1 }
+
+  verify-semantic-kinds-registered:
+    description: "Every `kind:` referenced by x-semantic-establishes / x-semantic-requires must appear in semantic-kinds.json, and every required kind must be established somewhere in the spec."
+    severity: error
+    given: "$"
+    message: "{{error}}"
+    then:
+      function: verifySemanticKindsRegistered

--- a/zeebe/gateway-protocol/spectral-functions/verifySemanticKindsRegistered.js
+++ b/zeebe/gateway-protocol/spectral-functions/verifySemanticKindsRegistered.js
@@ -1,4 +1,4 @@
-// Spectral custom function. Two responsibilities:
+// Spectral custom function. Three responsibilities:
 //
 //   1. Every `kind:` value referenced by `x-semantic-establishes` or
 //      `x-semantic-requires` must appear in `semantic-kinds.json`. Catches
@@ -9,6 +9,16 @@
 //      by at least one operation in the spec. Catches the case where the
 //      consumer was annotated but the producer wasn't (or producer uses a
 //      different — possibly typo'd — kind).
+//
+//   3. Edge endpoint resolution + derived requires. For every operation with
+//      `x-semantic-establishes.shape: edge`, each `identifiedBy[].semanticType`
+//      must be the identifier of exactly one registered entity kind (the
+//      registry's `identifiers: [...]` field). The resolved entity kinds are
+//      then treated as implicit `x-semantic-requires` for that operation and
+//      fed through the cross-reference check above. Authors get the
+//      validation ("you can't link to an entity nobody can produce") without
+//      having to redundantly write `x-semantic-requires` next to every edge
+//      establishment.
 //
 // The orphan check in the other direction (`establishes` with no consumer)
 // is intentionally not enforced — many producers are legitimately useful
@@ -63,24 +73,41 @@ function loadRegistry() {
   const raw = fs.readFileSync(file, 'utf8');
   const doc = JSON.parse(raw);
   const kinds = Array.isArray(doc.kinds) ? doc.kinds : [];
-  cachedRegistry = new Set(
-    kinds
-      .map((entry) => (typeof entry === 'string' ? entry : entry?.name))
-      .filter((name) => typeof name === 'string' && name.length > 0),
-  );
+  const names = new Set();
+  // semanticType (string) -> array of entity kind names that declare it as an
+  // identifier. Single-owner is the well-formed case; multi-owner is a
+  // registry config error and surfaces as an error against the first edge
+  // operation that triggers the lookup.
+  const identifierToKinds = new Map();
+  for (const entry of kinds) {
+    const name = typeof entry === 'string' ? entry : entry?.name;
+    if (typeof name !== 'string' || name.length === 0) continue;
+    names.add(name);
+    if (entry && typeof entry === 'object' && Array.isArray(entry.identifiers)) {
+      for (const id of entry.identifiers) {
+        if (typeof id !== 'string' || id.length === 0) continue;
+        const existing = identifierToKinds.get(id);
+        if (existing) existing.push(name);
+        else identifierToKinds.set(id, [name]);
+      }
+    }
+  }
+  cachedRegistry = { names, identifierToKinds };
   cachedFor = file;
   return cachedRegistry;
 }
 
 module.exports = (input, _opts, _context) => {
   const errors = [];
-  const registry = loadRegistry();
+  const { names: registry, identifierToKinds } = loadRegistry();
 
   const paths = input?.paths;
   if (!paths || typeof paths !== 'object') return errors;
 
   const established = new Set();
-  const required = []; // [{ kind, method, pathKey }]
+  // { kind, method, pathKey, source: 'requires' | 'edge-endpoint',
+  //   semanticType?: string }
+  const required = [];
 
   for (const [pathKey, pathItem] of Object.entries(paths)) {
     if (!pathItem || typeof pathItem !== 'object') continue;
@@ -96,11 +123,67 @@ module.exports = (input, _opts, _context) => {
             path: ['paths', pathKey, method, 'x-semantic-establishes', 'kind'],
           });
         }
+
+        // Edge endpoint resolution. For shape: edge, every identifiedBy entry's
+        // semanticType must resolve to exactly one registered entity. The
+        // resolved entity becomes an implicit requires.
+        if (est.shape === 'edge' && Array.isArray(est.identifiedBy)) {
+          for (let i = 0; i < est.identifiedBy.length; i++) {
+            const item = est.identifiedBy[i];
+            if (!item || typeof item !== 'object') continue;
+            const st = item.semanticType;
+            if (typeof st !== 'string' || st.length === 0) continue;
+            const owners = identifierToKinds.get(st);
+            if (!owners || owners.length === 0) {
+              errors.push({
+                message: `Edge endpoint semanticType '${st}' on ${method.toUpperCase()} ${pathKey} (x-semantic-establishes.identifiedBy[${i}]) is not declared as an identifier of any registered entity kind. Add it to the entity's 'identifiers' in semantic-kinds.json or fix the typo.`,
+                path: [
+                  'paths',
+                  pathKey,
+                  method,
+                  'x-semantic-establishes',
+                  'identifiedBy',
+                  i,
+                  'semanticType',
+                ],
+              });
+              continue;
+            }
+            if (owners.length > 1) {
+              errors.push({
+                message: `Edge endpoint semanticType '${st}' on ${method.toUpperCase()} ${pathKey} resolves to multiple entity kinds in semantic-kinds.json: ${owners.join(', ')}. Each semantic identifier must be owned by exactly one entity.`,
+                path: [
+                  'paths',
+                  pathKey,
+                  method,
+                  'x-semantic-establishes',
+                  'identifiedBy',
+                  i,
+                  'semanticType',
+                ],
+              });
+            }
+            for (const ownerKind of owners) {
+              required.push({
+                kind: ownerKind,
+                method,
+                pathKey,
+                source: 'edge-endpoint',
+                semanticType: st,
+              });
+            }
+          }
+        }
       }
 
       const req = op['x-semantic-requires'];
       if (req && typeof req.kind === 'string') {
-        required.push({ kind: req.kind, method, pathKey });
+        required.push({
+          kind: req.kind,
+          method,
+          pathKey,
+          source: 'requires',
+        });
         if (!registry.has(req.kind)) {
           errors.push({
             message: `Unknown semantic kind '${req.kind}' on ${method.toUpperCase()} ${pathKey} (x-semantic-requires). Add it to zeebe/gateway-protocol/src/main/proto/v2/semantic-kinds.json or fix the typo.`,
@@ -114,12 +197,24 @@ module.exports = (input, _opts, _context) => {
   // Cross-reference: every required kind must be established somewhere.
   // Skip kinds that already failed the registry check — the message above
   // is the actionable one.
-  for (const { kind, method, pathKey } of required) {
-    if (!registry.has(kind)) continue;
-    if (!established.has(kind)) {
+  for (const r of required) {
+    if (!registry.has(r.kind)) continue;
+    if (established.has(r.kind)) continue;
+    if (r.source === 'edge-endpoint') {
       errors.push({
-        message: `Semantic kind '${kind}' is required by ${method.toUpperCase()} ${pathKey} (x-semantic-requires) but no operation establishes it. Add x-semantic-establishes on the producer operation.`,
-        path: ['paths', pathKey, method, 'x-semantic-requires', 'kind'],
+        message: `Semantic kind '${r.kind}' is required (derived from x-semantic-establishes.identifiedBy.semanticType '${r.semanticType}' on ${r.method.toUpperCase()} ${r.pathKey}) but no operation establishes it. Add x-semantic-establishes on the producer operation, or remove '${r.semanticType}' from the entity's 'identifiers' if it is not actually an endpoint of this edge.`,
+        path: [
+          'paths',
+          r.pathKey,
+          r.method,
+          'x-semantic-establishes',
+          'identifiedBy',
+        ],
+      });
+    } else {
+      errors.push({
+        message: `Semantic kind '${r.kind}' is required by ${r.method.toUpperCase()} ${r.pathKey} (x-semantic-requires) but no operation establishes it. Add x-semantic-establishes on the producer operation.`,
+        path: ['paths', r.pathKey, r.method, 'x-semantic-requires', 'kind'],
       });
     }
   }

--- a/zeebe/gateway-protocol/spectral-functions/verifySemanticKindsRegistered.js
+++ b/zeebe/gateway-protocol/spectral-functions/verifySemanticKindsRegistered.js
@@ -1,0 +1,128 @@
+// Spectral custom function. Two responsibilities:
+//
+//   1. Every `kind:` value referenced by `x-semantic-establishes` or
+//      `x-semantic-requires` must appear in `semantic-kinds.json`. Catches
+//      typos at the point of declaration (the registry is the spell-check
+//      dictionary).
+//
+//   2. Cross-reference: every `x-semantic-requires.kind` must be established
+//      by at least one operation in the spec. Catches the case where the
+//      consumer was annotated but the producer wasn't (or producer uses a
+//      different — possibly typo'd — kind).
+//
+// The orphan check in the other direction (`establishes` with no consumer)
+// is intentionally not enforced — many producers are legitimately useful
+// without a consumer in this spec (e.g. setup/admin operations).
+//
+// Applied to the document root (`given: $`).
+//
+// The registry is JSON (not YAML) so it can be read with the built-in
+// JSON parser without taking on a runtime dependency on js-yaml.
+//
+// Tests override the registry path via the
+// `SPECTRAL_SEMANTIC_KINDS_REGISTRY` environment variable.
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const HTTP_METHODS = new Set(['get', 'post', 'put', 'patch', 'delete']);
+
+const REGISTRY_CANDIDATES = [
+  // CI invokes spectral from the repo root.
+  'zeebe/gateway-protocol/src/main/proto/v2/semantic-kinds.json',
+  // Local invocations from inside zeebe/gateway-protocol.
+  'src/main/proto/v2/semantic-kinds.json',
+];
+
+// Tests override the registry path with this env var so they can drive
+// the function with fixture-local kinds without polluting the production
+// registry. Spectral's function sandbox doesn't expose __dirname, so we
+// can't anchor the lookup to the function file — env var first, then
+// cwd-relative candidates.
+function resolveRegistryPath() {
+  const override = process.env.SPECTRAL_SEMANTIC_KINDS_REGISTRY;
+  if (typeof override === 'string' && override.length > 0) {
+    return path.resolve(override);
+  }
+  for (const candidate of REGISTRY_CANDIDATES) {
+    const abs = path.resolve(process.cwd(), candidate);
+    if (fs.existsSync(abs)) return abs;
+  }
+  // Last resort — let fs.readFileSync surface a clear ENOENT pointing at
+  // the canonical location.
+  return path.resolve(process.cwd(), REGISTRY_CANDIDATES[0]);
+}
+
+let cachedRegistry = null;
+let cachedFor = null;
+function loadRegistry() {
+  const file = resolveRegistryPath();
+  if (cachedRegistry !== null && cachedFor === file) return cachedRegistry;
+  const raw = fs.readFileSync(file, 'utf8');
+  const doc = JSON.parse(raw);
+  const kinds = Array.isArray(doc.kinds) ? doc.kinds : [];
+  cachedRegistry = new Set(
+    kinds
+      .map((entry) => (typeof entry === 'string' ? entry : entry?.name))
+      .filter((name) => typeof name === 'string' && name.length > 0),
+  );
+  cachedFor = file;
+  return cachedRegistry;
+}
+
+module.exports = (input, _opts, _context) => {
+  const errors = [];
+  const registry = loadRegistry();
+
+  const paths = input?.paths;
+  if (!paths || typeof paths !== 'object') return errors;
+
+  const established = new Set();
+  const required = []; // [{ kind, method, pathKey }]
+
+  for (const [pathKey, pathItem] of Object.entries(paths)) {
+    if (!pathItem || typeof pathItem !== 'object') continue;
+    for (const [method, op] of Object.entries(pathItem)) {
+      if (!HTTP_METHODS.has(method) || !op || typeof op !== 'object') continue;
+
+      const est = op['x-semantic-establishes'];
+      if (est && typeof est.kind === 'string') {
+        established.add(est.kind);
+        if (!registry.has(est.kind)) {
+          errors.push({
+            message: `Unknown semantic kind '${est.kind}' on ${method.toUpperCase()} ${pathKey} (x-semantic-establishes). Add it to zeebe/gateway-protocol/src/main/proto/v2/semantic-kinds.json or fix the typo.`,
+            path: ['paths', pathKey, method, 'x-semantic-establishes', 'kind'],
+          });
+        }
+      }
+
+      const req = op['x-semantic-requires'];
+      if (req && typeof req.kind === 'string') {
+        required.push({ kind: req.kind, method, pathKey });
+        if (!registry.has(req.kind)) {
+          errors.push({
+            message: `Unknown semantic kind '${req.kind}' on ${method.toUpperCase()} ${pathKey} (x-semantic-requires). Add it to zeebe/gateway-protocol/src/main/proto/v2/semantic-kinds.json or fix the typo.`,
+            path: ['paths', pathKey, method, 'x-semantic-requires', 'kind'],
+          });
+        }
+      }
+    }
+  }
+
+  // Cross-reference: every required kind must be established somewhere.
+  // Skip kinds that already failed the registry check — the message above
+  // is the actionable one.
+  for (const { kind, method, pathKey } of required) {
+    if (!registry.has(kind)) continue;
+    if (!established.has(kind)) {
+      errors.push({
+        message: `Semantic kind '${kind}' is required by ${method.toUpperCase()} ${pathKey} (x-semantic-requires) but no operation establishes it. Add x-semantic-establishes on the producer operation.`,
+        path: ['paths', pathKey, method, 'x-semantic-requires', 'kind'],
+      });
+    }
+  }
+
+  return errors;
+};

--- a/zeebe/gateway-protocol/spectral-functions/verifySemanticKindsRegistered.js
+++ b/zeebe/gateway-protocol/spectral-functions/verifySemanticKindsRegistered.js
@@ -197,6 +197,20 @@ module.exports = (input, _opts, _context) => {
   // Cross-reference: every required kind must be established somewhere.
   // Skip kinds that already failed the registry check — the message above
   // is the actionable one.
+  //
+  // Only meaningful against a complete spec (the bundled rest-api.yaml root
+  // with `openapi:` at top level). CI runs spectral twice — once on the
+  // bundled root and once with a per-file glob (see camunda/camunda#46274).
+  // In the per-file pass, sub-files like tenants.yaml only carry their own
+  // paths, so an edge whose producer lives in a sibling file (e.g.
+  // assignUserToTenant deriving User from Username, with createUser in
+  // users.yaml) would falsely fail here. Sub-files have no `openapi` at
+  // root — gate the cross-reference walk on its presence so the bundled
+  // pass is the single source of truth for this check, while the
+  // per-operation registry-membership checks above still fire correctly
+  // per-file.
+  if (typeof input?.openapi !== 'string') return errors;
+
   for (const r of required) {
     if (!registry.has(r.kind)) continue;
     if (established.has(r.kind)) continue;

--- a/zeebe/gateway-protocol/spectral-tests/README.md
+++ b/zeebe/gateway-protocol/spectral-tests/README.md
@@ -19,9 +19,13 @@ spectral-tests/
 ├── *.test.js           # Test files (one per custom function)
 └── fixtures/
     └── <rule-name>/    # Multi-part YAML spec fixtures per rule
-        ├── rest-api.yaml       # Entry point (mirrors real spec structure)
-        ├── things.yaml         # Domain schemas with valid + invalid cases
-        └── search-models.yaml  # Shared models (allOf composition targets)
+        ├── rest-api.yaml         # Entry point (mirrors real spec structure)
+        ├── things.yaml           # Domain schemas with valid + invalid cases
+        ├── search-models.yaml    # Shared models (allOf composition targets)
+        └── semantic-kinds.json   # Optional: fixture-local semantic-kinds
+                                  # registry (auto-loaded via the
+                                  # SPECTRAL_SEMANTIC_KINDS_REGISTRY env
+                                  # var by helpers.js when present).
 ```
 
 ## Adding tests for a new rule

--- a/zeebe/gateway-protocol/spectral-tests/fixtures/semantic-establishes/rest-api.yaml
+++ b/zeebe/gateway-protocol/spectral-tests/fixtures/semantic-establishes/rest-api.yaml
@@ -1,0 +1,45 @@
+# Entry point for x-semantic-establishes / x-semantic-requires rule tests.
+# Mirrors the real spec structure: paths $ref to a domain file.
+openapi: "3.0.3"
+info:
+  title: Test Fixture — semantic-establishes
+  version: "1.0"
+tags:
+  - name: Test
+
+paths:
+  # ── Valid ─────────────────────────────────────────────────────
+  /valid/widgets:
+    $ref: 'widgets.yaml#/paths/~1valid~1widgets'
+  /valid/widgets/{widgetId}:
+    $ref: 'widgets.yaml#/paths/~1valid~1widgets~1{widgetId}'
+  /valid/widgets/{widgetId}/owners/{username}:
+    $ref: 'widgets.yaml#/paths/~1valid~1widgets~1{widgetId}~1owners~1{username}'
+  /valid/widgets/{widgetId}/owners/search:
+    $ref: 'widgets.yaml#/paths/~1valid~1widgets~1{widgetId}~1owners~1search'
+
+  # ── Invalid: shape lint ───────────────────────────────────────
+  /invalid/missing-kind:
+    $ref: 'widgets.yaml#/paths/~1invalid~1missing-kind'
+  /invalid/bad-kind-case:
+    $ref: 'widgets.yaml#/paths/~1invalid~1bad-kind-case'
+  /invalid/typoed-key:
+    $ref: 'widgets.yaml#/paths/~1invalid~1typoed-key'
+  /invalid/bad-shape-enum:
+    $ref: 'widgets.yaml#/paths/~1invalid~1bad-shape-enum'
+  /invalid/empty-identified-by:
+    $ref: 'widgets.yaml#/paths/~1invalid~1empty-identified-by'
+  /invalid/identified-by-bad-in:
+    $ref: 'widgets.yaml#/paths/~1invalid~1identified-by-bad-in'
+
+  # ── Invalid: requires shape lint ──────────────────────────────
+  /invalid/requires-missing-bind:
+    $ref: 'widgets.yaml#/paths/~1invalid~1requires-missing-bind'
+
+  # ── Invalid: registry / cross-reference ───────────────────────
+  /invalid/unknown-establishes-kind:
+    $ref: 'widgets.yaml#/paths/~1invalid~1unknown-establishes-kind'
+  /invalid/unknown-requires-kind:
+    $ref: 'widgets.yaml#/paths/~1invalid~1unknown-requires-kind'
+  /invalid/orphan-requires:
+    $ref: 'widgets.yaml#/paths/~1invalid~1orphan-requires'

--- a/zeebe/gateway-protocol/spectral-tests/fixtures/semantic-establishes/rest-api.yaml
+++ b/zeebe/gateway-protocol/spectral-tests/fixtures/semantic-establishes/rest-api.yaml
@@ -13,6 +13,8 @@ paths:
     $ref: 'widgets.yaml#/paths/~1valid~1widgets'
   /valid/widgets/{widgetId}:
     $ref: 'widgets.yaml#/paths/~1valid~1widgets~1{widgetId}'
+  /valid/users:
+    $ref: 'widgets.yaml#/paths/~1valid~1users'
   /valid/widgets/{widgetId}/owners/{username}:
     $ref: 'widgets.yaml#/paths/~1valid~1widgets~1{widgetId}~1owners~1{username}'
   /valid/widgets/{widgetId}/owners/search:
@@ -43,3 +45,9 @@ paths:
     $ref: 'widgets.yaml#/paths/~1invalid~1unknown-requires-kind'
   /invalid/orphan-requires:
     $ref: 'widgets.yaml#/paths/~1invalid~1orphan-requires'
+
+  # ── Invalid: edge endpoint resolution / derived requires ──────
+  /invalid/widgets/{widgetId}/mystery/{mysteryId}:
+    $ref: 'widgets.yaml#/paths/~1invalid~1widgets~1{widgetId}~1mystery~1{mysteryId}'
+  /invalid/widgets/{widgetId}/frobs/{frobId}:
+    $ref: 'widgets.yaml#/paths/~1invalid~1widgets~1{widgetId}~1frobs~1{frobId}'

--- a/zeebe/gateway-protocol/spectral-tests/fixtures/semantic-establishes/semantic-kinds.json
+++ b/zeebe/gateway-protocol/spectral-tests/fixtures/semantic-establishes/semantic-kinds.json
@@ -1,9 +1,13 @@
 {
   "$comment": "Test-only registry for the semantic-establishes Spectral fixture. Loaded via SPECTRAL_SEMANTIC_KINDS_REGISTRY env var.",
   "kinds": [
-    { "name": "Widget", "shape": "entity" },
+    { "name": "Widget", "shape": "entity", "identifiers": ["WidgetId"] },
+    { "name": "User", "shape": "entity", "identifiers": ["Username"] },
     { "name": "WidgetOwnership", "shape": "edge" },
-    { "name": "OrphanedKind", "shape": "entity", "$comment": "Registered but never established in the fixture, to exercise the orphan-requires check." }
+    { "name": "OrphanedKind", "shape": "entity", "$comment": "Registered but never established in the fixture, to exercise the orphan-requires check." },
+    { "name": "Frob", "shape": "entity", "identifiers": ["FrobId"], "$comment": "Registered with an identifier but never established. Exercises the derived-requires orphan check on edge endpoints." },
+    { "name": "WidgetFrobLink", "shape": "edge", "$comment": "Edge whose endpoint Frob is unestablished — exercises derived-requires orphan." },
+    { "name": "WidgetMysteryLink", "shape": "edge", "$comment": "Edge whose endpoint semanticType resolves to no entity at all — exercises the unresolved-endpoint check." }
   ]
 }
 

--- a/zeebe/gateway-protocol/spectral-tests/fixtures/semantic-establishes/semantic-kinds.json
+++ b/zeebe/gateway-protocol/spectral-tests/fixtures/semantic-establishes/semantic-kinds.json
@@ -1,0 +1,9 @@
+{
+  "$comment": "Test-only registry for the semantic-establishes Spectral fixture. Loaded via SPECTRAL_SEMANTIC_KINDS_REGISTRY env var.",
+  "kinds": [
+    { "name": "Widget", "shape": "entity" },
+    { "name": "WidgetOwnership", "shape": "edge" },
+    { "name": "OrphanedKind", "shape": "entity", "$comment": "Registered but never established in the fixture, to exercise the orphan-requires check." }
+  ]
+}
+

--- a/zeebe/gateway-protocol/spectral-tests/fixtures/semantic-establishes/subfile-no-openapi.yaml
+++ b/zeebe/gateway-protocol/spectral-tests/fixtures/semantic-establishes/subfile-no-openapi.yaml
@@ -1,0 +1,35 @@
+# Sub-file fixture (no `openapi:` at root) for the per-file lint pass.
+#
+# Mirrors the real-spec shape where domain YAMLs (e.g. tenants.yaml) declare
+# an edge whose endpoint resolves to an entity established by an operation
+# in a sibling file (e.g. createWidget in widgets.yaml). Linting this file
+# in isolation must NOT raise a cross-reference orphan for `Widget` — the
+# producer-existence check is only meaningful against the bundled spec.
+#
+# See verifySemanticKindsRegistered.js (the openapi-presence guard) and
+# the per-file lint pass at .github/workflows/ci.yml referencing
+# camunda/camunda#46274.
+
+paths:
+  /sub/widgets/{widgetId}/owners/{username}:
+    put:
+      operationId: assignOwnerInSubfile
+      summary: Assign owner to a widget (sub-file edge)
+      x-semantic-establishes:
+        kind: WidgetOwnership
+        shape: edge
+        identifiedBy:
+          - { in: path, name: widgetId, semanticType: WidgetId }
+          - { in: path, name: username, semanticType: Username }
+      parameters:
+        - name: widgetId
+          in: path
+          required: true
+          schema: { type: string }
+        - name: username
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "204":
+          description: Assigned.

--- a/zeebe/gateway-protocol/spectral-tests/fixtures/semantic-establishes/widgets.yaml
+++ b/zeebe/gateway-protocol/spectral-tests/fixtures/semantic-establishes/widgets.yaml
@@ -46,6 +46,24 @@ paths:
         '200':
           description: OK.
 
+  # Establishes User. Required for the assignOwnerToWidget edge below to be
+  # valid: the edge's identifiedBy includes Username, which the registry
+  # declares as User's identifier, so User becomes a derived requires.
+  /valid/users:
+    post:
+      operationId: createUser
+      summary: Create a user
+      description: Establishes a User identified by username.
+      x-added-in-version: "8.8"
+      tags: [Test]
+      x-semantic-establishes:
+        kind: User
+        identifiedBy:
+          - { in: body, name: username, semanticType: Username }
+      responses:
+        '201':
+          description: Created.
+
   # ── Valid: edge establish + edge consumer ────────────────────
   /valid/widgets/{widgetId}/owners/{username}:
     put:
@@ -259,3 +277,66 @@ paths:
       responses:
         '200':
           description: OK.
+
+  # 11. Edge with an identifiedBy semanticType that no entity in the registry
+  #     declares as an identifier. Exercises the unresolved-endpoint check
+  #     (derived-requires resolution failure).
+  /invalid/widgets/{widgetId}/mystery/{mysteryId}:
+    put:
+      operationId: assignMysteryToWidget
+      summary: Assign mystery to widget
+      description: Should fail verify-semantic-kinds-registered — MysteryId is no entity's identifier.
+      x-added-in-version: "8.8"
+      tags: [Test]
+      parameters:
+        - name: widgetId
+          in: path
+          required: true
+          description: The widget id.
+          schema: { type: string }
+        - name: mysteryId
+          in: path
+          required: true
+          description: The mystery id.
+          schema: { type: string }
+      x-semantic-establishes:
+        kind: WidgetMysteryLink
+        shape: edge
+        identifiedBy:
+          - { in: path, name: widgetId,  semanticType: WidgetId }
+          - { in: path, name: mysteryId, semanticType: MysteryId }
+      responses:
+        '204':
+          description: Assigned.
+
+  # 12. Edge whose identifiedBy semanticType resolves to a registered entity
+  #     (Frob), but Frob is never established by any operation. Exercises
+  #     the derived-requires orphan check — the edge implicitly requires
+  #     Frob to exist, and nothing produces it.
+  /invalid/widgets/{widgetId}/frobs/{frobId}:
+    put:
+      operationId: assignFrobToWidget
+      summary: Assign frob to widget
+      description: Should fail verify-semantic-kinds-registered — Frob is registered but never established.
+      x-added-in-version: "8.8"
+      tags: [Test]
+      parameters:
+        - name: widgetId
+          in: path
+          required: true
+          description: The widget id.
+          schema: { type: string }
+        - name: frobId
+          in: path
+          required: true
+          description: The frob id.
+          schema: { type: string }
+      x-semantic-establishes:
+        kind: WidgetFrobLink
+        shape: edge
+        identifiedBy:
+          - { in: path, name: widgetId, semanticType: WidgetId }
+          - { in: path, name: frobId,   semanticType: FrobId }
+      responses:
+        '204':
+          description: Assigned.

--- a/zeebe/gateway-protocol/spectral-tests/fixtures/semantic-establishes/widgets.yaml
+++ b/zeebe/gateway-protocol/spectral-tests/fixtures/semantic-establishes/widgets.yaml
@@ -1,0 +1,261 @@
+# Domain file for semantic-establishes / semantic-requires test fixture.
+# Each operation exercises one named violation (or, for valid cases, the
+# happy path).
+openapi: "3.0.3"
+info:
+  title: Widgets domain (test fixture)
+  version: "1.0"
+tags:
+  - name: Test
+
+paths:
+  # ── Valid: single-key entity establish + matching consumer ───
+  /valid/widgets:
+    post:
+      operationId: createWidget
+      summary: Create a widget
+      description: Establishes a Widget identified by widgetId.
+      x-added-in-version: "8.8"
+      tags: [Test]
+      x-semantic-establishes:
+        kind: Widget
+        identifiedBy:
+          - { in: body, name: widgetId, semanticType: WidgetId }
+      responses:
+        '201':
+          description: Created.
+
+  /valid/widgets/{widgetId}:
+    get:
+      operationId: getWidget
+      summary: Get a widget
+      description: Requires a Widget to exist.
+      x-added-in-version: "8.8"
+      tags: [Test]
+      parameters:
+        - name: widgetId
+          in: path
+          required: true
+          description: The widget id.
+          schema: { type: string }
+      x-semantic-requires:
+        kind: Widget
+        bind:
+          widgetId: { from: body, name: widgetId }
+      responses:
+        '200':
+          description: OK.
+
+  # ── Valid: edge establish + edge consumer ────────────────────
+  /valid/widgets/{widgetId}/owners/{username}:
+    put:
+      operationId: assignOwnerToWidget
+      summary: Assign owner to widget
+      description: Establishes a WidgetOwnership edge.
+      x-added-in-version: "8.8"
+      tags: [Test]
+      parameters:
+        - name: widgetId
+          in: path
+          required: true
+          description: The widget id.
+          schema: { type: string }
+        - name: username
+          in: path
+          required: true
+          description: The username.
+          schema: { type: string }
+      x-semantic-establishes:
+        kind: WidgetOwnership
+        shape: edge
+        identifiedBy:
+          - { in: path, name: widgetId, semanticType: WidgetId }
+          - { in: path, name: username, semanticType: Username }
+      responses:
+        '204':
+          description: Assigned.
+
+  /valid/widgets/{widgetId}/owners/search:
+    post:
+      operationId: searchOwnersForWidget
+      summary: Search widget owners
+      description: Requires a WidgetOwnership to exist; binds only widgetId.
+      x-added-in-version: "8.8"
+      tags: [Test]
+      parameters:
+        - name: widgetId
+          in: path
+          required: true
+          description: The widget id.
+          schema: { type: string }
+      x-semantic-requires:
+        kind: WidgetOwnership
+        bind:
+          widgetId: { from: path, name: widgetId }
+      responses:
+        '200':
+          description: OK.
+
+  # ── Invalid: shape lint (semantic-establishes-shape) ─────────
+
+  # 1. Missing required `kind`.
+  /invalid/missing-kind:
+    post:
+      operationId: missingKind
+      summary: Missing kind
+      description: Should fail semantic-establishes-shape — missing kind.
+      x-added-in-version: "8.8"
+      tags: [Test]
+      x-semantic-establishes:
+        identifiedBy:
+          - { in: body, name: widgetId, semanticType: WidgetId }
+      responses:
+        '201':
+          description: Created.
+
+  # 2. kind violates PascalCase pattern.
+  /invalid/bad-kind-case:
+    post:
+      operationId: badKindCase
+      summary: Bad kind case
+      description: Should fail semantic-establishes-shape — kind not PascalCase.
+      x-added-in-version: "8.8"
+      tags: [Test]
+      x-semantic-establishes:
+        kind: widget
+        identifiedBy:
+          - { in: body, name: widgetId, semanticType: WidgetId }
+      responses:
+        '201':
+          description: Created.
+
+  # 3. Typo'd top-level key — additionalProperties: false rejects it.
+  /invalid/typoed-key:
+    post:
+      operationId: typoedKey
+      summary: Typoed key
+      description: Should fail semantic-establishes-shape — `identifedBy` typo.
+      x-added-in-version: "8.8"
+      tags: [Test]
+      x-semantic-establishes:
+        kind: Widget
+        identifedBy:
+          - { in: body, name: widgetId, semanticType: WidgetId }
+      responses:
+        '201':
+          description: Created.
+
+  # 4. Bad `shape` enum value.
+  /invalid/bad-shape-enum:
+    post:
+      operationId: badShapeEnum
+      summary: Bad shape enum
+      description: Should fail semantic-establishes-shape — shape not in enum.
+      x-added-in-version: "8.8"
+      tags: [Test]
+      x-semantic-establishes:
+        kind: Widget
+        shape: relation
+        identifiedBy:
+          - { in: body, name: widgetId, semanticType: WidgetId }
+      responses:
+        '201':
+          description: Created.
+
+  # 5. identifiedBy must have at least one item.
+  /invalid/empty-identified-by:
+    post:
+      operationId: emptyIdentifiedBy
+      summary: Empty identifiedBy
+      description: Should fail semantic-establishes-shape — empty identifiedBy.
+      x-added-in-version: "8.8"
+      tags: [Test]
+      x-semantic-establishes:
+        kind: Widget
+        identifiedBy: []
+      responses:
+        '201':
+          description: Created.
+
+  # 6. identifiedBy item with bad `in` enum value.
+  /invalid/identified-by-bad-in:
+    post:
+      operationId: identifiedByBadIn
+      summary: identifiedBy bad in
+      description: Should fail semantic-establishes-shape — `in: cookie` not in enum.
+      x-added-in-version: "8.8"
+      tags: [Test]
+      x-semantic-establishes:
+        kind: Widget
+        identifiedBy:
+          - { in: cookie, name: widgetId, semanticType: WidgetId }
+      responses:
+        '201':
+          description: Created.
+
+  # ── Invalid: requires shape lint ─────────────────────────────
+
+  # 7. Missing required `bind`.
+  /invalid/requires-missing-bind:
+    get:
+      operationId: requiresMissingBind
+      summary: Requires missing bind
+      description: Should fail semantic-requires-shape — missing bind.
+      x-added-in-version: "8.8"
+      tags: [Test]
+      x-semantic-requires:
+        kind: Widget
+      responses:
+        '200':
+          description: OK.
+
+  # ── Invalid: registry / cross-reference ──────────────────────
+
+  # 8. Establishes a kind not in the registry.
+  /invalid/unknown-establishes-kind:
+    post:
+      operationId: unknownEstablishesKind
+      summary: Unknown establishes kind
+      description: Should fail verify-semantic-kinds-registered.
+      x-added-in-version: "8.8"
+      tags: [Test]
+      x-semantic-establishes:
+        kind: Sprocket
+        identifiedBy:
+          - { in: body, name: sprocketId, semanticType: SprocketId }
+      responses:
+        '201':
+          description: Created.
+
+  # 9. Requires a kind not in the registry.
+  /invalid/unknown-requires-kind:
+    get:
+      operationId: unknownRequiresKind
+      summary: Unknown requires kind
+      description: Should fail verify-semantic-kinds-registered.
+      x-added-in-version: "8.8"
+      tags: [Test]
+      x-semantic-requires:
+        kind: Gizmo
+        bind:
+          gizmoId: { from: path, name: gizmoId }
+      responses:
+        '200':
+          description: OK.
+
+  # 10. Requires a kind that IS in the registry but is not established
+  #     anywhere in this spec — exercises the cross-reference check.
+  /invalid/orphan-requires:
+    get:
+      operationId: orphanRequires
+      summary: Orphan requires
+      description: Should fail verify-semantic-kinds-registered — kind in registry but never established here.
+      x-added-in-version: "8.8"
+      tags: [Test]
+      x-semantic-requires:
+        kind: OrphanedKind
+        bind:
+          orphanedId: { from: path, name: orphanedId }
+      responses:
+        '200':
+          description: OK.

--- a/zeebe/gateway-protocol/spectral-tests/helpers.js
+++ b/zeebe/gateway-protocol/spectral-tests/helpers.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { execSync } = require('node:child_process');
+const fs = require('node:fs');
 const path = require('node:path');
 
 const GATEWAY_PROTOCOL_DIR = path.resolve(__dirname, '..');
@@ -10,6 +11,11 @@ const FIXTURES_DIR = path.join(__dirname, 'fixtures');
 /**
  * Runs Spectral lint on a fixture's rest-api.yaml using the production ruleset.
  * Returns the parsed JSON results array.
+ *
+ * If the fixture directory contains a `semantic-kinds.json` file, it is
+ * exposed to the verifySemanticKindsRegistered function via the
+ * SPECTRAL_SEMANTIC_KINDS_REGISTRY env var so tests can use fixture-local
+ * kinds without polluting the production registry.
  */
 function lintFixture(fixtureName) {
   return lintFixtureFile(fixtureName, 'rest-api.yaml');
@@ -24,13 +30,21 @@ function lintFixture(fixtureName) {
  * Returns the parsed JSON results array.
  */
 function lintFixtureFile(fixtureName, fileName) {
-  const specFile = path.join(FIXTURES_DIR, fixtureName, fileName);
+  const fixtureDir = path.join(FIXTURES_DIR, fixtureName);
+  const specFile = path.join(fixtureDir, fileName);
   const cmd = `spectral lint "${specFile}" --ruleset "${RULESET_FILE}" --format json`;
+
+  const env = { ...process.env };
+  const fixtureRegistry = path.join(fixtureDir, 'semantic-kinds.json');
+  if (fs.existsSync(fixtureRegistry)) {
+    env.SPECTRAL_SEMANTIC_KINDS_REGISTRY = fixtureRegistry;
+  }
 
   try {
     const output = execSync(cmd, {
       encoding: 'utf8',
       cwd: GATEWAY_PROTOCOL_DIR,
+      env,
     });
     return output.trim() ? JSON.parse(output) : [];
   } catch (err) {

--- a/zeebe/gateway-protocol/spectral-tests/verifySemanticKindsRegistered.test.js
+++ b/zeebe/gateway-protocol/spectral-tests/verifySemanticKindsRegistered.test.js
@@ -1,0 +1,172 @@
+'use strict';
+
+const { describe, it, before } = require('node:test');
+const assert = require('node:assert/strict');
+const { lintFixture, filterByRule } = require('./helpers');
+
+const FIXTURE = 'semantic-establishes';
+const SHAPE_RULE = 'semantic-establishes-shape';
+const REQUIRES_SHAPE_RULE = 'semantic-requires-shape';
+const REGISTRY_RULE = 'verify-semantic-kinds-registered';
+
+describe('verifySemanticKindsRegistered + schema rules', () => {
+  let allResults;
+  let shapeViolations;
+  let requiresShapeViolations;
+  let registryViolations;
+
+  before(() => {
+    allResults = lintFixture(FIXTURE);
+    shapeViolations = filterByRule(allResults, SHAPE_RULE);
+    requiresShapeViolations = filterByRule(allResults, REQUIRES_SHAPE_RULE);
+    registryViolations = filterByRule(allResults, REGISTRY_RULE);
+  });
+
+  // ── Valid cases ──────────────────────────────────────────────
+
+  describe('valid: well-formed annotations matched to registry', () => {
+    it('produces no violations for createWidget (single-key entity establish)', () => {
+      const v = allResults.filter((e) => e.message.includes('createWidget'));
+      assert.equal(v.length, 0);
+    });
+
+    it('produces no violations for getWidget (matching consumer)', () => {
+      const v = allResults.filter(
+        (e) =>
+          e.message.includes('getWidget') &&
+          (e.code === SHAPE_RULE ||
+            e.code === REQUIRES_SHAPE_RULE ||
+            e.code === REGISTRY_RULE),
+      );
+      assert.equal(v.length, 0);
+    });
+
+    it('produces no violations for assignOwnerToWidget (edge establish)', () => {
+      const v = allResults.filter(
+        (e) =>
+          e.message.includes('assignOwnerToWidget') &&
+          (e.code === SHAPE_RULE ||
+            e.code === REQUIRES_SHAPE_RULE ||
+            e.code === REGISTRY_RULE),
+      );
+      assert.equal(v.length, 0);
+    });
+
+    it('produces no violations for searchOwnersForWidget (edge consumer binding partial tuple)', () => {
+      const v = allResults.filter(
+        (e) =>
+          e.message.includes('searchOwnersForWidget') &&
+          (e.code === SHAPE_RULE ||
+            e.code === REQUIRES_SHAPE_RULE ||
+            e.code === REGISTRY_RULE),
+      );
+      assert.equal(v.length, 0);
+    });
+  });
+
+  // ── Shape lint: x-semantic-establishes ───────────────────────
+
+  describe('semantic-establishes-shape', () => {
+    function violationsForPath(seg) {
+      return shapeViolations.filter(
+        (v) => Array.isArray(v.path) && v.path.includes(seg),
+      );
+    }
+
+    it('flags missing required `kind`', () => {
+      assert.ok(violationsForPath('/invalid/missing-kind').length >= 1);
+    });
+
+    it('flags `kind` violating PascalCase pattern', () => {
+      assert.ok(violationsForPath('/invalid/bad-kind-case').length >= 1);
+    });
+
+    it('flags typo on a top-level key (additionalProperties: false)', () => {
+      assert.ok(violationsForPath('/invalid/typoed-key').length >= 1);
+    });
+
+    it('flags bad `shape` enum value', () => {
+      assert.ok(violationsForPath('/invalid/bad-shape-enum').length >= 1);
+    });
+
+    it('flags empty `identifiedBy` array', () => {
+      assert.ok(violationsForPath('/invalid/empty-identified-by').length >= 1);
+    });
+
+    it('flags identifiedBy item with bad `in` enum value', () => {
+      assert.ok(
+        violationsForPath('/invalid/identified-by-bad-in').length >= 1,
+      );
+    });
+  });
+
+  // ── Shape lint: x-semantic-requires ──────────────────────────
+
+  describe('semantic-requires-shape', () => {
+    it('flags missing required `bind`', () => {
+      const v = requiresShapeViolations.filter(
+        (e) => Array.isArray(e.path) && e.path.includes('/invalid/requires-missing-bind'),
+      );
+      assert.ok(v.length >= 1);
+    });
+  });
+
+  // ── Registry / cross-reference ───────────────────────────────
+
+  describe('verify-semantic-kinds-registered', () => {
+    it('flags an `establishes` kind not in the registry', () => {
+      const v = registryViolations.filter((e) =>
+        e.message.includes("Unknown semantic kind 'Sprocket'"),
+      );
+      assert.equal(v.length, 1);
+      assert.match(v[0].message, /x-semantic-establishes/);
+    });
+
+    it('flags a `requires` kind not in the registry', () => {
+      const v = registryViolations.filter((e) =>
+        e.message.includes("Unknown semantic kind 'Gizmo'"),
+      );
+      assert.equal(v.length, 1);
+      assert.match(v[0].message, /x-semantic-requires/);
+    });
+
+    it('flags a `requires` kind that is registered but never established', () => {
+      const v = registryViolations.filter((e) =>
+        e.message.includes("Semantic kind 'OrphanedKind'"),
+      );
+      assert.equal(v.length, 1);
+      assert.match(v[0].message, /no operation establishes it/);
+    });
+
+    it('does not double-report an unknown kind as an orphan', () => {
+      // Sprocket and Gizmo are unknown — they get the registry message, not
+      // the orphan message.
+      const sprocketOrphan = registryViolations.filter(
+        (e) =>
+          e.message.includes('Sprocket') &&
+          e.message.includes('no operation establishes it'),
+      );
+      const gizmoOrphan = registryViolations.filter(
+        (e) =>
+          e.message.includes('Gizmo') &&
+          e.message.includes('no operation establishes it'),
+      );
+      assert.equal(sprocketOrphan.length, 0);
+      assert.equal(gizmoOrphan.length, 0);
+    });
+
+    it('does not flag the valid Widget consumer (Widget is established by createWidget)', () => {
+      const v = registryViolations.filter((e) =>
+        e.message.includes("Semantic kind 'Widget'"),
+      );
+      assert.equal(v.length, 0);
+    });
+
+    it('does not flag the valid WidgetOwnership consumer (established by assignOwnerToWidget)', () => {
+      const v = registryViolations.filter((e) =>
+        e.message.includes("Semantic kind 'WidgetOwnership'"),
+      );
+      assert.equal(v.length, 0);
+    });
+  });
+});

--- a/zeebe/gateway-protocol/spectral-tests/verifySemanticKindsRegistered.test.js
+++ b/zeebe/gateway-protocol/spectral-tests/verifySemanticKindsRegistered.test.js
@@ -2,7 +2,7 @@
 
 const { describe, it, before } = require('node:test');
 const assert = require('node:assert/strict');
-const { lintFixture, filterByRule } = require('./helpers');
+const { lintFixture, lintFixtureFile, filterByRule } = require('./helpers');
 
 const FIXTURE = 'semantic-establishes';
 const SHAPE_RULE = 'semantic-establishes-shape';
@@ -218,5 +218,46 @@ describe('verifySemanticKindsRegistered + schema rules', () => {
       );
       assert.equal(v.length, 0, JSON.stringify(v, null, 2));
     });
+  });
+});
+
+// ── Per-file lint pass: cross-reference must be skipped on sub-files ──
+//
+// CI runs spectral twice (see camunda/camunda#46274) — once on the bundled
+// rest-api.yaml root and once with a per-file glob over each domain YAML.
+// Sub-files like tenants.yaml only carry their own paths, so an edge whose
+// producer lives in a sibling file (e.g. assignUserToTenant deriving User
+// from Username, with createUser in users.yaml) used to false-positive
+// here. The verifier now gates the cross-reference walk on the document
+// having `openapi:` at root — sub-files don't, so the check is suppressed.
+// The per-operation registry-membership checks above still fire correctly
+// per-file.
+//
+// Regression for camunda/camunda#52308 (PR check failure on
+// "Semantic kind 'User' is required ... but no operation establishes it"
+// when linting tenants.yaml in isolation).
+
+describe('verifySemanticKindsRegistered: per-file lint pass on sub-files', () => {
+  let subfileResults;
+  let subfileRegistryViolations;
+
+  before(() => {
+    subfileResults = lintFixtureFile(FIXTURE, 'subfile-no-openapi.yaml');
+    subfileRegistryViolations = filterByRule(subfileResults, REGISTRY_RULE);
+  });
+
+  it('does not raise a cross-reference orphan for an entity established only in a sibling file', () => {
+    // The sub-file's edge resolves to Widget (via WidgetId) and User (via
+    // Username). Both producers (createWidget, createUser) live in the
+    // sibling widgets.yaml. Per-file linting must not flag either as
+    // orphaned — that's the bundled-pass's job.
+    const orphans = subfileRegistryViolations.filter((e) =>
+      e.message.includes('no operation establishes it'),
+    );
+    assert.equal(
+      orphans.length,
+      0,
+      JSON.stringify(subfileRegistryViolations, null, 2),
+    );
   });
 });

--- a/zeebe/gateway-protocol/spectral-tests/verifySemanticKindsRegistered.test.js
+++ b/zeebe/gateway-protocol/spectral-tests/verifySemanticKindsRegistered.test.js
@@ -168,5 +168,55 @@ describe('verifySemanticKindsRegistered + schema rules', () => {
       );
       assert.equal(v.length, 0);
     });
+
+    it('does not flag the valid edge endpoints Widget and User (both established in fixture)', () => {
+      // assignOwnerToWidget's identifiedBy contains WidgetId (→ Widget) and
+      // Username (→ User). Both entities are established by createWidget /
+      // createUser, so the derived-requires check must not fire on the
+      // valid edge.
+      const v = registryViolations.filter(
+        (e) =>
+          e.message.includes('assignOwnerToWidget') ||
+          e.message.includes('/valid/widgets/{widgetId}/owners/{username}'),
+      );
+      assert.equal(v.length, 0, JSON.stringify(v, null, 2));
+    });
+  });
+
+  // ── Edge endpoint resolution + derived requires ──────────────
+
+  describe('verify-semantic-kinds-registered: edge derived requires', () => {
+    it('flags an edge identifiedBy.semanticType that no entity owns', () => {
+      const v = registryViolations.filter((e) =>
+        e.message.includes("Edge endpoint semanticType 'MysteryId'"),
+      );
+      assert.equal(v.length, 1, JSON.stringify(registryViolations, null, 2));
+      assert.match(v[0].message, /assignMysteryToWidget|\/invalid\/widgets\/\{widgetId\}\/mystery/);
+    });
+
+    it('flags a derived requires kind that is registered but never established', () => {
+      // assignFrobToWidget's identifiedBy includes FrobId, the registry
+      // declares Frob.identifiers = ["FrobId"], but nothing in the fixture
+      // establishes Frob.
+      const v = registryViolations.filter(
+        (e) =>
+          e.message.includes("Semantic kind 'Frob'") &&
+          e.message.includes('derived from x-semantic-establishes.identifiedBy'),
+      );
+      assert.equal(v.length, 1, JSON.stringify(registryViolations, null, 2));
+      assert.match(v[0].message, /no operation establishes it/);
+      assert.match(v[0].message, /FrobId/);
+    });
+
+    it('does not flag a resolved-but-established endpoint as orphan (regression: WidgetId resolves to Widget which createWidget establishes)', () => {
+      // Both invalid edge fixtures have WidgetId in their identifiedBy.
+      // Widget IS established → no orphan errors for Widget.
+      const v = registryViolations.filter(
+        (e) =>
+          e.message.includes("Semantic kind 'Widget'") &&
+          e.message.includes('derived from'),
+      );
+      assert.equal(v.length, 0, JSON.stringify(v, null, 2));
+    });
   });
 });

--- a/zeebe/gateway-protocol/src/main/proto/v2/semantic-kinds.json
+++ b/zeebe/gateway-protocol/src/main/proto/v2/semantic-kinds.json
@@ -1,0 +1,19 @@
+{
+  "$comment": [
+    "Registry of semantic kinds used by `x-semantic-establishes` and",
+    "`x-semantic-requires` (see camunda/camunda#52272).",
+    "",
+    "Every value used as the `kind:` field of either annotation must appear",
+    "in the `kinds` array below. The Spectral rule",
+    "`verify-semantic-kinds-registered` enforces this.",
+    "",
+    "Adding a new entry: PR with the new kind plus the producer (and at least",
+    "one consumer) operation that uses it. Reviewer checks the kind name is",
+    "PascalCase, singular, and a noun (not a verb phrase).",
+    "",
+    "`shape` is the default `shape:` an operation should declare on",
+    "`x-semantic-establishes`. `entity` (single- or composite-key) means a",
+    "fetchable singleton; `edge` means observable only via member-list search."
+  ],
+  "kinds": []
+}

--- a/zeebe/gateway-protocol/src/main/proto/v2/semantic-kinds.json
+++ b/zeebe/gateway-protocol/src/main/proto/v2/semantic-kinds.json
@@ -13,7 +13,19 @@
     "",
     "`shape` is the default `shape:` an operation should declare on",
     "`x-semantic-establishes`. `entity` (single- or composite-key) means a",
-    "fetchable singleton; `edge` means observable only via member-list search."
+    "fetchable singleton; `edge` means observable only via member-list search.",
+    "",
+    "`identifiers` (entity kinds only) lists the semantic identifier types",
+    "that identify the entity (matching the `semanticType` values used in",
+    "`x-semantic-establishes.identifiedBy`). Edge operations whose",
+    "`identifiedBy` references one of these types implicitly require the",
+    "owning entity — the planner derives this rather than asking authors to",
+    "redundantly declare both `establishes: edge` and a sibling `requires`",
+    "for each endpoint. The Spectral rule rejects any edge whose",
+    "`identifiedBy` semanticType is not declared as the identifier of",
+    "exactly one registered entity, and the cross-reference check then",
+    "verifies the resolved endpoint kinds are actually established somewhere",
+    "in the spec."
   ],
   "kinds": []
 }


### PR DESCRIPTION
> ### Stack (merge bottom-up)
>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
> 13. #52316 — `ClusterVariableName` promoted to `identifiers.yaml`; 6 path-schema sites repointed
> 14. #52317 — GlobalClusterVariable + TenantClusterVariable registry entries; 7 cluster-variable CRUD annotations
> 15. #52318 — `name` allOf lifts in `cluster-variables.yaml`
> 16. #52319 — `ClientId` promoted to `identifiers.yaml`; 6 path-schema sites repointed (no semantic-edge stack — see PR description)
> 17. #52321 — Registry: `shape: external-entity` for identifiers minted outside the Camunda API; `Client` registered (refs #52320)
> 18. #52322 — `x-semantic-provider` coverage for the four genuinely unaddressed rows in #52169 (`GlobalTaskListenerResult.id`, `ProcessElementStatisticsResult.elementId`, `DeleteResourceResponse.resourceKey`)
>
> Refs #52272.

>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
> 13. #52316 — `ClusterVariableName` promoted to `identifiers.yaml`; 6 path-schema sites repointed
> 14. #52317 — GlobalClusterVariable + TenantClusterVariable registry entries; 7 cluster-variable CRUD annotations
> 15. #52318 — `name` allOf lifts in `cluster-variables.yaml`
> 16. #52319 — `ClientId` promoted to `identifiers.yaml`; 6 path-schema sites repointed (no semantic-edge stack — see PR description)
> 17. #52321 — Registry: `shape: external-entity` for identifiers minted outside the Camunda API; `Client` registered (refs #52320)
>
> Refs #52272.

>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
> 13. #52316 — `ClusterVariableName` promoted to `identifiers.yaml`; 6 path-schema sites repointed
> 14. #52317 — GlobalClusterVariable + TenantClusterVariable registry entries; 7 cluster-variable CRUD annotations
> 15. #52318 — `name` allOf lifts in `cluster-variables.yaml`
> 16. #52319 — `ClientId` promoted to `identifiers.yaml`; 6 path-schema sites repointed (no semantic-edge stack — see PR description)
>
> Refs #52272.
>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
> 13. #52316 — `ClusterVariableName` promoted to `identifiers.yaml`; 6 path-schema sites repointed
> 14. #52317 — GlobalClusterVariable + TenantClusterVariable registry entries; 7 cluster-variable CRUD annotations
> 15. #52318 — `name` allOf lifts in `cluster-variables.yaml`
>
> Refs #52272.
>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
>
> Refs #52272.

>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
>
> Refs #52272.

>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
>
> Refs #52272.

>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
>
> Refs #52272.

## Summary

Adds the lint scaffolding for the proposed OpenAPI extensions tracked in #52272 — `x-semantic-establishes` (producer) and `x-semantic-requires` (consumer) — **ahead of annotating any operations**. This PR ships the validation rails so that subsequent annotation PRs land with type-safety, not after.

Three rules in `zeebe/gateway-protocol/.spectral.yaml`:

| Rule | Engine | What it catches |
|---|---|---|
| `semantic-establishes-shape` | built-in `schema` | Missing/typo'd top-level keys (`additionalProperties: false`), non-PascalCase `kind`, bad `shape` enum, malformed `identifiedBy` tuple items, bad `in` enum values. |
| `semantic-requires-shape` | built-in `schema` | Same treatment for the consumer annotation. |
| `verify-semantic-kinds-registered` | custom function (`verifySemanticKindsRegistered.js`) | (a) Every `kind:` referenced anywhere must appear in `src/main/proto/v2/semantic-kinds.json` — catches typos at the point of declaration. (b) Every kind required by a consumer must be established somewhere in the spec — catches consumer/producer mismatches. |

The orphan check in the other direction (`establishes` with no consumer) is intentionally **not** enforced — many producers are useful without a consumer (setup/admin operations, etc.).

## Why these specific guards

`x-semantic-establishes` and `x-semantic-requires` use a free-form `kind:` string as the join key. Without a registry, a single typo (`Roel` vs `Role`) produces a silently broken chain that no schema validator can catch — both ends parse fine in isolation. The registry is the spell-check dictionary; the cross-reference check is the integrity constraint.

## Registry format

JSON, not YAML, because Spectral's function sandbox doesn't expose `__dirname` and bundles js-yaml only as a private dep. Keeping the format JSON means zero runtime dependency on top of what Spectral already ships. Kinds are listed as `{ name, shape, description }` objects; the lint only inspects `name`.

Production registry seeded **empty** — kinds will land alongside the operations that establish them. Production lint runs byte-identical (no annotations present yet, so the rules report nothing).

## Test approach

Modeled on the existing `verifyAddedInVersion` fixture. 17 new tests covering:

- 4 valid cases (single-key entity, edge, matching consumers).
- 6 shape-lint failures on `x-semantic-establishes` (missing `kind`, bad case, typo'd key, bad `shape` enum, empty `identifiedBy`, bad `in`).
- 1 shape-lint failure on `x-semantic-requires` (missing `bind`).
- 6 registry / cross-reference failures (unknown `establishes` kind, unknown `requires` kind, orphan `requires`, plus three negative assertions that the function doesn't false-fire on the valid cases or double-report unknown kinds as orphans).

Tests use a fixture-local `semantic-kinds.json` exposed to the function via the `SPECTRAL_SEMANTIC_KINDS_REGISTRY` env var (auto-set by `helpers.js` when the fixture contains the file). This avoids polluting the production registry with test kinds (`Widget`, `WidgetOwnership`, `OrphanedKind`).

Run with `node --test spectral-tests/*.test.js` — all 75 tests (58 pre-existing + 17 new) pass. Production structural and file-level lint passes both run clean (exit 0; only the documented Unicode-regex warnings remain).

## Out of scope (tracked under #52272)

- Annotating any actual operations with the new extensions.
- Promoting `RoleId`, `TenantId`, `GroupId`, `Username`, `MappingRuleId`, `GlobalListenerId`, `ClusterVariableName` to component schemas with `x-semantic-type`.
- The `camunda-schema-bundler` change to surface `kind`/`identifiedBy`/`bind` in `spec-metadata.json` for downstream tools.
- Editor auto-complete via JSON Schema modeline.

These each become their own PR once this lands and the design in #52272 is signed off.

## Refs

- Closes nothing yet (the umbrella issue stays open).
- Refs camunda/camunda#52272