### PR TITLE
feat: introduce shape: external-entity for identifiers minted outside the Camunda API

### DIFF
--- a/zeebe/gateway-protocol/spectral-functions/verifySemanticKindsRegistered.js
+++ b/zeebe/gateway-protocol/spectral-functions/verifySemanticKindsRegistered.js
@@ -20,6 +20,12 @@
 //      having to redundantly write `x-semantic-requires` next to every edge
 //      establishment.
 //
+//   Special case for `shape: external-entity` registry entries (camunda/camunda#52320):
+//   the producer-existence check is skipped, and any operation that tries
+//   to `establishes` or `requires` an external entity directly is rejected
+//   — external entities are *referenced* through edge `identifiedBy`
+//   tuples only.
+//
 // The orphan check in the other direction (`establishes` with no consumer)
 // is intentionally not enforced — many producers are legitimately useful
 // without a consumer in this spec (e.g. setup/admin operations).
@@ -74,6 +80,11 @@ function loadRegistry() {
   const doc = JSON.parse(raw);
   const kinds = Array.isArray(doc.kinds) ? doc.kinds : [];
   const names = new Set();
+  // Names of kinds whose `shape` is `external-entity`. Such entities are
+  // referenced via edge `identifiedBy` tuples only — the cross-reference
+  // check skips them, and the operation-walk below rejects any direct
+  // `establishes`/`requires` against them.
+  const externalNames = new Set();
   // semanticType (string) -> array of entity kind names that declare it as an
   // identifier. Single-owner is the well-formed case; multi-owner is a
   // registry config error and surfaces as an error against the first edge
@@ -83,23 +94,26 @@ function loadRegistry() {
     const name = typeof entry === 'string' ? entry : entry?.name;
     if (typeof name !== 'string' || name.length === 0) continue;
     names.add(name);
-    if (entry && typeof entry === 'object' && Array.isArray(entry.identifiers)) {
-      for (const id of entry.identifiers) {
-        if (typeof id !== 'string' || id.length === 0) continue;
-        const existing = identifierToKinds.get(id);
-        if (existing) existing.push(name);
-        else identifierToKinds.set(id, [name]);
+    if (entry && typeof entry === 'object') {
+      if (entry.shape === 'external-entity') externalNames.add(name);
+      if (Array.isArray(entry.identifiers)) {
+        for (const id of entry.identifiers) {
+          if (typeof id !== 'string' || id.length === 0) continue;
+          const existing = identifierToKinds.get(id);
+          if (existing) existing.push(name);
+          else identifierToKinds.set(id, [name]);
+        }
       }
     }
   }
-  cachedRegistry = { names, identifierToKinds };
+  cachedRegistry = { names, identifierToKinds, externalNames };
   cachedFor = file;
   return cachedRegistry;
 }
 
 module.exports = (input, _opts, _context) => {
   const errors = [];
-  const { names: registry, identifierToKinds } = loadRegistry();
+  const { names: registry, identifierToKinds, externalNames } = loadRegistry();
 
   const paths = input?.paths;
   if (!paths || typeof paths !== 'object') return errors;
@@ -120,6 +134,11 @@ module.exports = (input, _opts, _context) => {
         if (!registry.has(est.kind)) {
           errors.push({
             message: `Unknown semantic kind '${est.kind}' on ${method.toUpperCase()} ${pathKey} (x-semantic-establishes). Add it to zeebe/gateway-protocol/src/main/proto/v2/semantic-kinds.json or fix the typo.`,
+            path: ['paths', pathKey, method, 'x-semantic-establishes', 'kind'],
+          });
+        } else if (externalNames.has(est.kind)) {
+          errors.push({
+            message: `Semantic kind '${est.kind}' is registered as 'shape: external-entity' and cannot be established. External entities are minted outside the Camunda REST API and may only be referenced via membership-edge identifiedBy tuples.`,
             path: ['paths', pathKey, method, 'x-semantic-establishes', 'kind'],
           });
         }
@@ -189,6 +208,11 @@ module.exports = (input, _opts, _context) => {
             message: `Unknown semantic kind '${req.kind}' on ${method.toUpperCase()} ${pathKey} (x-semantic-requires). Add it to zeebe/gateway-protocol/src/main/proto/v2/semantic-kinds.json or fix the typo.`,
             path: ['paths', pathKey, method, 'x-semantic-requires', 'kind'],
           });
+        } else if (externalNames.has(req.kind)) {
+          errors.push({
+            message: `Semantic kind '${req.kind}' is registered as 'shape: external-entity' and cannot be required directly. External entities have no producer in this API; reference them via a membership edge instead.`,
+            path: ['paths', pathKey, method, 'x-semantic-requires', 'kind'],
+          });
         }
       }
     }
