### PR TITLE
feat: promote ClusterVariableName to identifiers.yaml component schema

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
@@ -123,7 +123,7 @@ paths:
           in: path
           required: true
           schema:
-            type: string
+            $ref: 'identifiers.yaml#/components/schemas/ClusterVariableName'
           description: The name of the cluster variable
       responses:
         '200':
@@ -161,7 +161,7 @@ paths:
           in: path
           required: true
           schema:
-            type: string
+            $ref: 'identifiers.yaml#/components/schemas/ClusterVariableName'
           description: The name of the cluster variable
       requestBody:
         required: true
@@ -203,7 +203,7 @@ paths:
           in: path
           required: true
           schema:
-            type: string
+            $ref: 'identifiers.yaml#/components/schemas/ClusterVariableName'
           description: The name of the cluster variable
       responses:
         '204':
@@ -242,7 +242,7 @@ paths:
           in: path
           required: true
           schema:
-            type: string
+            $ref: 'identifiers.yaml#/components/schemas/ClusterVariableName'
           description: The name of the cluster variable
       responses:
         '200':
@@ -286,7 +286,7 @@ paths:
           in: path
           required: true
           schema:
-            type: string
+            $ref: 'identifiers.yaml#/components/schemas/ClusterVariableName'
           description: The name of the cluster variable
       requestBody:
         required: true
@@ -334,7 +334,7 @@ paths:
           in: path
           required: true
           schema:
-            type: string
+            $ref: 'identifiers.yaml#/components/schemas/ClusterVariableName'
           description: The name of the cluster variable
       responses:
         '204':

--- a/zeebe/gateway-protocol/src/main/proto/v2/identifiers.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/identifiers.yaml
@@ -86,6 +86,14 @@ components:
       x-semantic-type: MappingRuleId
       x-semantic-client-minted: true
 
+    ClusterVariableName:
+      example: feature-flag-checkout
+      description: The name of a cluster variable. Unique within its scope (global or tenant-specific).
+      format: ClusterVariableName
+      type: string
+      x-semantic-type: ClusterVariableName
+      x-semantic-client-minted: true
+
     Tag:
       description: A tag. Needs to start with a letter; then alphanumerics, `_`, `-`, `:`, or `.`; length ≤ 100.
       example: business_key:1234


### PR DESCRIPTION
> ### Stack (merge bottom-up)
>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
> 13. #52316 — `ClusterVariableName` promoted to `identifiers.yaml`; 6 path-schema sites repointed
> 14. #52317 — GlobalClusterVariable + TenantClusterVariable registry entries; 7 cluster-variable CRUD annotations
> 15. #52318 — `name` allOf lifts in `cluster-variables.yaml`
> 16. #52319 — `ClientId` promoted to `identifiers.yaml`; 6 path-schema sites repointed (no semantic-edge stack — see PR description)
> 17. #52321 — Registry: `shape: external-entity` for identifiers minted outside the Camunda API; `Client` registered (refs #52320)
> 18. #52322 — `x-semantic-provider` coverage for the four genuinely unaddressed rows in #52169 (`GlobalTaskListenerResult.id`, `ProcessElementStatisticsResult.elementId`, `DeleteResourceResponse.resourceKey`)
>
> Refs #52272.

>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
> 13. #52316 — `ClusterVariableName` promoted to `identifiers.yaml`; 6 path-schema sites repointed
> 14. #52317 — GlobalClusterVariable + TenantClusterVariable registry entries; 7 cluster-variable CRUD annotations
> 15. #52318 — `name` allOf lifts in `cluster-variables.yaml`
> 16. #52319 — `ClientId` promoted to `identifiers.yaml`; 6 path-schema sites repointed (no semantic-edge stack — see PR description)
> 17. #52321 — Registry: `shape: external-entity` for identifiers minted outside the Camunda API; `Client` registered (refs #52320)
>
> Refs #52272.

>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
> 13. #52316 — `ClusterVariableName` promoted to `identifiers.yaml`; 6 path-schema sites repointed
> 14. #52317 — GlobalClusterVariable + TenantClusterVariable registry entries; 7 cluster-variable CRUD annotations
> 15. #52318 — `name` allOf lifts in `cluster-variables.yaml`
> 16. #52319 — `ClientId` promoted to `identifiers.yaml`; 6 path-schema sites repointed (no semantic-edge stack — see PR description)
>
> Refs #52272.
>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
> 13. #52316 — `ClusterVariableName` promoted to `identifiers.yaml`; 6 path-schema sites repointed
> 14. #52317 — GlobalClusterVariable + TenantClusterVariable registry entries; 7 cluster-variable CRUD annotations
> 15. #52318 — `name` allOf lifts in `cluster-variables.yaml`
>
> Refs #52272.
>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
>
> Refs #52272.

## Summary

Promote `ClusterVariableName` to a reusable component schema in `identifiers.yaml` and repoint the 6 inline `name` path-parameter schemas in `cluster-variables.yaml`.

## Changes

- **`identifiers.yaml`** — new `ClusterVariableName` component (`type: string`, `format: ClusterVariableName`, `x-semantic-type: ClusterVariableName`, `x-semantic-client-minted: true`, example `feature-flag-checkout`).
- **`cluster-variables.yaml`** — 6 path-schema sites now `$ref` `ClusterVariableName`:
  - global: `GET`/`PUT`/`DELETE /cluster-variables/global/{name}`
  - tenant: `GET`/`PUT`/`DELETE /cluster-variables/tenants/{tenantId}/{name}`

Body-side `name` properties (`CreateClusterVariableRequest`, `ClusterVariableResultBase`) are lifted in PR3 of this stack.

## Validation

- `spectral lint` clean (24 pre-existing warnings, 0 errors)
- `node --test 'spectral-tests/*.test.js'` → 79 pass

Refs #52272.