### PR TITLE
test: fix flaky E2E tests in stable/8.8 by adding proper wait conditions

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
@@ -311,7 +311,9 @@ class OperateProcessesPage {
 
   async selectProcessCheckboxByPIK(...PIK: string[]): Promise<void> {
     for (const key of PIK) {
-      await this.page.locator(`label[for$="${key}"]`).click();
+      const checkbox = this.page.locator(`label[for$="${key}"]`);
+      await checkbox.waitFor({state: 'visible', timeout: 30000});
+      await checkbox.click({timeout: 30000});
     }
   }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskDetailsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/TaskDetailsPage.ts
@@ -332,8 +332,8 @@ class TaskDetailsPage {
       const expectedValue = `${value}${index + 1}`;
       await element.fill(expectedValue);
 
-      // Assert that the value was added correctly
-      await expect(element).toHaveValue(expectedValue);
+      // Wait for the value to be set with a longer timeout
+      await expect(element).toHaveValue(expectedValue, {timeout: 15000});
     }
   }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/TasklistProcessesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/TasklistProcessesPage.ts
@@ -38,7 +38,12 @@ class TasklistProcessesPage {
   }
 
   public async searchForProcess(process: string) {
-    await this.searchProcessesInput.click();
+    // Wait for any existing modals to close before searching
+    await this.page.waitForTimeout(500);
+    // Wait for the search input to be enabled
+    await this.searchProcessesInput.waitFor({state: 'visible', timeout: 30000});
+    await expect(this.searchProcessesInput).toBeEnabled({timeout: 30000});
+    await this.searchProcessesInput.click({timeout: 30000});
     await this.searchProcessesInput.fill(process);
     await this.searchProcessesInput.press('Enter');
   }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -145,8 +145,18 @@ test.describe.serial('Process Instance Migration', () => {
         .poll(() => operateFiltersPanelPage.processVersionFilter.innerText())
         .toBe(sourceVersion);
 
-      await expect(operateProcessesPage.resultsText.first()).toBeVisible({
-        timeout: 30000,
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(operateProcessesPage.resultsText.first()).toBeVisible({
+            timeout: 30000,
+          });
+        },
+        onFailure: async () => {
+          await page.reload();
+          await operateFiltersPanelPage.selectProcess(sourceBpmnProcessId);
+          await sleep(1000);
+          await operateFiltersPanelPage.selectVersion(sourceVersion);
+        },
       });
     });
 


### PR DESCRIPTION
Fixes timeout issues in E2E tests by adding explicit waits and increasing timeouts for async operations. All changes add proper synchronization for race conditions.

Changes:
- OperateProcessesPage.ts: Add explicit wait for checkbox visibility (30s)
- TaskDetailsPage.ts: Increase form value assertion timeout to 15s
- TasklistProcessesPage.ts: Wait for modal close and input enabled state
- processInstanceMigration.spec.ts: Add retry logic with page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist
https://github.com/camunda/camunda/actions/runs/25382144684
<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
