### PR TITLE
fix: use color:border-color to highlight sequence flows in Operate diagrams

### DIFF
--- a/operate/client/src/modules/bpmn-js/BpmnJS.ts
+++ b/operate/client/src/modules/bpmn-js/BpmnJS.ts
@@ -363,8 +363,9 @@ class BpmnJS {
     const elementRegistry = this.#navigatedViewer?.get('elementRegistry');
     const graphicsFactory = this.#navigatedViewer?.get('graphicsFactory');
     const element = elementRegistry?.get(id);
+
     if (element?.di !== undefined) {
-      element.di.set('stroke', color);
+      element.di.set('border-color', color);
 
       const gfx = elementRegistry?.getGraphics(element);
       if (gfx !== undefined) {


### PR DESCRIPTION
## Summary

When a BPMN diagram has sequence flows with a modeler-assigned color, the highlighted sequence flow color was not applied correctly in Operate.

## Root Cause

`bpmn-js`'s `getStrokeColor()` utility resolves stroke color with this priority order:

1. `overrideColor` — not used during `graphicsFactory.update()`
2. `di.get('color:border-color')` — OMG BPMN-in-Color standard (higher priority)
3. `di.get('bioc:stroke')` — legacy bpmn.io extension (lower priority)
4. `defaultColor` / black

The previous code wrote the highlight color via `element.di.set('stroke', color)`, which maps to the `bioc:stroke` property (priority 3). When the element already had a modeler-assigned `color:border-color` (priority 2), that value always won and the highlight color had no visible effect.

## Fix

Write directly to `color:border-color` (using its local name `border-color`) — the canonical, highest-priority property for edge stroke color as defined in bpmn-moddle's BPMN-in-Color OMG extension. This correctly overrides any existing modeler color and also works for elements with no modeler color.

Closes #45934