### PR TITLE
fix: increase default snapshot timeout

### DIFF
--- a/docs/data-layer/backup-and-restore.md
+++ b/docs/data-layer/backup-and-restore.md
@@ -195,6 +195,61 @@ returns an error if it is not found.
 
 The backup executor uses a single-core thread pool with a queue capacity of 4096.
 
+#### Timeout Configuration
+
+Two independent timeout settings affect backup operations:
+
+**1. Socket timeout** (`socketTimeout`)
+
+Controls how long the HTTP client waits for a response from Elasticsearch/OpenSearch on any single
+request, including snapshot creation. Defaults to **0 (infinite)** — the HTTP connection will wait
+indefinitely for the snapshot call to return. This default is intentional: ES/OS snapshot
+operations on large datasets can legitimately take minutes or hours, and a finite socket timeout
+would cause spurious failures.
+
+> **Risk**: With an infinite socket timeout, if the ES/OS cluster becomes unresponsive mid-snapshot
+> (e.g. cluster restart, network partition, OOM), the backup thread will block indefinitely. The
+> only recovery is to restart the Camunda process. Monitor backup duration externally and alert if
+> a backup does not complete within the expected window.
+
+| Component | Property | Environment variable |
+|-----------|----------|----------------------|
+| Operate (ES) | `camunda.operate.elasticsearch.socketTimeout` | `CAMUNDA_OPERATE_ELASTICSEARCH_SOCKETTIMEOUT` |
+| Operate (OS) | `camunda.operate.opensearch.socketTimeout` | `CAMUNDA_OPERATE_OPENSEARCH_SOCKETTIMEOUT` |
+| Tasklist (ES) | `camunda.tasklist.elasticsearch.socketTimeout` | `CAMUNDA_TASKLIST_ELASTICSEARCH_SOCKETTIMEOUT` |
+| Tasklist (OS) | `camunda.tasklist.opensearch.socketTimeout` | `CAMUNDA_TASKLIST_OPENSEARCH_SOCKETTIMEOUT` |
+
+Value unit: **milliseconds**. Set to `0` for infinite (default). Only set a finite value if you
+have an external watchdog process that can restart Camunda on a stalled backup.
+
+**2. Snapshot polling timeout** (`snapshotTimeout`)
+
+When the socket timeout fires before the snapshot HTTP call returns (only relevant if `socketTimeout`
+is set to a finite value), Camunda falls back to a polling loop — repeatedly querying the ES/OS
+snapshot status until it completes. `snapshotTimeout` sets the maximum number of **seconds** the
+polling loop runs before giving up and marking the backup as failed.
+
+Defaults to **0 (infinite)** — polling continues until the snapshot completes or fails, regardless
+of how long it takes.
+
+| Component | Property | Environment variable |
+|-----------|----------|----------------------|
+| Orchestration Cluster (ES) | `camunda.data.secondary-storage.elasticsearch.backup.snapshot-timeout` | `CAMUNDA_DATA_SECONDARY_STORAGE_ELASTICSEARCH_BACKUP_SNAPSHOT__TIMEOUT` |
+| Orchestration Cluster (OS) | `camunda.data.secondary-storage.opensearch.backup.snapshot-timeout` | `CAMUNDA_DATA_SECONDARY_STORAGE_OPENSEARCH_BACKUP_SNAPSHOT__TIMEOUT` |
+| Operate (legacy, still supported) | `camunda.operate.backup.snapshotTimeout` | `CAMUNDA_OPERATE_BACKUP_SNAPSHOTTIMEOUT` |
+
+Value unit: **seconds**. Set to `0` for infinite (default). If you set `socketTimeout` to a finite
+value, set `snapshotTimeout` to a value that covers the worst-case snapshot duration for your data
+volume (e.g. `3600` for one hour).
+
+**Recommended configuration for large datasets**:
+
+```yaml
+# Keep socket timeout infinite (default) — do not set socketTimeout
+# Set a finite snapshot polling timeout only if you want time-bounded backups:
+camunda.data.secondary-storage.elasticsearch.backup.snapshot-timeout: 3600  # seconds
+```
+
 ### 1.6 API / Actuator Endpoints
 
 Backups are triggered, monitored, and deleted via Spring Boot actuator endpoints:

--- a/operate/common/src/main/java/io/camunda/operate/connect/ElasticsearchConnector.java
+++ b/operate/common/src/main/java/io/camunda/operate/connect/ElasticsearchConnector.java
@@ -74,6 +74,8 @@ public class ElasticsearchConnector {
   private PluginRepository esClientRepository = new PluginRepository();
   private final OperateProperties operateProperties;
 
+
+
   public ElasticsearchConnector(final OperateProperties operateProperties) {
     this.operateProperties = operateProperties;
   }
@@ -110,11 +112,8 @@ public class ElasticsearchConnector {
             .setHttpClientConfigCallback(
                 httpClientBuilder ->
                     configureHttpClient(
-                        httpClientBuilder, elsConfig, pluginRepository.asRequestInterceptor()));
-    if (elsConfig.getConnectTimeout() != null || elsConfig.getSocketTimeout() != null) {
-      restClientBuilder.setRequestConfigCallback(
-          configCallback -> setTimeouts(configCallback, elsConfig));
-    }
+                        httpClientBuilder, elsConfig, pluginRepository.asRequestInterceptor()))
+            .setRequestConfigCallback(configCallback -> setTimeouts(configCallback, elsConfig));
 
     final RestClientTransport transport =
         new RestClientTransport(restClientBuilder.build(), new JacksonJsonpMapper(objectMapper));
