### PR TITLE
deps: update Elasticsearch 8 CI test version to 8.19.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -559,7 +559,7 @@ jobs:
         include:
           - name: "Elasticsearch 8"
             database-type: "elasticsearch"
-            database-image-version: "8.19.11"
+            database-image-version: "8.19.15"
             database-name: "Elasticsearch 8"
             it-database-type: "es"
           - name: "Elasticsearch 9"
@@ -1026,7 +1026,7 @@ jobs:
           - 5000:5000
     env:
       LOCAL_DOCKER_IMAGE: localhost:5000/camunda/camunda
-      TEST_ELASTICSEARCH_IMAGE: docker.elastic.co/elasticsearch/elasticsearch:8.19.11
+      TEST_ELASTICSEARCH_IMAGE: docker.elastic.co/elasticsearch/elasticsearch:8.19.15
       DOCKER_PLATFORMS: "linux/arm64,linux/amd64" # build AMD64 last so it gets picked up by the test
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/zeebe-search-integration-tests.yml
+++ b/.github/workflows/zeebe-search-integration-tests.yml
@@ -31,16 +31,16 @@ jobs:
       fail-fast: false
       matrix: &database-matrix
         include:
-          # Elasticsearch 8 - Supported versions: 8.19.0 (min) to 8.19.11 (max)
+          # Elasticsearch 8 - Supported versions: 8.19.0 (min) to 8.19.15 (max)
           - database-name: "Elasticsearch 8.19.0"
             database-type: "elasticsearch8_19_0"
             database-container: "elasticsearch"
             database-image-version: "8.19.0"
             it-database-type: "es"
-          - database-name: "Elasticsearch 8.19.11"
-            database-type: "elasticsearch8_19_11"
+          - database-name: "Elasticsearch 8.19.15"
+            database-type: "elasticsearch8_19_15"
             database-container: "elasticsearch"
-            database-image-version: "8.19.11"
+            database-image-version: "8.19.15"
             it-database-type: "es"
           # Elasticsearch 9 - Supported versions: 9.2.0 (min) to 9.3.0 (max)
           - database-name: "Elasticsearch 9.2.0"


### PR DESCRIPTION
Bumps the max supported ES 8 version tested in CI from `8.19.11` to `8.19.15`.

- `ci.yml`: database integration test matrix + `TEST_ELASTICSEARCH_IMAGE`
- `zeebe-search-integration-tests.yml`: max-version matrix entry and comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)