### PR TITLE
fix: fix rdbms notnull spotbugs error

### DIFF
--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/cache/RdbmsEntityCacheLoader.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/cache/RdbmsEntityCacheLoader.java
@@ -83,7 +83,7 @@ public final class RdbmsEntityCacheLoader<K, Entity, CachedEntity, Query>
     return toCachedEntities(search.apply(query));
   }
 
-  private Map<K, CachedEntity> toCachedEntities(final Iterable<Entity> entities) {
+  private @NotNull Map<K, CachedEntity> toCachedEntities(final Iterable<Entity> entities) {
     return java.util.stream.StreamSupport.stream(entities.spliterator(), false)
         .collect(Collectors.toMap(keyExtractor, mapper));
   }


### PR DESCRIPTION
## Description

Fixes following RDBMS spotbugs error:

```
[ERROR] High: io.camunda.exporter.rdbms.cache.RdbmsEntityCacheLoader.loadAll(Set) may return null, but is declared @Nonnull [io.camunda.exporter.rdbms.cache.RdbmsEntityCacheLoader, io.camunda.exporter.rdbms.cache.RdbmsEntityCacheLoader] Returned at RdbmsEntityCacheLoader.java:[line 83]Known null at RdbmsEntityCacheLoader.java:[line 83] NP_NONNULL_RETURN_VIOLATION
```

