### PR TITLE
feat: promote ClientId to identifiers.yaml component schema

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/groups.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/groups.yaml
@@ -359,7 +359,7 @@ paths:
           required: true
           description: The client ID.
           schema:
-            type: string
+            $ref: 'identifiers.yaml#/components/schemas/ClientId'
       responses:
         "204":
           description: The client was assigned successfully to the group.
@@ -406,7 +406,7 @@ paths:
           required: true
           description: The client ID.
           schema:
-            type: string
+            $ref: 'identifiers.yaml#/components/schemas/ClientId'
       responses:
         "204":
           description: The client was unassigned successfully from the group.

--- a/zeebe/gateway-protocol/src/main/proto/v2/identifiers.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/identifiers.yaml
@@ -86,6 +86,19 @@ components:
       x-semantic-type: MappingRuleId
       x-semantic-client-minted: true
 
+    ClientId:
+      example: my-application
+      description: |
+        The unique identifier of an OAuth client.
+        Minted outside the Camunda REST API: in SaaS by Console, in Self-Managed
+        with OIDC by the external identity provider (e.g. EntraID, Keycloak,
+        Okta). In Self-Managed with Basic authentication, machine-to-machine
+        applications are modelled as users instead — see the user identifier.
+      format: ClientId
+      type: string
+      x-semantic-type: ClientId
+      x-semantic-client-minted: true
+
     ClusterVariableName:
       example: feature-flag-checkout
       description: The name of a cluster variable. Unique within its scope (global or tenant-specific).

--- a/zeebe/gateway-protocol/src/main/proto/v2/roles.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/roles.yaml
@@ -354,7 +354,7 @@ paths:
           required: true
           description: The client ID.
           schema:
-            type: string
+            $ref: 'identifiers.yaml#/components/schemas/ClientId'
       responses:
         "204":
           description: The role was assigned successfully to the client.
@@ -399,7 +399,7 @@ paths:
           required: true
           description: The client ID.
           schema:
-            type: string
+            $ref: 'identifiers.yaml#/components/schemas/ClientId'
       responses:
         "204":
           description: The role was unassigned successfully from the client.

--- a/zeebe/gateway-protocol/src/main/proto/v2/tenants.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/tenants.yaml
@@ -355,7 +355,7 @@ paths:
           required: true
           description: The unique identifier of the application.
           schema:
-            type: string
+            $ref: 'identifiers.yaml#/components/schemas/ClientId'
       responses:
         "204":
           description: The client was successfully assigned to the tenant.
@@ -396,7 +396,7 @@ paths:
           required: true
           description: The unique identifier of the application.
           schema:
-            type: string
+            $ref: 'identifiers.yaml#/components/schemas/ClientId'
       responses:
         "204":
           description: The client was successfully unassigned from the tenant.


### PR DESCRIPTION
> ### Stack (merge bottom-up)
>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
> 13. #52316 — `ClusterVariableName` promoted to `identifiers.yaml`; 6 path-schema sites repointed
> 14. #52317 — GlobalClusterVariable + TenantClusterVariable registry entries; 7 cluster-variable CRUD annotations
> 15. #52318 — `name` allOf lifts in `cluster-variables.yaml`
> 16. #52319 — `ClientId` promoted to `identifiers.yaml`; 6 path-schema sites repointed (no semantic-edge stack — see PR description)
> 17. #52321 — Registry: `shape: external-entity` for identifiers minted outside the Camunda API; `Client` registered (refs #52320)
> 18. #52322 — `x-semantic-provider` coverage for the four genuinely unaddressed rows in #52169 (`GlobalTaskListenerResult.id`, `ProcessElementStatisticsResult.elementId`, `DeleteResourceResponse.resourceKey`)
>
> Refs #52272.

