### PR TITLE
fix: increase default socket timeout for Operate and Tasklist snapshots

### DIFF
--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageElasticsearchTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageElasticsearchTest.java
@@ -828,14 +828,18 @@ public class SecondaryStorageElasticsearchTest {
     @Test
     void shouldUseOperatePropertiesDefaults() {
       assertThat(operateProperties.getElasticsearch())
-          .returns(null, OperateElasticsearchProperties::getSocketTimeout)
+          .returns(
+              OperateElasticsearchProperties.SOCKET_TIMEOUT_DEFAULT,
+              OperateElasticsearchProperties::getSocketTimeout)
           .returns(null, OperateElasticsearchProperties::getConnectTimeout);
     }
 
     @Test
     void shouldUseTasklistPropertiesDefaults() {
       assertThat(tasklistProperties.getElasticsearch())
-          .returns(null, TasklistElasticsearchProperties::getSocketTimeout)
+          .returns(
+              TasklistElasticsearchProperties.SOCKET_TIMEOUT_DEFAULT,
+              TasklistElasticsearchProperties::getSocketTimeout)
           .returns(null, TasklistElasticsearchProperties::getConnectTimeout);
     }
 

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageOpensearchTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageOpensearchTest.java
@@ -736,14 +736,18 @@ public class SecondaryStorageOpensearchTest {
     @Test
     void shouldUseOperatePropertiesDefaults() {
       assertThat(operateProperties.getOpensearch())
-          .returns(null, OperateOpensearchProperties::getSocketTimeout)
+          .returns(
+              OperateOpensearchProperties.SOCKET_TIMEOUT_DEFAULT,
+              OperateOpensearchProperties::getSocketTimeout)
           .returns(null, OperateOpensearchProperties::getConnectTimeout);
     }
 
     @Test
     void shouldUseTasklistPropertiesDefaults() {
       assertThat(tasklistProperties.getOpenSearch())
-          .returns(null, TasklistOpenSearchProperties::getSocketTimeout)
+          .returns(
+              TasklistOpenSearchProperties.SOCKET_TIMEOUT_DEFAULT,
+              TasklistOpenSearchProperties::getSocketTimeout)
           .returns(null, TasklistOpenSearchProperties::getConnectTimeout);
     }
 

--- a/operate/common/src/main/java/io/camunda/operate/connect/ElasticsearchConnector.java
+++ b/operate/common/src/main/java/io/camunda/operate/connect/ElasticsearchConnector.java
@@ -111,10 +111,8 @@ public class ElasticsearchConnector {
                 httpClientBuilder ->
                     configureHttpClient(
                         httpClientBuilder, elsConfig, pluginRepository.asRequestInterceptor()));
-    if (elsConfig.getConnectTimeout() != null || elsConfig.getSocketTimeout() != null) {
-      restClientBuilder.setRequestConfigCallback(
-          configCallback -> setTimeouts(configCallback, elsConfig));
-    }
+    restClientBuilder.setRequestConfigCallback(
+        configCallback -> setTimeouts(configCallback, elsConfig));
 
     final RestClientTransport transport =
         new RestClientTransport(restClientBuilder.build(), new JacksonJsonpMapper(objectMapper));
@@ -243,9 +241,7 @@ public class ElasticsearchConnector {
   }
 
   private Builder setTimeouts(final Builder builder, final ElasticsearchProperties elsConfig) {
-    if (elsConfig.getSocketTimeout() != null) {
-      builder.setSocketTimeout(elsConfig.getSocketTimeout());
-    }
+    builder.setSocketTimeout(elsConfig.getSocketTimeout());
     if (elsConfig.getConnectTimeout() != null) {
       builder.setConnectTimeout(elsConfig.getConnectTimeout());
     }

--- a/operate/common/src/main/java/io/camunda/operate/connect/OpensearchConnector.java
+++ b/operate/common/src/main/java/io/camunda/operate/connect/OpensearchConnector.java
@@ -381,10 +381,7 @@ public class OpensearchConnector {
 
   private RequestConfig.Builder setTimeouts(
       final RequestConfig.Builder builder, final OpensearchProperties os) {
-    if (os.getSocketTimeout() != null) {
-      // builder.setSocketTimeout(os.getSocketTimeout());
-      builder.setResponseTimeout(Timeout.ofMilliseconds(os.getSocketTimeout()));
-    }
+    builder.setResponseTimeout(Timeout.ofMilliseconds(os.getSocketTimeout()));
     if (os.getConnectTimeout() != null) {
       builder.setConnectTimeout(Timeout.ofMilliseconds(os.getConnectTimeout()));
     }

--- a/operate/common/src/main/java/io/camunda/operate/property/ElasticsearchProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/ElasticsearchProperties.java
@@ -22,6 +22,7 @@ public class ElasticsearchProperties {
   public static final String ELS_DATE_FORMAT_DEFAULT = "date_time";
 
   public static final int BULK_REQUEST_MAX_SIZE_IN_BYTES_DEFAULT = 1024 * 1024 * 90; // 90 MB
+  public static final int SOCKET_TIMEOUT_DEFAULT = 0;
 
   private String clusterName = "elasticsearch";
 
@@ -35,7 +36,7 @@ public class ElasticsearchProperties {
 
   private int batchSize = 200;
 
-  private Integer socketTimeout;
+  private Integer socketTimeout = SOCKET_TIMEOUT_DEFAULT;
   private Integer connectTimeout;
 
   private boolean createSchema = true;

--- a/operate/common/src/main/java/io/camunda/operate/property/OpensearchProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/OpensearchProperties.java
@@ -21,6 +21,7 @@ public class OpensearchProperties {
   public static final String OS_DATE_FORMAT_DEFAULT = "date_time";
 
   public static final int BULK_REQUEST_MAX_SIZE_IN_BYTES_DEFAULT = 1024 * 1024 * 90; // 90 MB
+  public static final int SOCKET_TIMEOUT_DEFAULT = 0;
 
   private String clusterName = "opensearch";
 
@@ -34,7 +35,7 @@ public class OpensearchProperties {
 
   private int batchSize = 200;
 
-  private Integer socketTimeout;
+  private Integer socketTimeout = SOCKET_TIMEOUT_DEFAULT;
   private Integer connectTimeout;
 
   private boolean createSchema = true;

--- a/tasklist/common/src/main/java/io/camunda/tasklist/connect/ElasticsearchConnector.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/connect/ElasticsearchConnector.java
@@ -110,10 +110,8 @@ public class ElasticsearchConnector {
                 httpClientBuilder ->
                     configureHttpClient(
                         httpClientBuilder, elsConfig, pluginRepository.asRequestInterceptor()));
-    if (elsConfig.getConnectTimeout() != null || elsConfig.getSocketTimeout() != null) {
-      restClientBuilder.setRequestConfigCallback(
-          configCallback -> setTimeouts(configCallback, elsConfig));
-    }
+    restClientBuilder.setRequestConfigCallback(
+        configCallback -> setTimeouts(configCallback, elsConfig));
 
     final RestClientTransport transport =
         new RestClientTransport(
@@ -285,9 +283,7 @@ public class ElasticsearchConnector {
   }
 
   private Builder setTimeouts(final Builder builder, final ElasticsearchProperties elsConfig) {
-    if (elsConfig.getSocketTimeout() != null) {
-      builder.setSocketTimeout(elsConfig.getSocketTimeout());
-    }
+    builder.setSocketTimeout(elsConfig.getSocketTimeout());
     if (elsConfig.getConnectTimeout() != null) {
       builder.setConnectTimeout(elsConfig.getConnectTimeout());
     }

--- a/tasklist/common/src/main/java/io/camunda/tasklist/connect/OpenSearchConnector.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/connect/OpenSearchConnector.java
@@ -335,10 +335,7 @@ public class OpenSearchConnector {
 
   private RequestConfig.Builder setTimeouts(
       final RequestConfig.Builder builder, final OpenSearchProperties os) {
-    if (os.getSocketTimeout() != null) {
-      // builder.setSocketTimeout(os.getSocketTimeout());
-      builder.setResponseTimeout(Timeout.ofMilliseconds(os.getSocketTimeout()));
-    }
+    builder.setResponseTimeout(Timeout.ofMilliseconds(os.getSocketTimeout()));
     if (os.getConnectTimeout() != null) {
       builder.setConnectTimeout(Timeout.ofMilliseconds(os.getConnectTimeout()));
     }

--- a/tasklist/common/src/main/java/io/camunda/tasklist/property/ElasticsearchProperties.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/property/ElasticsearchProperties.java
@@ -22,6 +22,7 @@ public class ElasticsearchProperties {
 
   public static final String ELS_DATE_FORMAT_DEFAULT = "date_time";
   public static final int DEFAULT_MAX_TERMS_COUNT = 10_000;
+  public static final int SOCKET_TIMEOUT_DEFAULT = 0;
 
   private String clusterName = "elasticsearch";
 
@@ -36,7 +37,7 @@ public class ElasticsearchProperties {
   private int batchSize = 200;
   private int maxTermsCount = DEFAULT_MAX_TERMS_COUNT;
 
-  private Integer socketTimeout;
+  private Integer socketTimeout = SOCKET_TIMEOUT_DEFAULT;
   private Integer connectTimeout;
 
   private boolean createSchema = true;

--- a/tasklist/common/src/main/java/io/camunda/tasklist/property/OpenSearchProperties.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/property/OpenSearchProperties.java
@@ -22,6 +22,7 @@ public class OpenSearchProperties {
 
   public static final String ELS_DATE_FORMAT_DEFAULT = "date_time";
   public static final int DEFAULT_MAX_TERMS_COUNT = 10_000;
+  public static final int SOCKET_TIMEOUT_DEFAULT = 0;
 
   private String clusterName = "opensearch-cluster";
 
@@ -36,7 +37,7 @@ public class OpenSearchProperties {
   private int batchSize = 200;
   private int maxTermsCount = DEFAULT_MAX_TERMS_COUNT;
 
-  private Integer socketTimeout;
+  private Integer socketTimeout = SOCKET_TIMEOUT_DEFAULT;
   private Integer connectTimeout;
 
   private boolean createSchema = true;

--- a/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/elasticsearch/ElasticsearchBackupRepository.java
+++ b/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/elasticsearch/ElasticsearchBackupRepository.java
@@ -559,12 +559,18 @@ public class ElasticsearchBackupRepository implements BackupRepository {
         // This is thrown even if the backup is still running
         final int snapshotTimeout = backupProps.snapshotTimeout();
         LOGGER.warn(
-            "Socket timeout while creating snapshot [{}] for backup id [{}]. Start waiting with polling timeout, {}",
+            "The Elasticsearch HTTP connection timed out while waiting for snapshot [{}] "
+                + "(backup id [{}]) to complete. The snapshot is likely still running in "
+                + "Elasticsearch. Polling will continue {}. "
+                + "If socket timeouts occur repeatedly, consider increasing the socket timeout via "
+                + "CAMUNDA_OPERATE_ELASTICSEARCH_SOCKETTIMEOUT or "
+                + "CAMUNDA_TASKLIST_ELASTICSEARCH_SOCKETTIMEOUT "
+                + "and consider doubling or tripling the current value.",
             snapshotRequest.snapshotName(),
             backupId,
-            (snapshotTimeout == 0)
-                ? "until completion."
-                : "at most " + snapshotTimeout + " seconds.");
+            snapshotTimeout == 0
+                ? "until completion"
+                : "for at most " + snapshotTimeout + " seconds");
         if (isSnapshotFinishedWithinTimeout(
             snapshotRequest.repositoryName(), snapshotRequest.snapshotName())) {
           onSuccess.run();

--- a/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/opensearch/OpensearchBackupRepository.java
+++ b/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/opensearch/OpensearchBackupRepository.java
@@ -296,7 +296,13 @@ public class OpensearchBackupRepository implements BackupRepository {
               if (e instanceof SocketTimeoutException) {
                 // This is thrown even if the backup is still running
                 LOGGER.warn(
-                    "Timeout while creating snapshot [{}] for backup id [{}]. Need to keep waiting with polling...",
+                    "The OpenSearch HTTP connection timed out while waiting for snapshot [{}] "
+                        + "(backup id [{}]) to complete. The snapshot is likely still running in "
+                        + "OpenSearch. Polling will continue until completion. "
+                        + "If socket timeouts occur repeatedly, consider increasing the socket timeout via "
+                        + "CAMUNDA_OPERATE_OPENSEARCH_SOCKETTIMEOUT or "
+                        + "CAMUNDA_TASKLIST_OPENSEARCH_SOCKETTIMEOUT "
+                        + "and consider doubling or tripling the current value.",
                     snapshotRequest.snapshotName(),
                     backupId);
                 // Keep waiting


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Increases default socket timeout so that snapshot creation does not time out as often. Also improves logging to give instructions for fixing timeouts if they persist.

The fix for 8.7 is a bit different so there is a separate PR for it rather than a backport: https://github.com/camunda/camunda/pull/52456

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

relates to https://github.com/camunda/camunda/issues/41861
