### PR TITLE
ci: fix preview env helm dependency version

### DIFF
--- a/.ci/preview-environments/charts/c8sm/Chart.lock
+++ b/.ci/preview-environments/charts/c8sm/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.8.7
 - name: camunda-platform
   repository: https://helm.camunda.io
-  version: 14.0.0
-digest: sha256:a7de15d6ea2ab8de040b683bb6def246c5e973653fdbf4b55d9ed6bde5bb3194
-generated: "2026-04-15T20:14:42.007398771Z"
+  version: 14.0.1
+digest: sha256:500eec42eb07c374e807395790e059002fae783b2ea8725747d2b26548ec6817
+generated: "2026-05-04T11:48:46.507206243+02:00"


### PR DESCRIPTION
## Description

Meant to fix https://github.com/camunda/camunda/actions/runs/25305743508/job/74182464805#step:10:137 which was caused by https://github.com/camunda/camunda/commit/0da7eab4db511d3ecc104d9bf3ffc092fee5101f (incomplete update)

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

INC-5299
