### PR TITLE
feat: register GlobalClusterVariable and TenantClusterVariable entities and annotate cluster-variable operations

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
@@ -9,6 +9,10 @@ paths:
         - Cluster Variable
       summary: Create a global-scoped cluster variable
       description: Create a global-scoped cluster variable.
+      x-semantic-establishes:
+        kind: GlobalClusterVariable
+        identifiedBy:
+          - { in: body, name: name, semanticType: ClusterVariableName }
       requestBody:
         required: true
         content:
@@ -39,6 +43,11 @@ paths:
         - Cluster Variable
       summary: Create a tenant-scoped cluster variable
       description: Create a new cluster variable for the given tenant.
+      x-semantic-establishes:
+        kind: TenantClusterVariable
+        identifiedBy:
+          - { in: path, name: tenantId, semanticType: TenantId }
+          - { in: body, name: name,     semanticType: ClusterVariableName }
       parameters:
         - name: tenantId
           in: path
@@ -118,6 +127,10 @@ paths:
         - Cluster Variable
       summary: Get a global-scoped cluster variable
       description: Get a global-scoped cluster variable.
+      x-semantic-requires:
+        kind: GlobalClusterVariable
+        bind:
+          name: { from: path, name: name }
       parameters:
         - name: name
           in: path
@@ -156,6 +169,10 @@ paths:
       description: |
         Updates the value of an existing global cluster variable.
         The variable must exist, otherwise a 404 error is returned.
+      x-semantic-requires:
+        kind: GlobalClusterVariable
+        bind:
+          name: { from: path, name: name }
       parameters:
         - name: name
           in: path
@@ -198,6 +215,10 @@ paths:
         - Cluster Variable
       summary: Delete a global-scoped cluster variable
       description: Delete a global-scoped cluster variable.
+      x-semantic-requires:
+        kind: GlobalClusterVariable
+        bind:
+          name: { from: path, name: name }
       parameters:
         - name: name
           in: path
@@ -231,6 +252,11 @@ paths:
         - Cluster Variable
       summary: Get a tenant-scoped cluster variable
       description: Get a tenant-scoped cluster variable.
+      x-semantic-requires:
+        kind: TenantClusterVariable
+        bind:
+          tenantId: { from: path, name: tenantId }
+          name:     { from: path, name: name }
       parameters:
         - name: tenantId
           in: path
@@ -275,6 +301,11 @@ paths:
       description: |
         Updates the value of an existing tenant-scoped cluster variable.
         The variable must exist, otherwise a 404 error is returned.
+      x-semantic-requires:
+        kind: TenantClusterVariable
+        bind:
+          tenantId: { from: path, name: tenantId }
+          name:     { from: path, name: name }
       parameters:
         - name: tenantId
           in: path
@@ -323,6 +354,11 @@ paths:
         - Cluster Variable
       summary: Delete a tenant-scoped cluster variable
       description: Delete a tenant-scoped cluster variable.
+      x-semantic-requires:
+        kind: TenantClusterVariable
+        bind:
+          tenantId: { from: path, name: tenantId }
+          name:     { from: path, name: name }
       parameters:
         - name: tenantId
           in: path

--- a/zeebe/gateway-protocol/src/main/proto/v2/semantic-kinds.json
+++ b/zeebe/gateway-protocol/src/main/proto/v2/semantic-kinds.json
@@ -93,6 +93,18 @@
       "shape": "entity",
       "identifiers": ["GlobalListenerId"],
       "description": "A global user task listener entity, identified by its client-minted id (a GlobalListenerId)."
+    },
+    {
+      "name": "GlobalClusterVariable",
+      "shape": "entity",
+      "identifiers": ["ClusterVariableName"],
+      "description": "A global-scoped cluster variable, identified by its client-minted name (a ClusterVariableName). Established by createGlobalClusterVariable."
+    },
+    {
+      "name": "TenantClusterVariable",
+      "shape": "entity",
+      "identifiers": ["ClusterVariableName"],
+      "description": "A tenant-scoped cluster variable, identified by the (tenantId, name) tuple. Established by createTenantClusterVariable. Only ClusterVariableName is listed in 'identifiers' here because TenantId is owned by the Tenant entity and must remain single-owner for the edge-derivation rule; the Tenant requirement of tenant-scoped operations is expressed via the tenantId path parameter."
     }
   ]
 


