### PR TITLE
fix: disable process instance statistics compat test for server versions < 8.9.2

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceStatisticsTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceStatisticsTest.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import java.util.function.Consumer;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
 @CompatibilityTest
@@ -261,6 +262,11 @@ public class ProcessInstanceStatisticsTest {
   }
 
   @Test
+  @DisabledIfSystemProperty(
+      named = "camunda.compatibility.test.version",
+      matches = "8\\.9\\.[01]",
+      disabledReason =
+          "Multi-instance body incident statistics was introduced in 8.9.2 (see #51251)")
   void shouldGetIncidentStatisticsForMultiInstanceBodyWithInvalidInputCollection() {
     // given
     final var processModel =


### PR DESCRIPTION
## Description

The multi-instance body incident statistics feature was introduced in 8.9.2 (#51251). Replace the Assumptions-based version check with @DisabledIfSystemProperty to align with the pattern used in DecisionInstanceSearchTest and ensure the test is properly skipped during compatibility test runs against 8.9.0 and 8.9.1.

## Related issues

related to https://camunda.slack.com/archives/C0A2AGG2Q2E/p1777867372941449
