### PR TITLE
deps: bump c8run versions to 8.9.2

### DIFF
--- a/c8run/.env
+++ b/c8run/.env
@@ -1,9 +1,9 @@
 # this is the version of camunda/ zeebe
-CAMUNDA_VERSION=8.9.1
+CAMUNDA_VERSION=8.9.2
 # docker images moved to a shortened tag, override compose with this value when using --docker
-CAMUNDA_DOCKER_VERSION=8.9.1
+CAMUNDA_DOCKER_VERSION=8.9.2
 # Look here: https://artifacts.camunda.com/ui/native/connectors/io/camunda/connector/connector-runtime-bundle/
-CONNECTORS_VERSION=8.9.1
+CONNECTORS_VERSION=8.9.2
 # version of docker compose artifact (used for --docker option)
 COMPOSE_TAG=8.9
 COMPOSE_EXTRACTED_FOLDER=docker-compose-8.9


### PR DESCRIPTION
## Summary
- bump the c8run Camunda version from 8.9.1 to 8.9.2
- bump the c8run Docker image version from 8.9.1 to 8.9.2
- bump the c8run connectors version from 8.9.1 to 8.9.2

## Testing
- not run (configuration-only version bump)