### PR TITLE
test: fix batch operations tests

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateOperationsDetailsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateOperationsDetailsPage.ts
@@ -57,7 +57,7 @@ export class OperateOperationsDetailsPage {
 
   async clickCancelFromOptionsMenu(): Promise<void> {
     await this.optionsMenuButton.click();
-    await this.page.getByRole('menuitem', {name: /^Cancel$/i}).click();
+    await this.page.getByRole('menuitem', {name: /^Cancel\b/i}).click();
   }
 
   async getBatchOperationStatus(): Promise<string> {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR updates the Playwright page object for the C8 orchestration cluster E2E test suite to make the “Cancel” action selection in Operate batch operation details less brittle, addressing recent test failures.
https://github.com/camunda/camunda/actions/runs/25368458362
## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [x] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
