### PR TITLE
fix: use shallow checkout in check-saas-version workflow

### DIFF
--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -266,6 +266,7 @@ runs:
           - 'parent/**'
           - '**/pom.xml'
           - '.mvn/**'
+          - '.ci/db-versions.yml'
 
         validate-pom-metadata-extra-change:
           - 'mvnw'

--- a/.github/workflows/check-saas-version.yml
+++ b/.github/workflows/check-saas-version.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 0
+          fetch-depth: 1
       - name: Install Python dependencies
         run: python3 -m pip install -q --disable-pip-version-check pyyaml==6.0.2
       - name: Compare SaaS version against main


### PR DESCRIPTION
## Summary

- `fetch-depth: 0` caused the workflow to clone the entire repository history, consistently timing out the job on the large camunda monorepo
- Changed to `fetch-depth: 1` since the workflow only needs the current `.ci/db-versions.yml` — `origin/main` is already fetched separately with `--depth=1` in the script

## Test plan

- [ ] Verify the job completes in seconds on a PR that modifies `.ci/db-versions.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)