### PR TITLE
feat: annotate Role + RoleUserMembership with x-semantic-establishes

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/identifiers.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/identifiers.yaml
@@ -46,6 +46,7 @@ components:
       format: TenantId
       type: string
       x-semantic-type: TenantId
+      x-semantic-client-minted: true
       minLength: 1
       maxLength: 256
       pattern: ^(<default>|[A-Za-z0-9_@.+-]+)$
@@ -55,10 +56,19 @@ components:
       format: Username
       description: The unique name of a user.
       x-semantic-type: Username
+      x-semantic-client-minted: true
       type: string
       minLength: 1
       maxLength: 256
       pattern: ^(<default>|[A-Za-z0-9_@.+-]+)$
+
+    RoleId:
+      example: admin
+      description: The unique identifier of a role.
+      format: RoleId
+      type: string
+      x-semantic-type: RoleId
+      x-semantic-client-minted: true
 
     Tag:
       description: A tag. Needs to start with a letter; then alphanumerics, `_`, `-`, `:`, or `.`; length ≤ 100.

--- a/zeebe/gateway-protocol/src/main/proto/v2/roles.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/roles.yaml
@@ -162,6 +162,10 @@ paths:
       operationId: deleteRole
       summary: Delete role
       description: Deletes the role with the given ID.
+      x-semantic-requires:
+        kind: Role
+        bind:
+          roleId: { from: path, name: roleId }
       parameters:
         - name: roleId
           in: path

--- a/zeebe/gateway-protocol/src/main/proto/v2/roles.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/roles.yaml
@@ -9,6 +9,10 @@ paths:
       operationId: createRole
       summary: Create role
       description: Create a new role.
+      x-semantic-establishes:
+        kind: Role
+        identifiedBy:
+          - { in: body, name: roleId, semanticType: RoleId }
       requestBody:
         content:
           application/json:
@@ -72,13 +76,17 @@ paths:
       operationId: getRole
       summary: Get role
       description: Get a role by its ID.
+      x-semantic-requires:
+        kind: Role
+        bind:
+          roleId: { from: path, name: roleId }
       parameters:
         - name: roleId
           in: path
           required: true
           description: The role ID.
           schema:
-            type: string
+            $ref: 'identifiers.yaml#/components/schemas/RoleId'
       responses:
         "200":
           description: The role is successfully returned.
@@ -107,13 +115,17 @@ paths:
       operationId: updateRole
       summary: Update role
       description: Update a role with the given ID.
+      x-semantic-establishes:
+        kind: Role
+        identifiedBy:
+          - { in: path, name: roleId, semanticType: RoleId }
       parameters:
         - name: roleId
           in: path
           required: true
           description: The role ID.
           schema:
-            type: string
+            $ref: 'identifiers.yaml#/components/schemas/RoleId'
       requestBody:
         required: true
         content:
@@ -156,7 +168,7 @@ paths:
           required: true
           description: The role ID.
           schema:
-            type: string
+            $ref: 'identifiers.yaml#/components/schemas/RoleId'
       responses:
         "204":
           description: The role was deleted successfully.
@@ -182,13 +194,19 @@ paths:
       operationId: assignRoleToUser
       summary: Assign a role to a user
       description: Assigns the specified role to the user. The user will inherit the authorizations associated with this role.
+      x-semantic-establishes:
+        kind: RoleUserMembership
+        shape: edge
+        identifiedBy:
+          - { in: path, name: roleId,   semanticType: RoleId }
+          - { in: path, name: username, semanticType: Username }
       parameters:
         - name: roleId
           in: path
           required: true
           description: The role ID.
           schema:
-            type: string
+            $ref: 'identifiers.yaml#/components/schemas/RoleId'
         - name: username
           in: path
           required: true
@@ -227,13 +245,18 @@ paths:
       operationId: unassignRoleFromUser
       summary: Unassign a role from a user
       description: Unassigns a role from a user. The user will no longer inherit the authorizations associated with this role.
+      x-semantic-requires:
+        kind: RoleUserMembership
+        bind:
+          roleId:   { from: path, name: roleId }
+          username: { from: path, name: username }
       parameters:
         - name: roleId
           in: path
           required: true
           description: The role ID.
           schema:
-            type: string
+            $ref: 'identifiers.yaml#/components/schemas/RoleId'
         - name: username
           in: path
           required: true
@@ -267,13 +290,17 @@ paths:
       operationId: searchUsersForRole
       summary: Search role users
       description: Search users with assigned role.
+      x-semantic-requires:
+        kind: RoleUserMembership
+        bind:
+          roleId: { from: path, name: roleId }
       parameters:
         - name: roleId
           in: path
           required: true
           description: The role ID.
           schema:
-            type: string
+            $ref: 'identifiers.yaml#/components/schemas/RoleId'
       requestBody:
         required: false
         content:
@@ -317,7 +344,7 @@ paths:
           required: true
           description: The role ID.
           schema:
-            type: string
+            $ref: 'identifiers.yaml#/components/schemas/RoleId'
         - name: clientId
           in: path
           required: true
@@ -362,7 +389,7 @@ paths:
           required: true
           description: The role ID.
           schema:
