### PR TITLE
feat(cpt): add input-variable-aware completeJob and completeUserTask

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestContext.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestContext.java
@@ -184,6 +184,33 @@ public interface CamundaProcessTestContext {
   void completeJobWithExampleData(final JobSelector jobSelector);
 
   /**
+   * Completes a job of the specified type. The given mapper receives the job's input variables
+   * (visible at the process-instance and element-local scopes, with local values shadowing global
+   * ones) and returns the output variables used to complete the job.
+   *
+   * @param jobType the type of the job to complete, matching the {@code zeebeJobType} in the BPMN
+   *     model
+   * @param variableMapper a function mapping input variables to output variables; must not be
+   *     {@code null} and must not return {@code null}
+   */
+  void completeJob(
+      final String jobType,
+      final Function<Map<String, Object>, Map<String, Object>> variableMapper);
+
+  /**
+   * Completes a job matching the specified selector. The given mapper receives the job's input
+   * variables (visible at the process-instance and element-local scopes, with local values
+   * shadowing global ones) and returns the output variables used to complete the job.
+   *
+   * @param jobSelector the selector to identify the job to complete
+   * @param variableMapper a function mapping input variables to output variables; must not be
+   *     {@code null} and must not return {@code null}
+   */
+  void completeJob(
+      final JobSelector jobSelector,
+      final Function<Map<String, Object>, Map<String, Object>> variableMapper);
+
+  /**
    * Throws a BPMN error from a job of the specified type.
    *
    * @param jobType the type of the job to throw the error from, matching the `zeebeJobType` in the
@@ -301,6 +328,32 @@ public interface CamundaProcessTestContext {
    * @param userTaskSelector the selector to identify the user task to complete
    */
   void completeUserTaskWithExampleData(final UserTaskSelector userTaskSelector);
+
+  /**
+   * Completes the user task with the given BPMN element ID. The given mapper receives the user
+   * task's input variables (visible at the process-instance and element-local scopes, with local
+   * values shadowing global ones) and returns the output variables used to complete the user task.
+   *
+   * @param elementId the BPMN element ID of the user task to complete
+   * @param variableMapper a function mapping input variables to output variables; must not be
+   *     {@code null} and must not return {@code null}
+   */
+  void completeUserTask(
+      final String elementId,
+      final Function<Map<String, Object>, Map<String, Object>> variableMapper);
+
+  /**
+   * Completes the user task matching the specified selector. The given mapper receives the user
+   * task's input variables (visible at the process-instance and element-local scopes, with local
+   * values shadowing global ones) and returns the output variables used to complete the user task.
+   *
+   * @param userTaskSelector the selector to identify the user task to complete
+   * @param variableMapper a function mapping input variables to output variables; must not be
+   *     {@code null} and must not return {@code null}
+   */
+  void completeUserTask(
+      final UserTaskSelector userTaskSelector,
+      final Function<Map<String, Object>, Map<String, Object>> variableMapper);
 
   /**
    * Mocks a DMN decision with the specified decision ID and sets the provided variables.

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestContext.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestContext.java
@@ -33,6 +33,7 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 /** The injected context for a process test. */
 public interface CamundaProcessTestContext {
@@ -184,31 +185,26 @@ public interface CamundaProcessTestContext {
   void completeJobWithExampleData(final JobSelector jobSelector);
 
   /**
-   * Completes a job of the specified type. The given mapper receives the job's input variables
-   * (visible at the process-instance and element-local scopes, with local values shadowing global
-   * ones) and returns the output variables used to complete the job.
+   * Completes a job of the specified type. The given mapper receives the job's input variables and
+   * returns the output variables used to complete the job.
    *
    * @param jobType the type of the job to complete, matching the {@code zeebeJobType} in the BPMN
    *     model
    * @param variableMapper a function mapping input variables to output variables; must not be
    *     {@code null} and must not return {@code null}
    */
-  void completeJob(
-      final String jobType,
-      final Function<Map<String, Object>, Map<String, Object>> variableMapper);
+  void completeJob(final String jobType, final UnaryOperator<Map<String, Object>> variableMapper);
 
   /**
    * Completes a job matching the specified selector. The given mapper receives the job's input
-   * variables (visible at the process-instance and element-local scopes, with local values
-   * shadowing global ones) and returns the output variables used to complete the job.
+   * variables and returns the output variables used to complete the job.
    *
    * @param jobSelector the selector to identify the job to complete
    * @param variableMapper a function mapping input variables to output variables; must not be
    *     {@code null} and must not return {@code null}
    */
   void completeJob(
-      final JobSelector jobSelector,
-      final Function<Map<String, Object>, Map<String, Object>> variableMapper);
+      final JobSelector jobSelector, final UnaryOperator<Map<String, Object>> variableMapper);
 
   /**
    * Throws a BPMN error from a job of the specified type.
@@ -331,21 +327,18 @@ public interface CamundaProcessTestContext {
 
   /**
    * Completes the user task with the given BPMN element ID. The given mapper receives the user
-   * task's input variables (visible at the process-instance and element-local scopes, with local
-   * values shadowing global ones) and returns the output variables used to complete the user task.
+   * task's input variables and returns the output variables used to complete the user task.
    *
    * @param elementId the BPMN element ID of the user task to complete
    * @param variableMapper a function mapping input variables to output variables; must not be
    *     {@code null} and must not return {@code null}
    */
   void completeUserTask(
-      final String elementId,
-      final Function<Map<String, Object>, Map<String, Object>> variableMapper);
+      final String elementId, final UnaryOperator<Map<String, Object>> variableMapper);
 
   /**
    * Completes the user task matching the specified selector. The given mapper receives the user
-   * task's input variables (visible at the process-instance and element-local scopes, with local
-   * values shadowing global ones) and returns the output variables used to complete the user task.
+   * task's input variables and returns the output variables used to complete the user task.
    *
    * @param userTaskSelector the selector to identify the user task to complete
    * @param variableMapper a function mapping input variables to output variables; must not be
@@ -353,7 +346,7 @@ public interface CamundaProcessTestContext {
    */
   void completeUserTask(
       final UserTaskSelector userTaskSelector,
-      final Function<Map<String, Object>, Map<String, Object>> variableMapper);
+      final UnaryOperator<Map<String, Object>> variableMapper);
 
   /**
    * Mocks a DMN decision with the specified decision ID and sets the provided variables.

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/CamundaDataSource.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/CamundaDataSource.java
@@ -106,6 +106,7 @@ public class CamundaDataSource {
     return client
         .newVariableSearchRequest()
         .filter(filter)
+        .withFullValues()
         .page(DEFAULT_PAGE_REQUEST)
         .send()
         .join()

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
@@ -37,6 +37,7 @@ import io.camunda.client.api.search.response.Incident;
 import io.camunda.client.api.search.response.Job;
 import io.camunda.client.api.search.response.ProcessInstance;
 import io.camunda.client.api.search.response.UserTask;
+import io.camunda.client.api.search.response.Variable;
 import io.camunda.process.test.api.CamundaAssertAwaitBehavior;
 import io.camunda.process.test.api.CamundaClientBuilderFactory;
 import io.camunda.process.test.api.CamundaProcessTestContext;
@@ -62,8 +63,12 @@ import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -336,6 +341,54 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
   }
 
   @Override
+  public void completeJob(
+      final String jobType,
+      final Function<Map<String, Object>, Map<String, Object>> variableMapper) {
+    completeJob(JobSelectors.byJobType(jobType), variableMapper);
+  }
+
+  @Override
+  public void completeJob(
+      final JobSelector jobSelector,
+      final Function<Map<String, Object>, Map<String, Object>> variableMapper) {
+    Objects.requireNonNull(variableMapper, "variableMapper must not be null");
+    final CamundaClient client = createClient();
+    final AtomicReference<Map<String, Object>> outputVariablesRef = new AtomicReference<>();
+
+    awaitJob(
+        jobSelector,
+        client,
+        job -> {
+          Map<String, Object> outputVariables = outputVariablesRef.get();
+          if (outputVariables == null) {
+            final Map<String, Object> inputVariables =
+                readInputVariables(
+                    client,
+                    jobSelector.describe(),
+                    "complete job",
+                    job.getProcessInstanceKey(),
+                    job.getElementInstanceKey());
+            outputVariables = variableMapper.apply(inputVariables);
+            if (outputVariables == null) {
+              throw new AssertionError(
+                  String.format(
+                      "Expected to complete job [%s] but the variableMapper returned null.",
+                      jobSelector.describe()));
+            }
+            outputVariablesRef.set(outputVariables);
+          }
+
+          LOGGER.debug(
+              "Mock: Complete job [{}, jobKey: '{}'] with variables {} from variableMapper",
+              jobSelector.describe(),
+              job.getJobKey(),
+              outputVariables);
+
+          client.newCompleteCommand(job.getJobKey()).variables(outputVariables).send().join();
+        });
+  }
+
+  @Override
   public void throwBpmnErrorFromJob(final String jobType, final String errorCode) {
     throwBpmnErrorFromJob(JobSelectors.byJobType(jobType), errorCode);
   }
@@ -477,6 +530,58 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
             LOGGER.warn("{} without example data due to errors. {}", logPrefix, e.getMessage());
             client.newCompleteUserTaskCommand(userTask.getUserTaskKey()).send().join();
           }
+        });
+  }
+
+  @Override
+  public void completeUserTask(
+      final String elementId,
+      final Function<Map<String, Object>, Map<String, Object>> variableMapper) {
+    completeUserTask(UserTaskSelectors.byElementId(elementId), variableMapper);
+  }
+
+  @Override
+  public void completeUserTask(
+      final UserTaskSelector userTaskSelector,
+      final Function<Map<String, Object>, Map<String, Object>> variableMapper) {
+    Objects.requireNonNull(variableMapper, "variableMapper must not be null");
+    final CamundaClient client = createClient();
+    final AtomicReference<Map<String, Object>> outputVariablesRef = new AtomicReference<>();
+
+    awaitUserTask(
+        userTaskSelector,
+        client,
+        userTask -> {
+          Map<String, Object> outputVariables = outputVariablesRef.get();
+          if (outputVariables == null) {
+            final Map<String, Object> inputVariables =
+                readInputVariables(
+                    client,
+                    userTaskSelector.describe(),
+                    "complete user task",
+                    userTask.getProcessInstanceKey(),
+                    userTask.getElementInstanceKey());
+            outputVariables = variableMapper.apply(inputVariables);
+            if (outputVariables == null) {
+              throw new AssertionError(
+                  String.format(
+                      "Expected to complete user task [%s] but the variableMapper returned null.",
+                      userTaskSelector.describe()));
+            }
+            outputVariablesRef.set(outputVariables);
+          }
+
+          LOGGER.debug(
+              "Mock: Complete user task [{}, userTaskKey: '{}'] with variables {} from variableMapper",
+              userTaskSelector.describe(),
+              userTask.getUserTaskKey(),
+              outputVariables);
+
+          client
+              .newCompleteUserTaskCommand(userTask.getUserTaskKey())
+              .variables(outputVariables)
+              .send()
+              .join();
         });
   }
 
@@ -722,6 +827,62 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
 
               job.ifPresent(jobConsumer);
             });
+  }
+
+  /**
+   * Reads the variables visible to an element by querying the process-instance and element-local
+   * scopes via the Search API and merging them, with local values shadowing global ones. Truncated
+   * values are rejected because they cannot be reliably deserialized.
+   */
+  private Map<String, Object> readInputVariables(
+      final CamundaClient client,
+      final String selectorDescription,
+      final String operation,
+      final long processInstanceKey,
+      final long elementInstanceKey) {
+
+    final List<Variable> variables =
+        client
+            .newVariableSearchRequest()
+            .filter(filter -> filter.processInstanceKey(processInstanceKey))
+            .send()
+            .join()
+            .items();
+
+    final Map<String, Variable> bestByName = new HashMap<>();
+    for (final Variable variable : variables) {
+      final Long scopeKey = variable.getScopeKey();
+      if (scopeKey == null) {
+        continue;
+      }
+      final boolean isLocal = scopeKey == elementInstanceKey;
+      final boolean isGlobal = scopeKey == processInstanceKey;
+      if (!isLocal && !isGlobal) {
+        // intermediate subprocess scopes are not part of v1 of this feature
+        continue;
+      }
+      final Variable existing = bestByName.get(variable.getName());
+      if (existing == null || (!isLocalScope(existing, elementInstanceKey) && isLocal)) {
+        bestByName.put(variable.getName(), variable);
+      }
+    }
+
+    final Map<String, Object> result = new HashMap<>();
+    for (final Variable variable : bestByName.values()) {
+      if (Boolean.TRUE.equals(variable.isTruncated())) {
+        throw new AssertionError(
+            String.format(
+                "Expected to %s [%s] but variable '%s' is truncated.",
+                operation, selectorDescription, variable.getName()));
+      }
+      result.put(variable.getName(), jsonMapper.fromJson(variable.getValue(), Object.class));
+    }
+    return result;
+  }
+
+  private static boolean isLocalScope(final Variable variable, final long elementInstanceKey) {
+    final Long scopeKey = variable.getScopeKey();
+    return scopeKey != null && scopeKey == elementInstanceKey;
   }
 
   private Optional<Job> findJob(final JobSelector jobSelector, final CamundaClient client) {

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
@@ -62,6 +62,7 @@ import java.io.ByteArrayInputStream;
 import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -837,11 +838,16 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
     final List<Variable> localVariables =
         fetchVariables(client, processInstanceKey, elementInstanceKey);
 
-    final JsonMapper clientJsonMapper = client.getConfiguration().getJsonMapper();
-    final Map<String, Object> result = new HashMap<>();
-    result.putAll(toVariableMap(clientJsonMapper, globalVariables));
-    result.putAll(toVariableMap(clientJsonMapper, localVariables));
-    return result;
+    // Merge by name first so that only the winning variable per name is deserialized.
+    final Map<String, Variable> mergedVariables = new HashMap<>();
+    for (final Variable variable : globalVariables) {
+      mergedVariables.put(variable.getName(), variable);
+    }
+    for (final Variable variable : localVariables) {
+      mergedVariables.put(variable.getName(), variable);
+    }
+
+    return toVariableMap(client.getConfiguration().getJsonMapper(), mergedVariables.values());
   }
 
   private static List<Variable> fetchVariables(
@@ -856,7 +862,7 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
   }
 
   private static Map<String, Object> toVariableMap(
-      final JsonMapper jsonMapper, final List<Variable> variables) {
+      final JsonMapper jsonMapper, final Collection<Variable> variables) {
     final Map<String, Object> result = new HashMap<>();
     for (final Variable variable : variables) {
       if (variable.isTruncated()) {

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
@@ -862,13 +862,17 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
             filter -> filter.processInstanceKey(processInstanceKey).scopeKey(elementInstanceKey));
 
     final Map<String, Object> result = new HashMap<>();
-    result.putAll(toVariableMap(globalVariables, selectorDescription, operation));
-    result.putAll(toVariableMap(localVariables, selectorDescription, operation));
+    result.putAll(toVariableMap(client, globalVariables, selectorDescription, operation));
+    result.putAll(toVariableMap(client, localVariables, selectorDescription, operation));
     return result;
   }
 
   private Map<String, Object> toVariableMap(
-      final List<Variable> variables, final String selectorDescription, final String operation) {
+      final CamundaClient client,
+      final List<Variable> variables,
+      final String selectorDescription,
+      final String operation) {
+    final JsonMapper clientJsonMapper = client.getConfiguration().getJsonMapper();
     final Map<String, Object> result = new HashMap<>();
     for (final Variable variable : variables) {
       if (Boolean.TRUE.equals(variable.isTruncated())) {
@@ -877,7 +881,7 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
                 "Expected to %s [%s] but variable '%s' is truncated.",
                 operation, selectorDescription, variable.getName()));
       }
-      result.put(variable.getName(), jsonMapper.fromJson(variable.getValue(), Object.class));
+      result.put(variable.getName(), clientJsonMapper.fromJson(variable.getValue(), Object.class));
     }
     return result;
   }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