@@ -196,9 +220,12 @@ module.exports = (input, _opts, _context) => {
 
   // Cross-reference: every required kind must be established somewhere.
   // Skip kinds that already failed the registry check — the message above
-  // is the actionable one.
+  // is the actionable one. Skip external entities — by definition they
+  // have no producer in this API, and the direct-reject above already
+  // catches anyone trying to require one with x-semantic-requires.
   for (const r of required) {
     if (!registry.has(r.kind)) continue;
+    if (externalNames.has(r.kind)) continue;
     if (established.has(r.kind)) continue;
     if (r.source === 'edge-endpoint') {
       errors.push({

--- a/zeebe/gateway-protocol/spectral-tests/fixtures/semantic-establishes/rest-api.yaml
+++ b/zeebe/gateway-protocol/spectral-tests/fixtures/semantic-establishes/rest-api.yaml
@@ -51,3 +51,11 @@ paths:
     $ref: 'widgets.yaml#/paths/~1invalid~1widgets~1{widgetId}~1mystery~1{mysteryId}'
   /invalid/widgets/{widgetId}/frobs/{frobId}:
     $ref: 'widgets.yaml#/paths/~1invalid~1widgets~1{widgetId}~1frobs~1{frobId}'
+
+  # ── External entity (camunda/camunda#52320) ──────────────────
+  /valid/widgets/{widgetId}/external-things/{externalThingId}:
+    $ref: 'widgets.yaml#/paths/~1valid~1widgets~1{widgetId}~1external-things~1{externalThingId}'
+  /invalid/external-things:
+    $ref: 'widgets.yaml#/paths/~1invalid~1external-things'
+  /invalid/external-things/{externalThingId}:
+    $ref: 'widgets.yaml#/paths/~1invalid~1external-things~1{externalThingId}'

--- a/zeebe/gateway-protocol/spectral-tests/fixtures/semantic-establishes/semantic-kinds.json
+++ b/zeebe/gateway-protocol/spectral-tests/fixtures/semantic-establishes/semantic-kinds.json
@@ -7,7 +7,9 @@
     { "name": "OrphanedKind", "shape": "entity", "$comment": "Registered but never established in the fixture, to exercise the orphan-requires check." },
     { "name": "Frob", "shape": "entity", "identifiers": ["FrobId"], "$comment": "Registered with an identifier but never established. Exercises the derived-requires orphan check on edge endpoints." },
     { "name": "WidgetFrobLink", "shape": "edge", "$comment": "Edge whose endpoint Frob is unestablished — exercises derived-requires orphan." },
-    { "name": "WidgetMysteryLink", "shape": "edge", "$comment": "Edge whose endpoint semanticType resolves to no entity at all — exercises the unresolved-endpoint check." }
+    { "name": "WidgetMysteryLink", "shape": "edge", "$comment": "Edge whose endpoint semanticType resolves to no entity at all — exercises the unresolved-endpoint check." },
+    { "name": "ExternalThing", "shape": "external-entity", "identifiers": ["ExternalThingId"], "$comment": "External entity (camunda/camunda#52320). Has no producer in the fixture spec; the cross-reference check must skip it." },
+    { "name": "WidgetExternalLink", "shape": "edge", "$comment": "Edge from Widget to ExternalThing — establishes correctly without needing an ExternalThing producer." }
   ]
 }
 

--- a/zeebe/gateway-protocol/spectral-tests/fixtures/semantic-establishes/widgets.yaml
+++ b/zeebe/gateway-protocol/spectral-tests/fixtures/semantic-establishes/widgets.yaml
@@ -340,3 +340,80 @@ paths:
       responses:
         '204':
           description: Assigned.
+
+  # 13. Edge whose endpoint resolves to an external-entity (ExternalThing).
+  #     The cross-reference check must NOT report ExternalThing as an
+  #     orphan, because external entities have no producer by definition
+  #     (camunda/camunda#52320).
+  /valid/widgets/{widgetId}/external-things/{externalThingId}:
+    put:
+      operationId: assignExternalThingToWidget
+      summary: Assign external thing to widget
+      description: Should pass — ExternalThing is an external-entity, no producer required.
+      x-added-in-version: "8.8"
+      tags: [Test]
+      parameters:
+        - name: widgetId
+          in: path
+          required: true
+          description: The widget id.
+          schema: { type: string }
+        - name: externalThingId
+          in: path
+          required: true
+          description: The external thing id.
+          schema: { type: string }
+      x-semantic-establishes:
+        kind: WidgetExternalLink
+        shape: edge
+        identifiedBy:
+          - { in: path, name: widgetId,        semanticType: WidgetId }
+          - { in: path, name: externalThingId, semanticType: ExternalThingId }
+      responses:
+        '204':
+          description: Assigned.
+
+  # 14. Operation that tries to `establishes` an external entity directly.
+  #     Should fail — external entities have no API producer (camunda/camunda#52320).
+  /invalid/external-things:
+    post:
+      operationId: createExternalThingDirectly
+      summary: Create an external thing
+      description: Should fail — ExternalThing is shape:external-entity and cannot be established.
+      x-added-in-version: "8.8"
+      tags: [Test]
+      x-semantic-establishes:
+        kind: ExternalThing
+        identifiedBy:
+          - { in: body, name: id, semanticType: ExternalThingId }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { type: object }
+      responses:
+        '201':
+          description: Created.
+
+  # 15. Operation that tries to `requires` an external entity directly.
+  #     Should fail — external entities are referenced via edges only.
+  /invalid/external-things/{externalThingId}:
+    get:
+      operationId: getExternalThingDirectly
+      summary: Get an external thing
+      description: Should fail — ExternalThing is shape:external-entity and cannot be required directly.
+      x-added-in-version: "8.8"
+      tags: [Test]
+      parameters:
+        - name: externalThingId
+          in: path
+          required: true
+          description: The external thing id.
+          schema: { type: string }
+      x-semantic-requires:
+        kind: ExternalThing
+        bind:
+          externalThingId: { from: path, name: externalThingId }
+      responses:
+        '200':
+          description: OK.

--- a/zeebe/gateway-protocol/spectral-tests/verifySemanticKindsRegistered.test.js
+++ b/zeebe/gateway-protocol/spectral-tests/verifySemanticKindsRegistered.test.js
@@ -219,4 +219,43 @@ describe('verifySemanticKindsRegistered + schema rules', () => {
       assert.equal(v.length, 0, JSON.stringify(v, null, 2));
     });
   });
+
+  // ── External entities (camunda/camunda#52320) ────────────────
+
+  describe('verify-semantic-kinds-registered: external entities', () => {
+    it('does not flag the valid edge whose endpoint resolves to an external entity', () => {
+      const v = registryViolations.filter(
+        (e) =>
+          e.message.includes('assignExternalThingToWidget') ||
+          e.message.includes('/valid/widgets/{widgetId}/external-things'),
+      );
+      assert.equal(v.length, 0, JSON.stringify(v, null, 2));
+    });
+
+    it('does not flag ExternalThing as an orphan derived requires (external entities have no producer)', () => {
+      const v = registryViolations.filter((e) =>
+        e.message.includes("Semantic kind 'ExternalThing'") &&
+        e.message.includes('derived from'),
+      );
+      assert.equal(v.length, 0, JSON.stringify(v, null, 2));
+    });
+
+    it('flags a direct x-semantic-establishes against an external entity', () => {
+      const v = registryViolations.filter((e) =>
+        e.message.includes("Semantic kind 'ExternalThing'") &&
+        e.message.includes('cannot be established'),
+      );
+      assert.equal(v.length, 1, JSON.stringify(registryViolations, null, 2));
+      assert.match(v[0].message, /external-entity/);
+    });
+
+    it('flags a direct x-semantic-requires against an external entity', () => {
+      const v = registryViolations.filter((e) =>
+        e.message.includes("Semantic kind 'ExternalThing'") &&
+        e.message.includes('cannot be required directly'),
+      );
+      assert.equal(v.length, 1, JSON.stringify(registryViolations, null, 2));
+      assert.match(v[0].message, /external-entity/);
+    });
+  });
 });

