### PR TITLE
deps: update PostgreSQL version to 42.7.11

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -156,7 +156,7 @@
     <version.checker-qual>3.54.0</version.checker-qual>
     <version.java-jwt>4.5.1</version.java-jwt>
     <version.reactive-streams>1.0.4</version.reactive-streams>
-    <version.postgresql>42.7.10</version.postgresql>
+    <version.postgresql>42.7.11</version.postgresql>
     <version.h2>2.4.240</version.h2>
     <version.aws-advanced-jdbc-wrapper>3.3.0</version.aws-advanced-jdbc-wrapper>
     <version.aws-signing>4.0.0</version.aws-signing>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Update postgresql to fix CVE.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

relates to camunda/camunda#52348