@@ -242,13 +241,9 @@ public class ElasticsearchConnector {
     return cert;
   }
 
-  private Builder setTimeouts(final Builder builder, final ElasticsearchProperties elsConfig) {
-    if (elsConfig.getSocketTimeout() != null) {
-      builder.setSocketTimeout(elsConfig.getSocketTimeout());
-    }
-    if (elsConfig.getConnectTimeout() != null) {
-      builder.setConnectTimeout(elsConfig.getConnectTimeout());
-    }
+  Builder setTimeouts(final Builder builder, final ElasticsearchProperties elsConfig) {
+    builder.setSocketTimeout(elsConfig.getSocketTimeout());
+    builder.setConnectTimeout(elsConfig.getConnectTimeout());
     return builder;
   }
 

--- a/operate/common/src/main/java/io/camunda/operate/connect/OpensearchConnector.java
+++ b/operate/common/src/main/java/io/camunda/operate/connect/OpensearchConnector.java
@@ -75,11 +75,10 @@ import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 @Conditional(OpensearchCondition.class)
 public class OpensearchConnector {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(OpensearchConnector.class);
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(OpensearchConnector.class);
   private PluginRepository osClientRepository = new PluginRepository();
   private final OperateProperties operateProperties;
-
   private final ObjectMapper objectMapper;
 
   public OpensearchConnector(
@@ -379,15 +378,10 @@ public class OpensearchConnector {
         proxyConfig.getPort());
   }
 
-  private RequestConfig.Builder setTimeouts(
+  RequestConfig.Builder setTimeouts(
       final RequestConfig.Builder builder, final OpensearchProperties os) {
-    if (os.getSocketTimeout() != null) {
-      // builder.setSocketTimeout(os.getSocketTimeout());
-      builder.setResponseTimeout(Timeout.ofMilliseconds(os.getSocketTimeout()));
-    }
-    if (os.getConnectTimeout() != null) {
-      builder.setConnectTimeout(Timeout.ofMilliseconds(os.getConnectTimeout()));
-    }
+    builder.setResponseTimeout(Timeout.ofMilliseconds(os.getSocketTimeout()));
+    builder.setConnectTimeout(Timeout.ofMilliseconds(os.getConnectTimeout()));
     return builder;
   }
 

--- a/operate/common/src/main/java/io/camunda/operate/property/ElasticsearchProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/ElasticsearchProperties.java
@@ -11,6 +11,7 @@ import static io.camunda.operate.util.ConversionUtils.stringIsEmpty;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.operate.connect.OperateDateTimeFormatter;
+
 import io.camunda.search.connect.plugin.PluginConfiguration;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -19,6 +20,8 @@ import java.util.function.Function;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 public class ElasticsearchProperties {
+  static final int DEFAULT_SOCKET_TIMEOUT_MS = 180_000;
+
   public static final String ELS_DATE_FORMAT_DEFAULT = "date_time";
 
   public static final int BULK_REQUEST_MAX_SIZE_IN_BYTES_DEFAULT = 1024 * 1024 * 90; // 90 MB
@@ -35,8 +38,8 @@ public class ElasticsearchProperties {
 
   private int batchSize = 200;
 
-  private Integer socketTimeout;
-  private Integer connectTimeout;
+  private Integer socketTimeout = DEFAULT_SOCKET_TIMEOUT_MS;
+  private Integer connectTimeout = DEFAULT_SOCKET_TIMEOUT_MS;
 
   private boolean createSchema = true;
 

--- a/operate/common/src/main/java/io/camunda/operate/property/OpensearchProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/OpensearchProperties.java
@@ -10,6 +10,7 @@ package io.camunda.operate.property;
 import static io.camunda.operate.util.ConversionUtils.stringIsEmpty;
 
 import io.camunda.operate.connect.OperateDateTimeFormatter;
+
 import io.camunda.search.connect.plugin.PluginConfiguration;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -18,6 +19,8 @@ import java.util.function.Function;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 public class OpensearchProperties {
+  static final int DEFAULT_SOCKET_TIMEOUT_MS = 180_000;
+
   public static final String OS_DATE_FORMAT_DEFAULT = "date_time";
 
   public static final int BULK_REQUEST_MAX_SIZE_IN_BYTES_DEFAULT = 1024 * 1024 * 90; // 90 MB
@@ -34,8 +37,8 @@ public class OpensearchProperties {
 
   private int batchSize = 200;
 
-  private Integer socketTimeout;
-  private Integer connectTimeout;
+  private Integer socketTimeout = DEFAULT_SOCKET_TIMEOUT_MS;
+  private Integer connectTimeout = DEFAULT_SOCKET_TIMEOUT_MS;
 
   private boolean createSchema = true;
 

--- a/operate/common/src/test/java/io/camunda/operate/connect/ElasticsearchConnectorTest.java
+++ b/operate/common/src/test/java/io/camunda/operate/connect/ElasticsearchConnectorTest.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.operate.connect;
 
+import static io.camunda.search.connect.configuration.ConnectConfiguration.DEFAULT_SOCKET_TIMEOUT_MS;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -17,8 +19,10 @@ import static org.mockito.Mockito.verify;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.operate.property.ElasticsearchProperties;
 import io.camunda.operate.property.OperateElasticsearchProperties;
 import io.camunda.operate.property.OperateProperties;
+import org.apache.http.client.config.RequestConfig;
 import org.junit.jupiter.api.Test;
 
 class ElasticsearchConnectorTest {
@@ -49,5 +53,37 @@ class ElasticsearchConnectorTest {
     connector.createEsClient(esProperties, mock());
 
     verify(connector, times(1)).checkHealth(any(ElasticsearchClient.class));
+  }
+
+  @Test
+  void shouldUseDefaultSocketAndConnectTimeoutWhenNotConfigured() {
+    // given
+    final var connector = new ElasticsearchConnector(new OperateProperties());
+    final var config = new ElasticsearchProperties();
+
+    // when
+    final var requestConfig =
+        connector.setTimeouts(RequestConfig.custom(), config).build();
+
+    // then
+    assertThat(requestConfig.getSocketTimeout()).isEqualTo(DEFAULT_SOCKET_TIMEOUT_MS);
+    assertThat(requestConfig.getConnectTimeout()).isEqualTo(DEFAULT_SOCKET_TIMEOUT_MS);
+  }
+
+  @Test
+  void shouldUseConfiguredSocketAndConnectTimeoutWhenSet() {
+    // given
+    final var connector = new ElasticsearchConnector(new OperateProperties());
+    final var config = new ElasticsearchProperties();
+    config.setSocketTimeout(5_000);
+    config.setConnectTimeout(3_000);
+
+    // when
+    final var requestConfig =
+        connector.setTimeouts(RequestConfig.custom(), config).build();
+
+    // then
+    assertThat(requestConfig.getSocketTimeout()).isEqualTo(5_000);
+    assertThat(requestConfig.getConnectTimeout()).isEqualTo(3_000);
   }
 }

--- a/operate/common/src/test/java/io/camunda/operate/connect/OpensearchConnectorTest.java
+++ b/operate/common/src/test/java/io/camunda/operate/connect/OpensearchConnectorTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.operate.connect;
 
+import static io.camunda.search.connect.configuration.ConnectConfiguration.DEFAULT_SOCKET_TIMEOUT_MS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
@@ -30,6 +31,8 @@ import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
 import org.apache.hc.client5.http.protocol.HttpClientContext;
 import org.apache.hc.core5.concurrent.FutureCallback;
 import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.core5.util.Timeout;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -162,6 +165,38 @@ public class OpensearchConnectorTest {
             credentialsProvider.getCredentials(
                 new AuthScope(new HttpHost("http", "opensearch-2", 9206)), context))
         .isNotNull();
+  }
+
+  @Test
+  void shouldUseDefaultResponseAndConnectTimeoutWhenNotConfigured() {
+    // given
+    final var config = new OperateOpensearchProperties();
+
+    // when
+    final var requestConfig =
+        opensearchConnector.setTimeouts(RequestConfig.custom(), config).build();
+
+    // then
+    assertThat(requestConfig.getResponseTimeout())
+        .isEqualTo(Timeout.ofMilliseconds(DEFAULT_SOCKET_TIMEOUT_MS));
+    assertThat(requestConfig.getConnectTimeout())
+        .isEqualTo(Timeout.ofMilliseconds(DEFAULT_SOCKET_TIMEOUT_MS));
+  }
+
+  @Test
+  void shouldUseConfiguredResponseAndConnectTimeoutWhenSet() {
+    // given
+    final var config = new OperateOpensearchProperties();
+    config.setSocketTimeout(5_000);
+    config.setConnectTimeout(3_000);
+
+    // when
+    final var requestConfig =
+        opensearchConnector.setTimeouts(RequestConfig.custom(), config).build();
+
+    // then
+    assertThat(requestConfig.getResponseTimeout()).isEqualTo(Timeout.ofMilliseconds(5_000));
+    assertThat(requestConfig.getConnectTimeout()).isEqualTo(Timeout.ofMilliseconds(3_000));
   }
 
   private static CloseableHttpAsyncClient getOpensearchApacheClient(

--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/configuration/ConnectConfiguration.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/configuration/ConnectConfiguration.java
@@ -14,6 +14,7 @@ import java.util.List;
 public class ConnectConfiguration {
 
   public static final DatabaseType DATABASE_TYPE_DEFAULT = DatabaseType.ELASTICSEARCH;
+  public static final int DEFAULT_SOCKET_TIMEOUT_MS = 180_000;
   private static final String CLUSTER_NAME_DEFAULT = "elasticsearch";
   private static final String DATE_FORMAT_FIELD = "yyyy-MM-dd'T'HH:mm:ss.SSSZZ";
   private static final String FIELD_DATE_FORMAT_DEFAULT = "date_time";
@@ -22,8 +23,8 @@ public class ConnectConfiguration {
   private String clusterName = CLUSTER_NAME_DEFAULT;
   private String dateFormat = DATE_FORMAT_FIELD;
   private String fieldDateFormat = FIELD_DATE_FORMAT_DEFAULT;
-  private Integer socketTimeout;
-  private Integer connectTimeout;
+  private Integer socketTimeout = DEFAULT_SOCKET_TIMEOUT_MS;
+  private Integer connectTimeout = DEFAULT_SOCKET_TIMEOUT_MS;
   private String url = URL_DEFAULT;
   private List<String> urls = new ArrayList<>();
   private String username;

--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/es/ElasticsearchConnector.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/es/ElasticsearchConnector.java
@@ -43,6 +43,8 @@ public final class ElasticsearchConnector {
   private final ObjectMapper objectMapper;
   private final PluginRepository pluginRepository;
 
+
+
   public ElasticsearchConnector(final ConnectConfiguration configuration) {
     this(
         configuration,
@@ -97,28 +99,19 @@ public final class ElasticsearchConnector {
 
   private RestClient createRestClient(final ConnectConfiguration configuration) {
     final var httpHosts = getHttpHosts(configuration);
-    final var restClientBuilder = RestClient.builder(httpHosts);
-
-    if (configuration.getConnectTimeout() != null || configuration.getSocketTimeout() != null) {
-      restClientBuilder.setRequestConfigCallback(
-          configCallback -> setTimeouts(configCallback, configuration));
-    }
-
     final Header[] defaultHeaders =
         new Header[] {
           new BasicHeader("Accept", "application/vnd.elasticsearch+json;compatible-with=8"),
           new BasicHeader("Content-Type", "application/vnd.elasticsearch+json;compatible-with=8")
         };
-    final var restClient =
-        restClientBuilder
-            .setDefaultHeaders(defaultHeaders)
-            .setHttpClientConfigCallback(
-                httpClientBuilder ->
-                    configureHttpClient(
-                        httpClientBuilder, configuration, pluginRepository.asRequestInterceptor()))
-            .build();
-
-    return restClient;
+    return RestClient.builder(httpHosts)
+        .setDefaultHeaders(defaultHeaders)
+        .setRequestConfigCallback(configCallback -> setTimeouts(configCallback, configuration))
+        .setHttpClientConfigCallback(
+            httpClientBuilder ->
+                configureHttpClient(
+                    httpClientBuilder, configuration, pluginRepository.asRequestInterceptor()))
+        .build();
   }
 
   protected HttpAsyncClientBuilder configureHttpClient(
@@ -158,13 +151,9 @@ public final class ElasticsearchConnector {
     }
   }
 
-  private Builder setTimeouts(final Builder builder, final ConnectConfiguration elsConfig) {
-    if (elsConfig.getSocketTimeout() != null) {
-      builder.setSocketTimeout(elsConfig.getSocketTimeout());
-    }
-    if (elsConfig.getConnectTimeout() != null) {
-      builder.setConnectTimeout(elsConfig.getConnectTimeout());
-    }
+  Builder setTimeouts(final Builder builder, final ConnectConfiguration elsConfig) {
+    builder.setSocketTimeout(elsConfig.getSocketTimeout());
+    builder.setConnectTimeout(elsConfig.getConnectTimeout());
     return builder;
   }
 

--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/os/OpensearchConnector.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/os/OpensearchConnector.java
@@ -46,12 +46,11 @@ import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 
 public final class OpensearchConnector {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(OpensearchConnector.class);
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(OpensearchConnector.class);
   private final ConnectConfiguration configuration;
   private final ObjectMapper objectMapper;
   private final PluginRepository pluginRepository;
-
   private final AwsCredentialsProvider credentialsProvider;
 
   public OpensearchConnector(final ConnectConfiguration configuration) {
@@ -205,15 +204,10 @@ public final class OpensearchConnector {
     return httpAsyncClientBuilder;
   }
 
-  private RequestConfig.Builder setTimeouts(
+  RequestConfig.Builder setTimeouts(
       final RequestConfig.Builder builder, final ConnectConfiguration os) {
-    if (os.getSocketTimeout() != null) {
-      // builder.setSocketTimeout(os.getSocketTimeout());
-      builder.setResponseTimeout(Timeout.ofMilliseconds(os.getSocketTimeout()));
-    }
-    if (os.getConnectTimeout() != null) {
-      builder.setConnectTimeout(Timeout.ofMilliseconds(os.getConnectTimeout()));
-    }
+    builder.setResponseTimeout(Timeout.ofMilliseconds(os.getSocketTimeout()));
+    builder.setConnectTimeout(Timeout.ofMilliseconds(os.getConnectTimeout()));
     return builder;
   }
 

--- a/search/search-client-connect/src/test/java/io/camunda/search/connect/es/ElasticsearchConnectorTest.java
+++ b/search/search-client-connect/src/test/java/io/camunda/search/connect/es/ElasticsearchConnectorTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.search.connect.es;
 
+import static io.camunda.search.connect.configuration.ConnectConfiguration.DEFAULT_SOCKET_TIMEOUT_MS;
 import static io.camunda.search.connect.plugin.util.TestDatabaseCustomHeaderSupplierImpl.KEY_CUSTOM_HEADER;
 import static io.camunda.search.connect.plugin.util.TestDatabaseCustomHeaderSupplierImpl.VALUE_CUSTOM_HEADER;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -14,15 +15,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import co.elastic.clients.transport.rest_client.RestClientTransport;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
-import io.camunda.search.connect.plugin.PluginConfiguration;
-import io.camunda.search.connect.plugin.PluginRepository;
-import io.camunda.search.connect.plugin.util.TestDatabaseCustomHeaderSupplierImpl;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.util.List;
-import net.bytebuddy.ByteBuddy;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpRequestWrapper;
 import org.apache.http.concurrent.FutureCallback;
@@ -88,6 +83,40 @@ class ElasticsearchConnectorTest {
 
     assertThat(reqWrapper.getFirstHeader(KEY_CUSTOM_HEADER).getValue())
         .isEqualTo(VALUE_CUSTOM_HEADER);
+  }
+
+  @Test
+  void shouldUseDefaultSocketAndConnectTimeoutWhenNotConfigured() {
+    // given
+    final var configuration = new ConnectConfiguration();
+    final var connector =
+        new ElasticsearchConnector(configuration, new ObjectMapper(), new PluginRepository());
+
+    // when
+    final var requestConfig =
+        connector.setTimeouts(RequestConfig.custom(), configuration).build();
+
+    // then
+    assertThat(requestConfig.getSocketTimeout()).isEqualTo(DEFAULT_SOCKET_TIMEOUT_MS);
+    assertThat(requestConfig.getConnectTimeout()).isEqualTo(DEFAULT_SOCKET_TIMEOUT_MS);
+  }
+
+  @Test
+  void shouldUseConfiguredSocketAndConnectTimeoutWhenSet() {
+    // given
+    final var configuration = new ConnectConfiguration();
+    configuration.setSocketTimeout(5_000);
+    configuration.setConnectTimeout(3_000);
+    final var connector =
+        new ElasticsearchConnector(configuration, new ObjectMapper(), new PluginRepository());
+
+    // when
+    final var requestConfig =
+        connector.setTimeouts(RequestConfig.custom(), configuration).build();
+
+    // then
+    assertThat(requestConfig.getSocketTimeout()).isEqualTo(5_000);
+    assertThat(requestConfig.getConnectTimeout()).isEqualTo(3_000);
   }
 
   private static final class NoopCallback implements FutureCallback<HttpResponse> {

--- a/search/search-client-connect/src/test/java/io/camunda/search/connect/os/OpensearchConnectorTest.java
+++ b/search/search-client-connect/src/test/java/io/camunda/search/connect/os/OpensearchConnectorTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.search.connect.os;
 
+import static io.camunda.search.connect.configuration.ConnectConfiguration.DEFAULT_SOCKET_TIMEOUT_MS;
 import static io.camunda.search.connect.plugin.util.TestDatabaseCustomHeaderSupplierImpl.KEY_CUSTOM_HEADER;
 import static io.camunda.search.connect.plugin.util.TestDatabaseCustomHeaderSupplierImpl.VALUE_CUSTOM_HEADER;
 
@@ -25,8 +26,10 @@ import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.CredentialsProvider;
 import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
 import org.apache.hc.client5.http.protocol.HttpClientContext;
+import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.core5.concurrent.FutureCallback;
 import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.util.Timeout;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -171,6 +174,42 @@ class OpensearchConnectorTest {
             credentialsProvider.getCredentials(
                 new AuthScope(new HttpHost("http", "opensearch-2", 9206)), context))
         .isNotNull();
+  }
+
+  @Test
+  void shouldUseDefaultResponseAndConnectTimeoutWhenNotConfigured() {
+    // given
+    final var configuration = new ConnectConfiguration();
+    final var connector =
+        new OpensearchConnector(configuration, new ObjectMapper(), null, new PluginRepository());
+
+    // when
+    final var requestConfig =
+        connector.setTimeouts(RequestConfig.custom(), configuration).build();
+
+    // then
+    Assertions.assertThat(requestConfig.getResponseTimeout())
+        .isEqualTo(Timeout.ofMilliseconds(DEFAULT_SOCKET_TIMEOUT_MS));
+    Assertions.assertThat(requestConfig.getConnectTimeout())
+        .isEqualTo(Timeout.ofMilliseconds(DEFAULT_SOCKET_TIMEOUT_MS));
+  }
+
+  @Test
+  void shouldUseConfiguredResponseAndConnectTimeoutWhenSet() {
+    // given
+    final var configuration = new ConnectConfiguration();
+    configuration.setSocketTimeout(5_000);
+    configuration.setConnectTimeout(3_000);
+    final var connector =
+        new OpensearchConnector(configuration, new ObjectMapper(), null, new PluginRepository());
+
+    // when
+    final var requestConfig =
+        connector.setTimeouts(RequestConfig.custom(), configuration).build();
+
+    // then
+    Assertions.assertThat(requestConfig.getResponseTimeout()).isEqualTo(Timeout.ofMilliseconds(5_000));
+    Assertions.assertThat(requestConfig.getConnectTimeout()).isEqualTo(Timeout.ofMilliseconds(3_000));
   }
 
   private static CloseableHttpAsyncClient getOpensearchApacheClient(

--- a/tasklist/common/src/main/java/io/camunda/tasklist/connect/ElasticsearchConnector.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/connect/ElasticsearchConnector.java
@@ -77,8 +77,8 @@ import org.springframework.util.StringUtils;
 @Conditional(ElasticSearchCondition.class)
 public class ElasticsearchConnector {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(ElasticsearchConnector.class);
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(ElasticsearchConnector.class);
   private final PluginRepository esClientRepository = new PluginRepository();
   @Autowired private TasklistProperties tasklistProperties;
 
@@ -109,11 +109,8 @@ public class ElasticsearchConnector {
             .setHttpClientConfigCallback(
                 httpClientBuilder ->
                     configureHttpClient(
-                        httpClientBuilder, elsConfig, pluginRepository.asRequestInterceptor()));
-    if (elsConfig.getConnectTimeout() != null || elsConfig.getSocketTimeout() != null) {
-      restClientBuilder.setRequestConfigCallback(
-          configCallback -> setTimeouts(configCallback, elsConfig));
-    }
+                        httpClientBuilder, elsConfig, pluginRepository.asRequestInterceptor()))
+            .setRequestConfigCallback(configCallback -> setTimeouts(configCallback, elsConfig));
 
     final RestClientTransport transport =
         new RestClientTransport(
@@ -284,13 +281,9 @@ public class ElasticsearchConnector {
     }
   }
 
-  private Builder setTimeouts(final Builder builder, final ElasticsearchProperties elsConfig) {
-    if (elsConfig.getSocketTimeout() != null) {
-      builder.setSocketTimeout(elsConfig.getSocketTimeout());
-    }
-    if (elsConfig.getConnectTimeout() != null) {
-      builder.setConnectTimeout(elsConfig.getConnectTimeout());
-    }
+  Builder setTimeouts(final Builder builder, final ElasticsearchProperties elsConfig) {
+    builder.setSocketTimeout(elsConfig.getSocketTimeout());
+    builder.setConnectTimeout(elsConfig.getConnectTimeout());
     return builder;
   }
 

--- a/tasklist/common/src/main/java/io/camunda/tasklist/connect/OpenSearchConnector.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/connect/OpenSearchConnector.java
@@ -75,6 +75,7 @@ import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 @Conditional(OpenSearchCondition.class)
 public class OpenSearchConnector {
 
+
   private static final Logger LOGGER = LoggerFactory.getLogger(OpenSearchConnector.class);
 
   private PluginRepository osClientRepository = new PluginRepository();
@@ -333,15 +334,10 @@ public class OpenSearchConnector {
     LOGGER.debug("Preemptive proxy authentication enabled for proxy");
   }
 
-  private RequestConfig.Builder setTimeouts(
+  RequestConfig.Builder setTimeouts(
       final RequestConfig.Builder builder, final OpenSearchProperties os) {
-    if (os.getSocketTimeout() != null) {
-      // builder.setSocketTimeout(os.getSocketTimeout());
-      builder.setResponseTimeout(Timeout.ofMilliseconds(os.getSocketTimeout()));
-    }
-    if (os.getConnectTimeout() != null) {
-      builder.setConnectTimeout(Timeout.ofMilliseconds(os.getConnectTimeout()));
-    }
+    builder.setResponseTimeout(Timeout.ofMilliseconds(os.getSocketTimeout()));
+    builder.setConnectTimeout(Timeout.ofMilliseconds(os.getConnectTimeout()));
     return builder;
   }
 

--- a/tasklist/common/src/main/java/io/camunda/tasklist/property/ElasticsearchProperties.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/property/ElasticsearchProperties.java
@@ -9,6 +9,7 @@ package io.camunda.tasklist.property;
 
 import static io.camunda.tasklist.util.ConversionUtils.stringIsEmpty;
 
+
 import io.camunda.search.connect.plugin.PluginConfiguration;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -17,6 +18,8 @@ import java.util.function.Function;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 public class ElasticsearchProperties {
+
+  static final int DEFAULT_SOCKET_TIMEOUT_MS = 180_000;
 
   public static final String DATE_FORMAT_DEFAULT = "yyyy-MM-dd'T'HH:mm:ss.SSSZZ";
 
@@ -36,8 +39,8 @@ public class ElasticsearchProperties {
   private int batchSize = 200;
   private int maxTermsCount = DEFAULT_MAX_TERMS_COUNT;
 
-  private Integer socketTimeout;
-  private Integer connectTimeout;
+  private Integer socketTimeout = DEFAULT_SOCKET_TIMEOUT_MS;
+  private Integer connectTimeout = DEFAULT_SOCKET_TIMEOUT_MS;
 
   private boolean createSchema = true;
 

--- a/tasklist/common/src/main/java/io/camunda/tasklist/property/OpenSearchProperties.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/property/OpenSearchProperties.java
@@ -9,6 +9,7 @@ package io.camunda.tasklist.property;
 
 import static io.camunda.tasklist.util.ConversionUtils.stringIsEmpty;
 
+
 import io.camunda.search.connect.plugin.PluginConfiguration;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -17,6 +18,8 @@ import java.util.function.Function;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 public class OpenSearchProperties {
+
+  static final int DEFAULT_SOCKET_TIMEOUT_MS = 180_000;
 
   public static final String DATE_FORMAT_DEFAULT = "yyyy-MM-dd'T'HH:mm:ss.SSSZZ";
 
@@ -36,8 +39,8 @@ public class OpenSearchProperties {
   private int batchSize = 200;
   private int maxTermsCount = DEFAULT_MAX_TERMS_COUNT;
 
-  private Integer socketTimeout;
-  private Integer connectTimeout;
+  private Integer socketTimeout = DEFAULT_SOCKET_TIMEOUT_MS;
+  private Integer connectTimeout = DEFAULT_SOCKET_TIMEOUT_MS;
 
   private boolean createSchema = true;
 

--- a/tasklist/common/src/test/java/io/camunda/tasklist/connect/ElasticsearchConnectorTest.java
+++ b/tasklist/common/src/test/java/io/camunda/tasklist/connect/ElasticsearchConnectorTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.connect;
+
+import static io.camunda.search.connect.configuration.ConnectConfiguration.DEFAULT_SOCKET_TIMEOUT_MS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.tasklist.property.ElasticsearchProperties;
+import io.camunda.tasklist.property.TasklistProperties;
+import org.apache.http.client.config.RequestConfig;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class ElasticsearchConnectorTest {
+
+  @Test
+  void shouldUseDefaultSocketAndConnectTimeoutWhenNotConfigured() {
+    // given
+    final var connector = Mockito.spy(new ElasticsearchConnector());
+    connector.setTasklistProperties(new TasklistProperties());
+    final var config = new ElasticsearchProperties();
+
+    // when
+    final var requestConfig = connector.setTimeouts(RequestConfig.custom(), config).build();
+
+    // then
+    assertThat(requestConfig.getSocketTimeout()).isEqualTo(DEFAULT_SOCKET_TIMEOUT_MS);
+    assertThat(requestConfig.getConnectTimeout()).isEqualTo(DEFAULT_SOCKET_TIMEOUT_MS);
+  }
+
+  @Test
+  void shouldUseConfiguredSocketAndConnectTimeoutWhenSet() {
+    // given
+    final var connector = Mockito.spy(new ElasticsearchConnector());
+    connector.setTasklistProperties(new TasklistProperties());
+    final var config = new ElasticsearchProperties();
+    config.setSocketTimeout(5_000);
+    config.setConnectTimeout(3_000);
+
+    // when
+    final var requestConfig = connector.setTimeouts(RequestConfig.custom(), config).build();
+
+    // then
+    assertThat(requestConfig.getSocketTimeout()).isEqualTo(5_000);
+    assertThat(requestConfig.getConnectTimeout()).isEqualTo(3_000);
+  }
+}
+
+

--- a/tasklist/common/src/test/java/io/camunda/tasklist/os/OpensearchConnectorTest.java
+++ b/tasklist/common/src/test/java/io/camunda/tasklist/os/OpensearchConnectorTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.tasklist.os;
 
+import static io.camunda.search.connect.configuration.ConnectConfiguration.DEFAULT_SOCKET_TIMEOUT_MS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -27,6 +28,9 @@ import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
 import org.apache.hc.client5.http.protocol.HttpClientContext;
 import org.apache.hc.core5.concurrent.FutureCallback;
 import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.core5.util.Timeout;
+import io.camunda.tasklist.property.OpenSearchProperties;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mockito;
@@ -109,6 +113,44 @@ class OpensearchConnectorTest {
             credentialsProvider.getCredentials(
                 new AuthScope(new HttpHost("http", "opensearch-2", 9206)), context))
         .isNotNull();
+  }
+
+  @Test
+  void shouldUseDefaultResponseAndConnectTimeoutWhenNotConfigured() {
+    // given
+    final var connector = Mockito.spy(new OpenSearchConnector());
+    connector.setTasklistProperties(new TasklistProperties());
+    connector.setTasklistObjectMapper(new ObjectMapper());
+    final var config = new OpenSearchProperties();
+
+    // when
+    final var requestConfig =
+        connector.setTimeouts(RequestConfig.custom(), config).build();
+
+    // then
+    assertThat(requestConfig.getResponseTimeout())
+        .isEqualTo(Timeout.ofMilliseconds(DEFAULT_SOCKET_TIMEOUT_MS));
+    assertThat(requestConfig.getConnectTimeout())
+        .isEqualTo(Timeout.ofMilliseconds(DEFAULT_SOCKET_TIMEOUT_MS));
+  }
+
+  @Test
+  void shouldUseConfiguredResponseAndConnectTimeoutWhenSet() {
+    // given
+    final var connector = Mockito.spy(new OpenSearchConnector());
+    connector.setTasklistProperties(new TasklistProperties());
+    connector.setTasklistObjectMapper(new ObjectMapper());
+    final var config = new OpenSearchProperties();
+    config.setSocketTimeout(5_000);
+    config.setConnectTimeout(3_000);
+
+    // when
+    final var requestConfig =
+        connector.setTimeouts(RequestConfig.custom(), config).build();
+
+    // then
+    assertThat(requestConfig.getResponseTimeout()).isEqualTo(Timeout.ofMilliseconds(5_000));
+    assertThat(requestConfig.getConnectTimeout()).isEqualTo(Timeout.ofMilliseconds(3_000));
   }
 
   private static CloseableHttpAsyncClient getOpensearchApacheClient(

--- a/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/elasticsearch/ElasticsearchBackupRepository.java
+++ b/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/elasticsearch/ElasticsearchBackupRepository.java
@@ -422,8 +422,12 @@ public class ElasticsearchBackupRepository implements BackupRepository {
       }
     }
     LOGGER.error(
-        "Snapshot [{}] did not finish after configured timeout. Snapshot process won't continue.",
-        snapshotName);
+        "Snapshot [{}] did not finish within the configured snapshot timeout of {} seconds. "
+            + "Backup will not continue. To increase the timeout, set "
+            + "'camunda.data.secondary-storage.elasticsearch.backup.snapshot-timeout' "
+            + "to a larger value in seconds, or set it to 0 to wait indefinitely.",
+        snapshotName,
+        backupProps.snapshotTimeout());
     return false;
   }
 
@@ -559,12 +563,21 @@ public class ElasticsearchBackupRepository implements BackupRepository {
         // This is thrown even if the backup is still running
         final int snapshotTimeout = backupProps.snapshotTimeout();
         LOGGER.warn(
-            "Socket timeout while creating snapshot [{}] for backup id [{}]. Start waiting with polling timeout, {}",
+            "The Elasticsearch HTTP connection timed out while waiting for snapshot [{}] "
+                + "(backup id [{}]) to complete. The snapshot is likely still running in "
+                + "Elasticsearch. Polling will continue to check its status {}. If socket timeouts "
+                + "occur repeatedly, consider increasing the socket timeout via "
+                + "CAMUNDA_OPERATE_ELASTICSEARCH_SOCKETTIMEOUT or "
+                + "CAMUNDA_TASKLIST_ELASTICSEARCH_SOCKETTIMEOUT.",
             snapshotRequest.snapshotName(),
             backupId,
-            (snapshotTimeout == 0)
-                ? "until completion."
-                : "at most " + snapshotTimeout + " seconds.");
+            snapshotTimeout == 0
+                ? "indefinitely (snapshotTimeout=0)"
+                : "for up to "
+                    + snapshotTimeout
+                    + " seconds (snapshotTimeout="
+                    + snapshotTimeout
+                    + ")");
         if (isSnapshotFinishedWithinTimeout(
             snapshotRequest.repositoryName(), snapshotRequest.snapshotName())) {
           onSuccess.run();

--- a/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/opensearch/OpensearchBackupRepository.java
+++ b/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/opensearch/OpensearchBackupRepository.java
@@ -295,12 +295,27 @@ public class OpensearchBackupRepository implements BackupRepository {
               }
               if (e instanceof SocketTimeoutException) {
                 // This is thrown even if the backup is still running
+                final int snapshotTimeout = backupProps.snapshotTimeout();
                 LOGGER.warn(
-                    "Timeout while creating snapshot [{}] for backup id [{}]. Need to keep waiting with polling...",
+                    "The OpenSearch HTTP connection timed out while waiting for snapshot [{}] "
+                        + "(backup id [{}]) to complete. The snapshot is likely still running in "
+                        + "OpenSearch. Polling will continue to check its status {}. If socket timeouts "
+                        + "occur repeatedly, consider increasing the socket timeout via "
+                        + "CAMUNDA_OPERATE_OPENSEARCH_SOCKETTIMEOUT or "
+                        + "CAMUNDA_TASKLIST_OPENSEARCH_SOCKETTIMEOUT.",
                     snapshotRequest.snapshotName(),
-                    backupId);
-                // Keep waiting
-                while (true) {
+                    backupId,
+                    snapshotTimeout == 0
+                        ? "indefinitely (snapshotTimeout=0)"
+                        : "for up to "
+                            + snapshotTimeout
+                            + " seconds (snapshotTimeout="
+                            + snapshotTimeout
+                            + ")");
+                final long startTime = System.currentTimeMillis();
+                int count = 0;
+                while (snapshotTimeout == 0
+                    || System.currentTimeMillis() - startTime <= snapshotTimeout * 1000L) {
                   final List<OpenSearchSnapshotInfo> snapshotInfos =
                       findSnapshots(snapshotRequest.repositoryName(), backupId);
                   final Optional<OpenSearchSnapshotInfo> maybeCurrentSnapshot =
@@ -323,10 +338,26 @@ public class OpensearchBackupRepository implements BackupRepository {
                     } catch (final InterruptedException ex) {
                       throw new RuntimeException(ex);
                     }
+                    count++;
+                    if (count % 600 == 0) { // approx. 1 minute
+                      LOGGER.info(
+                          "Waiting for snapshot [{}] to finish.", snapshotRequest.snapshotName());
+                    }
                   } else {
                     handleSnapshotReceived(maybeCurrentSnapshot.get(), onSuccess, onFailure);
                     break;
                   }
+                }
+                if (snapshotTimeout != 0
+                    && System.currentTimeMillis() - startTime > snapshotTimeout * 1000L) {
+                  LOGGER.error(
+                      "Snapshot [{}] did not finish within the configured snapshot timeout of {} "
+                          + "seconds. Backup will not continue. To increase the timeout, set "
+                          + "'camunda.data.secondary-storage.opensearch.backup.snapshot-timeout' "
+                          + "to a larger value in seconds, or set it to 0 to wait indefinitely.",
+                      snapshotRequest.snapshotName(),
+                      snapshotTimeout);
+                  onFailure.run();
                 }
               } else {
                 LOGGER.error(


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Increase a higher default timeout for snapshots. This is done for both the socket and connect timeout since they are both affected. Also improved the error message.

I increased it for all ES/OS connectors, including Tasklist and 

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

relates to https://github.com/camunda/camunda/issues/41861
