### PR TITLE
ci: read Elasticsearch version from db-versions.yml in e2e workflows

### DIFF
--- a/.github/workflows/operate-e2e-tests.yml
+++ b/.github/workflows/operate-e2e-tests.yml
@@ -41,11 +41,24 @@ concurrency:
   group: ${{ format('{0}-{1}', github.workflow, github.ref == 'refs/heads/main' && github.sha || github.ref) }}
 
 jobs:
+  read-versions:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      elasticsearch-8: ${{ steps.db-versions.outputs.elasticsearch-8 }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Read DB versions
+        id: db-versions
+        uses: ./.github/actions/read-db-versions
+
   test:
+    needs: [read-versions]
     runs-on: gcp-core-4-default
     services:
       elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:8.19.13
+        image: docker.elastic.co/elasticsearch/elasticsearch:${{ needs.read-versions.outputs.elasticsearch-8 }}
         env:
           discovery.type: single-node
           cluster.name: docker-cluster

--- a/.github/workflows/operate-e2e-tests.yml
+++ b/.github/workflows/operate-e2e-tests.yml
@@ -48,7 +48,7 @@ jobs:
     outputs:
       elasticsearch-8: ${{ steps.db-versions.outputs.elasticsearch-8 }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Read DB versions
         id: db-versions
         uses: ./.github/actions/read-db-versions

--- a/.github/workflows/tasklist-e2e-tests.yml
+++ b/.github/workflows/tasklist-e2e-tests.yml
@@ -37,15 +37,27 @@ jobs:
         uses: ./.github/actions/paths-filter
         id: filter
 
+  read-versions:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      elasticsearch-8: ${{ steps.db-versions.outputs.elasticsearch-8 }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Read DB versions
+        id: db-versions
+        uses: ./.github/actions/read-db-versions
+
   test:
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
-    needs: [detect-changes]
+    needs: [detect-changes, read-versions]
     if: ${{ needs.detect-changes.outputs.tasklist-backend-changes == 'true' || needs.detect-changes.outputs.tasklist-frontend-changes == 'true' }}
     services:
       elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:8.19.13
+        image: docker.elastic.co/elasticsearch/elasticsearch:${{ needs.read-versions.outputs.elasticsearch-8 }}
         env:
           discovery.type: single-node
           cluster.name: docker-cluster

--- a/.github/workflows/tasklist-e2e-tests.yml
+++ b/.github/workflows/tasklist-e2e-tests.yml
@@ -38,13 +38,15 @@ jobs:
         id: filter
 
   read-versions:
+    needs: [detect-changes]
+    if: ${{ needs.detect-changes.outputs.tasklist-backend-changes == 'true' || needs.detect-changes.outputs.tasklist-frontend-changes == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     outputs:
       elasticsearch-8: ${{ steps.db-versions.outputs.elasticsearch-8 }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Read DB versions
         id: db-versions
         uses: ./.github/actions/read-db-versions


### PR DESCRIPTION
## Summary
- Wires `operate-e2e-tests.yml` and `tasklist-e2e-tests.yml` into the centralized `.ci/db-versions.yml` via the `read-db-versions` action, replacing hardcoded `elasticsearch:8.19.13` tags.
- The two identity workflows listed in #52507 (`identity-e2e-tests.yml`, `identity-regression-test.yml`) were already wired and require no changes.

Closes #52507

## Test plan
- [ ] Workflows pick up the latest es8 version from `.ci/db-versions.yml` (`8.19.13` at the time of writing) and start the Elasticsearch service container successfully.
- [ ] `Operate / E2E Tests` job passes on this PR.
- [ ] `Tasklist / E2E Tests` job passes on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)