### PR TITLE
Start using the full RocksDB memory budget

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCache.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCache.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.RocksdbCfg;
 import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration.MemoryAllocationStrategy;
 import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory.SharedRocksDbResources;
+import io.camunda.zeebe.util.ByteValue;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.lang.management.ManagementFactory;
 import org.slf4j.Logger;
@@ -34,17 +35,14 @@ public class RocksDbSharedCache {
     try (final SharedRocksDbResources rocksDbResources =
         new SharedRocksDbResources(rocksDbMemoryLimit)) {
       LOGGER.info(
-          "Allocating {} bytes ({} MB) for RocksDB memory Limit (with {} MB cache size), with memory allocation strategy: {}. "
-              + "Total system memory: {} bytes ({} MB). Partitions per broker: {}",
-          rocksDbResources.getMemoryLimit(),
-          rocksDbResources.getMemoryLimit() / (1024 * 1024),
-          rocksDbResources.getBlockCacheSize() / (1024 * 1024),
-          memoryAllocationStrategy,
-          totalMemorySize,
-          totalMemorySize / (1024 * 1024),
+          "Memory allocation strategy `{}` allocated {} for RocksDB, with up to {} reserved for write buffers. Total system memory: {}. Partitions per broker: {}",
+          memoryAllocationStrategy.name(),
+          ByteValue.prettyPrint(rocksDbResources.getMemoryLimit()),
+          ByteValue.prettyPrint(rocksDbResources.getWriteBufferLimit()),
+          ByteValue.prettyPrint(totalMemorySize),
           partitionsPerBroker);
 
-      return rocksDbResources.getBlockCacheSize();
+      return rocksDbResources.getMemoryLimit();
     }
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCache.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RocksDbSharedCache.java
@@ -22,7 +22,7 @@ public class RocksDbSharedCache {
   public static final double ADVICE_MAX_MEMORY_FRACTION = 0.5;
   private static final Logger LOGGER = LoggerFactory.getLogger(RocksDbSharedCache.class);
 
-  public static long getSharedCacheSize(
+  public static long getRocksDbMemoryLimit(
       final BrokerCfg brokerCfg, final MeterRegistry meterRegistry, final int partitionsPerBroker) {
     final var rocksdbCfg = brokerCfg.getExperimental().getRocksdb();
     final long rocksDbMemoryLimit = getMemoryLimitBytes(rocksdbCfg, partitionsPerBroker);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -231,7 +231,8 @@ public final class ZeebePartitionFactory {
     final int partitionsPerBroker =
         getPartitionsPerBroker(clusterConfigurationService, localMemberId, brokerCfg);
     sharedRocksDbResources.allocate(
-        RocksDbSharedCache.getSharedCacheSize(brokerCfg, brokerMeterRegistry, partitionsPerBroker));
+        RocksDbSharedCache.getRocksDbMemoryLimit(
+            brokerCfg, brokerMeterRegistry, partitionsPerBroker));
   }
 
   /**

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
@@ -231,33 +231,25 @@ public final class ZeebeRocksDbFactory<
    * centralizes memory calculations to avoid duplication.
    */
   MemoryConfiguration calculateMemoryConfiguration() {
-    final var totalMemoryBudgetPerPartition =
-        sharedRocksDbResources.getMemoryLimit() / partitionCount;
-
-    // recommended by RocksDB, but we could tweak it; keep in mind we're also caching the indexes
-    // and filters into the block cache, so we don't need to account for more memory there
-    final var blockCacheMemoryPerPartition =
-        sharedRocksDbResources.getBlockCacheSize() / partitionCount;
-    // flushing the memtables is done asynchronously, so there may be multiple memtables in memory,
-    // although only a single one is writable. once we have too many memtables, writes will stop.
-    // since prefix iteration is our bread n butter, we will build an additional filter for each
-    // memtable which takes a bit of memory which must be accounted for from the memtable's memory
-    final var maxConcurrentMemtableCount = rocksDbConfiguration.getMaxWriteBufferNumber();
-    // this is a current guess and candidate for further tuning
-    // values can be between 0 and 0.25 (anything higher gets clamped to 0.25), we randomly picked
-    // 0.15
-    // prefix seek must be fast, so we allocate some extra memory of a single memtable budget to
-    // create
-    // a filter for each memtable, allowing us to skip the prefixes if possible
+    // RocksDB clamps memtable_prefix_bloom_size_ratio to [0, 0.25]; 0.15 is our current guess and a
+    // candidate for tuning. Prefix seek must be fast, so we trade some memtable budget for a per-
+    // memtable bloom filter that lets us skip prefixes.
     final var memtablePrefixFilterMemory = 0.15;
-    final var memtableMemory =
-        Math.round(
-            ((totalMemoryBudgetPerPartition - blockCacheMemoryPerPartition)
-                    / (double) maxConcurrentMemtableCount)
+
+    // The prefix bloom is included in the memtable's WriteBufferManager accounting, so we shrink
+    // write_buffer_size by the same fraction. Otherwise WBM would force flushes before each
+    // memtable reaches its configured size.
+    final var memtableBudget = sharedRocksDbResources.getWriteBufferLimit() / partitionCount;
+    final var maxMemtableSize =
+        (long)
+            (memtableBudget
+                / rocksDbConfiguration.getMaxWriteBufferNumber()
                 * (1 - memtablePrefixFilterMemory));
 
     return new MemoryConfiguration(
-        memtableMemory, memtablePrefixFilterMemory, maxConcurrentMemtableCount);
+        maxMemtableSize,
+        memtablePrefixFilterMemory,
+        rocksDbConfiguration.getMaxWriteBufferNumber());
   }
 
   /**
@@ -369,15 +361,7 @@ public final class ZeebeRocksDbFactory<
   }
 
   public static final class SharedRocksDbResources implements AutoCloseable {
-
-    // memoryLimit represents the total memory budget we expect RocksDB to use on this node.
-    // We follow the recommended heuristic where roughly 1/3 of that total budget is assigned to
-    // the block cache (cacheSize). This ratio can be tuned if needed.
-    // When sizing memoryLimit, remember that RocksDB's total memory footprint includes block
-    // cache, index and bloom filters, memtables, and blocks pinned by iterators. See:
-    // https://github.com/facebook/rocksdb/wiki/Setup-Options-and-Basic-Tuning#block-cache-size
-    // https://github.com/facebook/rocksdb/wiki/Memory-usage-in-RocksDB
-    private static final long CACHE_RATIO_OF_MEMORY_LIMIT = 3;
+    private static final double MEMTABLE_RATIO = 2 / 3.0;
 
     static {
       RocksDB.loadLibrary();
@@ -386,7 +370,7 @@ public final class ZeebeRocksDbFactory<
     private LRUCache sharedCache;
     private WriteBufferManager sharedWbm;
     private long memoryLimit;
-    private long blockCacheSize;
+    private long writeBufferLimit;
 
     public SharedRocksDbResources() {}
 
@@ -398,14 +382,13 @@ public final class ZeebeRocksDbFactory<
       if (isInitialized()) {
         close();
       }
+      writeBufferLimit = (long) (memoryLimit * MEMTABLE_RATIO);
+      this.memoryLimit = memoryLimit;
       // (#DBs) × write_buffer_size × max_write_buffer_number should be comfortably ≤ your WBM
       // limit, with headroom for memtable bloom/filter overhead. write_buffer_size is calculated in
       // zeebeRocksDBFactory.
-      final long blockCacheSize = memoryLimit / CACHE_RATIO_OF_MEMORY_LIMIT;
-      sharedCache = new LRUCache(blockCacheSize, 8, false, 0.15);
-      sharedWbm = new WriteBufferManager(blockCacheSize / 4, sharedCache);
-      this.memoryLimit = memoryLimit;
-      this.blockCacheSize = blockCacheSize;
+      sharedCache = new LRUCache(memoryLimit, 8, false, 0.15);
+      sharedWbm = new WriteBufferManager(writeBufferLimit, sharedCache);
     }
 
     public boolean isInitialized() {
@@ -424,8 +407,8 @@ public final class ZeebeRocksDbFactory<
       return memoryLimit;
     }
 
-    public long getBlockCacheSize() {
-      return blockCacheSize;
+    public long getWriteBufferLimit() {
+      return writeBufferLimit;
     }
 
     @Override

--- a/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactoryTest.java
+++ b/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactoryTest.java
@@ -102,7 +102,7 @@ final class ZeebeRocksDbFactoryTest {
             ColumnFamilyOptions::writeBufferSize,
             ColumnFamilyOptions::compactionPriority,
             ColumnFamilyOptions::numLevels)
-        .containsExactly(16_901_492L, CompactionPriority.OldestSmallestSeqFirst, 4);
+        .containsExactly(16_901_490L, CompactionPriority.OldestSmallestSeqFirst, 4);
 
     // then - user options should override defaults
     assertThat(customOptions)
@@ -274,7 +274,7 @@ final class ZeebeRocksDbFactoryTest {
     assertThat(columnFamilyOptions.memtablePrefixBloomSizeRatio()).isEqualTo(0.15);
     assertThat(columnFamilyOptions.minWriteBufferNumberToMerge()).isEqualTo(3);
     assertThat(columnFamilyOptions.maxWriteBufferNumber()).isEqualTo(6);
-    assertThat(columnFamilyOptions.writeBufferSize()).isEqualTo(50_704_475L);
+    assertThat(columnFamilyOptions.writeBufferSize()).isEqualTo(50_704_474L);
     assertThat(columnFamilyOptions.compactionPriority())
         .isEqualTo(CompactionPriority.OldestSmallestSeqFirst);
     assertThat(columnFamilyOptions.compactionStyle()).isEqualTo(org.rocksdb.CompactionStyle.LEVEL);


### PR DESCRIPTION
Ensures that we use the entire RocksDB memory budget instead of just one third of it. Two thirds of the full budget are available for write buffers, a significant increase from the previous `1/3 * 1/4 = 1/12`.

Relates to #50958