@@ -289,20 +289,7 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
   @Override
   public void completeJob(final JobSelector jobSelector, final Map<String, Object> variables) {
     final CamundaClient client = createClient();
-
-    // completing the job inside the await block to handle the eventual consistency of the API
-    awaitJob(
-        jobSelector,
-        client,
-        job -> {
-          LOGGER.debug(
-              "Mock: Complete job [{}, jobKey: '{}'] with variables {}",
-              jobSelector.describe(),
-              job.getJobKey(),
-              variables);
-
-          client.newCompleteCommand(job.getJobKey()).variables(variables).send().join();
-        });
+    doCompleteJob(client, jobSelector, job -> variables);
   }
 
   @Override
@@ -353,27 +340,35 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
     Objects.requireNonNull(variableMapper, "variableMapper must not be null");
     final CamundaClient client = createClient();
     final AtomicReference<Map<String, Object>> outputVariablesRef = new AtomicReference<>();
+    doCompleteJob(
+        client,
+        jobSelector,
+        job ->
+            mapOutputVariablesOnce(
+                client,
+                outputVariablesRef,
+                jobSelector.describe(),
+                "complete job",
+                job.getProcessInstanceKey(),
+                job.getElementInstanceKey(),
+                variableMapper));
+  }
 
+  // completing the job inside the await block to handle the eventual consistency of the API
+  private void doCompleteJob(
+      final CamundaClient client,
+      final JobSelector jobSelector,
+      final Function<Job, Map<String, Object>> variableResolver) {
     awaitJob(
         jobSelector,
         client,
         job -> {
-          final Map<String, Object> outputVariables =
-              mapOutputVariablesOnce(
-                  client,
-                  outputVariablesRef,
-                  jobSelector.describe(),
-                  "complete job",
-                  job.getProcessInstanceKey(),
-                  job.getElementInstanceKey(),
-                  variableMapper);
-
+          final Map<String, Object> outputVariables = variableResolver.apply(job);
           LOGGER.debug(
-              "Mock: Complete job [{}, jobKey: '{}'] with variables {} from variableMapper",
+              "Mock: Complete job [{}, jobKey: '{}'] with variables {}",
               jobSelector.describe(),
               job.getJobKey(),
               outputVariables);
-
           client.newCompleteCommand(job.getJobKey()).variables(outputVariables).send().join();
         });
   }
@@ -461,24 +456,7 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
   public void completeUserTask(
       final UserTaskSelector userTaskSelector, final Map<String, Object> variables) {
     final CamundaClient client = createClient();
-
-    // completing the user task inside the await block to handle the eventual consistency of the API
-    awaitUserTask(
-        userTaskSelector,
-        client,
-        userTask -> {
-          LOGGER.debug(
-              "Mock: Complete user task [{}, userTaskKey: '{}'] with variables {}",
-              userTaskSelector.describe(),
-              userTask.getUserTaskKey(),
-              variables);
-
-          client
-              .newCompleteUserTaskCommand(userTask.getUserTaskKey())
-              .variables(variables)
-              .send()
-              .join();
-        });
+    doCompleteUserTask(client, userTaskSelector, userTask -> variables);
   }
 
   @Override
@@ -536,27 +514,35 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
     Objects.requireNonNull(variableMapper, "variableMapper must not be null");
     final CamundaClient client = createClient();
     final AtomicReference<Map<String, Object>> outputVariablesRef = new AtomicReference<>();
+    doCompleteUserTask(
+        client,
+        userTaskSelector,
+        userTask ->
+            mapOutputVariablesOnce(
+                client,
+                outputVariablesRef,
+                userTaskSelector.describe(),
+                "complete user task",
+                userTask.getProcessInstanceKey(),
+                userTask.getElementInstanceKey(),
+                variableMapper));
+  }
 
+  // completing the user task inside the await block to handle the eventual consistency of the API
+  private void doCompleteUserTask(
+      final CamundaClient client,
+      final UserTaskSelector userTaskSelector,
+      final Function<UserTask, Map<String, Object>> variableResolver) {
     awaitUserTask(
         userTaskSelector,
         client,
         userTask -> {
-          final Map<String, Object> outputVariables =
-              mapOutputVariablesOnce(
-                  client,
-                  outputVariablesRef,
-                  userTaskSelector.describe(),
-                  "complete user task",
-                  userTask.getProcessInstanceKey(),
-                  userTask.getElementInstanceKey(),
-                  variableMapper);
-
+          final Map<String, Object> outputVariables = variableResolver.apply(userTask);
           LOGGER.debug(
-              "Mock: Complete user task [{}, userTaskKey: '{}'] with variables {} from variableMapper",
+              "Mock: Complete user task [{}, userTaskKey: '{}'] with variables {}",
               userTaskSelector.describe(),
               userTask.getUserTaskKey(),
               outputVariables);
-
           client
               .newCompleteUserTaskCommand(userTask.getUserTaskKey())
               .variables(outputVariables)

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
@@ -51,7 +51,6 @@ import io.camunda.process.test.api.assertions.UserTaskSelectors;
 import io.camunda.process.test.api.behavior.BehaviorCondition;
 import io.camunda.process.test.api.behavior.ConditionalBehaviorBuilder;
 import io.camunda.process.test.api.mock.JobWorkerMockBuilder;
-import io.camunda.process.test.impl.assertions.CamundaDataSource;
 import io.camunda.process.test.impl.client.CamundaClockClient;
 import io.camunda.process.test.impl.mock.BpmnExampleDataReader;
 import io.camunda.process.test.impl.mock.BpmnExampleDataReader.BpmnExampleDataReaderException;
@@ -829,8 +828,7 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
       return cached;
     }
     final Map<String, Object> inputVariables =
-        readInputVariables(
-            client, selectorDescription, operation, processInstanceKey, elementInstanceKey);
+        readInputVariables(client, processInstanceKey, elementInstanceKey);
     final Map<String, Object> outputVariables = variableMapper.apply(inputVariables);
     if (outputVariables == null) {
       throw new AssertionError(
@@ -845,43 +843,39 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
   /**
    * Reads the variables visible to an element by querying the process-instance-global and
    * element-local scopes via the Search API and merging them, with local values shadowing global
-   * ones. Truncated values are rejected because they cannot be reliably deserialized.
+   * ones. Variables are requested with full values so that they can always be deserialized.
    */
   private Map<String, Object> readInputVariables(
-      final CamundaClient client,
-      final String selectorDescription,
-      final String operation,
-      final long processInstanceKey,
-      final long elementInstanceKey) {
+      final CamundaClient client, final long processInstanceKey, final long elementInstanceKey) {
 
-    final CamundaDataSource dataSource = new CamundaDataSource(client);
     final List<Variable> globalVariables =
-        dataSource.findGlobalVariablesByProcessInstanceKey(processInstanceKey);
+        fetchVariables(client, processInstanceKey, processInstanceKey);
     final List<Variable> localVariables =
-        dataSource.findVariables(
-            filter -> filter.processInstanceKey(processInstanceKey).scopeKey(elementInstanceKey));
+        fetchVariables(client, processInstanceKey, elementInstanceKey);
 
+    final JsonMapper clientJsonMapper = client.getConfiguration().getJsonMapper();
     final Map<String, Object> result = new HashMap<>();
-    result.putAll(toVariableMap(client, globalVariables, selectorDescription, operation));
-    result.putAll(toVariableMap(client, localVariables, selectorDescription, operation));
+    result.putAll(toVariableMap(clientJsonMapper, globalVariables));
+    result.putAll(toVariableMap(clientJsonMapper, localVariables));
     return result;
   }
 
-  private Map<String, Object> toVariableMap(
-      final CamundaClient client,
-      final List<Variable> variables,
-      final String selectorDescription,
-      final String operation) {
-    final JsonMapper clientJsonMapper = client.getConfiguration().getJsonMapper();
+  private static List<Variable> fetchVariables(
+      final CamundaClient client, final long processInstanceKey, final long scopeKey) {
+    return client
+        .newVariableSearchRequest()
+        .filter(filter -> filter.processInstanceKey(processInstanceKey).scopeKey(scopeKey))
+        .withFullValues()
+        .send()
+        .join()
+        .items();
+  }
+
+  private static Map<String, Object> toVariableMap(
+      final JsonMapper jsonMapper, final List<Variable> variables) {
     final Map<String, Object> result = new HashMap<>();
     for (final Variable variable : variables) {
-      if (Boolean.TRUE.equals(variable.isTruncated())) {
-        throw new AssertionError(
-            String.format(
-                "Expected to %s [%s] but variable '%s' is truncated.",
-                operation, selectorDescription, variable.getName()));
-      }
-      result.put(variable.getName(), clientJsonMapper.fromJson(variable.getValue(), Object.class));
+      result.put(variable.getName(), jsonMapper.fromJson(variable.getValue(), Object.class));
     }
     return result;
   }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
@@ -69,7 +69,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -340,38 +339,17 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
       final JobSelector jobSelector, final UnaryOperator<Map<String, Object>> variableMapper) {
     Objects.requireNonNull(variableMapper, "variableMapper must not be null");
     final CamundaClient client = createClient();
-    final AtomicReference<Map<String, Object>> outputVariablesRef = new AtomicReference<>();
     doCompleteJob(
         client,
         jobSelector,
         job ->
             mapOutputVariablesOnce(
                 client,
-                outputVariablesRef,
                 jobSelector.describe(),
                 "complete job",
                 job.getProcessInstanceKey(),
                 job.getElementInstanceKey(),
                 variableMapper));
-  }
-
-  // completing the job inside the await block to handle the eventual consistency of the API
-  private void doCompleteJob(
-      final CamundaClient client,
-      final JobSelector jobSelector,
-      final Function<Job, Map<String, Object>> variableResolver) {
-    awaitJob(
-        jobSelector,
-        client,
-        job -> {
-          final Map<String, Object> outputVariables = variableResolver.apply(job);
-          LOGGER.debug(
-              "Mock: Complete job [{}, jobKey: '{}'] with variables {}",
-              jobSelector.describe(),
-              job.getJobKey(),
-              outputVariables);
-          client.newCompleteCommand(job.getJobKey()).variables(outputVariables).send().join();
-        });
   }
 
   @Override
@@ -514,42 +492,17 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
       final UnaryOperator<Map<String, Object>> variableMapper) {
     Objects.requireNonNull(variableMapper, "variableMapper must not be null");
     final CamundaClient client = createClient();
-    final AtomicReference<Map<String, Object>> outputVariablesRef = new AtomicReference<>();
     doCompleteUserTask(
         client,
         userTaskSelector,
         userTask ->
             mapOutputVariablesOnce(
                 client,
-                outputVariablesRef,
                 userTaskSelector.describe(),
                 "complete user task",
                 userTask.getProcessInstanceKey(),
                 userTask.getElementInstanceKey(),
                 variableMapper));
-  }
-
-  // completing the user task inside the await block to handle the eventual consistency of the API
-  private void doCompleteUserTask(
-      final CamundaClient client,
-      final UserTaskSelector userTaskSelector,
-      final Function<UserTask, Map<String, Object>> variableResolver) {
-    awaitUserTask(
-        userTaskSelector,
-        client,
-        userTask -> {
-          final Map<String, Object> outputVariables = variableResolver.apply(userTask);
-          LOGGER.debug(
-              "Mock: Complete user task [{}, userTaskKey: '{}'] with variables {}",
-              userTaskSelector.describe(),
-              userTask.getUserTaskKey(),
-              outputVariables);
-          client
-              .newCompleteUserTaskCommand(userTask.getUserTaskKey())
-              .variables(outputVariables)
-              .send()
-              .join();
-        });
   }
 
   @Override
@@ -741,6 +694,48 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
     return conditionalBehaviorEngine.when(condition);
   }
 
+  // completing the job inside the await block to handle the eventual consistency of the API
+  private void doCompleteJob(
+      final CamundaClient client,
+      final JobSelector jobSelector,
+      final Function<Job, Map<String, Object>> variableResolver) {
+    awaitJob(
+        jobSelector,
+        client,
+        job -> {
+          final Map<String, Object> outputVariables = variableResolver.apply(job);
+          LOGGER.debug(
+              "Mock: Complete job [{}, jobKey: '{}'] with variables {}",
+              jobSelector.describe(),
+              job.getJobKey(),
+              outputVariables);
+          client.newCompleteCommand(job.getJobKey()).variables(outputVariables).send().join();
+        });
+  }
+
+  // completing the user task inside the await block to handle the eventual consistency of the API
+  private void doCompleteUserTask(
+      final CamundaClient client,
+      final UserTaskSelector userTaskSelector,
+      final Function<UserTask, Map<String, Object>> variableResolver) {
+    awaitUserTask(
+        userTaskSelector,
+        client,
+        userTask -> {
+          final Map<String, Object> outputVariables = variableResolver.apply(userTask);
+          LOGGER.debug(
+              "Mock: Complete user task [{}, userTaskKey: '{}'] with variables {}",
+              userTaskSelector.describe(),
+              userTask.getUserTaskKey(),
+              outputVariables);
+          client
+              .newCompleteUserTaskCommand(userTask.getUserTaskKey())
+              .variables(outputVariables)
+              .send()
+              .join();
+        });
+  }
+
   private void awaitUserTask(
       final UserTaskSelector userTaskSelector,
       final CamundaClient client,
@@ -797,21 +792,15 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
   }
 
   /**
-   * Resolves the output variables for a variable-mapper-based completion, caching the result so
-   * that the mapper is invoked at most once even when the completion retries on transient errors.
+   * Resolves the output variables for a variable-mapper-based completion
    */
   private Map<String, Object> mapOutputVariablesOnce(
       final CamundaClient client,
-      final AtomicReference<Map<String, Object>> cache,
       final String selectorDescription,
       final String operation,
       final long processInstanceKey,
       final long elementInstanceKey,
       final UnaryOperator<Map<String, Object>> variableMapper) {
-    final Map<String, Object> cached = cache.get();
-    if (cached != null) {
-      return cached;
-    }
     final Map<String, Object> inputVariables =
         readInputVariables(client, processInstanceKey, elementInstanceKey);
     final Map<String, Object> outputVariables = variableMapper.apply(inputVariables);
@@ -821,7 +810,6 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
               "Expected to %s [%s] but the variableMapper returned null.",
               operation, selectorDescription));
     }
