### PR TITLE
Fix authorization config keys

### DIFF
--- a/dist/src/main/java/io/camunda/application/ModesAndProfilesProcessor.java
+++ b/dist/src/main/java/io/camunda/application/ModesAndProfilesProcessor.java
@@ -64,7 +64,7 @@ public class ModesAndProfilesProcessor implements SpringApplicationRunListener {
       setProperty("zeebe.broker.gateway.security.enabled", false); // embedded gateway
       setProperty("zeebe.gateway.security.enabled", false); // dedicated gateway
       setProperty("camunda.security.authentication.unprotected-api", true);
-      setProperty("camunda.security.authentication.authorizations.enabled", false);
+      setProperty("camunda.security.authorizations.enabled", false);
     }
 
     switch (getMode().toLowerCase()) {

--- a/dist/src/main/java/io/camunda/application/initializers/DefaultAuthenticationInitializer.java
+++ b/dist/src/main/java/io/camunda/application/initializers/DefaultAuthenticationInitializer.java
@@ -39,7 +39,7 @@ public class DefaultAuthenticationInitializer
               "zeebe.broker.gateway.security.enabled", false, // embedded gateway
               "zeebe.gateway.security.enabled", false, // dedicated gateway
               "camunda.security.authentication.unprotected-api", true,
-              "camunda.security,authorizations.enabled", false);
+              "camunda.security.authorizations.enabled", false);
       DefaultPropertiesPropertySource.addOrMerge(propertyMap, propertySources);
     }
   }

--- a/dist/src/test/java/io/camunda/application/ModesAndProfilesProcessorTest.java
+++ b/dist/src/test/java/io/camunda/application/ModesAndProfilesProcessorTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.SpringApplication;
+import org.springframework.mock.env.MockEnvironment;
+
+class ModesAndProfilesProcessorTest {
+
+  @Test
+  void shouldSetInsecureSecurityPropertiesUnderTheCorrectKeysWhenInsecureModeIsEnabled() {
+    // given a StandaloneCamunda app launched with --camunda.mode=all-in-one --camunda.insecure=true
+    final MockEnvironment environment = new MockEnvironment();
+    environment.setProperty("camunda.mode", "all-in-one");
+    environment.setProperty("camunda.insecure", "true");
+
+    // when the listener prepares the environment
+    new ModesAndProfilesProcessor(standaloneCamundaApplication(), new String[] {})
+        .environmentPrepared(null, environment);
+
+    // then all four insecure-mode defaults are bound under the keys SecurityConfiguration expects
+    assertThat(environment.getProperty("zeebe.broker.gateway.security.enabled", Boolean.class))
+        .isFalse();
+    assertThat(environment.getProperty("zeebe.gateway.security.enabled", Boolean.class)).isFalse();
+    assertThat(
+            environment.getProperty(
+                "camunda.security.authentication.unprotected-api", Boolean.class))
+        .isTrue();
+    assertThat(environment.getProperty("camunda.security.authorizations.enabled", Boolean.class))
+        .isFalse();
+  }
+
+  @Test
+  void shouldNotSetInsecureSecurityPropertiesWhenInsecureFlagIsAbsent() {
+    // given a StandaloneCamunda app launched with --camunda.mode=all-in-one but no insecure flag
+    final MockEnvironment environment = new MockEnvironment();
+    environment.setProperty("camunda.mode", "all-in-one");
+
+    // when the listener prepares the environment
+    new ModesAndProfilesProcessor(standaloneCamundaApplication(), new String[] {})
+        .environmentPrepared(null, environment);
+
+    // then no insecure-mode security defaults are bound
+    assertThat(environment.getProperty("zeebe.broker.gateway.security.enabled")).isNull();
+    assertThat(environment.getProperty("zeebe.gateway.security.enabled")).isNull();
+    assertThat(environment.getProperty("camunda.security.authentication.unprotected-api")).isNull();
+    assertThat(environment.getProperty("camunda.security.authorizations.enabled")).isNull();
+  }
+
+  private static SpringApplication standaloneCamundaApplication() {
+    final SpringApplication application = mock(SpringApplication.class);
+    when(application.getMainApplicationClass()).thenReturn((Class) StandaloneCamunda.class);
+    return application;
+  }
+}


### PR DESCRIPTION
## Description

`DefaultAuthenticationInitializer` has typo:

```
final Map<String, Object> propertyMap =
    Map.of(
        "zeebe.broker.gateway.security.enabled", false,
        "zeebe.gateway.security.enabled", false,
        "camunda.security.authentication.unprotected-api", true,
        "camunda.security,authorizations.enabled", false);   // ← comma instead of dot
 ```
 
`ModesAndProfilesProcessor.java` used when launched via `--camunda.insecure=true` mode flag has a different but also wrong key:

```
setProperty("camunda.security.authentication.authorizations.enabled", false);
```

That path doesn't exist on `SecurityConfiguration` (authorizations is a sibling of authentication, not nested under it), so the mode-based path is also a no-op for authorization disabling.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #[52486](https://github.com/camunda/camunda/issues/52486)
