### PR TITLE
refactor: centralize db version properties for CI reuse

### DIFF
--- a/.ci/db-versions.yml
+++ b/.ci/db-versions.yml
@@ -1,0 +1,23 @@
+# Database versions
+#
+# Single source of truth for all database versions tested in CI and deployed to SaaS.
+#
+# ── How to use this file in CI workflows ────────────────────────────────────────
+#   CI workflows read versions from this file via the reusable action:
+#     .github/actions/read-db-versions
+#
+# ── SaaS version ────────────────────────────────────────────────────────────────
+#   The `saas` field under elasticsearch identifies which version is deployed to
+#   SaaS environments. It must always reference one of the listed es8 versions via
+#   a YAML anchor so that the SaaS version cannot drift from what is tested in CI.
+# ────────────────────────────────────────────────────────────────────────────────
+
+elasticsearch:
+  es8:
+    - &saas "8.16.4"
+    - "8.18.8"
+  saas: *saas
+
+opensearch:
+  os2:
+    - "2.19.5"

--- a/.github/actions/read-db-versions/README.md
+++ b/.github/actions/read-db-versions/README.md
@@ -1,0 +1,52 @@
+# Read DB Versions
+
+Parses `.ci/db-versions.yml` and exposes the configured database versions as
+named outputs that downstream jobs can consume in service container image tags
+or environment variables.
+
+## Purpose
+
+Centralises all database version pins in a single YAML file (`.ci/db-versions.yml`)
+so that a version bump is a one-line change rather than a grep-and-replace across
+multiple workflow files.
+
+## Outputs
+
+|      Output       |                          Description                           |
+|-------------------|----------------------------------------------------------------|
+| `elasticsearch-8` | Latest supported ES 8 minor version (last entry in `es8` list) |
+| `opensearch-2`    | Latest supported OpenSearch 2 minor version                    |
+| `saas`            | Elasticsearch version currently deployed to SaaS environments  |
+
+## Example usage
+
+```yaml
+jobs:
+  read-versions:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      elasticsearch-8: ${{ steps.db-versions.outputs.elasticsearch-8 }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Read DB versions
+        id: db-versions
+        uses: ./.github/actions/read-db-versions
+
+  test:
+    needs: [read-versions]
+    services:
+      elasticsearch:
+        image: docker.elastic.co/elasticsearch/elasticsearch:${{ needs.read-versions.outputs.elasticsearch-8 }}
+```
+
+## How to update a version
+
+Edit `.ci/db-versions.yml`. The YAML anchor on the SaaS entry (`&saas`) ensures
+`saas` always references a version that is also present in the `es8` test list —
+update the anchor value when promoting SaaS to a new minor.
+
+## Owner
+
+@camunda/data-layer

--- a/.github/actions/read-db-versions/action.yml
+++ b/.github/actions/read-db-versions/action.yml
@@ -1,0 +1,27 @@
+name: Read DB Versions
+description: |
+  Parses .ci/db-versions.yml and exposes the configured database versions as named outputs.
+  The repository must already be checked out before this action is called.
+
+outputs:
+  elasticsearch-8:
+    value: ${{ steps.parse.outputs.elasticsearch-8 }}
+  opensearch-2:
+    value: ${{ steps.parse.outputs.opensearch-2 }}
+  saas:
+    value: ${{ steps.parse.outputs.saas }}
+
+runs:
+  using: composite
+  steps:
+    - name: Python setup
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: "3.x"
+    - name: Install Python dependencies
+      shell: bash
+      run: python3 -m pip install -q --disable-pip-version-check pyyaml==6.0.2
+    - name: Parse DB versions
+      id: parse
+      shell: bash
+      run: python3 .github/actions/read-db-versions/generate-db-versions.py >> "$GITHUB_OUTPUT"

