### PR TITLE
docs: add AGENTS.md, CLAUDE.md and docs/ for c8run

### DIFF
--- a/c8run/AGENTS.md
+++ b/c8run/AGENTS.md
@@ -1,0 +1,140 @@
+# Agent Instructions
+
+You are a contributor to the C8Run module inside the Camunda 8 monorepo. C8Run is the local, single-machine Camunda 8 distribution — it starts the Camunda stack and Connectors runtime without Docker, manages process lifecycles, and records PIDs for clean shutdown.
+
+Scope all changes to this Go module (`c8run/`) unless the task explicitly requires another module.
+
+## Critical Rules
+
+- NEVER commit secrets, tokens, LDAP credentials, or passwords from `.env`
+- NEVER edit generated artifacts — see [Package Layout](docs/package-layout.md) for the full list
+- NEVER add new external dependencies unless clearly necessary
+- ALWAYS scope changes to the smallest affected package
+- ALWAYS run `gofmt` on touched Go files before committing
+- ALWAYS run `go test ./...` from `c8run/` before submitting
+- ALWAYS cover platform behavior — changes under `internal/unix/` or `internal/windows/` need matching tests or an explicit reason why only one platform is affected
+
+## Quick Start
+
+1. Read `README.md`.
+2. Check [Package Layout](docs/package-layout.md) to identify the right package for your change.
+3. Determine platform scope: is this unix-only, windows-only, or shared across both?
+4. Check existing tests near the code you are changing.
+5. Make focused edits — preserve existing package boundaries and patterns.
+
+## Build Commands
+
+```bash
+# Build the end-user CLI (Linux/macOS)
+go build -o c8run ./cmd/c8run
+
+# Build the end-user CLI (Windows)
+go build -o c8run.exe ./cmd/c8run
+
+# Build the packager CLI
+go build -o packager ./cmd/packager
+```
+
+For packaging a full distribution archive, see [Package Layout — Packaging a Distribution](docs/package-layout.md#packaging-a-distribution).
+
+## Lint and Format
+
+```bash
+# Format all Go files (must be clean before committing)
+gofmt -w .
+
+# Check formatting without writing
+gofmt -l .
+
+# Vet for common errors
+go vet ./...
+```
+
+For Java, Markdown, or `pom.xml` changes outside `c8run/`, also run from the repository root:
+
+```bash
+./mvnw license:format spotless:apply -T1C
+```
+
+## Test Commands
+
+```bash
+# Run all Go tests in this module
+go test ./...
+
+# Run tests in a single package
+go test ./internal/start/...
+
+# Run a single test by name
+go test ./internal/start/... -run TestHealthCheck
+
+# Run with verbose output
+go test -v ./...
+```
+
+## Toolchain
+
+Go minimum: `1.24` (from `go.mod`). Toolchain: `go1.26.2`.
+
+Verify with:
+
+```bash
+go version
+```
+
+## Code Style
+
+### Formatting
+
+- Use `gofmt` — output must be clean before committing.
+- Formatting is managed by `gofmt`; do not override manually.
+
+### Package Design
+
+- Keep package APIs narrow and aligned with the current layout.
+- Do not add new dependencies unless clearly necessary.
+- Respect the unix/windows split — shared logic lives in packages above `internal/unix/` and `internal/windows/`.
+
+### Configuration Handling
+
+- Prefer structured YAML handling for runtime configuration. Avoid ad hoc string parsing of `application.yaml`.
+- Treat `.env` as local configuration only. Never commit its contents.
+- Update help text, `README.md`, and tests when changing public commands or flags.
+
+### Error Handling
+
+- Return errors with useful context — do not swallow them silently.
+- In tests, use `require` for setup/fail-fast checks and `assert` for non-fatal assertions.
+
+## Commit and Branch Conventions
+
+- Branches: `issueId-description` (e.g., `52119-add-agents-md`)
+- Commit format: Conventional Commits — `<type>: <description>` in present tense, under 120 characters
+- Valid types: `feat`, `fix`, `refactor`, `test`, `docs`, `style`, `build`, `ci`, `chore`, `perf`, `deps`
+- No scope required
+
+## Additional Agent Context
+
+| File / Path | Purpose |
+|---|---|
+| `README.md` | Build setup, Go version requirement, `.env` config, packaging steps |
+| `docs/local-development.md` | Prerequisites, quick start, and testing code changes against a local Camunda build |
+| `docs/package-layout.md` | Key package areas, runtime artifact list, packaging a distribution |
+| `docs/runtime-rules.md` | Config precedence, H2 rules, Connectors compatibility, ports, health check timeout, quickstart marker |
+| `docs/testing-guide.md` | Platform coverage, process lifecycle, packaging, startup test expectations |
+| `docs/process-lifecycle.md` | PID locking semantics, 4-state restart machine, signal handling, graceful shutdown, detached mode stub |
+| `docs/configuration.md` | JAVA_HOME fallback chain, config directory handling, H2 cleanup decision tree, RDBMS driver detection |
+| `docs/platform-differences.md` | Unix vs Windows: process groups, kill implementation, path/classpath conventions, archive formats, test tags |
+| `.env` | Local credentials and version pins — never committed |
+| `configuration/application.yaml` | Default runtime config loaded on every start |
+
+## Recommended Agent Workflow
+
+1. Read `README.md` and the relevant `docs/` file for your change area.
+2. Identify the target package and platform scope.
+3. Make focused edits — one package at a time where possible.
+4. Run `go test ./...` from `c8run/`.
+5. Run `gofmt -w .` and `go vet ./...`.
+6. Build the changed binary to confirm it compiles: `go build -o c8run ./cmd/c8run`.
+7. For packaging changes, also build and verify `packager`.
+8. Commit with Conventional Commits format, no scope.

--- a/c8run/AGENTS.md
+++ b/c8run/AGENTS.md
@@ -125,6 +125,8 @@ go version
 | `docs/process-lifecycle.md` | PID locking semantics, 4-state restart machine, signal handling, graceful shutdown, detached mode stub |
 | `docs/configuration.md` | JAVA_HOME fallback chain, config directory handling, H2 cleanup decision tree, RDBMS driver detection |
 | `docs/platform-differences.md` | Unix vs Windows: process groups, kill implementation, path/classpath conventions, archive formats, test tags |
+| `docs/release.md` | Release process: RC and public release steps, workflow inputs, artifact naming, post-release cleanup |
+| `docs/versions.md` | Branch layout, per-version feature matrix, backport policy |
 | `.env` | Local credentials and version pins — never committed |
 | `configuration/application.yaml` | Default runtime config loaded on every start |
 

--- a/c8run/AGENTS.md
+++ b/c8run/AGENTS.md
@@ -74,7 +74,7 @@ go test -v ./...
 
 ## Toolchain
 
-Go minimum: `1.24` (from `go.mod`). Toolchain: `go1.26.2`.
+Go minimum: `1.25` (from `go.mod`). Toolchain: `go1.26.2`.
 
 Verify with:
 
@@ -110,7 +110,7 @@ go version
 
 - Branches: `issueId-description` (e.g., `52119-add-agents-md`)
 - Commit format: Conventional Commits — `<type>: <description>` in present tense, under 120 characters
-- Valid types: `feat`, `fix`, `refactor`, `test`, `docs`, `style`, `build`, `ci`, `chore`, `perf`, `deps`
+- Valid types: `feat`, `fix`, `refactor`, `test`, `docs`, `style`, `build`, `ci`, `perf`, `deps`
 - No scope required
 
 ## Additional Agent Context

--- a/c8run/AGENTS.md
+++ b/c8run/AGENTS.md
@@ -115,20 +115,20 @@ go version
 
 ## Additional Agent Context
 
-| File / Path | Purpose |
-|---|---|
-| `README.md` | Build setup, Go version requirement, `.env` config, packaging steps |
-| `docs/local-development.md` | Prerequisites, quick start, and testing code changes against a local Camunda build |
-| `docs/package-layout.md` | Key package areas, runtime artifact list, packaging a distribution |
-| `docs/runtime-rules.md` | Config precedence, H2 rules, Connectors compatibility, ports, health check timeout, quickstart marker |
-| `docs/testing-guide.md` | Platform coverage, process lifecycle, packaging, startup test expectations |
-| `docs/process-lifecycle.md` | PID locking semantics, 4-state restart machine, signal handling, graceful shutdown, detached mode stub |
-| `docs/configuration.md` | JAVA_HOME fallback chain, config directory handling, H2 cleanup decision tree, RDBMS driver detection |
-| `docs/platform-differences.md` | Unix vs Windows: process groups, kill implementation, path/classpath conventions, archive formats, test tags |
-| `docs/release.md` | Release process: RC and public release steps, workflow inputs, artifact naming, post-release cleanup |
-| `docs/versions.md` | Branch layout, per-version feature matrix, backport policy |
-| `.env` | Local credentials and version pins — never committed |
-| `configuration/application.yaml` | Default runtime config loaded on every start |
+|           File / Path            |                                                   Purpose                                                    |
+|----------------------------------|--------------------------------------------------------------------------------------------------------------|
+| `README.md`                      | Build setup, Go version requirement, `.env` config, packaging steps                                          |
+| `docs/local-development.md`      | Prerequisites, quick start, and testing code changes against a local Camunda build                           |
+| `docs/package-layout.md`         | Key package areas, runtime artifact list, packaging a distribution                                           |
+| `docs/runtime-rules.md`          | Config precedence, H2 rules, Connectors compatibility, ports, health check timeout, quickstart marker        |
+| `docs/testing-guide.md`          | Platform coverage, process lifecycle, packaging, startup test expectations                                   |
+| `docs/process-lifecycle.md`      | PID locking semantics, 4-state restart machine, signal handling, graceful shutdown, detached mode stub       |
+| `docs/configuration.md`          | JAVA_HOME fallback chain, config directory handling, H2 cleanup decision tree, RDBMS driver detection        |
+| `docs/platform-differences.md`   | Unix vs Windows: process groups, kill implementation, path/classpath conventions, archive formats, test tags |
+| `docs/release.md`                | Release process: RC and public release steps, workflow inputs, artifact naming, post-release cleanup         |
+| `docs/versions.md`               | Branch layout, per-version feature matrix, backport policy                                                   |
+| `.env`                           | Local credentials and version pins — never committed                                                         |
+| `configuration/application.yaml` | Default runtime config loaded on every start                                                                 |
 
 ## Recommended Agent Workflow
 
@@ -140,3 +140,4 @@ go version
 6. Build the changed binary to confirm it compiles: `go build -o c8run ./cmd/c8run`.
 7. For packaging changes, also build and verify `packager`.
 8. Commit with Conventional Commits format, no scope.
+

--- a/c8run/CLAUDE.md
+++ b/c8run/CLAUDE.md
@@ -1,0 +1,5 @@
+# CLAUDE.md
+
+Read `AGENTS.md` for commands, rules, and agent workflow.
+
+@AGENTS.md

--- a/c8run/docs/configuration.md
+++ b/c8run/docs/configuration.md
@@ -4,14 +4,16 @@
 
 C8Run always loads `configuration/application.yaml` first via `--spring.config.additional-location`, then appends the user-provided `--config` file or directory last. Spring Boot resolves conflicts in favour of the last-loaded source, so user config always wins.
 
-If `--config` points to a directory, a trailing slash is added automatically so Spring Boot loads all YAML files inside it. If it points to a file, no slash is added. This directory-detection logic exists in both `cmd/c8run/main.go` and `internal/shutdown/shutdownhandler.go` — changes to one must be mirrored in the other.
+If `--config` points to a directory, a trailing slash is added automatically so Spring Boot loads all YAML files inside it. If it points to a file, no slash is added. This directory-detection logic lives in `cmd/c8run/main.go` for startup config path building.
+
+The shutdown handler (`internal/shutdown/shutdownhandler.go`) also handles directory config paths, but for a different purpose: it reads config files directly to determine the active RDBMS URL. When given a directory path it resolves `application.yaml` inside it. These are parallel concerns — a change to one does not mechanically require a change to the other, but both must agree on how a directory config path maps to a file.
 
 ## JAVA_HOME Resolution Fallback Chain
 
 `resolveJavaHomeAndBinary` in `internal/start/startuphandler.go` resolves the Java binary through a chain of fallbacks:
 
 1. **`JAVA_HOME` env var set + symlink resolves** → use it directly
-2. **`JAVA_HOME` env var set + symlink resolution fails** → retry by calling `getJavaHome()` (runs `java -XshowSettings:all` to extract the home path from output)
+2. **`JAVA_HOME` env var set + symlink resolution fails** → retry by calling `getJavaHome()` (runs the bundled `JavaHome` class via `exec.Command(javaBinary, "JavaHome")`, which prints `System.getProperty("java.home")`)
 3. **`JAVA_HOME` empty or still invalid** → `exec.LookPath("java")` to find the binary, then walk two directories up (`filepath.Dir(filepath.Dir(path))`) to derive `JAVA_HOME` from `bin/java`
 4. **Walk finds no matching binary** → build a hardcoded path as last resort
 
@@ -21,7 +23,7 @@ Changes to this chain must ensure all four fallback paths still produce a valid 
 
 `shouldDeleteDataDir` in `internal/shutdown/shutdownhandler.go` controls whether the H2 data directory is deleted on stop. Deletion only occurs when all of the following are true:
 
-1. `SecondaryStorageType` is `"rdbms"` or empty (empty defaults to rdbms)
+1. `SecondaryStorageType` is explicitly `"rdbms"` — an empty value skips deletion entirely
 2. The active RDBMS URL resolves to an in-memory H2 connection (`jdbc:h2:mem`)
 
 The RDBMS URL is resolved in this precedence order (first match wins):

--- a/c8run/docs/configuration.md
+++ b/c8run/docs/configuration.md
@@ -47,9 +47,11 @@ Vendor detection from the JDBC URL prefix:
 |---|---|---|
 | `jdbc:oracle:*` | Oracle | Yes — searches for `ojdbc*.jar` |
 | `jdbc:mysql:*` | MySQL | Yes — searches for `mysql-connector*.jar` |
-| `jdbc:postgresql:*` | PostgreSQL | No — requires `--extra-driver` |
-| `jdbc:mariadb:*` | MariaDB | No — requires `--extra-driver` |
-| `jdbc:sqlserver:*` | SQL Server | No — requires `--extra-driver` |
+| `jdbc:postgresql:*` | PostgreSQL | No — not auto-detected; provide `--extra-driver` if needed |
+| `jdbc:mariadb:*` | MariaDB | No — not auto-detected; provide `--extra-driver` if needed |
+| `jdbc:sqlserver:*` | SQL Server | No — not auto-detected; provide `--extra-driver` if needed |
+
+C8Run only fails early for missing drivers it explicitly validates during detection (currently Oracle/MySQL). For PostgreSQL, MariaDB, and SQL Server, a missing driver may only surface later at runtime.
 
 If `CAMUNDA_VERSION` is not set when driver detection runs, the function cannot resolve the lib directory and will fail if a driver is needed.
 

--- a/c8run/docs/configuration.md
+++ b/c8run/docs/configuration.md
@@ -1,0 +1,65 @@
+# Configuration
+
+## Config File Precedence
+
+C8Run always loads `configuration/application.yaml` first via `--spring.config.additional-location`, then appends the user-provided `--config` file or directory last. Spring Boot resolves conflicts in favour of the last-loaded source, so user config always wins.
+
+If `--config` points to a directory, a trailing slash is added automatically so Spring Boot loads all YAML files inside it. If it points to a file, no slash is added. This directory-detection logic exists in both `cmd/c8run/main.go` and `internal/shutdown/shutdownhandler.go` — changes to one must be mirrored in the other.
+
+## JAVA_HOME Resolution Fallback Chain
+
+`resolveJavaHomeAndBinary` in `internal/start/startuphandler.go` resolves the Java binary through a chain of fallbacks:
+
+1. **`JAVA_HOME` env var set + symlink resolves** → use it directly
+2. **`JAVA_HOME` env var set + symlink resolution fails** → retry by calling `getJavaHome()` (runs `java -XshowSettings:all` to extract the home path from output)
+3. **`JAVA_HOME` empty or still invalid** → `exec.LookPath("java")` to find the binary, then walk two directories up (`filepath.Dir(filepath.Dir(path))`) to derive `JAVA_HOME` from `bin/java`
+4. **Walk finds no matching binary** → build a hardcoded path as last resort
+
+Changes to this chain must ensure all four fallback paths still produce a valid binary. The two-directory walk assumes a standard `{JAVA_HOME}/bin/java` layout — non-standard JDK layouts (e.g. macOS `jre/` subdirectory structures) may fall through to the hardcoded path.
+
+## H2 Data Directory Cleanup
+
+`shouldDeleteDataDir` in `internal/shutdown/shutdownhandler.go` controls whether the H2 data directory is deleted on stop. Deletion only occurs when all of the following are true:
+
+1. `SecondaryStorageType` is `"rdbms"` or empty (empty defaults to rdbms)
+2. The active RDBMS URL resolves to an in-memory H2 connection (`jdbc:h2:mem`)
+
+The RDBMS URL is resolved in this precedence order (first match wins):
+1. `CAMUNDA_DATA_SECONDARY_STORAGE_RDBMS_URL` environment variable
+2. User-provided `--config` file (if supplied)
+3. `configuration/application.yaml`
+
+**File-based H2 (`jdbc:h2:file:*`) does NOT trigger deletion.** Only in-memory H2 is cleaned up on stop.
+
+If the version string is empty, deletion is skipped with a warning. The version string is sanitized before building the data directory path (`camunda-zeebe-{VERSION}/data`) to prevent path traversal — do not remove this guard.
+
+## YAML Config Parsing Resilience
+
+If a config YAML file cannot be parsed, the shutdown handler logs a warning and continues searching remaining config files rather than failing. This allows graceful fallback when one config is malformed or empty.
+
+## RDBMS Driver Detection
+
+When an external RDBMS URL is configured, `cmd/c8run/main.go` attempts to auto-detect and copy the correct JDBC driver JAR to `camunda-zeebe-{VERSION}/lib/`.
+
+Vendor detection from the JDBC URL prefix:
+
+| JDBC URL prefix | Vendor | Auto-detection |
+|---|---|---|
+| `jdbc:oracle:*` | Oracle | Yes — searches for `ojdbc*.jar` |
+| `jdbc:mysql:*` | MySQL | Yes — searches for `mysql-connector*.jar` |
+| `jdbc:postgresql:*` | PostgreSQL | No — requires `--extra-driver` |
+| `jdbc:mariadb:*` | MariaDB | No — requires `--extra-driver` |
+| `jdbc:sqlserver:*` | SQL Server | No — requires `--extra-driver` |
+
+If `CAMUNDA_VERSION` is not set when driver detection runs, the function cannot resolve the lib directory and will fail if a driver is needed.
+
+## Environment Variable Injection
+
+`internal/overrides/overrides.go` injects four environment variables required for local development (e.g. CSRF disabled) only if they are not already set. It does not override user-provided values.
+
+`AdjustJavaOpts` appends to `JAVA_OPTS`:
+- Username/password as `-Dcamunda.security.initialization.users[0].*` properties (only when non-default credentials are used)
+- Port as a Spring property (only when not 8080)
+- Keystore password if a keystore is configured
+
+Keystore password is appended unquoted — special characters in the password may break argument parsing.

--- a/c8run/docs/configuration.md
+++ b/c8run/docs/configuration.md
@@ -45,13 +45,13 @@ When an external RDBMS URL is configured, `cmd/c8run/main.go` attempts to auto-d
 
 Vendor detection from the JDBC URL prefix:
 
-| JDBC URL prefix | Vendor | Auto-detection |
-|---|---|---|
-| `jdbc:oracle:*` | Oracle | Yes — searches for `ojdbc*.jar` |
-| `jdbc:mysql:*` | MySQL | Yes — searches for `mysql-connector*.jar` |
+|   JDBC URL prefix   |   Vendor   |                       Auto-detection                       |
+|---------------------|------------|------------------------------------------------------------|
+| `jdbc:oracle:*`     | Oracle     | Yes — searches for `ojdbc*.jar`                            |
+| `jdbc:mysql:*`      | MySQL      | Yes — searches for `mysql-connector*.jar`                  |
 | `jdbc:postgresql:*` | PostgreSQL | No — not auto-detected; provide `--extra-driver` if needed |
-| `jdbc:mariadb:*` | MariaDB | No — not auto-detected; provide `--extra-driver` if needed |
-| `jdbc:sqlserver:*` | SQL Server | No — not auto-detected; provide `--extra-driver` if needed |
+| `jdbc:mariadb:*`    | MariaDB    | No — not auto-detected; provide `--extra-driver` if needed |
+| `jdbc:sqlserver:*`  | SQL Server | No — not auto-detected; provide `--extra-driver` if needed |
 
 C8Run only fails early for missing drivers it explicitly validates during detection (currently Oracle/MySQL). For PostgreSQL, MariaDB, and SQL Server, a missing driver may only surface later at runtime.
 

--- a/c8run/docs/local-development.md
+++ b/c8run/docs/local-development.md
@@ -1,0 +1,80 @@
+# Local Development with C8Run
+
+C8Run lets internal developers run the Orchestration Cluster locally for rapid development and testing — no Kubernetes required.
+
+## Prerequisites
+
+| Requirement | Notes |
+|---|---|
+| **JDK** | ≥ 21 for C8Run 8.9+. For 8.8 and earlier, use JDK 21–23 only. `JAVA_HOME` must be set. |
+| **Go** | 1.24+ (see `go.mod`) |
+| **Maven** | Configured with Camunda Nexus access (required when testing local code changes) |
+| **JFrog access** | Required for downloading artifacts |
+| **Camunda repo** | `camunda/camunda` cloned locally |
+
+### Nexus credentials
+
+For the `packager package` command, export the following before running:
+
+```bash
+export JAVA_ARTIFACTS_USER=firstname.lastname
+export JAVA_ARTIFACTS_PASSWORD=<your Okta password>
+```
+
+These go in `c8run/.env` for persistent local use. Never commit `.env`.
+
+## Quick Start (Pre-built distribution)
+
+Use this when you want to run the version pinned in `.env` without building Camunda from source.
+
+From `c8run/`:
+
+```bash
+go build -o c8run ./cmd/c8run
+go build -o packager ./cmd/packager
+./packager package
+./start.sh
+```
+
+Access your environment:
+
+| Endpoint | URL |
+|---|---|
+| REST API | http://localhost:8080 |
+| gRPC API | http://localhost:26500 |
+| Management API | http://localhost:9600/actuator |
+
+Default credentials: `demo` / `demo`
+
+## Testing Your Code Changes
+
+Use this when you want to run C8Run against a locally built Camunda distribution.
+
+### 1. Build the Camunda distribution
+
+From the repository root:
+
+```bash
+./mvnw -B -T1C -DskipTests -DskipChecks -Dflatten.skip=true \
+  -Dskip.fe.build=false -DskipOptimize clean package
+```
+
+This produces: `dist/target/camunda-zeebe-<version>-SNAPSHOT.tar.gz`
+
+### 2. Copy the distribution to C8Run and update `.env`
+
+```bash
+cp ./dist/target/camunda-zeebe-*.tar.gz ./c8run/
+```
+
+Edit `c8run/.env` and update `CAMUNDA_VERSION` to match your snapshot version.
+
+### 3. Package and run
+
+```bash
+cd c8run
+go build -o c8run ./cmd/c8run
+go build -o packager ./cmd/packager
+./packager package
+./start.sh
+```

--- a/c8run/docs/local-development.md
+++ b/c8run/docs/local-development.md
@@ -6,8 +6,8 @@ C8Run lets internal developers run the Orchestration Cluster locally for rapid d
 
 | Requirement | Notes |
 |---|---|
-| **JDK** | ≥ 21 for C8Run 8.9+. For 8.8 and earlier, use JDK 21–23 only. `JAVA_HOME` must be set. |
-| **Go** | 1.24+ (see `go.mod`) |
+| **JDK** | ≥ 21. `JAVA_HOME` must be set. (C8Run 8.8 and earlier had a known compatibility constraint with JDK > 23 — use JDK 21–23 for those versions.) |
+| **Go** | 1.25+ (see `go.mod`) |
 | **Maven** | Configured with Camunda Nexus access (required when testing local code changes) |
 | **JFrog access** | Required for downloading artifacts |
 | **Camunda repo** | `camunda/camunda` cloned locally |

--- a/c8run/docs/local-development.md
+++ b/c8run/docs/local-development.md
@@ -6,7 +6,7 @@ C8Run lets internal developers run the Orchestration Cluster locally for rapid d
 
 | Requirement | Notes |
 |---|---|
-| **JDK** | ≥ 21. `JAVA_HOME` must be set. (C8Run 8.8 and earlier had a known compatibility constraint with JDK > 23 — use JDK 21–23 for those versions.) |
+| **JDK** | `JAVA_HOME` must be set. Supported range depends on the version: **8.8 and earlier** require OpenJDK 21–23; **8.9 and later** support OpenJDK 21–25. |
 | **Go** | 1.25+ (see `go.mod`) |
 | **Maven** | Configured with Camunda Nexus access (required when testing local code changes) |
 | **JFrog access** | Required for downloading artifacts |

--- a/c8run/docs/local-development.md
+++ b/c8run/docs/local-development.md
@@ -78,3 +78,4 @@ go build -o packager ./cmd/packager
 ./packager package
 ./start.sh
 ```
+

--- a/c8run/docs/local-development.md
+++ b/c8run/docs/local-development.md
@@ -4,13 +4,13 @@ C8Run lets internal developers run the Orchestration Cluster locally for rapid d
 
 ## Prerequisites
 
-| Requirement | Notes |
-|---|---|
-| **JDK** | `JAVA_HOME` must be set. Supported range depends on the version: **8.8 and earlier** require OpenJDK 21–23; **8.9 and later** support OpenJDK 21–25. |
-| **Go** | 1.25+ (see `go.mod`) |
-| **Maven** | Configured with Camunda Nexus access (required when testing local code changes) |
-| **JFrog access** | Required for downloading artifacts |
-| **Camunda repo** | `camunda/camunda` cloned locally |
+|   Requirement    |                                                                        Notes                                                                         |
+|------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **JDK**          | `JAVA_HOME` must be set. Supported range depends on the version: **8.8 and earlier** require OpenJDK 21–23; **8.9 and later** support OpenJDK 21–25. |
+| **Go**           | 1.25+ (see `go.mod`)                                                                                                                                 |
+| **Maven**        | Configured with Camunda Nexus access (required when testing local code changes)                                                                      |
+| **JFrog access** | Required for downloading artifacts                                                                                                                   |
+| **Camunda repo** | `camunda/camunda` cloned locally                                                                                                                     |
 
 ### Nexus credentials
 
@@ -38,10 +38,10 @@ go build -o packager ./cmd/packager
 
 Access your environment:
 
-| Endpoint | URL |
-|---|---|
-| REST API | http://localhost:8080 |
-| gRPC API | http://localhost:26500 |
+|    Endpoint    |              URL               |
+|----------------|--------------------------------|
+| REST API       | http://localhost:8080          |
+| gRPC API       | http://localhost:26500         |
 | Management API | http://localhost:9600/actuator |
 
 Default credentials: `demo` / `demo`

--- a/c8run/docs/package-layout.md
+++ b/c8run/docs/package-layout.md
@@ -45,4 +45,4 @@ Then run from `c8run/`:
 ./package.sh
 ```
 
-The script builds the `packager` binary and runs `./packager package`. The output is a `camunda8-run-*.tar.gz` (Linux/macOS) or `.zip` (Windows) archive ready for distribution.
+The script builds the `packager` binary and runs `./packager package`. The output is a `camunda8-run-*.tar.gz` (Linux) or `.zip` (macOS/Windows) archive ready for distribution.

--- a/c8run/docs/package-layout.md
+++ b/c8run/docs/package-layout.md
@@ -1,0 +1,48 @@
+# Package Layout
+
+## Key Areas
+
+| Path | Description |
+|---|---|
+| `cmd/c8run/` | End-user CLI — `start`, `stop`, and `help` commands |
+| `cmd/packager/` | CLI for building distributable C8Run archives |
+| `internal/start/` | Java resolution, config locations, startup, health checks |
+| `internal/shutdown/` | Stop flow and H2 data cleanup rules |
+| `internal/processmanagement/` | PID files, lock files, process trees, killing, restart flow |
+| `internal/unix/` | Linux and macOS command/process implementation |
+| `internal/windows/` | Windows command/process implementation |
+| `internal/connectors/` | Connectors launcher compatibility logic |
+| `internal/packages/` | Distribution download, clean, extract, and package logic |
+| `configuration/` | Default runtime configuration loaded by every start |
+| `e2e_tests/` | API and Playwright checks used by C8Run CI |
+
+## Runtime and Generated Artifacts
+
+The following are runtime or packaging output. Do not edit them as source and do not commit them:
+
+- Extracted `camunda-zeebe-*/` directories
+- Built `camunda8-run-*/` archives
+- `jre/` — downloaded Java runtime
+- `camunda-data/` — runtime data directory
+- `log/` — log output (`camunda.log`, `connectors.log`)
+- Built binaries: `c8run`, `c8run.exe`, `packager`
+- PID files and lock files
+
+## Packaging a Distribution
+
+Ensure `.env` in `c8run/` contains the required variables:
+
+```dotenv
+CAMUNDA_VERSION=<version>
+CONNECTORS_VERSION=<version>
+JAVA_ARTIFACTS_USER=<firstname.lastname>
+JAVA_ARTIFACTS_PASSWORD=<your Okta password>
+```
+
+Then run from `c8run/`:
+
+```bash
+./package.sh
+```
+
+The script builds the `packager` binary and runs `./packager package`. The output is a `camunda8-run-*.tar.gz` (Linux/macOS) or `.zip` (Windows) archive ready for distribution.

--- a/c8run/docs/package-layout.md
+++ b/c8run/docs/package-layout.md
@@ -2,19 +2,19 @@
 
 ## Key Areas
 
-| Path | Description |
-|---|---|
-| `cmd/c8run/` | End-user CLI — `start`, `stop`, and `help` commands |
-| `cmd/packager/` | CLI for building distributable C8Run archives |
-| `internal/start/` | Java resolution, config locations, startup, health checks |
-| `internal/shutdown/` | Stop flow and H2 data cleanup rules |
+|             Path              |                         Description                         |
+|-------------------------------|-------------------------------------------------------------|
+| `cmd/c8run/`                  | End-user CLI — `start`, `stop`, and `help` commands         |
+| `cmd/packager/`               | CLI for building distributable C8Run archives               |
+| `internal/start/`             | Java resolution, config locations, startup, health checks   |
+| `internal/shutdown/`          | Stop flow and H2 data cleanup rules                         |
 | `internal/processmanagement/` | PID files, lock files, process trees, killing, restart flow |
-| `internal/unix/` | Linux and macOS command/process implementation |
-| `internal/windows/` | Windows command/process implementation |
-| `internal/connectors/` | Connectors launcher compatibility logic |
-| `internal/packages/` | Distribution download, clean, extract, and package logic |
-| `configuration/` | Default runtime configuration loaded by every start |
-| `e2e_tests/` | API and Playwright checks used by C8Run CI |
+| `internal/unix/`              | Linux and macOS command/process implementation              |
+| `internal/windows/`           | Windows command/process implementation                      |
+| `internal/connectors/`        | Connectors launcher compatibility logic                     |
+| `internal/packages/`          | Distribution download, clean, extract, and package logic    |
+| `configuration/`              | Default runtime configuration loaded by every start         |
+| `e2e_tests/`                  | API and Playwright checks used by C8Run CI                  |
 
 ## Runtime and Generated Artifacts
 

--- a/c8run/docs/platform-differences.md
+++ b/c8run/docs/platform-differences.md
@@ -1,0 +1,71 @@
+# Platform Differences
+
+C8Run supports Linux, macOS, and Windows. Implementation for each platform lives in `internal/unix/` (Linux + macOS) and `internal/windows/`. Changes to shared behavior must be reflected in both.
+
+## Process Creation
+
+| Behavior | Unix (`internal/unix/`) | Windows (`internal/windows/`) |
+|---|---|---|
+| Process group | `Setpgid: true` — new process group for signal handling | `CREATE_NEW_PROCESS_GROUP` flag |
+| Console window | n/a | `CREATE_NO_WINDOW` flag suppresses console |
+| SysProcAttr flags | `syscall.SysProcAttr{Setpgid: true}` | `syscall.SysProcAttr{CreationFlags: 0x08000000 \| 0x00000200}` |
+
+On Unix, `Setpgid` ensures child processes belong to the same process group so signals propagate correctly. On Windows, both flags are required together — `CREATE_NEW_PROCESS_GROUP` alone does not suppress the console window.
+
+## Process Kill
+
+| Behavior | Unix | Windows |
+|---|---|---|
+| Kill implementation | `os.FindProcess()` + `Kill()` (SIGKILL) | `windows.TerminateProcess()` + `WaitForSingleObject()` |
+| Child process enumeration | Not needed — Unix process groups handle tree | Explicit `processTree()` call to enumerate children |
+| Already-exited process | Returns error from `Kill()` | `ERROR_INVALID_PARAMETER` — must be handled explicitly |
+
+Unix returns a single PID for the process (group cleanup is OS-managed). Windows must explicitly enumerate and terminate child processes.
+
+## Binary and Path Conventions
+
+| Item | Unix | Windows |
+|---|---|---|
+| C8Run binary | `c8run` | `c8run.exe` |
+| Camunda startup script | `./camunda-zeebe-{VERSION}/bin/camunda` | `.\camunda-zeebe-{VERSION}\bin\camunda.bat` |
+| Path separator | `/` | `\` |
+| Classpath separator | `:` | `;` |
+| Connectors classpath | `{dir}/*:{dir}/custom_connectors/*` | `{dir}\*;{dir}\custom_connectors\*` |
+| Java binary lookup | `java` | `java.exe` |
+| Browser open command | `xdg-open` (Linux) / `open` (macOS) | `cmd /C start {url}` |
+
+## Spring Config Paths
+
+Spring Boot config paths use the native path separator. Unix uses `/`, Windows uses `\\` when constructing `--spring.config.additional-location` arguments. This is handled in `internal/start/startuphandler.go` — do not normalise separators across platforms.
+
+## Archive Format
+
+Distribution archives produced by the packager differ by platform:
+
+| Platform | Format |
+|---|---|
+| Linux | `.tar.gz` |
+| macOS | `.zip` |
+| Windows | `.zip` |
+
+Linux `.tar.gz` creation is used even on Windows if the archive type is explicitly requested (e.g. internal use). User-facing distribution archives always use the platform-native format above.
+
+## Architecture Detection
+
+| `runtime.GOARCH` | Mapped to |
+|---|---|
+| `amd64` | `x86_64` |
+| `arm64` | `aarch64` |
+| Windows (any) | `x86_64` (hardcoded) |
+| Other | Error — unsupported architecture |
+
+## Test Conventions
+
+Platform-specific tests use build tags to restrict execution:
+
+```go
+//go:build !windows   // Unix-only test
+//go:build windows    // Windows-only test
+```
+
+Unix tests check process liveness with `syscall.Kill(pid, 0)`. Windows tests use `windows.GetExitCodeProcess()`. When adding tests for platform-specific packages, always include the appropriate build tag and a matching test (or explicit comment) for the other platform.

--- a/c8run/docs/platform-differences.md
+++ b/c8run/docs/platform-differences.md
@@ -4,35 +4,35 @@ C8Run supports Linux, macOS, and Windows. Implementation for each platform lives
 
 ## Process Creation
 
-| Behavior | Unix (`internal/unix/`) | Windows (`internal/windows/`) |
-|---|---|---|
-| Process group | `Setpgid: true` — new process group for signal handling | `CREATE_NEW_PROCESS_GROUP` flag |
-| Console window | n/a | `CREATE_NO_WINDOW` flag suppresses console |
-| SysProcAttr flags | `syscall.SysProcAttr{Setpgid: true}` | `syscall.SysProcAttr{CreationFlags: 0x08000000 \| 0x00000200}` |
+|     Behavior      |                 Unix (`internal/unix/`)                 |          Windows (`internal/windows/`)           |              |
+| ---               | ---                                                     | ---                                              |              |
+| Process group     | `Setpgid: true` — new process group for signal handling | `CREATE_NEW_PROCESS_GROUP` flag                  |              |
+| Console window    | n/a                                                     | `CREATE_NO_WINDOW` flag suppresses console       |              |
+| SysProcAttr flags | `syscall.SysProcAttr{Setpgid: true}`                    | `syscall.SysProcAttr{CreationFlags: 0x08000000 \ | 0x00000200}` |
 
 On Unix, `Setpgid` ensures child processes belong to the same process group so signals propagate correctly. On Windows, both flags are required together — `CREATE_NEW_PROCESS_GROUP` alone does not suppress the console window.
 
 ## Process Kill
 
-| Behavior | Unix | Windows |
-|---|---|---|
-| Kill implementation | `os.FindProcess()` + `Kill()` (SIGKILL) | `windows.TerminateProcess()` + `WaitForSingleObject()` |
-| Child process enumeration | Not needed — Unix process groups handle tree | Explicit `processTree()` call to enumerate children |
-| Already-exited process | Returns error from `Kill()` | `ERROR_INVALID_PARAMETER` — must be handled explicitly |
+|         Behavior          |                     Unix                     |                        Windows                         |
+|---------------------------|----------------------------------------------|--------------------------------------------------------|
+| Kill implementation       | `os.FindProcess()` + `Kill()` (SIGKILL)      | `windows.TerminateProcess()` + `WaitForSingleObject()` |
+| Child process enumeration | Not needed — Unix process groups handle tree | Explicit `processTree()` call to enumerate children    |
+| Already-exited process    | Returns error from `Kill()`                  | `ERROR_INVALID_PARAMETER` — must be handled explicitly |
 
 Unix returns a single PID for the process (group cleanup is OS-managed). Windows must explicitly enumerate and terminate child processes.
 
 ## Binary and Path Conventions
 
-| Item | Unix | Windows |
-|---|---|---|
-| C8Run binary | `c8run` | `c8run.exe` |
+|          Item          |                  Unix                   |                   Windows                   |
+|------------------------|-----------------------------------------|---------------------------------------------|
+| C8Run binary           | `c8run`                                 | `c8run.exe`                                 |
 | Camunda startup script | `./camunda-zeebe-{VERSION}/bin/camunda` | `.\camunda-zeebe-{VERSION}\bin\camunda.bat` |
-| Path separator | `/` | `\` |
-| Classpath separator | `:` | `;` |
-| Connectors classpath | `{dir}/*:{dir}/custom_connectors/*` | `{dir}\*;{dir}\custom_connectors\*` |
-| Java binary lookup | `java` | `java.exe` |
-| Browser open command | `xdg-open` (Linux) / `open` (macOS) | `cmd /C start {url}` |
+| Path separator         | `/`                                     | `\`                                         |
+| Classpath separator    | `:`                                     | `;`                                         |
+| Connectors classpath   | `{dir}/*:{dir}/custom_connectors/*`     | `{dir}\*;{dir}\custom_connectors\*`         |
+| Java binary lookup     | `java`                                  | `java.exe`                                  |
+| Browser open command   | `xdg-open` (Linux) / `open` (macOS)     | `cmd /C start {url}`                        |
 
 ## Spring Config Paths
 
@@ -42,22 +42,22 @@ Spring Boot config paths use the native path separator. Unix uses `/`, Windows u
 
 Distribution archives produced by the packager differ by platform:
 
-| Platform | Format |
-|---|---|
-| Linux | `.tar.gz` |
-| macOS | `.zip` |
-| Windows | `.zip` |
+| Platform |  Format   |
+|----------|-----------|
+| Linux    | `.tar.gz` |
+| macOS    | `.zip`    |
+| Windows  | `.zip`    |
 
 Linux `.tar.gz` creation is used even on Windows if the archive type is explicitly requested (e.g. internal use). User-facing distribution archives always use the platform-native format above.
 
 ## Architecture Detection
 
-| `runtime.GOARCH` | Mapped to |
-|---|---|
-| `amd64` | `x86_64` |
-| `arm64` | `aarch64` |
-| Windows (any) | `x86_64` (hardcoded) |
-| Other | Error — unsupported architecture |
+| `runtime.GOARCH` |            Mapped to             |
+|------------------|----------------------------------|
+| `amd64`          | `x86_64`                         |
+| `arm64`          | `aarch64`                        |
+| Windows (any)    | `x86_64` (hardcoded)             |
+| Other            | Error — unsupported architecture |
 
 ## Test Conventions
 

--- a/c8run/docs/process-lifecycle.md
+++ b/c8run/docs/process-lifecycle.md
@@ -24,7 +24,7 @@ The health check only runs if the process is confirmed running. An unhealthy run
 
 ## Signal Handling
 
-C8Run listens for `SIGKILL`, `SIGINT`, and `SIGTERM`. On receiving a signal, `ShutdownProcesses` is called and the main goroutine waits for the shutdown WaitGroup before exiting.
+C8Run registers handlers for `SIGINT` and `SIGTERM` (and `os.Interrupt`). On receiving a signal, `ShutdownProcesses` is called and the main goroutine waits for the shutdown WaitGroup before exiting. `SIGKILL` cannot be caught by any process and bypasses the graceful shutdown path entirely.
 
 Graceful shutdown flow:
 1. Signal received → `ShutdownProcesses` called

--- a/c8run/docs/process-lifecycle.md
+++ b/c8run/docs/process-lifecycle.md
@@ -1,0 +1,46 @@
+# Process Lifecycle
+
+## PID File Locking
+
+Every PID file operation is protected by a corresponding `.lock` file using OS-level file locks. This is not optional — bypassing the lock mechanism causes race conditions when multiple processes access the same PID file.
+
+- **Read operations:** must acquire a shared read lock (`acquireRLock`) before reading
+- **Write operations:** must acquire an exclusive lock (`acquireLock`) before writing or deleting
+
+Do not add PID file reads or writes that skip lock acquisition.
+
+## Process Restart State Machine
+
+`AttemptToStartProcess` in `internal/processmanagement/processhandler.go` implements a 4-state decision:
+
+| State | Condition | Action |
+|---|---|---|
+| **No PID** | PID file does not exist | Start process |
+| **Running + healthy** | PID file exists, process alive, health check passes | Do nothing (skip start) |
+| **Running + unhealthy** | PID file exists, process alive, health check fails | Kill process, clean up PID, restart |
+| **Stale PID** | PID file exists, process is dead | Clean up PID file, start process |
+
+The health check only runs if the process is confirmed running. An unhealthy running process triggers a kill + cleanup before restart — not a graceful shutdown. Changes to restart logic must be tested against all four states.
+
+## Signal Handling
+
+C8Run listens for `SIGKILL`, `SIGINT`, and `SIGTERM`. On receiving a signal, `ShutdownProcesses` is called and the main goroutine waits for the shutdown WaitGroup before exiting.
+
+Graceful shutdown flow:
+1. Signal received → `ShutdownProcesses` called
+2. Connectors process stopped first
+3. Camunda process stopped
+4. PID files and lock files cleaned up
+5. WaitGroup completes → process exits
+
+`Ctrl+C` in foreground mode triggers the same shutdown path as `./c8run stop`.
+
+## Foreground vs. Background Start
+
+When `c8run start` runs in the foreground, `Ctrl+C` initiates graceful shutdown via the signal handler.
+
+The `--detached` flag is accepted by the CLI but **not yet implemented** — it is a stub. Backgrounding with `c8run start &` is a known limitation: without a lock file to coordinate between start and stop, zombie processes can result if the start command is interrupted mid-startup. Do not remove the TODO comment at this site without implementing the lock mechanism.
+
+## Kill Implementation
+
+Kill behavior differs by platform — see [Platform Differences](platform-differences.md) for specifics on how Unix and Windows each terminate the process tree.

--- a/c8run/docs/process-lifecycle.md
+++ b/c8run/docs/process-lifecycle.md
@@ -13,12 +13,12 @@ Do not add PID file reads or writes that skip lock acquisition.
 
 `AttemptToStartProcess` in `internal/processmanagement/processhandler.go` implements a 4-state decision:
 
-| State | Condition | Action |
-|---|---|---|
-| **No PID** | PID file does not exist | Start process |
-| **Running + healthy** | PID file exists, process alive, health check passes | Do nothing (skip start) |
-| **Running + unhealthy** | PID file exists, process alive, health check fails | Kill process, clean up PID, restart |
-| **Stale PID** | PID file exists, process is dead | Clean up PID file, start process |
+|          State          |                      Condition                      |               Action                |
+|-------------------------|-----------------------------------------------------|-------------------------------------|
+| **No PID**              | PID file does not exist                             | Start process                       |
+| **Running + healthy**   | PID file exists, process alive, health check passes | Do nothing (skip start)             |
+| **Running + unhealthy** | PID file exists, process alive, health check fails  | Kill process, clean up PID, restart |
+| **Stale PID**           | PID file exists, process is dead                    | Clean up PID file, start process    |
 
 The health check only runs if the process is confirmed running. An unhealthy running process triggers a kill + cleanup before restart — not a graceful shutdown. Changes to restart logic must be tested against all four states.
 

--- a/c8run/docs/release.md
+++ b/c8run/docs/release.md
@@ -1,0 +1,69 @@
+# Release Process
+
+Releases are owned by `@camunda/distribution` and triggered manually via the
+[C8Run Release GitHub workflow](https://github.com/camunda/camunda/actions/workflows/c8run-release.yaml).
+
+> [!WARNING]
+> Ensure the Docker Compose versions were released correctly prior to the C8Run release.
+
+---
+
+## Release Candidates
+
+### 1. Version Bump
+
+For each version:
+
+1. Clone [camunda/camunda](https://github.com/camunda/camunda).
+2. Create a new branch from the version base branch:
+   - `main` for the latest alpha.
+   - `stable/8.8` for 8.8, etc.
+3. Update `./c8run/.env` with the correct versions and tags.
+   - For the Connectors version, check the [Camunda Artifacts repo](https://artifacts.camunda.com/ui/native/connectors/io/camunda/connector/connector-runtime-bundle/).
+4. Create a PR from the branch and get it merged.
+
+### 2. Artifact
+
+For each version, click **Run workflow** in the
+[C8Run Release GitHub workflow](https://github.com/camunda/camunda/actions/workflows/c8run-release.yaml):
+
+| Input | Value |
+|---|---|
+| Run workflow from | `Branch: main` (always) |
+| Release branch | e.g. `stable/8.7` for 8.7 |
+| Camunda minor version | e.g. `8.7` |
+| Camunda app GH release | e.g. `8.7.4` |
+| Publish to Camunda apps GitHub release page | **Ticked** |
+| Publish to Camunda Download Center | **Unticked** (RCs are not published to the Download Center) |
+| Artifact version suffix | `-rc` (include the dash) |
+
+Then:
+
+1. Monitor the GitHub Action logs.
+2. Confirm `*-rc` artifacts are published in [Camunda repo GitHub releases](https://github.com/camunda/camunda/releases) under the correct Camunda tag version.
+3. Report back each version in the release train form in the Slack release thread that the RC artifacts for C8Run are created.
+
+---
+
+## Public Release
+
+For each version, click **Run workflow** in the
+[C8Run Release GitHub workflow](https://github.com/camunda/camunda/actions/workflows/c8run-release.yaml):
+
+| Input | Value |
+|---|---|
+| Run workflow from | `Branch: main` (always) |
+| Release branch | e.g. `stable/8.8` for 8.8, `main` for latest |
+| Camunda minor version | e.g. `8.6`, `8.7`, `8.8` |
+| Camunda app GH release | e.g. `8.7.1`, `8.8-alpha4.1` |
+| Publish to Camunda apps GitHub release page | **Ticked** |
+| Publish to Camunda Download Center | **Ticked** |
+| Artifact version suffix | *(leave empty)* |
+
+Then:
+
+1. Monitor the GitHub Action logs.
+2. Confirm artifacts are added to the [Camunda repo GitHub release](https://github.com/camunda/camunda/releases).
+3. Delete any prior C8Run releases tagged with `-pending-removal`.
+4. Delete the RC artifacts from the Camunda GitHub release (the version specified in the release inputs).
+5. Report back each version in the release train form in the Slack release thread that the C8Run release is complete.

--- a/c8run/docs/release.md
+++ b/c8run/docs/release.md
@@ -67,3 +67,4 @@ Then:
 3. Delete any prior C8Run releases tagged with `-pending-removal`.
 4. Delete the RC artifacts from the Camunda GitHub release (the version specified in the release inputs).
 5. Report back each version in the release train form in the Slack release thread that the C8Run release is complete.
+

--- a/c8run/docs/release.md
+++ b/c8run/docs/release.md
@@ -27,15 +27,15 @@ For each version:
 For each version, click **Run workflow** in the
 [C8Run Release GitHub workflow](https://github.com/camunda/camunda/actions/workflows/c8run-release.yaml):
 
-| Input | Value |
-|---|---|
-| Run workflow from | `Branch: main` (always) |
-| Release branch | e.g. `stable/8.7` for 8.7 |
-| Camunda minor version | e.g. `8.7` |
-| Camunda app GH release | e.g. `8.7.4` |
-| Publish to Camunda apps GitHub release page | **Ticked** |
-| Publish to Camunda Download Center | **Unticked** (RCs are not published to the Download Center) |
-| Artifact version suffix | `-rc` (include the dash) |
+|                    Input                    |                            Value                            |
+|---------------------------------------------|-------------------------------------------------------------|
+| Run workflow from                           | `Branch: main` (always)                                     |
+| Release branch                              | e.g. `stable/8.7` for 8.7                                   |
+| Camunda minor version                       | e.g. `8.7`                                                  |
+| Camunda app GH release                      | e.g. `8.7.4`                                                |
+| Publish to Camunda apps GitHub release page | **Ticked**                                                  |
+| Publish to Camunda Download Center          | **Unticked** (RCs are not published to the Download Center) |
+| Artifact version suffix                     | `-rc` (include the dash)                                    |
 
 Then:
 
@@ -50,15 +50,15 @@ Then:
 For each version, click **Run workflow** in the
 [C8Run Release GitHub workflow](https://github.com/camunda/camunda/actions/workflows/c8run-release.yaml):
 
-| Input | Value |
-|---|---|
-| Run workflow from | `Branch: main` (always) |
-| Release branch | e.g. `stable/8.8` for 8.8, `main` for latest |
-| Camunda minor version | e.g. `8.6`, `8.7`, `8.8` |
-| Camunda app GH release | e.g. `8.7.1`, `8.8-alpha4.1` |
-| Publish to Camunda apps GitHub release page | **Ticked** |
-| Publish to Camunda Download Center | **Ticked** |
-| Artifact version suffix | *(leave empty)* |
+|                    Input                    |                    Value                     |
+|---------------------------------------------|----------------------------------------------|
+| Run workflow from                           | `Branch: main` (always)                      |
+| Release branch                              | e.g. `stable/8.8` for 8.8, `main` for latest |
+| Camunda minor version                       | e.g. `8.6`, `8.7`, `8.8`                     |
+| Camunda app GH release                      | e.g. `8.7.1`, `8.8-alpha4.1`                 |
+| Publish to Camunda apps GitHub release page | **Ticked**                                   |
+| Publish to Camunda Download Center          | **Ticked**                                   |
+| Artifact version suffix                     | *(leave empty)*                              |
 
 Then:
 

--- a/c8run/docs/runtime-rules.md
+++ b/c8run/docs/runtime-rules.md
@@ -1,0 +1,88 @@
+# Runtime Rules
+
+## Intended Use
+
+C8Run is for local development and testing only. It is not a production deployment mechanism.
+
+## Config Precedence
+
+Always load `configuration/application.yaml` first, then append the user-provided `--config` file or directory last. User config always wins.
+
+## H2 Secondary Storage
+
+H2 is the default secondary storage for C8Run. It is supported for local development convenience only — not for production workloads. The H2 data directory lives inside `camunda-data/` and is cleaned up by `./c8run stop` when the `--remove-data` flag is used.
+
+## Connectors Launcher Compatibility
+
+| Connector bundle version | Launcher |
+|---|---|
+| `8.9.0` and newer (including snapshots) | Spring Boot `PropertiesLauncher` |
+| Older than `8.9.0` | Legacy connector runtime main class |
+
+Do not change this version gate without verifying both launcher paths still work.
+
+## Default Ports
+
+| Endpoint | Default port |
+|---|---|
+| Web / REST | `8080` |
+| Connectors health | `8086` |
+| Camunda metrics | `9600` |
+| Zeebe gRPC | `26500` |
+
+The `--port` flag changes the main web/REST port. If the user did not set `CAMUNDA_CLIENT_ZEEBE_REST_ADDRESS`, Connectors defaults to the selected Camunda port.
+
+**Connectors health port is always `8086`** — it is hardcoded and not affected by `--port`. When `--docker` mode is used, the main port flag is ignored entirely and fixed ports are used; a warning is logged if `--port` was provided.
+
+## Health Check Timeout
+
+Startup health checks use 24 retries with a 14-second delay between attempts (~5.6 minutes total). If Camunda does not become healthy within this window, C8Run reports failure. Connectors health checks are not yet implemented — the check currently returns success immediately without querying port 8086.
+
+## Startup URL and Quickstart Marker
+
+On the first run of C8Run 8.9.0+, the browser opens the Camunda quickstart docs URL instead of Operate. After that first run, a marker file is written to `~/.config/camunda/c8run/.c8run-quickstart-seen` and subsequent runs open Operate directly.
+
+If the user config directory cannot be resolved, the marker is stored in the C8Run base directory instead.
+
+To force the quickstart URL to appear again, delete the marker file.
+
+## Connectors Startup
+
+C8Run starts Connectors from the connector bundle plus `custom_connectors/*`. Connectors runs alongside the main Camunda process and shares the same shutdown lifecycle.
+
+## Logs and PIDs
+
+- `log/camunda.log` — Camunda process output
+- `log/connectors.log` — Connectors process output
+- PID files are written on start and cleaned on stop
+
+## Run and Stop
+
+From a prepared C8Run directory:
+
+```bash
+# Linux/macOS
+./c8run start
+./c8run stop
+
+# Unix convenience wrappers
+./start.sh
+./shutdown.sh
+
+# Windows
+c8run.exe start
+c8run.exe stop
+```
+
+Common start flags:
+
+```bash
+./c8run start --port 9090
+./c8run start --config ./my-config.yaml
+./c8run start --extra-driver ./driver.jar
+./c8run start --log-level debug
+./c8run start --username demo --password demo
+./c8run start --startup-url http://localhost:8080/operate
+```
+
+Use `./c8run help` to print all supported commands and flags. When running in the foreground, `Ctrl+C` initiates graceful shutdown.

--- a/c8run/docs/runtime-rules.md
+++ b/c8run/docs/runtime-rules.md
@@ -10,7 +10,7 @@ Always load `configuration/application.yaml` first, then append the user-provide
 
 ## H2 Secondary Storage
 
-H2 is the default secondary storage for C8Run. It is supported for local development convenience only — not for production workloads. On stop, C8Run automatically deletes the H2 data directory when the active RDBMS URL is in-memory H2 (`jdbc:h2:mem`). File-based H2 and other storage types are not cleaned up. See [Configuration — H2 Data Directory Cleanup](configuration.md#h2-data-directory-cleanup) for the full decision logic.
+H2 is the default secondary storage for C8Run. It is supported for local development convenience only — not for production workloads. The default URL is `jdbc:h2:file:./camunda-data/h2db`, so data persists across stop/start cycles. On stop, C8Run only deletes the H2 data directory when the active RDBMS URL is explicitly an in-memory H2 URL (`jdbc:h2:mem`). File-based H2 (the default) and other storage types are not cleaned up. See [Configuration — H2 Data Directory Cleanup](configuration.md#h2-data-directory-cleanup) for the full decision logic.
 
 ## Connectors Launcher Compatibility
 

--- a/c8run/docs/runtime-rules.md
+++ b/c8run/docs/runtime-rules.md
@@ -10,7 +10,7 @@ Always load `configuration/application.yaml` first, then append the user-provide
 
 ## H2 Secondary Storage
 
-H2 is the default secondary storage for C8Run. It is supported for local development convenience only — not for production workloads. The H2 data directory lives inside `camunda-data/` and is cleaned up by `./c8run stop` when the `--remove-data` flag is used.
+H2 is the default secondary storage for C8Run. It is supported for local development convenience only — not for production workloads. On stop, C8Run automatically deletes the H2 data directory when the active RDBMS URL is in-memory H2 (`jdbc:h2:mem`). File-based H2 and other storage types are not cleaned up. See [Configuration — H2 Data Directory Cleanup](configuration.md#h2-data-directory-cleanup) for the full decision logic.
 
 ## Connectors Launcher Compatibility
 
@@ -32,7 +32,7 @@ Do not change this version gate without verifying both launcher paths still work
 
 The `--port` flag changes the main web/REST port. If the user did not set `CAMUNDA_CLIENT_ZEEBE_REST_ADDRESS`, Connectors defaults to the selected Camunda port.
 
-**Connectors health port is always `8086`** — it is hardcoded and not affected by `--port`. When `--docker` mode is used, the main port flag is ignored entirely and fixed ports are used; a warning is logged if `--port` was provided.
+**Connectors health port is always `8086`** — it is hardcoded and not affected by `--port`.
 
 ## Health Check Timeout
 
@@ -40,11 +40,14 @@ Startup health checks use 24 retries with a 14-second delay between attempts (~5
 
 ## Startup URL and Quickstart Marker
 
-On the first run of C8Run 8.9.0+, the browser opens the Camunda quickstart docs URL instead of Operate. After that first run, a marker file is written to `~/.config/camunda/c8run/.c8run-quickstart-seen` and subsequent runs open Operate directly.
+On the first run of C8Run 8.9.0+, the browser opens the Camunda quickstart docs URL instead of Operate. After that first run, a marker file is written and subsequent runs open Operate directly.
 
-If the user config directory cannot be resolved, the marker is stored in the C8Run base directory instead.
+The marker path is resolved in this order:
+1. `os.UserConfigDir()` — platform-specific (`~/Library/Application Support` on macOS, `%AppData%` on Windows, `~/.config` on Linux)
+2. `~/.config/camunda/c8run/` — home-dir fallback if `UserConfigDir` fails
+3. C8Run base directory — last resort if home dir is also unavailable
 
-To force the quickstart URL to appear again, delete the marker file.
+To force the quickstart URL to appear again, delete the marker file from whichever location was resolved.
 
 ## Connectors Startup
 

--- a/c8run/docs/runtime-rules.md
+++ b/c8run/docs/runtime-rules.md
@@ -14,21 +14,21 @@ H2 is the default secondary storage for C8Run. It is supported for local develop
 
 ## Connectors Launcher Compatibility
 
-| Connector bundle version | Launcher |
-|---|---|
-| `8.9.0` and newer (including snapshots) | Spring Boot `PropertiesLauncher` |
-| Older than `8.9.0` | Legacy connector runtime main class |
+|        Connector bundle version         |              Launcher               |
+|-----------------------------------------|-------------------------------------|
+| `8.9.0` and newer (including snapshots) | Spring Boot `PropertiesLauncher`    |
+| Older than `8.9.0`                      | Legacy connector runtime main class |
 
 Do not change this version gate without verifying both launcher paths still work.
 
 ## Default Ports
 
-| Endpoint | Default port |
-|---|---|
-| Web / REST | `8080` |
-| Connectors health | `8086` |
-| Camunda metrics | `9600` |
-| Zeebe gRPC | `26500` |
+|     Endpoint      | Default port |
+|-------------------|--------------|
+| Web / REST        | `8080`       |
+| Connectors health | `8086`       |
+| Camunda metrics   | `9600`       |
+| Zeebe gRPC        | `26500`      |
 
 The `--port` flag changes the main web/REST port. If the user did not set `CAMUNDA_CLIENT_ZEEBE_REST_ADDRESS`, Connectors defaults to the selected Camunda port.
 

--- a/c8run/docs/testing-guide.md
+++ b/c8run/docs/testing-guide.md
@@ -1,0 +1,36 @@
+# Testing Guide
+
+## General Principles
+
+- Test observable behavior, not implementation details.
+- Keep tests small and focused on the package under test.
+
+## Platform Coverage
+
+Changes under `internal/unix/` or `internal/windows/` should include matching tests, or include an explicit comment explaining why only one platform is affected. Shared behavior should be tested at the shared package level above those directories.
+
+## Process Lifecycle
+
+For process lifecycle changes, cover:
+
+- PID file creation and cleanup
+- `.lock` file creation and cleanup
+- Stale process detection and handling
+- Foreground shutdown (Ctrl+C / signal handling)
+- `./c8run stop` flow
+- Windows child process tracking where applicable
+
+## Startup and Connectors
+
+For startup changes, cover both Camunda and Connectors when behavior is shared or coordinated. Verify health check behavior and the startup URL opening flow.
+
+## Packaging
+
+For packaging changes:
+
+- Verify the archive file list — the expected set of files must be present
+- Verify that runtime artifacts (PID files, `log/`, `camunda-data/`, `jre/`, extracted dirs, built binaries) are not included in the archive
+
+## E2E Tests
+
+API and Playwright-based E2E tests live in `e2e_tests/`. These are run by C8Run CI. Run locally only against a fully started C8Run instance.

--- a/c8run/docs/testing-guide.md
+++ b/c8run/docs/testing-guide.md
@@ -34,3 +34,71 @@ For packaging changes:
 ## E2E Tests
 
 API and Playwright-based E2E tests live in `e2e_tests/`. These are run by C8Run CI. Run locally only against a fully started C8Run instance.
+
+### Repositories
+
+| Repo | Role |
+|---|---|
+| `camunda/camunda` | In-repo smoke tests (`c8run/e2e_tests/`) + PR dispatch trigger |
+| `camunda/c8-cross-component-e2e-tests` | Full QA E2E suite (Playwright + TestRail) |
+
+### Layer 1 — In-repo smoke tests (`camunda/camunda`)
+
+**Workflow:** `.github/workflows/c8run-build.yaml`
+**Triggers:** PRs touching `c8run/**` and nightly at 23:30 UTC
+
+What runs:
+- Playwright tests (`c8run/e2e_tests/`) on Linux, macOS ARM, macOS Intel
+- `api_tests.sh` — v2 API smoke (process instances, user tasks, Zeebe topology)
+- Windows: same tests via `c8run.exe start --config e2e_tests/prefix-config.yaml`
+
+**RDBMS setup:** c8run starts with `--config e2e_tests/prefix-config.yaml`, which configures H2 file-based as the secondary storage. This is the only layer that passes an explicit config file.
+
+```yaml
+camunda:
+  data:
+    secondary-storage:
+      type: rdbms
+      rdbms:
+        url: jdbc:h2:file:./camunda-data/h2db
+        username: sa
+        password:
+        flushInterval: PT0.5S
+        queueSize: 1000
+```
+
+Linux/macOS use the `.github/actions/setup-c8run` composite action to build and start c8run. Windows builds `c8run.exe` from source and starts it inline.
+
+### Layer 2 — QA E2E suite (`camunda/c8-cross-component-e2e-tests`)
+
+**PR trigger:** When a PR in `camunda/camunda` touches `c8run/**`, `.github/workflows/trigger-c8run-e2e-tests.yml` dispatches a `run-c8run-tests` event to the QA repo, which runs `playwright_c8Run_tests_pr_trigger_linux.yml` against `stable/8.9` (Linux, RDBMS/H2 default).
+
+**Nightly runs:**
+
+| Workflow | OS | Schedule (UTC) | Versions | DB |
+|---|---|---|---|---|
+| `playwright_c8Run_nightly_tests_linux.yml` | Linux | 00:00 | 8.7, 8.8, 8.9, 8.10 | H2 (8.9+), ES (8.8 and older) |
+| `playwright_c8Run_nightly_tests_mac.yml` | macOS | 01:00 | 8.10 | H2 |
+| `playwright_c8Run_nightly_tests_windows.yml` | Windows | 02:00 | 8.10 | H2 |
+| `playwright_c8Run_nightly_tests_docker_linux.yml` | Linux (Docker Compose) | 01:00 | 8.7, 8.8, 8.9 | H2 (8.9), ES (older) |
+
+No config file is passed — H2 is the c8run default for 8.9+. The matrix sets `database: RDBMS` as an env var used for test filtering and TestRail reporting, not for DB configuration.
+
+**Release / on-demand runs:**
+
+| Workflow | Trigger | OS |
+|---|---|---|
+| `playwright_c8Run_release_test.yml` | `workflow_dispatch` (release validation) | Linux + macOS + Windows |
+| `playwright_c8Run_tests_manual_linux/mac/windows.yml` | `workflow_dispatch` | Respective OS |
+
+The release workflow publishes results to TestRail. Each action accepts `database`, `tasklist_version`, and `version` inputs.
+
+### RDBMS configuration summary
+
+| Layer | DB | How configured |
+|---|---|---|
+| In-repo smoke | H2 file-based | `--config e2e_tests/prefix-config.yaml` |
+| QA nightly / PR trigger (8.9+) | H2 default | No config file |
+| QA release / on-demand | H2 default | No config file |
+
+No external database (Postgres, MariaDB, etc.) is provisioned in any c8run E2E CI workflow. All RDBMS coverage is H2-only. External RDBMS testing (e.g. Postgres) is tracked but not yet wired into regular CI.

--- a/c8run/docs/testing-guide.md
+++ b/c8run/docs/testing-guide.md
@@ -37,10 +37,10 @@ API and Playwright-based E2E tests live in `e2e_tests/`. These are run by C8Run 
 
 ### Repositories
 
-| Repo | Role |
-|---|---|
-| `camunda/camunda` | In-repo smoke tests (`c8run/e2e_tests/`) + PR dispatch trigger |
-| `camunda/c8-cross-component-e2e-tests` | Full QA E2E suite (Playwright + TestRail) |
+|                  Repo                  |                              Role                              |
+|----------------------------------------|----------------------------------------------------------------|
+| `camunda/camunda`                      | In-repo smoke tests (`c8run/e2e_tests/`) + PR dispatch trigger |
+| `camunda/c8-cross-component-e2e-tests` | Full QA E2E suite (Playwright + TestRail)                      |
 
 ### Layer 1 — In-repo smoke tests (`camunda/camunda`)
 
@@ -75,30 +75,30 @@ Linux/macOS use the `.github/actions/setup-c8run` composite action to build and 
 
 **Nightly runs:**
 
-| Workflow | OS | Schedule (UTC) | Versions | DB |
-|---|---|---|---|---|
-| `playwright_c8Run_nightly_tests_linux.yml` | Linux | 00:00 | 8.7, 8.8, 8.9, 8.10 | H2 (8.9+), ES (8.8 and older) |
-| `playwright_c8Run_nightly_tests_mac.yml` | macOS | 01:00 | 8.10 | H2 |
-| `playwright_c8Run_nightly_tests_windows.yml` | Windows | 02:00 | 8.10 | H2 |
-| `playwright_c8Run_nightly_tests_docker_linux.yml` | Linux (Docker Compose) | 01:00 | 8.7, 8.8, 8.9 | H2 (8.9), ES (older) |
+|                     Workflow                      |           OS           | Schedule (UTC) |      Versions       |              DB               |
+|---------------------------------------------------|------------------------|----------------|---------------------|-------------------------------|
+| `playwright_c8Run_nightly_tests_linux.yml`        | Linux                  | 00:00          | 8.7, 8.8, 8.9, 8.10 | H2 (8.9+), ES (8.8 and older) |
+| `playwright_c8Run_nightly_tests_mac.yml`          | macOS                  | 01:00          | 8.10                | H2                            |
+| `playwright_c8Run_nightly_tests_windows.yml`      | Windows                | 02:00          | 8.10                | H2                            |
+| `playwright_c8Run_nightly_tests_docker_linux.yml` | Linux (Docker Compose) | 01:00          | 8.7, 8.8, 8.9       | H2 (8.9), ES (older)          |
 
 No config file is passed — H2 is the c8run default for 8.9+. The matrix sets `database: RDBMS` as an env var used for test filtering and TestRail reporting, not for DB configuration.
 
 **Release / on-demand runs:**
 
-| Workflow | Trigger | OS |
-|---|---|---|
-| `playwright_c8Run_release_test.yml` | `workflow_dispatch` (release validation) | Linux + macOS + Windows |
-| `playwright_c8Run_tests_manual_linux/mac/windows.yml` | `workflow_dispatch` | Respective OS |
+|                       Workflow                        |                 Trigger                  |           OS            |
+|-------------------------------------------------------|------------------------------------------|-------------------------|
+| `playwright_c8Run_release_test.yml`                   | `workflow_dispatch` (release validation) | Linux + macOS + Windows |
+| `playwright_c8Run_tests_manual_linux/mac/windows.yml` | `workflow_dispatch`                      | Respective OS           |
 
 The release workflow publishes results to TestRail. Each action accepts `database`, `tasklist_version`, and `version` inputs.
 
 ### RDBMS configuration summary
 
-| Layer | DB | How configured |
-|---|---|---|
-| In-repo smoke | H2 file-based | `--config e2e_tests/prefix-config.yaml` |
-| QA nightly / PR trigger (8.9+) | H2 default | No config file |
-| QA release / on-demand | H2 default | No config file |
+|             Layer              |      DB       |             How configured              |
+|--------------------------------|---------------|-----------------------------------------|
+| In-repo smoke                  | H2 file-based | `--config e2e_tests/prefix-config.yaml` |
+| QA nightly / PR trigger (8.9+) | H2 default    | No config file                          |
+| QA release / on-demand         | H2 default    | No config file                          |
 
 No external database (Postgres, MariaDB, etc.) is provisioned in any c8run E2E CI workflow. All RDBMS coverage is H2-only. External RDBMS testing (e.g. Postgres) is tracked but not yet wired into regular CI.

--- a/c8run/docs/versions.md
+++ b/c8run/docs/versions.md
@@ -1,0 +1,95 @@
+# Version Branches
+
+## Branch Layout
+
+Each minor version lives on its own stable branch. The latest unreleased minor version develops on
+`main` until its first stable release, at which point a new `stable/x.y` branch is cut and `main`
+moves on to the next minor.
+
+| Branch | Version | Status |
+|---|---|---|
+| `stable/8.7` | 8.7.x | Maintenance |
+| `stable/8.8` | 8.8.x | Maintenance |
+| `stable/8.9` | 8.9.x | Maintenance |
+| `main` | 8.10.x (alpha) → 8.11 once `stable/8.10` is cut | Active development |
+
+> [!IMPORTANT]
+> Breaking changes must never be backported to stable branches.
+> Bug fixes and security patches may be backported; new features and architectural changes must not.
+
+---
+
+## Feature Matrix
+
+| Feature | 8.7 | 8.8 | 8.9 | main (8.10+) |
+|---|---|---|---|---|
+| Supported JDK range | 21–23 | 21–23 | 21–25 | 21–25 |
+| Elasticsearch bundled | ✓ v8.13.4 | ✓ v8.17.3 | ✗ | ✗ |
+| `--disable-elasticsearch` flag | ✓ | ✓ | ✗ | ✗ |
+| Docker Compose bundled (`--docker` flag) | ✓ | ✓ | ✓ | ✗ |
+| RDBMS secondary storage | ✗ | ✗ | ✓ | ✓ |
+| H2 as default secondary storage | ✗ | ✗ | ✓ | ✓ |
+| `--extra-driver` flag | ✗ | ✗ | ✓ | ✓ |
+
+---
+
+## Per-Version Notes
+
+### 8.7 (`stable/8.7`)
+
+**Supported JDK:** OpenJDK 21–23. JDK 24+ is not supported on this branch.
+
+C8Run bundles Camunda, Elasticsearch, and Connectors into a single archive.
+
+- Elasticsearch (v8.13.4) is started and managed as a child process.
+- `--disable-elasticsearch` skips the bundled Elasticsearch so an external instance can be used.
+- `--docker` starts the stack via the bundled Docker Compose files instead of the native process
+  manager.
+- No secondary storage abstraction — Elasticsearch is the only supported backend.
+
+### 8.8 (`stable/8.8`)
+
+**Supported JDK:** OpenJDK 21–23. JDK 24+ is not supported on this branch.
+
+Elasticsearch (v8.17.3) is still bundled. `--disable-elasticsearch` is removed — the bundled
+Elasticsearch is always started.
+
+- `--username`, `--password`, and `--startup-url` flags added.
+- `--docker` flag retained.
+- No RDBMS support.
+
+### 8.9 (`stable/8.9`)
+
+**Supported JDK:** OpenJDK 21–25.
+
+Major architectural shift: Elasticsearch is no longer bundled. H2 becomes the default secondary
+storage, and RDBMS support is introduced.
+
+- H2 runs file-based by default (`jdbc:h2:file:./camunda-data/h2db`) — data persists across
+  restarts.
+- `--extra-driver` flag added (repeatable) to supply custom JDBC driver JARs for external RDBMS.
+- `--docker` flag is still present (Docker Compose variant ships alongside the Java-only archive).
+- `--disable-elasticsearch` removed entirely.
+- Go minimum bumped to 1.24.
+
+### main (8.10 alpha / future 8.11)
+
+**Supported JDK:** OpenJDK 21–25.
+
+Docker Compose is fully decoupled — c8run is now a Java-only distribution. The Docker Compose
+variant is published separately.
+
+- `--docker` flag removed.
+- RDBMS support and H2 defaults retained from 8.9.
+- Go minimum is 1.25.
+
+---
+
+## Backport Policy
+
+- **Never backport:** breaking API or flag changes, architectural changes, new dependencies.
+- **May backport:** bug fixes, security patches, documentation corrections.
+
+When fixing a bug that affects multiple versions, open separate PRs targeting each stable branch
+rather than merging to `main` and cherry-picking — this avoids accidentally pulling in unrelated
+`main` changes.

--- a/c8run/docs/versions.md
+++ b/c8run/docs/versions.md
@@ -6,12 +6,12 @@ Each minor version lives on its own stable branch. The latest unreleased minor v
 `main` until its first stable release, at which point a new `stable/x.y` branch is cut and `main`
 moves on to the next minor.
 
-| Branch | Version | Status |
-|---|---|---|
-| `stable/8.7` | 8.7.x | Maintenance |
-| `stable/8.8` | 8.8.x | Maintenance |
-| `stable/8.9` | 8.9.x | Maintenance |
-| `main` | 8.10.x (alpha) → 8.11 once `stable/8.10` is cut | Active development |
+|    Branch    |                     Version                     |       Status       |
+|--------------|-------------------------------------------------|--------------------|
+| `stable/8.7` | 8.7.x                                           | Maintenance        |
+| `stable/8.8` | 8.8.x                                           | Maintenance        |
+| `stable/8.9` | 8.9.x                                           | Maintenance        |
+| `main`       | 8.10.x (alpha) → 8.11 once `stable/8.10` is cut | Active development |
 
 > [!IMPORTANT]
 > Breaking changes must never be backported to stable branches.
@@ -21,15 +21,15 @@ moves on to the next minor.
 
 ## Feature Matrix
 
-| Feature | 8.7 | 8.8 | 8.9 | main (8.10+) |
-|---|---|---|---|---|
-| Supported JDK range | 21–23 | 21–23 | 21–25 | 21–25 |
-| Elasticsearch bundled | ✓ v8.13.4 | ✓ v8.17.3 | ✗ | ✗ |
-| `--disable-elasticsearch` flag | ✓ | ✓ | ✗ | ✗ |
-| Docker Compose bundled (`--docker` flag) | ✓ | ✓ | ✓ | ✗ |
-| RDBMS secondary storage | ✗ | ✗ | ✓ | ✓ |
-| H2 as default secondary storage | ✗ | ✗ | ✓ | ✓ |
-| `--extra-driver` flag | ✗ | ✗ | ✓ | ✓ |
+|                 Feature                  |    8.7    |    8.8    |  8.9  | main (8.10+) |
+|------------------------------------------|-----------|-----------|-------|--------------|
+| Supported JDK range                      | 21–23     | 21–23     | 21–25 | 21–25        |
+| Elasticsearch bundled                    | ✓ v8.13.4 | ✓ v8.17.3 | ✗     | ✗            |
+| `--disable-elasticsearch` flag           | ✓         | ✓         | ✗     | ✗            |
+| Docker Compose bundled (`--docker` flag) | ✓         | ✓         | ✓     | ✗            |
+| RDBMS secondary storage                  | ✗         | ✗         | ✓     | ✓            |
+| H2 as default secondary storage          | ✗         | ✗         | ✓     | ✓            |
+| `--extra-driver` flag                    | ✗         | ✗         | ✓     | ✓            |
 
 ---
 


### PR DESCRIPTION
Supersedes and closes #52120 and https://github.com/camunda/camunda/issues/52119

Restructures the AGENTS.md proposed in #52120 to align with the pattern used in `camunda-platform-helm`:

- **`c8run/CLAUDE.md`** — thin redirect (`@AGENTS.md` include), same pattern as helm repo
- **`c8run/AGENTS.md`** — restructured: Critical Rules upfront, separate Build/Lint/Test/Toolchain sections, Code Style with sub-sections, Recommended Agent Workflow at the end; detailed content linked out to `docs/`
- **`c8run/docs/`** — seven reference files so AGENTS.md stays concise:
  - `package-layout.md` — key package areas, runtime artifacts, packaging
  - `runtime-rules.md` — config precedence, H2, Connectors compatibility, ports, health check timeout, quickstart marker
  - `testing-guide.md` — platform coverage, process lifecycle, packaging, E2E
  - `local-development.md` — prerequisites (JDK version per c8run version), quick start, testing code changes against a local Camunda build
  - `process-lifecycle.md` — PID locking semantics, 4-state restart machine, signal handling, detached mode stub
  - `configuration.md` — JAVA_HOME fallback chain, config directory handling, H2 cleanup decision tree, RDBMS driver detection
  - `platform-differences.md` — Unix vs Windows: process groups, kill implementation, classpath separators, archive formats, test tags