### PR TITLE
feat: add `businessId` to process instance API Zod schemas

### DIFF
--- a/webapp/client/apps/orchestration-cluster-webapp/package.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/package.json
@@ -16,7 +16,7 @@
 		"test:integration": "playwright test --project=integration"
 	},
 	"dependencies": {
-		"@camunda/camunda-api-zod-schemas": "0.0.60",
+		"@camunda/camunda-api-zod-schemas": "0.0.61",
 		"@camunda/camunda-composite-components": "0.23.1",
 		"@carbon/react": "1.106.0",
 		"@tanstack/react-query": "5.100.5",

--- a/webapp/client/package-lock.json
+++ b/webapp/client/package-lock.json
@@ -56,7 +56,7 @@
 		"apps/orchestration-cluster-webapp": {
 			"name": "@camunda/orchestration-cluster-webapp",
 			"dependencies": {
-				"@camunda/camunda-api-zod-schemas": "0.0.60",
+				"@camunda/camunda-api-zod-schemas": "0.0.61",
 				"@camunda/camunda-composite-components": "0.23.1",
 				"@carbon/react": "1.106.0",
 				"@tanstack/react-query": "5.100.5",
@@ -8955,13 +8955,13 @@
 			"version": "0.0.1",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
-				"@camunda/camunda-api-zod-schemas": "0.0.60",
+				"@camunda/camunda-api-zod-schemas": "0.0.61",
 				"typescript": "6.0.3"
 			}
 		},
 		"packages/camunda-api-zod-schemas": {
 			"name": "@camunda/camunda-api-zod-schemas",
-			"version": "0.0.60",
+			"version": "0.0.61",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
 				"@types/node": "25.6.0",

--- a/webapp/client/packages/c8-mocks/package.json
+++ b/webapp/client/packages/c8-mocks/package.json
@@ -18,7 +18,7 @@
 		"typecheck": "tsc"
 	},
 	"devDependencies": {
-		"@camunda/camunda-api-zod-schemas": "0.0.60",
+		"@camunda/camunda-api-zod-schemas": "0.0.61",
 		"typescript": "6.0.3"
 	}
 }

--- a/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
+++ b/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.0.61
+
+### 🚀 Enhancements
+
+- Add `businessId` property to process-instance schema ([#52097](https://github.com/camunda/camunda/issues/52097))
+
+### ❤️ Contributors
+
+- Christoph Fricke ([@christoph-fricke](https://github.com/christoph-fricke))
+
 ## v0.0.60
 
 ### 🩹 Fixes

--- a/webapp/client/packages/camunda-api-zod-schemas/README.md
+++ b/webapp/client/packages/camunda-api-zod-schemas/README.md
@@ -29,7 +29,7 @@ Refer to the exported members from `lib/8.8/index.ts` and other files in the `li
 
 ## Publishing a new version
 
-1. Increment the version in `package.json`, dependency-version in `../c8-mocks/package.json`, and push changes to `main`.
+1. Increment the version in `package.json`, dependency-versions in the npm workspace packages, run `npm i`, and push changes to `main`.
 2. Run the [Publish Zod Schemas to npm](https://github.com/camunda/camunda/actions/workflows/publish-zod-schemas.yml) GitHub action.
    - By default, the dry-run option is enabled. Uncheck it to publish the new version.
 3. Update the `@camunda/camunda-api-zod-schemas` package versions in Operate, Admin and Tasklist.

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/process-instance.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/process-instance.ts
@@ -74,6 +74,7 @@ const queryProcessInstancesFilterSchema = z
 		elementId: advancedStringFilterSchema,
 		hasElementInstanceIncident: z.boolean(),
 		incidentErrorHashCode: advancedIntegerFilterSchema,
+		businessId: advancedStringFilterSchema,
 		tags: z
 			.array(
 				z
@@ -101,6 +102,7 @@ const queryProcessInstancesRequestBodySchema = getQueryRequestBodySchema({
 		'state',
 		'hasIncident',
 		'tenantId',
+		'businessId',
 	] as const,
 	filter: getOrFilterSchema(queryProcessInstancesFilterSchema),
 });
@@ -128,6 +130,7 @@ const createProcessInstanceRequestBodySchema = z.object({
 	awaitCompletion: z.boolean().optional(),
 	fetchVariables: z.array(z.string()).optional(),
 	requestTimeout: z.number().optional(),
+	businessId: z.string().min(1).max(256).optional(),
 	...processInstanceSchema
 		.pick({
 			processDefinitionId: true,
@@ -148,6 +151,7 @@ const createProcessInstanceResponseBodySchema = z.object({
 		tenantId: true,
 		processDefinitionKey: true,
 		processInstanceKey: true,
+		businessId: true,
 	}).shape,
 });
 

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/processes.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/processes.ts
@@ -32,6 +32,7 @@ const processInstanceSchema = z.object({
 	parentElementInstanceKey: z.string().nullable(),
 	rootProcessInstanceKey: z.string().nullable(),
 	tags: z.array(z.string()),
+	businessId: z.string().nullable(),
 });
 type ProcessInstance = z.infer<typeof processInstanceSchema>;
 

--- a/webapp/client/packages/camunda-api-zod-schemas/package.json
+++ b/webapp/client/packages/camunda-api-zod-schemas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda/camunda-api-zod-schemas",
-	"version": "0.0.60",
+	"version": "0.0.61",
 	"license": "LicenseRef-Camunda-1.0",
 	"description": "Zod schemas and TypeScript types for Camunda 8 unified API",
 	"author": "Vinicius Goulart <vinicius.goulart@camunda.com>",


### PR DESCRIPTION
## Description

Adds a nullable `businessId` property to process instances results, sorting, and filtering schemas. The API does not expose the field for decision instances  yet, otherwise I would have already included it in the same release

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Release package
- [ ] Update package version in Orchestration Cluster webapps

## Related issues

relates #52097
