### PR TITLE
feat: register Tenant entity and annotate tenant operations

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/semantic-kinds.json
+++ b/zeebe/gateway-protocol/src/main/proto/v2/semantic-kinds.json
@@ -44,6 +44,17 @@
       "name": "RoleUserMembership",
       "shape": "edge",
       "description": "Edge between a Role and a User, identified by the (roleId, username) tuple. Established by assignRoleToUser, observable only via searchUsersForRole."
+    },
+    {
+      "name": "Tenant",
+      "shape": "entity",
+      "identifiers": ["TenantId"],
+      "description": "A tenant entity, identified by its client-minted tenantId."
+    },
+    {
+      "name": "TenantUserMembership",
+      "shape": "edge",
+      "description": "Edge between a Tenant and a User, identified by the (tenantId, username) tuple. Established by assignUserToTenant, observable only via searchUsersForTenant."
     }
   ]
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/tenants.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/tenants.yaml
@@ -9,6 +9,10 @@ paths:
       operationId: createTenant
       summary: Create tenant
       description: Creates a new tenant.
+      x-semantic-establishes:
+        kind: Tenant
+        identifiedBy:
+          - { in: body, name: tenantId, semanticType: TenantId }
       requestBody:
         content:
           application/json:
@@ -85,6 +89,10 @@ paths:
       operationId: getTenant
       summary: Get tenant
       description: Retrieves a single tenant by tenant ID.
+      x-semantic-requires:
+        kind: Tenant
+        bind:
+          tenantId: { from: path, name: tenantId }
       parameters:
         - name: tenantId
           in: path
@@ -122,6 +130,10 @@ paths:
       operationId: updateTenant
       summary: Update tenant
       description: Updates an existing tenant.
+      x-semantic-requires:
+        kind: Tenant
+        bind:
+          tenantId: { from: path, name: tenantId }
       parameters:
         - name: tenantId
           in: path
@@ -165,6 +177,10 @@ paths:
       operationId: deleteTenant
       summary: Delete tenant
       description: Deletes an existing tenant.
+      x-semantic-requires:
+        kind: Tenant
+        bind:
+          tenantId: { from: path, name: tenantId }
       parameters:
         - name: tenantId
           in: path
@@ -199,6 +215,12 @@ paths:
       operationId: assignUserToTenant
       summary: Assign a user to a tenant
       description: Assign a single user to a specified tenant. The user can then access tenant data and perform authorized actions.
+      x-semantic-establishes:
+        kind: TenantUserMembership
+        shape: edge
+        identifiedBy:
+          - { in: path, name: tenantId, semanticType: TenantId }
+          - { in: path, name: username, semanticType: Username }
       parameters:
         - name: tenantId
           in: path
@@ -240,6 +262,11 @@ paths:
       description: |
         Unassigns the user from the specified tenant.
         The user can no longer access tenant data.
+      x-semantic-requires:
+        kind: TenantUserMembership
+        bind:
+          tenantId: { from: path, name: tenantId }
+          username: { from: path, name: username }
       parameters:
         - name: tenantId
           in: path
@@ -280,6 +307,10 @@ paths:
       operationId: searchUsersForTenant
       summary: Search users for tenant
       description: Retrieves a filtered and sorted list of users for a specified tenant.
+      x-semantic-requires:
+        kind: Tenant
+        bind:
+          tenantId: { from: path, name: tenantId }
       parameters:
         - name: tenantId
           in: path


### PR DESCRIPTION
> ### Stack (merge bottom-up)
>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
> 13. #52316 — `ClusterVariableName` promoted to `identifiers.yaml`; 6 path-schema sites repointed
> 14. #52317 — GlobalClusterVariable + TenantClusterVariable registry entries; 7 cluster-variable CRUD annotations
> 15. #52318 — `name` allOf lifts in `cluster-variables.yaml`
> 16. #52319 — `ClientId` promoted to `identifiers.yaml`; 6 path-schema sites repointed (no semantic-edge stack — see PR description)
> 17. #52321 — Registry: `shape: external-entity` for identifiers minted outside the Camunda API; `Client` registered (refs #52320)
> 18. #52322 — `x-semantic-provider` coverage for the four genuinely unaddressed rows in #52169 (`GlobalTaskListenerResult.id`, `ProcessElementStatisticsResult.elementId`, `DeleteResourceResponse.resourceKey`)
>
> Refs #52272.

