### PR TITLE
feat: lift Username in user schemas via allOf + per-site description

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/users.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/users.yaml
@@ -196,8 +196,9 @@ components:
           description: The password of the user.
           type: string
         username:
-          description: The username of the user.
-          type: string
+          description: The username of the new user.
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/Username'
         name:
           description: The name of the user.
           type: string
@@ -214,7 +215,9 @@ components:
         - username
       properties:
         username:
-          $ref: 'identifiers.yaml#/components/schemas/Username'
+          description: The username of the created user.
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/Username'
         name:
           description: The name of the user.
           nullable: true
@@ -245,7 +248,9 @@ components:
       type: object
       properties:
         username:
-          $ref: 'identifiers.yaml#/components/schemas/Username'
+          description: The username of the updated user.
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/Username'
         name:
           description: The name of the user.
           nullable: true
@@ -263,7 +268,9 @@ components:
       type: object
       properties:
         username:
-          $ref: 'identifiers.yaml#/components/schemas/Username'
+          description: The user username.
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/Username'
         name:
           description: The name of the user.
           nullable: true


### PR DESCRIPTION
> ### Stack (merge bottom-up)
>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
> 13. #52316 — `ClusterVariableName` promoted to `identifiers.yaml`; 6 path-schema sites repointed
> 14. #52317 — GlobalClusterVariable + TenantClusterVariable registry entries; 7 cluster-variable CRUD annotations
> 15. #52318 — `name` allOf lifts in `cluster-variables.yaml`
> 16. #52319 — `ClientId` promoted to `identifiers.yaml`; 6 path-schema sites repointed (no semantic-edge stack — see PR description)
> 17. #52321 — Registry: `shape: external-entity` for identifiers minted outside the Camunda API; `Client` registered (refs #52320)
> 18. #52322 — `x-semantic-provider` coverage for the four genuinely unaddressed rows in #52169 (`GlobalTaskListenerResult.id`, `ProcessElementStatisticsResult.elementId`, `DeleteResourceResponse.resourceKey`)
>
> Refs #52272.

>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
> 13. #52316 — `ClusterVariableName` promoted to `identifiers.yaml`; 6 path-schema sites repointed
> 14. #52317 — GlobalClusterVariable + TenantClusterVariable registry entries; 7 cluster-variable CRUD annotations
> 15. #52318 — `name` allOf lifts in `cluster-variables.yaml`
> 16. #52319 — `ClientId` promoted to `identifiers.yaml`; 6 path-schema sites repointed (no semantic-edge stack — see PR description)
> 17. #52321 — Registry: `shape: external-entity` for identifiers minted outside the Camunda API; `Client` registered (refs #52320)
>
> Refs #52272.

>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
> 13. #52316 — `ClusterVariableName` promoted to `identifiers.yaml`; 6 path-schema sites repointed
> 14. #52317 — GlobalClusterVariable + TenantClusterVariable registry entries; 7 cluster-variable CRUD annotations
> 15. #52318 — `name` allOf lifts in `cluster-variables.yaml`
> 16. #52319 — `ClientId` promoted to `identifiers.yaml`; 6 path-schema sites repointed (no semantic-edge stack — see PR description)
>
> Refs #52272.
>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
> 13. #52316 — `ClusterVariableName` promoted to `identifiers.yaml`; 6 path-schema sites repointed
> 14. #52317 — GlobalClusterVariable + TenantClusterVariable registry entries; 7 cluster-variable CRUD annotations
> 15. #52318 — `name` allOf lifts in `cluster-variables.yaml`
>
> Refs #52272.
>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
>
> Refs #52272.

>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
>
> Refs #52272.

>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
>
> Refs #52272.

>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
>
> Refs #52272.

Stacks on top of #52301 (which establishes the User entity and its identifier registry).

Mirrors the lift pattern already applied to `roleId` in `roles.yaml` — the four user schema sites that reference the `Username` component now wrap the `$ref` in an `allOf` so they can carry a site-specific description without falling foul of OpenAPI 3.0's "siblings of $ref are ignored" rule.

Sites changed in `users.yaml`:

| Schema | Before | After |
|---|---|---|
| `UserRequest.username` | inline `type: string` + description | `allOf` `$ref Username` + description |
| `UserCreateResult.username` | bare `$ref` (no description) | `allOf` + "The username of the created user." |
| `UserUpdateResult.username` | bare `$ref` (no description) | `allOf` + "The username of the updated user." |
| `UserResult.username` | bare `$ref` (no description) | `allOf` + "The user username." |

Byte-equivalent for openapi-generator output (`allOf` with a single `$ref` collapses to the referenced schema). Brings `users.yaml` in line with `roles.yaml`, where every `roleId` site already uses this shape.

`UserFilter.username` already wraps `allOf` around `StringFilterProperty` for a different reason and is left alone.

`Username` in `identifiers.yaml` already carries `x-semantic-client-minted: true` from an earlier commit — no identifiers change needed.

Spectral lint clean (0 errors, 24 pre-existing warnings unrelated).

Refs #52272