### PR DESCRIPTION
> ### Stack (merge bottom-up)
>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
> 13. #52316 — `ClusterVariableName` promoted to `identifiers.yaml`; 6 path-schema sites repointed
> 14. #52317 — GlobalClusterVariable + TenantClusterVariable registry entries; 7 cluster-variable CRUD annotations
> 15. #52318 — `name` allOf lifts in `cluster-variables.yaml`
> 16. #52319 — `ClientId` promoted to `identifiers.yaml`; 6 path-schema sites repointed (no semantic-edge stack — see PR description)
> 17. #52321 — Registry: `shape: external-entity` for identifiers minted outside the Camunda API; `Client` registered (refs #52320)
> 18. #52322 — `x-semantic-provider` coverage for the four genuinely unaddressed rows in #52169 (`GlobalTaskListenerResult.id`, `ProcessElementStatisticsResult.elementId`, `DeleteResourceResponse.resourceKey`)
>
> Refs #52272.

>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
> 13. #52316 — `ClusterVariableName` promoted to `identifiers.yaml`; 6 path-schema sites repointed
> 14. #52317 — GlobalClusterVariable + TenantClusterVariable registry entries; 7 cluster-variable CRUD annotations
> 15. #52318 — `name` allOf lifts in `cluster-variables.yaml`
> 16. #52319 — `ClientId` promoted to `identifiers.yaml`; 6 path-schema sites repointed (no semantic-edge stack — see PR description)
> 17. #52321 — Registry: `shape: external-entity` for identifiers minted outside the Camunda API; `Client` registered (refs #52320)
>
> Refs #52272.

>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
> 13. #52316 — `ClusterVariableName` promoted to `identifiers.yaml`; 6 path-schema sites repointed
> 14. #52317 — GlobalClusterVariable + TenantClusterVariable registry entries; 7 cluster-variable CRUD annotations
> 15. #52318 — `name` allOf lifts in `cluster-variables.yaml`
> 16. #52319 — `ClientId` promoted to `identifiers.yaml`; 6 path-schema sites repointed (no semantic-edge stack — see PR description)
>
> Refs #52272.
>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
> 13. #52316 — `ClusterVariableName` promoted to `identifiers.yaml`; 6 path-schema sites repointed
> 14. #52317 — GlobalClusterVariable + TenantClusterVariable registry entries; 7 cluster-variable CRUD annotations
> 15. #52318 — `name` allOf lifts in `cluster-variables.yaml`
>
> Refs #52272.
>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
>
> Refs #52272.

## Summary

Register two cluster-variable entity kinds and annotate the 7 CRUD operations with `x-semantic-establishes` / `x-semantic-requires`. The cross-scope `searchClusterVariables` is left unannotated.

## Registry — `semantic-kinds.json`

- `GlobalClusterVariable` (shape: entity, identifiers: `[ClusterVariableName]`) — established by `createGlobalClusterVariable`.
- `TenantClusterVariable` (shape: entity, identifiers: `[ClusterVariableName]`) — established by `createTenantClusterVariable`. Tenant requirement is expressed via the `tenantId` path parameter; only `ClusterVariableName` is listed in `identifiers` to satisfy the single-owner rule used for edge derivation (`TenantId` belongs to the `Tenant` entity).

## Annotations — `cluster-variables.yaml`

| Operation | Annotation |
| --- | --- |
| `createGlobalClusterVariable` | `x-semantic-establishes: GlobalClusterVariable` (body `name`) |
| `getGlobalClusterVariable` / `updateGlobalClusterVariable` / `deleteGlobalClusterVariable` | `x-semantic-requires: GlobalClusterVariable` (path `name`) |
| `createTenantClusterVariable` | `x-semantic-establishes: TenantClusterVariable` (path `tenantId`, body `name`) |
| `getTenantClusterVariable` / `updateTenantClusterVariable` / `deleteTenantClusterVariable` | `x-semantic-requires: TenantClusterVariable` (path `tenantId`, path `name`) |
| `searchClusterVariables` | none — cross-scope, no required entity |

## Validation

- `spectral lint` clean (24 pre-existing warnings, 0 errors)
- `node --test 'spectral-tests/*.test.js'` → 79 pass

Refs #52272.