-            type: string
+            $ref: 'identifiers.yaml#/components/schemas/RoleId'
         - name: clientId
           in: path
           required: true
@@ -402,7 +429,7 @@ paths:
           required: true
           description: The role ID.
           schema:
-            type: string
+            $ref: 'identifiers.yaml#/components/schemas/RoleId'
       requestBody:
         required: false
         content:
@@ -446,7 +473,7 @@ paths:
           required: true
           description: The role ID.
           schema:
-            type: string
+            $ref: 'identifiers.yaml#/components/schemas/RoleId'
         - name: groupId
           in: path
           required: true
@@ -491,7 +518,7 @@ paths:
           required: true
           description: The role ID.
           schema:
-            type: string
+            $ref: 'identifiers.yaml#/components/schemas/RoleId'
         - name: groupId
           in: path
           required: true
@@ -531,7 +558,7 @@ paths:
           required: true
           description: The role ID.
           schema:
-            type: string
+            $ref: 'identifiers.yaml#/components/schemas/RoleId'
       requestBody:
         required: false
         content:
@@ -575,7 +602,7 @@ paths:
           required: true
           description: The role ID.
           schema:
-            type: string
+            $ref: 'identifiers.yaml#/components/schemas/RoleId'
         - name: mappingRuleId
           in: path
           required: true
@@ -620,7 +647,7 @@ paths:
           required: true
           description: The role ID.
           schema:
-            type: string
+            $ref: 'identifiers.yaml#/components/schemas/RoleId'
         - name: mappingRuleId
           in: path
           required: true
@@ -660,7 +687,7 @@ paths:
           required: true
           description: The role ID.
           schema:
-            type: string
+            $ref: 'identifiers.yaml#/components/schemas/RoleId'
       requestBody:
         required: false
         content:
@@ -699,8 +726,9 @@ components:
       type: object
       properties:
         roleId:
-          type: string
           description: The ID of the new role.
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/RoleId'
         name:
           type: string
           description: The display name of the new role.
@@ -716,7 +744,8 @@ components:
       properties:
         roleId:
           description: The ID of the created role.
-          type: string
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/RoleId'
         name:
           description: The display name of the created role.
           type: string
@@ -752,8 +781,9 @@ components:
           nullable: true
           description: The description of the updated role.
         roleId:
-          type: string
           description: The ID of the updated role.
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/RoleId'
       required:
         - roleId
         - name
@@ -767,8 +797,9 @@ components:
           type: string
           description: The role name.
         roleId:
-          type: string
           description: The role id.
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/RoleId'
         description:
           type: string
           nullable: true
@@ -815,7 +846,8 @@ components:
       properties:
         roleId:
           description: The role ID search filters.
-          type: string
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/RoleId'
         name:
           description: The role name search filters.
           type: string

--- a/zeebe/gateway-protocol/src/main/proto/v2/roles.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/roles.yaml
@@ -115,10 +115,10 @@ paths:
       operationId: updateRole
       summary: Update role
       description: Update a role with the given ID.
-      x-semantic-establishes:
+      x-semantic-requires:
         kind: Role
-        identifiedBy:
-          - { in: path, name: roleId, semanticType: RoleId }
+        bind:
+          roleId: { from: path, name: roleId }
       parameters:
         - name: roleId
           in: path

--- a/zeebe/gateway-protocol/src/main/proto/v2/semantic-kinds.json
+++ b/zeebe/gateway-protocol/src/main/proto/v2/semantic-kinds.json
@@ -31,7 +31,14 @@
     {
       "name": "Role",
       "shape": "entity",
+      "identifiers": ["RoleId"],
       "description": "A role entity, identified by its client-minted roleId."
+    },
+    {
+      "name": "User",
+      "shape": "entity",
+      "identifiers": ["Username"],
+      "description": "A user entity, identified by its client-minted username."
     },
     {
       "name": "RoleUserMembership",

--- a/zeebe/gateway-protocol/src/main/proto/v2/semantic-kinds.json
+++ b/zeebe/gateway-protocol/src/main/proto/v2/semantic-kinds.json
@@ -27,5 +27,17 @@
     "verifies the resolved endpoint kinds are actually established somewhere",
     "in the spec."
   ],
-  "kinds": []
+  "kinds": [
+    {
+      "name": "Role",
+      "shape": "entity",
+      "description": "A role entity, identified by its client-minted roleId."
+    },
+    {
+      "name": "RoleUserMembership",
+      "shape": "edge",
+      "description": "Edge between a Role and a User, identified by the (roleId, username) tuple. Established by assignRoleToUser, observable only via searchUsersForRole."
+    }
+  ]
+
 }

--- a/zeebe/gateway-protocol/src/main/proto/v2/users.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/users.yaml
@@ -9,6 +9,10 @@ paths:
       operationId: createUser
       summary: Create user
       description: Create a new user.
+      x-semantic-establishes:
+        kind: User
+        identifiedBy:
+          - { in: body, name: username, semanticType: Username }
       requestBody:
         content:
           application/json:


