### PR TITLE
Reexport existing RPA resources to make them available in secondary storage

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
@@ -25,6 +25,7 @@ public final class EngineCfg implements ConfigurationEntry {
   private GlobalListenersCfg globalListeners = new GlobalListenersCfg();
   private ExpressionCfg expression = new ExpressionCfg();
   private ProcessInstanceCreationCfg processInstanceCreation = new ProcessInstanceCreationCfg();
+  private StartupCfg startup = new StartupCfg();
 
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
@@ -39,6 +40,7 @@ public final class EngineCfg implements ConfigurationEntry {
     globalListeners.init(globalConfig, brokerBase);
     expression.init(globalConfig, brokerBase);
     processInstanceCreation.init(globalConfig, brokerBase);
+    startup.init(globalConfig, brokerBase);
   }
 
   public MessagesCfg getMessages() {
@@ -137,6 +139,14 @@ public final class EngineCfg implements ConfigurationEntry {
     this.processInstanceCreation = processInstanceCreation;
   }
 
+  public StartupCfg getStartup() {
+    return startup;
+  }
+
+  public void setStartup(final StartupCfg startupCfg) {
+    startup = startupCfg;
+  }
+
   @Override
   public String toString() {
     return "EngineCfg{"
@@ -164,6 +174,8 @@ public final class EngineCfg implements ConfigurationEntry {
         + expression
         + ", processInstanceCreation="
         + processInstanceCreation
+        + ", startup="
+        + startup
         + '}';
   }
 
@@ -205,6 +217,7 @@ public final class EngineCfg implements ConfigurationEntry {
         .setGlobalListeners(globalListeners.createGlobalListenersConfiguration())
         .setExpressionEvaluationTimeout(expression.getTimeout())
         .setBusinessIdUniquenessEnabled(processInstanceCreation.isBusinessIdUniquenessEnabled())
-        .setIncludeVariablesInJobCompletedEvent(jobs.isIncludeVariablesInJobCompletedEvent());
+        .setIncludeVariablesInJobCompletedEvent(jobs.isIncludeVariablesInJobCompletedEvent())
+        .setEnableRpaReexportMigration(startup.isRpaReexportMigrationEnabled());
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/StartupCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/StartupCfg.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.system.configuration.engine;
+
+import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_ENABLE_RPA_REEXPORT_MIGRATION;
+
+import io.camunda.zeebe.broker.system.configuration.ConfigurationEntry;
+
+public class StartupCfg implements ConfigurationEntry {
+
+  private boolean rpaReexportMigrationEnabled = DEFAULT_ENABLE_RPA_REEXPORT_MIGRATION;
+
+  public boolean isRpaReexportMigrationEnabled() {
+    return rpaReexportMigrationEnabled;
+  }
+
+  public void setRpaReexportMigrationEnabled(final boolean rpaReexportMigrationEnabled) {
+    this.rpaReexportMigrationEnabled = rpaReexportMigrationEnabled;
+  }
+
+  @Override
+  public String toString() {
+    return "StartupCfg{" + "rpaReexportMigrationEnabled=" + rpaReexportMigrationEnabled + '}';
+  }
+}

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
@@ -67,6 +67,8 @@ final class EngineCfgTest {
     assertThat(configuration.getExpressionEvaluationTimeout()).isEqualTo(Duration.ofSeconds(5));
     assertThat(configuration.isBusinessIdUniquenessEnabled())
         .isEqualTo(EngineConfiguration.DEFAULT_BUSINESS_ID_UNIQUENESS_ENABLED);
+    assertThat(configuration.isEnableRpaReexportMigration())
+        .isEqualTo(EngineConfiguration.DEFAULT_ENABLE_RPA_REEXPORT_MIGRATION);
   }
 
   @Test
@@ -105,6 +107,7 @@ final class EngineCfgTest {
         taskListeners.get(1), "test2", new String[] {"assigning", "canceling"}, "2", true);
     assertThat(configuration.getExpressionEvaluationTimeout()).isEqualTo(Duration.ofSeconds(2));
     assertThat(configuration.isBusinessIdUniquenessEnabled()).isTrue();
+    assertThat(configuration.isEnableRpaReexportMigration()).isFalse();
   }
 
   void assertListenerCfg(

--- a/zeebe/broker/src/test/resources/system/engine.yaml
+++ b/zeebe/broker/src/test/resources/system/engine.yaml
@@ -44,3 +44,5 @@ zeebe:
           timeout: 2s
         processInstanceCreation:
           businessIdUniquenessEnabled: true
+        startup:
+          rpaReexportMigrationEnabled: false

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -63,6 +63,7 @@ public final class EngineConfiguration {
   public static final boolean DEFAULT_ENABLE_IDENTITY_SETUP = true;
   public static final Duration DEFAULT_EXPRESSION_EVALUATION_TIMEOUT = Duration.ofSeconds(5);
   public static final boolean DEFAULT_BUSINESS_ID_UNIQUENESS_ENABLED = false;
+  public static final boolean DEFAULT_ENABLE_RPA_REEXPORT_MIGRATION = true;
 
   private int maxIdFieldLength = DEFAULT_MAX_ID_FIELD_LENGTH;
   private int maxNameFieldLength = DEFAULT_MAX_NAME_FIELD_LENGTH;
@@ -106,6 +107,7 @@ public final class EngineConfiguration {
   private Duration expressionEvaluationTimeout = DEFAULT_EXPRESSION_EVALUATION_TIMEOUT;
   private boolean includeVariablesInJobCompletedEvent =
       DEFAULT_JOBS_INCLUDE_VARIABLES_IN_JOB_COMPLETED_EVENT;
+  private boolean enableRpaReexportMigration = DEFAULT_ENABLE_RPA_REEXPORT_MIGRATION;
 
   /**
    * Controls uniqueness enforcement of business IDs across active process instances.
@@ -485,6 +487,16 @@ public final class EngineConfiguration {
   public EngineConfiguration setIncludeVariablesInJobCompletedEvent(
       final boolean includeVariablesInJobCompletedEvent) {
     this.includeVariablesInJobCompletedEvent = includeVariablesInJobCompletedEvent;
+    return this;
+  }
+
+  public boolean isEnableRpaReexportMigration() {
+    return enableRpaReexportMigration;
+  }
+
+  public EngineConfiguration setEnableRpaReexportMigration(
+      final boolean enableRpaReexportMigration) {
+    this.enableRpaReexportMigration = enableRpaReexportMigration;
     return this;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -56,6 +56,8 @@ import io.camunda.zeebe.engine.processing.metrics.job.JobMetricsProcessors;
 import io.camunda.zeebe.engine.processing.metrics.usage.UsageMetricsProcessors;
 import io.camunda.zeebe.engine.processing.resource.ResourceDeletionDeleteProcessor;
 import io.camunda.zeebe.engine.processing.resource.ResourceFetchProcessor;
+import io.camunda.zeebe.engine.processing.resource.ResourceReexportReexportProcessor;
+import io.camunda.zeebe.engine.processing.resource.ResourceReexportStartProcessor;
 import io.camunda.zeebe.engine.processing.resource.RpaReexportMigrator;
 import io.camunda.zeebe.engine.processing.scaling.ScalingProcessors;
 import io.camunda.zeebe.engine.processing.signal.SignalBroadcastProcessor;
@@ -83,6 +85,7 @@ import io.camunda.zeebe.protocol.record.intent.DeploymentDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.intent.ResourceDeletionIntent;
 import io.camunda.zeebe.protocol.record.intent.ResourceIntent;
+import io.camunda.zeebe.protocol.record.intent.ResourceReexportIntent;
 import io.camunda.zeebe.protocol.record.intent.SignalIntent;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
@@ -657,6 +660,14 @@ public final class EngineProcessors {
     typedRecordProcessors.withListener(
         new RpaReexportMigrator(
             config.isEnableRpaReexportMigration(), processingState.getResourceState()));
+    typedRecordProcessors.onCommand(
+        ValueType.RESOURCE_REEXPORT,
+        ResourceReexportIntent.START,
+        new ResourceReexportStartProcessor(writers));
+    typedRecordProcessors.onCommand(
+        ValueType.RESOURCE_REEXPORT,
+        ResourceReexportIntent.REEXPORT,
+        new ResourceReexportReexportProcessor(writers, processingState));
   }
 
   private static void addSignalBroadcastProcessors(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -56,6 +56,7 @@ import io.camunda.zeebe.engine.processing.metrics.job.JobMetricsProcessors;
 import io.camunda.zeebe.engine.processing.metrics.usage.UsageMetricsProcessors;
 import io.camunda.zeebe.engine.processing.resource.ResourceDeletionDeleteProcessor;
 import io.camunda.zeebe.engine.processing.resource.ResourceFetchProcessor;
+import io.camunda.zeebe.engine.processing.resource.RpaReexportMigrator;
 import io.camunda.zeebe.engine.processing.scaling.ScalingProcessors;
 import io.camunda.zeebe.engine.processing.signal.SignalBroadcastProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer;
@@ -354,7 +355,8 @@ public final class EngineProcessors {
     IdentitySetupProcessors.addIdentitySetupProcessors(
         keyGenerator, typedRecordProcessors, writers, securityConfig, config);
 
-    addResourceFetchProcessors(typedRecordProcessors, writers, processingState, authCheckBehavior);
+    addResourceFetchProcessors(
+        typedRecordProcessors, writers, processingState, authCheckBehavior, config);
 
     BatchOperationSetupProcessors.addBatchOperationProcessors(
         keyGenerator,
@@ -645,11 +647,16 @@ public final class EngineProcessors {
       final TypedRecordProcessors typedRecordProcessors,
       final Writers writers,
       final ProcessingState processingState,
-      final AuthorizationCheckBehavior authCheckBehavior) {
+      final AuthorizationCheckBehavior authCheckBehavior,
+      final EngineConfiguration config) {
     final var resourceFetchProcessor =
         new ResourceFetchProcessor(writers, processingState, authCheckBehavior);
     typedRecordProcessors.onCommand(
         ValueType.RESOURCE, ResourceIntent.FETCH, resourceFetchProcessor);
+    // Migration to reexport resources to secondary storage
+    typedRecordProcessors.withListener(
+        new RpaReexportMigrator(
+            config.isEnableRpaReexportMigration(), processingState.getResourceState()));
   }
 
   private static void addSignalBroadcastProcessors(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceReexportReexportProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceReexportReexportProcessor.java
@@ -15,7 +15,9 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.deployment.PersistedResource;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.ResourceState;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ResourceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.ResourceReexportRecord;
+import io.camunda.zeebe.protocol.record.intent.ResourceIntent;
 import io.camunda.zeebe.protocol.record.intent.ResourceReexportIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -57,7 +59,7 @@ public class ResourceReexportReexportProcessor
 
     if (foundResource.get() != null) {
       final var resource = foundResource.get();
-      // TODO recreate resource record and write reexport event.
+      reexportResource(resource);
       commandWriter.appendFollowUpCommand(
           command.getKey(),
           ResourceReexportIntent.REEXPORT,
@@ -68,5 +70,21 @@ public class ResourceReexportReexportProcessor
       stateWriter.appendFollowUpEvent(
           command.getKey(), ResourceReexportIntent.FINISHED, command.getValue());
     }
+  }
+
+  private void reexportResource(final PersistedResource resource) {
+    final var resourceRecord =
+        new ResourceRecord()
+            .setResourceId(resource.getResourceId())
+            .setVersion(resource.getVersion())
+            .setResourceKey(resource.getResourceKey())
+            .setChecksum(resource.getChecksum())
+            .setResourceName(resource.getResourceName())
+            .setTenantId(resource.getTenantId())
+            .setDeploymentKey(resource.getDeploymentKey())
+            .setVersionTag(resource.getVersionTag())
+            .setResource(BufferUtil.wrapString(resource.getResource()));
+    stateWriter.appendFollowUpEvent(
+        resource.getResourceKey(), ResourceIntent.REEXPORTED, resourceRecord);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceReexportReexportProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceReexportReexportProcessor.java
@@ -47,7 +47,9 @@ public class ResourceReexportReexportProcessor
 
     resourceState.visitResourcesByKey(
         value.getTenantId(),
-        value.getResourceKey(),
+        // We already reexported the key inside the command. We need to ensure we
+        // continue with the next one.
+        value.getResourceKey() + 1,
         resource -> {
           if (!BufferUtil.bufferAsString(resource.getResourceName()).endsWith(RPA_FILE_EXTENSION)) {
             return true; // We should only reexport RPA resources.

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceReexportReexportProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceReexportReexportProcessor.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.resource;
+
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.deployment.PersistedResource;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.engine.state.immutable.ResourceState;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ResourceReexportRecord;
+import io.camunda.zeebe.protocol.record.intent.ResourceReexportIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.concurrent.atomic.AtomicReference;
+
+@ExcludeAuthorizationCheck
+public class ResourceReexportReexportProcessor
+    implements TypedRecordProcessor<ResourceReexportRecord> {
+
+  private static final String RPA_FILE_EXTENSION = ".rpa";
+
+  private final StateWriter stateWriter;
+  private final TypedCommandWriter commandWriter;
+  private final ResourceState resourceState;
+
+  public ResourceReexportReexportProcessor(
+      final Writers writers, final ProcessingState processingState) {
+    stateWriter = writers.state();
+    commandWriter = writers.command();
+    resourceState = processingState.getResourceState();
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<ResourceReexportRecord> command) {
+    final var value = command.getValue();
+    final var foundResource = new AtomicReference<PersistedResource>();
+
+    resourceState.visitResourcesByKey(
+        value.getTenantId(),
+        value.getResourceKey(),
+        resource -> {
+          if (!BufferUtil.bufferAsString(resource.getResourceName()).endsWith(RPA_FILE_EXTENSION)) {
+            return true; // We should only reexport RPA resources.
+          }
+          foundResource.set(resource.copy());
+          return false; // stop the loop, we only want to reexport one resource at a time so we
+          // don't impact the stream processor significantly.
+        });
+
+    if (foundResource.get() != null) {
+      final var resource = foundResource.get();
+      // TODO recreate resource record and write reexport event.
+      commandWriter.appendFollowUpCommand(
+          command.getKey(),
+          ResourceReexportIntent.REEXPORT,
+          new ResourceReexportRecord()
+              .setResourceKey(resource.getResourceKey())
+              .setTenantId(resource.getTenantId()));
+    } else {
+      stateWriter.appendFollowUpEvent(
+          command.getKey(), ResourceReexportIntent.FINISHED, command.getValue());
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceReexportReexportProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceReexportReexportProcessor.java
@@ -51,7 +51,9 @@ public class ResourceReexportReexportProcessor
         // continue with the next one.
         value.getResourceKey() + 1,
         resource -> {
-          if (!BufferUtil.bufferAsString(resource.getResourceName()).endsWith(RPA_FILE_EXTENSION)) {
+          if (!BufferUtil.bufferAsString(resource.getResourceName())
+              .toLowerCase()
+              .endsWith(RPA_FILE_EXTENSION)) {
             return true; // We should only reexport RPA resources.
           }
           foundResource.set(resource.copy());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceReexportStartProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceReexportStartProcessor.java
@@ -30,9 +30,9 @@ public class ResourceReexportStartProcessor
 
   @Override
   public void processRecord(final TypedRecord<ResourceReexportRecord> command) {
-    commandWriter.appendFollowUpCommand(
-        command.getKey(), ResourceReexportIntent.REEXPORT, new ResourceReexportRecord());
     stateWriter.appendFollowUpEvent(
         command.getKey(), ResourceReexportIntent.STARTED, command.getValue());
+    commandWriter.appendFollowUpCommand(
+        command.getKey(), ResourceReexportIntent.REEXPORT, new ResourceReexportRecord());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceReexportStartProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceReexportStartProcessor.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.resource;
+
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ResourceReexportRecord;
+import io.camunda.zeebe.protocol.record.intent.ResourceReexportIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+
+@ExcludeAuthorizationCheck
+public class ResourceReexportStartProcessor
+    implements TypedRecordProcessor<ResourceReexportRecord> {
+
+  private final StateWriter stateWriter;
+  private final TypedCommandWriter commandWriter;
+
+  public ResourceReexportStartProcessor(final Writers writers) {
+    stateWriter = writers.state();
+    commandWriter = writers.command();
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<ResourceReexportRecord> command) {
+    commandWriter.appendFollowUpCommand(
+        command.getKey(), ResourceReexportIntent.REEXPORT, new ResourceReexportRecord());
+    stateWriter.appendFollowUpEvent(
+        command.getKey(), ResourceReexportIntent.STARTED, command.getValue());
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceReexportStartProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceReexportStartProcessor.java
@@ -33,6 +33,6 @@ public class ResourceReexportStartProcessor
     stateWriter.appendFollowUpEvent(
         command.getKey(), ResourceReexportIntent.STARTED, command.getValue());
     commandWriter.appendFollowUpCommand(
-        command.getKey(), ResourceReexportIntent.REEXPORT, new ResourceReexportRecord());
+        command.getKey(), ResourceReexportIntent.REEXPORT, command.getValue());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/RpaReexportMigrator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/RpaReexportMigrator.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.resource;
+
+import io.camunda.zeebe.engine.Loggers;
+import io.camunda.zeebe.engine.state.immutable.ResourceState;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
+import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
+import org.slf4j.Logger;
+
+public final class RpaReexportMigrator implements StreamProcessorLifecycleAware {
+
+  private static final Logger LOG = Loggers.PROCESS_PROCESSOR_LOGGER;
+  private final boolean enableRpaReexportMigration;
+  private final ResourceState resourceState;
+
+  public RpaReexportMigrator(
+      final boolean enableRpaReexportMigration, final ResourceState resourceState) {
+    this.enableRpaReexportMigration = enableRpaReexportMigration;
+    this.resourceState = resourceState;
+  }
+
+  @Override
+  public void onRecovered(final ReadonlyStreamProcessorContext context) {
+    // We can disable the migration by disabling the feature flag. This is useful to prevent
+    // interference in our engine tests, as this setup will write "unexpected" commands/events
+    if (!enableRpaReexportMigration) {
+      return;
+    }
+
+    if (context.getPartitionId() != Protocol.DEPLOYMENT_PARTITION) {
+      // We should only create users on the deployment partition. The command will be distributed to
+      // the other partitions using our command distribution mechanism.
+      LOG.debug(
+          "Skipping RPA reexport migration on partition {} as it is not the deployment partition",
+          context.getPartitionId());
+      return;
+    }
+
+    if (resourceState.hasRanRpaReexportMigration()) {
+      LOG.debug("RPA reexport migration already ran. Skipping.");
+      return;
+    }
+
+    // We use a timestamp of 0L to ensure this is runs immediately once the stream processor is
+    // started
+    context
+        .getScheduleService()
+        .runAtAsync(
+            0L,
+            (taskResultBuilder) -> {
+              //              taskResultBuilder.appendCommandRecord(); TODO: append command
+              return taskResultBuilder.build();
+            });
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/RpaReexportMigrator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/RpaReexportMigrator.java
@@ -10,6 +10,8 @@ package io.camunda.zeebe.engine.processing.resource;
 import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.state.immutable.ResourceState;
 import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ResourceReexportRecord;
+import io.camunda.zeebe.protocol.record.intent.ResourceReexportIntent;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
 import org.slf4j.Logger;
@@ -55,7 +57,8 @@ public final class RpaReexportMigrator implements StreamProcessorLifecycleAware 
         .runAtAsync(
             0L,
             (taskResultBuilder) -> {
-              //              taskResultBuilder.appendCommandRecord(); TODO: append command
+              taskResultBuilder.appendCommandRecord(
+                  ResourceReexportIntent.START, new ResourceReexportRecord());
               return taskResultBuilder.build();
             });
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/RpaReexportMigrator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/RpaReexportMigrator.java
@@ -37,7 +37,7 @@ public final class RpaReexportMigrator implements StreamProcessorLifecycleAware 
     }
 
     if (context.getPartitionId() != Protocol.DEPLOYMENT_PARTITION) {
-      // We should only create users on the deployment partition. The command will be distributed to
+      // We should only reexport on the deployment partition. The command will be distributed to
       // the other partitions using our command distribution mechanism.
       LOG.debug(
           "Skipping RPA reexport migration on partition {} as it is not the deployment partition",

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -586,6 +586,7 @@ public final class EventAppliers implements EventApplier {
     register(ResourceIntent.CREATED, new ResourceCreatedApplier(state.getResourceState()));
     register(ResourceIntent.DELETED, new ResourceDeletedApplier(state.getResourceState()));
     register(ResourceIntent.FETCHED, NOOP_EVENT_APPLIER);
+    register(ResourceIntent.REEXPORTED, NOOP_EVENT_APPLIER);
   }
 
   private void registerUserTaskAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -63,6 +63,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ResourceDeletionIntent;
 import io.camunda.zeebe.protocol.record.intent.ResourceIntent;
+import io.camunda.zeebe.protocol.record.intent.ResourceReexportIntent;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
 import io.camunda.zeebe.protocol.record.intent.RuntimeInstructionIntent;
 import io.camunda.zeebe.protocol.record.intent.SignalIntent;
@@ -587,6 +588,10 @@ public final class EventAppliers implements EventApplier {
     register(ResourceIntent.DELETED, new ResourceDeletedApplier(state.getResourceState()));
     register(ResourceIntent.FETCHED, NOOP_EVENT_APPLIER);
     register(ResourceIntent.REEXPORTED, NOOP_EVENT_APPLIER);
+    register(
+        ResourceReexportIntent.STARTED,
+        new ResourceReexportStartedApplier(state.getResourceState()));
+    register(ResourceReexportIntent.FINISHED, NOOP_EVENT_APPLIER);
   }
 
   private void registerUserTaskAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ResourceReexportStartedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ResourceReexportStartedApplier.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableResourceState;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ResourceReexportRecord;
+import io.camunda.zeebe.protocol.record.intent.ResourceReexportIntent;
+
+public final class ResourceReexportStartedApplier
+    implements TypedEventApplier<ResourceReexportIntent, ResourceReexportRecord> {
+
+  private final MutableResourceState resourceState;
+
+  public ResourceReexportStartedApplier(final MutableResourceState resourceState) {
+    this.resourceState = resourceState;
+  }
+
+  @Override
+  public void applyState(final long key, final ResourceReexportRecord value) {
+    resourceState.markRpaReexportMigrationAsRan();
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbResourceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbResourceState.java
@@ -242,6 +242,12 @@ public class DbResourceState implements MutableResourceState {
   }
 
   @Override
+  public void markRpaReexportMigrationAsRan() {
+    rpaReexportMigrationKey.wrapString(RPA_REEXPORT_MIGRATION_KEY_VALUE);
+    rpaReexportMigrationColumnFamily.upsert(rpaReexportMigrationKey, DbNil.INSTANCE);
+  }
+
+  @Override
   public Optional<PersistedResource> findLatestResourceById(
       final String resourceId, final String tenantId) {
     return getResourceFromCache(tenantId, resourceId);
@@ -291,12 +297,6 @@ public class DbResourceState implements MutableResourceState {
   }
 
   @Override
-  public void clearCache() {
-    resourcesByTenantIdAndIdCache.invalidateAll();
-    versionManager.clear();
-  }
-
-  @Override
   public void visitResourcesByKey(
       final String tenantId,
       final long startResourceKey,
@@ -310,6 +310,12 @@ public class DbResourceState implements MutableResourceState {
         (key, value) -> {
           return visitor.test(value);
         });
+  }
+
+  @Override
+  public void clearCache() {
+    resourcesByTenantIdAndIdCache.invalidateAll();
+    versionManager.clear();
   }
 
   private PersistedResource getPersistedResourceById(final String resourceId, final String tenantId)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbResourceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbResourceState.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.ResourceRecord;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Predicate;
 
 public class DbResourceState implements MutableResourceState {
 
@@ -293,6 +294,22 @@ public class DbResourceState implements MutableResourceState {
   public void clearCache() {
     resourcesByTenantIdAndIdCache.invalidateAll();
     versionManager.clear();
+  }
+
+  @Override
+  public void visitResourcesByKey(
+      final String tenantId,
+      final long startResourceKey,
+      final Predicate<PersistedResource> visitor) {
+    // Use an empty tenant prefix so the start key sorts before all real tenant entries,
+    // ensuring the iteration covers resources across all tenants.
+    tenantIdKey.wrapString(tenantId);
+    dbResourceKey.wrapLong(startResourceKey);
+    resourcesByKey.whileTrue(
+        tenantAwareResourceKey,
+        (key, value) -> {
+          return visitor.test(value);
+        });
   }
 
   private PersistedResource getPersistedResourceById(final String resourceId, final String tenantId)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbResourceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbResourceState.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.impl.DbCompositeKey;
 import io.camunda.zeebe.db.impl.DbForeignKey;
 import io.camunda.zeebe.db.impl.DbLong;
+import io.camunda.zeebe.db.impl.DbNil;
 import io.camunda.zeebe.db.impl.DbString;
 import io.camunda.zeebe.db.impl.DbTenantAwareKey;
 import io.camunda.zeebe.db.impl.DbTenantAwareKey.PlacementType;
@@ -28,8 +29,8 @@ import java.util.concurrent.ExecutionException;
 
 public class DbResourceState implements MutableResourceState {
 
+  public static final String RPA_REEXPORT_MIGRATION_KEY_VALUE = "rpa-reexport-migration";
   private static final int DEFAULT_VERSION_VALUE = 0;
-
   private final DbString tenantIdKey;
   private final DbLong dbResourceKey;
   private final DbTenantAwareKey<DbLong> tenantAwareResourceKey;
@@ -64,6 +65,9 @@ public class DbResourceState implements MutableResourceState {
           DbTenantAwareKey<DbCompositeKey<DbString, DbString>>,
           DbForeignKey<DbTenantAwareKey<DbLong>>>
       resourceKeyByResourceIdAndVersionTagColumnFamily;
+
+  private final DbString rpaReexportMigrationKey;
+  private final ColumnFamily<DbString, DbNil> rpaReexportMigrationColumnFamily;
 
   private final LoadingCache<TenantIdAndResourceId, PersistedResource>
       resourcesByTenantIdAndIdCache;
@@ -122,6 +126,12 @@ public class DbResourceState implements MutableResourceState {
     versionManager =
         new VersionManager(
             DEFAULT_VERSION_VALUE, zeebeDb, ZbColumnFamilies.RESOURCE_VERSION, transactionContext);
+
+    rpaReexportMigrationKey = new DbString();
+    rpaReexportMigrationKey.wrapString(RPA_REEXPORT_MIGRATION_KEY_VALUE);
+    rpaReexportMigrationColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.DEFAULT, transactionContext, rpaReexportMigrationKey, DbNil.INSTANCE);
 
     resourcesByTenantIdAndIdCache =
         CacheBuilder.newBuilder()
@@ -271,6 +281,12 @@ public class DbResourceState implements MutableResourceState {
   @Override
   public int getNextResourceVersion(final String resourceId, final String tenantId) {
     return (int) versionManager.getHighestResourceVersion(resourceId, tenantId) + 1;
+  }
+
+  @Override
+  public boolean hasRanRpaReexportMigration() {
+    rpaReexportMigrationKey.wrapString(RPA_REEXPORT_MIGRATION_KEY_VALUE);
+    return rpaReexportMigrationColumnFamily.exists(rpaReexportMigrationKey);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ResourceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ResourceState.java
@@ -79,8 +79,8 @@ public interface ResourceState {
    * @param tenantId the tenant id of the resources to iterate over. Caution! This will iterate past
    *     this tenant into other tenants.
    * @param startResourceKey the resource key to start iterating from (inclusive)
-   * @param visitor called for each resource found at or after the start key; return {@code false} to
-   *     stop iteration early, {@code true} to continue
+   * @param visitor called for each resource found at or after the start key; return {@code false}
+   *     to stop iteration early, {@code true} to continue
    */
   void visitResourcesByKey(
       final String tenantId, long startResourceKey, Predicate<PersistedResource> visitor);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ResourceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ResourceState.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.state.immutable;
 
 import io.camunda.zeebe.engine.state.deployment.PersistedResource;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 public interface ResourceState {
   /**
@@ -69,6 +70,20 @@ public interface ResourceState {
    * @return a boolean indicating if the migration ran.
    */
   boolean hasRanRpaReexportMigration();
+
+  /**
+   * Iterates over all resources in the RESOURCES column family, starting at the entry at or after
+   * the given {@code startResourceKey}. The consumer receives each {@link PersistedResource} in key
+   * order.
+   *
+   * @param tenantId the tenant id of the resources to iterate over. Caution! This will iterate past
+   *     this tenant into other tenants.
+   * @param startResourceKey the resource key to start iterating from (inclusive)
+   * @param visitor called for each resource found at or after the start key; return {@code false} to
+   *     stop iteration early, {@code true} to continue
+   */
+  void visitResourcesByKey(
+      final String tenantId, long startResourceKey, Predicate<PersistedResource> visitor);
 
   void clearCache();
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ResourceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ResourceState.java
@@ -63,5 +63,12 @@ public interface ResourceState {
    */
   int getNextResourceVersion(String resourceId, String tenantId);
 
+  /**
+   * Returns if the RPA reexport migration has already ran. If it did we don't need to run it again.
+   *
+   * @return a boolean indicating if the migration ran.
+   */
+  boolean hasRanRpaReexportMigration();
+
   void clearCache();
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableResourceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableResourceState.java
@@ -80,4 +80,6 @@ public interface MutableResourceState extends ResourceState {
    * @param record the record of the resource that is deleted
    */
   void deleteResourceInResourceKeyByResourceIdAndVersionTagColumnFamily(ResourceRecord record);
+
+  void markRpaReexportMigrationAsRan();
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/RpaReexportMigrationMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/RpaReexportMigrationMultiPartitionTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ResourceReexportIntent;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class RpaReexportMigrationMultiPartitionTest {
+
+  private static final String TEST_RPA_RESOURCE = "/resource/test-rpa-1.rpa";
+  private static final int PARTITION_COUNT = 2;
+
+  @Rule public final EngineRule engine = EngineRule.multiplePartition(PARTITION_COUNT);
+  @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldOnlyRunMigrationOnDeploymentPartition() {
+    // given - deploy an RPA resource (lands on deployment partition)
+    engine.deployment().withJsonClasspathResource(TEST_RPA_RESOURCE).deploy();
+
+    // when - enable migration and restart
+    engine.stop();
+    engine.withEngineConfig(cfg -> cfg.setEnableRpaReexportMigration(true));
+    engine.start();
+
+    // then - migration finishes on partition 1
+    RecordingExporter.resourceReexportRecords(ResourceReexportIntent.FINISHED)
+        .withPartitionId(Protocol.DEPLOYMENT_PARTITION)
+        .getFirst();
+
+    // verify all RESOURCE_REEXPORT records are only on the deployment partition
+    assertThat(
+            RecordingExporter.records()
+                .withValueType(ValueType.RESOURCE_REEXPORT)
+                .limit(r -> r.getIntent() == ResourceReexportIntent.FINISHED)
+                .asList())
+        .extracting(r -> r.getPartitionId())
+        .containsOnly(Protocol.DEPLOYMENT_PARTITION);
+
+    // verify no RESOURCE_REEXPORT records on partition 2
+    assertThat(
+            RecordingExporter.records()
+                .withValueType(ValueType.RESOURCE_REEXPORT)
+                .limit(r -> r.getIntent() == ResourceReexportIntent.FINISHED)
+                .withPartitionId(PARTITION_COUNT)
+                .asList())
+        .isEmpty();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/RpaReexportMigrationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/RpaReexportMigrationTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+import io.camunda.zeebe.protocol.record.intent.ResourceIntent;
+import io.camunda.zeebe.protocol.record.intent.ResourceReexportIntent;
+import io.camunda.zeebe.protocol.record.value.deployment.Resource;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class RpaReexportMigrationTest {
+
+  private static final String TEST_RPA_RESOURCE = "/resource/test-rpa-1.rpa";
+  private static final String TEST_GENERIC_RESOURCE = "/resource/test-generic-1.txt";
+
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+  @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldRunMigrationLifecycleAndReexportRpaResources() {
+    // given - an RPA resource deployed before migration runs (migration disabled by default)
+    engine.deployment().withJsonClasspathResource(TEST_RPA_RESOURCE).deploy();
+    final var createdRecord =
+        RecordingExporter.resourceRecords().withIntent(ResourceIntent.CREATED).getFirst();
+
+    // when - enable migration and restart the engine
+    engine.stop();
+    engine.withEngineConfig(cfg -> cfg.setEnableRpaReexportMigration(true));
+    engine.start();
+
+    // then - migration completes with FINISHED event
+    RecordingExporter.resourceReexportRecords(ResourceReexportIntent.FINISHED).getFirst();
+
+    // verify the full expected intent lifecycle
+    final var reexportIntents =
+        RecordingExporter.resourceReexportRecords()
+            .limit(r -> r.getIntent() == ResourceReexportIntent.FINISHED)
+            .asList()
+            .stream()
+            .map(Record::getIntent)
+            .toList();
+    assertThat(reexportIntents)
+        .containsExactly(
+            ResourceReexportIntent.START,
+            ResourceReexportIntent.STARTED,
+            ResourceReexportIntent.REEXPORT,
+            ResourceReexportIntent.REEXPORT,
+            ResourceReexportIntent.FINISHED);
+
+    // verify the REEXPORTED event matches the original CREATED event
+    final var reexportedRecord =
+        RecordingExporter.resourceRecords().withIntent(ResourceIntent.REEXPORTED).getFirst();
+    final Resource reexported = reexportedRecord.getValue();
+    final Resource created = createdRecord.getValue();
+    assertThat(reexported.getResourceKey()).isEqualTo(created.getResourceKey());
+    assertThat(reexported.getResourceId()).isEqualTo(created.getResourceId());
+    assertThat(reexported.getResourceName()).isEqualTo(created.getResourceName());
+    assertThat(reexported.getVersion()).isEqualTo(created.getVersion());
+    assertThat(reexported.getTenantId()).isEqualTo(created.getTenantId());
+    assertThat(reexported.getDeploymentKey()).isEqualTo(created.getDeploymentKey());
+    assertThat(reexported.getChecksum()).isEqualTo(created.getChecksum());
+  }
+
+  @Test
+  public void shouldNotReexportNonRpaResources() {
+    // given - only a non-RPA resource is deployed
+    engine.deployment().withJsonClasspathResource(TEST_GENERIC_RESOURCE).deploy();
+
+    // when - enable migration and restart
+    engine.stop();
+    engine.withEngineConfig(cfg -> cfg.setEnableRpaReexportMigration(true));
+    engine.start();
+
+    // then - migration finishes without any REEXPORTED event
+    RecordingExporter.resourceReexportRecords(ResourceReexportIntent.FINISHED).getFirst();
+
+    // use the FINISHED record as a boundary so the assertion doesn't block
+    assertThat(
+            RecordingExporter.records()
+                .limit(
+                    r ->
+                        r.getValueType() == ValueType.RESOURCE_REEXPORT
+                            && r.getIntent() == ResourceReexportIntent.FINISHED)
+                .withValueType(ValueType.RESOURCE)
+                .withIntent(ResourceIntent.REEXPORTED)
+                .asList())
+        .isEmpty();
+  }
+
+  @Test
+  public void shouldNotRunMigrationAgainAfterRestart() {
+    // given - deploy an RPA resource and run the migration once
+    engine.deployment().withJsonClasspathResource(TEST_RPA_RESOURCE).deploy();
+
+    engine.stop();
+    engine.withEngineConfig(cfg -> cfg.setEnableRpaReexportMigration(true));
+    engine.start();
+
+    final var finishedRecord =
+        RecordingExporter.resourceReexportRecords(ResourceReexportIntent.FINISHED).getFirst();
+
+    // when - restart the engine again (migration already ran)
+    engine.stop();
+    engine.start();
+
+    // trigger a marker deployment so we know the engine is running past the migration window
+    final var markerDeploymentKey =
+        engine.deployment().withJsonClasspathResource(TEST_RPA_RESOURCE).deploy().getKey();
+    final var markerRecord =
+        RecordingExporter.deploymentRecords(DeploymentIntent.CREATED)
+            .filter(r -> r.getKey() == markerDeploymentKey)
+            .getFirst();
+
+    // then - no new RESOURCE_REEXPORT records were written after the FINISHED event
+    // We use limit(markerPos) to bound the stream, then post-filter by position to exclude
+    // replayed records (which have the same positions as the original migration records).
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getPosition() >= markerRecord.getPosition())
+                .withValueType(ValueType.RESOURCE_REEXPORT)
+                .asList()
+                .stream()
+                .filter(r -> r.getPosition() > finishedRecord.getPosition())
+                .toList())
+        .isEmpty();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/RpaReexportMigrationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/RpaReexportMigrationTest.java
@@ -25,6 +25,7 @@ import org.junit.rules.TestWatcher;
 public class RpaReexportMigrationTest {
 
   private static final String TEST_RPA_RESOURCE = "/resource/test-rpa-1.rpa";
+  private static final String TEST_RPA_RESOURCE_2 = "/resource/test-rpa-2.rpa";
   private static final String TEST_GENERIC_RESOURCE = "/resource/test-generic-1.txt";
 
   @Rule public final EngineRule engine = EngineRule.singlePartition();
@@ -73,6 +74,52 @@ public class RpaReexportMigrationTest {
     assertThat(reexported.getTenantId()).isEqualTo(created.getTenantId());
     assertThat(reexported.getDeploymentKey()).isEqualTo(created.getDeploymentKey());
     assertThat(reexported.getChecksum()).isEqualTo(created.getChecksum());
+  }
+
+  @Test
+  public void shouldReexportAllRpaResources() {
+    // given - two RPA resources deployed before migration runs
+    engine
+        .deployment()
+        .withJsonClasspathResource(TEST_RPA_RESOURCE)
+        .withJsonClasspathResource(TEST_RPA_RESOURCE_2)
+        .deploy();
+    final var createdRecords =
+        RecordingExporter.resourceRecords().withIntent(ResourceIntent.CREATED).limit(2).asList();
+
+    // when - enable migration and restart the engine
+    engine.stop();
+    engine.withEngineConfig(cfg -> cfg.setEnableRpaReexportMigration(true));
+    engine.start();
+
+    // then - migration completes with FINISHED event
+    RecordingExporter.resourceReexportRecords(ResourceReexportIntent.FINISHED).getFirst();
+
+    // verify one REEXPORT command per resource plus one final REEXPORT that finds nothing
+    // and triggers FINISHED (i.e. n+1 REEXPORTs for n resources)
+    final var reexportIntents =
+        RecordingExporter.resourceReexportRecords()
+            .limit(r -> r.getIntent() == ResourceReexportIntent.FINISHED)
+            .asList()
+            .stream()
+            .map(Record::getIntent)
+            .toList();
+    assertThat(reexportIntents)
+        .containsExactly(
+            ResourceReexportIntent.START,
+            ResourceReexportIntent.STARTED,
+            ResourceReexportIntent.REEXPORT,
+            ResourceReexportIntent.REEXPORT,
+            ResourceReexportIntent.REEXPORT,
+            ResourceReexportIntent.FINISHED);
+
+    // verify a REEXPORTED event was written for each deployed resource
+    final var reexportedRecords =
+        RecordingExporter.resourceRecords().withIntent(ResourceIntent.REEXPORTED).limit(2).asList();
+    assertThat(reexportedRecords)
+        .extracting(r -> r.getValue().getResourceKey())
+        .containsExactlyInAnyOrderElementsOf(
+            createdRecords.stream().map(r -> r.getValue().getResourceKey()).toList());
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/ResourceStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/ResourceStateTest.java
@@ -14,6 +14,8 @@ import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableResourceState;
 import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.ResourceRecord;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -149,6 +151,117 @@ public class ResourceStateTest {
         resourceState.findResourceByIdAndVersionTag(
             resourceRecord.getResourceId(), "v1.0", tenantId);
     assertThat(deleted).isEmpty();
+  }
+
+  @Test
+  void shouldVisitAllResourcesByKeyFromBeginning() {
+    // given
+    resourceState.storeResourceInResourceColumnFamily(resourceRecord(1L, "resource-1"));
+    resourceState.storeResourceInResourceColumnFamily(resourceRecord(2L, "resource-2"));
+    resourceState.storeResourceInResourceColumnFamily(resourceRecord(3L, "resource-3"));
+
+    // when - using empty string tenant and key 0 to visit all resources (as used by the migrator)
+    final List<Long> visitedKeys = new ArrayList<>();
+    resourceState.visitResourcesByKey(
+        "",
+        0,
+        resource -> {
+          visitedKeys.add(resource.getResourceKey());
+          return true;
+        });
+
+    // then
+    assertThat(visitedKeys).containsExactly(1L, 2L, 3L);
+  }
+
+  @Test
+  void shouldVisitResourcesByKeyStartingFromGivenKey() {
+    // given
+    resourceState.storeResourceInResourceColumnFamily(resourceRecord(1L, "resource-1"));
+    resourceState.storeResourceInResourceColumnFamily(resourceRecord(2L, "resource-2"));
+    resourceState.storeResourceInResourceColumnFamily(resourceRecord(3L, "resource-3"));
+
+    // when - start from key 2
+    final List<Long> visitedKeys = new ArrayList<>();
+    resourceState.visitResourcesByKey(
+        tenantId,
+        2,
+        resource -> {
+          visitedKeys.add(resource.getResourceKey());
+          return true;
+        });
+
+    // then - only resources with key >= 2 are visited
+    assertThat(visitedKeys).containsExactly(2L, 3L);
+  }
+
+  @Test
+  void shouldStopVisitingWhenVisitorReturnsFalse() {
+    // given
+    resourceState.storeResourceInResourceColumnFamily(resourceRecord(1L, "resource-1"));
+    resourceState.storeResourceInResourceColumnFamily(resourceRecord(2L, "resource-2"));
+    resourceState.storeResourceInResourceColumnFamily(resourceRecord(3L, "resource-3"));
+
+    // when - visitor stops after finding the first resource
+    final List<Long> visitedKeys = new ArrayList<>();
+    resourceState.visitResourcesByKey(
+        "",
+        0,
+        resource -> {
+          visitedKeys.add(resource.getResourceKey());
+          return false; // stop after first
+        });
+
+    // then - only the first resource is visited
+    assertThat(visitedKeys).containsExactly(1L);
+  }
+
+  @Test
+  void shouldNotVisitWhenNoResourcesAreStored() {
+    // when
+    final List<Long> visitedKeys = new ArrayList<>();
+    resourceState.visitResourcesByKey(
+        "",
+        0,
+        resource -> {
+          visitedKeys.add(resource.getResourceKey());
+          return true;
+        });
+
+    // then
+    assertThat(visitedKeys).isEmpty();
+  }
+
+  @Test
+  void shouldReturnFalseWhenMigrationHasNotRan() {
+    // when
+    final boolean hasRan = resourceState.hasRanRpaReexportMigration();
+
+    // then
+    assertThat(hasRan).isFalse();
+  }
+
+  @Test
+  void shouldReturnTrueAfterMigrationIsMarkedAsRan() {
+    // given
+    resourceState.markRpaReexportMigrationAsRan();
+
+    // when
+    final boolean hasRan = resourceState.hasRanRpaReexportMigration();
+
+    // then
+    assertThat(hasRan).isTrue();
+  }
+
+  private ResourceRecord resourceRecord(final long resourceKey, final String resourceId) {
+    return new ResourceRecord()
+        .setResourceId(resourceId)
+        .setVersion(1)
+        .setResourceKey(resourceKey)
+        .setTenantId(tenantId)
+        .setDeploymentKey(1L)
+        .setResourceName(resourceId + ".rpa")
+        .setVersionTag("v1.0");
   }
 
   private ResourceRecord sampleResourceRecord() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -139,6 +139,7 @@ public final class EngineRule extends ExternalResource {
         // identity setup is disabled by default so we can have deterministic writes
         // if you need it enabled, use #withIdentitySetup
         cfg.setEnableIdentitySetup(false);
+        cfg.setEnableRpaReexportMigration(false);
       };
   private SearchClientsProxy searchClientsProxy;
   private BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter;

--- a/zeebe/engine/src/test/resources/state/appliers/golden/ResourceReexport_STARTED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/ResourceReexport_STARTED_v1.golden
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableResourceState;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ResourceReexportRecord;
+import io.camunda.zeebe.protocol.record.intent.ResourceReexportIntent;
+
+public final class ResourceReexportStartedApplier
+    implements TypedEventApplier<ResourceReexportIntent, ResourceReexportRecord> {
+
+  private final MutableResourceState resourceState;
+
+  public ResourceReexportStartedApplier(final MutableResourceState resourceState) {
+    this.resourceState = resourceState;
+  }
+
+  @Override
+  public void applyState(final long key, final ResourceReexportRecord value) {
+    resourceState.markRpaReexportMigrationAsRan();
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ResourceCreatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ResourceCreatedHandler.java
@@ -19,7 +19,8 @@ import java.util.List;
 
 public class ResourceCreatedHandler implements ExportHandler<DeployedResourceEntity, Resource> {
 
-  private static final ResourceIntent SUPPORTED_INTENT = ResourceIntent.CREATED;
+  private static final List<ResourceIntent> SUPPORTED_INTENTS =
+      List.of(ResourceIntent.CREATED, ResourceIntent.REEXPORTED);
   private final String indexName;
 
   public ResourceCreatedHandler(final String indexName) {
@@ -39,7 +40,7 @@ public class ResourceCreatedHandler implements ExportHandler<DeployedResourceEnt
   @Override
   public boolean handlesRecord(final Record<Resource> record) {
     return getHandledValueType().equals(record.getValueType())
-        && SUPPORTED_INTENT.equals(record.getIntent());
+        && SUPPORTED_INTENTS.contains(record.getIntent());
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ResourceCreatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ResourceCreatedHandlerTest.java
@@ -58,12 +58,28 @@ public class ResourceCreatedHandlerTest {
     assertThat(underTest.handlesRecord(record)).isTrue();
   }
 
+  @Test
+  void shouldHandleReexportedRecord() {
+    // given
+    final Resource value =
+        ImmutableResource.builder()
+            .from(factory.generateObject(Resource.class))
+            .withResourceName("my-script.rpa")
+            .build();
+    final Record<Resource> record =
+        factory.generateRecord(
+            ValueType.RESOURCE, r -> r.withIntent(ResourceIntent.REEXPORTED).withValue(value));
+
+    // when - then
+    assertThat(underTest.handlesRecord(record)).isTrue();
+  }
+
   @ParameterizedTest
   @EnumSource(
       value = ResourceIntent.class,
-      names = {"CREATED"},
+      names = {"CREATED", "REEXPORTED"},
       mode = Mode.EXCLUDE)
-  void shouldNotHandleRecordForNonCreatedIntent(final ResourceIntent intent) {
+  void shouldNotHandleRecordForUnsupportedIntent(final ResourceIntent intent) {
     // given
     final Resource value =
         ImmutableResource.builder()

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
@@ -139,7 +139,8 @@ final class TestSupport {
             ValueType.CONDITIONAL_SUBSCRIPTION,
             ValueType.CONDITIONAL_EVALUATION,
             ValueType.EXPRESSION,
-            ValueType.JOB_METRICS_BATCH);
+            ValueType.JOB_METRICS_BATCH,
+            ValueType.RESOURCE_REEXPORT);
     return EnumSet.complementOf(excludedValueTypes).stream();
   }
 

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
@@ -140,7 +140,8 @@ final class TestSupport {
             ValueType.CONDITIONAL_SUBSCRIPTION,
             ValueType.CONDITIONAL_EVALUATION,
             ValueType.EXPRESSION,
-            ValueType.JOB_METRICS_BATCH);
+            ValueType.JOB_METRICS_BATCH,
+            ValueType.RESOURCE_REEXPORT);
     return EnumSet.complementOf(excludedValueTypes).stream();
   }
 

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ResourceExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ResourceExportHandler.java
@@ -43,7 +43,8 @@ public class ResourceExportHandler implements RdbmsExportHandler<Resource> {
   @Override
   public void export(final Record<Resource> record) {
     switch (record.getIntent()) {
-      case ResourceIntent.CREATED -> deployedResourceWriter.create(map(record));
+      case ResourceIntent.CREATED, ResourceIntent.REEXPORTED ->
+          deployedResourceWriter.create(map(record));
       case ResourceIntent.DELETED ->
           deployedResourceWriter.delete(record.getValue().getResourceKey());
       default -> LOG.warn("Unexpected intent {} for resource record", record.getIntent());

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ResourceExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ResourceExportHandler.java
@@ -25,7 +25,7 @@ public class ResourceExportHandler implements RdbmsExportHandler<Resource> {
   private static final Logger LOG = LoggerFactory.getLogger(ResourceExportHandler.class);
 
   private static final Set<ResourceIntent> EXPORTABLE_INTENTS =
-      Set.of(ResourceIntent.CREATED, ResourceIntent.DELETED);
+      Set.of(ResourceIntent.CREATED, ResourceIntent.DELETED, ResourceIntent.REEXPORTED);
 
   private final DeployedResourceWriter deployedResourceWriter;
 

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/ResourceExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/ResourceExportHandlerTest.java
@@ -49,7 +49,7 @@ class ResourceExportHandlerTest {
   @ParameterizedTest
   @EnumSource(
       value = ResourceIntent.class,
-      names = {"CREATED", "DELETED"},
+      names = {"CREATED", "DELETED", "REEXPORTED"},
       mode = Mode.INCLUDE)
   void shouldExportSupportedIntents(final ResourceIntent intent) {
     // given
@@ -68,7 +68,7 @@ class ResourceExportHandlerTest {
   @ParameterizedTest
   @EnumSource(
       value = ResourceIntent.class,
-      names = {"CREATED", "DELETED"},
+      names = {"CREATED", "DELETED", "REEXPORTED"},
       mode = Mode.EXCLUDE)
   void shouldNotExportUnsupportedIntents(final ResourceIntent intent) {
     // given
@@ -102,6 +102,44 @@ class ResourceExportHandlerTest {
     final Record<Resource> record =
         factory.generateRecord(
             ValueType.RESOURCE, r -> r.withIntent(ResourceIntent.CREATED).withValue(value));
+
+    // when
+    handler.export(record);
+
+    // then
+    verify(writer).create(dbModelCaptor.capture());
+    final DeployedResourceDbModel model = dbModelCaptor.getValue();
+    assertThat(model.resourceKey()).isEqualTo(42L);
+    assertThat(model.resourceId()).isEqualTo("res-id");
+    assertThat(model.resourceName()).isEqualTo("my-script.rpa");
+    assertThat(model.resourceType()).isEqualTo("rpa");
+    assertThat(model.version()).isEqualTo(3);
+    assertThat(model.versionTag()).isEqualTo("v3");
+    assertThat(model.deploymentKey()).isEqualTo(100L);
+    assertThat(model.tenantId()).isEqualTo("tenant-1");
+    assertThat(model.resourceContent()).isEqualTo("rpa-content");
+
+    verifyNoMoreInteractions(writer);
+  }
+
+  @Test
+  void shouldHandleReexportedRecord() {
+    // given
+    final Resource value =
+        ImmutableResource.builder()
+            .from(factory.generateObject(Resource.class))
+            .withResourceKey(42L)
+            .withResourceId("res-id")
+            .withResourceName("my-script.rpa")
+            .withVersion(3)
+            .withVersionTag("v3")
+            .withDeploymentKey(100L)
+            .withTenantId("tenant-1")
+            .withResourceProp("rpa-content")
+            .build();
+    final Record<Resource> record =
+        factory.generateRecord(
+            ValueType.RESOURCE, r -> r.withIntent(ResourceIntent.REEXPORTED).withValue(value));
 
     // when
     handler.export(record);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/UnifiedRecordValue.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/UnifiedRecordValue.java
@@ -35,6 +35,7 @@ import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.FormRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.ResourceRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ResourceReexportRecord;
 import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.error.ErrorRecord;
 import io.camunda.zeebe.protocol.impl.record.value.escalation.EscalationRecord;
@@ -189,6 +190,7 @@ public class UnifiedRecordValue extends UnpackedObject implements RecordValue {
       case ValueType.AUTHORIZATION -> new AuthorizationRecord();
       case ValueType.ROLE -> new RoleRecord();
       case ValueType.TENANT -> new TenantRecord();
+      case ValueType.RESOURCE_REEXPORT -> new ResourceReexportRecord();
       case ValueType.SCALE -> new ScaleRecord();
       case ValueType.GROUP -> new GroupRecord();
       case ValueType.MAPPING_RULE -> new MappingRuleRecord();

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ResourceReexportRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ResourceReexportRecord.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.deployment;
+
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.ResourceReexportRecordValue;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+
+public class ResourceReexportRecord extends UnifiedRecordValue
+    implements ResourceReexportRecordValue {
+  private final LongProperty resourceKeyProp = new LongProperty("resourceKey", -1L);
+  private final StringProperty tenantIdProp = new StringProperty("tenantId", "");
+
+  public ResourceReexportRecord() {
+    super(2);
+    declareProperty(resourceKeyProp).declareProperty(tenantIdProp);
+  }
+
+  @Override
+  public long getResourceKey() {
+    return resourceKeyProp.getValue();
+  }
+
+  public ResourceReexportRecord setResourceKey(final long resourceKey) {
+    resourceKeyProp.setValue(resourceKey);
+    return this;
+  }
+
+  @Override
+  public String getTenantId() {
+    return BufferUtil.bufferAsString(tenantIdProp.getValue());
+  }
+
+  public ResourceReexportRecord setTenantId(final String tenantId) {
+    tenantIdProp.setValue(tenantId);
+    return this;
+  }
+}

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -41,6 +41,7 @@ import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRequiremen
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentDistributionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ResourceReexportRecord;
 import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.error.ErrorRecord;
 import io.camunda.zeebe.protocol.impl.record.value.escalation.EscalationRecord;
@@ -79,7 +80,6 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationVariableInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.RuntimeInstructionRecord;
-import io.camunda.zeebe.protocol.impl.record.value.deployment.ResourceReexportRecord;
 import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.scaling.ScaleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.signal.SignalRecord;

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -79,6 +79,7 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationVariableInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.RuntimeInstructionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ResourceReexportRecord;
 import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.scaling.ScaleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.signal.SignalRecord;
@@ -4628,6 +4629,30 @@ final class JsonSerializableToJsonTest {
       "configKey": -1
     }
     """
+      },
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      //////////////////////////////////// ResourceReexportRecord /////////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "ResourceReexportRecord",
+        (Supplier<ResourceReexportRecord>)
+            () -> new ResourceReexportRecord().setResourceKey(123L).setTenantId("tenant-1"),
+        """
+        {
+          "resourceKey": 123,
+          "tenantId": "tenant-1"
+        }
+        """
+      },
+      {
+        "Empty ResourceReexportRecord",
+        (Supplier<ResourceReexportRecord>) ResourceReexportRecord::new,
+        """
+        {
+          "resourceKey": -1,
+          "tenantId": ""
+        }
+        """
       }
     };
   }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ResourceReexportRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ResourceReexportRecord.golden
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.deployment;
+
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.ResourceReexportRecordValue;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+
+public class ResourceReexportRecord extends UnifiedRecordValue
+    implements ResourceReexportRecordValue {
+  private final LongProperty resourceKeyProp = new LongProperty("resourceKey", -1L);
+  private final StringProperty tenantIdProp = new StringProperty("tenantId", "");
+
+  public ResourceReexportRecord() {
+    super(2);
+    declareProperty(resourceKeyProp).declareProperty(tenantIdProp);
+  }
+
+  @Override
+  public long getResourceKey() {
+    return resourceKeyProp.getValue();
+  }
+
+  public ResourceReexportRecord setResourceKey(final long resourceKey) {
+    resourceKeyProp.setValue(resourceKey);
+    return this;
+  }
+
+  @Override
+  public String getTenantId() {
+    return BufferUtil.bufferAsString(tenantIdProp.getValue());
+  }
+
+  public ResourceReexportRecord setTenantId(final String tenantId) {
+    tenantIdProp.setValue(tenantId);
+    return this;
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
@@ -64,6 +64,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ResourceDeletionIntent;
 import io.camunda.zeebe.protocol.record.intent.ResourceIntent;
+import io.camunda.zeebe.protocol.record.intent.ResourceReexportIntent;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
 import io.camunda.zeebe.protocol.record.intent.RuntimeInstructionIntent;
 import io.camunda.zeebe.protocol.record.intent.SignalIntent;
@@ -123,6 +124,7 @@ import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceResultRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.ResourceDeletionRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.ResourceReexportRecordValue;
 import io.camunda.zeebe.protocol.record.value.RoleRecordValue;
 import io.camunda.zeebe.protocol.record.value.RuntimeInstructionRecordValue;
 import io.camunda.zeebe.protocol.record.value.SignalRecordValue;
@@ -263,6 +265,9 @@ public final class ValueTypeMapping {
     mapping.put(
         ValueType.RESOURCE_DELETION,
         new Mapping<>(ResourceDeletionRecordValue.class, ResourceDeletionIntent.class));
+    mapping.put(
+        ValueType.RESOURCE_REEXPORT,
+        new Mapping<>(ResourceReexportRecordValue.class, ResourceReexportIntent.class));
     mapping.put(
         ValueType.COMMAND_DISTRIBUTION,
         new Mapping<>(CommandDistributionRecordValue.class, CommandDistributionIntent.class));

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
@@ -124,7 +124,6 @@ import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceResultRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.ResourceDeletionRecordValue;
-import io.camunda.zeebe.protocol.record.value.deployment.ResourceReexportRecordValue;
 import io.camunda.zeebe.protocol.record.value.RoleRecordValue;
 import io.camunda.zeebe.protocol.record.value.RuntimeInstructionRecordValue;
 import io.camunda.zeebe.protocol.record.value.SignalRecordValue;
@@ -141,6 +140,7 @@ import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsRec
 import io.camunda.zeebe.protocol.record.value.deployment.Form;
 import io.camunda.zeebe.protocol.record.value.deployment.Process;
 import io.camunda.zeebe.protocol.record.value.deployment.Resource;
+import io.camunda.zeebe.protocol.record.value.deployment.ResourceReexportRecordValue;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointRecordValue;
 import io.camunda.zeebe.protocol.record.value.scaling.ScaleRecordValue;
 import java.util.Collections;

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -86,6 +86,7 @@ public interface Intent {
     map.put(ValueType.PROCESS_MESSAGE_SUBSCRIPTION, ProcessMessageSubscriptionIntent.class);
     map.put(ValueType.RESOURCE, ResourceIntent.class);
     map.put(ValueType.RESOURCE_DELETION, ResourceDeletionIntent.class);
+    map.put(ValueType.RESOURCE_REEXPORT, ResourceReexportIntent.class);
     map.put(ValueType.ROLE, RoleIntent.class);
     map.put(ValueType.RUNTIME_INSTRUCTION, RuntimeInstructionIntent.class);
     map.put(ValueType.SCALE, ScaleIntent.class);

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ResourceIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ResourceIntent.java
@@ -19,7 +19,8 @@ public enum ResourceIntent implements Intent {
   CREATED((short) 0),
   DELETED((short) 1),
   FETCH((short) 2),
-  FETCHED((short) 3);
+  FETCHED((short) 3),
+  REEXPORTED((short) 4);
 
   private final short value;
 
@@ -41,6 +42,8 @@ public enum ResourceIntent implements Intent {
         return FETCH;
       case 3:
         return FETCHED;
+      case 4:
+        return REEXPORTED;
       default:
         return UNKNOWN;
     }
@@ -57,6 +60,7 @@ public enum ResourceIntent implements Intent {
       case CREATED:
       case DELETED:
       case FETCHED:
+      case REEXPORTED:
         return true;
       default:
         return false;

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ResourceReexportIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ResourceReexportIntent.java
@@ -16,8 +16,10 @@
 package io.camunda.zeebe.protocol.record.intent;
 
 public enum ResourceReexportIntent implements Intent {
-  REEXPORT(0),
-  REEXPORTED(1);
+  START(0),
+  STARTED(1),
+  REEXPORT(2),
+  FINISHED(3);
 
   private final short value;
 
@@ -37,7 +39,8 @@ public enum ResourceReexportIntent implements Intent {
   @Override
   public boolean isEvent() {
     switch (this) {
-      case REEXPORTED:
+      case STARTED:
+      case FINISHED:
         return true;
       default:
         return false;
@@ -47,9 +50,13 @@ public enum ResourceReexportIntent implements Intent {
   public static Intent from(final short value) {
     switch (value) {
       case 0:
-        return REEXPORT;
+        return START;
       case 1:
-        return REEXPORTED;
+        return STARTED;
+      case 2:
+        return REEXPORT;
+      case 3:
+        return FINISHED;
       default:
         return Intent.UNKNOWN;
     }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ResourceReexportIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ResourceReexportIntent.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.intent;
+
+public enum ResourceReexportIntent implements Intent {
+  REEXPORT(0),
+  REEXPORTED(1);
+
+  private final short value;
+
+  ResourceReexportIntent(final int value) {
+    this.value = (short) value;
+  }
+
+  public short getIntent() {
+    return value;
+  }
+
+  @Override
+  public short value() {
+    return value;
+  }
+
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case REEXPORTED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  public static Intent from(final short value) {
+    switch (value) {
+      case 0:
+        return REEXPORT;
+      case 1:
+        return REEXPORTED;
+      default:
+        return Intent.UNKNOWN;
+    }
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/deployment/ResourceReexportRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/deployment/ResourceReexportRecordValue.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value.deployment;
+
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ImmutableProtocol(builder = ImmutableResourceReexportRecordValue.Builder.class)
+public interface ResourceReexportRecordValue extends RecordValue {
+
+  /**
+   * @return the key of the last reexported resource or -1 if no reexport happened yet.
+   */
+  long getResourceKey();
+
+  /**
+   * @return the tenant id of the last reexported resource or an empty string if no reexport
+   *     happened yet.
+   */
+  String getTenantId();
+}

--- a/zeebe/protocol/src/main/resources/protocol.xml
+++ b/zeebe/protocol/src/main/resources/protocol.xml
@@ -84,6 +84,7 @@
       <validValue name="EXPRESSION">66</validValue>
       <validValue name="JOB_METRICS_BATCH">67</validValue>
       <validValue name="GLOBAL_LISTENER">68</validValue>
+      <validValue name="RESOURCE_REEXPORT">69</validValue>
 
       <!-- Management records / record not related to process automation -->
       <!-- value 252 was used for "REDISTRIBUTION, do not use-->

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -31,6 +31,7 @@ import static io.camunda.zeebe.protocol.record.ValueType.PROCESS_INSTANCE;
 import static io.camunda.zeebe.protocol.record.ValueType.PROCESS_INSTANCE_CREATION;
 import static io.camunda.zeebe.protocol.record.ValueType.PROCESS_INSTANCE_MIGRATION;
 import static io.camunda.zeebe.protocol.record.ValueType.PROCESS_INSTANCE_MODIFICATION;
+import static io.camunda.zeebe.protocol.record.ValueType.RESOURCE_REEXPORT;
 import static io.camunda.zeebe.protocol.record.ValueType.ROLE;
 import static io.camunda.zeebe.protocol.record.ValueType.RUNTIME_INSTRUCTION;
 import static io.camunda.zeebe.protocol.record.ValueType.SIGNAL;
@@ -143,6 +144,7 @@ import io.camunda.zeebe.protocol.record.value.deployment.Form;
 import io.camunda.zeebe.protocol.record.value.deployment.Process;
 import io.camunda.zeebe.protocol.record.value.deployment.ProcessMetadataValue;
 import io.camunda.zeebe.protocol.record.value.deployment.Resource;
+import io.camunda.zeebe.protocol.record.value.deployment.ResourceReexportRecordValue;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointRecordValue;
 import io.camunda.zeebe.protocol.record.value.scaling.ScaleRecordValue;
 import java.time.Instant;
@@ -226,7 +228,8 @@ public class CompactRecordLogger {
           entry(EXPRESSION.name(), "EXPR"),
           entry(IDENTITY_SETUP.name(), "ID"),
           entry(CHECKPOINT.name(), "CHK"),
-          entry(GLOBAL_LISTENER.name(), "GL"));
+          entry(GLOBAL_LISTENER.name(), "GL"),
+          entry(RESOURCE_REEXPORT.name(), "RES_REEX"));
 
   private static final Map<RecordType, Character> RECORD_TYPE_ABBREVIATIONS =
       ofEntries(
@@ -322,6 +325,7 @@ public class CompactRecordLogger {
     valueLoggers.put(ValueType.GLOBAL_LISTENER_BATCH, this::summarizeGlobalListenerBatch);
     valueLoggers.put(ValueType.JOB_METRICS_BATCH, this::summarizeJobMetricsBatch);
     valueLoggers.put(ValueType.GLOBAL_LISTENER, this::summarizeGlobalListener);
+    valueLoggers.put(RESOURCE_REEXPORT, this::summarizeResourceReexport);
   }
 
   public CompactRecordLogger(final Collection<Record<?>> records) {
@@ -1920,6 +1924,18 @@ public class CompactRecordLogger {
     }
 
     return result.append(formatTenant(value));
+  }
+
+  private String summarizeResourceReexport(final Record<?> record) {
+    final var value = (ResourceReexportRecordValue) record.getValue();
+    final var resourceKey = value.getResourceKey();
+    final var tenantId = value.getTenantId();
+    final var result = new StringBuilder();
+
+    result.append("resourceKey:").append(shortenKey(resourceKey));
+    result.append("tenantId:").append(tenantId);
+
+    return result.toString();
   }
 
   private String formatPinnedTime(final long time) {

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -44,6 +44,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ResourceDeletionIntent;
+import io.camunda.zeebe.protocol.record.intent.ResourceReexportIntent;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
 import io.camunda.zeebe.protocol.record.intent.SignalIntent;
 import io.camunda.zeebe.protocol.record.intent.SignalSubscriptionIntent;
@@ -114,6 +115,7 @@ import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsRec
 import io.camunda.zeebe.protocol.record.value.deployment.Form;
 import io.camunda.zeebe.protocol.record.value.deployment.Process;
 import io.camunda.zeebe.protocol.record.value.deployment.Resource;
+import io.camunda.zeebe.protocol.record.value.deployment.ResourceReexportRecordValue;
 import io.camunda.zeebe.protocol.record.value.scaling.ScaleRecordValue;
 import java.time.Duration;
 import java.util.Collection;
@@ -534,6 +536,16 @@ public final class RecordingExporter implements Exporter {
 
   public static ResourceRecordStream resourceRecords() {
     return new ResourceRecordStream(records(ValueType.RESOURCE, Resource.class));
+  }
+
+  public static ResourceReexportRecordStream resourceReexportRecords() {
+    return new ResourceReexportRecordStream(
+        records(ValueType.RESOURCE_REEXPORT, ResourceReexportRecordValue.class));
+  }
+
+  public static ResourceReexportRecordStream resourceReexportRecords(
+      final ResourceReexportIntent intent) {
+    return resourceReexportRecords().withIntent(intent);
   }
 
   public static ErrorRecordStream errorRecords() {

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/ResourceReexportRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/ResourceReexportRecordStream.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.test.util.record;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.deployment.ResourceReexportRecordValue;
+import java.util.stream.Stream;
+
+public class ResourceReexportRecordStream
+    extends ExporterRecordStream<ResourceReexportRecordValue, ResourceReexportRecordStream> {
+
+  public ResourceReexportRecordStream(
+      final Stream<Record<ResourceReexportRecordValue>> wrappedStream) {
+    super(wrappedStream);
+  }
+
+  @Override
+  protected ResourceReexportRecordStream supply(
+      final Stream<Record<ResourceReexportRecordValue>> wrappedStream) {
+    return new ResourceReexportRecordStream(wrappedStream);
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds a migration that will write REEXPORTED events for existing RPA resources. It will only do this once.


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #51273