>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
> 13. #52316 — `ClusterVariableName` promoted to `identifiers.yaml`; 6 path-schema sites repointed
> 14. #52317 — GlobalClusterVariable + TenantClusterVariable registry entries; 7 cluster-variable CRUD annotations
> 15. #52318 — `name` allOf lifts in `cluster-variables.yaml`
> 16. #52319 — `ClientId` promoted to `identifiers.yaml`; 6 path-schema sites repointed (no semantic-edge stack — see PR description)
> 17. #52321 — Registry: `shape: external-entity` for identifiers minted outside the Camunda API; `Client` registered (refs #52320)
>
> Refs #52272.

>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
> 13. #52316 — `ClusterVariableName` promoted to `identifiers.yaml`; 6 path-schema sites repointed
> 14. #52317 — GlobalClusterVariable + TenantClusterVariable registry entries; 7 cluster-variable CRUD annotations
> 15. #52318 — `name` allOf lifts in `cluster-variables.yaml`
> 16. #52319 — `ClientId` promoted to `identifiers.yaml`; 6 path-schema sites repointed (no semantic-edge stack — see PR description)
>
> Refs #52272.
## Summary

Promote `ClientId` to a reusable component schema in `identifiers.yaml` and repoint the 6 inline `clientId` path-parameter schemas across `groups.yaml`, `roles.yaml`, and `tenants.yaml`.

This is a **type-only cleanup PR**, intentionally not part of a 3-PR semantic stack like the other identifier rollouts. See "Why no semantic-edge stack" below.

## Changes

- **`identifiers.yaml`** — new `ClientId` component (`type: string`, `format: ClientId`, `x-semantic-type: ClientId`, `x-semantic-client-minted: true`, example `my-application`). Description records that the value is minted outside the Camunda REST API: in SaaS by Console, in Self-Managed with OIDC by the external IdP. In Self-Managed with Basic auth, m2m apps are modelled as users instead.
- 6 path-schema sites repointed to `$ref` `ClientId`:
  - `groups.yaml` — `PUT`/`DELETE /groups/{groupId}/clients/{clientId}`
  - `roles.yaml` — `PUT`/`DELETE /roles/{roleId}/clients/{clientId}`
  - `tenants.yaml` — `PUT`/`DELETE /tenants/{tenantId}/clients/{clientId}`

## Why no semantic-edge stack

I attempted the usual 3-PR shape (promote → register entities + annotate edges → allOf lifts in body schemas) and discovered that the edge layer is structurally blocked.

- The `verify-semantic-kinds-registered` rule derives a required entity for each `identifiedBy.semanticType` on a `shape: edge` operation. For the 6 client membership edges, that derived requirement would be a `Client` entity (owner of `ClientId`).
- "Every required kind must be established somewhere in the spec." The Camunda REST API has **no producer for Client**: there is no `createClient`, no `getClient`, and no global `searchClients` — only the per-owner edge endpoints (`searchClientsForGroup` / `…ForRole` / `…ForTenant`). Per [the docs](https://docs.camunda.io/docs/next/components/admin/client/), client credentials are minted by Console (SaaS) or by an external IdP (Self-Managed with OIDC); in Self-Managed with Basic auth, "client" isn't a distinct concept at all.
- This is genuinely different from `User` (`createUser` exists), `MappingRule` (`createMappingRule` exists), and `GlobalTaskListener` (`createGlobalTaskListener` exists). All three have a producer that "establishes" the entity in registry terms even when the underlying identity may be IdP-managed in deployment.

So the membership-edge annotations (`GroupClientMembership`, `RoleClientMembership`, `TenantClientMembership`) are deferred until either:

1. a global discovery operation for clients is added to the API, or
2. the registry/validator gains a first-class concept of "external entity" (no producer required) — which would also clean up the modelling of `User` for OIDC-only deployments.

The body-side `clientId` properties in `GroupClientResult` / `RoleClientResult` / `TenantClientResult` are **not** lifted in this PR — that lift only makes sense alongside the edge annotations.

## Validation

- `spectral lint` clean (24 pre-existing warnings, 0 errors)
- `node --test 'spectral-tests/*.test.js'` → 79 pass

Refs #52272.