### PR TITLE
feat: register MappingRule entity and annotate mapping-rule operations

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/groups.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/groups.yaml
@@ -478,6 +478,12 @@ paths:
       operationId: assignMappingRuleToGroup
       summary: Assign a mapping rule to a group
       description: Assigns a mapping rule to a group.
+      x-semantic-establishes:
+        kind: GroupMappingRuleMembership
+        shape: edge
+        identifiedBy:
+          - { in: path, name: groupId,       semanticType: GroupId }
+          - { in: path, name: mappingRuleId, semanticType: MappingRuleId }
       parameters:
         - name: groupId
           in: path
@@ -523,6 +529,11 @@ paths:
       operationId: unassignMappingRuleFromGroup
       summary: Unassign a mapping rule from a group
       description: Unassigns a mapping rule from a group.
+      x-semantic-requires:
+        kind: GroupMappingRuleMembership
+        bind:
+          groupId:       { from: path, name: groupId }
+          mappingRuleId: { from: path, name: mappingRuleId }
       parameters:
         - name: groupId
           in: path
@@ -563,6 +574,10 @@ paths:
       operationId: searchMappingRulesForGroup
       summary: Search group mapping rules
       description: Search mapping rules assigned to a group.
+      x-semantic-requires:
+        kind: Group
+        bind:
+          groupId: { from: path, name: groupId }
       parameters:
         - name: groupId
           in: path

--- a/zeebe/gateway-protocol/src/main/proto/v2/mapping-rules.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/mapping-rules.yaml
@@ -10,6 +10,10 @@ paths:
       summary: Create mapping rule
       description: |
         Create a new mapping rule
+      x-semantic-establishes:
+        kind: MappingRule
+        identifiedBy:
+          - { in: body, name: mappingRuleId, semanticType: MappingRuleId }
       requestBody:
         content:
           application/json:
@@ -50,6 +54,10 @@ paths:
       summary: Update mapping rule
       description: |
         Update a mapping rule.
+      x-semantic-requires:
+        kind: MappingRule
+        bind:
+          mappingRuleId: { from: path, name: mappingRuleId }
       parameters:
         - name: mappingRuleId
           in: path
@@ -98,6 +106,10 @@ paths:
       summary: Delete a mapping rule
       description: |
         Deletes the mapping rule with the given ID.
+      x-semantic-requires:
+        kind: MappingRule
+        bind:
+          mappingRuleId: { from: path, name: mappingRuleId }
       parameters:
         - name: mappingRuleId
           in: path
@@ -129,6 +141,10 @@ paths:
       summary: Get a mapping rule
       description: |
         Gets the mapping rule with the given ID.
+      x-semantic-requires:
+        kind: MappingRule
+        bind:
+          mappingRuleId: { from: path, name: mappingRuleId }
       parameters:
         - name: mappingRuleId
           in: path

--- a/zeebe/gateway-protocol/src/main/proto/v2/roles.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/roles.yaml
@@ -600,6 +600,12 @@ paths:
       operationId: assignRoleToMappingRule
       summary: Assign a role to a mapping rule
       description: Assigns a role to a mapping rule.
+      x-semantic-establishes:
+        kind: RoleMappingRuleMembership
+        shape: edge
+        identifiedBy:
+          - { in: path, name: roleId,        semanticType: RoleId }
+          - { in: path, name: mappingRuleId, semanticType: MappingRuleId }
       parameters:
         - name: roleId
           in: path
@@ -645,6 +651,11 @@ paths:
       operationId: unassignRoleFromMappingRule
       summary: Unassign a role from a mapping rule
       description: Unassigns a role from a mapping rule.
+      x-semantic-requires:
+        kind: RoleMappingRuleMembership
+        bind:
+          roleId:        { from: path, name: roleId }
+          mappingRuleId: { from: path, name: mappingRuleId }
       parameters:
         - name: roleId
           in: path
@@ -685,6 +696,10 @@ paths:
       operationId: searchMappingRulesForRole
       summary: Search role mapping rules
       description: Search mapping rules with assigned role.
+      x-semantic-requires:
+        kind: Role
+        bind:
+          roleId: { from: path, name: roleId }
       parameters:
         - name: roleId
           in: path

--- a/zeebe/gateway-protocol/src/main/proto/v2/semantic-kinds.json
+++ b/zeebe/gateway-protocol/src/main/proto/v2/semantic-kinds.json
@@ -66,6 +66,27 @@
       "name": "GroupUserMembership",
       "shape": "edge",
       "description": "Edge between a Group and a User, identified by the (groupId, username) tuple. Established by assignUserToGroup, observable only via searchUsersForGroup."
+    },
+    {
+      "name": "MappingRule",
+      "shape": "entity",
+      "identifiers": ["MappingRuleId"],
+      "description": "A mapping rule entity, identified by its client-minted mappingRuleId."
+    },
+    {
+      "name": "RoleMappingRuleMembership",
+      "shape": "edge",
+      "description": "Edge between a Role and a MappingRule, identified by the (roleId, mappingRuleId) tuple. Established by assignRoleToMappingRule, observable only via searchMappingRulesForRole."
+    },
+    {
+      "name": "GroupMappingRuleMembership",
+      "shape": "edge",
+      "description": "Edge between a Group and a MappingRule, identified by the (groupId, mappingRuleId) tuple. Established by assignMappingRuleToGroup, observable only via searchMappingRulesForGroup."
+    },
+    {
+      "name": "TenantMappingRuleMembership",
+      "shape": "edge",
+      "description": "Edge between a Tenant and a MappingRule, identified by the (tenantId, mappingRuleId) tuple. Established by assignMappingRuleToTenant, observable only via searchMappingRulesForTenant."
     }
   ]
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/tenants.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/tenants.yaml
@@ -681,6 +681,12 @@ paths:
       operationId: assignMappingRuleToTenant
       summary: Assign a mapping rule to a tenant
       description: Assign a single mapping rule to a specified tenant.
