### PR TITLE
fix: update exporter position metric on gossip

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -480,6 +480,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
 
     if (state.getPosition(exporterId) < exporterState.position()) {
       state.setExporterState(exporterId, exporterState.position(), exporterState.metadata());
+      metrics.setLastUpdatedExportedPosition(exporterId, exporterState.position());
     }
   }
 


### PR DESCRIPTION
This metric was only updated by leaders. Instead of removing this metric on step down, followers can continue to update it based on exporter state received via gossip.