### PR TITLE
ci: add workflow for running orchestraction-cluster-smoke-tests as part of the unified CI

### DIFF
--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -216,6 +216,15 @@ outputs:
         steps.ci-github-actions.outputs.ci-relevant == 'true' ||
         steps.filter-webapp-client.outputs.webapp-client-change == 'true'
       }}
+  orchestration-cluster-smoke-tests:
+    description: Output whether the orchestration cluster smoke tests should be run based on GitHub event and files changed
+    value: >-
+      ${{
+        github.event_name == 'push' ||
+        github.event_name == 'schedule' ||
+        steps.ci-github-actions.outputs.ci-relevant == 'true' ||
+        steps.filter-orchestration-cluster-smoke-tests.outputs.orchestration-cluster-smoke-tests-change == 'true'
+      }}
   docs-changes:
     description: Output whether Documentation tests should be run based on GitHub event and files changed
     value: >-
@@ -410,6 +419,15 @@ runs:
       filters: |
         webapp-client-change:
           - 'webapp/client/**'
+
+  - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+    id: filter-orchestration-cluster-smoke-tests
+    with:
+      base: ${{ github.event.merge_group.base_ref || '' }}
+      ref: ${{ github.event.merge_group.head_ref || github.ref }}
+      filters: |
+        orchestration-cluster-smoke-tests-change:
+          - 'qa/orchestration-cluster-smoke-tests/**'
 
   - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
     id: filter-docs

--- a/.github/workflows/ci-orchestration-cluster-smoke-tests.yml
+++ b/.github/workflows/ci-orchestration-cluster-smoke-tests.yml
@@ -36,7 +36,6 @@ jobs:
       TEST_OWNER: Core Features
       TEST_PRODUCT: Orchestration Cluster
       TEST_TYPE: Smoke
-      RESOLVED_DOCKER_TAG: ${{ needs.utils-get-snapshot-docker-tag.outputs.snapshot_tag != '' && needs.utils-get-snapshot-docker-tag.outputs.snapshot_tag || needs.utils-get-snapshot-docker-tag.outputs.version_tag }}
     defaults:
       run:
         working-directory: qa/orchestration-cluster-smoke-tests
@@ -59,10 +58,51 @@ jobs:
       - name: Lint smoke tests
         run: npm run lint
 
+      - name: Setup Camunda build
+        uses: ./.github/actions/setup-build
+        with:
+          dockerhub-readonly: true
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          minimus: true
+
+      - name: Build Operate frontend
+        uses: ./.github/actions/build-frontend
+        id: build-operate-fe
+        with:
+          directory: ./operate/client
+          package-manager: "npm"
+
+      - name: Build Tasklist frontend
+        uses: ./.github/actions/build-frontend
+        id: build-tasklist-fe
+        with:
+          directory: ./tasklist/client
+          package-manager: "npm"
+
+      - name: Build Zeebe and Camunda Platform
+        uses: ./.github/actions/build-zeebe
+        id: build-camunda
+        with:
+          maven-extra-args: -DskipQaBuild=true -PskipFrontendBuild
+
+      - name: Build Camunda Docker image
+        uses: ./.github/actions/build-platform-docker
+        id: build-camunda-docker
+        with:
+          repository: camunda/camunda
+          version: |
+            ${{ needs.utils-get-snapshot-docker-tag.outputs.version_tag }}
+            ${{ needs.utils-get-snapshot-docker-tag.outputs.snapshot_tag }}
+          distball: ${{ steps.build-camunda.outputs.distball }}
+          platforms: linux/amd64
+          dockerfile: camunda.Dockerfile
+
       - name: Resolve Camunda Docker image
         run: |
-          echo "CAMUNDA_DOCKER_IMAGE=camunda/camunda:${RESOLVED_DOCKER_TAG}" >> "$GITHUB_ENV"
-          echo "Using CAMUNDA_DOCKER_IMAGE=camunda/camunda:${RESOLVED_DOCKER_TAG}"
+          echo "CAMUNDA_DOCKER_IMAGE=${{ steps.build-camunda-docker.outputs.image }}" >> "$GITHUB_ENV"
+          echo "Using CAMUNDA_DOCKER_IMAGE=${{ steps.build-camunda-docker.outputs.image }}"
 
       - name: Install Playwright browser
         run: npx playwright install --with-deps chromium

