### PR TITLE
docs: add CI pressure simulation techniques to flaky test guide

### DIFF
--- a/docs/zeebe/failing-tests.md
+++ b/docs/zeebe/failing-tests.md
@@ -49,7 +49,7 @@ If the module under test has no such file, add one temporarily to its `src/test/
 directory (do **not** commit it), then run the test class with Maven:
 
 ```shell
-./mvnw verify -pl <module> -Dtest=MyFlakeyTest \
+./mvnw verify -pl <module> -Dtest=MyFlakyTest \
   -DskipITs -DskipUTs=false -DskipTests=false -Dquickly
 ```
 
@@ -61,7 +61,7 @@ CPU-throttled systemd scope to simulate a busy CI runner. No root access is requ
 ```shell
 systemd-run --scope --user -p CPUQuota=10% \
   --working-directory="$(pwd)" -- \
-  ./mvnw verify -pl <module> -Dtest=MyFlakeyTest \
+  ./mvnw verify -pl <module> -Dtest=MyFlakyTest \
     -DskipITs -DskipUTs=false -DskipTests=false -Dquickly
 ```
 
@@ -74,7 +74,7 @@ thread scheduling delays more reliably:
 ```shell
 systemd-run --scope --user -p CPUQuota=10% \
   --working-directory="$(pwd)" -- \
-  ./mvnw verify -pl <module> -Dtest=MyFlakeyTest \
+  ./mvnw verify -pl <module> -Dtest=MyFlakyTest \
     -DskipITs -DskipUTs=false -DskipTests=false -Dquickly \
     -DargLine="-Xmx48m -XX:+UseSerialGC"
 ```

--- a/docs/zeebe/failing-tests.md
+++ b/docs/zeebe/failing-tests.md
@@ -36,7 +36,8 @@ thread-scheduler starvation. You can recreate these conditions locally.
 
 #### Enable in-class parallel execution
 
-CI runs test methods within a class concurrently via `junit-platform.properties` (see e.g.
+Some modules configure test methods within a class to run concurrently via
+`junit-platform.properties` (see e.g.
 `zeebe/backup-stores/gcs/src/test/resources/junit-platform.properties`):
 
 ```properties

--- a/docs/zeebe/failing-tests.md
+++ b/docs/zeebe/failing-tests.md
@@ -28,6 +28,60 @@ Here are some tips to do so:
   it [repeat until the test fails](https://www.jetbrains.com/help/idea/run-debug-configuration-junit.html#tests)
   .
 
+### Simulate CI pressure locally
+
+If simple repetition doesn't reproduce the failure, the test likely depends on conditions specific
+to CI: concurrent test method execution within a class, GC pressure from many parallel JVMs, or
+thread-scheduler starvation. You can recreate these conditions locally.
+
+#### Enable in-class parallel execution
+
+CI runs test methods within a class concurrently via `junit-platform.properties` (see e.g.
+`zeebe/backup-stores/gcs/src/test/resources/junit-platform.properties`):
+
+```properties
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=concurrent
+junit.jupiter.execution.parallel.mode.classes.default=same_thread
+```
+
+If the module under test has no such file, add one temporarily to its `src/test/resources/`
+directory (do **not** commit it), then run the test class with Maven:
+
+```shell
+./mvnw verify -pl <module> -Dtest=MyFlakeyTest \
+  -DskipITs -DskipUTs=false -DskipTests=false -Dquickly
+```
+
+#### Throttle CPU with cgroups (Linux)
+
+On modern Linux (Fedora 33+, Ubuntu 22+) with cgroups v2, you can run the test JVM in a
+CPU-throttled systemd scope to simulate a busy CI runner. No root access is required:
+
+```shell
+systemd-run --scope --user -p CPUQuota=10% \
+  --working-directory="$(pwd)" -- \
+  ./mvnw verify -pl <module> -Dtest=MyFlakeyTest \
+    -DskipITs -DskipUTs=false -DskipTests=false -Dquickly
+```
+
+Start at `CPUQuota=20%` and reduce until the failure reproduces. A value of `5–10%` typically
+matches the effective CPU available to a test fork on a busy CI runner.
+
+You can combine this with JVM heap pressure to reproduce races that depend on GC timing or
+thread scheduling delays more reliably:
+
+```shell
+systemd-run --scope --user -p CPUQuota=10% \
+  --working-directory="$(pwd)" -- \
+  ./mvnw verify -pl <module> -Dtest=MyFlakeyTest \
+    -DskipITs -DskipUTs=false -DskipTests=false -Dquickly \
+    -DargLine="-Xmx48m -XX:+UseSerialGC"
+```
+
+`-XX:+UseSerialGC` with a small heap forces frequent stop-the-world GCs, which helps expose
+races that depend on GC timing or thread scheduling delays.
+
 If you cannot reproduce it locally, the next step is to reproduce it in our CI environment.
 
 ## Reproduce in CI


### PR DESCRIPTION
## Summary

- Adds a **"Simulate CI pressure locally"** subsection to `docs/zeebe/failing-tests.md`, between the existing IntelliJ-loop tip and the "Reproduce in CI" section
- Covers two techniques for tests that don't reproduce under simple repetition:
  - Enabling in-class parallel execution via a temporary `junit-platform.properties` (matching CI's `mode.default=concurrent`)
  - CPU-throttling the test JVM with `systemd-run --scope --user -p CPUQuota=X%` (cgroups v2, no root needed), optionally combined with `-Xmx48m -XX:+UseSerialGC` for GC pressure


## Example

I used this as part of reviewing https://github.com/camunda/camunda/pull/51768 see comment here https://github.com/camunda/camunda/pull/51768#issuecomment-4379269061

I was able to reproduce the issue (when removing the fix) with this approach, while it was not reproducible from IntelliJ running tests 10k times or more (single test, but also complete test class) in a loop as described.

I realized that these occurences often is due to pressure on the CI machines, I first tried it with `stress --cpu 12 --vm 1 --vm-bytes 2G`, but was not able to reproduce it either. 

Later, I found the `cgroup` approach, which seems pretty neat (I felt, at least).


@npepinpe was wondering why this is actually under `docs/zeebe` can't this be under `docs/testing`? Should we move it?


---
🤖 Generated with [Claude Code](https://claude.com/claude-code)