### PR TITLE
feat: migrate Optimize SM E2E tests from TestCafe to Playwright

### DIFF
--- a/.github/workflows/optimize-e2e-tests-sm-playwright.yml
+++ b/.github/workflows/optimize-e2e-tests-sm-playwright.yml
@@ -1,0 +1,170 @@
+# description: Runs Optimize Self-Managed E2E tests using Playwright against the
+#              c8-orchestration-cluster-e2e-test-suite. Replaces the legacy TestCafe
+#              workflow (optimize-e2e-tests-sm.yml) for the Playwright test suite.
+# test location: /qa/c8-orchestration-cluster-e2e-test-suite/tests/optimize
+# type: CI
+# owner: @camunda/core-features
+---
+name: Optimize E2E Self-Managed (Playwright)
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/optimize-e2e-tests-sm-playwright.yml"
+      - "optimize/**"
+      - "optimize.Dockerfile"
+      - "qa/c8-orchestration-cluster-e2e-test-suite/**"
+  push:
+    branches:
+      - "main"
+      - "stable/**"
+      - "release/**"
+    paths:
+      - ".github/workflows/optimize-e2e-tests-sm-playwright.yml"
+      - "optimize/**"
+      - "optimize.Dockerfile"
+      - "qa/c8-orchestration-cluster-e2e-test-suite/**"
+  workflow_dispatch: {}
+
+# Limit to 1 concurrent run per ref — cancel in-progress if a new commit arrives
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  id-token: write # required for Vault authentication
+
+jobs:
+  optimize-e2e-sm-playwright:
+    name: Optimize E2E Self-Managed (Playwright)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@79632e33d6953d190b940ffa440bf97821cabd80
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_CORE_DOMAIN_BOT_TOKEN;
+
+      - name: Set CAMUNDA_DOCKER_IMAGE
+        run: |
+          branch="${{ github.ref_name }}"
+          if [[ "$branch" == "main" ]]; then
+            echo "CAMUNDA_DOCKER_IMAGE=camunda/camunda:SNAPSHOT" >> "$GITHUB_ENV"
+            echo "OPTIMIZE_VERSION=SNAPSHOT" >> "$GITHUB_ENV"
+            echo "IDENTITY_VERSION=SNAPSHOT" >> "$GITHUB_ENV"
+          elif [[ "$branch" == stable/* ]]; then
+            minor="${branch#stable/}"
+            echo "CAMUNDA_DOCKER_IMAGE=camunda/camunda:${minor}-SNAPSHOT" >> "$GITHUB_ENV"
+            echo "OPTIMIZE_VERSION=${minor}-SNAPSHOT" >> "$GITHUB_ENV"
+            echo "IDENTITY_VERSION=${minor}-SNAPSHOT" >> "$GITHUB_ENV"
+          else
+            echo "CAMUNDA_DOCKER_IMAGE=camunda/camunda:SNAPSHOT" >> "$GITHUB_ENV"
+            echo "OPTIMIZE_VERSION=SNAPSHOT" >> "$GITHUB_ENV"
+            echo "IDENTITY_VERSION=SNAPSHOT" >> "$GITHUB_ENV"
+          fi
+
+      - name: Start core services (Elasticsearch, Keycloak, Camunda)
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
+        run: DATABASE=elasticsearch docker compose up -d elasticsearch keycloak camunda
+
+      - name: Wait for Camunda to be ready
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
+        run: |
+          echo "Waiting for Camunda to be ready..."
+          for i in {1..90}; do
+            status=$(curl -s -m 5 http://localhost:8080/operate || echo "Failed")
+            if [[ "$status" != "Failed" ]]; then
+              echo "Camunda is ready!"
+              break
+            fi
+            echo "Waiting... ($i/90)"
+            sleep 10
+          done
+
+      - name: Start Identity and Optimize
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
+        run: DATABASE=elasticsearch docker compose up -d identity optimize
+
+      - name: Wait for Optimize to be ready
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
+        run: |
+          echo "Waiting for Optimize to be ready..."
+          for i in {1..90}; do
+            status=$(curl -s -m 10 http://localhost:8090/api/readyz || echo "Failed")
+            if [[ "$status" != "Failed" ]]; then
+              echo "Optimize is ready!"
+              break
+            fi
+            echo "Waiting for Optimize... ($i/90)"
+            sleep 10
+          done
+
+      - name: List running Docker containers
+        run: docker ps -a
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: qa/c8-orchestration-cluster-e2e-test-suite/package-lock.json
+
+      - name: Install dependencies
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+        run: |
+          rm -rf node_modules package-lock.json
+          npm install
+
+      - name: Install Playwright browsers
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Optimize E2E tests
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+        env:
+          LOCAL_TEST: "false"
+          CORE_APPLICATION_URL: "http://localhost:8080"
+          CAMUNDA_AUTH_STRATEGY: "BASIC"
+          CAMUNDA_BASIC_AUTH_USERNAME: "demo"
+          CAMUNDA_BASIC_AUTH_PASSWORD: "demo"
+          ZEEBE_REST_ADDRESS: "http://localhost:8080"
+          CAMUNDA_TASKLIST_V2_MODE_ENABLED: "true"
+          OPTIMIZE_URL: "http://localhost:8090"
+        run: npm run test -- --project=chromium tests/optimize/
+
+      - name: Upload HTML report
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: optimize-e2e-sm-playwright-html-report
+          path: qa/c8-orchestration-cluster-e2e-test-suite/html-report/**
+          retention-days: 30
+
+      - name: Upload JSON report
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: optimize-e2e-sm-playwright-json-report
+          path: qa/c8-orchestration-cluster-e2e-test-suite/json-report/**
+          retention-days: 30
+
+      - name: Print Docker logs on failure
+        if: failure()
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
+        run: |
+          docker compose logs keycloak
+          docker compose logs identity
+          docker compose logs optimize
+          docker compose logs camunda

--- a/.github/workflows/optimize-e2e-tests-sm-playwright.yml
+++ b/.github/workflows/optimize-e2e-tests-sm-playwright.yml
@@ -24,6 +24,8 @@ on:
       - "optimize/**"
       - "optimize.Dockerfile"
       - "qa/c8-orchestration-cluster-e2e-test-suite/**"
+  schedule:
+    - cron: "0 2 * * *"
   workflow_dispatch: {}
 
 # Limit to 1 concurrent run per ref — cancel in-progress if a new commit arrives
@@ -58,44 +60,109 @@ jobs:
             secret/data/products/camunda/ci/github-actions SLACK_CORE_DOMAIN_BOT_TOKEN;
 
       - name: Set CAMUNDA_DOCKER_IMAGE
+        env:
+          BRANCH: ${{ github.head_ref || github.ref_name }}
         run: |
-          branch="${{ github.ref_name }}"
-          if [[ "$branch" == "main" ]]; then
-            echo "CAMUNDA_DOCKER_IMAGE=camunda/camunda:SNAPSHOT" >> "$GITHUB_ENV"
-            echo "OPTIMIZE_VERSION=SNAPSHOT" >> "$GITHUB_ENV"
-            echo "IDENTITY_VERSION=SNAPSHOT" >> "$GITHUB_ENV"
-          elif [[ "$branch" == stable/* ]]; then
-            minor="${branch#stable/}"
-            echo "CAMUNDA_DOCKER_IMAGE=camunda/camunda:${minor}-SNAPSHOT" >> "$GITHUB_ENV"
-            echo "OPTIMIZE_VERSION=${minor}-SNAPSHOT" >> "$GITHUB_ENV"
-            echo "IDENTITY_VERSION=${minor}-SNAPSHOT" >> "$GITHUB_ENV"
+          echo "DATABASE=elasticsearch" >> "$GITHUB_ENV"
+          if [[ "$BRANCH" == "main" ]]; then
+            {
+              echo "CAMUNDA_DOCKER_IMAGE=camunda/camunda:SNAPSHOT"
+              echo "OPTIMIZE_VERSION=8-SNAPSHOT"
+              echo "IDENTITY_VERSION=SNAPSHOT"
+            } >> "$GITHUB_ENV"
+          elif [[ "$BRANCH" == stable/* ]]; then
+            minor="${BRANCH#stable/}"
+            {
+              echo "CAMUNDA_DOCKER_IMAGE=camunda/camunda:${minor}-SNAPSHOT"
+              echo "OPTIMIZE_VERSION=8-${minor}-SNAPSHOT"
+              echo "IDENTITY_VERSION=${minor}-SNAPSHOT"
+            } >> "$GITHUB_ENV"
           else
-            echo "CAMUNDA_DOCKER_IMAGE=camunda/camunda:SNAPSHOT" >> "$GITHUB_ENV"
-            echo "OPTIMIZE_VERSION=SNAPSHOT" >> "$GITHUB_ENV"
-            echo "IDENTITY_VERSION=SNAPSHOT" >> "$GITHUB_ENV"
+            {
+              echo "CAMUNDA_DOCKER_IMAGE=camunda/camunda:SNAPSHOT"
+              echo "OPTIMIZE_VERSION=8-SNAPSHOT"
+              echo "IDENTITY_VERSION=SNAPSHOT"
+            } >> "$GITHUB_ENV"
           fi
 
-      - name: Start core services (Elasticsearch, Keycloak, Camunda)
+      - name: Start Elasticsearch
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
-        run: DATABASE=elasticsearch docker compose up -d elasticsearch keycloak camunda
+        run: docker compose up -d elasticsearch
+
+      - name: Wait for Elasticsearch to be ready
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
+        run: |
+          echo "Waiting for Elasticsearch cluster health..."
+          for i in {1..60}; do
+            status=$(curl -s -m 5 "http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=5s" | grep -o '"status":"[^"]*"' || true)
+            if [[ "$status" == '"status":"yellow"' || "$status" == '"status":"green"' ]]; then
+              echo "Elasticsearch is healthy: $status"
+              break
+            fi
+            echo "Waiting for Elasticsearch... ($i/60)"
+            sleep 5
+          done
+          if [[ $i -eq 60 ]]; then
+            echo "Elasticsearch did not become healthy in time"
+            docker compose logs elasticsearch
+            exit 1
+          fi
+
+      - name: Start Keycloak
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
+        run: docker compose up -d keycloak
+
+      - name: Wait for Keycloak to be ready
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
+        run: |
+          echo "Waiting for Keycloak to be ready..."
+          for i in {1..90}; do
+            status=$(docker inspect --format='{{.State.Health.Status}}' keycloak 2>/dev/null || echo "missing")
+            if [[ "$status" == "healthy" ]]; then
+              echo "Keycloak is healthy"
+              break
+            fi
+            echo "Waiting for Keycloak... ($i/90), status=$status"
+            sleep 5
+          done
+          if [[ $i -eq 90 ]]; then
+            echo "Keycloak did not become healthy in time"
+            docker inspect --format='{{json .State.Health}}' keycloak || true
+            docker compose logs keycloak
+            exit 1
+          fi
+
+      - name: Start Camunda
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
+        run: docker compose up -d camunda
 
       - name: Wait for Camunda to be ready
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
         run: |
           echo "Waiting for Camunda to be ready..."
           for i in {1..90}; do
-            status=$(curl -s -m 5 http://localhost:8080/operate || echo "Failed")
-            if [[ "$status" != "Failed" ]]; then
-              echo "Camunda is ready!"
+            code=$(curl -s -o /dev/null -w "%{http_code}" -m 5 http://localhost:8080/operate || echo "000")
+            if [[ "$code" == "200" || "$code" == "302" || "$code" == "401" ]]; then
+              echo "Camunda is ready with HTTP $code"
               break
             fi
-            echo "Waiting... ($i/90)"
+            echo "Waiting for Camunda... ($i/90), HTTP=$code"
             sleep 10
           done
+          if [[ $i -eq 90 ]]; then
+            echo "Camunda did not become ready in time"
+            docker compose logs camunda
+            exit 1
+          fi
 
       - name: Start Identity and Optimize
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
-        run: DATABASE=elasticsearch docker compose up -d identity optimize
+        run: |
+          docker compose up -d identity optimize || {
+            docker compose logs identity
+            docker compose logs keycloak
+            exit 1
+          }
 
       - name: Wait for Optimize to be ready
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
@@ -110,6 +177,10 @@ jobs:
             echo "Waiting for Optimize... ($i/90)"
             sleep 10
           done
+          if [[ $i -eq 90 ]]; then
+            echo "Optimize did not become ready in time"
+            exit 1
+          fi
 
       - name: List running Docker containers
         run: docker ps -a
@@ -142,7 +213,7 @@ jobs:
           ZEEBE_REST_ADDRESS: "http://localhost:8080"
           CAMUNDA_TASKLIST_V2_MODE_ENABLED: "true"
           OPTIMIZE_URL: "http://localhost:8090"
-        run: npm run test -- --project=chromium tests/optimize/
+        run: npm run test -- --project=optimize-e2e --workers=1
 
       - name: Upload HTML report
         if: always()
@@ -164,6 +235,7 @@ jobs:
         if: failure()
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
         run: |
+          docker compose logs elasticsearch
           docker compose logs keycloak
           docker compose logs identity
           docker compose logs optimize

--- a/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
@@ -139,3 +139,69 @@ services:
       - zeebe_network
     env_file:
       - envs/.env.database.${DATABASE}
+
+  identity:
+    depends_on:
+      keycloak:
+        condition: service_healthy
+    restart: on-failure
+    container_name: identity
+    image: camunda/identity:${IDENTITY_VERSION:-SNAPSHOT}
+    ports:
+      - '8081:8081'
+    healthcheck:
+      test: ['CMD', 'wget', '-q', '--tries=1', '--spider', 'http://localhost:8082/actuator/health']
+      interval: 5s
+      timeout: 15s
+      retries: 30
+      start_period: 60s
+    environment:
+      SERVER_PORT: 8081
+      KEYCLOAK_URL: http://keycloak:8080/auth
+      IDENTITY_AUTH_PROVIDER_BACKEND_URL: http://keycloak:8080/auth/realms/camunda-platform
+      KEYCLOAK_INIT_OPTIMIZE_SECRET: XALaRPl5qwTEItdwCMiPS62nVpKs7dL7
+      KEYCLOAK_INIT_OPTIMIZE_ROOT_URL: http://localhost:8090
+      KEYCLOAK_USERS_0_USERNAME: 'demo'
+      KEYCLOAK_USERS_0_PASSWORD: 'demo'
+      KEYCLOAK_USERS_0_FIRST_NAME: 'demo'
+      KEYCLOAK_USERS_0_ROLES_0: 'Identity'
+      KEYCLOAK_USERS_0_ROLES_1: 'Optimize'
+    networks:
+      - zeebe_network
+
+  optimize:
+    container_name: optimize
+    image: camunda/optimize:${OPTIMIZE_VERSION:-SNAPSHOT}
+    depends_on:
+      identity:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_started
+    ports:
+      - '8090:8090'
+      - '8092:8092'
+    environment:
+      - SPRING_PROFILES_ACTIVE=ccsm
+      - CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_URL=http://localhost:18080/auth/realms/camunda-platform
+      - CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_BACKEND_URL=http://keycloak:8080/auth/realms/camunda-platform
+      - CAMUNDA_OPTIMIZE_IDENTITY_BASE_URL=http://identity:8081/
+      - CAMUNDA_OPTIMIZE_IDENTITY_CLIENTID=optimize
+      - CAMUNDA_OPTIMIZE_IDENTITY_CLIENTSECRET=XALaRPl5qwTEItdwCMiPS62nVpKs7dL7
+      - CAMUNDA_OPTIMIZE_IDENTITY_AUDIENCE=optimize-api
+      - OPTIMIZE_ELASTICSEARCH_HOST=elasticsearch
+      - OPTIMIZE_ELASTICSEARCH_HTTP_PORT=9200
+      - CAMUNDA_OPTIMIZE_SECURITY_AUTH_COOKIE_SAME_SITE_ENABLED=false
+      - CAMUNDA_OPTIMIZE_ENTERPRISE=false
+      - CAMUNDA_OPTIMIZE_ZEEBE_ENABLED=true
+      - CAMUNDA_OPTIMIZE_ZEEBE_NAME=zeebe-record
+      - CAMUNDA_OPTIMIZE_ZEEBE_PARTITION_COUNT=2
+      - CAMUNDA_OPTIMIZE_IMPORT_DATA_SKIP_DATA_AFTER_NESTED_DOC_LIMIT_REACHED=true
+      - SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI=http://keycloak:8080/auth/realms/camunda-platform/protocol/openid-connect/certs
+    healthcheck:
+      test: ['CMD-SHELL', 'curl -f http://localhost:8090/api/readyz || exit 1']
+      interval: 30s
+      timeout: 10s
+      retries: 10
+      start_period: 60s
+    networks:
+      - zeebe_network

--- a/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
@@ -11,6 +11,12 @@ services:
       POSTGRES_DB: identity
       POSTGRES_USER: identity
       POSTGRES_PASSWORD: 't2L@!AqSMg8%I%NmHM'
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U identity -d identity']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
     networks:
       - zeebe_network
 
@@ -73,25 +79,30 @@ services:
 
   keycloak:
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
     container_name: keycloak
-    image: bitnami/keycloak:26.3.3
+    image: quay.io/keycloak/keycloak:26.3.3
+    command: start-dev
     ports:
       - '18080:8080'
+      - '9000:9000'
     environment:
-      KEYCLOAK_HTTP_RELATIVE_PATH: /auth
-      KEYCLOAK_DATABASE_HOST: postgres
-      KEYCLOAK_DATABASE_NAME: identity
-      KEYCLOAK_DATABASE_USER: identity
-      KEYCLOAK_DATABASE_PASSWORD: 't2L@!AqSMg8%I%NmHM'
-      KEYCLOAK_ADMIN_USER: admin
-      KEYCLOAK_ADMIN_PASSWORD: admin
+      KC_DB: postgres
+      KC_DB_URL: jdbc:postgresql://postgres:5432/identity
+      KC_DB_USERNAME: identity
+      KC_DB_PASSWORD: 't2L@!AqSMg8%I%NmHM'
+      KC_HTTP_RELATIVE_PATH: /auth
+      KC_HTTP_PORT: '8080'
+      KC_BOOTSTRAP_ADMIN_USERNAME: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
+      KC_HEALTH_ENABLED: 'true'
     healthcheck:
-      test: ['CMD', 'curl', '-f', 'http://localhost:8080/auth']
-      interval: 30s
-      timeout: 15s
-      retries: 8
-      start_period: 30s
+      test: ['CMD-SHELL', 'curl -sf http://localhost:9000/health/ready 2>/dev/null || exit 1']
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 60s
     networks:
       - zeebe_network
 
@@ -171,7 +182,7 @@ services:
 
   optimize:
     container_name: optimize
-    image: camunda/optimize:${OPTIMIZE_VERSION:-SNAPSHOT}
+    image: camunda/optimize:${OPTIMIZE_VERSION:-8-latest}
     depends_on:
       identity:
         condition: service_healthy

--- a/qa/c8-orchestration-cluster-e2e-test-suite/fixtures.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/fixtures.ts
@@ -40,6 +40,11 @@ import {OperateOperationsDetailsPage} from '@pages/OperateOperationsDetailsPage'
 import {OperateOperationsLogPage} from '@pages/OperateOperationsLogPage';
 import {SwaggerPage} from '@pages/SwaggerPage';
 import {OperateBatchOperationsPage} from '@pages/OperateBatchOperationsPage';
+import {OptimizeLoginPage} from '@pages/OptimizeLoginPage';
+import {OptimizeHomePage} from '@pages/OptimizeHomePage';
+import {OptimizeCollectionPage} from '@pages/OptimizeCollectionPage';
+import {OptimizeDashboardPage} from '@pages/OptimizeDashboardPage';
+import {OptimizeProcessReportPage} from '@pages/OptimizeProcessReportPage';
 
 type PlaywrightFixtures = {
   makeAxeBuilder: () => AxeBuilder;
@@ -77,6 +82,11 @@ type PlaywrightFixtures = {
   swaggerPage: SwaggerPage;
   identityGlobalTaskListenersPage: IdentityGlobalTaskListenersPage;
   suppressHelperModals: void;
+  optimizeLoginPage: OptimizeLoginPage;
+  optimizeHomePage: OptimizeHomePage;
+  optimizeCollectionPage: OptimizeCollectionPage;
+  optimizeDashboardPage: OptimizeDashboardPage;
+  optimizeProcessReportPage: OptimizeProcessReportPage;
 };
 
 const test = base.extend<PlaywrightFixtures>({
@@ -209,6 +219,21 @@ const test = base.extend<PlaywrightFixtures>({
   },
   identityMcpProcessesPage: async ({page}, use) => {
     await use(new IdentityMcpProcessesPage(page));
+  },
+  optimizeLoginPage: async ({page}, use) => {
+    await use(new OptimizeLoginPage(page));
+  },
+  optimizeHomePage: async ({page}, use) => {
+    await use(new OptimizeHomePage(page));
+  },
+  optimizeCollectionPage: async ({page}, use) => {
+    await use(new OptimizeCollectionPage(page));
+  },
+  optimizeDashboardPage: async ({page}, use) => {
+    await use(new OptimizeDashboardPage(page));
+  },
+  optimizeProcessReportPage: async ({page}, use) => {
+    await use(new OptimizeProcessReportPage(page));
   },
 });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OptimizeCollectionPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OptimizeCollectionPage.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Page, Locator} from '@playwright/test';
+
+export class OptimizeCollectionPage {
+  private page: Page;
+  readonly collectionTitle: Locator;
+  readonly collectionContextMenu: Locator;
+  readonly entitiesTab: Locator;
+  readonly userTab: Locator;
+  readonly alertTab: Locator;
+  readonly sourcesTab: Locator;
+  readonly addButton: Locator;
+  readonly emptyStateAddButton: Locator;
+  readonly sourceModalSearchField: Locator;
+  readonly selectAllCheckbox: Locator;
+  readonly bulkRemoveButton: Locator;
+  readonly modalNameInput: Locator;
+  readonly modalConfirmButton: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.collectionTitle = page.locator('.Collection h2');
+    this.collectionContextMenu = page.locator(
+      '.Collection .cds--overflow-menu__wrapper button',
+    );
+    const tabButton = page.locator('.Collection .cds--tabs__nav-item');
+    this.entitiesTab = tabButton.filter({hasText: 'Dashboards'});
+    this.userTab = tabButton.filter({hasText: 'Users'});
+    this.alertTab = tabButton.filter({hasText: 'Alerts'});
+    this.sourcesTab = tabButton.filter({hasText: 'Data sources'});
+    const activeTab = page.locator('.Collection .cds--tab-content:not([hidden])');
+    this.addButton = activeTab.locator('.cds--toolbar-content > .cds--btn--primary');
+    this.emptyStateAddButton = activeTab.locator('.EmptyState .cds--btn--primary');
+    this.sourceModalSearchField = page.locator('.SourcesModal .cds--search-input');
+    this.selectAllCheckbox = page.locator('.Table thead .cds--table-column-checkbox label');
+    this.bulkRemoveButton = activeTab
+      .locator('.cds--action-list button')
+      .filter({hasText: 'Remove'});
+    this.modalNameInput = page.locator('.Modal.is-visible input[type="text"]');
+    this.modalConfirmButton = page.locator(
+      '.Modal.is-visible .cds--modal-footer .cds--btn:last-child:not([disabled])',
+    );
+  }
+
+  overflowMenuOption(text: string): Locator {
+    return this.page.locator('.cds--overflow-menu-options__option').filter({hasText: text});
+  }
+
+  itemCheckbox(index: number): Locator {
+    return this.page
+      .locator('.Table tbody tr')
+      .nth(index)
+      .locator('.cds--table-column-checkbox label');
+  }
+
+  async editName(newName: string): Promise<void> {
+    await this.collectionContextMenu.click();
+    await this.overflowMenuOption('Edit').click();
+    await this.modalNameInput.fill(newName);
+    await this.modalConfirmButton.click();
+  }
+
+  async copyCollection(copyName: string): Promise<void> {
+    await this.collectionContextMenu.click();
+    await this.overflowMenuOption('Copy').click();
+    await this.modalNameInput.fill(copyName);
+    await this.modalConfirmButton.click();
+  }
+
+  async deleteCollection(): Promise<void> {
+    await this.collectionContextMenu.click();
+    await this.overflowMenuOption('Delete').click();
+    await this.modalConfirmButton.click();
+  }
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OptimizeCollectionPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OptimizeCollectionPage.ts
@@ -35,11 +35,21 @@ export class OptimizeCollectionPage {
     this.userTab = tabButton.filter({hasText: 'Users'});
     this.alertTab = tabButton.filter({hasText: 'Alerts'});
     this.sourcesTab = tabButton.filter({hasText: 'Data sources'});
-    const activeTab = page.locator('.Collection .cds--tab-content:not([hidden])');
-    this.addButton = activeTab.locator('.cds--toolbar-content > .cds--btn--primary');
-    this.emptyStateAddButton = activeTab.locator('.EmptyState .cds--btn--primary');
-    this.sourceModalSearchField = page.locator('.SourcesModal .cds--search-input');
-    this.selectAllCheckbox = page.locator('.Table thead .cds--table-column-checkbox label');
+    const activeTab = page.locator(
+      '.Collection .cds--tab-content:not([hidden])',
+    );
+    this.addButton = activeTab.locator(
+      '.cds--toolbar-content > .cds--btn--primary',
+    );
+    this.emptyStateAddButton = activeTab.locator(
+      '.EmptyState .cds--btn--primary',
+    );
+    this.sourceModalSearchField = page.locator(
+      '.SourcesModal .cds--search-input',
+    );
+    this.selectAllCheckbox = page.locator(
+      '.Table thead .cds--table-column-checkbox label',
+    );
     this.bulkRemoveButton = activeTab
       .locator('.cds--action-list button')
       .filter({hasText: 'Remove'});
@@ -50,7 +60,9 @@ export class OptimizeCollectionPage {
   }
 
   overflowMenuOption(text: string): Locator {
-    return this.page.locator('.cds--overflow-menu-options__option').filter({hasText: text});
+    return this.page
+      .locator('.cds--overflow-menu-options__option')
+      .filter({hasText: text});
   }
 
   itemCheckbox(index: number): Locator {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OptimizeDashboardPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OptimizeDashboardPage.ts
@@ -28,7 +28,9 @@ export class OptimizeDashboardPage {
     this.autoRefreshButton = page.locator('.tools .AutoRefreshSelect button');
     this.reportTile = page.locator('.OptimizeReportTile');
     this.fullscreenButton = page.locator('.fullscreen-button');
-    this.addTileButton = page.locator('.CreateTileModal button').filter({hasText: 'Add tile'});
+    this.addTileButton = page
+      .locator('.CreateTileModal button')
+      .filter({hasText: 'Add tile'});
     this.createTileModal = page.locator('.CreateTileModal');
     this.modalConfirmButton = page.locator(
       '.Modal.is-visible .cds--modal-footer .cds--btn:last-child:not([disabled])',
@@ -41,6 +43,8 @@ export class OptimizeDashboardPage {
 
   async save(): Promise<void> {
     await this.saveButton.click();
+    await this.saveButton.waitFor({state: 'hidden'});
+    await this.editButton.waitFor({state: 'visible'});
   }
 
   async clickAutoRefreshOption(option: string): Promise<void> {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OptimizeDashboardPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OptimizeDashboardPage.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Page, Locator} from '@playwright/test';
+
+export class OptimizeDashboardPage {
+  private page: Page;
+  readonly dashboardName: Locator;
+  readonly editButton: Locator;
+  readonly saveButton: Locator;
+  readonly autoRefreshButton: Locator;
+  readonly reportTile: Locator;
+  readonly fullscreenButton: Locator;
+  readonly addTileButton: Locator;
+  readonly createTileModal: Locator;
+  readonly modalConfirmButton: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.dashboardName = page.locator('.DashboardView .name');
+    this.editButton = page.locator('.edit-button');
+    this.saveButton = page.locator('button').filter({hasText: 'Save'});
+    this.autoRefreshButton = page.locator('.tools .AutoRefreshSelect button');
+    this.reportTile = page.locator('.OptimizeReportTile');
+    this.fullscreenButton = page.locator('.fullscreen-button');
+    this.addTileButton = page.locator('.CreateTileModal button').filter({hasText: 'Add tile'});
+    this.createTileModal = page.locator('.CreateTileModal');
+    this.modalConfirmButton = page.locator(
+      '.Modal.is-visible .cds--modal-footer .cds--btn:last-child:not([disabled])',
+    );
+  }
+
+  reportTileAt(index: number): Locator {
+    return this.reportTile.nth(index);
+  }
+
+  async save(): Promise<void> {
+    await this.saveButton.click();
+  }
+
+  async clickAutoRefreshOption(option: string): Promise<void> {
+    await this.autoRefreshButton.click();
+    await this.page
+      .locator('.cds--menu-item')
+      .filter({hasText: option})
+      .click();
+  }
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OptimizeHomePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OptimizeHomePage.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Page, Locator} from '@playwright/test';
+
+export class OptimizeHomePage {
+  private page: Page;
+  readonly createNewButton: Locator;
+  readonly noDataNotice: Locator;
+  readonly entityList: Locator;
+  readonly searchField: Locator;
+  readonly bulkDeleteButton: Locator;
+  readonly selectAllCheckbox: Locator;
+  readonly modalNameInput: Locator;
+  readonly modalConfirmButton: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.createNewButton = page.locator('.CreateNewButton');
+    this.noDataNotice = page.locator('.NoDataNotice');
+    this.entityList = page.locator('.EntityList');
+    this.searchField = page.locator('input.cds--search-input');
+    this.bulkDeleteButton = page
+      .locator('.cds--action-list button')
+      .filter({hasText: 'Delete'});
+    this.selectAllCheckbox = page.locator('thead .cds--checkbox--inline');
+    this.modalNameInput = page.locator('.Modal.is-visible input[type="text"]');
+    this.modalConfirmButton = page.locator(
+      '.Modal.is-visible .cds--modal-footer .cds--btn:last-child:not([disabled])',
+    );
+  }
+
+  listItem(type: string): Locator {
+    return this.page
+      .locator('.EntityList tbody tr td:nth-child(2) span')
+      .filter({hasText: new RegExp(type, 'i')})
+      .locator('..')
+      .locator('..');
+  }
+
+  listItemLink(type: string): Locator {
+    return this.listItem(type).locator('td:nth-child(2) a');
+  }
+
+  listItemContextMenu(item: Locator): Locator {
+    return item.locator('button.cds--overflow-menu');
+  }
+
+  menuOption(text: string): Locator {
+    return this.page
+      .locator('.cds--menu-item')
+      .filter({hasText: text})
+      .filter({hasNot: this.page.locator('[hidden]')});
+  }
+
+  async clickCreateNew(entityType: 'Collection' | 'Dashboard' | 'Report'): Promise<void> {
+    await this.createNewButton.click();
+    await this.menuOption(entityType).click();
+  }
+
+  async bulkDeleteAll(): Promise<void> {
+    await this.selectAllCheckbox.click();
+    await this.bulkDeleteButton.click();
+    await this.modalConfirmButton.click();
+  }
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OptimizeHomePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OptimizeHomePage.ts
@@ -58,7 +58,9 @@ export class OptimizeHomePage {
       .filter({hasNot: this.page.locator('[hidden]')});
   }
 
-  async clickCreateNew(entityType: 'Collection' | 'Dashboard' | 'Report'): Promise<void> {
+  async clickCreateNew(
+    entityType: 'Collection' | 'Dashboard' | 'Report',
+  ): Promise<void> {
     await this.createNewButton.click();
     await this.menuOption(entityType).click();
   }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OptimizeLoginPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OptimizeLoginPage.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Page, Locator, expect} from '@playwright/test';
+import {waitForAssertion} from '../utils/waitForAssertion';
+
+export class OptimizeLoginPage {
+  private page: Page;
+  readonly usernameInput: Locator;
+  readonly passwordInput: Locator;
+  readonly submitButton: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.usernameInput = page.locator('input[name="username"]');
+    this.passwordInput = page.locator('input[name="password"]');
+    this.submitButton = page.locator('[type="submit"]');
+  }
+
+  async login(username: string, password: string): Promise<void> {
+    await waitForAssertion({
+      assertion: async () => {
+        await expect(this.usernameInput).toBeVisible({timeout: 30000});
+      },
+      onFailure: async () => {
+        await this.page.reload();
+      },
+    });
+    await this.usernameInput.fill(username);
+    await this.passwordInput.fill(password);
+    await this.submitButton.click();
+  }
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OptimizeProcessReportPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OptimizeProcessReportPage.ts
@@ -49,5 +49,6 @@ export class OptimizeProcessReportPage {
 
   async save(): Promise<void> {
     await this.saveButton.click();
+    await this.saveButton.waitFor({state: 'hidden'});
   }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OptimizeProcessReportPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OptimizeProcessReportPage.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Page, Locator} from '@playwright/test';
+
+export class OptimizeProcessReportPage {
+  private page: Page;
+  readonly reportName: Locator;
+  readonly reportRenderer: Locator;
+  readonly controlPanel: Locator;
+  readonly reportTable: Locator;
+  readonly reportChart: Locator;
+  readonly reportNumber: Locator;
+  readonly saveButton: Locator;
+  readonly warningMessage: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.reportName = page.locator('.ReportView .name');
+    this.reportRenderer = page.locator('.ReportRenderer').nth(0);
+    this.controlPanel = page.locator('.ReportControlPanel');
+    this.reportTable = this.reportRenderer.locator('.Table');
+    this.reportChart = this.reportRenderer.locator('canvas');
+    this.reportNumber = this.reportRenderer.locator('.Number .data');
+    this.saveButton = page.locator('button').filter({hasText: 'Save'});
+    this.warningMessage = page.locator('.Message--warning');
+  }
+
+  dropdownOption(text: string): Locator {
+    return this.page
+      .locator('.Dropdown.is-open .DropdownOption')
+      .filter({hasText: text});
+  }
+
+  configurationOption(text: string): Locator {
+    return this.page
+      .locator('.Configuration .DropdownOption')
+      .filter({hasText: text});
+  }
+
+  flowNode(id: string): Locator {
+    return this.page.locator(`.BPMNDiagram [data-element-id="${id}"]`);
+  }
+
+  async save(): Promise<void> {
+    await this.saveButton.click();
+  }
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/UtilitiesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/UtilitiesPage.ts
@@ -28,6 +28,8 @@ export async function navigateToApp(
     await page.goto(
       process.env.CORE_APPLICATION_URL + '/' + appName.toLowerCase() + '/login',
     );
+  } else if (appName == 'optimize') {
+    await page.goto(process.env.OPTIMIZE_URL!);
   }
 }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/playwright.config.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/playwright.config.ts
@@ -101,6 +101,7 @@ const normalProjects = [
       : ['tests/**/*.spec.ts'],
     testIgnore: [
       'tests/tasklist/task-panel.spec.ts',
+      'tests/optimize/**',
       'v2-stateless-tests/**',
       'tests/api/**/*.spec.ts',
     ],
@@ -120,6 +121,7 @@ const normalProjects = [
       : ['tests/**/*.spec.ts'],
     testIgnore: [
       'tests/tasklist/task-panel.spec.ts',
+      'tests/optimize/**',
       'v2-stateless-tests/**',
       'tests/api/**/*.spec.ts',
     ],
@@ -139,6 +141,7 @@ const normalProjects = [
       : ['tests/**/*.spec.ts'],
     testIgnore: [
       'tests/tasklist/task-panel.spec.ts',
+      'tests/optimize/**',
       'v2-stateless-tests/**',
       'tests/api/**/*.spec.ts',
     ],
@@ -170,6 +173,12 @@ const normalProjects = [
   {
     name: 'operate-e2e',
     testMatch: ['tests/operate/*.spec.ts'],
+    use: devices['Desktop Chrome'],
+    testIgnore: ['v2-stateless-tests/**', 'tests/api/**/*.spec.ts'],
+  },
+  {
+    name: 'optimize-e2e',
+    testMatch: ['tests/optimize/*.spec.ts'],
     use: devices['Desktop Chrome'],
     testIgnore: ['v2-stateless-tests/**', 'tests/api/**/*.spec.ts'],
   },

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/optimize/alerts.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/optimize/alerts.spec.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test} from 'fixtures';
+import {expect} from '@playwright/test';
+import {navigateToApp} from '@pages/UtilitiesPage';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+
+test.beforeEach(async ({page, optimizeLoginPage, optimizeHomePage}) => {
+  await navigateToApp(page, 'optimize');
+  await optimizeLoginPage.login('demo', 'demo');
+  await expect(optimizeHomePage.createNewButton).toBeVisible({timeout: 60000});
+});
+
+test.afterEach(async ({page}, testInfo) => {
+  await captureScreenshot(page, testInfo);
+  await captureFailureVideo(page, testInfo);
+});
+
+test.describe('Alerts', () => {
+  test.fixme(
+    'shouldCreateEditCopyAndRemoveAlert',
+    async ({
+      page,
+      optimizeHomePage,
+      optimizeCollectionPage,
+      optimizeProcessReportPage,
+    }) => {
+      // This test requires:
+      // 1. 'Order process' deployed to Zeebe and imported by Optimize
+      // 2. A number-type report (Process instance count) created in a collection
+      //
+      // Once data seeding is implemented:
+      // - Create a collection with 'Order process' as data source
+      // - Create a "Process instance count" report named 'Number Report'
+      // - Navigate to the collection's Alerts tab
+      // - CREATE: click newAlertButton, fill name, email, select report, confirm
+      // - assert alert is listed with name, report, and email
+      // - EDIT: hover alert, open context menu, click Edit, change name, confirm
+      // - assert updated name is shown
+      // - COPY: hover alert, open context menu, click Copy, enter new name, confirm
+      // - assert copied alert is listed
+      // - DELETE: hover alert, open context menu, click Delete, confirm
+      // - assert alert is no longer listed
+      //
+      // TODO: Enable after process data seeding is implemented.
+    },
+  );
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/optimize/alerts.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/optimize/alerts.spec.ts
@@ -10,45 +10,126 @@ import {test} from 'fixtures';
 import {expect} from '@playwright/test';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {captureScreenshot, captureFailureVideo} from '@setup';
+import {deploy} from 'utils/zeebeClient';
+import {sleep} from 'utils/sleep';
 
-test.beforeEach(async ({page, optimizeLoginPage, optimizeHomePage}) => {
-  await navigateToApp(page, 'optimize');
-  await optimizeLoginPage.login('demo', 'demo');
-  await expect(optimizeHomePage.createNewButton).toBeVisible({timeout: 60000});
-});
-
-test.afterEach(async ({page}, testInfo) => {
-  await captureScreenshot(page, testInfo);
-  await captureFailureVideo(page, testInfo);
+test.beforeAll(async () => {
+  await deploy(['./resources/orderProcess_v_1.bpmn']);
+  await sleep(30000);
 });
 
 test.describe('Alerts', () => {
-  test.fixme(
-    'shouldCreateEditCopyAndRemoveAlert',
-    async ({
-      page,
-      optimizeHomePage,
-      optimizeCollectionPage,
-      optimizeProcessReportPage,
-    }) => {
-      // This test requires:
-      // 1. 'Order process' deployed to Zeebe and imported by Optimize
-      // 2. A number-type report (Process instance count) created in a collection
-      //
-      // Once data seeding is implemented:
-      // - Create a collection with 'Order process' as data source
-      // - Create a "Process instance count" report named 'Number Report'
-      // - Navigate to the collection's Alerts tab
-      // - CREATE: click newAlertButton, fill name, email, select report, confirm
-      // - assert alert is listed with name, report, and email
-      // - EDIT: hover alert, open context menu, click Edit, change name, confirm
-      // - assert updated name is shown
-      // - COPY: hover alert, open context menu, click Copy, enter new name, confirm
-      // - assert copied alert is listed
-      // - DELETE: hover alert, open context menu, click Delete, confirm
-      // - assert alert is no longer listed
-      //
-      // TODO: Enable after process data seeding is implemented.
-    },
-  );
+  test.beforeEach(async ({page, optimizeLoginPage, optimizeHomePage}) => {
+    await navigateToApp(page, 'optimize');
+    await optimizeLoginPage.login('demo', 'demo');
+    await expect(optimizeHomePage.createNewButton).toBeVisible({
+      timeout: 60000,
+    });
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('shouldCreateEditCopyAndRemoveAlert', async ({
+    page,
+    optimizeHomePage,
+    optimizeCollectionPage,
+    optimizeProcessReportPage,
+  }) => {
+    await optimizeHomePage.clickCreateNew('Collection');
+    await optimizeHomePage.modalNameInput.fill('Alert Test Collection');
+    await optimizeHomePage.modalConfirmButton.click();
+    await optimizeHomePage.modalConfirmButton.click();
+    await expect(optimizeCollectionPage.collectionTitle).toBeVisible();
+
+    await optimizeHomePage.createNewButton.click();
+    await optimizeHomePage.menuOption('Report').click();
+    await page
+      .locator('.Modal .DefinitionSelection input')
+      .fill('Order process');
+    await expect(
+      page
+        .locator('.cds--list-box__menu-item')
+        .filter({hasText: 'Order process'}),
+    ).toBeVisible({timeout: 60000});
+    await page
+      .locator('.cds--list-box__menu-item')
+      .filter({hasText: 'Order process'})
+      .first()
+      .click();
+    await page.locator('.TemplateModal .cds--radio-button').first().click();
+    await optimizeHomePage.modalConfirmButton.click();
+    await page
+      .locator('.EntityNameForm .name-input input')
+      .fill('Count Report');
+    await optimizeProcessReportPage.save();
+
+    await page.goto(process.env.OPTIMIZE_URL!);
+    await expect(optimizeHomePage.entityList).toBeVisible();
+    await optimizeHomePage
+      .listItem('collection')
+      .filter({hasText: 'Alert Test Collection'})
+      .locator('td:nth-child(2) a')
+      .click();
+    await expect(optimizeCollectionPage.collectionTitle).toBeVisible();
+    await optimizeCollectionPage.alertTab.click();
+    await optimizeCollectionPage.addButton.click();
+    await page
+      .locator('.AlertModal')
+      .getByLabel('Alert name')
+      .fill('Test Alert');
+    await page
+      .locator('.AlertModal')
+      .getByLabel('Send email to')
+      .fill('demo@example.com');
+    await page
+      .locator('.AlertModal .cds--combo-box input')
+      .fill('Count Report');
+    await page
+      .locator('.cds--list-box__menu-item')
+      .filter({hasText: 'Count Report'})
+      .click();
+    await optimizeCollectionPage.modalConfirmButton.click();
+
+    const alertList = page.locator('.AlertList');
+    await expect(alertList).toContainText('Test Alert');
+
+    const alertRow = alertList.locator('tbody tr').first();
+    await alertRow.hover();
+    await alertRow.locator('button.cds--overflow-menu').click();
+    await page
+      .locator('.cds--overflow-menu-options__option')
+      .filter({hasText: 'Edit'})
+      .click();
+    await page
+      .locator('.AlertModal')
+      .getByLabel('Alert name')
+      .fill('Saved Alert');
+    await optimizeCollectionPage.modalConfirmButton.click();
+
+    await expect(alertList).toContainText('Saved Alert');
+
+    await alertRow.hover();
+    await alertRow.locator('button.cds--overflow-menu').click();
+    await page
+      .locator('.cds--overflow-menu-options__option')
+      .filter({hasText: 'Copy'})
+      .click();
+    await optimizeCollectionPage.modalNameInput.fill('Copied Alert');
+    await optimizeCollectionPage.modalConfirmButton.click();
+
+    await expect(alertList).toContainText('Copied Alert');
+
+    await alertRow.hover();
+    await alertRow.locator('button.cds--overflow-menu').click();
+    await page
+      .locator('.cds--overflow-menu-options__option')
+      .filter({hasText: 'Delete'})
+      .click();
+    await optimizeCollectionPage.modalConfirmButton.click();
+
+    await expect(alertList).not.toContainText('Saved Alert');
+  });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/optimize/collection.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/optimize/collection.spec.ts
@@ -12,6 +12,8 @@ import {navigateToApp} from '@pages/UtilitiesPage';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import type {OptimizeHomePage} from '@pages/OptimizeHomePage';
 import type {Page} from '@playwright/test';
+import {deploy} from 'utils/zeebeClient';
+import {sleep} from 'utils/sleep';
 
 async function createCollection(
   page: Page,
@@ -21,31 +23,35 @@ async function createCollection(
   await optimizeHomePage.clickCreateNew('Collection');
   await optimizeHomePage.modalNameInput.fill(name);
   await optimizeHomePage.modalConfirmButton.click();
-  // Data sources selection step: confirm without selecting any sources
   await optimizeHomePage.modalConfirmButton.click();
 }
 
-test.beforeEach(async ({page, optimizeLoginPage, optimizeHomePage}) => {
-  await navigateToApp(page, 'optimize');
-  await optimizeLoginPage.login('demo', 'demo');
-  await expect(optimizeHomePage.createNewButton).toBeVisible({timeout: 60000});
-});
-
-test.afterEach(async ({page}, testInfo) => {
-  await captureScreenshot(page, testInfo);
-  await captureFailureVideo(page, testInfo);
+test.beforeAll(async () => {
+  await deploy(['./resources/orderProcess_v_1.bpmn']);
+  await sleep(30000);
 });
 
 test.describe('Collection', () => {
+  test.beforeEach(async ({page, optimizeLoginPage, optimizeHomePage}) => {
+    await navigateToApp(page, 'optimize');
+    await optimizeLoginPage.login('demo', 'demo');
+    await expect(optimizeHomePage.createNewButton).toBeVisible({
+      timeout: 60000,
+    });
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
   test('shouldCreateCollection', async ({
     page,
     optimizeHomePage,
     optimizeCollectionPage,
   }) => {
-    // given / when
     await createCollection(page, optimizeHomePage, 'Test Collection');
 
-    // then
     await expect(optimizeCollectionPage.collectionTitle).toContainText(
       'Test Collection',
     );
@@ -56,14 +62,11 @@ test.describe('Collection', () => {
     optimizeHomePage,
     optimizeCollectionPage,
   }) => {
-    // given
     await createCollection(page, optimizeHomePage);
     await expect(optimizeCollectionPage.collectionTitle).toBeVisible();
 
-    // when
     await optimizeCollectionPage.editName('Renamed Collection');
 
-    // then
     await expect(optimizeCollectionPage.collectionTitle).toContainText(
       'Renamed Collection',
     );
@@ -74,14 +77,11 @@ test.describe('Collection', () => {
     optimizeHomePage,
     optimizeCollectionPage,
   }) => {
-    // given
     await createCollection(page, optimizeHomePage);
     await expect(optimizeCollectionPage.collectionTitle).toBeVisible();
 
-    // when
     await optimizeCollectionPage.copyCollection('Copied Collection');
 
-    // then
     await expect(optimizeCollectionPage.collectionTitle).toContainText(
       'Copied Collection',
     );
@@ -92,45 +92,97 @@ test.describe('Collection', () => {
     optimizeHomePage,
     optimizeCollectionPage,
   }) => {
-    // given
     await createCollection(page, optimizeHomePage, 'Collection To Delete');
     await expect(optimizeCollectionPage.collectionTitle).toContainText(
       'Collection To Delete',
     );
 
-    // when
     await optimizeCollectionPage.deleteCollection();
 
-    // then - back on home page with the collection removed
     await expect(optimizeHomePage.entityList).toBeVisible();
     await expect(
-      optimizeHomePage.listItem('collection').filter({hasText: 'Collection To Delete'}),
-    ).not.toBeVisible();
+      optimizeHomePage
+        .listItem('collection')
+        .filter({hasText: 'Collection To Delete'}),
+    ).toBeHidden();
   });
 
-  test.fixme(
-    'shouldAddAndDeleteDataSources',
-    async ({page, optimizeHomePage, optimizeCollectionPage}) => {
-      // Requires process definitions deployed to Zeebe and imported by Optimize.
-      // TODO: Deploy 'Big variable process' and 'Order process' BPMNs via
-      // deploy() utility, wait for Optimize data import, then enable.
-    },
-  );
+  test('shouldAddAndDeleteDataSources', async ({
+    page,
+    optimizeHomePage,
+    optimizeCollectionPage,
+  }) => {
+    await createCollection(page, optimizeHomePage);
+    await expect(optimizeCollectionPage.collectionTitle).toBeVisible();
+    await optimizeCollectionPage.sourcesTab.click();
+    await optimizeCollectionPage.emptyStateAddButton.click();
+    await optimizeCollectionPage.sourceModalSearchField.fill('Order process');
+    await expect(
+      page
+        .locator('.SourcesModal .cds--list-box__menu-item')
+        .filter({hasText: 'Order process'}),
+    ).toBeVisible({timeout: 60000});
+    await optimizeCollectionPage.selectAllCheckbox.click();
+    await optimizeCollectionPage.modalConfirmButton.click();
 
-  test.fixme(
-    'shouldCreateKpiReport',
-    async ({page, optimizeHomePage, optimizeCollectionPage}) => {
-      // Requires 'Order process' deployed and imported by Optimize.
-      // TODO: Enable after process data seeding is implemented.
-    },
-  );
+    const sourceRow = page
+      .locator('.EntityList tbody tr')
+      .filter({hasText: 'Order process'});
+    await expect(sourceRow).toBeVisible();
 
-  test.fixme(
-    'shouldManageUserPermissions',
-    async ({page, optimizeHomePage, optimizeCollectionPage}) => {
-      // Requires 'Order process' deployed and imported by Optimize.
-      // Also requires additional test users configured in Keycloak.
-      // TODO: Enable after process data seeding is implemented.
-    },
-  );
+    await optimizeCollectionPage.selectAllCheckbox.click();
+    await optimizeCollectionPage.bulkRemoveButton.click();
+    await optimizeCollectionPage.modalConfirmButton.click();
+
+    await expect(sourceRow).toBeHidden();
+  });
+
+  test('shouldCreateKpiReport', async ({
+    page,
+    optimizeHomePage,
+    optimizeCollectionPage,
+  }) => {
+    await createCollection(page, optimizeHomePage);
+    await expect(optimizeCollectionPage.collectionTitle).toBeVisible();
+    await optimizeHomePage.createNewButton.click();
+    await optimizeHomePage.menuOption('Process KPI').click();
+    await page.locator('input#KpiSelectionComboBox').fill('Automation rate');
+    await page
+      .locator('.cds--list-box__menu-item')
+      .filter({hasText: 'Automation rate'})
+      .click();
+    await page
+      .locator('.Modal .DefinitionSelection input')
+      .fill('Order process');
+    await expect(
+      page
+        .locator('.cds--list-box__menu-item')
+        .filter({hasText: 'Order process'}),
+    ).toBeVisible({timeout: 60000});
+    await page
+      .locator('.cds--list-box__menu-item')
+      .filter({hasText: 'Order process'})
+      .click();
+    await optimizeHomePage.modalConfirmButton.click();
+    await optimizeHomePage.modalConfirmButton.click();
+
+    await expect(page.locator('.edit-button')).toBeVisible({timeout: 10000});
+  });
+
+  test('shouldManageUserPermissions', async ({
+    page,
+    optimizeHomePage,
+    optimizeCollectionPage,
+  }) => {
+    await createCollection(page, optimizeHomePage);
+    await expect(optimizeCollectionPage.collectionTitle).toBeVisible();
+    await optimizeCollectionPage.userTab.click();
+
+    const demoUserRow = page
+      .locator('.EntityList tbody tr')
+      .filter({hasText: 'demo'});
+    await expect(demoUserRow).toBeVisible();
+    await expect(demoUserRow).toContainText('Manager');
+    await expect(optimizeCollectionPage.addButton).toBeVisible();
+  });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/optimize/collection.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/optimize/collection.spec.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test} from 'fixtures';
+import {expect} from '@playwright/test';
+import {navigateToApp} from '@pages/UtilitiesPage';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import type {OptimizeHomePage} from '@pages/OptimizeHomePage';
+import type {Page} from '@playwright/test';
+
+async function createCollection(
+  page: Page,
+  optimizeHomePage: OptimizeHomePage,
+  name: string = 'Test Collection',
+): Promise<void> {
+  await optimizeHomePage.clickCreateNew('Collection');
+  await optimizeHomePage.modalNameInput.fill(name);
+  await optimizeHomePage.modalConfirmButton.click();
+  // Data sources selection step: confirm without selecting any sources
+  await optimizeHomePage.modalConfirmButton.click();
+}
+
+test.beforeEach(async ({page, optimizeLoginPage, optimizeHomePage}) => {
+  await navigateToApp(page, 'optimize');
+  await optimizeLoginPage.login('demo', 'demo');
+  await expect(optimizeHomePage.createNewButton).toBeVisible({timeout: 60000});
+});
+
+test.afterEach(async ({page}, testInfo) => {
+  await captureScreenshot(page, testInfo);
+  await captureFailureVideo(page, testInfo);
+});
+
+test.describe('Collection', () => {
+  test('shouldCreateCollection', async ({
+    page,
+    optimizeHomePage,
+    optimizeCollectionPage,
+  }) => {
+    // given / when
+    await createCollection(page, optimizeHomePage, 'Test Collection');
+
+    // then
+    await expect(optimizeCollectionPage.collectionTitle).toContainText(
+      'Test Collection',
+    );
+  });
+
+  test('shouldRenameCollection', async ({
+    page,
+    optimizeHomePage,
+    optimizeCollectionPage,
+  }) => {
+    // given
+    await createCollection(page, optimizeHomePage);
+    await expect(optimizeCollectionPage.collectionTitle).toBeVisible();
+
+    // when
+    await optimizeCollectionPage.editName('Renamed Collection');
+
+    // then
+    await expect(optimizeCollectionPage.collectionTitle).toContainText(
+      'Renamed Collection',
+    );
+  });
+
+  test('shouldCopyCollection', async ({
+    page,
+    optimizeHomePage,
+    optimizeCollectionPage,
+  }) => {
+    // given
+    await createCollection(page, optimizeHomePage);
+    await expect(optimizeCollectionPage.collectionTitle).toBeVisible();
+
+    // when
+    await optimizeCollectionPage.copyCollection('Copied Collection');
+
+    // then
+    await expect(optimizeCollectionPage.collectionTitle).toContainText(
+      'Copied Collection',
+    );
+  });
+
+  test('shouldDeleteCollection', async ({
+    page,
+    optimizeHomePage,
+    optimizeCollectionPage,
+  }) => {
+    // given
+    await createCollection(page, optimizeHomePage, 'Collection To Delete');
+    await expect(optimizeCollectionPage.collectionTitle).toContainText(
+      'Collection To Delete',
+    );
+
+    // when
+    await optimizeCollectionPage.deleteCollection();
+
+    // then - back on home page with the collection removed
+    await expect(optimizeHomePage.entityList).toBeVisible();
+    await expect(
+      optimizeHomePage.listItem('collection').filter({hasText: 'Collection To Delete'}),
+    ).not.toBeVisible();
+  });
+
+  test.fixme(
+    'shouldAddAndDeleteDataSources',
+    async ({page, optimizeHomePage, optimizeCollectionPage}) => {
+      // Requires process definitions deployed to Zeebe and imported by Optimize.
+      // TODO: Deploy 'Big variable process' and 'Order process' BPMNs via
+      // deploy() utility, wait for Optimize data import, then enable.
+    },
+  );
+
+  test.fixme(
+    'shouldCreateKpiReport',
+    async ({page, optimizeHomePage, optimizeCollectionPage}) => {
+      // Requires 'Order process' deployed and imported by Optimize.
+      // TODO: Enable after process data seeding is implemented.
+    },
+  );
+
+  test.fixme(
+    'shouldManageUserPermissions',
+    async ({page, optimizeHomePage, optimizeCollectionPage}) => {
+      // Requires 'Order process' deployed and imported by Optimize.
+      // Also requires additional test users configured in Keycloak.
+      // TODO: Enable after process data seeding is implemented.
+    },
+  );
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/optimize/dashboard.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/optimize/dashboard.spec.ts
@@ -13,6 +13,8 @@ import {captureScreenshot, captureFailureVideo} from '@setup';
 import type {OptimizeHomePage} from '@pages/OptimizeHomePage';
 import type {OptimizeDashboardPage} from '@pages/OptimizeDashboardPage';
 import type {Page} from '@playwright/test';
+import {deploy} from 'utils/zeebeClient';
+import {sleep} from 'utils/sleep';
 
 async function createBlankDashboard(
   page: Page,
@@ -25,35 +27,37 @@ async function createBlankDashboard(
   await optimizeDashboardPage.save();
 }
 
-test.beforeEach(async ({page, optimizeLoginPage, optimizeHomePage}) => {
-  await navigateToApp(page, 'optimize');
-  await optimizeLoginPage.login('demo', 'demo');
-  await expect(optimizeHomePage.createNewButton).toBeVisible({timeout: 60000});
-});
-
-test.afterEach(async ({page}, testInfo) => {
-  await captureScreenshot(page, testInfo);
-  await captureFailureVideo(page, testInfo);
+test.beforeAll(async () => {
+  await deploy(['./resources/orderProcess_v_1.bpmn']);
+  await sleep(30000);
 });
 
 test.describe('Dashboard', () => {
+  test.beforeEach(async ({page, optimizeLoginPage, optimizeHomePage}) => {
+    await navigateToApp(page, 'optimize');
+    await optimizeLoginPage.login('demo', 'demo');
+    await expect(optimizeHomePage.createNewButton).toBeVisible({
+      timeout: 60000,
+    });
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
   test('shouldRenameDashboard', async ({
     page,
     optimizeHomePage,
     optimizeDashboardPage,
   }) => {
-    // given
     await createBlankDashboard(page, optimizeHomePage, optimizeDashboardPage);
     await expect(optimizeDashboardPage.dashboardName).toBeVisible();
 
-    // when - enter edit mode and rename
     await optimizeDashboardPage.editButton.click();
-    await page
-      .locator('.EntityNameForm .name-input input')
-      .fill('New Name');
+    await page.locator('.EntityNameForm .name-input input').fill('New Name');
     await optimizeDashboardPage.save();
 
-    // then
     await expect(optimizeDashboardPage.dashboardName).toHaveText('New Name');
   });
 
@@ -62,21 +66,17 @@ test.describe('Dashboard', () => {
     optimizeHomePage,
     optimizeDashboardPage,
   }) => {
-    // given
     await createBlankDashboard(page, optimizeHomePage, optimizeDashboardPage);
-    const originalName = await optimizeDashboardPage.dashboardName.textContent();
+    const originalName =
+      await optimizeDashboardPage.dashboardName.textContent();
 
-    // when - edit then cancel
     await optimizeDashboardPage.editButton.click();
     await page
       .locator('.EntityNameForm .name-input input')
       .fill('Should Not Be Saved');
     await page.getByRole('button', {name: 'Cancel'}).click();
 
-    // then - name is unchanged
-    await expect(optimizeDashboardPage.dashboardName).toHaveText(
-      originalName!,
-    );
+    await expect(optimizeDashboardPage.dashboardName).toHaveText(originalName!);
   });
 
   test('shouldCreateReportAndAddToDashboard', async ({
@@ -85,23 +85,19 @@ test.describe('Dashboard', () => {
     optimizeDashboardPage,
     optimizeProcessReportPage,
   }) => {
-    // given - create a blank report
     await optimizeHomePage.createNewButton.click();
     await optimizeHomePage.menuOption('Report').click();
     await page.getByRole('button', {name: 'Blank report'}).click();
     await optimizeHomePage.modalConfirmButton.click();
     await optimizeProcessReportPage.save();
 
-    // go back to home
     await page.goto(process.env.OPTIMIZE_URL!);
     await expect(optimizeHomePage.createNewButton).toBeVisible();
 
-    // when - create a blank dashboard and add the report
     await optimizeHomePage.createNewButton.click();
     await optimizeHomePage.menuOption('Dashboard').click();
     await page.getByRole('button', {name: 'Blank dashboard'}).click();
 
-    // add report tile via the add tile button
     await page.locator('.AddButton').click();
     await page
       .locator('.cds--list-box__menu-item')
@@ -113,24 +109,50 @@ test.describe('Dashboard', () => {
 
     await optimizeDashboardPage.save();
 
-    // then - report tile is visible
     await expect(optimizeDashboardPage.reportTile).toBeVisible();
   });
 
-  test.fixme(
-    'shouldCreateDashboardFromTemplate',
-    async ({page, optimizeHomePage, optimizeDashboardPage}) => {
-      // Requires 'Order process' deployed and imported by Optimize.
-      // TODO: Deploy process BPMN, wait for Optimize import, then enable.
-    },
-  );
+  test('shouldCreateDashboardFromTemplate', async ({
+    page,
+    optimizeHomePage,
+    optimizeDashboardPage,
+  }) => {
+    await optimizeHomePage.createNewButton.click();
+    await optimizeHomePage.menuOption('Dashboard').click();
+    await page
+      .locator('.Modal .DefinitionSelection input')
+      .fill('Order process');
+    await expect(
+      page
+        .locator('.cds--list-box__menu-item')
+        .filter({hasText: 'Order process'}),
+    ).toBeVisible({timeout: 60000});
+    await page
+      .locator('.cds--list-box__menu-item')
+      .filter({hasText: 'Order process'})
+      .click();
+    await page
+      .locator('.Modal .templateContainer button')
+      .filter({hasText: 'Improve productivity'})
+      .click();
+    await optimizeHomePage.modalConfirmButton.click();
+    await optimizeDashboardPage.save();
 
-  test.fixme(
-    'shouldShareDashboard',
-    async ({page, optimizeHomePage, optimizeDashboardPage}) => {
-      // Requires 'Order process' deployed, imported, and at least one
-      // dashboard created from a template.
-      // TODO: Enable after process data seeding is implemented.
-    },
-  );
+    await expect(optimizeDashboardPage.dashboardName).toHaveText(
+      'Improve productivity',
+    );
+    await expect(optimizeDashboardPage.reportTile).toBeVisible();
+  });
+
+  test('shouldShareDashboard', async ({
+    page,
+    optimizeHomePage,
+    optimizeDashboardPage,
+  }) => {
+    await createBlankDashboard(page, optimizeHomePage, optimizeDashboardPage);
+    await page.locator('.share-button button').click();
+    await page.locator('.ShareEntity .cds--toggle__switch').click();
+
+    await expect(page.locator('.ShareEntity input[type="text"]')).toBeVisible();
+  });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/optimize/dashboard.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/optimize/dashboard.spec.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test} from 'fixtures';
+import {expect} from '@playwright/test';
+import {navigateToApp} from '@pages/UtilitiesPage';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import type {OptimizeHomePage} from '@pages/OptimizeHomePage';
+import type {OptimizeDashboardPage} from '@pages/OptimizeDashboardPage';
+import type {Page} from '@playwright/test';
+
+async function createBlankDashboard(
+  page: Page,
+  optimizeHomePage: OptimizeHomePage,
+  optimizeDashboardPage: OptimizeDashboardPage,
+): Promise<void> {
+  await optimizeHomePage.createNewButton.click();
+  await optimizeHomePage.menuOption('Dashboard').click();
+  await page.getByRole('button', {name: 'Blank dashboard'}).click();
+  await optimizeDashboardPage.save();
+}
+
+test.beforeEach(async ({page, optimizeLoginPage, optimizeHomePage}) => {
+  await navigateToApp(page, 'optimize');
+  await optimizeLoginPage.login('demo', 'demo');
+  await expect(optimizeHomePage.createNewButton).toBeVisible({timeout: 60000});
+});
+
+test.afterEach(async ({page}, testInfo) => {
+  await captureScreenshot(page, testInfo);
+  await captureFailureVideo(page, testInfo);
+});
+
+test.describe('Dashboard', () => {
+  test('shouldRenameDashboard', async ({
+    page,
+    optimizeHomePage,
+    optimizeDashboardPage,
+  }) => {
+    // given
+    await createBlankDashboard(page, optimizeHomePage, optimizeDashboardPage);
+    await expect(optimizeDashboardPage.dashboardName).toBeVisible();
+
+    // when - enter edit mode and rename
+    await optimizeDashboardPage.editButton.click();
+    await page
+      .locator('.EntityNameForm .name-input input')
+      .fill('New Name');
+    await optimizeDashboardPage.save();
+
+    // then
+    await expect(optimizeDashboardPage.dashboardName).toHaveText('New Name');
+  });
+
+  test('shouldCancelDashboardEditing', async ({
+    page,
+    optimizeHomePage,
+    optimizeDashboardPage,
+  }) => {
+    // given
+    await createBlankDashboard(page, optimizeHomePage, optimizeDashboardPage);
+    const originalName = await optimizeDashboardPage.dashboardName.textContent();
+
+    // when - edit then cancel
+    await optimizeDashboardPage.editButton.click();
+    await page
+      .locator('.EntityNameForm .name-input input')
+      .fill('Should Not Be Saved');
+    await page.getByRole('button', {name: 'Cancel'}).click();
+
+    // then - name is unchanged
+    await expect(optimizeDashboardPage.dashboardName).toHaveText(
+      originalName!,
+    );
+  });
+
+  test('shouldCreateReportAndAddToDashboard', async ({
+    page,
+    optimizeHomePage,
+    optimizeDashboardPage,
+    optimizeProcessReportPage,
+  }) => {
+    // given - create a blank report
+    await optimizeHomePage.createNewButton.click();
+    await optimizeHomePage.menuOption('Report').click();
+    await page.getByRole('button', {name: 'Blank report'}).click();
+    await optimizeHomePage.modalConfirmButton.click();
+    await optimizeProcessReportPage.save();
+
+    // go back to home
+    await page.goto(process.env.OPTIMIZE_URL!);
+    await expect(optimizeHomePage.createNewButton).toBeVisible();
+
+    // when - create a blank dashboard and add the report
+    await optimizeHomePage.createNewButton.click();
+    await optimizeHomePage.menuOption('Dashboard').click();
+    await page.getByRole('button', {name: 'Blank dashboard'}).click();
+
+    // add report tile via the add tile button
+    await page.locator('.AddButton').click();
+    await page
+      .locator('.cds--list-box__menu-item')
+      .filter({hasText: 'Blank report'})
+      .click();
+    await page
+      .locator('.CreateTileModal .cds--modal-footer .cds--btn--primary')
+      .click();
+
+    await optimizeDashboardPage.save();
+
+    // then - report tile is visible
+    await expect(optimizeDashboardPage.reportTile).toBeVisible();
+  });
+
+  test.fixme(
+    'shouldCreateDashboardFromTemplate',
+    async ({page, optimizeHomePage, optimizeDashboardPage}) => {
+      // Requires 'Order process' deployed and imported by Optimize.
+      // TODO: Deploy process BPMN, wait for Optimize import, then enable.
+    },
+  );
+
+  test.fixme(
+    'shouldShareDashboard',
+    async ({page, optimizeHomePage, optimizeDashboardPage}) => {
+      // Requires 'Order process' deployed, imported, and at least one
+      // dashboard created from a template.
+      // TODO: Enable after process data seeding is implemented.
+    },
+  );
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/optimize/homepage.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/optimize/homepage.spec.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test} from 'fixtures';
+import {expect} from '@playwright/test';
+import {navigateToApp} from '@pages/UtilitiesPage';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+
+test.beforeEach(async ({page, optimizeLoginPage, optimizeHomePage}) => {
+  await navigateToApp(page, 'optimize');
+  await optimizeLoginPage.login('demo', 'demo');
+  await expect(optimizeHomePage.createNewButton).toBeVisible({timeout: 60000});
+});
+
+test.afterEach(async ({page}, testInfo) => {
+  await captureScreenshot(page, testInfo);
+  await captureFailureVideo(page, testInfo);
+});
+
+test.describe('Homepage', () => {
+  test('shouldShowCreateNewMenuOptions', async ({optimizeHomePage}) => {
+    // when
+    await optimizeHomePage.createNewButton.click();
+
+    // then
+    await expect(optimizeHomePage.menuOption('Collection')).toBeVisible();
+    await expect(optimizeHomePage.menuOption('Dashboard')).toBeVisible();
+    await expect(optimizeHomePage.menuOption('Report')).toBeVisible();
+  });
+
+  test('shouldNavigateToReportViewAndEditPages', async ({
+    page,
+    optimizeHomePage,
+    optimizeProcessReportPage,
+  }) => {
+    // given - create a blank report and save it
+    await optimizeHomePage.createNewButton.click();
+    await optimizeHomePage.menuOption('Report').click();
+    await page.getByRole('button', {name: 'Blank report'}).click();
+    await optimizeHomePage.modalConfirmButton.click();
+    await optimizeProcessReportPage.save();
+
+    // navigate back to home
+    await page.goto(process.env.OPTIMIZE_URL!);
+    await expect(optimizeHomePage.entityList).toBeVisible();
+
+    // when - click through to view page
+    await optimizeHomePage.listItemLink('report').click();
+
+    // then - empty state is shown for a blank report
+    await expect(optimizeHomePage.noDataNotice).toContainText(
+      'Report configuration is incomplete',
+    );
+
+    // navigate back and open edit via context menu
+    await page.goto(process.env.OPTIMIZE_URL!);
+    await optimizeHomePage.listItem('report').hover();
+    await optimizeHomePage
+      .listItemContextMenu(optimizeHomePage.listItem('report'))
+      .click();
+    await page.locator('.cds--menu-item').filter({hasText: 'Edit'}).click();
+
+    await expect(optimizeProcessReportPage.controlPanel).toBeVisible();
+  });
+
+  test('shouldNavigateToDashboardViewAndEditPages', async ({
+    page,
+    optimizeHomePage,
+    optimizeDashboardPage,
+  }) => {
+    // given - create a blank dashboard and save it
+    await optimizeHomePage.createNewButton.click();
+    await optimizeHomePage.menuOption('Dashboard').click();
+    await page.getByRole('button', {name: 'Blank dashboard'}).click();
+    await optimizeDashboardPage.save();
+
+    // navigate back to home
+    await page.goto(process.env.OPTIMIZE_URL!);
+    await expect(optimizeHomePage.entityList).toBeVisible();
+
+    // when - click through to view page
+    await optimizeHomePage.listItemLink('dashboard').click();
+
+    // then - edit button is visible on dashboard view
+    await expect(optimizeDashboardPage.editButton).toBeVisible();
+
+    // navigate back and open edit via context menu
+    await page.goto(process.env.OPTIMIZE_URL!);
+    await optimizeHomePage.listItem('dashboard').hover();
+    await optimizeHomePage
+      .listItemContextMenu(optimizeHomePage.listItem('dashboard'))
+      .click();
+    await page.locator('.cds--menu-item').filter({hasText: 'Edit'}).click();
+
+    await expect(optimizeDashboardPage.addTileButton).toBeVisible();
+  });
+
+  test.fixme(
+    'shouldSearchEntitiesAcrossCollectionsDashboardsAndReports',
+    async () => {
+      // Requires pre-existing entities with known names.
+      // TODO: Seed data (Collection "Sales", Dashboard "Sales Dashboard",
+      // Report "Incoming Leads") via Optimize API before enabling.
+    },
+  );
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/optimize/homepage.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/optimize/homepage.spec.ts
@@ -11,23 +11,23 @@ import {expect} from '@playwright/test';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 
-test.beforeEach(async ({page, optimizeLoginPage, optimizeHomePage}) => {
-  await navigateToApp(page, 'optimize');
-  await optimizeLoginPage.login('demo', 'demo');
-  await expect(optimizeHomePage.createNewButton).toBeVisible({timeout: 60000});
-});
-
-test.afterEach(async ({page}, testInfo) => {
-  await captureScreenshot(page, testInfo);
-  await captureFailureVideo(page, testInfo);
-});
-
 test.describe('Homepage', () => {
+  test.beforeEach(async ({page, optimizeLoginPage, optimizeHomePage}) => {
+    await navigateToApp(page, 'optimize');
+    await optimizeLoginPage.login('demo', 'demo');
+    await expect(optimizeHomePage.createNewButton).toBeVisible({
+      timeout: 60000,
+    });
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
   test('shouldShowCreateNewMenuOptions', async ({optimizeHomePage}) => {
-    // when
     await optimizeHomePage.createNewButton.click();
 
-    // then
     await expect(optimizeHomePage.menuOption('Collection')).toBeVisible();
     await expect(optimizeHomePage.menuOption('Dashboard')).toBeVisible();
     await expect(optimizeHomePage.menuOption('Report')).toBeVisible();
@@ -38,26 +38,21 @@ test.describe('Homepage', () => {
     optimizeHomePage,
     optimizeProcessReportPage,
   }) => {
-    // given - create a blank report and save it
     await optimizeHomePage.createNewButton.click();
     await optimizeHomePage.menuOption('Report').click();
     await page.getByRole('button', {name: 'Blank report'}).click();
     await optimizeHomePage.modalConfirmButton.click();
     await optimizeProcessReportPage.save();
 
-    // navigate back to home
     await page.goto(process.env.OPTIMIZE_URL!);
     await expect(optimizeHomePage.entityList).toBeVisible();
 
-    // when - click through to view page
     await optimizeHomePage.listItemLink('report').click();
 
-    // then - empty state is shown for a blank report
     await expect(optimizeHomePage.noDataNotice).toContainText(
       'Report configuration is incomplete',
     );
 
-    // navigate back and open edit via context menu
     await page.goto(process.env.OPTIMIZE_URL!);
     await optimizeHomePage.listItem('report').hover();
     await optimizeHomePage
@@ -73,23 +68,18 @@ test.describe('Homepage', () => {
     optimizeHomePage,
     optimizeDashboardPage,
   }) => {
-    // given - create a blank dashboard and save it
     await optimizeHomePage.createNewButton.click();
     await optimizeHomePage.menuOption('Dashboard').click();
     await page.getByRole('button', {name: 'Blank dashboard'}).click();
     await optimizeDashboardPage.save();
 
-    // navigate back to home
     await page.goto(process.env.OPTIMIZE_URL!);
     await expect(optimizeHomePage.entityList).toBeVisible();
 
-    // when - click through to view page
     await optimizeHomePage.listItemLink('dashboard').click();
 
-    // then - edit button is visible on dashboard view
     await expect(optimizeDashboardPage.editButton).toBeVisible();
 
-    // navigate back and open edit via context menu
     await page.goto(process.env.OPTIMIZE_URL!);
     await optimizeHomePage.listItem('dashboard').hover();
     await optimizeHomePage
@@ -97,15 +87,84 @@ test.describe('Homepage', () => {
       .click();
     await page.locator('.cds--menu-item').filter({hasText: 'Edit'}).click();
 
-    await expect(optimizeDashboardPage.addTileButton).toBeVisible();
+    await expect(page.locator('.AddButton')).toBeVisible();
   });
 
-  test.fixme(
-    'shouldSearchEntitiesAcrossCollectionsDashboardsAndReports',
-    async () => {
-      // Requires pre-existing entities with known names.
-      // TODO: Seed data (Collection "Sales", Dashboard "Sales Dashboard",
-      // Report "Incoming Leads") via Optimize API before enabling.
-    },
-  );
+  test('shouldSearchEntitiesAcrossCollectionsDashboardsAndReports', async ({
+    page,
+    optimizeHomePage,
+    optimizeDashboardPage,
+    optimizeProcessReportPage,
+  }) => {
+    await optimizeHomePage.clickCreateNew('Collection');
+    await optimizeHomePage.modalNameInput.fill('Alpha-Search-Collection');
+    await optimizeHomePage.modalConfirmButton.click();
+    await optimizeHomePage.modalConfirmButton.click();
+
+    await page.goto(process.env.OPTIMIZE_URL!);
+    await expect(optimizeHomePage.createNewButton).toBeVisible();
+
+    await optimizeHomePage.createNewButton.click();
+    await optimizeHomePage.menuOption('Dashboard').click();
+    await page.getByRole('button', {name: 'Blank dashboard'}).click();
+    await page
+      .locator('.EntityNameForm .name-input input')
+      .fill('Alpha-Search-Dashboard');
+    await optimizeDashboardPage.save();
+
+    await page.goto(process.env.OPTIMIZE_URL!);
+    await expect(optimizeHomePage.createNewButton).toBeVisible();
+
+    await optimizeHomePage.createNewButton.click();
+    await optimizeHomePage.menuOption('Report').click();
+    await page.getByRole('button', {name: 'Blank report'}).click();
+    await optimizeHomePage.modalConfirmButton.click();
+    await page
+      .locator('.EntityNameForm .name-input input')
+      .fill('Alpha-Search-Report');
+    await optimizeProcessReportPage.save();
+
+    await page.goto(process.env.OPTIMIZE_URL!);
+    await expect(optimizeHomePage.entityList).toBeVisible();
+
+    await optimizeHomePage.searchField.fill('Alpha-Search');
+
+    await expect(
+      page
+        .locator('.EntityList tbody tr')
+        .filter({hasText: 'Alpha-Search-Collection'}),
+    ).toBeVisible();
+    await expect(
+      page
+        .locator('.EntityList tbody tr')
+        .filter({hasText: 'Alpha-Search-Dashboard'}),
+    ).toBeVisible();
+    await expect(
+      page
+        .locator('.EntityList tbody tr')
+        .filter({hasText: 'Alpha-Search-Report'}),
+    ).toBeVisible();
+
+    await optimizeHomePage.searchField.fill('Alpha-Search-Dashboard');
+
+    await expect(
+      page
+        .locator('.EntityList tbody tr')
+        .filter({hasText: 'Alpha-Search-Dashboard'}),
+    ).toBeVisible();
+    await expect(
+      page
+        .locator('.EntityList tbody tr')
+        .filter({hasText: 'Alpha-Search-Collection'}),
+    ).toBeHidden();
+    await expect(
+      page
+        .locator('.EntityList tbody tr')
+        .filter({hasText: 'Alpha-Search-Report'}),
+    ).toBeHidden();
+
+    await optimizeHomePage.searchField.clear();
+
+    await expect(optimizeHomePage.entityList).toBeVisible();
+  });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/optimize/login.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/optimize/login.spec.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test} from 'fixtures';
+import {expect} from '@playwright/test';
+import {navigateToApp} from '@pages/UtilitiesPage';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+
+test.describe('Optimize Login', () => {
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('shouldRedirectToKeycloakLoginPage', async ({page}) => {
+    // when
+    await navigateToApp(page, 'optimize');
+
+    // then - Keycloak login form is visible
+    await expect(page.locator('input[name="username"]')).toBeVisible({
+      timeout: 30000,
+    });
+    await expect(page.locator('input[name="password"]')).toBeVisible();
+    await expect(page.locator('[type="submit"]')).toBeVisible();
+  });
+
+  test('shouldLoginToOptimizeSuccessfully', async ({
+    page,
+    optimizeLoginPage,
+    optimizeHomePage,
+  }) => {
+    // given
+    await navigateToApp(page, 'optimize');
+
+    // when
+    await optimizeLoginPage.login('demo', 'demo');
+
+    // then - Optimize home page is shown with Create New button
+    await expect(optimizeHomePage.createNewButton).toBeVisible({
+      timeout: 60000,
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/optimize/login.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/optimize/login.spec.ts
@@ -18,10 +18,8 @@ test.describe('Optimize Login', () => {
   });
 
   test('shouldRedirectToKeycloakLoginPage', async ({page}) => {
-    // when
     await navigateToApp(page, 'optimize');
 
-    // then - Keycloak login form is visible
     await expect(page.locator('input[name="username"]')).toBeVisible({
       timeout: 30000,
     });
@@ -34,13 +32,9 @@ test.describe('Optimize Login', () => {
     optimizeLoginPage,
     optimizeHomePage,
   }) => {
-    // given
     await navigateToApp(page, 'optimize');
-
-    // when
     await optimizeLoginPage.login('demo', 'demo');
 
-    // then - Optimize home page is shown with Create New button
     await expect(optimizeHomePage.createNewButton).toBeVisible({
       timeout: 60000,
     });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/optimize/report.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/optimize/report.spec.ts
@@ -10,31 +10,38 @@ import {test} from 'fixtures';
 import {expect} from '@playwright/test';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {captureScreenshot, captureFailureVideo} from '@setup';
+import {deploy} from 'utils/zeebeClient';
+import {sleep} from 'utils/sleep';
 
-test.beforeEach(async ({page, optimizeLoginPage, optimizeHomePage}) => {
-  await navigateToApp(page, 'optimize');
-  await optimizeLoginPage.login('demo', 'demo');
-  await expect(optimizeHomePage.createNewButton).toBeVisible({timeout: 60000});
-});
-
-test.afterEach(async ({page}, testInfo) => {
-  await captureScreenshot(page, testInfo);
-  await captureFailureVideo(page, testInfo);
+test.beforeAll(async () => {
+  await deploy(['./resources/orderProcess_v_1.bpmn']);
+  await sleep(30000);
 });
 
 test.describe('Process Report', () => {
+  test.beforeEach(async ({page, optimizeLoginPage, optimizeHomePage}) => {
+    await navigateToApp(page, 'optimize');
+    await optimizeLoginPage.login('demo', 'demo');
+    await expect(optimizeHomePage.createNewButton).toBeVisible({
+      timeout: 60000,
+    });
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
   test('shouldCreateBlankReport', async ({
     page,
     optimizeHomePage,
     optimizeProcessReportPage,
   }) => {
-    // when - create a blank report
     await optimizeHomePage.createNewButton.click();
     await optimizeHomePage.menuOption('Report').click();
     await page.getByRole('button', {name: 'Blank report'}).click();
     await optimizeHomePage.modalConfirmButton.click();
 
-    // then - control panel is visible (edit mode)
     await expect(optimizeProcessReportPage.controlPanel).toBeVisible();
   });
 
@@ -43,17 +50,16 @@ test.describe('Process Report', () => {
     optimizeHomePage,
     optimizeProcessReportPage,
   }) => {
-    // given
     await optimizeHomePage.createNewButton.click();
     await optimizeHomePage.menuOption('Report').click();
     await page.getByRole('button', {name: 'Blank report'}).click();
     await optimizeHomePage.modalConfirmButton.click();
 
-    // when - name and save the report
-    await page.locator('.EntityNameForm .name-input input').fill('Invoice Pipeline');
+    await page
+      .locator('.EntityNameForm .name-input input')
+      .fill('Invoice Pipeline');
     await optimizeProcessReportPage.save();
 
-    // then
     await expect(optimizeProcessReportPage.reportName).toHaveText(
       'Invoice Pipeline',
     );
@@ -64,37 +70,72 @@ test.describe('Process Report', () => {
     optimizeHomePage,
     optimizeProcessReportPage,
   }) => {
-    // given - create and save a blank report
     await optimizeHomePage.createNewButton.click();
     await optimizeHomePage.menuOption('Report').click();
     await page.getByRole('button', {name: 'Blank report'}).click();
     await optimizeHomePage.modalConfirmButton.click();
     await optimizeProcessReportPage.save();
 
-    // navigate back to home then into the report view
     await page.goto(process.env.OPTIMIZE_URL!);
     await optimizeHomePage.listItemLink('report').click();
 
-    // then
     await expect(optimizeHomePage.noDataNotice).toContainText(
       'Report configuration is incomplete',
     );
   });
 
-  test.fixme(
-    'shouldCreateReportFromTemplate',
-    async ({page, optimizeHomePage, optimizeProcessReportPage}) => {
-      // Requires 'Order process' deployed and imported by Optimize.
-      // TODO: Deploy process BPMN, wait for Optimize import, then enable.
-    },
-  );
+  test('shouldCreateReportFromTemplate', async ({
+    page,
+    optimizeHomePage,
+    optimizeProcessReportPage,
+  }) => {
+    await optimizeHomePage.createNewButton.click();
+    await optimizeHomePage.menuOption('Report').click();
+    await page
+      .locator('.Modal .DefinitionSelection input')
+      .fill('Order process');
+    await expect(
+      page
+        .locator('.cds--list-box__menu-item')
+        .filter({hasText: 'Order process'}),
+    ).toBeVisible({timeout: 60000});
+    await page
+      .locator('.cds--list-box__menu-item')
+      .filter({hasText: 'Order process'})
+      .first()
+      .click();
+    await page.locator('.TemplateModal .cds--radio-button').first().click();
+    await optimizeHomePage.modalConfirmButton.click();
 
-  test.fixme(
-    'shouldShareReport',
-    async ({page, optimizeHomePage, optimizeProcessReportPage}) => {
-      // Requires a report with actual data (process definition deployed +
-      // imported by Optimize).
-      // TODO: Enable after process data seeding is implemented.
-    },
-  );
+    await expect(optimizeProcessReportPage.controlPanel).toBeVisible();
+  });
+
+  test('shouldShareReport', async ({
+    page,
+    optimizeHomePage,
+    optimizeProcessReportPage,
+  }) => {
+    await optimizeHomePage.createNewButton.click();
+    await optimizeHomePage.menuOption('Report').click();
+    await page
+      .locator('.Modal .DefinitionSelection input')
+      .fill('Order process');
+    await expect(
+      page
+        .locator('.cds--list-box__menu-item')
+        .filter({hasText: 'Order process'}),
+    ).toBeVisible({timeout: 60000});
+    await page
+      .locator('.cds--list-box__menu-item')
+      .filter({hasText: 'Order process'})
+      .first()
+      .click();
+    await page.locator('.TemplateModal .cds--radio-button').first().click();
+    await optimizeHomePage.modalConfirmButton.click();
+    await optimizeProcessReportPage.save();
+    await page.locator('.share-button button').click();
+    await page.locator('.ShareEntity .cds--toggle__switch').click();
+
+    await expect(page.locator('.ShareEntity input[type="text"]')).toBeVisible();
+  });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/optimize/report.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/optimize/report.spec.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test} from 'fixtures';
+import {expect} from '@playwright/test';
+import {navigateToApp} from '@pages/UtilitiesPage';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+
+test.beforeEach(async ({page, optimizeLoginPage, optimizeHomePage}) => {
+  await navigateToApp(page, 'optimize');
+  await optimizeLoginPage.login('demo', 'demo');
+  await expect(optimizeHomePage.createNewButton).toBeVisible({timeout: 60000});
+});
+
+test.afterEach(async ({page}, testInfo) => {
+  await captureScreenshot(page, testInfo);
+  await captureFailureVideo(page, testInfo);
+});
+
+test.describe('Process Report', () => {
+  test('shouldCreateBlankReport', async ({
+    page,
+    optimizeHomePage,
+    optimizeProcessReportPage,
+  }) => {
+    // when - create a blank report
+    await optimizeHomePage.createNewButton.click();
+    await optimizeHomePage.menuOption('Report').click();
+    await page.getByRole('button', {name: 'Blank report'}).click();
+    await optimizeHomePage.modalConfirmButton.click();
+
+    // then - control panel is visible (edit mode)
+    await expect(optimizeProcessReportPage.controlPanel).toBeVisible();
+  });
+
+  test('shouldCreateAndNameReport', async ({
+    page,
+    optimizeHomePage,
+    optimizeProcessReportPage,
+  }) => {
+    // given
+    await optimizeHomePage.createNewButton.click();
+    await optimizeHomePage.menuOption('Report').click();
+    await page.getByRole('button', {name: 'Blank report'}).click();
+    await optimizeHomePage.modalConfirmButton.click();
+
+    // when - name and save the report
+    await page.locator('.EntityNameForm .name-input input').fill('Invoice Pipeline');
+    await optimizeProcessReportPage.save();
+
+    // then
+    await expect(optimizeProcessReportPage.reportName).toHaveText(
+      'Invoice Pipeline',
+    );
+  });
+
+  test('shouldShowNoDataNoticeForBlankReport', async ({
+    page,
+    optimizeHomePage,
+    optimizeProcessReportPage,
+  }) => {
+    // given - create and save a blank report
+    await optimizeHomePage.createNewButton.click();
+    await optimizeHomePage.menuOption('Report').click();
+    await page.getByRole('button', {name: 'Blank report'}).click();
+    await optimizeHomePage.modalConfirmButton.click();
+    await optimizeProcessReportPage.save();
+
+    // navigate back to home then into the report view
+    await page.goto(process.env.OPTIMIZE_URL!);
+    await optimizeHomePage.listItemLink('report').click();
+
+    // then
+    await expect(optimizeHomePage.noDataNotice).toContainText(
+      'Report configuration is incomplete',
+    );
+  });
+
+  test.fixme(
+    'shouldCreateReportFromTemplate',
+    async ({page, optimizeHomePage, optimizeProcessReportPage}) => {
+      // Requires 'Order process' deployed and imported by Optimize.
+      // TODO: Deploy process BPMN, wait for Optimize import, then enable.
+    },
+  );
+
+  test.fixme(
+    'shouldShareReport',
+    async ({page, optimizeHomePage, optimizeProcessReportPage}) => {
+      // Requires a report with actual data (process definition deployed +
+      // imported by Optimize).
+      // TODO: Enable after process data seeding is implemented.
+    },
+  );
+});


### PR DESCRIPTION
## Summary

Migrates the Optimize Self-Managed E2E test suite from the legacy TestCafe framework (`optimize/client/e2e/sm-tests/`) to Playwright (`qa/c8-orchestration-cluster-e2e-test-suite/`), aligning it with the rest of the C8 orchestration cluster E2E tests.

The legacy TestCafe workflow and tests are left intact until this new workflow is validated in CI.

---

## What was implemented

### Section 1 — Infrastructure & Setup

- **`qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml`**: Added two new services:
  - `identity` (`camunda/identity:SNAPSHOT`) — depends on `keycloak` (healthy), seeds the `demo/demo` user with `Identity` and `Optimize` roles, exposes port 8081 with an actuator healthcheck on port 8082.
  - `optimize` (`camunda/optimize:SNAPSHOT`, `SPRING_PROFILES_ACTIVE=ccsm`) — depends on `identity` (healthy) + `elasticsearch`, exposes port 8090 with a `GET /api/readyz` healthcheck.

- **`qa/c8-orchestration-cluster-e2e-test-suite/.env`**: Added `OPTIMIZE_URL=http://localhost:8090` for local development.

- **`qa/c8-orchestration-cluster-e2e-test-suite/pages/UtilitiesPage.ts`**: Added `optimize` case to `navigateToApp()` using `process.env.OPTIMIZE_URL`.

- **`qa/c8-orchestration-cluster-e2e-test-suite/tests/optimize/`**: Created the test directory scaffold.

---

### Section 2 — Page Objects

Five new Playwright page object classes added to `qa/c8-orchestration-cluster-e2e-test-suite/pages/`:

| File | Responsibility |
|---|---|
| `OptimizeLoginPage.ts` | Keycloak login form (username/password/submit) with `waitForAssertion` retry |
| `OptimizeHomePage.ts` | Entity list, Create New menu, search, bulk delete |
| `OptimizeCollectionPage.ts` | Collection CRUD, tabs (entities/users/alerts/sources), edit/copy/delete flows |
| `OptimizeDashboardPage.ts` | Dashboard rename, save, auto-refresh, tile management |
| `OptimizeProcessReportPage.ts` | Report view/edit, control panel, dropdown/configuration options, save |

All five page objects are registered as fixtures in `qa/c8-orchestration-cluster-e2e-test-suite/fixtures.ts`.

---

### Section 3 — Test Migration

Six Playwright spec files migrated from the legacy TestCafe suites:

| Spec file | Migrated from (TestCafe) | Notes |
|---|---|---|
| `tests/optimize/login.spec.ts` | `Auth.js` | Login redirect + successful login |
| `tests/optimize/homepage.spec.ts` | `Homepage.js` | Create menu, navigation to report/dashboard views |
| `tests/optimize/collection.spec.ts` | `Collection.js` | Create, rename, copy, delete collection |
| `tests/optimize/dashboard.spec.ts` | `Dashboard.js` | Rename, cancel edit, create report and add to dashboard |
| `tests/optimize/report.spec.ts` | `SingleReport.js` | Create blank report, name report, no-data notice |
| `tests/optimize/alerts.spec.ts` | `Alerts.js` | Alert CRUD (all `test.fixme` — requires deployed `Order process`) |

Tests that require pre-deployed BPMN process data (alerts, data-sources, KPI reports, sharing) are marked `test.fixme` with clear TODOs, consistent with the approach used in other specs in this suite.

---

### Section 4 — CI Workflow

- **`.github/workflows/optimize-e2e-tests-sm-playwright.yml`**: New workflow wiring the Playwright Optimize tests into CI.

  - Triggers on PR + push to `main`/`stable/**`/`release/**` for changes to `optimize/**`, `optimize.Dockerfile`, the test suite, or the workflow file itself.
  - Startup order respects service dependencies: `elasticsearch` + `keycloak` + `camunda` first (with health polling), then `identity` + `optimize`.
  - Sets `CAMUNDA_DOCKER_IMAGE`, `OPTIMIZE_VERSION`, and `IDENTITY_VERSION` from the branch name (`main` → `SNAPSHOT`, `stable/8.x` → `8.x-SNAPSHOT`).
  - Injects `OPTIMIZE_URL=http://localhost:8090` at runtime so the tests can reach Optimize.
  - Runs: `npm run test -- --project=chromium tests/optimize/`
  - Uploads Playwright HTML + JSON reports as artifacts (30-day retention) on `always()`.
  - Dumps `docker compose logs` for all four relevant services on failure.

---

## Why

The legacy Optimize SM E2E tests run against a live frontend dev server (`yarn e2e:ci:sm:headless`) which requires building the full Optimize frontend. This is slow and couples the E2E tests to the frontend build pipeline. Playwright tests in the orchestration cluster suite run against the deployed Docker image directly — faster, more stable, and consistent with how all other Camunda app E2E tests work.

## Alternatives considered

- Keeping TestCafe and adding Playwright alongside it — rejected as it increases maintenance burden.
- Migrating all skipped/fixme tests immediately — deferred because they require a deployed `Order process` BPMN definition and Optimize import pipeline, which needs separate setup work.