>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
> 13. #52316 — `ClusterVariableName` promoted to `identifiers.yaml`; 6 path-schema sites repointed
> 14. #52317 — GlobalClusterVariable + TenantClusterVariable registry entries; 7 cluster-variable CRUD annotations
> 15. #52318 — `name` allOf lifts in `cluster-variables.yaml`
> 16. #52319 — `ClientId` promoted to `identifiers.yaml`; 6 path-schema sites repointed (no semantic-edge stack — see PR description)
> 17. #52321 — Registry: `shape: external-entity` for identifiers minted outside the Camunda API; `Client` registered (refs #52320)
>
> Refs #52272.

>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
> 13. #52316 — `ClusterVariableName` promoted to `identifiers.yaml`; 6 path-schema sites repointed
> 14. #52317 — GlobalClusterVariable + TenantClusterVariable registry entries; 7 cluster-variable CRUD annotations
> 15. #52318 — `name` allOf lifts in `cluster-variables.yaml`
> 16. #52319 — `ClientId` promoted to `identifiers.yaml`; 6 path-schema sites repointed (no semantic-edge stack — see PR description)
>
> Refs #52272.
>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
> 13. #52316 — `ClusterVariableName` promoted to `identifiers.yaml`; 6 path-schema sites repointed
> 14. #52317 — GlobalClusterVariable + TenantClusterVariable registry entries; 7 cluster-variable CRUD annotations
> 15. #52318 — `name` allOf lifts in `cluster-variables.yaml`
>
> Refs #52272.
>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
>
> Refs #52272.

>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
>
> Refs #52272.

>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
>
> Refs #52272.

>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
>
> Refs #52272.

Stacks on top of #52302.

Mirrors the existing Role/User pattern for Tenant. Adds two registry entries to `semantic-kinds.json`:

- `Tenant` — entity, identifiers `[TenantId]`
- `TenantUserMembership` — edge

…and applies `x-semantic-establishes` / `x-semantic-requires` to the tenant operations whose path/body params already point at registered identifier kinds:

| Operation | Annotation |
|---|---|
| `createTenant` | `establishes Tenant` (body.tenantId → TenantId) |
| `getTenant` | `requires Tenant` |
| `updateTenant` | `requires Tenant` |
| `deleteTenant` | `requires Tenant` |
| `assignUserToTenant` | `establishes TenantUserMembership` (edge) |
| `unassignUserFromTenant` | `requires TenantUserMembership` |
| `searchUsersForTenant` | `requires Tenant` |

### Scope: only the tenant-user edge

The other tenant edges (`/tenants/{tenantId}/clients/{clientId}`, `/groups/{groupId}`, `/roles/{roleId}`, `/mapping-rules/{mappingRuleId}`) are intentionally left unannotated. Their path parameters use bare `type: string` rather than `$ref`s into `identifiers.yaml`, and the corresponding identifier kinds (`ClientId`, `GroupId`, `MappingRuleId`) are not yet registered. Annotating those edges requires fixing the path schemas and adding the identifier kinds first — a separate concern that matches the scope of #52301 (which also stopped at `RoleUserMembership`).

### Validation

- Spectral lint: 0 errors, 24 pre-existing `oas3-valid-schema-example` warnings unrelated.
- spectral-tests: 79/79 passing (registry validator accepts the new edge endpoint resolution).

A follow-up PR will lift the 5 schema-property `tenantId` sites in `tenants.yaml` (`TenantCreateRequest`, `TenantCreateResult`, `TenantUpdateResult`, `TenantResult`, `TenantFilter`) to `allOf` + per-site description, mirroring #52302 for users.

Refs #52272