### PR TITLE
fix: increase default socket timeout for Operate and Tasklist snapshots

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/connect/OpensearchConnector.java
+++ b/operate/common/src/main/java/io/camunda/operate/connect/OpensearchConnector.java
@@ -427,10 +427,7 @@ public class OpensearchConnector {
 
   private RequestConfig.Builder setTimeouts(
       final RequestConfig.Builder builder, final OpensearchProperties os) {
-    if (os.getSocketTimeout() != null) {
-      // builder.setSocketTimeout(os.getSocketTimeout());
-      builder.setResponseTimeout(Timeout.ofMilliseconds(os.getSocketTimeout()));
-    }
+    builder.setResponseTimeout(Timeout.ofMilliseconds(os.getSocketTimeout()));
     if (os.getConnectTimeout() != null) {
       builder.setConnectTimeout(Timeout.ofMilliseconds(os.getConnectTimeout()));
     }

--- a/operate/common/src/main/java/io/camunda/operate/property/ElasticsearchProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/ElasticsearchProperties.java
@@ -21,20 +21,15 @@ public class ElasticsearchProperties {
   public static final String ELS_DATE_FORMAT_DEFAULT = "date_time";
 
   public static final int BULK_REQUEST_MAX_SIZE_IN_BYTES_DEFAULT = 1024 * 1024 * 90; // 90 MB
-
+  public static final int DEFAULT_SOCKET_TIMEOUT = 0;
   private String clusterName = "elasticsearch";
-
   @Deprecated private String host = "localhost";
-
   @Deprecated private int port = 9200;
-
   private String dateFormat = OperateDateTimeFormatter.DATE_FORMAT_DEFAULT;
-
   private String elsDateFormat = ELS_DATE_FORMAT_DEFAULT;
-
   private int batchSize = 200;
 
-  private Integer socketTimeout;
+  private Integer socketTimeout = DEFAULT_SOCKET_TIMEOUT;
   private Integer connectTimeout;
 
   private boolean createSchema = true;

--- a/operate/common/src/main/java/io/camunda/operate/property/OpensearchProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/OpensearchProperties.java
@@ -21,20 +21,15 @@ public class OpensearchProperties {
   public static final String OS_DATE_FORMAT_DEFAULT = "date_time";
 
   public static final int BULK_REQUEST_MAX_SIZE_IN_BYTES_DEFAULT = 1024 * 1024 * 90; // 90 MB
-
+  public static final int DEFAULT_SOCKET_TIMEOUT = 0;
   private String clusterName = "opensearch";
-
   @Deprecated private String host = "localhost";
-
   @Deprecated private int port = 9200;
-
   private String dateFormat = OperateDateTimeFormatter.DATE_FORMAT_DEFAULT;
-
   private String osDateFormat = OS_DATE_FORMAT_DEFAULT;
-
   private int batchSize = 200;
 
-  private Integer socketTimeout;
+  private Integer socketTimeout = DEFAULT_SOCKET_TIMEOUT;
   private Integer connectTimeout;
 
   private boolean createSchema = true;

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/backup/BackupRepository.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/backup/BackupRepository.java
@@ -58,7 +58,19 @@ public interface BackupRepository {
     final var incompleteCheckTimeoutInMilliseconds = incompleteCheckTimeoutInSeconds * 1000;
     try {
       final var now = Instant.now().toEpochMilli();
-      return (now - lastSnapshotFinishedTime) > (incompleteCheckTimeoutInMilliseconds);
+      final boolean timedOut =
+          (now - lastSnapshotFinishedTime) > incompleteCheckTimeoutInMilliseconds;
+      if (timedOut) {
+        LOGGER.warn(
+            "Backup is considered INCOMPLETE because no new snapshot was started within the "
+                + "incomplete-check timeout of {} seconds after the last snapshot finished. "
+                + "If backups are still in progress and snapshots are taking longer than expected, "
+                + "increase CAMUNDA_OPERATE_BACKUP_INCOMPLETECHECKTIMEOUTINSECONDS "
+                + "(current value: {}, recommended: double or triple it).",
+            incompleteCheckTimeoutInSeconds,
+            incompleteCheckTimeoutInSeconds);
+      }
+      return timedOut;
     } catch (final Exception e) {
       LOGGER.warn(
           "Couldn't check incomplete timeout for backup. Return incomplete check is timed out", e);

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/backup/ElasticsearchBackupRepository.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/backup/ElasticsearchBackupRepository.java
@@ -372,8 +372,13 @@ public class ElasticsearchBackupRepository implements BackupRepository {
     }
     LOGGER.error(
         String.format(
-            "Snapshot [%s] did not finish after configured timeout. Snapshot process won't continue.",
-            snapshotName));
+            "Snapshot [%s] did not finish within the configured snapshot timeout of %d seconds. "
+                + "Backup will not continue. To increase the timeout, set "
+                + "CAMUNDA_OPERATE_BACKUP_SNAPSHOTTIMEOUT to a larger value in seconds (current value: %d), "
+                + "or set it to 0 to wait indefinitely.",
+            snapshotName,
+            operateProperties.getBackup().getSnapshotTimeout(),
+            operateProperties.getBackup().getSnapshotTimeout()));
     return false;
   }
 
@@ -525,15 +530,18 @@ public class ElasticsearchBackupRepository implements BackupRepository {
       try {
         if (ex instanceof SocketTimeoutException) {
           // This is thrown even if the backup is still running
-          final int snapshotTimeout = operateProperties.getBackup().getSnapshotTimeout();
+          final Integer socketTimeout = operateProperties.getElasticsearch().getSocketTimeout();
           LOGGER.warn(
               String.format(
-                  "Socket timeout while creating snapshot [%s] for backup id [%d]. Start waiting with polling timeout, %s",
+                  "The Elasticsearch HTTP connection timed out while waiting for snapshot [%s] "
+                      + "(backup id [%d]) to complete. The snapshot is likely still running in "
+                      + "Elasticsearch. Polling will continue to check its status. If socket timeouts "
+                      + "occur repeatedly, consider increasing the socket timeout via "
+                      + "CAMUNDA_OPERATE_ELASTICSEARCH_SOCKETTIMEOUT (current value: %s ms). "
+                      + "Consider doubling or tripling the current value.",
                   snapshotRequest.snapshotName(),
                   backupId,
-                  (snapshotTimeout == 0)
-                      ? "until completion."
-                      : "at most " + snapshotTimeout + " seconds."));
+                  socketTimeout != null ? socketTimeout : "not set"));
           if (isSnapshotFinishedWithinTimeout(
               snapshotRequest.repositoryName(), snapshotRequest.snapshotName())) {
             onSuccess.run();

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/backup/OpensearchBackupRepository.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/backup/OpensearchBackupRepository.java
@@ -252,32 +252,23 @@ public class OpensearchBackupRepository implements BackupRepository {
         .async()
         .snapshot()
         .create(requestBuilder)
-        .thenAccept(
-            response -> {
-              try {
-                handleSnapshotReceived(response.snapshot(), onSuccess, onFailure);
-              } catch (final Exception e) {
-                LOGGER.error(
-                    format(
-                        "Exception while handling snapshot response for [%s], backup id [%d].",
-                        snapshotRequest.snapshotName(), backupId),
-                    e);
-                try {
-                  onFailure.run();
-                } catch (final Exception ex) {
-                  LOGGER.error("Exception while calling onFailure callback", ex);
-                }
-              }
-            })
+        .thenAccept(response -> handleSnapshotReceived(response.snapshot(), onSuccess, onFailure))
         .exceptionally(
             e -> {
               try {
                 if (e instanceof SocketTimeoutException) {
                   // This is thrown even if the backup is still running
+                  final Integer socketTimeout =
+                      operateProperties.getOpensearch().getSocketTimeout();
                   LOGGER.warn(
                       format(
-                          "Timeout while creating snapshot [%s] for backup id [%d]. Need to keep waiting with polling...",
-                          snapshotRequest.snapshotName(), backupId));
+                          "The OpenSearch HTTP connection timed out while waiting for snapshot [%s] "
+                              + "(backup id [%d]) to complete. The snapshot is likely still running in "
+                              + "OpenSearch. Polling will continue to check its status. If socket timeouts "
+                              + "occur repeatedly, consider increasing the socket timeout via "
+                              + "CAMUNDA_OPERATE_OPENSEARCH_SOCKETTIMEOUT (current value: %s ms). "
+                              + "Consider doubling or tripling the current value.",
+                          snapshotRequest.snapshotName(), backupId, socketTimeout));
                   // Keep waiting
                   while (true) {
                     final List<OpenSearchSnapshotInfo> snapshotInfos =

--- a/tasklist/common/src/main/java/io/camunda/tasklist/property/ElasticsearchProperties.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/property/ElasticsearchProperties.java
@@ -24,21 +24,17 @@ public class ElasticsearchProperties {
   public static final int DEFAULT_MAX_TERMS_COUNT = 10_000;
   public static final long BULK_REQUEST_MAX_SIZE_IN_BYTES_DEFAULT = 1024L * 1024L * 90L; // 90 MB
 
+  public static final int DEFAULT_SOCKET_TIMEOUT = 0;
   private String clusterName = "elasticsearch";
-
   @Deprecated private String host = "localhost";
-
   @Deprecated private int port = 9200;
-
   private String dateFormat = DATE_FORMAT_DEFAULT;
-
   private String elsDateFormat = ELS_DATE_FORMAT_DEFAULT;
-
   private int batchSize = 200;
   private int maxTermsCount = DEFAULT_MAX_TERMS_COUNT;
   private long bulkRequestMaxSizeInBytes = BULK_REQUEST_MAX_SIZE_IN_BYTES_DEFAULT;
 
-  private Integer socketTimeout;
+  private Integer socketTimeout = DEFAULT_SOCKET_TIMEOUT;
   private Integer connectTimeout;
 
   private boolean createSchema = true;

--- a/tasklist/common/src/main/java/io/camunda/tasklist/property/OpenSearchProperties.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/property/OpenSearchProperties.java
@@ -22,21 +22,16 @@ public class OpenSearchProperties {
 
   public static final String ELS_DATE_FORMAT_DEFAULT = "date_time";
   public static final int DEFAULT_MAX_TERMS_COUNT = 10_000;
-
+  public static final int DEFAULT_SOCKET_TIMEOUT = 0;
   private String clusterName = "opensearch-cluster";
-
   @Deprecated private String host = "localhost";
-
   @Deprecated private int port = 9205;
-
   private String dateFormat = DATE_FORMAT_DEFAULT;
-
   private String elsDateFormat = ELS_DATE_FORMAT_DEFAULT;
-
   private int batchSize = 200;
   private int maxTermsCount = DEFAULT_MAX_TERMS_COUNT;
 
-  private Integer socketTimeout;
+  private Integer socketTimeout = DEFAULT_SOCKET_TIMEOUT;
   private Integer connectTimeout;
 
   private boolean createSchema = true;

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/es/BackupManagerElasticSearch.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/es/BackupManagerElasticSearch.java
@@ -460,11 +460,24 @@ public class BackupManagerElasticSearch extends BackupManager {
   }
 
   private boolean isWithinGracePeriodForIncomplete(final long lastSnapshotFinishedTime) {
-    final var incompleteCheckTimeoutInMilliseconds =
-        tasklistProperties.getBackup().getIncompleteCheckTimeoutInSeconds() * 1000;
+    final var incompleteCheckTimeoutInSeconds =
+        tasklistProperties.getBackup().getIncompleteCheckTimeoutInSeconds();
+    final var incompleteCheckTimeoutInMilliseconds = incompleteCheckTimeoutInSeconds * 1000;
     try {
-      return Instant.now().toEpochMilli() - lastSnapshotFinishedTime
-          < incompleteCheckTimeoutInMilliseconds;
+      final boolean withinGrace =
+          Instant.now().toEpochMilli() - lastSnapshotFinishedTime
+              < incompleteCheckTimeoutInMilliseconds;
+      if (!withinGrace) {
+        LOGGER.warn(
+            "Backup is considered INCOMPLETE because no new snapshot was started within the "
+                + "incomplete-check timeout of {} seconds after the last snapshot finished. "
+                + "If backups are still in progress and snapshots are taking longer than expected, "
+                + "increase CAMUNDA_TASKLIST_BACKUP_INCOMPLETECHECKTIMEOUTINSECONDS "
+                + "(current value: {}, recommended: double or triple it).",
+            incompleteCheckTimeoutInSeconds,
+            incompleteCheckTimeoutInSeconds);
+      }
+      return withinGrace;
     } catch (final Exception e) {
       LOGGER.warn(
           "Couldn't check incomplete timeout for backup. Return incomplete check is timed out", e);
@@ -549,8 +562,13 @@ public class BackupManagerElasticSearch extends BackupManager {
     }
     LOGGER.error(
         String.format(
-            "Snapshot [%s] did not finish after configured timeout. Snapshot process won't continue.",
-            snapshotName));
+            "Snapshot [%s] did not finish within the configured snapshot timeout of %d seconds. "
+                + "Backup will not continue. To increase the timeout, set "
+                + "CAMUNDA_TASKLIST_BACKUP_SNAPSHOTTIMEOUT to a larger value in seconds (current value: %d), "
+                + "or set it to 0 to wait indefinitely.",
+            snapshotName,
+            tasklistProperties.getBackup().getSnapshotTimeout(),
+            tasklistProperties.getBackup().getSnapshotTimeout()));
     return false;
   }
 
@@ -614,15 +632,16 @@ public class BackupManagerElasticSearch extends BackupManager {
     public void onFailure(final Exception e) {
       if (e instanceof SocketTimeoutException) {
         // backup is still running
-        final int snapshotTimeout = tasklistProperties.getBackup().getSnapshotTimeout();
+        final Integer socketTimeout = tasklistProperties.getElasticsearch().getSocketTimeout();
         LOGGER.warn(
             String.format(
-                "Socket timeout while creating snapshot [%s]. Start waiting with polling timeout, %s",
-                snapshotRequest.snapshot(),
-                snapshotRequest.userMetadata().get("backupId"),
-                (snapshotTimeout == 0)
-                    ? "until completion."
-                    : "at most " + snapshotTimeout + " seconds."));
+                "The Elasticsearch HTTP connection timed out while waiting for snapshot [%s] "
+                    + "to complete. The snapshot is likely still running in Elasticsearch. "
+                    + "Polling will continue to check its status. If socket timeouts occur "
+                    + "repeatedly, consider increasing the socket timeout via "
+                    + "CAMUNDA_TASKLIST_ELASTICSEARCH_SOCKETTIMEOUT (current value: %s ms). "
+                    + "Consider doubling or tripling the current value.",
+                snapshotRequest.snapshot(), socketTimeout != null ? socketTimeout : "not set"));
         if (isSnapshotFinishedWithinTimeout(snapshotRequest.snapshot())) {
           onSuccess.run();
         } else {

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/os/BackupManagerOpenSearch.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/os/BackupManagerOpenSearch.java
@@ -384,11 +384,19 @@ public class BackupManagerOpenSearch extends BackupManager {
                     Metadata.extractBackupIdFromSnapshotName(snapshotRequest.snapshot());
                 if (e.getCause() instanceof SocketTimeoutException) {
                   // This is thrown even if the backup is still running
+                  final Integer socketTimeout =
+                      tasklistProperties.getOpenSearch().getSocketTimeout();
                   LOGGER.warn(
                       format(
-                          "Timeout while creating snapshot [%s] for backup id [%d]. Need to keep waiting with polling...",
+                          "The OpenSearch HTTP connection timed out while waiting for snapshot [%s] "
+                              + "(backup id [%d]) to complete. The snapshot is likely still running in "
+                              + "OpenSearch. Polling will continue to check its status. If socket timeouts "
+                              + "occur repeatedly, consider increasing the socket timeout via "
+                              + "CAMUNDA_TASKLIST_OPENSEARCH_SOCKETTIMEOUT (current value: %s ms). "
+                              + "Consider doubling or tripling the current value.",
                           snapshotRequest.snapshot(),
-                          Metadata.extractBackupIdFromSnapshotName(snapshotRequest.snapshot())));
+                          backupId,
+                          socketTimeout != null ? socketTimeout : "not set"));
                   // Keep waiting
                   final List<SnapshotInfo> snapshotInfos = findSnapshots(backupId);
                   final Optional<SnapshotInfo> maybeCurrentSnapshot =
@@ -591,11 +599,24 @@ public class BackupManagerOpenSearch extends BackupManager {
     if (lastSnapshotFinishedTime == null) {
       return false;
     }
-    final var incompleteCheckTimeoutInMilliseconds =
-        tasklistProperties.getBackup().getIncompleteCheckTimeoutInSeconds() * 1000;
+    final var incompleteCheckTimeoutInSeconds =
+        tasklistProperties.getBackup().getIncompleteCheckTimeoutInSeconds();
+    final var incompleteCheckTimeoutInMilliseconds = incompleteCheckTimeoutInSeconds * 1000;
     try {
-      return Instant.now().toEpochMilli() - Long.valueOf(lastSnapshotFinishedTime)
-          < incompleteCheckTimeoutInMilliseconds;
+      final boolean withinGrace =
+          Instant.now().toEpochMilli() - Long.valueOf(lastSnapshotFinishedTime)
+              < incompleteCheckTimeoutInMilliseconds;
+      if (!withinGrace) {
+        LOGGER.warn(
+            "Backup is considered INCOMPLETE because no new snapshot was started within the "
+                + "incomplete-check timeout of {} seconds after the last snapshot finished. "
+                + "If backups are still in progress and snapshots are taking longer than expected, "
+                + "increase CAMUNDA_TASKLIST_BACKUP_INCOMPLETECHECKTIMEOUTINSECONDS "
+                + "(current value: {}, recommended: double or triple it).",
+            incompleteCheckTimeoutInSeconds,
+            incompleteCheckTimeoutInSeconds);
+      }
+      return withinGrace;
     } catch (final Exception e) {
       LOGGER.warn(
           "Couldn't check incomplete timeout for backup. Return incomplete check is timed out", e);
@@ -652,8 +673,13 @@ public class BackupManagerOpenSearch extends BackupManager {
     }
     LOGGER.error(
         String.format(
-            "Snapshot [%s] did not finish after configured timeout. Snapshot process won't continue.",
-            snapshotName));
+            "Snapshot [%s] did not finish within the configured snapshot timeout of %d seconds. "
+                + "Backup will not continue. To increase the timeout, set "
+                + "CAMUNDA_TASKLIST_BACKUP_SNAPSHOTTIMEOUT to a larger value in seconds (current value: %d), "
+                + "or set it to 0 to wait indefinitely.",
+            snapshotName,
+            tasklistProperties.getBackup().getSnapshotTimeout(),
+            tasklistProperties.getBackup().getSnapshotTimeout()));
     return false;
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Sets the default connect timeout explicitly to 0. This should not change socket timeout behavior, but makes it explicit and more easily adjustable. Also improves logging to give better guidance.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

relates to https://github.com/camunda/camunda/issues/41861
