### PR TITLE
feat: lift groupId in group schemas via allOf + per-site description

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/groups.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/groups.yaml
@@ -652,7 +652,8 @@ components:
       additionalProperties: false
       properties:
         groupId:
-          type: string
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/GroupId'
           description: The ID of the new group.
         name:
           type: string
@@ -668,8 +669,9 @@ components:
       type: object
       properties:
         groupId:
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/GroupId'
           description: The ID of the created group.
-          type: string
         name:
           description: The display name of the created group.
           type: string
@@ -698,7 +700,8 @@ components:
       type: object
       properties:
         groupId:
-          type: string
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/GroupId'
           description: The unique external group ID.
         name:
           type: string
@@ -720,7 +723,8 @@ components:
           type: string
           description: The group name.
         groupId:
-          type: string
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/GroupId'
           description: The group ID.
         description:
           type: string


### PR DESCRIPTION
> ### Stack (merge bottom-up)
>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
> 13. #52316 — `ClusterVariableName` promoted to `identifiers.yaml`; 6 path-schema sites repointed
> 14. #52317 — GlobalClusterVariable + TenantClusterVariable registry entries; 7 cluster-variable CRUD annotations
> 15. #52318 — `name` allOf lifts in `cluster-variables.yaml`
> 16. #52319 — `ClientId` promoted to `identifiers.yaml`; 6 path-schema sites repointed (no semantic-edge stack — see PR description)
> 17. #52321 — Registry: `shape: external-entity` for identifiers minted outside the Camunda API; `Client` registered (refs #52320)
> 18. #52322 — `x-semantic-provider` coverage for the four genuinely unaddressed rows in #52169 (`GlobalTaskListenerResult.id`, `ProcessElementStatisticsResult.elementId`, `DeleteResourceResponse.resourceKey`)
>
> Refs #52272.

>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
> 13. #52316 — `ClusterVariableName` promoted to `identifiers.yaml`; 6 path-schema sites repointed
> 14. #52317 — GlobalClusterVariable + TenantClusterVariable registry entries; 7 cluster-variable CRUD annotations
> 15. #52318 — `name` allOf lifts in `cluster-variables.yaml`
> 16. #52319 — `ClientId` promoted to `identifiers.yaml`; 6 path-schema sites repointed (no semantic-edge stack — see PR description)
> 17. #52321 — Registry: `shape: external-entity` for identifiers minted outside the Camunda API; `Client` registered (refs #52320)
>
> Refs #52272.

>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
> 13. #52316 — `ClusterVariableName` promoted to `identifiers.yaml`; 6 path-schema sites repointed
> 14. #52317 — GlobalClusterVariable + TenantClusterVariable registry entries; 7 cluster-variable CRUD annotations
> 15. #52318 — `name` allOf lifts in `cluster-variables.yaml`
> 16. #52319 — `ClientId` promoted to `identifiers.yaml`; 6 path-schema sites repointed (no semantic-edge stack — see PR description)
>
> Refs #52272.
>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
> 13. #52316 — `ClusterVariableName` promoted to `identifiers.yaml`; 6 path-schema sites repointed
> 14. #52317 — GlobalClusterVariable + TenantClusterVariable registry entries; 7 cluster-variable CRUD annotations
> 15. #52318 — `name` allOf lifts in `cluster-variables.yaml`
>
> Refs #52272.
>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
>
> Refs #52272.

>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
>
> Refs #52272.

>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
>
> Refs #52272.

Stacks on top of #52310.

Mirrors #52302 (`username` lifts) and #52308 (`tenantId` lifts), and the equivalent `roleId` shape already in `roles.yaml`. The four group schema sites that reference the `GroupId` component now wrap the `$ref` in an `allOf` so they can carry a site-specific description without falling foul of OpenAPI 3.0's "siblings of $ref are ignored" rule.

Sites changed in `groups.yaml`:

| Schema | Before | After |
|---|---|---|
| `GroupCreateRequest.groupId` | inline `type: string` + description | `allOf` `$ref GroupId` + description |
| `GroupCreateResult.groupId` | inline `type: string` + description | `allOf` + description |
| `GroupUpdateResult.groupId` | inline `type: string` + description | `allOf` + description |
| `GroupResult.groupId` | inline `type: string` + description | `allOf` + description |

`GroupFilter.groupId` already wraps `allOf` around `StringFilterProperty` for filter wrapping and is left alone (same as `RoleFilter.roleId` and `UserFilter.username`).

Byte-equivalent for openapi-generator output (`allOf` with a single `$ref` collapses to the referenced schema). Brings `groups.yaml` in line with `roles.yaml`, `users.yaml` and `tenants.yaml`.

Spectral lint clean (0 errors, 24 pre-existing warnings unrelated).

Refs #52272