--- a/zeebe/gateway-protocol/src/main/proto/v2/semantic-kinds.json
+++ b/zeebe/gateway-protocol/src/main/proto/v2/semantic-kinds.json
@@ -12,10 +12,17 @@
     "PascalCase, singular, and a noun (not a verb phrase).",
     "",
     "`shape` is the default `shape:` an operation should declare on",
-    "`x-semantic-establishes`. `entity` (single- or composite-key) means a",
-    "fetchable singleton; `edge` means observable only via member-list search.",
+    "`x-semantic-establishes`. Three values:",
+    "  • `entity` — single- or composite-key fetchable singleton.",
+    "  • `edge` — membership relationship observable only via member-list search.",
+    "  • `external-entity` (camunda/camunda#52320) — identifier minted outside",
+    "    the Camunda REST API (e.g. an OAuth ClientId minted by Console or an",
+    "    external IdP). Referenced via edge `identifiedBy` tuples only; it is",
+    "    an error to use an external kind directly in `x-semantic-establishes`",
+    "    or `x-semantic-requires`, and the producer-existence cross-reference",
+    "    is skipped for it.",
     "",
-    "`identifiers` (entity kinds only) lists the semantic identifier types",
+    "`identifiers` (entity and external-entity kinds) lists the semantic identifier types",
     "that identify the entity (matching the `semanticType` values used in",
     "`x-semantic-establishes.identifiedBy`). Edge operations whose",
     "`identifiedBy` references one of these types implicitly require the",