-    cache.set(outputVariables);
     return outputVariables;
   }
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
@@ -875,6 +875,18 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
       final JsonMapper jsonMapper, final List<Variable> variables) {
     final Map<String, Object> result = new HashMap<>();
     for (final Variable variable : variables) {
+      if (variable.isTruncated()) {
+        throw new AssertionError(
+            "Expected variable '"
+                + variable.getName()
+                + "' to have a full value, but the Search API returned a truncated value.");
+      }
+
+      if (variable.getValue() == null) {
+        result.put(variable.getName(), null);
+        continue;
+      }
+
       result.put(variable.getName(), jsonMapper.fromJson(variable.getValue(), Object.class));
     }
     return result;

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
@@ -343,7 +343,7 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
         client,
         jobSelector,
         job ->
-            mapOutputVariablesOnce(
+            resolveOutputVariablesFromInputVariables(
                 client,
                 jobSelector.describe(),
                 "complete job",
@@ -496,7 +496,7 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
         client,
         userTaskSelector,
         userTask ->
-            mapOutputVariablesOnce(
+            resolveOutputVariablesFromInputVariables(
                 client,
                 userTaskSelector.describe(),
                 "complete user task",
@@ -792,7 +792,7 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
   }
 
   /** Resolves the output variables for a variable-mapper-based completion */
-  private Map<String, Object> mapOutputVariablesOnce(
+  private Map<String, Object> resolveOutputVariablesFromInputVariables(
       final CamundaClient client,
       final String selectorDescription,
       final String operation,

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
@@ -51,6 +51,7 @@ import io.camunda.process.test.api.assertions.UserTaskSelectors;
 import io.camunda.process.test.api.behavior.BehaviorCondition;
 import io.camunda.process.test.api.behavior.ConditionalBehaviorBuilder;
 import io.camunda.process.test.api.mock.JobWorkerMockBuilder;
+import io.camunda.process.test.impl.assertions.CamundaDataSource;
 import io.camunda.process.test.impl.client.CamundaClockClient;
 import io.camunda.process.test.impl.mock.BpmnExampleDataReader;
 import io.camunda.process.test.impl.mock.BpmnExampleDataReader.BpmnExampleDataReaderException;
@@ -359,24 +360,15 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
         jobSelector,
         client,
         job -> {
-          Map<String, Object> outputVariables = outputVariablesRef.get();
-          if (outputVariables == null) {
-            final Map<String, Object> inputVariables =
-                readInputVariables(
-                    client,
-                    jobSelector.describe(),
-                    "complete job",
-                    job.getProcessInstanceKey(),
-                    job.getElementInstanceKey());
-            outputVariables = variableMapper.apply(inputVariables);
-            if (outputVariables == null) {
-              throw new AssertionError(
-                  String.format(
-                      "Expected to complete job [%s] but the variableMapper returned null.",
-                      jobSelector.describe()));
-            }
-            outputVariablesRef.set(outputVariables);
-          }
+          final Map<String, Object> outputVariables =
+              mapOutputVariablesOnce(
+                  client,
+                  outputVariablesRef,
+                  jobSelector.describe(),
+                  "complete job",
+                  job.getProcessInstanceKey(),
+                  job.getElementInstanceKey(),
+                  variableMapper);
 
           LOGGER.debug(
               "Mock: Complete job [{}, jobKey: '{}'] with variables {} from variableMapper",
@@ -552,24 +544,15 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
         userTaskSelector,
         client,
         userTask -> {
-          Map<String, Object> outputVariables = outputVariablesRef.get();
-          if (outputVariables == null) {
-            final Map<String, Object> inputVariables =
-                readInputVariables(
-                    client,
-                    userTaskSelector.describe(),
-                    "complete user task",
-                    userTask.getProcessInstanceKey(),
-                    userTask.getElementInstanceKey());
-            outputVariables = variableMapper.apply(inputVariables);
-            if (outputVariables == null) {
-              throw new AssertionError(
-                  String.format(
-                      "Expected to complete user task [%s] but the variableMapper returned null.",
-                      userTaskSelector.describe()));
-            }
-            outputVariablesRef.set(outputVariables);
-          }
+          final Map<String, Object> outputVariables =
+              mapOutputVariablesOnce(
+                  client,
+                  outputVariablesRef,
+                  userTaskSelector.describe(),
+                  "complete user task",
+                  userTask.getProcessInstanceKey(),
+                  userTask.getElementInstanceKey(),
+                  variableMapper);
 
           LOGGER.debug(
               "Mock: Complete user task [{}, userTaskKey: '{}'] with variables {} from variableMapper",
@@ -830,9 +813,39 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
   }
 
   /**
-   * Reads the variables visible to an element by querying the process-instance and element-local
-   * scopes via the Search API and merging them, with local values shadowing global ones. Truncated
-   * values are rejected because they cannot be reliably deserialized.
+   * Resolves the output variables for a variable-mapper-based completion, caching the result so
+   * that the mapper is invoked at most once even when the completion retries on transient errors.
+   */
+  private Map<String, Object> mapOutputVariablesOnce(
+      final CamundaClient client,
+      final AtomicReference<Map<String, Object>> cache,
+      final String selectorDescription,
+      final String operation,
+      final long processInstanceKey,
+      final long elementInstanceKey,
+      final Function<Map<String, Object>, Map<String, Object>> variableMapper) {
+    final Map<String, Object> cached = cache.get();
+    if (cached != null) {
+      return cached;
+    }
+    final Map<String, Object> inputVariables =
+        readInputVariables(
+            client, selectorDescription, operation, processInstanceKey, elementInstanceKey);
+    final Map<String, Object> outputVariables = variableMapper.apply(inputVariables);
+    if (outputVariables == null) {
+      throw new AssertionError(
+          String.format(
+              "Expected to %s [%s] but the variableMapper returned null.",
+              operation, selectorDescription));
+    }
+    cache.set(outputVariables);
+    return outputVariables;
+  }
+
+  /**
+   * Reads the variables visible to an element by querying the process-instance-global and
+   * element-local scopes via the Search API and merging them, with local values shadowing global
+   * ones. Truncated values are rejected because they cannot be reliably deserialized.
    */
   private Map<String, Object> readInputVariables(
       final CamundaClient client,
@@ -841,34 +854,23 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
       final long processInstanceKey,
       final long elementInstanceKey) {
 
-    final List<Variable> variables =
-        client
-            .newVariableSearchRequest()
-            .filter(filter -> filter.processInstanceKey(processInstanceKey))
-            .send()
-            .join()
-            .items();
-
-    final Map<String, Variable> bestByName = new HashMap<>();
-    for (final Variable variable : variables) {
-      final Long scopeKey = variable.getScopeKey();
-      if (scopeKey == null) {
-        continue;
-      }
-      final boolean isLocal = scopeKey == elementInstanceKey;
-      final boolean isGlobal = scopeKey == processInstanceKey;
-      if (!isLocal && !isGlobal) {
-        // intermediate subprocess scopes are not part of v1 of this feature
-        continue;
-      }
-      final Variable existing = bestByName.get(variable.getName());
-      if (existing == null || (!isLocalScope(existing, elementInstanceKey) && isLocal)) {
-        bestByName.put(variable.getName(), variable);
-      }
-    }
+    final CamundaDataSource dataSource = new CamundaDataSource(client);
+    final List<Variable> globalVariables =
+        dataSource.findGlobalVariablesByProcessInstanceKey(processInstanceKey);
+    final List<Variable> localVariables =
+        dataSource.findVariables(
+            filter -> filter.processInstanceKey(processInstanceKey).scopeKey(elementInstanceKey));
 
     final Map<String, Object> result = new HashMap<>();
-    for (final Variable variable : bestByName.values()) {
+    result.putAll(toVariableMap(globalVariables, selectorDescription, operation));
+    result.putAll(toVariableMap(localVariables, selectorDescription, operation));
+    return result;
+  }
+
+  private Map<String, Object> toVariableMap(
+      final List<Variable> variables, final String selectorDescription, final String operation) {
+    final Map<String, Object> result = new HashMap<>();
+    for (final Variable variable : variables) {
       if (Boolean.TRUE.equals(variable.isTruncated())) {
         throw new AssertionError(
             String.format(
@@ -878,11 +880,6 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
       result.put(variable.getName(), jsonMapper.fromJson(variable.getValue(), Object.class));
     }
     return result;
-  }
-
-  private static boolean isLocalScope(final Variable variable, final long elementInstanceKey) {
-    final Long scopeKey = variable.getScopeKey();
-    return scopeKey != null && scopeKey == elementInstanceKey;
   }
 
   private Optional<Job> findJob(final JobSelector jobSelector, final CamundaClient client) {

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
@@ -72,6 +72,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 import org.camunda.bpm.model.dmn.Dmn;
 import org.camunda.bpm.model.dmn.DmnModelInstance;
 import org.camunda.bpm.model.dmn.instance.Decision;
@@ -342,15 +343,13 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
 
   @Override
   public void completeJob(
-      final String jobType,
-      final Function<Map<String, Object>, Map<String, Object>> variableMapper) {
+      final String jobType, final UnaryOperator<Map<String, Object>> variableMapper) {
     completeJob(JobSelectors.byJobType(jobType), variableMapper);
   }
 
   @Override
   public void completeJob(
-      final JobSelector jobSelector,
-      final Function<Map<String, Object>, Map<String, Object>> variableMapper) {
+      final JobSelector jobSelector, final UnaryOperator<Map<String, Object>> variableMapper) {
     Objects.requireNonNull(variableMapper, "variableMapper must not be null");
     final CamundaClient client = createClient();
     final AtomicReference<Map<String, Object>> outputVariablesRef = new AtomicReference<>();
@@ -526,15 +525,14 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
 
   @Override
   public void completeUserTask(
-      final String elementId,
-      final Function<Map<String, Object>, Map<String, Object>> variableMapper) {
+      final String elementId, final UnaryOperator<Map<String, Object>> variableMapper) {
     completeUserTask(UserTaskSelectors.byElementId(elementId), variableMapper);
   }
 
   @Override
   public void completeUserTask(
       final UserTaskSelector userTaskSelector,
-      final Function<Map<String, Object>, Map<String, Object>> variableMapper) {
+      final UnaryOperator<Map<String, Object>> variableMapper) {
     Objects.requireNonNull(variableMapper, "variableMapper must not be null");
     final CamundaClient client = createClient();
     final AtomicReference<Map<String, Object>> outputVariablesRef = new AtomicReference<>();
@@ -822,7 +820,7 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
       final String operation,
       final long processInstanceKey,
       final long elementInstanceKey,
-      final Function<Map<String, Object>, Map<String, Object>> variableMapper) {
+      final UnaryOperator<Map<String, Object>> variableMapper) {
     final Map<String, Object> cached = cache.get();
     if (cached != null) {
       return cached;

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
@@ -791,9 +791,7 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
             });
   }
 
-  /**
-   * Resolves the output variables for a variable-mapper-based completion
-   */
+  /** Resolves the output variables for a variable-mapper-based completion */
   private Map<String, Object> mapOutputVariablesOnce(
       final CamundaClient client,
       final String selectorDescription,

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/CamundaProcessTestExtensionIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/CamundaProcessTestExtensionIT.java
@@ -163,6 +163,45 @@ public class CamundaProcessTestExtensionIT {
         .isCompleted();
   }
 
+  private long deployProcessModel(final BpmnModelInstance processModel) {
+    return client
+        .newDeployResourceCommand()
+        .addProcessModel(processModel, "testProcess.bpmn")
+        .send()
+        .join()
+        .getProcesses()
+        .get(0)
+        .getProcessDefinitionKey();
+  }
+
+  private BpmnModelInstance processModelWithServiceTask() {
+    return Bpmn.createExecutableProcess("test-process-with-service-task")
+        .startEvent("start-1")
+        .serviceTask("service-task-1")
+        .zeebeJobType("test")
+        .boundaryEvent("error-boundary-event")
+        .error("bpmn-error")
+        .zeebeOutputExpression("abc", "error_code")
+        .endEvent("error-end")
+        .moveToActivity("service-task-1")
+        .endEvent("success-end")
+        .done();
+  }
+
+  private BpmnModelInstance processModelWithUserTask() {
+    return Bpmn.createExecutableProcess("test-process-with-user-task")
+        .startEvent("start-1")
+        .userTask("user-task-1")
+        .name("user-task")
+        .zeebeUserTask()
+        .boundaryEvent("error-boundary-event")
+        .error("bpmn-error")
+        .endEvent("error-end")
+        .moveToActivity("user-task-1")
+        .endEvent("success-end")
+        .done();
+  }
+
   @Nested
   class TimerEventTests {
 
@@ -338,92 +377,60 @@ public class CamundaProcessTestExtensionIT {
     }
   }
 
-  @Test
-  void shouldCompleteJobWithVariableMapper() {
-    // given
-    final long processDefinitionKey = deployProcessModel(processModelWithServiceTask());
-    final ProcessInstanceEvent processInstanceEvent =
-        client
-            .newCreateInstanceCommand()
-            .processDefinitionKey(processDefinitionKey)
-            .variables(Collections.singletonMap("id", 1))
-            .send()
-            .join();
+  @Nested
+  class JobCompletionTests {
+    @Test
+    void shouldCompleteJobWithVariableMapper() {
+      // given
+      final long processDefinitionKey = deployProcessModel(processModelWithServiceTask());
+      final ProcessInstanceEvent processInstanceEvent =
+          client
+              .newCreateInstanceCommand()
+              .processDefinitionKey(processDefinitionKey)
+              .variables(Collections.singletonMap("id", 1))
+              .send()
+              .join();
 
-    // when
-    processTestContext.completeJob(
-        "test",
-        inputVars -> {
-          final int id = ((Number) inputVars.get("id")).intValue();
-          return Collections.singletonMap("user", id == 1 ? "Alice" : "Bob");
-        });
+      // when
+      processTestContext.completeJob(
+          "test",
+          inputVars -> {
+            final int id = ((Number) inputVars.get("id")).intValue();
+            return Collections.singletonMap("user", id == 1 ? "Alice" : "Bob");
+          });
 
-    // then
-    assertThatProcessInstance(processInstanceEvent).isCompleted();
-    assertThatProcessInstance(processInstanceEvent).hasVariable("user", "Alice");
+      // then
+      assertThatProcessInstance(processInstanceEvent).isCompleted();
+      assertThatProcessInstance(processInstanceEvent).hasVariable("user", "Alice");
+    }
   }
 
-  @Test
-  void shouldCompleteUserTaskWithVariableMapper() {
-    // given
-    final long processDefinitionKey = deployProcessModel(processModelWithUserTask());
-    final ProcessInstanceEvent processInstanceEvent =
-        client
-            .newCreateInstanceCommand()
-            .processDefinitionKey(processDefinitionKey)
-            .variables(Collections.singletonMap("id", 2))
-            .send()
-            .join();
+  @Nested
+  class UserTaskCompletionTests {
 
-    // when
-    processTestContext.completeUserTask(
-        "user-task-1",
-        inputVars -> {
-          final int id = ((Number) inputVars.get("id")).intValue();
-          return Collections.singletonMap("user", id == 1 ? "Alice" : "Bob");
-        });
+    @Test
+    void shouldCompleteUserTaskWithVariableMapper() {
+      // given
+      final long processDefinitionKey = deployProcessModel(processModelWithUserTask());
+      final ProcessInstanceEvent processInstanceEvent =
+          client
+              .newCreateInstanceCommand()
+              .processDefinitionKey(processDefinitionKey)
+              .variables(Collections.singletonMap("id", 2))
+              .send()
+              .join();
 
-    // then
-    assertThatProcessInstance(processInstanceEvent).isCompleted();
-    assertThatProcessInstance(processInstanceEvent).hasVariable("user", "Bob");
-  }
+      // when
+      processTestContext.completeUserTask(
+          "user-task-1",
+          inputVars -> {
+            final int id = ((Number) inputVars.get("id")).intValue();
+            return Collections.singletonMap("user", id == 1 ? "Alice" : "Bob");
+          });
 
-  private long deployProcessModel(final BpmnModelInstance processModel) {
-    return client
-        .newDeployResourceCommand()
-        .addProcessModel(processModel, "testProcess.bpmn")
-        .send()
-        .join()
-        .getProcesses()
-        .get(0)
-        .getProcessDefinitionKey();
-  }
-
-  private BpmnModelInstance processModelWithServiceTask() {
-    return Bpmn.createExecutableProcess("test-process-with-service-task")
-        .startEvent("start-1")
-        .serviceTask("service-task-1")
-        .zeebeJobType("test")
-        .boundaryEvent("error-boundary-event")
-        .error("bpmn-error")
-        .zeebeOutputExpression("abc", "error_code")
-        .endEvent("error-end")
-        .moveToActivity("service-task-1")
-        .endEvent("success-end")
-        .done();
-  }
-
-  private BpmnModelInstance processModelWithUserTask() {
-    return Bpmn.createExecutableProcess("test-process-with-user-task")
-        .startEvent("start-1")
-        .userTask("user-task-1")
-        .name("user-task")
-        .zeebeUserTask()
-        .boundaryEvent("error-boundary-event")
-        .error("bpmn-error")
-        .endEvent("error-end")
-        .moveToActivity("user-task-1")
-        .endEvent("success-end")
-        .done();
+      // then
+      assertThatProcessInstance(processInstanceEvent).isCompleted();
+      assertThatProcessInstance(processInstanceEvent).hasVariable("user", "Bob");
+    }
   }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/CamundaProcessTestExtensionIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/CamundaProcessTestExtensionIT.java
@@ -174,34 +174,6 @@ public class CamundaProcessTestExtensionIT {
         .getProcessDefinitionKey();
   }
 
-  private BpmnModelInstance processModelWithServiceTask() {
-    return Bpmn.createExecutableProcess("test-process-with-service-task")
-        .startEvent("start-1")
-        .serviceTask("service-task-1")
-        .zeebeJobType("test")
-        .boundaryEvent("error-boundary-event")
-        .error("bpmn-error")
-        .zeebeOutputExpression("abc", "error_code")
-        .endEvent("error-end")
-        .moveToActivity("service-task-1")
-        .endEvent("success-end")
-        .done();
-  }
-
-  private BpmnModelInstance processModelWithUserTask() {
-    return Bpmn.createExecutableProcess("test-process-with-user-task")
-        .startEvent("start-1")
-        .userTask("user-task-1")
-        .name("user-task")
-        .zeebeUserTask()
-        .boundaryEvent("error-boundary-event")
-        .error("bpmn-error")
-        .endEvent("error-end")
-        .moveToActivity("user-task-1")
-        .endEvent("success-end")
-        .done();
-  }
-
   @Nested
   class TimerEventTests {
 
@@ -403,6 +375,20 @@ public class CamundaProcessTestExtensionIT {
       assertThatProcessInstance(processInstanceEvent).isCompleted();
       assertThatProcessInstance(processInstanceEvent).hasVariable("user", "Alice");
     }
+
+    private BpmnModelInstance processModelWithServiceTask() {
+      return Bpmn.createExecutableProcess("test-process-with-service-task")
+          .startEvent("start-1")
+          .serviceTask("service-task-1")
+          .zeebeJobType("test")
+          .boundaryEvent("error-boundary-event")
+          .error("bpmn-error")
+          .zeebeOutputExpression("abc", "error_code")
+          .endEvent("error-end")
+          .moveToActivity("service-task-1")
+          .endEvent("success-end")
+          .done();
+    }
   }
 
   @Nested
@@ -431,6 +417,20 @@ public class CamundaProcessTestExtensionIT {
       // then
       assertThatProcessInstance(processInstanceEvent).isCompleted();
       assertThatProcessInstance(processInstanceEvent).hasVariable("user", "Bob");
+    }
+
+    private BpmnModelInstance processModelWithUserTask() {
+      return Bpmn.createExecutableProcess("test-process-with-user-task")
+          .startEvent("start-1")
+          .userTask("user-task-1")
+          .name("user-task")
+          .zeebeUserTask()
+          .boundaryEvent("error-boundary-event")
+          .error("bpmn-error")
+          .endEvent("error-end")
+          .moveToActivity("user-task-1")
+          .endEvent("success-end")
+          .done();
     }
   }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/CamundaProcessTestExtensionIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/CamundaProcessTestExtensionIT.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.process.test.api;
 
+import static io.camunda.process.test.api.CamundaAssert.assertThatProcessInstance;
 import static io.camunda.process.test.api.assertions.ElementSelectors.byId;
 import static io.camunda.process.test.api.assertions.ElementSelectors.byName;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,6 +31,7 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.awaitility.Awaitility;
@@ -334,5 +336,94 @@ public class CamundaProcessTestExtensionIT {
                     .contains("camundaProcessTestExtensionIT/greeting.dmn");
               });
     }
+  }
+
+  @Test
+  void shouldCompleteJobWithVariableMapper() {
+    // given
+    final long processDefinitionKey = deployProcessModel(processModelWithServiceTask());
+    final ProcessInstanceEvent processInstanceEvent =
+        client
+            .newCreateInstanceCommand()
+            .processDefinitionKey(processDefinitionKey)
+            .variables(Collections.singletonMap("id", 1))
+            .send()
+            .join();
+
+    // when
+    processTestContext.completeJob(
+        "test",
+        inputVars -> {
+          final int id = ((Number) inputVars.get("id")).intValue();
+          return Collections.singletonMap("user", id == 1 ? "Alice" : "Bob");
+        });
+
+    // then
+    assertThatProcessInstance(processInstanceEvent).isCompleted();
+    assertThatProcessInstance(processInstanceEvent).hasVariable("user", "Alice");
+  }
+
+  @Test
+  void shouldCompleteUserTaskWithVariableMapper() {
+    // given
+    final long processDefinitionKey = deployProcessModel(processModelWithUserTask());
+    final ProcessInstanceEvent processInstanceEvent =
+        client
+            .newCreateInstanceCommand()
+            .processDefinitionKey(processDefinitionKey)
+            .variables(Collections.singletonMap("id", 2))
+            .send()
+            .join();
+
+    // when
+    processTestContext.completeUserTask(
+        "user-task-1",
+        inputVars -> {
+          final int id = ((Number) inputVars.get("id")).intValue();
+          return Collections.singletonMap("user", id == 1 ? "Alice" : "Bob");
+        });
+
+    // then
+    assertThatProcessInstance(processInstanceEvent).isCompleted();
+    assertThatProcessInstance(processInstanceEvent).hasVariable("user", "Bob");
+  }
+
+  private long deployProcessModel(final BpmnModelInstance processModel) {
+    return client
+        .newDeployResourceCommand()
+        .addProcessModel(processModel, "testProcess.bpmn")
+        .send()
+        .join()
+        .getProcesses()
+        .get(0)
+        .getProcessDefinitionKey();
+  }
+
+  private BpmnModelInstance processModelWithServiceTask() {
+    return Bpmn.createExecutableProcess("test-process-with-service-task")
+        .startEvent("start-1")
+        .serviceTask("service-task-1")
+        .zeebeJobType("test")
+        .boundaryEvent("error-boundary-event")
+        .error("bpmn-error")
+        .zeebeOutputExpression("abc", "error_code")
+        .endEvent("error-end")
+        .moveToActivity("service-task-1")
+        .endEvent("success-end")
+        .done();
+  }
+
+  private BpmnModelInstance processModelWithUserTask() {
+    return Bpmn.createExecutableProcess("test-process-with-user-task")
+        .startEvent("start-1")
+        .userTask("user-task-1")
+        .name("user-task")
+        .zeebeUserTask()
+        .boundaryEvent("error-boundary-event")
+        .error("bpmn-error")
+        .endEvent("error-end")
+        .moveToActivity("user-task-1")
+        .endEvent("success-end")
+        .done();
   }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CamundaProcessTestContextIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CamundaProcessTestContextIT.java
@@ -349,6 +349,56 @@ public class CamundaProcessTestContextIT {
   }
 
   @Test
+  void shouldCompleteJobWithVariableMapper() {
+    // given
+    final long processDefinitionKey = deployProcessModel(processModelWithServiceTask());
+    final ProcessInstanceEvent processInstanceEvent =
+        client
+            .newCreateInstanceCommand()
+            .processDefinitionKey(processDefinitionKey)
+            .variables(Collections.singletonMap("id", 1))
+            .send()
+            .join();
+
+    // when
+    processTestContext.completeJob(
+        "test",
+        inputVars -> {
+          final int id = ((Number) inputVars.get("id")).intValue();
+          return Collections.singletonMap("user", id == 1 ? "Alice" : "Bob");
+        });
+
+    // then
+    assertThatProcessInstance(processInstanceEvent).isCompleted();
+    assertThatProcessInstance(processInstanceEvent).hasVariable("user", "Alice");
+  }
+
+  @Test
+  void shouldCompleteUserTaskWithVariableMapper() {
+    // given
+    final long processDefinitionKey = deployProcessModel(processModelWithUserTask());
+    final ProcessInstanceEvent processInstanceEvent =
+        client
+            .newCreateInstanceCommand()
+            .processDefinitionKey(processDefinitionKey)
+            .variables(Collections.singletonMap("id", 2))
+            .send()
+            .join();
+
+    // when
+    processTestContext.completeUserTask(
+        "user-task-1",
+        inputVars -> {
+          final int id = ((Number) inputVars.get("id")).intValue();
+          return Collections.singletonMap("user", id == 1 ? "Alice" : "Bob");
+        });
+
+    // then
+    assertThatProcessInstance(processInstanceEvent).isCompleted();
+    assertThatProcessInstance(processInstanceEvent).hasVariable("user", "Bob");
+  }
+
+  @Test
   void shouldFindUserTaskByElementId() {
     // Given
     final long processDefinitionKey = deployProcessModel(processModelWithUserTask());

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CamundaProcessTestContextIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CamundaProcessTestContextIT.java
@@ -349,56 +349,6 @@ public class CamundaProcessTestContextIT {
   }
 
   @Test
-  void shouldCompleteJobWithVariableMapper() {
-    // given
-    final long processDefinitionKey = deployProcessModel(processModelWithServiceTask());
-    final ProcessInstanceEvent processInstanceEvent =
-        client
-            .newCreateInstanceCommand()
-            .processDefinitionKey(processDefinitionKey)
-            .variables(Collections.singletonMap("id", 1))
-            .send()
-            .join();
-
-    // when
-    processTestContext.completeJob(
-        "test",
-        inputVars -> {
-          final int id = ((Number) inputVars.get("id")).intValue();
-          return Collections.singletonMap("user", id == 1 ? "Alice" : "Bob");
-        });
-
-    // then
-    assertThatProcessInstance(processInstanceEvent).isCompleted();
-    assertThatProcessInstance(processInstanceEvent).hasVariable("user", "Alice");
-  }
-
-  @Test
-  void shouldCompleteUserTaskWithVariableMapper() {
-    // given
-    final long processDefinitionKey = deployProcessModel(processModelWithUserTask());
-    final ProcessInstanceEvent processInstanceEvent =
-        client
-            .newCreateInstanceCommand()
-            .processDefinitionKey(processDefinitionKey)
-            .variables(Collections.singletonMap("id", 2))
-            .send()
-            .join();
-
-    // when
-    processTestContext.completeUserTask(
-        "user-task-1",
-        inputVars -> {
-          final int id = ((Number) inputVars.get("id")).intValue();
-          return Collections.singletonMap("user", id == 1 ? "Alice" : "Bob");
-        });
-
-    // then
-    assertThatProcessInstance(processInstanceEvent).isCompleted();
-    assertThatProcessInstance(processInstanceEvent).hasVariable("user", "Bob");
-  }
-
-  @Test
   void shouldFindUserTaskByElementId() {
     // Given
     final long processDefinitionKey = deployProcessModel(processModelWithUserTask());

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CompleteJobTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CompleteJobTest.java
@@ -35,9 +35,11 @@ import io.camunda.client.api.response.CompleteJobResponse;
 import io.camunda.client.api.search.enums.JobKind;
 import io.camunda.client.api.search.enums.JobState;
 import io.camunda.client.api.search.filter.JobFilter;
+import io.camunda.client.api.search.filter.VariableFilter;
 import io.camunda.client.api.search.filter.builder.IntegerProperty;
 import io.camunda.client.api.search.filter.builder.JobStateProperty;
 import io.camunda.client.api.search.response.Job;
+import io.camunda.client.api.search.response.Variable;
 import io.camunda.process.test.api.CamundaClientBuilderFactory;
 import io.camunda.process.test.api.CamundaProcessTestContext;
 import io.camunda.process.test.api.assertions.JobSelectors;
@@ -46,7 +48,9 @@ import io.camunda.process.test.impl.extension.CamundaProcessTestContextImpl;
 import io.camunda.process.test.impl.extension.ConditionalBehaviorEngine;
 import io.camunda.process.test.impl.runtime.CamundaProcessTestRuntime;
 import io.camunda.process.test.utils.DevAwaitBehavior;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -589,6 +593,364 @@ public class CompleteJobTest {
 
       // then
       verify(camundaClient, times(2)).newCompleteCommand(JOB_KEY);
+    }
+  }
+
+  @Nested
+  @org.mockito.junit.jupiter.MockitoSettings(strictness = org.mockito.quality.Strictness.LENIENT)
+  class CompleteJobWithVariableMapper {
+
+    private static final long PROCESS_INSTANCE_KEY = 200L;
+    private static final long ELEMENT_INSTANCE_KEY = 300L;
+
+    @Captor private ArgumentCaptor<Consumer<VariableFilter>> variableFilterCaptor;
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private VariableFilter variableFilter;
+
+    @BeforeEach
+    void setup() {
+      camundaProcessTestContext =
+          new CamundaProcessTestContextImpl(
+              camundaProcessTestRuntime,
+              clientCreationCallback,
+              clockClient,
+              DevAwaitBehavior::expectSuccess,
+              jsonMapper,
+              new ConditionalBehaviorEngine());
+
+      when(camundaClient
+              .newJobSearchRequest()
+              .filter(jobFilterCaptor.capture())
+              .send()
+              .join()
+              .items())
+          .thenReturn(Collections.singletonList(job));
+
+      when(job.getJobKey()).thenReturn(JOB_KEY);
+      when(job.getType()).thenReturn(JOB_TYPE);
+      when(job.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+      when(job.getElementInstanceKey()).thenReturn(ELEMENT_INSTANCE_KEY);
+
+      when(camundaClient
+              .newVariableSearchRequest()
+              .filter(variableFilterCaptor.capture())
+              .send()
+              .join()
+              .items())
+          .thenReturn(Collections.emptyList());
+    }
+
+    private Variable variable(
+        final String name, final String value, final long scopeKey, final boolean truncated) {
+      final Variable variable = mock(Variable.class);
+      when(variable.getName()).thenReturn(name);
+      when(variable.getValue()).thenReturn(value);
+      when(variable.getScopeKey()).thenReturn(scopeKey);
+      when(variable.isTruncated()).thenReturn(truncated);
+      return variable;
+    }
+
+    @Test
+    void shouldCompleteJobWithVariableMapper() {
+      // given
+      final Variable idVariable = variable("id", "1", PROCESS_INSTANCE_KEY, false);
+      final Variable localVariable = variable("local", "\"hello\"", ELEMENT_INSTANCE_KEY, false);
+      when(camundaClient
+              .newVariableSearchRequest()
+              .filter(variableFilterCaptor.capture())
+              .send()
+              .join()
+              .items())
+          .thenReturn(Arrays.asList(idVariable, localVariable));
+      when(jsonMapper.fromJson("1", Object.class)).thenReturn(1);
+      when(jsonMapper.fromJson("\"hello\"", Object.class)).thenReturn("hello");
+
+      final Map<String, Object> capturedInput = new HashMap<>();
+      final Map<String, Object> outputVariables = Collections.singletonMap("user", "Alice");
+
+      // when
+      camundaProcessTestContext.completeJob(
+          JOB_TYPE,
+          inputVars -> {
+            capturedInput.putAll(inputVars);
+            return outputVariables;
+          });
+
+      // then
+      org.assertj.core.api.Assertions.assertThat(capturedInput)
+          .containsEntry("id", 1)
+          .containsEntry("local", "hello");
+      verify(camundaClient.newCompleteCommand(JOB_KEY).variables(outputVariables)).send();
+    }
+
+    @Test
+    void shouldCompleteJobWithVariableMapperBySelector() {
+      // given
+      final Map<String, Object> outputVariables = Collections.singletonMap("user", "Bob");
+
+      // when
+      camundaProcessTestContext.completeJob(
+          JobSelectors.byJobType(JOB_TYPE), inputVars -> outputVariables);
+
+      // then
+      verify(camundaClient.newCompleteCommand(JOB_KEY).variables(outputVariables)).send();
+    }
+
+    @Test
+    void shouldCompleteJobWithEmptyInputVariables() {
+      // given - the default mock returns an empty list of variables
+      final Map<String, Object> capturedInput = new HashMap<>();
+      capturedInput.put("sentinel", "untouched");
+
+      // when
+      camundaProcessTestContext.completeJob(
+          JOB_TYPE,
+          inputVars -> {
+            capturedInput.clear();
+            capturedInput.putAll(inputVars);
+            return Collections.emptyMap();
+          });
+
+      // then
+      org.assertj.core.api.Assertions.assertThat(capturedInput).isEmpty();
+      verify(camundaClient.newCompleteCommand(JOB_KEY).variables(Collections.emptyMap())).send();
+    }
+
+    @Test
+    void shouldPreferLocalOverGlobalVariable() {
+      // given - same name 'id' at both scopes; local must win
+      final Variable globalId = variable("id", "1", PROCESS_INSTANCE_KEY, false);
+      final Variable localId = variable("id", "2", ELEMENT_INSTANCE_KEY, false);
+      when(camundaClient
+              .newVariableSearchRequest()
+              .filter(variableFilterCaptor.capture())
+              .send()
+              .join()
+              .items())
+          .thenReturn(Arrays.asList(globalId, localId));
+      when(jsonMapper.fromJson("2", Object.class)).thenReturn(2);
+
+      final Map<String, Object> capturedInput = new HashMap<>();
+
+      // when
+      camundaProcessTestContext.completeJob(
+          JOB_TYPE,
+          inputVars -> {
+            capturedInput.putAll(inputVars);
+            return Collections.emptyMap();
+          });
+
+      // then
+      org.assertj.core.api.Assertions.assertThat(capturedInput).containsEntry("id", 2);
+    }
+
+    @Test
+    void shouldFilterVariablesByProcessInstanceKey() {
+      // when
+      camundaProcessTestContext.completeJob(JOB_TYPE, inputVars -> Collections.emptyMap());
+
+      // then
+      variableFilterCaptor.getValue().accept(variableFilter);
+      verify(variableFilter).processInstanceKey(PROCESS_INSTANCE_KEY);
+    }
+
+    @Test
+    void shouldFailIfVariableMapperIsNull() {
+      // given
+      clearInvocations(camundaClient);
+
+      // when/then
+      assertThatThrownBy(
+              () ->
+                  camundaProcessTestContext.completeJob(
+                      JOB_TYPE, (Function<Map<String, Object>, Map<String, Object>>) null))
+          .isInstanceOf(NullPointerException.class)
+          .hasMessageContaining("variableMapper");
+
+      // and: no search/completion took place
+      verify(camundaClient, org.mockito.Mockito.never()).newJobSearchRequest();
+    }
+
+    @Test
+    void shouldRetryCompletionWithoutReinvokingMapper() {
+      // given
+      when(camundaClient
+              .newCompleteCommand(JOB_KEY)
+              .variables(ArgumentMatchers.<Map<String, Object>>any())
+              .send()
+              .join())
+          .thenThrow(new ClientException("expected"))
+          .thenReturn(mock(CompleteJobResponse.class));
+
+      final java.util.concurrent.atomic.AtomicInteger mapperInvocations =
+          new java.util.concurrent.atomic.AtomicInteger();
+
+      clearInvocations(camundaClient);
+
+      // when
+      camundaProcessTestContext.completeJob(
+          JOB_TYPE,
+          inputVars -> {
+            mapperInvocations.incrementAndGet();
+            return Collections.emptyMap();
+          });
+
+      // then
+      org.assertj.core.api.Assertions.assertThat(mapperInvocations.get()).isEqualTo(1);
+      verify(camundaClient, times(2)).newCompleteCommand(JOB_KEY);
+    }
+  }
+
+  @Nested
+  @org.mockito.junit.jupiter.MockitoSettings(strictness = org.mockito.quality.Strictness.LENIENT)
+  class CompleteJobWithVariableMapperFailureCases {
+
+    private static final long PROCESS_INSTANCE_KEY = 200L;
+    private static final long ELEMENT_INSTANCE_KEY = 300L;
+
+    @Captor private ArgumentCaptor<Consumer<VariableFilter>> variableFilterCaptor;
+
+    @BeforeEach
+    void setup() {
+      camundaProcessTestContext =
+          new CamundaProcessTestContextImpl(
+              camundaProcessTestRuntime,
+              clientCreationCallback,
+              clockClient,
+              DevAwaitBehavior::expectFailure,
+              jsonMapper,
+              new ConditionalBehaviorEngine());
+    }
+
+    private Variable variable(
+        final String name, final String value, final long scopeKey, final boolean truncated) {
+      final Variable variable = mock(Variable.class);
+      when(variable.getName()).thenReturn(name);
+      when(variable.getValue()).thenReturn(value);
+      when(variable.getScopeKey()).thenReturn(scopeKey);
+      when(variable.isTruncated()).thenReturn(truncated);
+      return variable;
+    }
+
+    private void mockJobFound() {
+      when(camundaClient
+              .newJobSearchRequest()
+              .filter(jobFilterCaptor.capture())
+              .send()
+              .join()
+              .items())
+          .thenReturn(Collections.singletonList(job));
+      when(job.getJobKey()).thenReturn(JOB_KEY);
+      when(job.getType()).thenReturn(JOB_TYPE);
+      when(job.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+      when(job.getElementInstanceKey()).thenReturn(ELEMENT_INSTANCE_KEY);
+    }
+
+    @Test
+    void shouldFailIfNoJobIsPresentForVariableMapper() {
+      // given
+      when(camundaClient
+              .newJobSearchRequest()
+              .filter(jobFilterCaptor.capture())
+              .send()
+              .join()
+              .items())
+          .thenReturn(Collections.emptyList());
+
+      final java.util.concurrent.atomic.AtomicInteger mapperInvocations =
+          new java.util.concurrent.atomic.AtomicInteger();
+
+      // when/then
+      assertThatThrownBy(
+              () ->
+                  camundaProcessTestContext.completeJob(
+                      JOB_TYPE,
+                      inputVars -> {
+                        mapperInvocations.incrementAndGet();
+                        return Collections.emptyMap();
+                      }))
+          .isInstanceOf(AssertionError.class)
+          .hasMessageContaining(
+              "Expected to complete job [jobType: %s] but no job is available.", JOB_TYPE);
+
+      // and: mapper was never invoked
+      org.assertj.core.api.Assertions.assertThat(mapperInvocations.get()).isZero();
+    }
+
+    @Test
+    void shouldFailIfVariableMapperReturnsNull() {
+      // given
+      mockJobFound();
+      when(camundaClient
+              .newVariableSearchRequest()
+              .filter(variableFilterCaptor.capture())
+              .send()
+              .join()
+              .items())
+          .thenReturn(Collections.emptyList());
+
+      // when/then
+      assertThatThrownBy(() -> camundaProcessTestContext.completeJob(JOB_TYPE, inputVars -> null))
+          .isInstanceOf(AssertionError.class)
+          .hasMessageContaining(
+              "Expected to complete job [jobType: %s] but the variableMapper returned null.",
+              JOB_TYPE);
+
+      // and: completion command was never sent
+      verify(camundaClient, org.mockito.Mockito.never()).newCompleteCommand(JOB_KEY);
+    }
+
+    @Test
+    void shouldPropagateExceptionFromVariableMapper() {
+      // given
+      mockJobFound();
+      when(camundaClient
+              .newVariableSearchRequest()
+              .filter(variableFilterCaptor.capture())
+              .send()
+              .join()
+              .items())
+          .thenReturn(Collections.emptyList());
+
+      // when/then
+      assertThatThrownBy(
+              () ->
+                  camundaProcessTestContext.completeJob(
+                      JOB_TYPE,
+                      inputVars -> {
+                        throw new IllegalStateException("boom");
+                      }))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("boom");
+
+      // and: completion command was never sent
+      verify(camundaClient, org.mockito.Mockito.never()).newCompleteCommand(JOB_KEY);
+    }
+
+    @Test
+    void shouldFailIfInputVariableIsTruncated() {
+      // given
+      mockJobFound();
+      final Variable truncated = variable("big", "\"...\"", PROCESS_INSTANCE_KEY, true);
+      when(camundaClient
+              .newVariableSearchRequest()
+              .filter(variableFilterCaptor.capture())
+              .send()
+              .join()
+              .items())
+          .thenReturn(Collections.singletonList(truncated));
+
+      // when/then
+      assertThatThrownBy(
+              () ->
+                  camundaProcessTestContext.completeJob(
+                      JOB_TYPE, inputVars -> Collections.emptyMap()))
+          .isInstanceOf(AssertionError.class)
+          .hasMessageContaining("variable 'big' is truncated");
+
+      // and: completion command was never sent
+      verify(camundaClient, org.mockito.Mockito.never()).newCompleteCommand(JOB_KEY);
     }
   }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CompleteJobTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CompleteJobTest.java
@@ -777,35 +777,6 @@ public class CompleteJobTest {
       // and: no search/completion took place
       verify(camundaClient, org.mockito.Mockito.never()).newJobSearchRequest();
     }
-
-    @Test
-    void shouldRetryCompletionWithoutReinvokingMapper() {
-      // given
-      when(camundaClient
-              .newCompleteCommand(JOB_KEY)
-              .variables(ArgumentMatchers.<Map<String, Object>>any())
-              .send()
-              .join())
-          .thenThrow(new ClientException("expected"))
-          .thenReturn(mock(CompleteJobResponse.class));
-
-      final java.util.concurrent.atomic.AtomicInteger mapperInvocations =
-          new java.util.concurrent.atomic.AtomicInteger();
-
-      clearInvocations(camundaClient);
-
-      // when
-      camundaProcessTestContext.completeJob(
-          JOB_TYPE,
-          inputVars -> {
-            mapperInvocations.incrementAndGet();
-            return Collections.emptyMap();
-          });
-
-      // then
-      org.assertj.core.api.Assertions.assertThat(mapperInvocations.get()).isEqualTo(1);
-      verify(camundaClient, times(2)).newCompleteCommand(JOB_KEY);
-    }
   }
 
   @Nested
@@ -827,13 +798,6 @@ public class CompleteJobTest {
               DevAwaitBehavior::expectFailure,
               jsonMapper,
               new ConditionalBehaviorEngine());
-    }
-
-    private Variable variable(final String name, final String value) {
-      final Variable variable = mock(Variable.class);
-      when(variable.getName()).thenReturn(name);
-      when(variable.getValue()).thenReturn(value);
-      return variable;
     }
 
     private void mockJobFound() {

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CompleteJobTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CompleteJobTest.java
@@ -635,10 +635,7 @@ public class CompleteJobTest {
       when(camundaClient
               .newVariableSearchRequest()
               .filter(variableFilterCaptor.capture())
-              .page(
-                  ArgumentMatchers
-                      .<java.util.function.Consumer<io.camunda.client.api.search.page.AnyPage>>
-                          any())
+              .withFullValues()
               .send()
               .join()
               .items())
@@ -647,28 +644,22 @@ public class CompleteJobTest {
       when(camundaClient.getConfiguration().getJsonMapper()).thenReturn(jsonMapper);
     }
 
-    private Variable variable(
-        final String name, final String value, final long scopeKey, final boolean truncated) {
+    private Variable variable(final String name, final String value) {
       final Variable variable = mock(Variable.class);
       when(variable.getName()).thenReturn(name);
       when(variable.getValue()).thenReturn(value);
-      when(variable.getScopeKey()).thenReturn(scopeKey);
-      when(variable.isTruncated()).thenReturn(truncated);
       return variable;
     }
 
     @Test
     void shouldCompleteJobWithVariableMapper() {
       // given
-      final Variable idVariable = variable("id", "1", PROCESS_INSTANCE_KEY, false);
-      final Variable localVariable = variable("local", "\"hello\"", ELEMENT_INSTANCE_KEY, false);
+      final Variable idVariable = variable("id", "1");
+      final Variable localVariable = variable("local", "\"hello\"");
       when(camundaClient
               .newVariableSearchRequest()
               .filter(variableFilterCaptor.capture())
-              .page(
-                  ArgumentMatchers
-                      .<java.util.function.Consumer<io.camunda.client.api.search.page.AnyPage>>
-                          any())
+              .withFullValues()
               .send()
               .join()
               .items())
@@ -730,15 +721,12 @@ public class CompleteJobTest {
     @Test
     void shouldPreferLocalOverGlobalVariable() {
       // given - same name 'id' at both scopes; local must win
-      final Variable globalId = variable("id", "1", PROCESS_INSTANCE_KEY, false);
-      final Variable localId = variable("id", "2", ELEMENT_INSTANCE_KEY, false);
+      final Variable globalId = variable("id", "1");
+      final Variable localId = variable("id", "2");
       when(camundaClient
               .newVariableSearchRequest()
               .filter(variableFilterCaptor.capture())
-              .page(
-                  ArgumentMatchers
-                      .<java.util.function.Consumer<io.camunda.client.api.search.page.AnyPage>>
-                          any())
+              .withFullValues()
               .send()
               .join()
               .items())
@@ -837,13 +825,10 @@ public class CompleteJobTest {
               new ConditionalBehaviorEngine());
     }
 
-    private Variable variable(
-        final String name, final String value, final long scopeKey, final boolean truncated) {
+    private Variable variable(final String name, final String value) {
       final Variable variable = mock(Variable.class);
       when(variable.getName()).thenReturn(name);
       when(variable.getValue()).thenReturn(value);
-      when(variable.getScopeKey()).thenReturn(scopeKey);
-      when(variable.isTruncated()).thenReturn(truncated);
       return variable;
     }
 
@@ -899,10 +884,7 @@ public class CompleteJobTest {
       when(camundaClient
               .newVariableSearchRequest()
               .filter(variableFilterCaptor.capture())
-              .page(
-                  ArgumentMatchers
-                      .<java.util.function.Consumer<io.camunda.client.api.search.page.AnyPage>>
-                          any())
+              .withFullValues()
               .send()
               .join()
               .items())
@@ -926,10 +908,7 @@ public class CompleteJobTest {
       when(camundaClient
               .newVariableSearchRequest()
               .filter(variableFilterCaptor.capture())
-              .page(
-                  ArgumentMatchers
-                      .<java.util.function.Consumer<io.camunda.client.api.search.page.AnyPage>>
-                          any())
+              .withFullValues()
               .send()
               .join()
               .items())
@@ -945,35 +924,6 @@ public class CompleteJobTest {
                       }))
           .isInstanceOf(IllegalStateException.class)
           .hasMessageContaining("boom");
-
-      // and: completion command was never sent
-      verify(camundaClient, org.mockito.Mockito.never()).newCompleteCommand(JOB_KEY);
-    }
-
-    @Test
-    void shouldFailIfInputVariableIsTruncated() {
-      // given
-      mockJobFound();
-      final Variable truncated = variable("big", "\"...\"", PROCESS_INSTANCE_KEY, true);
-      when(camundaClient
-              .newVariableSearchRequest()
-              .filter(variableFilterCaptor.capture())
-              .page(
-                  ArgumentMatchers
-                      .<java.util.function.Consumer<io.camunda.client.api.search.page.AnyPage>>
-                          any())
-              .send()
-              .join()
-              .items())
-          .thenReturn(Collections.singletonList(truncated));
-
-      // when/then
-      assertThatThrownBy(
-              () ->
-                  camundaProcessTestContext.completeJob(
-                      JOB_TYPE, inputVars -> Collections.emptyMap()))
-          .isInstanceOf(AssertionError.class)
-          .hasMessageContaining("variable 'big' is truncated");
 
       // and: completion command was never sent
       verify(camundaClient, org.mockito.Mockito.never()).newCompleteCommand(JOB_KEY);

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CompleteJobTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CompleteJobTest.java
@@ -54,6 +54,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -769,7 +770,7 @@ public class CompleteJobTest {
       assertThatThrownBy(
               () ->
                   camundaProcessTestContext.completeJob(
-                      JOB_TYPE, (Function<Map<String, Object>, Map<String, Object>>) null))
+                      JOB_TYPE, (UnaryOperator<Map<String, Object>>) null))
           .isInstanceOf(NullPointerException.class)
           .hasMessageContaining("variableMapper");
 

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CompleteJobTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CompleteJobTest.java
@@ -643,6 +643,8 @@ public class CompleteJobTest {
               .join()
               .items())
           .thenReturn(Collections.emptyList());
+
+      when(camundaClient.getConfiguration().getJsonMapper()).thenReturn(jsonMapper);
     }
 
     private Variable variable(

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CompleteJobTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CompleteJobTest.java
@@ -723,6 +723,7 @@ public class CompleteJobTest {
       // given - same name 'id' at both scopes; local must win
       final Variable globalId = variable("id", "1");
       final Variable localId = variable("id", "2");
+      // first call fetches global-scope variables, second call fetches element-local variables
       when(camundaClient
               .newVariableSearchRequest()
               .filter(variableFilterCaptor.capture())
@@ -730,7 +731,9 @@ public class CompleteJobTest {
               .send()
               .join()
               .items())
-          .thenReturn(Arrays.asList(globalId, localId));
+          .thenReturn(Collections.singletonList(globalId))
+          .thenReturn(Collections.singletonList(localId));
+      when(jsonMapper.fromJson("1", Object.class)).thenReturn(1);
       when(jsonMapper.fromJson("2", Object.class)).thenReturn(2);
 
       final Map<String, Object> capturedInput = new HashMap<>();

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CompleteJobTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CompleteJobTest.java
@@ -635,6 +635,10 @@ public class CompleteJobTest {
       when(camundaClient
               .newVariableSearchRequest()
               .filter(variableFilterCaptor.capture())
+              .page(
+                  ArgumentMatchers
+                      .<java.util.function.Consumer<io.camunda.client.api.search.page.AnyPage>>
+                          any())
               .send()
               .join()
               .items())
@@ -659,6 +663,10 @@ public class CompleteJobTest {
       when(camundaClient
               .newVariableSearchRequest()
               .filter(variableFilterCaptor.capture())
+              .page(
+                  ArgumentMatchers
+                      .<java.util.function.Consumer<io.camunda.client.api.search.page.AnyPage>>
+                          any())
               .send()
               .join()
               .items())
@@ -725,6 +733,10 @@ public class CompleteJobTest {
       when(camundaClient
               .newVariableSearchRequest()
               .filter(variableFilterCaptor.capture())
+              .page(
+                  ArgumentMatchers
+                      .<java.util.function.Consumer<io.camunda.client.api.search.page.AnyPage>>
+                          any())
               .send()
               .join()
               .items())
@@ -885,6 +897,10 @@ public class CompleteJobTest {
       when(camundaClient
               .newVariableSearchRequest()
               .filter(variableFilterCaptor.capture())
+              .page(
+                  ArgumentMatchers
+                      .<java.util.function.Consumer<io.camunda.client.api.search.page.AnyPage>>
+                          any())
               .send()
               .join()
               .items())
@@ -908,6 +924,10 @@ public class CompleteJobTest {
       when(camundaClient
               .newVariableSearchRequest()
               .filter(variableFilterCaptor.capture())
+              .page(
+                  ArgumentMatchers
+                      .<java.util.function.Consumer<io.camunda.client.api.search.page.AnyPage>>
+                          any())
               .send()
               .join()
               .items())
@@ -936,6 +956,10 @@ public class CompleteJobTest {
       when(camundaClient
               .newVariableSearchRequest()
               .filter(variableFilterCaptor.capture())
+              .page(
+                  ArgumentMatchers
+                      .<java.util.function.Consumer<io.camunda.client.api.search.page.AnyPage>>
+                          any())
               .send()
               .join()
               .items())

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CompleteUserTaskTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CompleteUserTaskTest.java
@@ -30,7 +30,9 @@ import io.camunda.client.api.command.ClientException;
 import io.camunda.client.api.response.CompleteUserTaskResponse;
 import io.camunda.client.api.search.enums.UserTaskState;
 import io.camunda.client.api.search.filter.UserTaskFilter;
+import io.camunda.client.api.search.filter.VariableFilter;
 import io.camunda.client.api.search.response.UserTask;
+import io.camunda.client.api.search.response.Variable;
 import io.camunda.process.test.api.CamundaClientBuilderFactory;
 import io.camunda.process.test.api.CamundaProcessTestContext;
 import io.camunda.process.test.api.assertions.UserTaskSelectors;
@@ -39,9 +41,12 @@ import io.camunda.process.test.impl.extension.CamundaProcessTestContextImpl;
 import io.camunda.process.test.impl.extension.ConditionalBehaviorEngine;
 import io.camunda.process.test.impl.runtime.CamundaProcessTestRuntime;
 import io.camunda.process.test.utils.DevAwaitBehavior;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -236,6 +241,376 @@ public class CompleteUserTaskTest {
           .hasMessageContaining(
               "Expected to complete user task [elementId: %s] but no user task is available.",
               USER_TASK_ELEMENT_ID);
+    }
+  }
+
+  @Nested
+  @org.mockito.junit.jupiter.MockitoSettings(strictness = org.mockito.quality.Strictness.LENIENT)
+  class CompleteUserTaskWithVariableMapper {
+
+    private static final long PROCESS_INSTANCE_KEY = 200L;
+    private static final long ELEMENT_INSTANCE_KEY = 300L;
+
+    @Captor private ArgumentCaptor<Consumer<VariableFilter>> variableFilterCaptor;
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private VariableFilter variableFilter;
+
+    @BeforeEach
+    void setup() {
+      camundaProcessTestContext =
+          new CamundaProcessTestContextImpl(
+              camundaProcessTestRuntime,
+              clientCreationCallback,
+              clockClient,
+              DevAwaitBehavior::expectSuccess,
+              jsonMapper,
+              new ConditionalBehaviorEngine());
+
+      when(camundaClient
+              .newUserTaskSearchRequest()
+              .filter(userTaskFilterCaptor.capture())
+              .send()
+              .join()
+              .items())
+          .thenReturn(Collections.singletonList(userTask));
+
+      when(userTask.getUserTaskKey()).thenReturn(USER_TASK_KEY);
+      when(userTask.getElementId()).thenReturn(USER_TASK_ELEMENT_ID);
+      when(userTask.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+      when(userTask.getElementInstanceKey()).thenReturn(ELEMENT_INSTANCE_KEY);
+
+      when(camundaClient
+              .newVariableSearchRequest()
+              .filter(variableFilterCaptor.capture())
+              .send()
+              .join()
+              .items())
+          .thenReturn(Collections.emptyList());
+    }
+
+    private Variable variable(
+        final String name, final String value, final long scopeKey, final boolean truncated) {
+      final Variable variable = mock(Variable.class);
+      when(variable.getName()).thenReturn(name);
+      when(variable.getValue()).thenReturn(value);
+      when(variable.getScopeKey()).thenReturn(scopeKey);
+      when(variable.isTruncated()).thenReturn(truncated);
+      return variable;
+    }
+
+    @Test
+    void shouldCompleteUserTaskWithVariableMapper() {
+      // given
+      final Variable idVariable = variable("id", "1", PROCESS_INSTANCE_KEY, false);
+      final Variable localVariable = variable("local", "\"hello\"", ELEMENT_INSTANCE_KEY, false);
+      when(camundaClient
+              .newVariableSearchRequest()
+              .filter(variableFilterCaptor.capture())
+              .send()
+              .join()
+              .items())
+          .thenReturn(Arrays.asList(idVariable, localVariable));
+      when(jsonMapper.fromJson("1", Object.class)).thenReturn(1);
+      when(jsonMapper.fromJson("\"hello\"", Object.class)).thenReturn("hello");
+
+      final Map<String, Object> capturedInput = new HashMap<>();
+      final Map<String, Object> outputVariables = Collections.singletonMap("user", "Alice");
+
+      // when
+      camundaProcessTestContext.completeUserTask(
+          USER_TASK_ELEMENT_ID,
+          inputVars -> {
+            capturedInput.putAll(inputVars);
+            return outputVariables;
+          });
+
+      // then
+      org.assertj.core.api.Assertions.assertThat(capturedInput)
+          .containsEntry("id", 1)
+          .containsEntry("local", "hello");
+      verify(camundaClient.newCompleteUserTaskCommand(USER_TASK_KEY).variables(outputVariables))
+          .send();
+    }
+
+    @Test
+    void shouldCompleteUserTaskWithVariableMapperBySelector() {
+      // given
+      final Map<String, Object> outputVariables = Collections.singletonMap("user", "Bob");
+
+      // when
+      camundaProcessTestContext.completeUserTask(
+          UserTaskSelectors.byElementId(USER_TASK_ELEMENT_ID), inputVars -> outputVariables);
+
+      // then
+      verify(camundaClient.newCompleteUserTaskCommand(USER_TASK_KEY).variables(outputVariables))
+          .send();
+    }
+
+    @Test
+    void shouldCompleteUserTaskWithEmptyInputVariables() {
+      // given - the default mock returns an empty list of variables
+      final Map<String, Object> capturedInput = new HashMap<>();
+      capturedInput.put("sentinel", "untouched");
+
+      // when
+      camundaProcessTestContext.completeUserTask(
+          USER_TASK_ELEMENT_ID,
+          inputVars -> {
+            capturedInput.clear();
+            capturedInput.putAll(inputVars);
+            return Collections.emptyMap();
+          });
+
+      // then
+      org.assertj.core.api.Assertions.assertThat(capturedInput).isEmpty();
+      verify(
+              camundaClient
+                  .newCompleteUserTaskCommand(USER_TASK_KEY)
+                  .variables(Collections.emptyMap()))
+          .send();
+    }
+
+    @Test
+    void shouldPreferLocalOverGlobalVariable() {
+      // given - same name 'id' at both scopes; local must win
+      final Variable globalId = variable("id", "1", PROCESS_INSTANCE_KEY, false);
+      final Variable localId = variable("id", "2", ELEMENT_INSTANCE_KEY, false);
+      when(camundaClient
+              .newVariableSearchRequest()
+              .filter(variableFilterCaptor.capture())
+              .send()
+              .join()
+              .items())
+          .thenReturn(Arrays.asList(globalId, localId));
+      when(jsonMapper.fromJson("2", Object.class)).thenReturn(2);
+
+      final Map<String, Object> capturedInput = new HashMap<>();
+
+      // when
+      camundaProcessTestContext.completeUserTask(
+          USER_TASK_ELEMENT_ID,
+          inputVars -> {
+            capturedInput.putAll(inputVars);
+            return Collections.emptyMap();
+          });
+
+      // then
+      org.assertj.core.api.Assertions.assertThat(capturedInput).containsEntry("id", 2);
+    }
+
+    @Test
+    void shouldFilterVariablesByProcessInstanceKey() {
+      // when
+      camundaProcessTestContext.completeUserTask(
+          USER_TASK_ELEMENT_ID, inputVars -> Collections.emptyMap());
+
+      // then
+      variableFilterCaptor.getValue().accept(variableFilter);
+      verify(variableFilter).processInstanceKey(PROCESS_INSTANCE_KEY);
+    }
+
+    @Test
+    void shouldFailIfVariableMapperIsNull() {
+      // given
+      clearInvocations(camundaClient);
+
+      // when/then
+      assertThatThrownBy(
+              () ->
+                  camundaProcessTestContext.completeUserTask(
+                      USER_TASK_ELEMENT_ID,
+                      (Function<Map<String, Object>, Map<String, Object>>) null))
+          .isInstanceOf(NullPointerException.class)
+          .hasMessageContaining("variableMapper");
+
+      // and: no search/completion took place
+      verify(camundaClient, org.mockito.Mockito.never()).newUserTaskSearchRequest();
+    }
+
+    @Test
+    void shouldRetryCompletionWithoutReinvokingMapper() {
+      // given
+      when(camundaClient
+              .newCompleteUserTaskCommand(USER_TASK_KEY)
+              .variables(org.mockito.ArgumentMatchers.<Map<String, Object>>any())
+              .send()
+              .join())
+          .thenThrow(new ClientException("expected"))
+          .thenReturn(mock(CompleteUserTaskResponse.class));
+
+      final java.util.concurrent.atomic.AtomicInteger mapperInvocations =
+          new java.util.concurrent.atomic.AtomicInteger();
+
+      clearInvocations(camundaClient);
+
+      // when
+      camundaProcessTestContext.completeUserTask(
+          USER_TASK_ELEMENT_ID,
+          inputVars -> {
+            mapperInvocations.incrementAndGet();
+            return Collections.emptyMap();
+          });
+
+      // then
+      org.assertj.core.api.Assertions.assertThat(mapperInvocations.get()).isEqualTo(1);
+      verify(camundaClient, times(2)).newCompleteUserTaskCommand(USER_TASK_KEY);
+    }
+  }
+
+  @Nested
+  @org.mockito.junit.jupiter.MockitoSettings(strictness = org.mockito.quality.Strictness.LENIENT)
+  class CompleteUserTaskWithVariableMapperFailureCases {
+
+    private static final long PROCESS_INSTANCE_KEY = 200L;
+    private static final long ELEMENT_INSTANCE_KEY = 300L;
+
+    @Captor private ArgumentCaptor<Consumer<VariableFilter>> variableFilterCaptor;
+
+    @BeforeEach
+    void setup() {
+      camundaProcessTestContext =
+          new CamundaProcessTestContextImpl(
+              camundaProcessTestRuntime,
+              clientCreationCallback,
+              clockClient,
+              DevAwaitBehavior::expectFailure,
+              jsonMapper,
+              new ConditionalBehaviorEngine());
+    }
+
+    private Variable variable(
+        final String name, final String value, final long scopeKey, final boolean truncated) {
+      final Variable variable = mock(Variable.class);
+      when(variable.getName()).thenReturn(name);
+      when(variable.getValue()).thenReturn(value);
+      when(variable.getScopeKey()).thenReturn(scopeKey);
+      when(variable.isTruncated()).thenReturn(truncated);
+      return variable;
+    }
+
+    private void mockUserTaskFound() {
+      when(camundaClient
+              .newUserTaskSearchRequest()
+              .filter(userTaskFilterCaptor.capture())
+              .send()
+              .join()
+              .items())
+          .thenReturn(Collections.singletonList(userTask));
+      when(userTask.getUserTaskKey()).thenReturn(USER_TASK_KEY);
+      when(userTask.getElementId()).thenReturn(USER_TASK_ELEMENT_ID);
+      when(userTask.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+      when(userTask.getElementInstanceKey()).thenReturn(ELEMENT_INSTANCE_KEY);
+    }
+
+    @Test
+    void shouldFailIfNoUserTaskIsPresentForVariableMapper() {
+      // given
+      when(camundaClient
+              .newUserTaskSearchRequest()
+              .filter(userTaskFilterCaptor.capture())
+              .send()
+              .join()
+              .items())
+          .thenReturn(Collections.emptyList());
+
+      final java.util.concurrent.atomic.AtomicInteger mapperInvocations =
+          new java.util.concurrent.atomic.AtomicInteger();
+
+      // when/then
+      assertThatThrownBy(
+              () ->
+                  camundaProcessTestContext.completeUserTask(
+                      USER_TASK_ELEMENT_ID,
+                      inputVars -> {
+                        mapperInvocations.incrementAndGet();
+                        return Collections.emptyMap();
+                      }))
+          .isInstanceOf(AssertionError.class)
+          .hasMessageContaining(
+              "Expected to complete user task [elementId: %s] but no user task is available.",
+              USER_TASK_ELEMENT_ID);
+
+      // and: mapper was never invoked
+      org.assertj.core.api.Assertions.assertThat(mapperInvocations.get()).isZero();
+    }
+
+    @Test
+    void shouldFailIfVariableMapperReturnsNull() {
+      // given
+      mockUserTaskFound();
+      when(camundaClient
+              .newVariableSearchRequest()
+              .filter(variableFilterCaptor.capture())
+              .send()
+              .join()
+              .items())
+          .thenReturn(Collections.emptyList());
+
+      // when/then
+      assertThatThrownBy(
+              () ->
+                  camundaProcessTestContext.completeUserTask(
+                      USER_TASK_ELEMENT_ID, inputVars -> null))
+          .isInstanceOf(AssertionError.class)
+          .hasMessageContaining(
+              "Expected to complete user task [elementId: %s] but the variableMapper returned null.",
+              USER_TASK_ELEMENT_ID);
+
+      // and: completion command was never sent
+      verify(camundaClient, org.mockito.Mockito.never()).newCompleteUserTaskCommand(USER_TASK_KEY);
+    }
+
+    @Test
+    void shouldPropagateExceptionFromVariableMapper() {
+      // given
+      mockUserTaskFound();
+      when(camundaClient
+              .newVariableSearchRequest()
+              .filter(variableFilterCaptor.capture())
+              .send()
+              .join()
+              .items())
+          .thenReturn(Collections.emptyList());
+
+      // when/then
+      assertThatThrownBy(
+              () ->
+                  camundaProcessTestContext.completeUserTask(
+                      USER_TASK_ELEMENT_ID,
+                      inputVars -> {
+                        throw new IllegalStateException("boom");
+                      }))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("boom");
+
+      // and: completion command was never sent
+      verify(camundaClient, org.mockito.Mockito.never()).newCompleteUserTaskCommand(USER_TASK_KEY);
+    }
+
+    @Test
+    void shouldFailIfInputVariableIsTruncated() {
+      // given
+      mockUserTaskFound();
+      final Variable truncated = variable("big", "\"...\"", PROCESS_INSTANCE_KEY, true);
+      when(camundaClient
+              .newVariableSearchRequest()
+              .filter(variableFilterCaptor.capture())
+              .send()
+              .join()
+              .items())
+          .thenReturn(Collections.singletonList(truncated));
+
+      // when/then
+      assertThatThrownBy(
+              () ->
+                  camundaProcessTestContext.completeUserTask(
+                      USER_TASK_ELEMENT_ID, inputVars -> Collections.emptyMap()))
+          .isInstanceOf(AssertionError.class)
+          .hasMessageContaining("variable 'big' is truncated");
+
+      // and: completion command was never sent
+      verify(camundaClient, org.mockito.Mockito.never()).newCompleteUserTaskCommand(USER_TASK_KEY);
     }
   }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CompleteUserTaskTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CompleteUserTaskTest.java
@@ -283,6 +283,10 @@ public class CompleteUserTaskTest {
       when(camundaClient
               .newVariableSearchRequest()
               .filter(variableFilterCaptor.capture())
+              .page(
+                  org.mockito.ArgumentMatchers
+                      .<java.util.function.Consumer<io.camunda.client.api.search.page.AnyPage>>
+                          any())
               .send()
               .join()
               .items())
@@ -307,6 +311,10 @@ public class CompleteUserTaskTest {
       when(camundaClient
               .newVariableSearchRequest()
               .filter(variableFilterCaptor.capture())
+              .page(
+                  org.mockito.ArgumentMatchers
+                      .<java.util.function.Consumer<io.camunda.client.api.search.page.AnyPage>>
+                          any())
               .send()
               .join()
               .items())
@@ -379,6 +387,10 @@ public class CompleteUserTaskTest {
       when(camundaClient
               .newVariableSearchRequest()
               .filter(variableFilterCaptor.capture())
+              .page(
+                  org.mockito.ArgumentMatchers
+                      .<java.util.function.Consumer<io.camunda.client.api.search.page.AnyPage>>
+                          any())
               .send()
               .join()
               .items())
@@ -542,6 +554,10 @@ public class CompleteUserTaskTest {
       when(camundaClient
               .newVariableSearchRequest()
               .filter(variableFilterCaptor.capture())
+              .page(
+                  org.mockito.ArgumentMatchers
+                      .<java.util.function.Consumer<io.camunda.client.api.search.page.AnyPage>>
+                          any())
               .send()
               .join()
               .items())
@@ -568,6 +584,10 @@ public class CompleteUserTaskTest {
       when(camundaClient
               .newVariableSearchRequest()
               .filter(variableFilterCaptor.capture())
+              .page(
+                  org.mockito.ArgumentMatchers
+                      .<java.util.function.Consumer<io.camunda.client.api.search.page.AnyPage>>
+                          any())
               .send()
               .join()
               .items())
@@ -596,6 +616,10 @@ public class CompleteUserTaskTest {
       when(camundaClient
               .newVariableSearchRequest()
               .filter(variableFilterCaptor.capture())
+              .page(
+                  org.mockito.ArgumentMatchers
+                      .<java.util.function.Consumer<io.camunda.client.api.search.page.AnyPage>>
+                          any())
               .send()
               .join()
               .items())

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CompleteUserTaskTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CompleteUserTaskTest.java
@@ -46,7 +46,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -424,8 +424,7 @@ public class CompleteUserTaskTest {
       assertThatThrownBy(
               () ->
                   camundaProcessTestContext.completeUserTask(
-                      USER_TASK_ELEMENT_ID,
-                      (Function<Map<String, Object>, Map<String, Object>>) null))
+                      USER_TASK_ELEMENT_ID, (UnaryOperator<Map<String, Object>>) null))
           .isInstanceOf(NullPointerException.class)
           .hasMessageContaining("variableMapper");
 

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CompleteUserTaskTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CompleteUserTaskTest.java
@@ -431,35 +431,6 @@ public class CompleteUserTaskTest {
       // and: no search/completion took place
       verify(camundaClient, org.mockito.Mockito.never()).newUserTaskSearchRequest();
     }
-
-    @Test
-    void shouldRetryCompletionWithoutReinvokingMapper() {
-      // given
-      when(camundaClient
-              .newCompleteUserTaskCommand(USER_TASK_KEY)
-              .variables(org.mockito.ArgumentMatchers.<Map<String, Object>>any())
-              .send()
-              .join())
-          .thenThrow(new ClientException("expected"))
-          .thenReturn(mock(CompleteUserTaskResponse.class));
-
-      final java.util.concurrent.atomic.AtomicInteger mapperInvocations =
-          new java.util.concurrent.atomic.AtomicInteger();
-
-      clearInvocations(camundaClient);
-
-      // when
-      camundaProcessTestContext.completeUserTask(
-          USER_TASK_ELEMENT_ID,
-          inputVars -> {
-            mapperInvocations.incrementAndGet();
-            return Collections.emptyMap();
-          });
-
-      // then
-      org.assertj.core.api.Assertions.assertThat(mapperInvocations.get()).isEqualTo(1);
-      verify(camundaClient, times(2)).newCompleteUserTaskCommand(USER_TASK_KEY);
-    }
   }
 
   @Nested
@@ -481,13 +452,6 @@ public class CompleteUserTaskTest {
               DevAwaitBehavior::expectFailure,
               jsonMapper,
               new ConditionalBehaviorEngine());
-    }
-
-    private Variable variable(final String name, final String value) {
-      final Variable variable = mock(Variable.class);
-      when(variable.getName()).thenReturn(name);
-      when(variable.getValue()).thenReturn(value);
-      return variable;
     }
 
     private void mockUserTaskFound() {

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CompleteUserTaskTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CompleteUserTaskTest.java
@@ -283,10 +283,7 @@ public class CompleteUserTaskTest {
       when(camundaClient
               .newVariableSearchRequest()
               .filter(variableFilterCaptor.capture())
-              .page(
-                  org.mockito.ArgumentMatchers
-                      .<java.util.function.Consumer<io.camunda.client.api.search.page.AnyPage>>
-                          any())
+              .withFullValues()
               .send()
               .join()
               .items())
@@ -295,28 +292,22 @@ public class CompleteUserTaskTest {
       when(camundaClient.getConfiguration().getJsonMapper()).thenReturn(jsonMapper);
     }
 
-    private Variable variable(
-        final String name, final String value, final long scopeKey, final boolean truncated) {
+    private Variable variable(final String name, final String value) {
       final Variable variable = mock(Variable.class);
       when(variable.getName()).thenReturn(name);
       when(variable.getValue()).thenReturn(value);
-      when(variable.getScopeKey()).thenReturn(scopeKey);
-      when(variable.isTruncated()).thenReturn(truncated);
       return variable;
     }
 
     @Test
     void shouldCompleteUserTaskWithVariableMapper() {
       // given
-      final Variable idVariable = variable("id", "1", PROCESS_INSTANCE_KEY, false);
-      final Variable localVariable = variable("local", "\"hello\"", ELEMENT_INSTANCE_KEY, false);
+      final Variable idVariable = variable("id", "1");
+      final Variable localVariable = variable("local", "\"hello\"");
       when(camundaClient
               .newVariableSearchRequest()
               .filter(variableFilterCaptor.capture())
-              .page(
-                  org.mockito.ArgumentMatchers
-                      .<java.util.function.Consumer<io.camunda.client.api.search.page.AnyPage>>
-                          any())
+              .withFullValues()
               .send()
               .join()
               .items())
@@ -384,15 +375,12 @@ public class CompleteUserTaskTest {
     @Test
     void shouldPreferLocalOverGlobalVariable() {
       // given - same name 'id' at both scopes; local must win
-      final Variable globalId = variable("id", "1", PROCESS_INSTANCE_KEY, false);
-      final Variable localId = variable("id", "2", ELEMENT_INSTANCE_KEY, false);
+      final Variable globalId = variable("id", "1");
+      final Variable localId = variable("id", "2");
       when(camundaClient
               .newVariableSearchRequest()
               .filter(variableFilterCaptor.capture())
-              .page(
-                  org.mockito.ArgumentMatchers
-                      .<java.util.function.Consumer<io.camunda.client.api.search.page.AnyPage>>
-                          any())
+              .withFullValues()
               .send()
               .join()
               .items())
@@ -493,13 +481,10 @@ public class CompleteUserTaskTest {
               new ConditionalBehaviorEngine());
     }
 
-    private Variable variable(
-        final String name, final String value, final long scopeKey, final boolean truncated) {
+    private Variable variable(final String name, final String value) {
       final Variable variable = mock(Variable.class);
       when(variable.getName()).thenReturn(name);
       when(variable.getValue()).thenReturn(value);
-      when(variable.getScopeKey()).thenReturn(scopeKey);
-      when(variable.isTruncated()).thenReturn(truncated);
       return variable;
     }
 
@@ -556,10 +541,7 @@ public class CompleteUserTaskTest {
       when(camundaClient
               .newVariableSearchRequest()
               .filter(variableFilterCaptor.capture())
-              .page(
-                  org.mockito.ArgumentMatchers
-                      .<java.util.function.Consumer<io.camunda.client.api.search.page.AnyPage>>
-                          any())
+              .withFullValues()
               .send()
               .join()
               .items())
@@ -586,10 +568,7 @@ public class CompleteUserTaskTest {
       when(camundaClient
               .newVariableSearchRequest()
               .filter(variableFilterCaptor.capture())
-              .page(
-                  org.mockito.ArgumentMatchers
-                      .<java.util.function.Consumer<io.camunda.client.api.search.page.AnyPage>>
-                          any())
+              .withFullValues()
               .send()
               .join()
               .items())
@@ -605,35 +584,6 @@ public class CompleteUserTaskTest {
                       }))
           .isInstanceOf(IllegalStateException.class)
           .hasMessageContaining("boom");
-
-      // and: completion command was never sent
-      verify(camundaClient, org.mockito.Mockito.never()).newCompleteUserTaskCommand(USER_TASK_KEY);
-    }
-
-    @Test
-    void shouldFailIfInputVariableIsTruncated() {
-      // given
-      mockUserTaskFound();
-      final Variable truncated = variable("big", "\"...\"", PROCESS_INSTANCE_KEY, true);
-      when(camundaClient
-              .newVariableSearchRequest()
-              .filter(variableFilterCaptor.capture())
-              .page(
-                  org.mockito.ArgumentMatchers
-                      .<java.util.function.Consumer<io.camunda.client.api.search.page.AnyPage>>
-                          any())
-              .send()
-              .join()
-              .items())
-          .thenReturn(Collections.singletonList(truncated));
-
-      // when/then
-      assertThatThrownBy(
-              () ->
-                  camundaProcessTestContext.completeUserTask(
-                      USER_TASK_ELEMENT_ID, inputVars -> Collections.emptyMap()))
-          .isInstanceOf(AssertionError.class)
-          .hasMessageContaining("variable 'big' is truncated");
 
       // and: completion command was never sent
       verify(camundaClient, org.mockito.Mockito.never()).newCompleteUserTaskCommand(USER_TASK_KEY);

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CompleteUserTaskTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CompleteUserTaskTest.java
@@ -291,6 +291,8 @@ public class CompleteUserTaskTest {
               .join()
               .items())
           .thenReturn(Collections.emptyList());
+
+      when(camundaClient.getConfiguration().getJsonMapper()).thenReturn(jsonMapper);
     }
 
     private Variable variable(

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CompleteUserTaskTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/extensions/CompleteUserTaskTest.java
@@ -377,6 +377,7 @@ public class CompleteUserTaskTest {
       // given - same name 'id' at both scopes; local must win
       final Variable globalId = variable("id", "1");
       final Variable localId = variable("id", "2");
+      // first call fetches global-scope variables, second call fetches element-local variables
       when(camundaClient
               .newVariableSearchRequest()
               .filter(variableFilterCaptor.capture())
@@ -384,7 +385,9 @@ public class CompleteUserTaskTest {
               .send()
               .join()
               .items())
-          .thenReturn(Arrays.asList(globalId, localId));
+          .thenReturn(Collections.singletonList(globalId))
+          .thenReturn(Collections.singletonList(localId));
+      when(jsonMapper.fromJson("1", Object.class)).thenReturn(1);
       when(jsonMapper.fromJson("2", Object.class)).thenReturn(2);
 
       final Map<String, Object> capturedInput = new HashMap<>();


### PR DESCRIPTION
## Description
Add new overloads on `CamundaProcessTestContext` that accept a `Function<Map<String, Object>, Map<String, Object>>`. The mapper receives the entity's input variables and returns the output variables used to complete the job or user task.

This enables steering completion based on input variables inside when/then conditional behaviors without manually fetching variables via the Search API.

Sanity checks: 
* a null mapper raises NullPointerException
* a mapper returning null raises AssertionError
* truncated input variables raise AssertionError

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #50556