+      x-semantic-establishes:
+        kind: TenantMappingRuleMembership
+        shape: edge
+        identifiedBy:
+          - { in: path, name: tenantId,      semanticType: TenantId }
+          - { in: path, name: mappingRuleId, semanticType: MappingRuleId }
       parameters:
         - name: tenantId
           in: path
@@ -720,6 +726,11 @@ paths:
       operationId: unassignMappingRuleFromTenant
       summary: Unassign a mapping rule from a tenant
       description: Unassigns a single mapping rule from a specified tenant without deleting the rule.
+      x-semantic-requires:
+        kind: TenantMappingRuleMembership
+        bind:
+          tenantId:      { from: path, name: tenantId }
+          mappingRuleId: { from: path, name: mappingRuleId }
       parameters:
         - name: tenantId
           in: path
@@ -760,6 +771,10 @@ paths:
       operationId: searchMappingRulesForTenant
       summary: Search mapping rules for tenant
       description: Retrieves a filtered and sorted list of MappingRules for a specified tenant.
+      x-semantic-requires:
+        kind: Tenant
+        bind:
+          tenantId: { from: path, name: tenantId }
       parameters:
         - name: tenantId
           in: path


### PR DESCRIPTION
> ### Stack (merge bottom-up)
>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
> 13. #52316 — `ClusterVariableName` promoted to `identifiers.yaml`; 6 path-schema sites repointed
> 14. #52317 — GlobalClusterVariable + TenantClusterVariable registry entries; 7 cluster-variable CRUD annotations
> 15. #52318 — `name` allOf lifts in `cluster-variables.yaml`
> 16. #52319 — `ClientId` promoted to `identifiers.yaml`; 6 path-schema sites repointed (no semantic-edge stack — see PR description)
> 17. #52321 — Registry: `shape: external-entity` for identifiers minted outside the Camunda API; `Client` registered (refs #52320)
> 18. #52322 — `x-semantic-provider` coverage for the four genuinely unaddressed rows in #52169 (`GlobalTaskListenerResult.id`, `ProcessElementStatisticsResult.elementId`, `DeleteResourceResponse.resourceKey`)
>
> Refs #52272.

>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
> 13. #52316 — `ClusterVariableName` promoted to `identifiers.yaml`; 6 path-schema sites repointed
> 14. #52317 — GlobalClusterVariable + TenantClusterVariable registry entries; 7 cluster-variable CRUD annotations
> 15. #52318 — `name` allOf lifts in `cluster-variables.yaml`
> 16. #52319 — `ClientId` promoted to `identifiers.yaml`; 6 path-schema sites repointed (no semantic-edge stack — see PR description)
> 17. #52321 — Registry: `shape: external-entity` for identifiers minted outside the Camunda API; `Client` registered (refs #52320)
>
> Refs #52272.

>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
> 13. #52316 — `ClusterVariableName` promoted to `identifiers.yaml`; 6 path-schema sites repointed
> 14. #52317 — GlobalClusterVariable + TenantClusterVariable registry entries; 7 cluster-variable CRUD annotations
> 15. #52318 — `name` allOf lifts in `cluster-variables.yaml`
> 16. #52319 — `ClientId` promoted to `identifiers.yaml`; 6 path-schema sites repointed (no semantic-edge stack — see PR description)
>
> Refs #52272.
>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
> 13. #52316 — `ClusterVariableName` promoted to `identifiers.yaml`; 6 path-schema sites repointed
> 14. #52317 — GlobalClusterVariable + TenantClusterVariable registry entries; 7 cluster-variable CRUD annotations
> 15. #52318 — `name` allOf lifts in `cluster-variables.yaml`
>
> Refs #52272.
>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
>
> Refs #52272.

>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
>
> Refs #52272.

Adds `MappingRule` (entity) and the three membership edges (`RoleMappingRuleMembership`, `GroupMappingRuleMembership`, `TenantMappingRuleMembership`) to the semantic-kinds registry, and annotates the operations that produce or consume them.

### Entity ops (mapping-rules.yaml)
| Operation | Annotation |
|---|---|
| `createMappingRule` | establishes `MappingRule` |
| `getMappingRule` | requires `MappingRule` |
| `updateMappingRule` | requires `MappingRule` |
| `deleteMappingRule` | requires `MappingRule` |

### Edge ops
| Operation | Annotation |
|---|---|
| `assignRoleToMappingRule` | establishes `RoleMappingRuleMembership` |
| `unassignRoleFromMappingRule` | requires `RoleMappingRuleMembership` |
| `searchMappingRulesForRole` | requires `Role` |
| `assignMappingRuleToGroup` | establishes `GroupMappingRuleMembership` |
| `unassignMappingRuleFromGroup` | requires `GroupMappingRuleMembership` |
| `searchMappingRulesForGroup` | requires `Group` |
| `assignMappingRuleToTenant` | establishes `TenantMappingRuleMembership` |
| `unassignMappingRuleFromTenant` | requires `TenantMappingRuleMembership` |
| `searchMappingRulesForTenant` | requires `Tenant` |

Spectral lint clean. 79 spectral-tests pass.

Refs #52272.