### PR TITLE
build: remove templating over SBE schema

### DIFF
--- a/zeebe/protocol/pom.xml
+++ b/zeebe/protocol/pom.xml
@@ -155,8 +155,8 @@
             <phase>generate-sources</phase>
             <configuration>
               <arguments>
-                <argument>${project.basedir}/src/main/resources/protocol.xml</argument>
-                <argument>${project.basedir}/src/main/resources/cluster-management-protocol.xml</argument>
+                <argument>${project.build.resources[0].directory}/protocol.xml</argument>
+                <argument>${project.build.resources[0].directory}/cluster-management-protocol.xml</argument>
               </arguments>
             </configuration>
           </execution>

--- a/zeebe/protocol/pom.xml
+++ b/zeebe/protocol/pom.xml
@@ -25,7 +25,6 @@
   <properties>
     <version.java>8</version.java>
     <license.header.file>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header.file>
-    <protocol.version>7</protocol.version>
   </properties>
 
   <dependencies>
@@ -104,13 +103,6 @@
   </dependencies>
 
   <build>
-    <resources>
-      <resource>
-        <filtering>true</filtering>
-        <directory>src/main/resources</directory>
-      </resource>
-    </resources>
-
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -133,20 +125,6 @@
           </execution>
         </executions>
 
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-resources-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default-resources</id>
-            <goals>
-              <goal>resources</goal>
-            </goals>
-            <phase>generate-sources</phase>
-          </execution>
-        </executions>
       </plugin>
 
       <plugin>
@@ -177,8 +155,8 @@
             <phase>generate-sources</phase>
             <configuration>
               <arguments>
-                <argument>${project.build.outputDirectory}/protocol.xml</argument>
-                <argument>${project.build.outputDirectory}/cluster-management-protocol.xml</argument>
+                <argument>${project.basedir}/src/main/resources/protocol.xml</argument>
+                <argument>${project.basedir}/src/main/resources/cluster-management-protocol.xml</argument>
               </arguments>
             </configuration>
           </execution>

--- a/zeebe/protocol/src/main/resources/cluster-management-protocol.xml
+++ b/zeebe/protocol/src/main/resources/cluster-management-protocol.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
   xmlns:xi="http://www.w3.org/2001/XInclude" package="io.camunda.zeebe.protocol.management"
-  id="1" version="1" semanticVersion="${project.version}"
+  id="1" version="1"
   description="Zeebe Cluster Management Protocol" byteOrder="littleEndian">
 
   <xi:include href="common-types.xml"/>

--- a/zeebe/protocol/src/main/resources/protocol.xml
+++ b/zeebe/protocol/src/main/resources/protocol.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
   xmlns:xi="http://www.w3.org/2001/XInclude" package="io.camunda.zeebe.protocol.record"
-  id="0" version="${protocol.version}" semanticVersion="${project.version}"
+  id="0" version="7"
   description="Zeebe Protocol" byteOrder="littleEndian">
 
   <xi:include href="common-types.xml"/>


### PR DESCRIPTION
## Description
Removed the templating over the SBE schema files in `zeebe/protocol/` in order to simplify the build process.
The semanticVersion is not used anywhere and we can avoid bumping the protocolVersion of a schema when only the other one is changed: right now it's bumped everytime you make a change to either of them which is unnecessary.

