### PR TITLE
deps: update Elasticsearch 8 test version to 8.19.15

### DIFF
--- a/.github/actions/compose/README.md
+++ b/.github/actions/compose/README.md
@@ -28,7 +28,7 @@ steps:
     compose_file: .github/actions/compose/docker-compose.elasticsearch.yml
     project_name: elasticsearch
   env:
-    ELASTIC_VERSION: 8.19.11
+    ELASTIC_VERSION: 8.19.15
     ELASTIC_JVM_MEMORY: 1
     ELASTIC_HTTP_PORT: 9200
 ```

--- a/.github/actions/compose/docker-compose.elasticsearch.yml
+++ b/.github/actions/compose/docker-compose.elasticsearch.yml
@@ -2,7 +2,7 @@ version: "3.9"
 services:
   elasticsearch:
     container_name: elasticsearch-${ELASTIC_HTTP_PORT:-9200}
-    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-8.19.11}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-8.19.15}
     environment:
       - TZ=Europe/Berlin
       - xpack.security.enabled=false

--- a/.github/actions/compose/docker-compose.smoketest.yml
+++ b/.github/actions/compose/docker-compose.smoketest.yml
@@ -1,7 +1,7 @@
 services:
   elasticsearch:
     container_name: elasticsearch
-    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-8.19.11}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-8.19.15}
     environment:
       - TZ=Europe/Berlin
       - xpack.security.enabled=false

--- a/.github/actions/docker-logs/README.md
+++ b/.github/actions/docker-logs/README.md
@@ -25,7 +25,7 @@ steps:
     compose_file: .github/actions/compose/docker-compose.elasticsearch.yml
     project_name: elasticsearch
   env:
-    ELASTIC_VERSION: 8.19.11
+    ELASTIC_VERSION: 8.19.15
     ELASTIC_JVM_MEMORY: 1
 ...
 - name: Docker log dump

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -559,7 +559,7 @@ jobs:
         include:
           - name: "Elasticsearch 8"
             database-type: "elasticsearch"
-            database-image-version: "8.19.11"
+            database-image-version: "8.19.15"
             database-name: "Elasticsearch 8"
             it-database-type: "es"
           - name: "Elasticsearch 9"
@@ -1026,7 +1026,7 @@ jobs:
           - 5000:5000
     env:
       LOCAL_DOCKER_IMAGE: localhost:5000/camunda/camunda
-      TEST_ELASTICSEARCH_IMAGE: docker.elastic.co/elasticsearch/elasticsearch:8.19.11
+      TEST_ELASTICSEARCH_IMAGE: docker.elastic.co/elasticsearch/elasticsearch:8.19.15
       DOCKER_PLATFORMS: "linux/arm64,linux/amd64" # build AMD64 last so it gets picked up by the test
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/identity-e2e-tests.yml
+++ b/.github/workflows/identity-e2e-tests.yml
@@ -49,7 +49,7 @@ jobs:
     timeout-minutes: 15
     services:
       elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:8.19.13
+        image: docker.elastic.co/elasticsearch/elasticsearch:8.19.15
         env:
           discovery.type: single-node
           cluster.name: docker-cluster

--- a/.github/workflows/identity-regression-test.yml
+++ b/.github/workflows/identity-regression-test.yml
@@ -109,7 +109,7 @@ jobs:
 
     services:
       elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:8.19.13
+        image: docker.elastic.co/elasticsearch/elasticsearch:8.19.15
         env:
           discovery.type: single-node
           cluster.name: "ci-${{ matrix.case }}"

--- a/.github/workflows/operate-e2e-tests.yml
+++ b/.github/workflows/operate-e2e-tests.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: gcp-core-4-default
     services:
       elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:8.19.13
+        image: docker.elastic.co/elasticsearch/elasticsearch:8.19.15
         env:
           discovery.type: single-node
           cluster.name: docker-cluster

--- a/.github/workflows/tasklist-e2e-tests.yml
+++ b/.github/workflows/tasklist-e2e-tests.yml
@@ -47,7 +47,7 @@ jobs:
     if: ${{ needs.detect-changes.outputs.tasklist-backend-changes == 'true' || needs.detect-changes.outputs.tasklist-frontend-changes == 'true' }}
     services:
       elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:8.19.13
+        image: docker.elastic.co/elasticsearch/elasticsearch:8.19.15
         env:
           discovery.type: single-node
           cluster.name: docker-cluster

--- a/.github/workflows/zeebe-search-integration-tests.yml
+++ b/.github/workflows/zeebe-search-integration-tests.yml
@@ -31,16 +31,16 @@ jobs:
       fail-fast: false
       matrix: &database-matrix
         include:
-          # Elasticsearch 8 - Supported versions: 8.19.0 (min) to 8.19.11 (max)
+          # Elasticsearch 8 - Supported versions: 8.19.0 (min) to 8.19.15 (max)
           - database-name: "Elasticsearch 8.19.0"
             database-type: "elasticsearch8_19_0"
             database-container: "elasticsearch"
             database-image-version: "8.19.0"
             it-database-type: "es"
-          - database-name: "Elasticsearch 8.19.11"
-            database-type: "elasticsearch8_19_11"
+          - database-name: "Elasticsearch 8.19.15"
+            database-type: "elasticsearch8_19_15"
             database-container: "elasticsearch"
-            database-image-version: "8.19.11"
+            database-image-version: "8.19.15"
             it-database-type: "es"
           # Elasticsearch 9 - Supported versions: 9.2.0 (min) to 9.3.0 (max)
           - database-name: "Elasticsearch 9.2.0"

--- a/db/docker-compose.yml
+++ b/db/docker-compose.yml
@@ -92,7 +92,7 @@ services:
       start_period: 5s
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${IMAGE_VERSION:-8.19.11}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${IMAGE_VERSION:-8.19.15}
     container_name: elasticsearch
     environment:
       - discovery.type=single-node

--- a/operate/config/docker-compose.identity.yml
+++ b/operate/config/docker-compose.identity.yml
@@ -2,7 +2,7 @@ version: "3.6"
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.19.13
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.19.15
     container_name: elasticsearch
     environment:
       - discovery.type=single-node

--- a/operate/config/docker-compose.mt.yml
+++ b/operate/config/docker-compose.mt.yml
@@ -2,7 +2,7 @@ version: "3.6"
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.19.13
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.19.15
     container_name: elasticsearch
     environment:
       - discovery.type=single-node

--- a/operate/config/docker-compose.test.yml
+++ b/operate/config/docker-compose.test.yml
@@ -2,7 +2,7 @@ version: "3.6"
 #this docker-compose will start Elastic, Zeebe (with external data folder, which allows to update Zeebe), Operate and Tasklist
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.19.13
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.19.15
     container_name: elasticsearch
     environment:
       - discovery.type=single-node

--- a/operate/docker-compose.yml
+++ b/operate/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.19.13
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.19.15
     container_name: elasticsearch
     environment:
       - discovery.type=single-node

--- a/operate/qa/integration-tests/src/test/resources/config/application-test.yml
+++ b/operate/qa/integration-tests/src/test/resources/config/application-test.yml
@@ -1,5 +1,5 @@
 testcontainers:
-  elasticsearch: "docker.elastic.co/elasticsearch/elasticsearch:8.19.11"
+  elasticsearch: "docker.elastic.co/elasticsearch/elasticsearch:8.19.15"
   opensearch: "opensearchproject/opensearch:2.19.4"
 
 # Unified Configuration

--- a/optimize/client/docker-compose.yml
+++ b/optimize/client/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION:-8.19.11}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION:-8.19.15}
     container_name: elasticsearch
     profiles: ['cloud', 'self-managed', 'cloud:elasticsearch', 'self-managed:elasticsearch']
     environment:

--- a/optimize/docker-compose.ccsm-with-optimize.yml
+++ b/optimize/docker-compose.ccsm-with-optimize.yml
@@ -111,7 +111,7 @@ services:
       - identity-network
   elasticsearch:
     profiles: ["", "elasticsearch"]
-    image: docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION:-8.19.11}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION:-8.19.15}
     container_name: elasticsearch
     environment:
       - cluster.name=elasticsearch

--- a/optimize/docker-compose.ccsm-without-optimize.yml
+++ b/optimize/docker-compose.ccsm-without-optimize.yml
@@ -93,7 +93,7 @@ services:
       - localhost
   elasticsearch:
     profiles: ["", "elasticsearch"]
-    image: docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION:-8.19.11}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION:-8.19.15}
     container_name: elasticsearch
     environment:
       - cluster.name=elasticsearch

--- a/optimize/docker-compose.yml
+++ b/optimize/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION:-8.19.11}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION:-8.19.15}
     # By leaving the first profile entry blank, this container will also start if no profile is defined (default)
     profiles: ["", "elasticsearch", "setup-integration-test"]
     container_name: elasticsearch

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -58,10 +58,10 @@
 
     <!-- DATABASE -->
     <!-- Elasticsearch-->
-    <version.elasticsearch-java-client>8.19.14</version.elasticsearch-java-client>
-    <version.elasticsearch>8.19.14</version.elasticsearch>
+    <version.elasticsearch>8.19.15</version.elasticsearch>
+    <version.elasticsearch-java-client>8.19.15</version.elasticsearch-java-client>
     <!-- The least supported elasticsearch version we should test against-->
-    <elasticsearch.test.version>8.19.11</elasticsearch.test.version>
+    <elasticsearch.test.version>8.19.15</elasticsearch.test.version>
     <!-- The ElasticSearch version of the previous Optimize version -->
     <previous.optimize.elasticsearch.version>8.16.6</previous.optimize.elasticsearch.version>
     <!-- https://www.elastic.co/guide/en/elasticsearch/client/java-api/6.5/_using_another_logger.html -->

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -54,8 +54,8 @@
     <version.commons-text>1.15.0</version.commons-text>
     <version.cron-utils>9.2.1</version.cron-utils>
     <version.docker-java-api>3.7.1</version.docker-java-api>
-    <version.elasticsearch-java-client>8.19.14</version.elasticsearch-java-client>
-    <version.elasticsearch>8.19.14</version.elasticsearch>
+    <version.elasticsearch-java-client>8.19.15</version.elasticsearch-java-client>
+    <version.elasticsearch>8.19.15</version.elasticsearch>
     <version.error-prone>2.48.0</version.error-prone>
     <version.grpc>1.79.0</version.grpc>
     <version.gson>2.13.2</version.gson>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - zeebe_network
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.19.13
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.19.15
     container_name: elasticsearch
     environment:
       - discovery.type=single-node

--- a/tasklist/config/docker-compose.yml
+++ b/tasklist/config/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - zeebe_network
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.19.13
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.19.15
     container_name: elasticsearch
     environment:
       - discovery.type=single-node

--- a/zeebe/exporters/elasticsearch-exporter/docker-compose.yml
+++ b/zeebe/exporters/elasticsearch-exporter/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
     elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:8.19.13
+        image: docker.elastic.co/elasticsearch/elasticsearch:8.19.15
         ports:
             - "9200:9200"
             - "9300:9300"


### PR DESCRIPTION
## Summary

- Bumps all CI workflow and docker-compose Elasticsearch 8 image references to `8.19.15` (from `8.19.11`, `8.19.13`, and `8.19.14`)
- Updates `version.elasticsearch` and `version.elasticsearch-java-client` in `parent/pom.xml` and `optimize/pom.xml`
- Updates `elasticsearch.test.version` in `optimize/pom.xml`
- Updates the max-version comment and test matrix entry in `zeebe-search-integration-tests.yml`

25 files changed, all purely version string updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)