### PR TITLE
test(qa): add MCP message subscription search API tests (8.10 new fields)

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/mcp-process-alpha-v2.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/mcp-process-alpha-v2.bpmn
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="e2e-test" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="mcpProcessAlpha" name="MCP Process Alpha" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Alpha tool triggered">
+      <bpmn:extensionElements>
+        <zeebe:properties>
+          <zeebe:property name="io.camunda.tool:name" value="alpha-tool-name" />
+          <zeebe:property name="io.camunda.tool:purpose" value="Tool for executing an alpha process triggered by MCP (v2)." />
+          <zeebe:property name="io.camunda.tool:results" value="Alpha tool returns the result of the alpha process execution." />
+          <zeebe:property name="io.camunda.tool:when_to_use" value="Use the alpha tool when an alpha process needs to be triggered." />
+          <zeebe:property name="io.camunda.tool:when_not_to_use" value="Do not use the alpha tool for bravo processes." />
+        </zeebe:properties>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1" messageRef="Message_alpha" />
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="EndEvent_1" />
+  </bpmn:process>
+  <bpmn:message id="Message_alpha" name="alpha-tool-name" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="mcpProcessAlpha">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_1" bpmnElement="StartEvent_1">
+        <dc:Bounds x="150" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="242" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+        <di:waypoint x="186" y="118" />
+        <di:waypoint x="242" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/mcp-process-intermediate-event.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/mcp-process-intermediate-event.bpmn
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="e2e-test" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="mcpIntermediateProcess" name="MCP Intermediate Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:intermediateCatchEvent id="Event_intermediate">
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1" messageRef="Message_intermediate" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="Event_intermediate" />
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="Event_intermediate" targetRef="EndEvent_1" />
+  </bpmn:process>
+  <bpmn:message id="Message_intermediate" name="mcp-intermediate-message">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=999" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="mcpIntermediateProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_1" bpmnElement="StartEvent_1">
+        <dc:Bounds x="150" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_intermediate_di" bpmnElement="Event_intermediate">
+        <dc:Bounds x="242" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="334" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+        <di:waypoint x="186" y="118" />
+        <di:waypoint x="242" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_2_di" bpmnElement="Flow_2">
+        <di:waypoint x="278" y="118" />
+        <di:waypoint x="334" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/mcp-process-with-inputs.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/mcp-process-with-inputs.bpmn
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="e2e-test" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="mcpProcessWithInputs" name="MCP Process With Inputs" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="With inputs tool triggered">
+      <bpmn:extensionElements>
+        <zeebe:properties>
+          <zeebe:property name="io.camunda.tool:name" value="mcp-process-with-inputs" />
+          <zeebe:property name="io.camunda.tool:purpose" value="Tool for executing a process with typed inputs triggered by MCP." />
+          <zeebe:property name="io.camunda.tool:input_1_name" value="firstName" />
+          <zeebe:property name="io.camunda.tool:input_1_type" value="string" />
+          <zeebe:property name="io.camunda.tool:input_1_description" value="The first name of the person." />
+          <zeebe:property name="io.camunda.tool:input_2_name" value="amount" />
+          <zeebe:property name="io.camunda.tool:input_2_type" value="integer" />
+          <zeebe:property name="io.camunda.tool:input_2_description" value="The amount to process." />
+          <zeebe:property name="io.camunda.tool:input_2_required" value="true" />
+        </zeebe:properties>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1" messageRef="Message_with_inputs" />
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="EndEvent_1" />
+  </bpmn:process>
+  <bpmn:message id="Message_with_inputs" name="mcp-process-with-inputs" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="mcpProcessWithInputs">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_1" bpmnElement="StartEvent_1">
+        <dc:Bounds x="150" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="242" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+        <di:waypoint x="186" y="118" />
+        <di:waypoint x="242" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message-subscriptions/mcp-message-subscription-search.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message-subscriptions/mcp-message-subscription-search.spec.ts
@@ -27,8 +27,8 @@ test.beforeAll(async () => {
   await deploy(['./resources/mcpProcessBravo.bpmn']);
   await deploy(['./resources/mcp-process-with-inputs.bpmn']);
   await deploy(['./resources/mcp-process-intermediate-event.bpmn']);
-  // Deploy Alpha a second time to create version 2 (used by sort-by-version test)
-  await deploy(['./resources/mcpProcessAlpha.bpmn']);
+  // Deploy a modified Alpha (same processId, different BPMN content) to create version 2
+  await deploy(['./resources/mcp-process-alpha-v2.bpmn']);
   // Create an instance so the PROCESS_EVENT (intermediate) subscription becomes active
   await createInstances('mcpIntermediateProcess', 1, 1);
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message-subscriptions/mcp-message-subscription-search.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message-subscriptions/mcp-message-subscription-search.spec.ts
@@ -281,9 +281,11 @@ test.describe('MCP Message Subscription Search API Tests', () => {
       json.items.forEach(
         (it: {
           processDefinitionId: string;
+          toolName: string;
           extensionProperties: Record<string, string>;
         }) => {
           expect(it.processDefinitionId).toBe('mcpProcessAlpha');
+          expect(it.toolName).toBe('alpha-tool-name');
           expect(it.extensionProperties['io.camunda.tool:name']).toBe(
             'alpha-tool-name',
           );
@@ -417,6 +419,7 @@ test.describe('MCP Message Subscription Search API Tests', () => {
 
         // mcpProcessAlpha v2 must appear first
         expect(versions[0]).toBeGreaterThanOrEqual(2);
+        expect(json.items[0].processDefinitionId).toBe('mcpProcessAlpha');
       }).toPass({
         intervals: [5_000, 10_000, 15_000],
         timeout: 30_000,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message-subscriptions/mcp-message-subscription-search.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message-subscriptions/mcp-message-subscription-search.spec.ts
@@ -1,0 +1,426 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {
+  buildUrl,
+  jsonHeaders,
+  assertEqualsForKeys,
+  assertStatusCode,
+  assertUnauthorizedRequest,
+} from '../../../../utils/http';
+import {validateResponse} from '../../../../json-body-assertions';
+import {
+  expectedMcpSubscriptionAlpha,
+  expectedMcpSubscriptionBravo,
+  expectedMcpSubscriptionWithInputs,
+} from '../../../../utils/beans/requestBeans';
+import {createInstances, deploy} from '../../../../utils/zeebeClient';
+
+test.beforeAll(async () => {
+  await deploy(['./resources/mcpProcessAlpha.bpmn']);
+  await deploy(['./resources/mcpProcessBravo.bpmn']);
+  await deploy(['./resources/mcp-process-with-inputs.bpmn']);
+  await deploy(['./resources/mcp-process-intermediate-event.bpmn']);
+  // Deploy Alpha a second time to create version 2 (used by sort-by-version test)
+  await deploy(['./resources/mcpProcessAlpha.bpmn']);
+  // Create an instance so the PROCESS_EVENT (intermediate) subscription becomes active
+  await createInstances('mcpIntermediateProcess', 1, 1);
+});
+
+test.describe('MCP Message Subscription Search API Tests', () => {
+  test('Search MCP Subscriptions Unauthorized', async ({request}) => {
+    const res = await request.post(buildUrl('/message-subscriptions/search'), {
+      headers: {},
+      data: {filter: {messageSubscriptionType: 'START_EVENT'}},
+    });
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('MCP Message Subscription Search Flow', async ({request}) => {
+    await test.step('SC-API-01 — Filter by messageSubscriptionType START_EVENT', async () => {
+      await expect(async () => {
+        const res = await request.post(
+          buildUrl('/message-subscriptions/search'),
+          {
+            headers: jsonHeaders(),
+            data: {filter: {messageSubscriptionType: 'START_EVENT'}},
+          },
+        );
+        await assertStatusCode(res, 200);
+        await validateResponse(
+          {
+            path: '/message-subscriptions/search',
+            method: 'POST',
+            status: '200',
+          },
+          res,
+        );
+        const json = await res.json();
+        expect(json.page.totalItems).toBeGreaterThanOrEqual(3);
+
+        const mcpIds = json.items.map(
+          (it: {processDefinitionId: string}) => it.processDefinitionId,
+        );
+        expect(mcpIds).toContain('mcpProcessAlpha');
+        expect(mcpIds).toContain('mcpProcessBravo');
+        expect(mcpIds).toContain('mcpProcessWithInputs');
+        expect(mcpIds).not.toContain('mcpIntermediateProcess');
+
+        json.items.forEach((it: {messageSubscriptionType: string}) => {
+          expect(it.messageSubscriptionType).toBe('START_EVENT');
+        });
+      }).toPass({
+        intervals: [5_000, 10_000, 15_000],
+        timeout: 30_000,
+      });
+    });
+
+    await test.step('SC-API-02 — Filter by messageSubscriptionType PROCESS_EVENT', async () => {
+      await expect(async () => {
+        const res = await request.post(
+          buildUrl('/message-subscriptions/search'),
+          {
+            headers: jsonHeaders(),
+            data: {filter: {messageSubscriptionType: 'PROCESS_EVENT'}},
+          },
+        );
+        await assertStatusCode(res, 200);
+        await validateResponse(
+          {
+            path: '/message-subscriptions/search',
+            method: 'POST',
+            status: '200',
+          },
+          res,
+        );
+        const json = await res.json();
+        expect(json.page.totalItems).toBeGreaterThanOrEqual(1);
+
+        const processIds = json.items.map(
+          (it: {processDefinitionId: string}) => it.processDefinitionId,
+        );
+        expect(processIds).toContain('mcpIntermediateProcess');
+        expect(processIds).not.toContain('mcpProcessAlpha');
+
+        json.items.forEach((it: {messageSubscriptionType: string}) => {
+          expect(it.messageSubscriptionType).toBe('PROCESS_EVENT');
+        });
+      }).toPass({
+        intervals: [5_000, 10_000, 15_000],
+        timeout: 30_000,
+      });
+    });
+
+    await test.step('SC-API-03 — No type filter returns both START_EVENT and PROCESS_EVENT', async () => {
+      const res = await request.post(
+        buildUrl('/message-subscriptions/search'),
+        {
+          headers: jsonHeaders(),
+          data: {page: {limit: 100}},
+        },
+      );
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: '/message-subscriptions/search',
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+      const json = await res.json();
+      const types = json.items.map(
+        (it: {messageSubscriptionType: string}) => it.messageSubscriptionType,
+      );
+      expect(types).toContain('START_EVENT');
+      expect(types).toContain('PROCESS_EVENT');
+    });
+
+    await test.step('SC-API-04 — extensionProperties contains tool metadata', async () => {
+      const res = await request.post(
+        buildUrl('/message-subscriptions/search'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              processDefinitionId:
+                expectedMcpSubscriptionAlpha.processDefinitionId,
+              messageSubscriptionType: 'START_EVENT',
+            },
+          },
+        },
+      );
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: '/message-subscriptions/search',
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+      const json = await res.json();
+      expect(json.page.totalItems).toBeGreaterThanOrEqual(1);
+
+      json.items.forEach(
+        (it: {extensionProperties: Record<string, string>}) => {
+          expect(it.extensionProperties).toBeDefined();
+          expect(it.extensionProperties['io.camunda.tool:name']).toBe(
+            'alpha-tool-name',
+          );
+          expect(
+            it.extensionProperties['io.camunda.tool:purpose'],
+          ).toBeDefined();
+        },
+      );
+    });
+
+    await test.step('SC-API-05 — processDefinitionName and processDefinitionVersion returned', async () => {
+      const res = await request.post(
+        buildUrl('/message-subscriptions/search'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              processDefinitionId:
+                expectedMcpSubscriptionBravo.processDefinitionId,
+              messageSubscriptionType: 'START_EVENT',
+            },
+          },
+        },
+      );
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: '/message-subscriptions/search',
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+      const json = await res.json();
+      expect(json.page.totalItems).toBeGreaterThanOrEqual(1);
+
+      json.items.forEach(
+        (it: {
+          processDefinitionName: string;
+          processDefinitionVersion: number;
+        }) => {
+          assertEqualsForKeys(it, expectedMcpSubscriptionBravo, [
+            'processDefinitionName',
+            'messageName',
+            'tenantId',
+          ]);
+          expect(it.processDefinitionVersion).toBeGreaterThanOrEqual(1);
+        },
+      );
+    });
+
+    await test.step('SC-API-06 — processInstanceKey and elementInstanceKey are null for start events', async () => {
+      const res = await request.post(
+        buildUrl('/message-subscriptions/search'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              messageSubscriptionType: 'START_EVENT',
+            },
+          },
+        },
+      );
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: '/message-subscriptions/search',
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+      const json = await res.json();
+      expect(json.page.totalItems).toBeGreaterThanOrEqual(1);
+
+      json.items.forEach(
+        (it: {processInstanceKey: unknown; elementInstanceKey: unknown}) => {
+          expect(it.processInstanceKey).toBeNull();
+          expect(it.elementInstanceKey).toBeNull();
+        },
+      );
+    });
+
+    await test.step('SC-API-07 — Filter by toolName', async () => {
+      const res = await request.post(
+        buildUrl('/message-subscriptions/search'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              toolName: 'alpha-tool-name',
+            },
+          },
+        },
+      );
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: '/message-subscriptions/search',
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+      const json = await res.json();
+      expect(json.page.totalItems).toBeGreaterThanOrEqual(1);
+
+      json.items.forEach(
+        (it: {
+          processDefinitionId: string;
+          extensionProperties: Record<string, string>;
+        }) => {
+          expect(it.processDefinitionId).toBe('mcpProcessAlpha');
+          expect(it.extensionProperties['io.camunda.tool:name']).toBe(
+            'alpha-tool-name',
+          );
+        },
+      );
+    });
+
+    await test.step('SC-API-08 — Filter by processDefinitionId for with-inputs process includes extensionProperties with input metadata', async () => {
+      const res = await request.post(
+        buildUrl('/message-subscriptions/search'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              processDefinitionId:
+                expectedMcpSubscriptionWithInputs.processDefinitionId,
+              messageSubscriptionType: 'START_EVENT',
+            },
+          },
+        },
+      );
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: '/message-subscriptions/search',
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+      const json = await res.json();
+      expect(json.page.totalItems).toBeGreaterThanOrEqual(1);
+
+      json.items.forEach(
+        (it: {extensionProperties: Record<string, string>}) => {
+          assertEqualsForKeys(it, expectedMcpSubscriptionWithInputs, [
+            'processDefinitionId',
+            'messageSubscriptionType',
+            'tenantId',
+          ]);
+          expect(it.extensionProperties['io.camunda.tool:input_1_name']).toBe(
+            'firstName',
+          );
+          expect(it.extensionProperties['io.camunda.tool:input_1_type']).toBe(
+            'string',
+          );
+          expect(it.extensionProperties['io.camunda.tool:input_2_name']).toBe(
+            'amount',
+          );
+          expect(
+            it.extensionProperties['io.camunda.tool:input_2_required'],
+          ).toBe('true');
+        },
+      );
+    });
+
+    await test.step('SC-API-09 — Sort by processDefinitionName ascending', async () => {
+      const res = await request.post(
+        buildUrl('/message-subscriptions/search'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {messageSubscriptionType: 'START_EVENT'},
+            sort: [{field: 'processDefinitionName', order: 'ASC'}],
+          },
+        },
+      );
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: '/message-subscriptions/search',
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+      const json = await res.json();
+      expect(json.page.totalItems).toBeGreaterThanOrEqual(2);
+
+      const names: (string | null)[] = json.items
+        .map(
+          (it: {processDefinitionName: string | null}) =>
+            it.processDefinitionName,
+        )
+        .filter((n: string | null) => n !== null);
+
+      for (let i = 0; i < names.length - 1; i++) {
+        expect(
+          (names[i] as string).localeCompare(names[i + 1] as string),
+        ).toBeLessThanOrEqual(0);
+      }
+    });
+
+    await test.step('SC-API-10 — Sort by processDefinitionVersion descending', async () => {
+      // Deploying mcpProcessAlpha twice yields version 2; all other processes are at version 1.
+      // Sorting all START_EVENT subscriptions DESC by version must place Alpha (v2) first.
+      await expect(async () => {
+        const res = await request.post(
+          buildUrl('/message-subscriptions/search'),
+          {
+            headers: jsonHeaders(),
+            data: {
+              filter: {messageSubscriptionType: 'START_EVENT'},
+              sort: [{field: 'processDefinitionVersion', order: 'DESC'}],
+              page: {limit: 100},
+            },
+          },
+        );
+        await assertStatusCode(res, 200);
+        await validateResponse(
+          {
+            path: '/message-subscriptions/search',
+            method: 'POST',
+            status: '200',
+          },
+          res,
+        );
+        const json = await res.json();
+        expect(json.page.totalItems).toBeGreaterThanOrEqual(2);
+
+        const versions: number[] = json.items
+          .map(
+            (it: {processDefinitionVersion: number | null}) =>
+              it.processDefinitionVersion,
+          )
+          .filter((v: number | null) => v !== null);
+
+        for (let i = 0; i < versions.length - 1; i++) {
+          expect(versions[i]).toBeGreaterThanOrEqual(versions[i + 1]);
+        }
+
+        // mcpProcessAlpha v2 must appear first
+        expect(versions[0]).toBeGreaterThanOrEqual(2);
+      }).toPass({
+        intervals: [5_000, 10_000, 15_000],
+        timeout: 30_000,
+      });
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message-subscriptions/mcp-message-subscription-search.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message-subscriptions/mcp-message-subscription-search.spec.ts
@@ -15,11 +15,6 @@ import {
   assertUnauthorizedRequest,
 } from '../../../../utils/http';
 import {validateResponse} from '../../../../json-body-assertions';
-import {
-  expectedMcpSubscriptionAlpha,
-  expectedMcpSubscriptionBravo,
-  expectedMcpSubscriptionWithInputs,
-} from '../../../../utils/beans/requestBeans';
 import {createInstances, deploy} from '../../../../utils/zeebeClient';
 
 test.beforeAll(async () => {
@@ -149,8 +144,7 @@ test.describe('MCP Message Subscription Search API Tests', () => {
           headers: jsonHeaders(),
           data: {
             filter: {
-              processDefinitionId:
-                expectedMcpSubscriptionAlpha.processDefinitionId,
+              processDefinitionId: 'mcpProcessAlpha',
               messageSubscriptionType: 'START_EVENT',
             },
           },
@@ -188,8 +182,7 @@ test.describe('MCP Message Subscription Search API Tests', () => {
           headers: jsonHeaders(),
           data: {
             filter: {
-              processDefinitionId:
-                expectedMcpSubscriptionBravo.processDefinitionId,
+              processDefinitionId: 'mcpProcessBravo',
               messageSubscriptionType: 'START_EVENT',
             },
           },
@@ -212,11 +205,15 @@ test.describe('MCP Message Subscription Search API Tests', () => {
           processDefinitionName: string;
           processDefinitionVersion: number;
         }) => {
-          assertEqualsForKeys(it, expectedMcpSubscriptionBravo, [
-            'processDefinitionName',
-            'messageName',
-            'tenantId',
-          ]);
+          assertEqualsForKeys(
+            it,
+            {
+              processDefinitionName: 'MCP Process Bravo',
+              messageName: 'bravo-tool-name',
+              tenantId: '<default>',
+            },
+            ['processDefinitionName', 'messageName', 'tenantId'],
+          );
           expect(it.processDefinitionVersion).toBeGreaterThanOrEqual(1);
         },
       );
@@ -300,8 +297,7 @@ test.describe('MCP Message Subscription Search API Tests', () => {
           headers: jsonHeaders(),
           data: {
             filter: {
-              processDefinitionId:
-                expectedMcpSubscriptionWithInputs.processDefinitionId,
+              processDefinitionId: 'mcpProcessWithInputs',
               messageSubscriptionType: 'START_EVENT',
             },
           },
@@ -321,11 +317,15 @@ test.describe('MCP Message Subscription Search API Tests', () => {
 
       json.items.forEach(
         (it: {extensionProperties: Record<string, string>}) => {
-          assertEqualsForKeys(it, expectedMcpSubscriptionWithInputs, [
-            'processDefinitionId',
-            'messageSubscriptionType',
-            'tenantId',
-          ]);
+          assertEqualsForKeys(
+            it,
+            {
+              processDefinitionId: 'mcpProcessWithInputs',
+              messageSubscriptionType: 'START_EVENT',
+              tenantId: '<default>',
+            },
+            ['processDefinitionId', 'messageSubscriptionType', 'tenantId'],
+          );
           expect(it.extensionProperties['io.camunda.tool:input_1_name']).toBe(
             'firstName',
           );

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
@@ -225,6 +225,42 @@ export const messageSubscriptionRequiredFields = [
   'correlationKey',
   'tenantId',
 ];
+// All required fields for 8.10+ message subscription responses that include MCP new fields.
+// Used in follow-on MCP API test PRs that validate full response shapes.
+export const mcpMessageSubscriptionRequiredFields = [
+  ...messageSubscriptionRequiredFields,
+  'messageSubscriptionType',
+  'extensionProperties',
+  'processDefinitionName',
+  'processDefinitionVersion',
+  'toolName',
+  'inboundConnectorType',
+];
+
+export const expectedMcpSubscriptionAlpha = {
+  messageSubscriptionType: 'START_EVENT',
+  processDefinitionId: 'mcpProcessAlpha',
+  processDefinitionName: 'MCP Process Alpha',
+  messageName: 'alpha-tool-name',
+  tenantId: '<default>',
+};
+
+export const expectedMcpSubscriptionBravo = {
+  messageSubscriptionType: 'START_EVENT',
+  processDefinitionId: 'mcpProcessBravo',
+  processDefinitionName: 'MCP Process Bravo',
+  messageName: 'bravo-tool-name',
+  tenantId: '<default>',
+};
+
+export const expectedMcpSubscriptionWithInputs = {
+  messageSubscriptionType: 'START_EVENT',
+  processDefinitionId: 'mcpProcessWithInputs',
+  processDefinitionName: 'MCP Process With Inputs',
+  messageName: 'mcp-process-with-inputs',
+  tenantId: '<default>',
+};
+
 export const documentRequiredFields = [
   'camunda.document.type',
   'storeId',

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
@@ -229,6 +229,8 @@ export const messageSubscriptionRequiredFields = [
 // Used in follow-on MCP API test PRs that validate full response shapes.
 export const mcpMessageSubscriptionRequiredFields = [
   ...messageSubscriptionRequiredFields,
+  'processDefinitionKey',
+  'rootProcessInstanceKey',
   'messageSubscriptionType',
   'extensionProperties',
   'processDefinitionName',

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
@@ -225,20 +225,6 @@ export const messageSubscriptionRequiredFields = [
   'correlationKey',
   'tenantId',
 ];
-// All required fields for 8.10+ message subscription responses that include MCP new fields.
-// Used in follow-on MCP API test PRs that validate full response shapes.
-export const mcpMessageSubscriptionRequiredFields = [
-  ...messageSubscriptionRequiredFields,
-  'processDefinitionKey',
-  'rootProcessInstanceKey',
-  'messageSubscriptionType',
-  'extensionProperties',
-  'processDefinitionName',
-  'processDefinitionVersion',
-  'toolName',
-  'inboundConnectorType',
-];
-
 export const expectedMcpSubscriptionAlpha = {
   messageSubscriptionType: 'START_EVENT',
   processDefinitionId: 'mcpProcessAlpha',

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/beans/requestBeans.ts
@@ -225,30 +225,6 @@ export const messageSubscriptionRequiredFields = [
   'correlationKey',
   'tenantId',
 ];
-export const expectedMcpSubscriptionAlpha = {
-  messageSubscriptionType: 'START_EVENT',
-  processDefinitionId: 'mcpProcessAlpha',
-  processDefinitionName: 'MCP Process Alpha',
-  messageName: 'alpha-tool-name',
-  tenantId: '<default>',
-};
-
-export const expectedMcpSubscriptionBravo = {
-  messageSubscriptionType: 'START_EVENT',
-  processDefinitionId: 'mcpProcessBravo',
-  processDefinitionName: 'MCP Process Bravo',
-  messageName: 'bravo-tool-name',
-  tenantId: '<default>',
-};
-
-export const expectedMcpSubscriptionWithInputs = {
-  messageSubscriptionType: 'START_EVENT',
-  processDefinitionId: 'mcpProcessWithInputs',
-  processDefinitionName: 'MCP Process With Inputs',
-  messageName: 'mcp-process-with-inputs',
-  tenantId: '<default>',
-};
-
 export const documentRequiredFields = [
   'camunda.document.type',
   'storeId',


### PR DESCRIPTION
## Summary

- Adds API tests for the new fields on `POST /v2/message-subscriptions/search` introduced in Camunda 8.10
- Covers `messageSubscriptionType`, `extensionProperties`, `processDefinitionName`, `processDefinitionVersion`, and `toolName` filter/sort fields
- Adds 3 BPMN resource files: MCP start event with inputs, standard intermediate catch event, and an existing MCP process used across scenarios

## Test scenarios

| Scenario | Coverage |
|----------|----------|
| SC-API-01 | Filter by `messageSubscriptionType = START_EVENT` — only start event subscriptions returned |
| SC-API-02 | Filter by `messageSubscriptionType = PROCESS_EVENT` — only intermediate event subscriptions |
| SC-API-03 | No type filter returns both `START_EVENT` and `PROCESS_EVENT` |
| SC-API-04 | `extensionProperties` contains `io.camunda.tool:*` metadata |
| SC-API-05 | `processDefinitionName` and `processDefinitionVersion` are populated |
| SC-API-06 | `processInstanceKey` and `elementInstanceKey` are `null` for start events |
| SC-API-07 | Filter by `toolName` field |
| SC-API-08 | `extensionProperties` for processes with inputs contains input parameter metadata |
| SC-API-09 | Sort by `processDefinitionName` ascending |
| SC-API-10 | Sort by `processDefinitionVersion` descending |

## Files changed

- `resources/mcp-process-with-inputs.bpmn` — new: MCP start event with `firstName` (string) and `amount` (integer, required) inputs
- `resources/mcp-process-intermediate-event.bpmn` — new: standard intermediate message catch event (PROCESS_EVENT contrast)
- `tests/api/v2/message-subscriptions/mcp-message-subscription-search.spec.ts` — new test spec

## Test plan

- [x] Run the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) against this branch before review (https://github.com/camunda/camunda/actions/runs/25375639893/job/74410107694)
- [x] Verify `Search MCP Subscriptions Unauthorized` and `MCP Message Subscription Search Flow` pass
- [x] Check that all 10 test steps (SC-API-01..10) complete successfully

Closes #52439
Relates to #51550

🤖 Generated with [Claude Code](https://claude.com/claude-code)