### PR TITLE
docs: document service access on authenticated benchmark clusters

### DIFF
--- a/load-tests/setup/README.md
+++ b/load-tests/setup/README.md
@@ -238,6 +238,26 @@ make template scenario=max          # renders platform manifests
 make template-load-test scenario=max  # renders load test manifests
 ```
 
+### Accessing Services
+
+Benchmark clusters have authentication enabled. Logging into Operate, Tasklist and Admin webapps requires both Camunda and Keycloak reachable locally so that the SSO redirect works.
+
+1. Port-forward both Camunda and Keycloak:
+
+   ```sh
+    kubectl -n <namespace> port-forward svc/camunda 8080:8080 &
+    kubectl -n <namespace> port-forward pod/keycloak-0 18080:8080 &
+    wait
+   ```
+
+2. Get the `demo` user password:
+
+   ```sh
+   kubectl -n <namespace> get secret camunda-credentials -o jsonpath="{.data.identity-firstuser-password}" | base64 --decode
+   ```
+
+3. Open <http://localhost:8080> and log in with user `demo` and the password from the previous step.
+
 ### How to clean up a load test
 
 After you're done with your load test, you should remove the remaining namespace.

--- a/load-tests/setup/README.md
+++ b/load-tests/setup/README.md
@@ -244,17 +244,17 @@ Benchmark clusters have authentication enabled. Logging into Operate, Tasklist a
 
 1. Port-forward both Camunda and Keycloak:
 
-   ```sh
-    kubectl -n <namespace> port-forward svc/camunda 8080:8080 &
-    kubectl -n <namespace> port-forward pod/keycloak-0 18080:8080 &
-    wait
-   ```
+```sh
+kubectl -n <namespace> port-forward svc/camunda 8080:8080 &
+kubectl -n <namespace> port-forward pod/keycloak-0 18080:8080 &
+wait
+```
 
 2. Get the `demo` user password:
 
-   ```sh
-   kubectl -n <namespace> get secret camunda-credentials -o jsonpath="{.data.identity-firstuser-password}" | base64 --decode
-   ```
+```sh
+kubectl -n <namespace> get secret camunda-credentials -o jsonpath="{.data.identity-firstuser-password}" | base64 --decode
+```
 
 3. Open <http://localhost:8080> and log in with user `demo` and the password from the previous step.
 


### PR DESCRIPTION
## Summary
- Adds an "Accessing Services" section to `load-tests/setup/README.md` under the self-managed setup guide, needed for 8.9+ benchmark clusters with authentication enabled. Operate, Tasklist and Admin webapps require Keycloak reachable locally for SSO redirects