### PR TITLE
feat: wire multi-variable filter to process instances search

### DIFF
--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterRow.test.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterRow.test.tsx
@@ -43,7 +43,7 @@ describe('<VariableFilterRow />', () => {
         fieldName="conditions[0]"
         rowIndex={0}
         onDelete={vi.fn()}
-        isDeleteHidden={true}
+        isDeleteHidden
       />,
       {wrapper: getWrapper()},
     );
@@ -61,7 +61,7 @@ describe('<VariableFilterRow />', () => {
         fieldName="conditions[0]"
         rowIndex={0}
         onDelete={vi.fn()}
-        isDeleteHidden={true}
+        isDeleteHidden
       />,
       {wrapper: getWrapper({operator: 'exists'})},
     );
@@ -77,14 +77,13 @@ describe('<VariableFilterRow />', () => {
         fieldName="conditions[0]"
         rowIndex={0}
         onDelete={vi.fn()}
-        isDeleteHidden={true}
+        isDeleteHidden
       />,
       {wrapper: getWrapper()},
     );
-
-    expect(screen.getByTestId('delete-variable-filter-0')).toHaveStyle({
-      visibility: 'hidden',
-    });
+    expect(
+      screen.getByTestId('delete-variable-filter-test-id'),
+    ).not.toBeVisible();
   });
 
   it('should show delete button when isDeleteHidden is false', () => {
@@ -98,9 +97,7 @@ describe('<VariableFilterRow />', () => {
       {wrapper: getWrapper()},
     );
 
-    expect(screen.getByTestId('delete-variable-filter-0')).toHaveStyle({
-      visibility: 'visible',
-    });
+    expect(screen.getByTestId('delete-variable-filter-test-id')).toBeVisible();
   });
 
   it('should update name input when user types', async () => {
@@ -109,7 +106,7 @@ describe('<VariableFilterRow />', () => {
         fieldName="conditions[0]"
         rowIndex={0}
         onDelete={vi.fn()}
-        isDeleteHidden={true}
+        isDeleteHidden
       />,
       {wrapper: getWrapper()},
     );
@@ -125,7 +122,7 @@ describe('<VariableFilterRow />', () => {
         fieldName="conditions[0]"
         rowIndex={0}
         onDelete={vi.fn()}
-        isDeleteHidden={true}
+        isDeleteHidden
       />,
       {wrapper: getWrapper({name: 'status'})},
     );
@@ -158,7 +155,7 @@ describe('<VariableFilterRow />', () => {
         fieldName="conditions[0]"
         rowIndex={0}
         onDelete={vi.fn()}
-        isDeleteHidden={true}
+        isDeleteHidden
       />,
       {wrapper: getWrapper()},
     );
@@ -177,7 +174,7 @@ describe('<VariableFilterRow />', () => {
         fieldName="conditions[0]"
         rowIndex={0}
         onDelete={vi.fn()}
-        isDeleteHidden={true}
+        isDeleteHidden
       />,
       {wrapper: getWrapper({operator: 'exists'})},
     );

--- a/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterRow.test.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/VariablesFilter/VariableFilterRow.test.tsx
@@ -81,9 +81,7 @@ describe('<VariableFilterRow />', () => {
       />,
       {wrapper: getWrapper()},
     );
-    expect(
-      screen.getByTestId('delete-variable-filter-test-id'),
-    ).not.toBeVisible();
+    expect(screen.getByTestId('delete-variable-filter-0')).not.toBeVisible();
   });
 
   it('should show delete button when isDeleteHidden is false', () => {
@@ -97,7 +95,7 @@ describe('<VariableFilterRow />', () => {
       {wrapper: getWrapper()},
     );
 
-    expect(screen.getByTestId('delete-variable-filter-test-id')).toBeVisible();
+    expect(screen.getByTestId('delete-variable-filter-0')).toBeVisible();
   });
 
   it('should update name input when user types', async () => {

--- a/operate/client/src/App/Processes/ListView/InstancesTable/InstancesTableWrapper.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/InstancesTableWrapper.tsx
@@ -23,6 +23,7 @@ import {useSearchParams} from 'react-router-dom';
 import {variableFilterStore} from 'modules/stores/variableFilter';
 import {processInstancesSelectionStore} from 'modules/stores/instancesSelection';
 import {useEffect, useMemo} from 'react';
+import {MULTI_VARIABLE_FILTER} from 'modules/feature-flags';
 
 const ROW_HEIGHT = 34;
 const SCROLL_STEP_SIZE = 5 * ROW_HEIGHT;
@@ -46,7 +47,10 @@ const InstancesTableWrapper: React.FC = observer(() => {
   const hasIncidentsFilter = searchParams.get('incidents') === 'true';
 
   const variable = variableFilterStore.variable;
-  const filter = useProcessInstancesSearchFilter(variable);
+  const conditions = MULTI_VARIABLE_FILTER
+    ? variableFilterStore.conditions
+    : undefined;
+  const filter = useProcessInstancesSearchFilter(variable, conditions);
   const sort = useProcessInstancesSearchSort();
 
   const enablePeriodicRefetch =

--- a/operate/client/src/modules/hooks/processInstancesSearch.test.ts
+++ b/operate/client/src/modules/hooks/processInstancesSearch.test.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {buildVariableEntry, parseOneOfValues} from './processInstancesSearch';
+import type {VariableCondition} from 'modules/stores/variableFilter';
+
+const makeCondition = (
+  overrides: Partial<VariableCondition> = {},
+): VariableCondition => ({
+  name: 'status',
+  operator: 'equals',
+  value: '"active"',
+  ...overrides,
+});
+
+describe('buildVariableEntry', () => {
+  it('should build equals entry as plain string value', () => {
+    expect(
+      buildVariableEntry(
+        makeCondition({operator: 'equals', value: '"active"'}),
+      ),
+    ).toEqual({
+      name: 'status',
+      value: '"active"',
+    });
+  });
+
+  it('should build notEqual entry as {$neq}', () => {
+    expect(
+      buildVariableEntry(
+        makeCondition({operator: 'notEqual', value: '"inactive"'}),
+      ),
+    ).toEqual({
+      name: 'status',
+      value: {$neq: '"inactive"'},
+    });
+  });
+
+  it('should build contains entry as {$like: "*value*"}', () => {
+    expect(
+      buildVariableEntry(
+        makeCondition({operator: 'contains', value: 'active'}),
+      ),
+    ).toEqual({
+      name: 'status',
+      value: {$like: '*active*'},
+    });
+  });
+
+  it('should build oneOf entry as {$in: [...]} from JSON array', () => {
+    expect(
+      buildVariableEntry(
+        makeCondition({operator: 'oneOf', value: '["active","pending"]'}),
+      ),
+    ).toEqual({
+      name: 'status',
+      value: {$in: ['"active"', '"pending"']},
+    });
+  });
+
+  it('should build exists entry as {$exists: true}', () => {
+    expect(
+      buildVariableEntry(makeCondition({operator: 'exists', value: ''})),
+    ).toEqual({
+      name: 'status',
+      value: {$exists: true},
+    });
+  });
+
+  it('should build doesNotExist entry as {$exists: false}', () => {
+    expect(
+      buildVariableEntry(makeCondition({operator: 'doesNotExist', value: ''})),
+    ).toEqual({
+      name: 'status',
+      value: {$exists: false},
+    });
+  });
+});
+
+describe('parseOneOfValues', () => {
+  it('should parse a JSON array of strings and JSON-stringify each value', () => {
+    expect(parseOneOfValues('["a","b","c"]')).toEqual(['"a"', '"b"', '"c"']);
+  });
+
+  it('should fall back to comma-split for non-JSON input', () => {
+    expect(parseOneOfValues('a, b, c')).toEqual(['a', 'b', 'c']);
+  });
+
+  it('should filter out empty entries from comma-split', () => {
+    expect(parseOneOfValues('a,,b')).toEqual(['a', 'b']);
+  });
+
+  it('should handle a JSON array of numbers by converting to strings', () => {
+    expect(parseOneOfValues('[1,2,3]')).toEqual(['1', '2', '3']);
+  });
+});
+
+describe('buildVariableEntry — multi-condition', () => {
+  it('should produce one entry per condition with mixed operators', () => {
+    const conditions: VariableCondition[] = [
+      {name: 'status', operator: 'equals', value: '"active"'},
+      {name: 'region', operator: 'contains', value: 'eu'},
+      {name: 'priority', operator: 'exists', value: ''},
+    ];
+
+    expect(conditions.map(buildVariableEntry)).toEqual([
+      {name: 'status', value: '"active"'},
+      {name: 'region', value: {$like: '*eu*'}},
+      {name: 'priority', value: {$exists: true}},
+    ]);
+  });
+
+  it('should produce byte-equivalent output to legacy path for single equals', () => {
+    const condition: VariableCondition = {
+      name: 'myVar',
+      operator: 'equals',
+      value: '"hello"',
+    };
+
+    const mvfResult = buildVariableEntry(condition);
+
+    const legacyResult = {
+      name: 'myVar',
+      value: '"hello"',
+    };
+
+    expect(mvfResult).toEqual(legacyResult);
+  });
+});

--- a/operate/client/src/modules/hooks/processInstancesSearch.test.ts
+++ b/operate/client/src/modules/hooks/processInstancesSearch.test.ts
@@ -11,12 +11,13 @@ import type {VariableCondition} from 'modules/stores/variableFilter';
 
 const makeCondition = (
   overrides: Partial<VariableCondition> = {},
-): VariableCondition => ({
-  name: 'status',
-  operator: 'equals',
-  value: '"active"',
-  ...overrides,
-});
+): VariableCondition =>
+  ({
+    name: 'status',
+    operator: 'equals',
+    value: '"active"',
+    ...overrides,
+  }) as VariableCondition;
 
 describe('buildVariableEntry', () => {
   it('should build equals entry as plain string value', () => {

--- a/operate/client/src/modules/hooks/processInstancesSearch.test.ts
+++ b/operate/client/src/modules/hooks/processInstancesSearch.test.ts
@@ -9,23 +9,15 @@
 import {buildVariableEntry, parseOneOfValues} from './processInstancesSearch';
 import type {VariableCondition} from 'modules/stores/variableFilter';
 
-const makeCondition = (
-  overrides: Partial<VariableCondition> = {},
-): VariableCondition =>
-  ({
-    name: 'status',
-    operator: 'equals',
-    value: '"active"',
-    ...overrides,
-  }) as VariableCondition;
+const mockCondition = {
+  name: 'status',
+  operator: 'equals',
+  value: '"active"',
+} satisfies VariableCondition;
 
 describe('buildVariableEntry', () => {
   it('should build equals entry as plain string value', () => {
-    expect(
-      buildVariableEntry(
-        makeCondition({operator: 'equals', value: '"active"'}),
-      ),
-    ).toEqual({
+    expect(buildVariableEntry(mockCondition)).toEqual({
       name: 'status',
       value: '"active"',
     });
@@ -33,9 +25,11 @@ describe('buildVariableEntry', () => {
 
   it('should build notEqual entry as {$neq}', () => {
     expect(
-      buildVariableEntry(
-        makeCondition({operator: 'notEqual', value: '"inactive"'}),
-      ),
+      buildVariableEntry({
+        ...mockCondition,
+        operator: 'notEqual',
+        value: '"inactive"',
+      }),
     ).toEqual({
       name: 'status',
       value: {$neq: '"inactive"'},
@@ -44,9 +38,11 @@ describe('buildVariableEntry', () => {
 
   it('should build contains entry as {$like: "*value*"}', () => {
     expect(
-      buildVariableEntry(
-        makeCondition({operator: 'contains', value: 'active'}),
-      ),
+      buildVariableEntry({
+        ...mockCondition,
+        operator: 'contains',
+        value: 'active',
+      }),
     ).toEqual({
       name: 'status',
       value: {$like: '*active*'},
@@ -55,9 +51,11 @@ describe('buildVariableEntry', () => {
 
   it('should build oneOf entry as {$in: [...]} from JSON array', () => {
     expect(
-      buildVariableEntry(
-        makeCondition({operator: 'oneOf', value: '["active","pending"]'}),
-      ),
+      buildVariableEntry({
+        ...mockCondition,
+        operator: 'oneOf',
+        value: '["active","pending"]',
+      }),
     ).toEqual({
       name: 'status',
       value: {$in: ['"active"', '"pending"']},
@@ -66,7 +64,11 @@ describe('buildVariableEntry', () => {
 
   it('should build exists entry as {$exists: true}', () => {
     expect(
-      buildVariableEntry(makeCondition({operator: 'exists', value: ''})),
+      buildVariableEntry({
+        ...mockCondition,
+        operator: 'exists',
+        value: '',
+      }),
     ).toEqual({
       name: 'status',
       value: {$exists: true},
@@ -75,7 +77,11 @@ describe('buildVariableEntry', () => {
 
   it('should build doesNotExist entry as {$exists: false}', () => {
     expect(
-      buildVariableEntry(makeCondition({operator: 'doesNotExist', value: ''})),
+      buildVariableEntry({
+        ...mockCondition,
+        operator: 'doesNotExist',
+        value: '',
+      }),
     ).toEqual({
       name: 'status',
       value: {$exists: false},

--- a/operate/client/src/modules/hooks/processInstancesSearch.ts
+++ b/operate/client/src/modules/hooks/processInstancesSearch.ts
@@ -13,30 +13,80 @@ import {
 import {useMemo} from 'react';
 import {useSearchParams} from 'react-router-dom';
 import {getValidVariableValues} from 'modules/utils/filter/getValidVariableValues';
-import type {Variable} from 'modules/stores/variableFilter';
+import type {Variable, VariableCondition} from 'modules/stores/variableFilter';
+import {MULTI_VARIABLE_FILTER} from 'modules/feature-flags';
+import type {QueryProcessInstancesRequestBody} from '@camunda/camunda-api-zod-schemas/8.10';
 
-function useProcessInstancesSearchFilter(variable?: Variable) {
+type VariableEntry = NonNullable<
+  NonNullable<QueryProcessInstancesRequestBody['filter']>['variables']
+>[number];
+
+function useProcessInstancesSearchFilter(
+  variable?: Variable,
+  conditions?: VariableCondition[],
+) {
   const [searchParams] = useSearchParams();
 
   return useMemo(() => {
     const filter = parseProcessInstancesSearchFilter(searchParams);
 
-    if (filter && variable?.name && variable?.values) {
-      const parsed = (getValidVariableValues(variable.values) ?? []).map((v) =>
-        JSON.stringify(v),
-      );
-      if (parsed.length > 0) {
-        filter.variables = [
-          {
-            name: variable?.name,
-            value: parsed.length === 1 ? parsed[0]! : {$in: parsed},
-          },
-        ];
+    if (MULTI_VARIABLE_FILTER) {
+      if (filter && conditions && conditions.length > 0) {
+        filter.variables = conditions.map(buildVariableEntry);
+      }
+    } else {
+      if (filter && variable?.name && variable?.values) {
+        const parsed = (getValidVariableValues(variable.values) ?? []).map(
+          (v) => JSON.stringify(v),
+        );
+        if (parsed.length > 0) {
+          filter.variables = [
+            {
+              name: variable.name,
+              value: parsed.length === 1 ? parsed[0]! : {$in: parsed},
+            },
+          ];
+        }
       }
     }
 
     return filter;
-  }, [searchParams, variable]);
+  }, [searchParams, variable, conditions]);
+}
+
+function buildVariableEntry(condition: VariableCondition): VariableEntry {
+  switch (condition.operator) {
+    case 'equals':
+      return {name: condition.name, value: condition.value};
+    case 'notEqual':
+      return {name: condition.name, value: {$neq: condition.value}};
+    case 'contains':
+      return {name: condition.name, value: {$like: `*${condition.value}*`}};
+    case 'oneOf':
+      return {
+        name: condition.name,
+        value: {$in: parseOneOfValues(condition.value)},
+      };
+    case 'exists':
+      return {name: condition.name, value: {$exists: true}};
+    case 'doesNotExist':
+      return {name: condition.name, value: {$exists: false}};
+  }
+}
+
+function parseOneOfValues(raw: string): string[] {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (Array.isArray(parsed)) {
+      return parsed.map((v) => JSON.stringify(v));
+    }
+  } catch {
+    // fall through to comma-split
+  }
+  return raw
+    .split(',')
+    .map((v) => v.trim())
+    .filter(Boolean);
 }
 
 function useProcessInstancesSearchSort() {
@@ -48,4 +98,9 @@ function useProcessInstancesSearchSort() {
   );
 }
 
-export {useProcessInstancesSearchFilter, useProcessInstancesSearchSort};
+export {
+  useProcessInstancesSearchFilter,
+  useProcessInstancesSearchSort,
+  buildVariableEntry,
+  parseOneOfValues,
+};


### PR DESCRIPTION
## Description

- Connect `variableFilterStore.conditions` to the POST `/v2/process-instances/search` payload as AND-combined `filter.variables[]` entries                                                                          
- Map filter operators to backend query equivalents

## Related issues

closes #51810 