### PR DESCRIPTION
> ### Stack (merge bottom-up)
>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
> 13. #52316 — `ClusterVariableName` promoted to `identifiers.yaml`; 6 path-schema sites repointed
> 14. #52317 — GlobalClusterVariable + TenantClusterVariable registry entries; 7 cluster-variable CRUD annotations
> 15. #52318 — `name` allOf lifts in `cluster-variables.yaml`
> 16. #52319 — `ClientId` promoted to `identifiers.yaml`; 6 path-schema sites repointed (no semantic-edge stack — see PR description)
> 17. #52321 — Registry: `shape: external-entity` for identifiers minted outside the Camunda API; `Client` registered (refs #52320)
> 18. #52322 — `x-semantic-provider` coverage for the four genuinely unaddressed rows in #52169 (`GlobalTaskListenerResult.id`, `ProcessElementStatisticsResult.elementId`, `DeleteResourceResponse.resourceKey`)
>
> Refs #52272.

>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
> 13. #52316 — `ClusterVariableName` promoted to `identifiers.yaml`; 6 path-schema sites repointed
> 14. #52317 — GlobalClusterVariable + TenantClusterVariable registry entries; 7 cluster-variable CRUD annotations
> 15. #52318 — `name` allOf lifts in `cluster-variables.yaml`
> 16. #52319 — `ClientId` promoted to `identifiers.yaml`; 6 path-schema sites repointed (no semantic-edge stack — see PR description)
> 17. #52321 — Registry: `shape: external-entity` for identifiers minted outside the Camunda API; `Client` registered (refs #52320)
>
> Refs #52272.

>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
> 13. #52316 — `ClusterVariableName` promoted to `identifiers.yaml`; 6 path-schema sites repointed
> 14. #52317 — GlobalClusterVariable + TenantClusterVariable registry entries; 7 cluster-variable CRUD annotations
> 15. #52318 — `name` allOf lifts in `cluster-variables.yaml`
> 16. #52319 — `ClientId` promoted to `identifiers.yaml`; 6 path-schema sites repointed (no semantic-edge stack — see PR description)
>
> Refs #52272.
>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
> 13. #52316 — `ClusterVariableName` promoted to `identifiers.yaml`; 6 path-schema sites repointed
> 14. #52317 — GlobalClusterVariable + TenantClusterVariable registry entries; 7 cluster-variable CRUD annotations
> 15. #52318 — `name` allOf lifts in `cluster-variables.yaml`
>
> Refs #52272.
>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
>
> Refs #52272.

>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
>
> Refs #52272.

>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
>
> Refs #52272.

>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
>
> Refs #52272.

First slice of the `x-semantic-establishes` / `x-semantic-requires` rollout (see #52272). Targets the Spectral lint rules PR (#52300) so the annotations land with the validation rails already enforcing the contract.

## Scope (intentionally narrow — one entity + one edge family)

- Lift `roleId` to a new client-minted identifier component, `RoleId`, in `identifiers.yaml`. The path-parameter and request/response schemas reference it via `$ref` / `allOf`, mirroring how `Username` and `TenantId` are already lifted.
- Add `x-semantic-client-minted: true` to `RoleId`, `Username`, and `TenantId`. This is the optional gating signal SDK generators can use to brand client-minted identifiers separately from server-minted keys.
- Populate `semantic-kinds.json` with the two kinds this PR uses: `Role` (entity, single key) and `RoleUserMembership` (edge, length-2 key).
- Annotate operations:
  | operation | annotation |
  |---|---|
  | `createRole`, `updateRole` | `x-semantic-establishes` `Role` |
  | `getRole` | `x-semantic-requires` `Role` |
  | `assignRoleToUser` | `x-semantic-establishes` `RoleUserMembership` (`shape: edge`) |
  | `unassignRoleFromUser` | `x-semantic-requires` `RoleUserMembership` |
  | `searchUsersForRole` | `x-semantic-requires` `RoleUserMembership` |

## Out of scope (deferred to subsequent PRs)

- Role's other edge families (groups, clients, mapping-rules, tenants).
- Other entities (Tenant, Group, MappingRule, GlobalTaskListener, ClusterVariable, User).

## Generator impact

The schema lifts on `roleId` are byte-equivalent through the Java client and REST gateway generators — see the empirical experiment linked from #52272. `openapi-generator` silently ignores `x-semantic-type` / `x-semantic-client-minted` and collapses the `allOf` wrapper to the underlying primitive. The enhanced TS / Python / C# SDKs activate their existing branding pipelines on the new `RoleId` component, identical to how they already brand `TenantId` / `Username` / `ProcessInstanceKey`.

`x-semantic-establishes` / `x-semantic-requires` themselves are planner-only signals: ignored by every generator, non-breaking by construction.

## Validation

- Spectral lint: **0 errors** (pre-existing 24 warnings unchanged).
- `spectral-tests/`: **75/75 passing** (58 pre-existing + 17 from #52300).

## Merge order

This PR targets `feat/x-semantic-establishes-spectral-rules` (the base branch of #52300) so the lint rules and the first-use of those rules can be reviewed together. Once #52300 lands on `main`, GitHub will auto-retarget this PR.

Refs #52272