### PR TITLE
feat: add OpenAPI spec for AgentInstance query endpoints

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -1,0 +1,341 @@
+## Endpoint definitions
+
+paths:
+  /agent-instances/{agentInstanceKey}:
+    get:
+      x-eventually-consistent: true
+      tags:
+        - Agent instance
+      operationId: getAgentInstance
+      summary: Get agent instance
+      description: Returns agent instance as JSON.
+      parameters:
+        - name: agentInstanceKey
+          in: path
+          required: true
+          description: The key of the agent instance to retrieve.
+          schema:
+            $ref: 'keys.yaml#/components/schemas/AgentInstanceKey'
+      responses:
+        "200":
+          description: The agent instance is successfully returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentInstanceResult'
+        "400":
+          $ref: 'common-responses.yaml#/components/responses/InvalidData'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "403":
+          $ref: 'common-responses.yaml#/components/responses/Forbidden'
+        "404":
+          description: |
+            The agent instance with the given key was not found.
+            More details are provided in the response body.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.10"
+
+  /agent-instances/search:
+    post:
+      x-eventually-consistent: true
+      tags:
+        - Agent instance
+      operationId: searchAgentInstances
+      summary: Search agent instances
+      description: Search for agent instances based on given criteria.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AgentInstanceSearchQuery'
+      responses:
+        "200":
+          description: The agent instance search result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentInstanceSearchQueryResult'
+        "400":
+          $ref: 'common-responses.yaml#/components/responses/InvalidData'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "403":
+          $ref: 'common-responses.yaml#/components/responses/Forbidden'
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.10"
+
+## Schema definitions
+
+components:
+  schemas:
+    AgentInstanceSearchQuerySortRequest:
+      type: object
+      required:
+        - field
+      properties:
+        field:
+          description: The field to sort by.
+          type: string
+          enum:
+            - creationDate
+            - lastUpdatedDate
+            - completionDate
+            - status
+        order:
+          $ref: 'search-models.yaml#/components/schemas/SortOrderEnum'
+
+    AgentInstanceSearchQuery:
+      description: Agent instance search request.
+      type: object
+      additionalProperties: false
+      allOf:
+        - $ref: 'search-models.yaml#/components/schemas/SearchQueryRequest'
+      properties:
+        sort:
+          description: Sort field criteria.
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentInstanceSearchQuerySortRequest'
+        filter:
+          description: The agent instance search filters.
+          allOf:
+            - $ref: '#/components/schemas/AgentInstanceFilter'
+
+    AgentInstanceFilter:
+      description: Agent instance search filter.
+      type: object
+      properties:
+        agentInstanceKey:
+          description: The unique key of the agent instance.
+          allOf:
+            - $ref: 'keys.yaml#/components/schemas/AgentInstanceKeyFilterProperty'
+        status:
+          description: The current status of the agent instance.
+          allOf:
+            - $ref: '#/components/schemas/AgentInstanceStatusFilterProperty'
+        elementId:
+          description: The BPMN element ID of the agent task.
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/ElementIdFilterProperty'
+        processInstanceKey:
+          description: The key of the process instance that owns this agent instance.
+          allOf:
+            - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKeyFilterProperty'
+        processDefinitionKey:
+          description: The key of the process definition associated with this agent instance.
+          allOf:
+            - $ref: 'keys.yaml#/components/schemas/ProcessDefinitionKeyFilterProperty'
+        tenantId:
+          description: The tenant ID of the agent instance.
+          allOf:
+            - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
+        creationDate:
+          description: The creation date of the agent instance.
+          allOf:
+            - $ref: 'filters.yaml#/components/schemas/DateTimeFilterProperty'
+        lastUpdatedDate:
+          description: The date the agent instance was last updated.
+          allOf:
+            - $ref: 'filters.yaml#/components/schemas/DateTimeFilterProperty'
+        completionDate:
+          description: The completion date of the agent instance.
+          allOf:
+            - $ref: 'filters.yaml#/components/schemas/DateTimeFilterProperty'
+
+    AgentInstanceSearchQueryResult:
+      description: Agent instance search response.
+      type: object
+      required:
+        - items
+      allOf:
+        - $ref: 'search-models.yaml#/components/schemas/SearchQueryResponse'
+      properties:
+        items:
+          description: The matching agent instances.
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentInstanceResult'
+
+    AgentInstanceResult:
+      type: object
+      required:
+        - agentInstanceKey
+        - status
+        - definition
+        - metrics
+        - limits
+        - elementId
+        - processInstanceKey
+        - processDefinitionKey
+        - tenantId
+        - creationDate
+        - lastUpdatedDate
+        - completionDate
+      properties:
+        agentInstanceKey:
+          description: The unique key for this agent instance.
+          allOf:
+            - $ref: 'keys.yaml#/components/schemas/AgentInstanceKey'
+        status:
+          $ref: '#/components/schemas/AgentInstanceStatusEnum'
+        definition:
+          description: The static definition of the agent, including model, provider, and system prompt.
+          allOf:
+            - $ref: '#/components/schemas/AgentInstanceDefinition'
+        metrics:
+          description: Aggregated metrics across all iterations of this agent instance.
+          allOf:
+            - $ref: '#/components/schemas/AgentInstanceMetrics'
+        limits:
+          description: The configured limits for this agent instance, set once at creation.
+          allOf:
+            - $ref: '#/components/schemas/AgentInstanceLimits'
+        elementId:
+          description: The BPMN element ID of the ad-hoc sub-process or AI agent task that owns this agent instance.
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/ElementId'
+        processInstanceKey:
+          description: The key of the process instance that owns this agent instance.
+          allOf:
+            - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
+        processDefinitionKey:
+          description: The key of the process definition associated with this agent instance.
+          allOf:
+            - $ref: 'keys.yaml#/components/schemas/ProcessDefinitionKey'
+        tenantId:
+          description: The tenant ID of this agent instance.
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/TenantId'
+        creationDate:
+          type: string
+          format: date-time
+          description: The date when this agent instance was created.
+        lastUpdatedDate:
+          type: string
+          format: date-time
+          description: The date when this agent instance was last updated.
+        completionDate:
+          type: string
+          format: date-time
+          nullable: true
+          description: The date when this agent instance completed. Null while the agent is still running.
+
+    AgentInstanceDefinition:
+      description: The static definition of an agent instance, set once at creation.
+      type: object
+      required:
+        - model
+        - provider
+        - systemPrompt
+      properties:
+        model:
+          type: string
+          description: The LLM model identifier (for example, gpt-4o).
+        provider:
+          type: string
+          description: The LLM provider (for example, openai or anthropic).
+        systemPrompt:
+          type: string
+          description: The system prompt configured for this agent instance.
+
+    AgentInstanceMetrics:
+      description: Aggregated metrics for an agent instance across all model calls.
+      type: object
+      required:
+        - inputTokens
+        - outputTokens
+        - modelCalls
+        - toolCalls
+      properties:
+        inputTokens:
+          type: integer
+          format: int64
+          description: Total input tokens consumed across all model calls.
+        outputTokens:
+          type: integer
+          format: int64
+          description: Total output tokens produced across all model calls.
+        modelCalls:
+          type: integer
+          format: int64
+          description: Total number of LLM calls made.
+        toolCalls:
+          type: integer
+          format: int64
+          description: Total number of tool calls made.
+
+    AgentInstanceLimits:
+      description: The configured limits for an agent instance, set once at creation.
+      type: object
+      required:
+        - maxModelCalls
+        - maxTokens
+        - maxToolCalls
+      properties:
+        maxModelCalls:
+          type: integer
+          format: int64
+          description: Maximum LLM calls allowed. -1 if no limit is configured.
+        maxToolCalls:
+          type: integer
+          format: int64
+          description: Maximum tool calls allowed. -1 if no limit is configured.
+        maxTokens:
+          type: integer
+          format: int64
+          description: Maximum total tokens allowed. -1 if no limit is configured.
+
+    AgentInstanceStatusEnum:
+      description: The current status of an agent instance.
+      type: string
+      enum:
+        - COMPLETED
+        - IDLE
+        - INITIALIZING
+        - THINKING
+        - TOOL_CALLING
+        - TOOL_DISCOVERY
+
+    ## Filters
+
+    AgentInstanceStatusFilterProperty:
+      description: AgentInstanceStatusEnum property with full advanced search capabilities.
+      oneOf:
+        - type: string
+          title: Exact match
+          description: Matches the value exactly.
+          allOf:
+            - $ref: '#/components/schemas/AgentInstanceStatusEnum'
+        - $ref: '#/components/schemas/AdvancedAgentInstanceStatusFilter'
+
+    AdvancedAgentInstanceStatusFilter:
+      title: Advanced filter
+      description: Advanced AgentInstanceStatusEnum filter.
+      type: object
+      properties:
+        $eq:
+          description: Checks for equality with the provided value.
+          allOf:
+            - $ref: '#/components/schemas/AgentInstanceStatusEnum'
+        $neq:
+          description: Checks for inequality with the provided value.
+          allOf:
+            - $ref: '#/components/schemas/AgentInstanceStatusEnum'
+        $exists:
+          description: Checks if the current property exists.
+          type: boolean
+        $in:
+          description: Checks if the property matches any of the provided values.
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentInstanceStatusEnum'
+        $like:
+          $ref: 'filters.yaml#/components/schemas/LikeFilter'