@@ -105,6 +112,12 @@
       "shape": "entity",
       "identifiers": ["ClusterVariableName"],
       "description": "A tenant-scoped cluster variable, identified by the (tenantId, name) tuple. Established by createTenantClusterVariable. Only ClusterVariableName is listed in 'identifiers' here because TenantId is owned by the Tenant entity and must remain single-owner for the edge-derivation rule; the Tenant requirement of tenant-scoped operations is expressed via the tenantId path parameter."
+    },
+    {
+      "name": "Client",
+      "shape": "external-entity",
+      "identifiers": ["ClientId"],
+      "description": "An OAuth client. Minted outside the Camunda REST API: by Console in SaaS, by the configured external IdP (EntraID, Keycloak, Okta, …) in Self-Managed with OIDC. Not modelled at all under Self-Managed Basic auth, where m2m apps are users instead. Referenced by the client-membership edges only — never established or fetched via this API."
     }
   ]
 


### PR DESCRIPTION
> ### Stack (merge bottom-up)
>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
> 13. #52316 — `ClusterVariableName` promoted to `identifiers.yaml`; 6 path-schema sites repointed
> 14. #52317 — GlobalClusterVariable + TenantClusterVariable registry entries; 7 cluster-variable CRUD annotations
> 15. #52318 — `name` allOf lifts in `cluster-variables.yaml`
> 16. #52319 — `ClientId` promoted to `identifiers.yaml`; 6 path-schema sites repointed (no semantic-edge stack — see PR description)
> 17. #52321 — Registry: `shape: external-entity` for identifiers minted outside the Camunda API; `Client` registered (refs #52320)
> 18. #52322 — `x-semantic-provider` coverage for the four genuinely unaddressed rows in #52169 (`GlobalTaskListenerResult.id`, `ProcessElementStatisticsResult.elementId`, `DeleteResourceResponse.resourceKey`)
>
> Refs #52272.

