### PR TITLE
ci: add oidc redirect URI to avoid localhost

### DIFF
--- a/.ci/preview-environments/charts/c8sm/values.yaml
+++ b/.ci/preview-environments/charts/c8sm/values.yaml
@@ -198,6 +198,7 @@ camunda-platform:
       authentication:
         method: oidc
         oidc:
+          redirectUrl: https://{{ include "ingress.domain" . }}/orchestration
           secret:
             existingSecret: camunda-credentials
             existingSecretKey: identity-orchestration-client-token


### PR DESCRIPTION
## Description

This pull request makes a small change to the OIDC configuration in the `c8sm` Helm chart values file, adding a `redirectUrl` for authentication. This ensures that after authentication, users are redirected to the correct orchestration endpoint.

* Added `redirectUrl` field to the OIDC authentication configuration in `.ci/preview-environments/charts/c8sm/values.yaml`.

This change is necessary to avoid users that want to access Operate or Tasklist in preview environments being redirected to localhost:8080, which breaks the login flow and subsequently also the smoke tests.

Go to https://medic-fix-previ.camunda.camunda.cloud/console and try navigating to Operate or Tasklist from there using the sidebar.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Related INC-5299