--- a/zeebe/gateway-protocol/src/main/proto/v2/keys.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/keys.yaml
@@ -156,6 +156,15 @@ components:
       format: int64
       minimum: 1
 
+    AgentInstanceKey:
+      description: System-generated key for an agent instance.
+      format: AgentInstanceKey
+      x-semantic-type: AgentInstanceKey
+      example: "4503599627370496"
+      type: string
+      allOf:
+        - $ref: '#/components/schemas/LongKey'
+
     AuditLogKey:
       allOf:
         - $ref: '#/components/schemas/LongKey'
@@ -465,6 +474,43 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/DecisionEvaluationInstanceKey"
+
+    AgentInstanceKeyFilterProperty:
+      description: AgentInstanceKey property with full advanced search capabilities.
+      oneOf:
+        - type: string
+          title: Exact match
+          description: Matches the value exactly.
+          allOf:
+            - $ref: "#/components/schemas/AgentInstanceKey"
+        - $ref: '#/components/schemas/AdvancedAgentInstanceKeyFilter'
+
+    AdvancedAgentInstanceKeyFilter:
+      title: Advanced filter
+      description: Advanced AgentInstanceKey filter.
+      type: object
+      properties:
+        $eq:
+          description: Checks for equality with the provided value.
+          allOf:
+            - $ref: "#/components/schemas/AgentInstanceKey"
+        $neq:
+          description: Checks for inequality with the provided value.
+          allOf:
+            - $ref: "#/components/schemas/AgentInstanceKey"
+        $exists:
+          description: Checks if the current property exists.
+          type: boolean
+        $in:
+          description: Checks if the property matches any of the provided values.
+          type: array
+          items:
+            $ref: "#/components/schemas/AgentInstanceKey"
+        $notIn:
+          description: Checks if the property matches none of the provided values.
+          type: array
+          items:
+            $ref: "#/components/schemas/AgentInstanceKey"
 
     AuditLogKeyFilterProperty:
       description: AuditLogKey property with full advanced search capabilities.