>
> 1. #52300 — Spectral lint rules + registry scaffolding
> 2. #52301 — Role + User registry entries; createUser establishes; role operation annotations
> 3. #52302 — `username` allOf lifts in `users.yaml`
> 4. #52307 — Tenant registry entry; tenant CRUD + tenant-user edge annotations
> 5. #52308 — `tenantId` allOf lifts in `tenants.yaml`
> 6. #52309 — `GroupId` promoted to `identifiers.yaml`; 17 path-schema sites repointed
> 7. #52310 — Group registry entry; group CRUD + group-user edge annotations
> 8. #52311 — `groupId` allOf lifts in `groups.yaml`
> 9. #52312 — `MappingRuleId` promoted to `identifiers.yaml`; 9 path-schema sites repointed
> 10. #52313 — MappingRule registry entry; mapping-rule CRUD + 3 membership edge annotations
> 11. #52314 — `mappingRuleId` allOf lifts in `mapping-rules.yaml`
> 12. #52315 — GlobalTaskListener registry entry; 4 global-listener CRUD annotations
> 13. #52316 — `ClusterVariableName` promoted to `identifiers.yaml`; 6 path-schema sites repointed
> 14. #52317 — GlobalClusterVariable + TenantClusterVariable registry entries; 7 cluster-variable CRUD annotations
> 15. #52318 — `name` allOf lifts in `cluster-variables.yaml`
> 16. #52319 — `ClientId` promoted to `identifiers.yaml`; 6 path-schema sites repointed (no semantic-edge stack — see PR description)
> 17. #52321 — Registry: `shape: external-entity` for identifiers minted outside the Camunda API; `Client` registered (refs #52320)
>
> Refs #52272.

Implements PR A of camunda/camunda#52320 — adds the `shape: external-entity` registry concept that lets us model identifiers minted outside the Camunda REST API (OAuth `ClientId` from Console / external IdP, etc.) without breaking the producer-existence cross-reference.

## What this does

- `verifySemanticKindsRegistered.js` tracks `externalNames` from registry entries with `shape: 'external-entity'` and:
  - rejects `x-semantic-establishes.kind` against an external entity (no operation in this API can mint one),
  - rejects `x-semantic-requires.kind` against an external entity (members reference externals via edge `identifiedBy`, not via a sibling `requires`),
  - skips the producer-existence cross-reference for external kinds (they have no producer by definition).
- `semantic-kinds.json` registry comment now describes all three shapes (`entity`, `edge`, `external-entity`), and adds the `Client` entry so subsequent stack PRs can annotate the client-membership edges.

The op-level `x-semantic-establishes.shape` enum stays `[entity, edge]` — operations never `establishes: external-entity`. The new shape is registry-only.

## Why this is structurally needed

Promoting `ClientId` (#52319) and registering `Client` as a normal entity forces a choice between two bad options: register the entity and have the cross-reference check fire on every membership edge ("required but no operation establishes it"), or leave the identifier unowned and have the edge-derivation rule reject every membership edge that references it. `external-entity` resolves this cleanly.

## Coverage

The Spectral fixture is extended with `ExternalThing` (external-entity) plus three operations covering the defect class on both sides:
- one valid edge that references it via `identifiedBy` (must not orphan-fail),
- one invalid op that tries to `establishes` it directly,
- one invalid op that tries to `requires` it directly.

4 new tests in `spectral-tests/verifySemanticKindsRegistered.test.js` (83 total, all passing). `spectral lint` on the production spec stays at 0 errors / 24 pre-existing warnings — `Client` is registered but not yet referenced anywhere, so no production behaviour change in this PR.

## Stack

- Base: `feat/x-semantic-establishes-client-id` (#52319 — ClientId promotion).
- This PR: PR A — registry shape only.
- Next: PR B — annotate the 9 client-membership operations and 3 edges (GroupClientMembership, RoleClientMembership, TenantClientMembership).
- Then: PR C — `allOf` lifts for `clientId` in `GroupClientResult` / `RoleClientResult` / `TenantClientResult`.

Refs camunda/camunda#52320
Refs camunda/camunda#52272