### PR TITLE
fix: drop export of extensionProperties

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/MessageSubscriptionSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/MessageSubscriptionSearchIT.java
@@ -24,6 +24,7 @@ import io.camunda.qa.util.multidb.MultiDbTest;
 import java.util.Comparator;
 import java.util.List;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 @MultiDbTest
@@ -224,6 +225,7 @@ public class MessageSubscriptionSearchIT {
   }
 
   @Test
+  @Disabled("Will be re-eavaluated once we start exporting extensionProperties again")
   void shouldReturnExtensionPropertiesForStartEventSubscription() {
     // when
     final var result =

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/mcp-processes.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/mcp-processes.spec.ts
@@ -164,7 +164,8 @@ test.describe('Identity MCP Processes', () => {
     });
   });
 
-  test('MCP Processes rows can be expanded to show more tool information', async ({
+  // TODO: Re-evaluate once extensionProperties are exported again
+  test.skip('MCP Processes rows can be expanded to show more tool information', async ({
     identityMcpProcessesPage,
   }) => {
     await identityMcpProcessesPage.navigateToMcpProcesses();

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AbstractEventHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AbstractEventHandler.java
@@ -146,7 +146,6 @@ public abstract class AbstractEventHandler<R extends RecordValue>
               .map(p -> p.get(elementId))
               .orElse(Map.of());
       entity
-          .setExtensionProperties(ext)
           .setToolName(ProcessCacheUtil.getToolName(ext))
           .setInboundConnectorType(ProcessCacheUtil.getInboundConnectorType(ext));
     }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AbstractEventHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AbstractEventHandler.java
@@ -12,7 +12,6 @@ import static io.camunda.webapps.schema.descriptors.template.MessageSubscription
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.CORRELATION_KEY;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.DATE_TIME;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.EVENT_SOURCE_TYPE;
-import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.EXTENSION_PROPERTIES;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.FLOW_NODE_ID;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.INBOUND_CONNECTOR_TYPE;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.INCIDENT_ERROR_MSG;
@@ -99,7 +98,6 @@ public abstract class AbstractEventHandler<R extends RecordValue>
     jsonMap.put(FLOW_NODE_ID, entity.getFlowNodeId());
     jsonMap.put(PROCESS_DEFINITION_NAME, entity.getProcessDefinitionName());
     jsonMap.put(PROCESS_DEFINITION_VERSION, entity.getProcessDefinitionVersion());
-    jsonMap.put(EXTENSION_PROPERTIES, entity.getExtensionProperties());
     jsonMap.put(TOOL_NAME, entity.getToolName());
     jsonMap.put(INBOUND_CONNECTOR_TYPE, entity.getInboundConnectorType());
     jsonMap.put(positionFieldName, positionFieldValue);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromMessageStartEventSubscriptionHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromMessageStartEventSubscriptionHandlerTest.java
@@ -234,7 +234,7 @@ final class MessageSubscriptionFromMessageStartEventSubscriptionHandlerTest {
     // then
     assertThat(entity.getToolName()).isEqualTo("myTool");
     assertThat(entity.getInboundConnectorType()).isEqualTo("io.camunda:http-webhook:1");
-    assertThat(entity.getExtensionProperties()).isEqualTo(extProps);
+    // TODO: Add an assertion for the extension properties once they are included in the entity
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromMessageStartEventSubscriptionHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromMessageStartEventSubscriptionHandlerTest.java
@@ -303,7 +303,6 @@ final class MessageSubscriptionFromMessageStartEventSubscriptionHandlerTest {
     expectedUpdateFields.put("processDefinitionKey", null);
     expectedUpdateFields.put("processDefinitionName", null);
     expectedUpdateFields.put("processDefinitionVersion", null);
-    expectedUpdateFields.put("extensionProperties", null);
     expectedUpdateFields.put("toolName", null);
     expectedUpdateFields.put("inboundConnectorType", null);
     expectedUpdateFields.put("metadata", metadataMap);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromProcessMessageSubscriptionHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromProcessMessageSubscriptionHandlerTest.java
@@ -372,7 +372,7 @@ final class MessageSubscriptionFromProcessMessageSubscriptionHandlerTest {
     // then
     assertThat(entity.getToolName()).isEqualTo("myTool");
     assertThat(entity.getInboundConnectorType()).isEqualTo("io.camunda:http-webhook:1");
-    assertThat(entity.getExtensionProperties()).isEqualTo(extProps);
+    // TODO: Add an assertion for the extension properties once they are included in the entity
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromProcessMessageSubscriptionHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromProcessMessageSubscriptionHandlerTest.java
@@ -441,7 +441,6 @@ final class MessageSubscriptionFromProcessMessageSubscriptionHandlerTest {
     expectedUpdateFields.put("processDefinitionKey", null);
     expectedUpdateFields.put("processDefinitionName", null);
     expectedUpdateFields.put("processDefinitionVersion", null);
-    expectedUpdateFields.put("extensionProperties", null);
     expectedUpdateFields.put("toolName", null);
     expectedUpdateFields.put("inboundConnectorType", null);
     expectedUpdateFields.put("metadata", metadataMap);

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionExportHandler.java
@@ -94,7 +94,7 @@ public class MessageSubscriptionExportHandler
         .processDefinitionName(
             cached.map(CachedProcessEntity::name).filter(s -> !s.isBlank()).orElse(null))
         .processDefinitionVersion(cached.map(CachedProcessEntity::version).orElse(null))
-        .extensionProperties(ext)
+        .extensionProperties(Map.of())
         .toolName(ProcessCacheUtil.getToolName(ext))
         .inboundConnectorType(ProcessCacheUtil.getInboundConnectorType(ext))
         .build();

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionFromMessageStartEventSubscriptionExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionFromMessageStartEventSubscriptionExportHandler.java
@@ -93,7 +93,7 @@ public class MessageSubscriptionFromMessageStartEventSubscriptionExportHandler
         .processDefinitionName(
             cached.map(CachedProcessEntity::name).filter(s -> !s.isBlank()).orElse(null))
         .processDefinitionVersion(cached.map(CachedProcessEntity::version).orElse(null))
-        .extensionProperties(ext)
+        .extensionProperties(Map.of())
         .toolName(ProcessCacheUtil.getToolName(ext))
         .inboundConnectorType(ProcessCacheUtil.getInboundConnectorType(ext))
         .build();

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/message/MessageSubscriptionExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/message/MessageSubscriptionExportHandlerTest.java
@@ -195,7 +195,7 @@ final class MessageSubscriptionExportHandlerTest {
         .isEqualTo(DateUtil.toOffsetDateTime(Instant.ofEpochMilli(timestamp)));
     assertThat(model.processDefinitionName()).isEqualTo(processName);
     assertThat(model.processDefinitionVersion()).isEqualTo(processVersion);
-    assertThat(model.extensionProperties()).isEqualTo(extProps);
+    assertThat(model.extensionProperties()).isEqualTo(Map.of());
     assertThat(model.toolName()).isEqualTo("myTool");
     assertThat(model.inboundConnectorType()).isEqualTo("io.camunda:http-webhook:1");
   }

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/message/MessageSubscriptionFromMessageStartEventSubscriptionExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/message/MessageSubscriptionFromMessageStartEventSubscriptionExportHandlerTest.java
@@ -187,7 +187,7 @@ final class MessageSubscriptionFromMessageStartEventSubscriptionExportHandlerTes
         .isEqualTo(DateUtil.toOffsetDateTime(Instant.ofEpochMilli(timestamp)));
     assertThat(model.processDefinitionName()).isEqualTo(processName);
     assertThat(model.processDefinitionVersion()).isEqualTo(processVersion);
-    assertThat(model.extensionProperties()).isEqualTo(extProps);
+    assertThat(model.extensionProperties()).isEqualTo(Map.of());
     assertThat(model.toolName()).isEqualTo("myTool");
     assertThat(model.inboundConnectorType()).isEqualTo("io.camunda:http-webhook:1");
   }


### PR DESCRIPTION
## Description

`extensionProperties` is causing some issues during benchmarking, see [relevant thread](https://camunda.slack.com/archives/C0A731LU0FP/p1777990214799149).

It is decided that we temporarily stop the export of `extensionProperties`.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
