### PR TITLE
fix(load-test): specifically configure the Elasticsearch hostname

### DIFF
--- a/load-tests/camunda-platform-values.yaml
+++ b/load-tests/camunda-platform-values.yaml
@@ -22,6 +22,12 @@ global:
   # THIS GETS OVERRIDDEN IN THE OTHER VALUES FILES, e.g. for OpenSearch and RDBMS
   elasticsearch:
     enabled: true
+    url:
+      # The Elasticsearch host value used to connect to Elasticsearch depends
+      # on the "elasticsearch.fullnameOverride" value.
+      # If you change the "elasticsearch.fullnameOverride" value, make sure to
+      # update this host value accordingly.
+      host: elastic
   # Disable global ingress
   ingress:
     enabled: false
@@ -338,7 +344,12 @@ prometheusServiceMonitor:
 ########################################################################################
 elasticsearch:
   enabled: true
-  clusterName: "elasticsearch"
+  # Override the default name for ConfigMap, Service, etc.
+  # Changing this value also changes the name of the Kubernetes Service used by
+  # the other components to connect to Elasticsearch, make sure to update
+  # the "global.elasticsearch.url.host" value accordingly.
+  fullnameOverride: elastic
+  clusterName: elasticsearch
   master:
     fullnameOverride: elastic
     nameOverride: elastic

--- a/load-tests/prometheus-elasticsearch-exporter-values.yaml
+++ b/load-tests/prometheus-elasticsearch-exporter-values.yaml
@@ -1,5 +1,8 @@
 fullnameOverride: "prom-els-exporter"
 
+es:
+  uri: http://elastic:9200
+
 commonLabels:
   camunda.io/created-by: __AUTHOR__
   camunda.io/purpose: load-test

--- a/load-tests/setup/default/Makefile
+++ b/load-tests/setup/default/Makefile
@@ -135,8 +135,7 @@ ifeq ($(secondary_storage),elasticsearch)
     --namespace $(namespace) \
     --version $(prometheus_elasticsearch_exporter_chart_version) \
     --wait --timeout 5m0s \
-    -f prometheus-elasticsearch-exporter-values.yaml \
-    --set es.uri="http://$(namespace)-elasticsearch:9200"
+    -f prometheus-elasticsearch-exporter-values.yaml
 else
 	@echo "Skipping Elasticsearch Prometheus Exporter installation (secondary_storage=$(secondary_storage))"
 endif


### PR DESCRIPTION
## Description

It is currently assumed from the name of the namespace, which require the "logic" to be reproduced in different places.

Instead, we just enforce a static Service name to "elastic" ; it's also similar to all the other Kubernetes Services we are deploying.

After this change, we will have a spurious `ConfigMap` named after the old name ; I think this is acceptable.

This changes a default deployment like this:

```diff
diff --git a/charts/elasticsearch/templates/configmap.yaml b/charts/elasticsearch/templates/configmap.yaml
index 8656135..75e4d28 100644
--- a/charts/elasticsearch/templates/configmap.yaml
+++ b/charts/elasticsearch/templates/configmap.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: c8-jb-es-uri-elasticsearch
+  name: elastic
   namespace: "default"
   labels:
     app.kubernetes.io/instance: c8-jb-es-uri
diff --git a/charts/elasticsearch/templates/master/statefulset.yaml b/charts/elasticsearch/templates/master/statefulset.yaml
index 550ae4a..0988138 100644
--- a/charts/elasticsearch/templates/master/statefulset.yaml
+++ b/charts/elasticsearch/templates/master/statefulset.yaml
@@ -248,7 +248,7 @@ spec:
           emptyDir: {}
         - name: config
           configMap:
-            name: c8-jb-es-uri-elasticsearch
+            name: elastic
   volumeClaimTemplates:
     - apiVersion: v1
       kind: PersistentVolumeClaim
diff --git a/charts/elasticsearch/templates/service.yaml b/charts/elasticsearch/templates/service.yaml
index 50a3625..0e9a513 100644
--- a/charts/elasticsearch/templates/service.yaml
+++ b/charts/elasticsearch/templates/service.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: c8-jb-es-uri-elasticsearch
+  name: elastic
   namespace: "default"
   labels:
     app.kubernetes.io/instance: c8-jb-es-uri
diff --git a/templates/optimize/configmap.yaml b/templates/optimize/configmap.yaml
index 8d995c1..8c1dc9c 100644
--- a/templates/optimize/configmap.yaml
+++ b/templates/optimize/configmap.yaml
@@ -24,7 +24,7 @@ data:
     es:
       connection:
         nodes:
-          - host: "c8-jb-es-uri-elasticsearch"
+          - host: "elastic"
             httpPort: 9200
     spring:
       servlet:
diff --git a/templates/optimize/deployment.yaml b/templates/optimize/deployment.yaml
index d114840..ce5f2ca 100644
--- a/templates/optimize/deployment.yaml
+++ b/templates/optimize/deployment.yaml
@@ -43,7 +43,7 @@ spec:
         app.kubernetes.io/component: optimize
         app.kubernetes.io/version: "8.9.0"
       annotations:
-        checksum/config: 2855a9af596848681034c32e3978c8c98ca0b37a7fe0f81eef14cebefcd19b4c
+        checksum/config: 32dc48fb886a9fb041358ad05179a60b6c8da43ba14d8bc7877e0bf181b17826
     spec:
       imagePullSecrets:
         - name: harbor-registry
@@ -62,7 +62,7 @@ spec:
           env:
             
             - name: OPTIMIZE_ELASTICSEARCH_HOST
-              value: "c8-jb-es-uri-elasticsearch"
+              value: "elastic"
             - name: OPTIMIZE_ELASTICSEARCH_HTTP_PORT
               value: "9200"
             - name: OPTIMIZE_LOG_APPENDER
@@ -103,7 +103,7 @@ spec:
           env:
             
             - name: OPTIMIZE_ELASTICSEARCH_HOST
-              value: "c8-jb-es-uri-elasticsearch"
+              value: "elastic"
             - name: OPTIMIZE_ELASTICSEARCH_HTTP_PORT
               value: "9200"
             - name: SPRING_PROFILES_ACTIVE
diff --git a/templates/orchestration/configmap.yaml b/templates/orchestration/configmap.yaml
index 34e47bd..85d3e12 100644
--- a/templates/orchestration/configmap.yaml
+++ b/templates/orchestration/configmap.yaml
@@ -108,7 +108,7 @@ data:
             minimum-age: "1d"
           elasticsearch:
             aws-enabled: false
-            url: "http://c8-jb-es-uri-elasticsearch:9200"
+            url: "http://elastic:9200"
             cluster-name: "elasticsearch"
             username: ""
             password: "${VALUES_ELASTICSEARCH_PASSWORD:}"
@@ -245,7 +245,7 @@ data:
           elasticsearch:
             className: "io.camunda.zeebe.exporter.ElasticsearchExporter"
             args:
-              url: "http://c8-jb-es-uri-elasticsearch:9200"
+              url: "http://elastic:9200"
               index:
                 prefix: "zeebe-record"
               retention:
diff --git a/templates/orchestration/statefulset.yaml b/templates/orchestration/statefulset.yaml
index 9ffe3c1..2675de6 100644
--- a/templates/orchestration/statefulset.yaml
+++ b/templates/orchestration/statefulset.yaml
@@ -44,7 +44,7 @@ spec:
         app.kubernetes.io/component: zeebe-broker
         app.kubernetes.io/version: "SNAPSHOT"
       annotations:
-        checksum/config: 369f25f51e03abb18ffa2adf035f8f7eb9d435b2909f17b73e80e17ab471bf3b
+        checksum/config: 0b7d2d17b4767d11d07fa78a9be2dbbd235c48b02b9dde540a221a043ad9c98a
     spec:
       imagePullSecrets:
         - name: harbor-registry
```

I also did something similar for a deployment using PostgreSQL and it produces a similar diff, here with PostgreSQL with a secondary storage:

```diff
diff --git a/charts/elasticsearch/templates/configmap.yaml b/charts/elasticsearch/templates/configmap.yaml
index db2a0d0..c94485d 100644
--- a/charts/elasticsearch/templates/configmap.yaml
+++ b/charts/elasticsearch/templates/configmap.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: c8-jb-test-es-pg-elasticsearch
+  name: elastic
   namespace: "default"
   labels:
     app.kubernetes.io/instance: c8-jb-test-es-pg
diff --git a/charts/elasticsearch/templates/master/statefulset.yaml b/charts/elasticsearch/templates/master/statefulset.yaml
index 19acf4f..8505af3 100644
--- a/charts/elasticsearch/templates/master/statefulset.yaml
+++ b/charts/elasticsearch/templates/master/statefulset.yaml
@@ -248,7 +248,7 @@ spec:
           emptyDir: {}
         - name: config
           configMap:
-            name: c8-jb-test-es-pg-elasticsearch
+            name: elastic
   volumeClaimTemplates:
     - apiVersion: v1
       kind: PersistentVolumeClaim
diff --git a/charts/elasticsearch/templates/service.yaml b/charts/elasticsearch/templates/service.yaml
index 118795d..f44f071 100644
--- a/charts/elasticsearch/templates/service.yaml
+++ b/charts/elasticsearch/templates/service.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: c8-jb-test-es-pg-elasticsearch
+  name: elastic
   namespace: "default"
   labels:
     app.kubernetes.io/instance: c8-jb-test-es-pg
diff --git a/templates/optimize/configmap.yaml b/templates/optimize/configmap.yaml
index 0870892..ce9cb52 100644
--- a/templates/optimize/configmap.yaml
+++ b/templates/optimize/configmap.yaml
@@ -24,7 +24,7 @@ data:
     es:
       connection:
         nodes:
-          - host: "c8-jb-test-es-pg-elasticsearch"
+          - host: "elastic"
             httpPort: 9200
     spring:
       servlet:
diff --git a/templates/optimize/deployment.yaml b/templates/optimize/deployment.yaml
index 612ddac..b95970c 100644
--- a/templates/optimize/deployment.yaml
+++ b/templates/optimize/deployment.yaml
@@ -43,7 +43,7 @@ spec:
         app.kubernetes.io/component: optimize
         app.kubernetes.io/version: "8.9.0"
       annotations:
-        checksum/config: cd3b08ba77d64000eaddd8d73b076c5aa34c3e533b873d01222c7c8adafd3d82
+        checksum/config: 16216c600909b86d7ef2f16ab5ec2ca3a4beeb543f6cdcc8f66f226a618e4b4f
     spec:
       imagePullSecrets:
         - name: harbor-registry
@@ -62,7 +62,7 @@ spec:
           env:
             
             - name: OPTIMIZE_ELASTICSEARCH_HOST
-              value: "c8-jb-test-es-pg-elasticsearch"
+              value: "elastic"
             - name: OPTIMIZE_ELASTICSEARCH_HTTP_PORT
               value: "9200"
             - name: OPTIMIZE_LOG_APPENDER
@@ -103,7 +103,7 @@ spec:
           env:
             
             - name: OPTIMIZE_ELASTICSEARCH_HOST
-              value: "c8-jb-test-es-pg-elasticsearch"
+              value: "elastic"
             - name: OPTIMIZE_ELASTICSEARCH_HTTP_PORT
               value: "9200"
             - name: SPRING_PROFILES_ACTIVE
diff --git a/templates/orchestration/configmap.yaml b/templates/orchestration/configmap.yaml
index 271a642..4042c39 100644
--- a/templates/orchestration/configmap.yaml
+++ b/templates/orchestration/configmap.yaml
@@ -111,7 +111,7 @@ data:
             minimum-age: "1d"
           elasticsearch:
             aws-enabled: false
-            url: "http://c8-jb-test-es-pg-elasticsearch:9200"
+            url: "http://elastic:9200"
             cluster-name: "elasticsearch"
             username: ""
             password: "${VALUES_ELASTICSEARCH_PASSWORD:}"
@@ -253,7 +253,7 @@ data:
           elasticsearch:
             className: "io.camunda.zeebe.exporter.ElasticsearchExporter"
             args:
-              url: "http://c8-jb-test-es-pg-elasticsearch:9200"
+              url: "http://elastic:9200"
               index:
                 prefix: "zeebe-record"
               retention:
diff --git a/templates/orchestration/statefulset.yaml b/templates/orchestration/statefulset.yaml
index 99ff0f8..19fd4ee 100644
--- a/templates/orchestration/statefulset.yaml
+++ b/templates/orchestration/statefulset.yaml
@@ -44,7 +44,7 @@ spec:
         app.kubernetes.io/component: zeebe-broker
         app.kubernetes.io/version: "SNAPSHOT"
       annotations:
-        checksum/config: 3470b6d98389d1350e503ec55224a280c0551375c5a822a00e7f4011d7638c70
+        checksum/config: 452e9be7264a039767d9503bf4712c10cd840d99aaf59fc72a38702b265eaddd
     spec:
       imagePullSecrets:
         - name: harbor-registry
```


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
