### PR TITLE
refactor: run current version in-process for most update tests

### DIFF
--- a/zeebe/qa/update-tests/README.md
+++ b/zeebe/qa/update-tests/README.md
@@ -1,29 +1,43 @@
 see [Testing Guide](https://github.com/camunda/camunda/blob/main/docs/testing/acceptance.md#rolling-update-tests) for more information
 
-## Pre-requisites
+## How the current version is run
 
-To run the upgradability tests, a Docker image for Zeebe must be built with the tag 'current-test'. To do that you can run (in the camunda/zeebe dir):
+| Test                                                | Previous version | Current version              |
+|-----------------------------------------------------|------------------|------------------------------|
+| `SnapshotTest`, `NoSnapshotTest`                    | Docker container | In-process via Spring Boot   |
+| `OldGatewayTest`                                    | Docker container | In-process via Spring Boot   |
+| `BackupCompatibilityAcceptance` (S3, GCS, Azure)    | Docker container | In-process via Spring Boot   |
+| `RollingUpdateTest`                                 | Docker container | Docker container (see below) |
+
+The "current version" is loaded as the test classpath itself. There is no need to pre-build a
+`camunda/camunda:current-test` Docker image for these tests.
+
+`RollingUpdateTest` is the exception: it stops a node in a multi-broker cluster, replaces its
+image with the current version, and lets it rejoin gossip. This is fundamentally a deployment-level
+test that only makes sense with real container images. Before running it, build the image (from
+the camunda/camunda dir):
 
 ```
-docker build --build-arg DISTBALL='dist/target/camunda-zeebe*.tar.gz' -t camunda/zeebe:current-test --target app .
+docker build --build-arg DISTBALL='dist/target/camunda-zeebe*.tar.gz' -t camunda/camunda:current-test --target app .
 ```
+
+Override the image used for the current version with the `CAMUNDA_TEST_DOCKER_IMAGE` env var.
 
 ## Debugging
 
-If you need to debug a remote container, you can use the `RemoteDebugger#configureContainer` utility
-method, or use the `withDebugger` flagged when starting your `ContainerState`, which will do it for
-you.
+For the previous-version container or for `RollingUpdateTest`, you can use
+`RemoteDebugger#configureContainer` (or the `withDebugger` flag of `ContainerState`) to launch the
+container with a remote debugger that waits for your local debugger to attach. See
+[this IntelliJ tutorial](https://www.jetbrains.com/help/idea/tutorial-remote-debug.htm) for setup.
 
-By using this utility, it will launch the container with a remote debugger which will wait for your
-local debugger to connect before starting the container. See
-[this IntelliJ tutorial](https://www.jetbrains.com/help/idea/tutorial-remote-debug.htm) on how to
-use a remote debugger with IntelliJ.
+For the current-version side of `SnapshotTest`, `NoSnapshotTest`, and `OldGatewayTest`, the broker
+runs in the same JVM as the test, so a regular run-with-debugger from your IDE is enough — no
+remote attach needed.
 
 ### Limitations
 
-One current limitation is that if your code relies on timeouts (which, for example, the update
-tests do), then when your debugger is at a break point, only the remote JVM is stopped - this means
-your tests will definitely time out. The current workaround is to simply increase all timeouts,
-but in the long term we should find a solution for this. This means not only the startup timeout of
-the container, but also any use of `Awaitility` in the tests themselves, e.g. waiting for a message
-to be published.
+If your code relies on timeouts (which, for example, the update tests do), then when your debugger
+is at a break point, only the remote JVM is stopped — this means your tests will definitely time
+out. The current workaround is to simply increase all timeouts, but in the long term we should find
+a solution for this. This means not only the startup timeout of the container, but also any use of
+`Awaitility` in the tests themselves, e.g. waiting for a message to be published.

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/ContainerState.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/ContainerState.java
@@ -17,11 +17,18 @@ import io.camunda.container.CamundaContainer.BrokerContainer;
 import io.camunda.container.CamundaContainer.GatewayContainer;
 import io.camunda.container.ZeebeTopologyWaitStrategy;
 import io.camunda.container.volume.CamundaVolume;
+import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.qa.util.actuator.PartitionsActuator;
-import io.camunda.zeebe.qa.util.testcontainers.ZeebeTestContainerDefaults;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.cluster.TestZeebePort;
 import io.camunda.zeebe.test.testcontainers.RemoteDebugger;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.util.FileUtil;
 import io.camunda.zeebe.util.VersionUtil;
-import java.net.URI;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
@@ -35,14 +42,30 @@ import org.agrona.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.unit.DataSize;
+import org.testcontainers.Testcontainers;
 import org.testcontainers.containers.ContainerFetchException;
 import org.testcontainers.containers.ContainerLaunchException;
 import org.testcontainers.containers.Network;
 import org.testcontainers.utility.DockerImageName;
 
+/**
+ * Test fixture used by update tests. Runs the previous version as a Docker container; runs the
+ * current version directly via Spring Boot ({@link TestStandaloneBroker}). The two are mutually
+ * exclusive: at any given time the state is backed by either an old broker container or an
+ * in-process current broker, never both.
+ *
+ * <p>Data is handed over from the old container to the in-process broker by extracting the Docker
+ * volume to a host directory and pointing the in-process broker at it via {@link
+ * TestStandaloneBroker#withWorkingDirectory(Path)}.
+ *
+ * <p>An optional legacy {@link GatewayContainer} can be paired with the in-process broker; the
+ * broker advertises itself as {@code host.testcontainers.internal} and the gateway dials back via
+ * {@link Testcontainers#exposeHostPorts(int...)}.
+ */
 final class ContainerState implements AutoCloseable {
 
   public static final int PARTITION_COUNT = 2;
+
   private static final RetryPolicy<Void> CONTAINER_START_RETRY_POLICY =
       new RetryPolicy<Void>().withMaxRetries(5).withBackoff(3, 30, ChronoUnit.SECONDS);
   private static final Pattern DOUBLE_NEWLINE = Pattern.compile("\n\n");
@@ -50,8 +73,6 @@ final class ContainerState implements AutoCloseable {
   private static final Logger LOG = LoggerFactory.getLogger(ContainerState.class);
   private static final DockerImageName PREVIOUS_VERSION =
       DockerImageName.parse("camunda/camunda").withTag(VersionUtil.getPreviousVersion());
-  private static final DockerImageName CURRENT_VERSION =
-      ZeebeTestContainerDefaults.defaultTestImage();
 
   static {
     CONTAINER_START_RETRY_POLICY
@@ -66,33 +87,39 @@ final class ContainerState implements AutoCloseable {
             });
   }
 
-  private final CamundaVolume volume = CamundaVolume.newVolume();
+  /** Volume backing the old container's data folder; null once it has been extracted/closed. */
+  private CamundaVolume volume;
+
+  /** Host directory holding extracted data for the in-process broker; null when not in use. */
+  private Path inProcessDataDir;
 
   private Network network = Network.SHARED;
-  private BrokerContainer broker;
-  private GatewayContainer gateway;
+
+  // mutually exclusive
+  private BrokerContainer oldBroker;
+  private TestStandaloneBroker newBroker;
+
+  /** Optional legacy gateway container; only valid alongside an in-process new broker. */
+  private GatewayContainer oldGateway;
+
   private CamundaClient client;
   private PartitionsActuator partitionsActuator;
-
-  private DockerImageName brokerImage;
-  private DockerImageName gatewayImage;
-  private boolean withRemoteDebugging;
-
+  private boolean useNewBroker;
+  private boolean useOldGateway;
   private String withUser;
-  private String withVersionOverride;
 
   CamundaClient client() {
     return client;
   }
 
   ContainerState withOldBroker() {
-    broker(PREVIOUS_VERSION);
+    useNewBroker = false;
     return this;
   }
 
   ContainerState withNewBroker() {
-    withVersionOverride(VersionUtil.getVersion().replace("-SNAPSHOT", ""));
-    return broker(CURRENT_VERSION);
+    useNewBroker = true;
+    return this;
   }
 
   ContainerState withNetwork(final Network network) {
@@ -101,7 +128,7 @@ final class ContainerState implements AutoCloseable {
   }
 
   ContainerState withOldGateway() {
-    gatewayImage = PREVIOUS_VERSION;
+    useOldGateway = true;
     return this;
   }
 
@@ -110,24 +137,24 @@ final class ContainerState implements AutoCloseable {
     return this;
   }
 
-  ContainerState withVersionOverride(final String version) {
-    withVersionOverride = version;
-    return this;
-  }
-
-  private ContainerState broker(final DockerImageName image) {
-    brokerImage = image;
-    return this;
-  }
-
   public void start(final boolean enableDebug) {
     start(enableDebug, false);
   }
 
   public void start(final boolean enableDebug, final boolean withRemoteDebugging) {
-    final URI grpcAddress;
-    broker =
-        new BrokerContainer(brokerImage)
+    if (useNewBroker) {
+      startNewBroker();
+    } else {
+      startOldBroker(enableDebug, withRemoteDebugging);
+    }
+  }
+
+  private void startOldBroker(final boolean enableDebug, final boolean withRemoteDebugging) {
+    if (volume == null) {
+      volume = CamundaVolume.newVolume();
+    }
+    oldBroker =
+        new BrokerContainer(PREVIOUS_VERSION)
             .withUnifiedConfig(
                 cfg -> {
                   cfg.getCluster().setPartitionCount(PARTITION_COUNT);
@@ -141,81 +168,143 @@ final class ContainerState implements AutoCloseable {
                   cfg.getData().getSecondaryStorage().setType(SecondaryStorageType.none);
                 })
             .withEnv("ZEEBE_LOG_LEVEL", "DEBUG")
+            .withEnv("ZEEBE_BROKER_NETWORK_MAXMESSAGESIZE", "128KB")
+            .withEnv("CAMUNDA_DATABASE_TYPE", "NONE")
+            .withEnv("CAMUNDA_REST_ENABLED", "false")
+            .withEnv(CREATE_SCHEMA_ENV_VAR, "false")
             .withTopologyCheck(new ZeebeTopologyWaitStrategy(1, 1, PARTITION_COUNT))
             .withCamundaData(volume)
             .withNetwork(network);
-    this.withRemoteDebugging = withRemoteDebugging;
-
-    if (brokerImage.equals(PREVIOUS_VERSION)) {
-      broker
-          .withEnv("ZEEBE_BROKER_NETWORK_MAXMESSAGESIZE", "128KB")
-          .withEnv("CAMUNDA_DATABASE_TYPE", "NONE")
-          .withEnv("CAMUNDA_REST_ENABLED", "false")
-          .withEnv(CREATE_SCHEMA_ENV_VAR, "false");
-    }
 
     if (withRemoteDebugging) {
-      RemoteDebugger.configureContainer(broker);
+      RemoteDebugger.configureContainer(oldBroker);
       LOG.info("================================================");
       LOG.info("About to start broker....");
       LOG.info(
           "The broker will wait for a debugger to connect to it at port "
               + RemoteDebugger.DEFAULT_REMOTE_DEBUGGER_PORT
               + ". It will wait for "
-              + RemoteDebugger.DEFAULT_START_TIMEOUT.toString());
+              + RemoteDebugger.DEFAULT_START_TIMEOUT);
       LOG.info("================================================");
     }
-
     if (enableDebug) {
-      broker = broker.withEnv("ZEEBE_DEBUG", "true");
+      oldBroker.withEnv("ZEEBE_DEBUG", "true");
     }
-
     if (!Strings.isEmpty(withUser)) {
-      broker.withCreateContainerCmdModifier(
-          createContainerCmd -> createContainerCmd.withUser(withUser));
+      oldBroker.withCreateContainerCmdModifier(c -> c.withUser(withUser));
     }
 
-    if (!Strings.isEmpty(withVersionOverride)) {
-      broker.withEnv(VersionUtil.VERSION_OVERRIDE_ENV_NAME, withVersionOverride);
-    }
-
-    Failsafe.with(CONTAINER_START_RETRY_POLICY).run(() -> broker.self().start());
-
-    if (gatewayImage == null) {
-      grpcAddress = broker.getGrpcAddress();
-    } else {
-      gateway =
-          new GatewayContainer(gatewayImage)
-              .withUnifiedConfig(
-                  cfg -> {
-                    cfg.getCluster()
-                        .setInitialContactPoints(List.of(broker.getInternalClusterAddress()));
-                    cfg.getData().getSecondaryStorage().setType(SecondaryStorageType.none);
-                  })
-              .withEnv("ZEEBE_LOG_LEVEL", "DEBUG")
-              .withEnv(CREATE_SCHEMA_ENV_VAR, "false")
-              .withEnv(UNPROTECTED_API_ENV_VAR, "true")
-              .withEnv(AUTHORIZATION_CHECKS_ENV_VAR, "false")
-              .withTopologyCheck(new ZeebeTopologyWaitStrategy(1, 1, PARTITION_COUNT))
-              .withNetwork(network);
-
-      if (gatewayImage.equals(PREVIOUS_VERSION)) {
-        // Gateway configuration is not part of the Unified config yet in 8.8.x
-        gateway
-            .withEnv(
-                "ZEEBE_GATEWAY_CLUSTER_INITIALCONTACTPOINTS", broker.getInternalClusterAddress())
-            .withEnv("ZEEBE_GATEWAY_NETWORK_HOST", "0.0.0.0")
-            .withEnv("ZEEBE_GATEWAY_CLUSTER_MEMBERID", gateway.getInternalHost())
-            .withEnv("ZEEBE_GATEWAY_CLUSTER_HOST", gateway.getInternalHost());
-      }
-
-      Failsafe.with(CONTAINER_START_RETRY_POLICY).run(() -> gateway.self().start());
-      grpcAddress = gateway.getGrpcAddress();
-    }
+    Failsafe.with(CONTAINER_START_RETRY_POLICY).run(() -> oldBroker.self().start());
 
     client =
-        CamundaClient.newClientBuilder().grpcAddress(grpcAddress).preferRestOverGrpc(false).build();
-    partitionsActuator = PartitionsActuator.of(broker);
+        CamundaClient.newClientBuilder()
+            .grpcAddress(oldBroker.getGrpcAddress())
+            .preferRestOverGrpc(false)
+            .build();
+    partitionsActuator = PartitionsActuator.of(oldBroker);
+  }
+
+  private void startNewBroker() {
+    // The current version reports "X.Y.Z-SNAPSHOT" by default; this trips
+    // VersionCompatibilityCheck (pre-release versions are rejected). Override to the release form.
+    VersionUtil.overrideVersionForTesting(VersionUtil.getVersion().replace("-SNAPSHOT", ""));
+
+    // RecordingExporter is global static state; clear records left from a previous scenario.
+    RecordingExporter.reset();
+
+    final Path workingDir = handoverFromVolumeIfPresent();
+
+    newBroker =
+        new TestStandaloneBroker()
+            .withRecordingExporter(true)
+            .withUnifiedConfig(
+                cfg -> {
+                  cfg.getCluster().setPartitionCount(PARTITION_COUNT);
+                  cfg.getData().getPrimaryStorage().getLogStream().setLogIndexDensity(1);
+                  cfg.getData().setSnapshotPeriod(Duration.ofMinutes(1));
+                  cfg.getData()
+                      .getPrimaryStorage()
+                      .getLogStream()
+                      .setLogSegmentSize(DataSize.ofMegabytes(64));
+                  cfg.getCluster().getNetwork().setMaxMessageSize(DataSize.ofKilobytes(128));
+                  cfg.getData().getSecondaryStorage().setType(SecondaryStorageType.none);
+                });
+    if (workingDir != null) {
+      newBroker.withWorkingDirectory(workingDir);
+    }
+
+    if (useOldGateway) {
+      startNewBrokerWithLegacyGateway();
+    } else {
+      newBroker.start();
+      client = newBroker.newClientBuilder().preferRestOverGrpc(false).build();
+    }
+
+    partitionsActuator = PartitionsActuator.of(newBroker);
+  }
+
+  private void startNewBrokerWithLegacyGateway() {
+    // The legacy gateway container needs to dial the in-process broker. Make the broker advertise
+    // itself as host.testcontainers.internal so the container can reach it through the
+    // Testcontainers SSH-forward sidecar.
+    final var clusterPort = newBroker.mappedPort(TestZeebePort.CLUSTER);
+    newBroker.withClusterConfig(
+        c -> {
+          c.getNetwork().setAdvertisedHost("host.testcontainers.internal");
+          c.getNetwork().getInternalApi().setAdvertisedPort(clusterPort);
+        });
+    Testcontainers.exposeHostPorts(clusterPort);
+    newBroker.start();
+
+    final var brokerContactPoint = "host.testcontainers.internal:" + clusterPort;
+    oldGateway =
+        new GatewayContainer(PREVIOUS_VERSION)
+            .withUnifiedConfig(
+                cfg -> {
+                  cfg.getCluster().setInitialContactPoints(List.of(brokerContactPoint));
+                  cfg.getData().getSecondaryStorage().setType(SecondaryStorageType.none);
+                })
+            .withEnv("ZEEBE_LOG_LEVEL", "DEBUG")
+            .withEnv(CREATE_SCHEMA_ENV_VAR, "false")
+            .withEnv(UNPROTECTED_API_ENV_VAR, "true")
+            .withEnv(AUTHORIZATION_CHECKS_ENV_VAR, "false")
+            // Pre-8.10 gateway image: Unified config does not yet drive the gateway
+            .withEnv("ZEEBE_GATEWAY_CLUSTER_INITIALCONTACTPOINTS", brokerContactPoint)
+            .withEnv("ZEEBE_GATEWAY_NETWORK_HOST", "0.0.0.0")
+            .withTopologyCheck(new ZeebeTopologyWaitStrategy(1, 1, PARTITION_COUNT))
+            .withNetwork(network);
+    oldGateway.withEnv("ZEEBE_GATEWAY_CLUSTER_MEMBERID", oldGateway.getInternalHost());
+    oldGateway.withEnv("ZEEBE_GATEWAY_CLUSTER_HOST", oldGateway.getInternalHost());
+
+    Failsafe.with(CONTAINER_START_RETRY_POLICY).run(() -> oldGateway.self().start());
+
+    client =
+        CamundaClient.newClientBuilder()
+            .grpcAddress(oldGateway.getGrpcAddress())
+            .preferRestOverGrpc(false)
+            .build();
+  }
+
+  private Path handoverFromVolumeIfPresent() {
+    if (volume == null) {
+      return null;
+    }
+    try {
+      inProcessDataDir = Files.createTempDirectory("update-test-data");
+      // The broker resolves data.directory ("data") relative to its working directory. The volume
+      // root holds the data directory's contents directly (mount path was
+      // /usr/local/camunda/data), so extract under <workingDir>/data so paths line up.
+      final Path dataSubdir = Files.createDirectory(inProcessDataDir.resolve("data"));
+      volume.extract(dataSubdir);
+    } catch (final IOException e) {
+      throw new UncheckedIOException("Failed to extract volume to host directory", e);
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      LangUtil.rethrowUnchecked(e);
+    }
+    volume.close();
+    volume = null;
+    return inProcessDataDir;
   }
 
   public PartitionsActuator getPartitionsActuator() {
@@ -224,22 +313,11 @@ final class ContainerState implements AutoCloseable {
 
   @SuppressWarnings("java:S2925") // allow Thread.sleep usage in test if remote debugging is enabled
   public void onFailure() {
-    if (broker != null) {
-      log("Broker", broker.getLogs());
+    if (oldBroker != null) {
+      log("Broker", oldBroker.getLogs());
     }
-
-    if (gateway != null) {
-      log("Gateway", gateway.getLogs());
-    }
-
-    if (withRemoteDebugging) {
-      try {
-        LOG.info("Blocking for an hour to allow analysis with remote debugging");
-        Thread.sleep(Duration.ofHours(1).toMillis());
-      } catch (final InterruptedException e) {
-        Thread.currentThread().interrupt();
-        LangUtil.rethrowUnchecked(e);
-      }
+    if (oldGateway != null) {
+      log("Gateway", oldGateway.getLogs());
     }
   }
 
@@ -253,35 +331,43 @@ final class ContainerState implements AutoCloseable {
   }
 
   /**
-   * @return true if a record was found the element with the specified intent. Otherwise, returns
-   *     false
+   * Returns true if any record produced by the active broker contains all the given substrings in
+   * its JSON form. For the old container this scans the broker logs; for the in-process current
+   * broker this scans records captured by the {@link RecordingExporter}.
+   *
+   * <p>Both backends produce identical JSON via {@code Record#toString()}, so callers can match on
+   * the same strings (e.g. {@code "\"intent\":\"CREATED\""}, {@code "\"valueType\":\"INCIDENT\""}).
    */
+  public boolean hasLogContaining(final String... pieces) {
+    return getLogContaining(pieces) != null;
+  }
+
+  public String getLogContaining(final String... pieces) {
+    if (oldBroker != null) {
+      return Arrays.stream(oldBroker.getLogs().split("\n"))
+          .filter(line -> Arrays.stream(pieces).allMatch(line::contains))
+          .findFirst()
+          .orElse(null);
+    }
+    if (newBroker != null) {
+      return RecordingExporter.getRecords().stream()
+          .map(Record::toString)
+          .filter(s -> Arrays.stream(pieces).allMatch(s::contains))
+          .findFirst()
+          .orElse(null);
+    }
+    return null;
+  }
+
   public boolean hasElementInState(final String elementId, final String intent) {
     return hasLogContaining(
         String.format("\"elementId\":\"%s\"", elementId),
         String.format("\"intent\":\"%s\"", intent));
   }
 
-  /**
-   * @return true if the message was found in the specified intent. Otherwise, returns false
-   */
   public boolean hasMessageInState(final String name, final String intent) {
     return hasLogContaining(
         String.format("\"name\":\"%s\"", name), String.format("\"intent\":\"%s\"", intent));
-  }
-
-  // returns true if it finds a line that contains every piece.
-  boolean hasLogContaining(final String... pieces) {
-    return getLogContaining(pieces) != null;
-  }
-
-  public String getLogContaining(final String... pieces) {
-    final String[] lines = broker.getLogs().split("\n");
-
-    return Arrays.stream(lines)
-        .filter(line -> Arrays.stream(pieces).allMatch(line::contains))
-        .findFirst()
-        .orElse(null);
   }
 
   public long getIncidentKey() {
@@ -303,25 +389,36 @@ final class ContainerState implements AutoCloseable {
     return incidentKey;
   }
 
-  /** Close all opened resources. */
+  /** Closes the active broker and any associated resources. Safe to call repeatedly. */
   @Override
   public void close() {
     if (client != null) {
       client.close();
       client = null;
     }
-
-    if (gateway != null) {
-      gateway.shutdownGracefully(CLOSE_TIMEOUT);
-      gateway = null;
+    if (oldGateway != null) {
+      oldGateway.shutdownGracefully(CLOSE_TIMEOUT);
+      oldGateway = null;
     }
-
-    if (broker != null) {
-      broker.shutdownGracefully(CLOSE_TIMEOUT);
-      broker = null;
+    if (oldBroker != null) {
+      oldBroker.shutdownGracefully(CLOSE_TIMEOUT);
+      oldBroker = null;
     }
-
-    brokerImage = null;
-    gatewayImage = null;
+    if (newBroker != null) {
+      newBroker.close();
+      newBroker = null;
+      VersionUtil.resetVersionForTesting();
+      RecordingExporter.reset();
+    }
+    if (inProcessDataDir != null) {
+      try {
+        FileUtil.deleteFolder(inProcessDataDir);
+      } catch (final IOException e) {
+        LOG.warn("Failed to delete in-process data directory {}", inProcessDataDir, e);
+      }
+      inProcessDataDir = null;
+    }
+    partitionsActuator = null;
+    useOldGateway = false;
   }
 }

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/ContainerState.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/ContainerState.java
@@ -66,6 +66,9 @@ final class ContainerState implements AutoCloseable {
 
   public static final int PARTITION_COUNT = 2;
 
+  /** Mount path of the broker's data folder inside the legacy container image. */
+  private static final String BROKER_DATA_PATH_IN_CONTAINER = "/usr/local/camunda/data";
+
   private static final RetryPolicy<Void> CONTAINER_START_RETRY_POLICY =
       new RetryPolicy<Void>().withMaxRetries(5).withBackoff(3, 30, ChronoUnit.SECONDS);
   private static final Pattern DOUBLE_NEWLINE = Pattern.compile("\n\n");
@@ -236,7 +239,7 @@ final class ContainerState implements AutoCloseable {
     if (useOldGateway) {
       startNewBrokerWithLegacyGateway();
     } else {
-      newBroker.start();
+      newBroker.start().awaitCompleteTopology(1, PARTITION_COUNT, 1, Duration.ofSeconds(30));
       client = newBroker.newClientBuilder().preferRestOverGrpc(false).build();
     }
 
@@ -244,37 +247,46 @@ final class ContainerState implements AutoCloseable {
   }
 
   private void startNewBrokerWithLegacyGateway() {
-    // The legacy gateway container needs to dial the in-process broker. Make the broker advertise
-    // itself as host.testcontainers.internal so the container can reach it through the
-    // Testcontainers SSH-forward sidecar.
-    final var clusterPort = newBroker.mappedPort(TestZeebePort.CLUSTER);
+    // Bridge container ↔ in-process gossip both ways:
+    //   • Gateway → broker: broker advertises host.testcontainers.internal for both its
+    //     cluster-API (gossip) and command-API ports, and Testcontainers exposes both through
+    //     the SSH-forward sidecar so the gateway container can reach them.
+    //   • Broker → gateway: pin the gateway container's cluster-API port to a known host port
+    //     and have the gateway advertise localhost:<thatPort>, which the host-side broker can dial.
+    final var brokerClusterPort = newBroker.mappedPort(TestZeebePort.CLUSTER);
+    final var brokerCommandPort = newBroker.mappedPort(TestZeebePort.COMMAND);
     newBroker.withClusterConfig(
         c -> {
           c.getNetwork().setAdvertisedHost("host.testcontainers.internal");
-          c.getNetwork().getInternalApi().setAdvertisedPort(clusterPort);
+          c.getNetwork().getInternalApi().setAdvertisedPort(brokerClusterPort);
+          c.getNetwork().getCommandApi().setAdvertisedPort(brokerCommandPort);
         });
-    Testcontainers.exposeHostPorts(clusterPort);
+    Testcontainers.exposeHostPorts(brokerClusterPort, brokerCommandPort);
     newBroker.start();
 
-    final var brokerContactPoint = "host.testcontainers.internal:" + clusterPort;
+    final var gatewayHostPort =
+        io.camunda.zeebe.test.util.socket.SocketUtil.getNextAddress().getPort();
+    final var brokerContactPoint = "host.testcontainers.internal:" + brokerClusterPort;
     oldGateway =
         new GatewayContainer(PREVIOUS_VERSION)
             .withUnifiedConfig(
                 cfg -> {
                   cfg.getCluster().setInitialContactPoints(List.of(brokerContactPoint));
+                  cfg.getCluster().getNetwork().setHost("0.0.0.0");
+                  // Make the gateway reachable from the host-side broker via
+                  // localhost:<gatewayHostPort>. The container's port 26502 is pinned to that host
+                  // port below.
+                  cfg.getCluster().getNetwork().setAdvertisedHost("localhost");
+                  cfg.getCluster().getNetwork().getInternalApi().setAdvertisedPort(gatewayHostPort);
                   cfg.getData().getSecondaryStorage().setType(SecondaryStorageType.none);
                 })
             .withEnv("ZEEBE_LOG_LEVEL", "DEBUG")
             .withEnv(CREATE_SCHEMA_ENV_VAR, "false")
             .withEnv(UNPROTECTED_API_ENV_VAR, "true")
             .withEnv(AUTHORIZATION_CHECKS_ENV_VAR, "false")
-            // Pre-8.10 gateway image: Unified config does not yet drive the gateway
-            .withEnv("ZEEBE_GATEWAY_CLUSTER_INITIALCONTACTPOINTS", brokerContactPoint)
-            .withEnv("ZEEBE_GATEWAY_NETWORK_HOST", "0.0.0.0")
-            .withTopologyCheck(new ZeebeTopologyWaitStrategy(1, 1, PARTITION_COUNT))
-            .withNetwork(network);
-    oldGateway.withEnv("ZEEBE_GATEWAY_CLUSTER_MEMBERID", oldGateway.getInternalHost());
-    oldGateway.withEnv("ZEEBE_GATEWAY_CLUSTER_HOST", oldGateway.getInternalHost());
+            .withTopologyCheck(new ZeebeTopologyWaitStrategy(1, 1, PARTITION_COUNT));
+    // Pin the gateway container's cluster API port so the host-side broker can dial it back.
+    oldGateway.setPortBindings(List.of(gatewayHostPort + ":26502"));
 
     Failsafe.with(CONTAINER_START_RETRY_POLICY).run(() -> oldGateway.self().start());
 
@@ -291,20 +303,25 @@ final class ContainerState implements AutoCloseable {
     }
     try {
       inProcessDataDir = Files.createTempDirectory("update-test-data");
-      // The broker resolves data.directory ("data") relative to its working directory. The volume
-      // root holds the data directory's contents directly (mount path was
-      // /usr/local/camunda/data), so extract under <workingDir>/data so paths line up.
-      final Path dataSubdir = Files.createDirectory(inProcessDataDir.resolve("data"));
-      volume.extract(dataSubdir);
+      // CamundaVolume.extract spawns a tiny container with the volume mounted at
+      // /usr/local/camunda/data and tars the requested path. By default it tars /tmp, which only
+      // contains the archive itself; ask it to tar the volume mount path instead. BusyBox tar
+      // strips the leading slash, so entries land at <extractRoot>/usr/local/camunda/data/...
+      // The broker resolves data.directory ("data") against its working directory, so picking
+      // /usr/local/camunda as the working directory makes the broker read from the right place.
+      volume.extract(
+          inProcessDataDir, builder -> builder.withContainerPath(BROKER_DATA_PATH_IN_CONTAINER));
     } catch (final IOException e) {
       throw new UncheckedIOException("Failed to extract volume to host directory", e);
     } catch (final InterruptedException e) {
       Thread.currentThread().interrupt();
       LangUtil.rethrowUnchecked(e);
     }
-    volume.close();
+    // The Docker volume is still referenced by the (stopped) old broker container at this point;
+    // attempting to remove it now would race the container teardown. Drop the reference and let
+    // the Testcontainers reaper clean it up at JVM shutdown.
     volume = null;
-    return inProcessDataDir;
+    return inProcessDataDir.resolve("usr/local/camunda");
   }
 
   public PartitionsActuator getPartitionsActuator() {
@@ -318,6 +335,11 @@ final class ContainerState implements AutoCloseable {
     }
     if (oldGateway != null) {
       log("Gateway", oldGateway.getLogs());
+    }
+    if (newBroker != null) {
+      final var records = RecordingExporter.getRecords();
+      LOG.error("RecordingExporter captured {} records", records.size());
+      records.forEach(r -> LOG.error("  {}", r.toJson()));
     }
   }
 
@@ -350,8 +372,10 @@ final class ContainerState implements AutoCloseable {
           .orElse(null);
     }
     if (newBroker != null) {
+      // Record#toString() truncates the JSON to 1024 chars (CopiedRecord), which can elide fields
+      // we look for (e.g. JOB records carry "elementId" near the tail). Use toJson() instead.
       return RecordingExporter.getRecords().stream()
-          .map(Record::toString)
+          .map(Record::toJson)
           .filter(s -> Arrays.stream(pieces).allMatch(s::contains))
           .findFirst()
           .orElse(null);


### PR DESCRIPTION
## Summary

Update tests under `zeebe/qa/update-tests/` no longer require the `camunda/camunda:current-test`
Docker image (and the upfront `docker build` step) for the common cases. The previous version
still runs in a Docker container; the current version is now booted directly via Spring Boot
using `TestStandaloneBroker`.

| Test                                              | Previous | Current                    |
|---------------------------------------------------|----------|----------------------------|
| `SnapshotTest`, `NoSnapshotTest`                  | container | in-process (this PR)       |
| `OldGatewayTest`                                  | container | in-process (this PR)       |
| `BackupCompatibilityAcceptance` (S3, GCS, Azure)  | container | in-process (already)       |
| `RollingUpdateTest`                               | container | container (see below)      |

`RollingUpdateTest` stays container-only: converting it would require broadening
`BrokerNode<T extends GenericContainer<T>>` and orchestrating gossip between an in-process
broker on the host and the remaining cluster nodes in a Docker network. Since rolling-upgrade
is fundamentally a deployment-level test, the existing container path remains the natural
fit. The README is updated to reflect that this is the only update test that still requires
the `current-test` image.

## What's in `ContainerState`

- `withNewBroker()` flips the fixture to in-process mode (no dual mode for the same broker —
  old is always a container, new is always in-process).
- For Snapshot/NoSnapshot: data is handed over from the old container by extracting the Docker
  volume to a host directory (`CamundaVolume.extract` with the broker data mount path), and
  `TestStandaloneBroker.withWorkingDirectory` is rebased onto the volume's parent path so
  `data.directory` resolves correctly.
- For OldGateway: the broker advertises `host.testcontainers.internal` for both cluster and
  command-API (both ports are exposed via `Testcontainers.exposeHostPorts`), and the gateway
  container's port 26502 is pinned to a host port so the host-side broker can dial it back via
  `localhost:<pinnedPort>`.
- Log-scan helpers (`hasLogContaining`, `hasElementInState`, `hasMessageInState`,
  `getIncidentKey`) now query records captured by `RecordingExporter` when the in-process
  broker is active. They use `Record#toJson()` (not `toString()`, which truncates at 1024
  chars and would elide `JobRecord.elementId`).
- The current-version startup overrides `VersionUtil.overrideVersionForTesting` to strip
  `-SNAPSHOT` so `VersionCompatibilityCheck` accepts the upgrade, and resets it on close.
- `awaitCompleteTopology` blocks `start()` until log replay finishes, which is needed because
  Spring Boot returns from `run()` before the broker has resumed processing.

## Verified

- `./mvnw verify -pl zeebe/qa/update-tests -DskipTests=false -DskipUTs -Dquickly -Dit.test='SnapshotTest,NoSnapshotTest,OldGatewayTest'`
  passes (43/43) with `camunda/camunda:current-test` *not* present locally.
- `BackupCompatibilityAcceptance` is unchanged.