### PR TITLE
fix: recover from invalid exporter position 0

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainer.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainer.java
@@ -85,6 +85,7 @@ final class ExporterContainer implements Controller {
   private void initPosition() {
     position = exportersState.getPosition(getId());
     lastUnacknowledgedPosition = position;
+    lastAcknowledgedPosition = position;
     if (position == ExportersState.VALUE_NOT_FOUND) {
       exportersState.setPosition(getId(), -1L);
     }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExportersState.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExportersState.java
@@ -73,6 +73,7 @@ public final class ExportersState {
   public long getPosition(final String exporterId) {
     return findExporterStateEntry(exporterId)
         .map(ExporterStateEntry::getPosition)
+        .map(ExportersState::normalizePosition)
         .orElse(VALUE_NOT_FOUND);
   }
 
@@ -103,8 +104,20 @@ public final class ExportersState {
     final LongArrayList positions = new LongArrayList();
 
     visitExporterState(
-        (exporterId, exporterStateEntry) -> positions.addLong(exporterStateEntry.getPosition()));
-    return positions.longStream().min().orElse(-1L);
+        (exporterId, exporterStateEntry) ->
+            positions.addLong(normalizePosition(exporterStateEntry.getPosition())));
+    return positions.longStream().min().orElse(VALUE_NOT_FOUND);
+  }
+
+  /**
+   * Position 0 is not a valid log entry position; the first valid position is 1. A persisted 0 is
+   * the result of a historical bug where {@code undoSoftPauseExporter} flushed the long default
+   * value of {@code lastAcknowledgedPosition}. Treat such entries as uninitialized so seek and
+   * compaction behave like for a fresh exporter and the first real acknowledgment overwrites the
+   * stale entry.
+   */
+  private static long normalizePosition(final long position) {
+    return position == 0 ? VALUE_NOT_FOUND : position;
   }
 
   /**
@@ -114,8 +127,9 @@ public final class ExportersState {
     final var max = new MutableLong(Long.MIN_VALUE);
     visitExporterState(
         (exporterId, exporterStateEntry) -> {
-          if (max.longValue() < exporterStateEntry.getPosition()) {
-            max.set(exporterStateEntry.getPosition());
+          final var position = normalizePosition(exporterStateEntry.getPosition());
+          if (max.longValue() < position) {
+            max.set(position);
           }
         });
     return max.get();

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerTest.java
@@ -306,7 +306,7 @@ final class ExporterContainerTest {
       assertThat(exporter.getRecord()).isNotNull();
       assertThat(exporter.getRecord()).isEqualTo(mockedRecord);
       assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
-      assertThat(exporterContainer.getPosition()).isZero();
+      assertThat(exporterContainer.getPosition()).isEqualTo(-1L);
     }
 
     @Test
@@ -330,7 +330,7 @@ final class ExporterContainerTest {
       assertThat(exporter.getRecord()).isNotNull();
       assertThat(exporter.getRecord()).isEqualTo(secondRecord);
       assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(2);
-      assertThat(exporterContainer.getPosition()).isZero();
+      assertThat(exporterContainer.getPosition()).isEqualTo(-1L);
     }
 
     @Test
@@ -375,8 +375,8 @@ final class ExporterContainerTest {
 
       // then
       assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
-      assertThat(exporterContainer.getPosition()).isZero();
-      assertThat(runtime.getState().getPosition(EXPORTER_ID)).isZero();
+      assertThat(exporterContainer.getPosition()).isEqualTo(-1L);
+      assertThat(runtime.getState().getPosition(EXPORTER_ID)).isEqualTo(-1L);
     }
 
     @Test
@@ -425,7 +425,7 @@ final class ExporterContainerTest {
 
       // then
       assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
-      assertThat(exporterContainer.getPosition()).isZero();
+      assertThat(exporterContainer.getPosition()).isEqualTo(-1L);
     }
 
     @Test
@@ -447,7 +447,7 @@ final class ExporterContainerTest {
       awaitPreviousCall();
 
       assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
-      assertThat(exporterContainer.getPosition()).isZero();
+      assertThat(exporterContainer.getPosition()).isEqualTo(-1L);
       assertThat(exporterContainer.readMetadata()).isNotPresent();
 
       // when
@@ -477,7 +477,7 @@ final class ExporterContainerTest {
 
       // then
       assertThat(exporter.getRecord()).isNull();
-      assertThat(exporterContainer.getLastUnacknowledgedPosition()).isZero();
+      assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(-1L);
       assertThat(exporterContainer.getPosition()).isEqualTo(1);
     }
 
@@ -529,7 +529,7 @@ final class ExporterContainerTest {
       assertThat(exporter.getRecord()).isNotNull();
       assertThat(exporter.getRecord()).isEqualTo(firstRecord);
       assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
-      assertThat(exporterContainer.getPosition()).isZero();
+      assertThat(exporterContainer.getPosition()).isEqualTo(-1L);
     }
 
     @Test
@@ -917,7 +917,7 @@ final class ExporterContainerTest {
       assertThat(exporter.getRecord()).isNull();
       // filtered record still advances committed position
       assertThat(exporterContainer.getPosition()).isEqualTo(1);
-      assertThat(exporterContainer.getLastUnacknowledgedPosition()).isZero();
+      assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(-1L);
     }
 
     @Test
@@ -943,7 +943,7 @@ final class ExporterContainerTest {
       // then
       assertThat(exporter.getRecord()).isNull();
       assertThat(exporterContainer.getPosition()).isEqualTo(1);
-      assertThat(exporterContainer.getLastUnacknowledgedPosition()).isZero();
+      assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(-1L);
     }
 
     @Test
@@ -969,7 +969,7 @@ final class ExporterContainerTest {
       // then
       assertThat(exporter.getRecord()).isNull();
       assertThat(exporterContainer.getPosition()).isEqualTo(1);
-      assertThat(exporterContainer.getLastUnacknowledgedPosition()).isZero();
+      assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(-1L);
     }
 
     @Test
@@ -995,7 +995,7 @@ final class ExporterContainerTest {
       // then
       assertThat(exporter.getRecord()).isNull();
       assertThat(exporterContainer.getPosition()).isEqualTo(1);
-      assertThat(exporterContainer.getLastUnacknowledgedPosition()).isZero();
+      assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(-1L);
     }
 
     @Test
@@ -1022,7 +1022,7 @@ final class ExporterContainerTest {
       assertThat(exporter.getRecord()).isNotNull().isEqualTo(mockedRecord);
       assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
       // committed position is still previous value until record is acknowledged
-      assertThat(exporterContainer.getPosition()).isZero();
+      assertThat(exporterContainer.getPosition()).isEqualTo(-1L);
     }
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerTest.java
@@ -28,6 +28,7 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.nio.file.Path;
 import java.util.Map;
+import org.agrona.collections.MutableLong;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -458,6 +459,33 @@ final class ExporterContainerTest {
       assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
       assertThat(exporterContainer.getPosition()).isEqualTo(1);
       assertThat(exporterContainer.readMetadata()).isPresent().hasValue(metadata);
+    }
+
+    @Test
+    void shouldNotPersistPositionZeroOnResumeWithoutAcknowledgment() throws Exception {
+      // given - a fresh exporter that never acknowledges (e.g. BlockingExporter)
+      exporterContainer.configureExporter();
+      exporterContainer.initMetadata();
+      exporterContainer.openExporter();
+      exporterContainer.softPauseExporter();
+
+      // when
+      exporterContainer.undoSoftPauseExporter();
+      awaitPreviousCall();
+
+      // then - position 0 must never be persisted, see #52257. Inspect the raw stored value
+      // since getPosition() normalizes 0 to VALUE_NOT_FOUND on read.
+      final var rawStoredPosition = new MutableLong(Long.MIN_VALUE);
+      runtime
+          .getState()
+          .visitExporterState(
+              (id, entry) -> {
+                if (EXPORTER_ID.equals(id)) {
+                  rawStoredPosition.set(entry.getPosition());
+                }
+              });
+      assertThat(rawStoredPosition.get()).isEqualTo(-1L);
+      assertThat(exporterContainer.getPosition()).isEqualTo(-1L);
     }
 
     @Test

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorPauseTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorPauseTest.java
@@ -87,7 +87,7 @@ public final class ExporterDirectorPauseTest {
 
     // then
     verify(exporter, timeout(TIMEOUT).times(1)).export(any());
-    assertThat(exporter.getController().getLastExportedRecordPosition()).isZero();
+    assertThat(exporter.getController().getLastExportedRecordPosition()).isEqualTo(-1L);
   }
 
   @Test

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExportersStateTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExportersStateTest.java
@@ -276,4 +276,16 @@ public final class ExportersStateTest {
     // when/then
     assertThat(state.getHighestPosition()).isEqualTo(Long.MIN_VALUE);
   }
+
+  @Test
+  public void shouldNormalizePersistedZeroPositionToNotFound() {
+    // given - simulates a cluster that hit the historical bug from #52257
+    state.setPosition("corrupted", 0L);
+    state.setPosition("healthy", 5L);
+
+    // when/then
+    assertThat(state.getPosition("corrupted")).isEqualTo(ExportersState.VALUE_NOT_FOUND);
+    assertThat(state.getPosition("healthy")).isEqualTo(5L);
+    assertThat(state.getLowestPosition()).isEqualTo(-1L);
+  }
 }


### PR DESCRIPTION
`ExporterContainer.lastAcknowledgedPosition` defaults to `0` and was never explicitly initialized. When `undoSoftPauseExporter` ran for an exporter that had not acknowledged anything in the meantime — typical for a `BlockingExporter` substituted for a missing exporter — it persisted `0` as the exporter position. Position `0` is not a valid log entry position, so the next leader transition wedged on `seekToNextEvent(0)` and compaction stayed pinned.

Initialize `lastAcknowledgedPosition` from the persisted position so the existing position-advances-only guard short-circuits when nothing has actually been acknowledged. To recover clusters that already persisted `0`, normalize a persisted `0` to `VALUE_NOT_FOUND` on read in `ExportersState`; the next `initPosition` writes `-1` back, self-healing the entry.

closes #52257