### PR TITLE
feat: register Group entity and annotate group operations

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/groups.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/groups.yaml
@@ -8,6 +8,10 @@ paths:
       operationId: createGroup
       summary: Create group
       description: Create a new group.
+      x-semantic-establishes:
+        kind: Group
+        identifiedBy:
+          - { in: body, name: groupId, semanticType: GroupId }
       requestBody:
         content:
           application/json:
@@ -71,6 +75,10 @@ paths:
       operationId: getGroup
       summary: Get group
       description: Get a group by its ID.
+      x-semantic-requires:
+        kind: Group
+        bind:
+          groupId: { from: path, name: groupId }
       parameters:
         - name: groupId
           in: path
@@ -106,6 +114,10 @@ paths:
       operationId: updateGroup
       summary: Update group
       description: Update a group with the given ID.
+      x-semantic-requires:
+        kind: Group
+        bind:
+          groupId: { from: path, name: groupId }
       parameters:
         - name: groupId
           in: path
@@ -149,6 +161,10 @@ paths:
       operationId: deleteGroup
       summary: Delete group
       description: Deletes the group with the given ID.
+      x-semantic-requires:
+        kind: Group
+        bind:
+          groupId: { from: path, name: groupId }
       parameters:
         - name: groupId
           in: path
@@ -183,6 +199,12 @@ paths:
       description: |
         Assigns a user to a group, making the user a member of the group.
         Group members inherit the group authorizations, roles, and tenant assignments.
+      x-semantic-establishes:
+        kind: GroupUserMembership
+        shape: edge
+        identifiedBy:
+          - { in: path, name: groupId,  semanticType: GroupId }
+          - { in: path, name: username, semanticType: Username }
       parameters:
         - name: groupId
           in: path
@@ -230,6 +252,11 @@ paths:
       description: |
         Unassigns a user from a group.
         The user is removed as a group member, with associated authorizations, roles, and tenant assignments no longer applied.
+      x-semantic-requires:
+        kind: GroupUserMembership
+        bind:
+          groupId:  { from: path, name: groupId }
+          username: { from: path, name: username }
       parameters:
         - name: groupId
           in: path
@@ -270,6 +297,10 @@ paths:
       operationId: searchUsersForGroup
       summary: Search group users
       description: Search users assigned to a group.
+      x-semantic-requires:
+        kind: Group
+        bind:
+          groupId: { from: path, name: groupId }
       parameters:
         - name: groupId
           in: path

--- a/zeebe/gateway-protocol/src/main/proto/v2/semantic-kinds.json
+++ b/zeebe/gateway-protocol/src/main/proto/v2/semantic-kinds.json
@@ -55,6 +55,17 @@
       "name": "TenantUserMembership",
       "shape": "edge",
       "description": "Edge between a Tenant and a User, identified by the (tenantId, username) tuple. Established by assignUserToTenant, observable only via searchUsersForTenant."
+    },
+    {
+      "name": "Group",
+      "shape": "entity",
+      "identifiers": ["GroupId"],
+      "description": "A group entity, identified by its client-minted groupId."
+    },
+    {
+      "name": "GroupUserMembership",
+      "shape": "edge",
+      "description": "Edge between a Group and a User, identified by the (groupId, username) tuple. Established by assignUserToGroup, observable only via searchUsersForGroup."
     }
   ]
 


### PR DESCRIPTION
> ### Stack (merge bottom-up)
>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
> 13. #52316 — `ClusterVariableName` promoted to `identifiers.yaml`; 6 path-schema sites repointed
> 14. #52317 — GlobalClusterVariable + TenantClusterVariable registry entries; 7 cluster-variable CRUD annotations
> 15. #52318 — `name` allOf lifts in `cluster-variables.yaml`
> 16. #52319 — `ClientId` promoted to `identifiers.yaml`; 6 path-schema sites repointed (no semantic-edge stack — see PR description)
> 17. #52321 — Registry: `shape: external-entity` for identifiers minted outside the Camunda API; `Client` registered (refs #52320)
> 18. #52322 — `x-semantic-provider` coverage for the four genuinely unaddressed rows in #52169 (`GlobalTaskListenerResult.id`, `ProcessElementStatisticsResult.elementId`, `DeleteResourceResponse.resourceKey`)
>
> Refs #52272.

>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
> 13. #52316 — `ClusterVariableName` promoted to `identifiers.yaml`; 6 path-schema sites repointed
> 14. #52317 — GlobalClusterVariable + TenantClusterVariable registry entries; 7 cluster-variable CRUD annotations
> 15. #52318 — `name` allOf lifts in `cluster-variables.yaml`
> 16. #52319 — `ClientId` promoted to `identifiers.yaml`; 6 path-schema sites repointed (no semantic-edge stack — see PR description)
> 17. #52321 — Registry: `shape: external-entity` for identifiers minted outside the Camunda API; `Client` registered (refs #52320)
>
> Refs #52272.

>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
> 13. #52316 — `ClusterVariableName` promoted to `identifiers.yaml`; 6 path-schema sites repointed
> 14. #52317 — GlobalClusterVariable + TenantClusterVariable registry entries; 7 cluster-variable CRUD annotations
> 15. #52318 — `name` allOf lifts in `cluster-variables.yaml`
> 16. #52319 — `ClientId` promoted to `identifiers.yaml`; 6 path-schema sites repointed (no semantic-edge stack — see PR description)
>
> Refs #52272.
>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
> 13. #52316 — `ClusterVariableName` promoted to `identifiers.yaml`; 6 path-schema sites repointed
> 14. #52317 — GlobalClusterVariable + TenantClusterVariable registry entries; 7 cluster-variable CRUD annotations
> 15. #52318 — `name` allOf lifts in `cluster-variables.yaml`
>
> Refs #52272.
>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
>
> Refs #52272.

>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
>
> Refs #52272.

>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
>
> Refs #52272.

Stacks on top of #52309.

Mirrors the existing Role/User/Tenant pattern for Group. Adds two registry entries to `semantic-kinds.json`:

- `Group` — entity, identifiers `[GroupId]`
- `GroupUserMembership` — edge

…and applies `x-semantic-establishes` / `x-semantic-requires` to the group operations whose path/body params now point at registered identifier kinds (thanks to #52309):

| Operation | Annotation |
|---|---|
| `createGroup` | `establishes Group` (body.groupId → GroupId) |
| `getGroup` | `requires Group` |
| `updateGroup` | `requires Group` |
| `deleteGroup` | `requires Group` |
| `assignUserToGroup` | `establishes GroupUserMembership` (edge) |
| `unassignUserFromGroup` | `requires GroupUserMembership` |
| `searchUsersForGroup` | `requires Group` |

### Scope: only the group-user edge

The other group edges (`/groups/{groupId}/clients/{clientId}`, `/mapping-rules/{mappingRuleId}`, `/roles/{roleId}`) are intentionally left unannotated. Their non-group path parameters use bare `type: string` rather than `$ref`s into `identifiers.yaml`, and the corresponding identifier kinds (`ClientId`, `MappingRuleId`) are not yet registered. Annotating those edges requires fixing the path schemas and adding the identifier kinds first — same scope as the Role (#52301) and Tenant (#52307) PRs.

### Validation

- Spectral lint: 0 errors, 24 pre-existing `oas3-valid-schema-example` warnings unrelated.
- spectral-tests: all passing (registry validator accepts the new edge endpoint resolution).

A follow-up PR will lift the 4 schema-property `groupId` sites in `groups.yaml` to `allOf` + per-site description, mirroring #52302 for users and #52308 for tenants.

Refs #52272