--- a/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
@@ -26,6 +26,7 @@ servers:
         description: The schema of the Orchestration Cluster REST API server.
 tags:
   - name: Ad-hoc sub-process
+  - name: Agent instance
   - name: Audit Log
   - name: Authentication
   - name: Authorization
@@ -62,6 +63,12 @@ tags:
   - name: Variable
 
 paths:
+  # Agent instance endpoints
+  /agent-instances/{agentInstanceKey}:
+    $ref: 'agent-instances.yaml#/paths/~1agent-instances~1{agentInstanceKey}'
+  /agent-instances/search:
+    $ref: 'agent-instances.yaml#/paths/~1agent-instances~1search'
+
   # Audit Log endpoints
   /audit-logs/search:
     $ref: 'audit-logs.yaml#/paths/~1audit-logs~1search'


### PR DESCRIPTION
## Description

Defines the REST API contract for the `AgentInstance` query endpoints.

### What this PR introduces

Two new read endpoints backed by the engine's `AgentInstance` record (exported to secondary storage):

| Method | Path | Operation ID |
|--------|------|--------------|
| `GET` | `/v2/agent-instances/{agentInstanceKey}` | `getAgentInstance` |
| `POST` | `/v2/agent-instances/search` | `searchAgentInstances` |

Both endpoints are `x-eventually-consistent: true` (read from secondary storage) and tagged `Agent instance`.

### Schema overview

The response schema (`AgentInstanceResult`) is based on the initial `AgentInstance` engine record agreed on in the [design discussion](https://camunda.slack.com/archives/C0AH08C7UA2/p1777464488432059?thread_ts=1777379141.220219&cid=C0AH08C7UA2):

- **Identity**: `agentInstanceKey`, `elementId`, `processInstanceKey`, `processDefinitionKey`, `tenantId`
- **Status** (mirrors engine record): `INITIALIZING` → `TOOL_DISCOVERY` → `THINKING` / `TOOL_CALLING` / `IDLE` → `COMPLETED`
- **Definition** (set once at creation): `model`, `provider`, `systemPrompt`
- **Limits** (set once; `-1` = no limit): `maxTokens`, `maxModelCalls`, `maxToolCalls`
- **Metrics** (engine aggregates totals): `inputTokens`, `outputTokens`, `modelCalls`, `toolCalls`
- **Timestamps**: `creationDate`, `lastUpdatedDate`, `completionDate` (nullable while running)

> [!NOTE]
> Derived metrics such as `metrics.totalTokens` (`metrics.inputTokens + metrics.outputTokens`) and `metrics.totalDurationMs` (`instance.completionDate - instance.creationDate`) – could be added later, but currently are intentionally omitted — as they can be computed client-side from the fields already present in `AgentInstanceResult`.

### Scope and future work

This is the initial design iteration. The model is intentionally minimal to unblock Operate UI (display agent status and metrics) and downstream consumers (Optimize). It does not yet cover:
- Per-conversation/iteration metrics
- `processDefinitionVersion` / `versionTag` identity fields
- A `FAILED` status (tracked as an incident on the element instance for now)

These may be addressed in follow-up tasks as the feature evolves.

## Related issues

Closes #51503