### PR TITLE
refactor: move LongPollingIT and ProcessInstanceMigrationClusteredTest to engine/client/multipartition package

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusteringRule.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusteringRule.java
@@ -115,6 +115,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.context.LifecycleProperties;
 
+/**
+ * @deprecated Do not use this class in new tests. It is a JUnit 4 {@link
+ *     org.junit.rules.ExternalResource} that wires up an embedded cluster manually, which is
+ *     fragile and hard to maintain. New tests should use the {@code @ZeebeIntegration} JUnit 5
+ *     extension together with {@link io.camunda.zeebe.qa.util.cluster.TestCluster}, which provides
+ *     the same multi-broker/multi-partition capabilities with a cleaner lifecycle and better
+ *     isolation.
+ */
+@Deprecated
 public class ClusteringRule extends ExternalResource {
   private static final Logger LOGGER = LoggerFactory.getLogger(ClusteringRule.class);
   private static final AtomicLong CLUSTER_COUNT = new AtomicLong(0);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/multipartition/LongPollingIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/multipartition/LongPollingIT.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.zeebe.it.cluster.clustering;
+package io.camunda.zeebe.it.engine.client.multipartition;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/multipartition/ProcessInstanceMigrationClusteredTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/multipartition/ProcessInstanceMigrationClusteredTest.java
@@ -5,12 +5,13 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.zeebe.it.cluster.clustering;
+package io.camunda.zeebe.it.engine.client.multipartition;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.api.response.DeploymentEvent;
 import io.camunda.client.api.response.ProcessInstanceEvent;
+import io.camunda.zeebe.it.cluster.clustering.ClusteringRule;
 import io.camunda.zeebe.it.util.GrpcClientRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;


### PR DESCRIPTION
## Summary

- Moves `LongPollingIT` and `ProcessInstanceMigrationClusteredTest` from `io.camunda.zeebe.it.cluster.clustering` to `io.camunda.zeebe.it.engine.client.multipartition`, attributing them to the correct team (core features rather than zeebe-distributed-platform)
- Deprecates `ClusteringRule` with a Javadoc pointing to `@ZeebeIntegration` + `TestCluster` as the replacement — new tests should not use it

## Test plan

- [ ] Verify tests still compile and run under the new package
- [ ] Confirm test ownership attribution reflects the core features team

🤖 Generated with [Claude Code](https://claude.com/claude-code)