--- a/.github/workflows/ci-orchestration-cluster-smoke-tests.yml
+++ b/.github/workflows/ci-orchestration-cluster-smoke-tests.yml
@@ -1,0 +1,108 @@
+# description: Runs orchestration cluster smoke tests against an Orchestration Cluster with Operate and Tasklist.
+# test location: /qa/orchestration-cluster-smoke-tests
+# called by: ci.yml
+# type: CI
+# owner: @camunda/core-features
+---
+name: Orchestration Cluster Smoke Tests
+
+on:
+  workflow_call: {}
+
+permissions: {}
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  GHA_BEST_PRACTICES_LINTER: enabled
+
+jobs:
+  utils-get-snapshot-docker-tag:
+    uses: ./.github/workflows/generate-snapshot-docker-tag.yml
+    secrets: inherit
+    permissions:
+      contents: read
+
+  run-smoke-tests:
+    name: Run Smoke Tests
+    needs: [utils-get-snapshot-docker-tag]
+    if: ${{ !cancelled() && needs.utils-get-snapshot-docker-tag.result != 'failure' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions: {}
+    env:
+      TEST_OWNER: Core Features
+      TEST_PRODUCT: Orchestration Cluster
+      TEST_TYPE: Smoke
+      RESOLVED_DOCKER_TAG: ${{ needs.utils-get-snapshot-docker-tag.outputs.snapshot_tag != '' && needs.utils-get-snapshot-docker-tag.outputs.snapshot_tag || needs.utils-get-snapshot-docker-tag.outputs.version_tag }}
+    defaults:
+      run:
+        working-directory: qa/orchestration-cluster-smoke-tests
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Print metadata
+        uses: ./.github/actions/print-metadata
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: qa/orchestration-cluster-smoke-tests/.nvmrc
+          cache: npm
+          cache-dependency-path: qa/orchestration-cluster-smoke-tests/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint smoke tests
+        run: npm run lint
+
+      - name: Resolve Camunda Docker image
+        run: |
+          echo "CAMUNDA_DOCKER_IMAGE=camunda/camunda:${RESOLVED_DOCKER_TAG}" >> "$GITHUB_ENV"
+          echo "Using CAMUNDA_DOCKER_IMAGE=camunda/camunda:${RESOLVED_DOCKER_TAG}"
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Start Camunda cluster
+        run: npm run cluster:up
+
+      - name: Wait for Camunda cluster
+        run: npm run cluster:wait
+
+      - name: Run smoke tests
+        run: npm run test
+
+      - name: Capture docker logs
+        if: failure()
+        run: docker compose logs camunda
+        working-directory: qa/orchestration-cluster-smoke-tests/config
+
+      - name: Upload smoke test reports
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: orchestration-cluster-smoke-tests-report
+          path: qa/orchestration-cluster-smoke-tests/reports/html
+          if-no-files-found: ignore
+          retention-days: 30
+
+      - name: Stop Camunda cluster
+        if: always()
+        run: npm run cluster:down
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          job_name: "ci-orchestration-cluster-smoke-tests/run-smoke-tests"
+          build_status: ${{ job.status }}
+          detailed_junit_tests: true
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          user_description: "team-core-features"

--- a/.github/workflows/ci-orchestration-cluster-smoke-tests.yml
+++ b/.github/workflows/ci-orchestration-cluster-smoke-tests.yml
@@ -118,6 +118,8 @@ jobs:
       - name: Capture docker logs
         if: failure()
         run: docker compose logs camunda
+        env:
+          DATABASE: elasticsearch
         working-directory: qa/orchestration-cluster-smoke-tests/config
 
       - name: Upload smoke test reports

--- a/.github/workflows/ci-orchestration-cluster-smoke-tests.yml
+++ b/.github/workflows/ci-orchestration-cluster-smoke-tests.yml
@@ -31,7 +31,7 @@ jobs:
     needs: [utils-get-snapshot-docker-tag]
     if: ${{ !cancelled() && needs.utils-get-snapshot-docker-tag.result != 'failure' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     permissions: {}
     env:
       TEST_OWNER: Core Features

--- a/.github/workflows/ci-orchestration-cluster-smoke-tests.yml
+++ b/.github/workflows/ci-orchestration-cluster-smoke-tests.yml
@@ -7,6 +7,7 @@
 name: Orchestration Cluster Smoke Tests
 
 on:
+  workflow_dispatch: {}
   workflow_call: {}
 
 permissions: {}
@@ -48,9 +49,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: qa/orchestration-cluster-smoke-tests/.nvmrc
-          cache: npm
-          cache-dependency-path: qa/orchestration-cluster-smoke-tests/package-lock.json
+          node-version-file: qa/orchestration-cluster-smoke-tests/.nvmrc
 
       - name: Install dependencies
         run: npm ci
@@ -139,7 +138,6 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/observe-build-status
         with:
-          job_name: "ci-orchestration-cluster-smoke-tests/run-smoke-tests"
           build_status: ${{ job.status }}
           detailed_junit_tests: true
           secret_vault_address: ${{ secrets.VAULT_ADDR }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
       rdbms-integration-tests: ${{steps.filter.outputs.rdbms-integration-tests}}
       renovate-config-changes: ${{ steps.filter.outputs.renovate-config-changes }}
       webapp-client-changes: ${{ steps.filter.outputs.webapp-client-changes }}
+      orchestration-cluster-smoke-tests: ${{ steps.filter.outputs.orchestration-cluster-smoke-tests }}
       docs-changes: ${{ steps.filter.outputs.docs-changes }}
       c8-e2e-test-suite-changes: ${{ steps.filter.outputs.c8-e2e-test-suite-changes }}
     runs-on: ubuntu-latest
@@ -1611,6 +1612,15 @@ jobs:
     secrets: inherit
     permissions: { }
 
+  # TODO: Enable when we are willing to run these tests on every PR.
+  # orchestration-cluster-smoke-tests:
+  #   if: needs.detect-changes.outputs.orchestration-cluster-smoke-tests == 'true' || needs.detect-changes.outputs.java-code-changes == 'true' || needs.detect-changes.outputs.frontend-changes == 'true'
+  #   name: "Orchestration Cluster / [Smoke] UI"
+  #   needs: [ detect-changes ]
+  #   uses: ./.github/workflows/ci-orchestration-cluster-smoke-tests.yml
+  #   secrets: inherit
+  #   permissions: { }
+
   c8-e2e-test-suite:
     if: needs.detect-changes.outputs.c8-e2e-test-suite-changes == 'true'
     name: "Lint / C8 E2E Test Suite"
@@ -1822,6 +1832,7 @@ jobs:
       - junit-vintage-check
       - maven-spotless-linter
       - openapi-lint
+      - orchestration-cluster-smoke-tests
       - operate-ci
       - optimize-ci
       - protobuf-checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1612,14 +1612,14 @@ jobs:
     secrets: inherit
     permissions: { }
 
-  # TODO: Enable when we are willing to run these tests on every PR.
-  # orchestration-cluster-smoke-tests:
-  #   if: needs.detect-changes.outputs.orchestration-cluster-smoke-tests == 'true' || needs.detect-changes.outputs.java-code-changes == 'true' || needs.detect-changes.outputs.frontend-changes == 'true'
-  #   name: "Orchestration Cluster / [Smoke] UI"
-  #   needs: [ detect-changes ]
-  #   uses: ./.github/workflows/ci-orchestration-cluster-smoke-tests.yml
-  #   secrets: inherit
-  #   permissions: { }
+  orchestration-cluster-smoke-tests:
+    if: needs.detect-changes.outputs.orchestration-cluster-smoke-tests == 'true' || needs.detect-changes.outputs.java-code-changes == 'true' || needs.detect-changes.outputs.frontend-changes == 'true'
+    name: "Orchestration Cluster / [Smoke] UI / Core Features"
+    needs: [ detect-changes ]
+    uses: ./.github/workflows/ci-orchestration-cluster-smoke-tests.yml
+    secrets: inherit
+    permissions:
+      contents: read
 
   c8-e2e-test-suite:
     if: needs.detect-changes.outputs.c8-e2e-test-suite-changes == 'true'

--- a/qa/orchestration-cluster-smoke-tests/README.md
+++ b/qa/orchestration-cluster-smoke-tests/README.md
@@ -22,8 +22,7 @@ in the package.
 
 1. Run `npm run cluster:up` to start an Orchestration Cluster with
    ElasticSearch.
-2. Wait until Camunda is available under
-   [http://localhost:8080](http://localhost:8080).
+2. Run `npm run cluster:wait` to wait until Operate and Tasklist are ready.
 3. Run `npm run test` to execute the smoke test suite.
 4. Run `npm run cluster:down` to remove the Orchestration Cluster.
 

--- a/qa/orchestration-cluster-smoke-tests/package.json
+++ b/qa/orchestration-cluster-smoke-tests/package.json
@@ -6,6 +6,7 @@
   "private": true,
   "scripts": {
     "cluster:up": "cd ./config && DATABASE=elasticsearch docker compose up -d camunda",
+    "cluster:wait": "bash ./scripts/wait-for-cluster.sh",
     "cluster:down": "cd ./config && DATABASE=elasticsearch docker compose down",
     "format": "prettier --write .",
     "lint": "tsc --noEmit && eslint . && prettier -c .",

--- a/qa/orchestration-cluster-smoke-tests/playwright.config.ts
+++ b/qa/orchestration-cluster-smoke-tests/playwright.config.ts
@@ -20,7 +20,7 @@ const ciReporters: ReporterDescription[] = [
   ['dot'],
   ['github'],
   ['html', {outputFolder: `${REPORTS_BASE_DIR}/html`}],
-  ['junit', {outputFile: `${REPORTS_BASE_DIR}/results.xml`}],
+  ['junit', {outputFile: `${REPORTS_BASE_DIR}/TEST-smoke.xml`}],
 ];
 
 export default defineConfig({

--- a/qa/orchestration-cluster-smoke-tests/scripts/wait-for-cluster.sh
+++ b/qa/orchestration-cluster-smoke-tests/scripts/wait-for-cluster.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Waits until Tasklist and Operate endpoints are reachable on the local cluster.
+# Pings the cluster every 5s for up to 60 attempts. => Timeout after 5min.
+
+set -euo pipefail
+
+readonly max_attempts=60
+readonly wait_seconds=5
+
+for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+  if curl -sf http://localhost:8080/tasklist >/dev/null \
+    && curl -sf http://localhost:8080/operate >/dev/null; then
+    echo "Orchestration Cluster is ready."
+    exit 0
+  fi
+
+  echo "Waiting for Orchestration Cluster to become ready... (${attempt}/${max_attempts})"
+  sleep "$wait_seconds"
+done
+
+echo "Orchestration Cluster failed to become ready in time."
+exit 1

--- a/qa/orchestration-cluster-smoke-tests/test/pages/operate/process-instance-page.ts
+++ b/qa/orchestration-cluster-smoke-tests/test/pages/operate/process-instance-page.ts
@@ -67,11 +67,11 @@ class VariablesPanel extends View {
 
     return {
       container,
-      viewButton: container.getByRole('button', {name: 'View full value'}),
-      editButton: container.getByRole('button', {name: 'Edit variable'}),
-      editField: container.getByRole('textbox', {name: 'Value'}),
-      exitButton: container.getByRole('button', {name: 'Exit edit mode'}),
-      saveButton: container.getByRole('button', {name: 'Save variable'}),
+      openButton: container.getByRole('button', {name: 'Open'}),
+      editButton: container.getByRole('button', {name: 'Edit'}),
+      editField: container.getByRole('textbox', {name: 'Editor content'}),
+      exitButton: container.getByRole('button', {name: 'Exit'}),
+      saveButton: container.getByRole('button', {name: 'Save'}),
     };
   }
 }

--- a/qa/orchestration-cluster-smoke-tests/test/smoke/retrying-processes.test.ts
+++ b/qa/orchestration-cluster-smoke-tests/test/smoke/retrying-processes.test.ts
@@ -44,7 +44,9 @@ test.describe('Retrying processes', {tag: '@operate'}, () => {
       await instancePage.variablesPanel.trigger.click();
       await expect(variable.container).toBeVisible();
       await variable.editButton.click();
-      await variable.editField.fill('7');
+      // Field is not input/textarea element. "fill()" does not work.
+      // Will add 2 in front of the existing value => 23.
+      await variable.editField.pressSequentially('2');
       await variable.saveButton.click();
 
       await expect(


### PR DESCRIPTION
## Description

Adds a new CI workflow `ci-orchestration-cluster-smoke-tests.yml` for running smoke tests from [`qa/orchestration-cluster-smoke-tests`](https://github.com/camunda/camunda/tree/main/qa/orchestration-cluster-smoke-tests) in the unified CI.

The goal of the pipeline is to:
- run in PRs that contain changes that can effect Operate or Tasklist.
- run in PRs when the smoke test suite has been changed.
- Build a Camunda image that contains the changes
- Start an Orchestration Cluster with these changes
- Run the tests against the started cluster
- In the future, the test run must likely be sharded to reduce the test run duration

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable commented code in `ci.yml` to run it
- [ ] This PR is stacked on https://github.com/camunda/camunda/pull/52243.

## Related issues

relates #50125
