### PR TITLE
fix: disable web-modeler in Helm chart integration test

### DIFF
--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -318,6 +318,8 @@ jobs:
             pullSecrets:
               - name: index-docker-io
               - name: registry-camunda-cloud
+        webModeler:
+          enabled: false
       vault-secret-mapping: |
         secret/data/products/zeebe/ci/zeebe REGISTRY_HUB_DOCKER_COM_USR | TEST_DOCKER_USERNAME;
         secret/data/products/zeebe/ci/zeebe REGISTRY_HUB_DOCKER_COM_PSW | TEST_DOCKER_PASSWORD;


### PR DESCRIPTION
## Description

The `camunda-platform-8.10` Helm chart enables web-modeler by default, but the `docker-build-helm-integration` workflow only overrides the `orchestration` image tag in `extra-values`. This leaves the web-modeler image tag empty, causing `InvalidImageName` on the `web-modeler-restapi` and `web-modeler-websockets` pods.

Web-modeler is a separate product with its own release pipeline — there is no snapshot image tag published from this repo that could be used here. The workflow tests that the unified orchestration image deploys correctly via Helm; web-modeler is not the subject of the test.

Fix: disable web-modeler in the `extra-values` override.

Regression introduced by d3b09e5e3 (fix: update default camunda-helm-dir to camunda-platform-8.10).

## Checklist

- [ ] Enable backports when necessary

## Related issues

<!-- No issue — fixes a CI regression -->