--- a/.github/actions/read-db-versions/generate-db-versions.py
+++ b/.github/actions/read-db-versions/generate-db-versions.py
@@ -1,0 +1,21 @@
+"""
+Reads .ci/db-versions.yml and writes the configured database versions as key=value
+lines to stdout, ready to be appended to $GITHUB_OUTPUT.
+"""
+
+import yaml
+
+
+def set_output(name, value):
+    print(f"{name}={value}")
+
+
+with open(".ci/db-versions.yml") as f:
+    versions = yaml.safe_load(f)
+
+es8_versions = versions["elasticsearch"]["es8"]
+os2_versions = versions["opensearch"]["os2"]
+
+set_output("elasticsearch-8", es8_versions[-1])
+set_output("opensearch-2",    os2_versions[-1])
+set_output("saas",            versions["elasticsearch"]["saas"])

--- a/.github/conftest-unified-ci-rules.rego
+++ b/.github/conftest-unified-ci-rules.rego
@@ -130,6 +130,7 @@ get_jobs_without_cihealth(jobInput) = jobs_without_cihealth {
 
         # not enforced on "special" jobs needed for control flow in Unified CI
         job_id != "detect-changes"
+        job_id != "generate-db-versions"
         job_id != "check-results"
         job_id != "test-summary"
         job_id != "get-concurrency-group-dynamically"
@@ -212,6 +213,7 @@ get_jobs_without_printmetadata(jobInput) = jobs_without_printmetadata {
 
         # not enforced on Unified CI jobs that are part of change detection control flow structure
         job_id != "detect-changes"
+        job_id != "generate-db-versions"
         job_id != "setup-tests"
         job_id != "check-results"
 

--- a/.github/workflows/check-saas-version.yml
+++ b/.github/workflows/check-saas-version.yml
@@ -1,0 +1,68 @@
+# description: Guards against accidentally downgrading the SaaS Elasticsearch version in .ci/db-versions.yml
+# test location: .ci/db-versions.yml
+# type: CI
+# owner: @camunda/data-layer
+---
+# Guards against accidentally downgrading the SaaS Elasticsearch version in
+# .ci/db-versions.yml.
+
+name: Check SaaS version
+
+on:
+  pull_request:
+    paths:
+      - .ci/db-versions.yml
+
+jobs:
+  check-saas-version:
+    name: Check SaaS version does not decrease
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Install Python dependencies
+        run: python3 -m pip install -q --disable-pip-version-check pyyaml==6.0.2
+      - name: Compare SaaS version against base branch
+        env:
+          SKIP_LABEL: "ci:allow-saas-downgrade"
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+          BASE_BRANCH: ${{ github.base_ref }}
+        shell: bash
+        run: |
+          if echo "$PR_LABELS" | python3 -c "import json,sys; sys.exit(0 if '$SKIP_LABEL' in json.load(sys.stdin) else 1)"; then
+            echo "Label '$SKIP_LABEL' is set — skipping version check."
+            exit 0
+          fi
+
+          PR_VERSION=$(python3 -c "import yaml; print(yaml.safe_load(open('.ci/db-versions.yml'))['elasticsearch']['saas'])")
+          git fetch origin "$BASE_BRANCH" --depth=1
+          if ! git show "origin/$BASE_BRANCH:.ci/db-versions.yml" > /dev/null 2>&1; then
+            echo ".ci/db-versions.yml does not exist on $BASE_BRANCH — nothing to compare against."
+            exit 0
+          fi
+          BASE_VERSION=$(git show "origin/$BASE_BRANCH:.ci/db-versions.yml" | python3 -c "import yaml,sys; print(yaml.safe_load(sys.stdin)['elasticsearch']['saas'])")
+
+          echo "SaaS version on $BASE_BRANCH: $BASE_VERSION"
+          echo "SaaS version on this PR:      $PR_VERSION"
+
+          python3 - <<EOF
+          import sys
+
+          def parse(v):
+              return tuple(int(x) for x in v.split("."))
+
+          pr   = parse("$PR_VERSION")
+          base = parse("$BASE_VERSION")
+
+          if pr < base:
+              print(f"::error::SaaS version decreased: {base} -> {pr}.")
+              print(f"::error::If this is intentional, add the label '$SKIP_LABEL' to the PR.")
+              sys.exit(1)
+
+          print(f"OK: {base} -> {pr}")
+          EOF

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,23 @@ jobs:
         uses: ./.github/actions/paths-filter
         id: filter
 
+  generate-db-versions:
+    name: "Generate DB versions"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [ detect-changes ]
+    permissions:
+      contents: read
+    outputs:
+      elasticsearch-8: ${{ steps.db-versions.outputs.elasticsearch-8 }}
+      opensearch-2: ${{ steps.db-versions.outputs.opensearch-2 }}
+      saas: ${{ steps.db-versions.outputs.saas }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Read DB versions
+        id: db-versions
+        uses: ./.github/actions/read-db-versions
+
   actionlint:
     if: needs.detect-changes.outputs.actionlint == 'true'
     name: "Lint / Actionlint"
@@ -535,7 +552,7 @@ jobs:
 
   elasticsearch-integration-tests:
     if: needs.detect-changes.outputs.java-code-changes == 'true'
-    needs: [ detect-changes ]
+    needs: [ detect-changes, generate-db-versions ]
     name: "General / Integration / Elasticsearch ITs"
     timeout-minutes: 20
     permissions: { }  # GITHUB_TOKEN unused in this job
@@ -554,7 +571,7 @@ jobs:
       # Set up an elastic search service container
       # https://docs.github.com/en/actions/use-cases-and-examples/using-containerized-services/about-service-containers
       elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:8.18.8
+        image: docker.elastic.co/elasticsearch/elasticsearch:${{ needs.generate-db-versions.outputs.elasticsearch-8 }}
         # Exposing the ports allow to be accessible via http://localhost:9200 in the runner
         ports:
           - 9200:9200
@@ -637,7 +654,7 @@ jobs:
 
   opensearch-integration-tests:
     if: needs.detect-changes.outputs.java-code-changes == 'true'
-    needs: [ detect-changes ]
+    needs: [ detect-changes, generate-db-versions ]
     name: "General / Integration / OpenSearch ITs"
     timeout-minutes: 20
     permissions: { }  # GITHUB_TOKEN unused in this job
@@ -656,7 +673,7 @@ jobs:
       # Set up an OpenSearch service container
       # https://docs.github.com/en/actions/use-cases-and-examples/using-containerized-services/about-service-containers
       opensearch:
-        image: opensearchproject/opensearch:2.19.5
+        image: opensearchproject/opensearch:${{ needs.generate-db-versions.outputs.opensearch-2 }}
         # Exposing the ports allow to be accessible via http://localhost:9200 in the runner
         ports:
           - 9200:9200
@@ -1185,7 +1202,7 @@ jobs:
   docker-checks:
     if: needs.detect-changes.outputs.camunda-docker-tests == 'true'
     name: "Docker / Tool / Checks"
-    needs: [ detect-changes ]
+    needs: [ detect-changes, generate-db-versions ]
     runs-on: ubuntu-latest
     outputs:
       flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
@@ -1200,7 +1217,7 @@ jobs:
           - 5000:5000
     env:
       LOCAL_DOCKER_IMAGE: localhost:5000/camunda/camunda
-      TEST_ELASTICSEARCH_IMAGE: docker.elastic.co/elasticsearch/elasticsearch:8.16.4
+      TEST_ELASTICSEARCH_IMAGE: docker.elastic.co/elasticsearch/elasticsearch:${{ needs.generate-db-versions.outputs.saas }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-build
@@ -1592,6 +1609,7 @@ jobs:
       - docker-checks
       - elasticsearch-integration-tests
       - general-unit-tests
+      - generate-db-versions
       - identity-frontend-sbom-snyk
       - identity-frontend-tests
       - integration-tests

--- a/.github/workflows/identity-e2e-tests.yml
+++ b/.github/workflows/identity-e2e-tests.yml
@@ -44,12 +44,27 @@ permissions:
   contents: read # for git clone
 
 jobs:
+  generate-db-versions:
+    name: "Generate DB versions"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      elasticsearch-8: ${{ steps.db-versions.outputs.elasticsearch-8 }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Read DB versions
+        id: db-versions
+        uses: ./.github/actions/read-db-versions
+
   test:
+    needs: [ generate-db-versions ]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     services:
       elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:8.18.8
+        image: docker.elastic.co/elasticsearch/elasticsearch:${{ needs.generate-db-versions.outputs.elasticsearch-8 }}
         env:
           discovery.type: single-node
           cluster.name: docker-cluster

--- a/.github/workflows/operate-e2e-tests.yml
+++ b/.github/workflows/operate-e2e-tests.yml
@@ -41,11 +41,24 @@ concurrency:
   group: ${{ format('{0}-{1}', github.workflow, github.ref == 'refs/heads/main' && github.sha || github.ref) }}
 
 jobs:
+  read-versions:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      elasticsearch-8: ${{ steps.db-versions.outputs.elasticsearch-8 }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Read DB versions
+        id: db-versions
+        uses: ./.github/actions/read-db-versions
+
   test:
     runs-on: gcp-core-4-default
+    needs: [read-versions]
     services:
       elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:8.18.8
+        image: docker.elastic.co/elasticsearch/elasticsearch:${{ needs.read-versions.outputs.elasticsearch-8 }}
         env:
           discovery.type: single-node
           cluster.name: docker-cluster

--- a/.github/workflows/tasklist-e2e-tests.yml
+++ b/.github/workflows/tasklist-e2e-tests.yml
@@ -37,17 +37,29 @@ jobs:
         uses: ./.github/actions/paths-filter
         id: filter
 
+  read-versions:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      elasticsearch-8: ${{ steps.db-versions.outputs.elasticsearch-8 }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Read DB versions
+        id: db-versions
+        uses: ./.github/actions/read-db-versions
+
   test:
     strategy:
       fail-fast: false
       matrix:
         tasklist_mode: [v1, v2] # Run both V1 and V2 modes
     runs-on: ubuntu-latest
-    needs: [detect-changes]
+    needs: [detect-changes, read-versions]
     if: ${{ needs.detect-changes.outputs.tasklist-backend-changes == 'true' || needs.detect-changes.outputs.tasklist-frontend-changes == 'true' }}
     services:
       elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:8.18.8
+        image: docker.elastic.co/elasticsearch/elasticsearch:${{ needs.read-versions.outputs.elasticsearch-8 }}
         env:
           discovery.type: single-node
           cluster.name: docker-cluster

--- a/operate/docker-compose.yml
+++ b/operate/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.18.8
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTICSEARCH_VERSION:-8.18.8}
     container_name: elasticsearch
     environment:
       - discovery.type=single-node


### PR DESCRIPTION
## Summary

Backport of #51049 to `stable/8.8`.

- Adds `.ci/db-versions.yml` as SSOT for Elasticsearch and OpenSearch versions on this branch (ES8 `8.18.8`, OS2 `2.19.5`, SaaS `8.16.4`)
- Adds `.github/actions/read-db-versions/` composite action + Python script
- Adds `generate-db-versions` job to `ci.yml`; elasticsearch/opensearch integration test jobs and `docker-checks` consume versions from outputs
- Adds local `generate-db-versions` job to `identity-e2e-tests.yml`
- Adds `check-saas-version.yml` to guard against SaaS ES version decreases on this branch; bypass via `ci:allow-saas-downgrade` label
- Exempts `generate-db-versions` from CI Health metrics enforcement in `conftest-unified-ci-rules.rego`

No minimal supported version changes. No RDBMS (not supported on 8.8).

Closes #51049 (partial — 8.8 scope only)

## Test plan

- [ ] CI passes on this PR
- [ ] `check-saas-version.yml` triggers and passes
- [ ] `generate-db-versions` job outputs correct ES/OS versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)