### PR TITLE
test(qa): stabilize nightly API tests against stable/8.9 cluster

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-cancel-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-cancel-api-tests.spec.ts
@@ -22,7 +22,7 @@ import {
   cancelBatchOperation,
   createCompletedBatchOperation,
 } from '@requestHelpers';
-import { validateResponse } from 'json-body-assertions';
+import {validateResponse} from 'json-body-assertions';
 
 /* eslint-disable playwright/expect-expect */
 
@@ -48,8 +48,12 @@ test.describe.parallel('Cancel Batch Operation Tests', () => {
       });
 
     await test.step('Cancel batch operation', async () => {
-      const res = await cancelBatchOperation(request, key);
-      await assertStatusCode(res, 204);
+      // The batch operation may not be visible to the cancel endpoint
+      // immediately after creation; retry on 404 until it is.
+      await expect(async () => {
+        const res = await cancelBatchOperation(request, key);
+        await assertStatusCode(res, 204);
+      }).toPass(defaultAssertionOptions);
     });
 
     await test.step('Poll batch status', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/cluster-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/cluster-api-tests.spec.ts
@@ -31,7 +31,14 @@ test.describe('Cluster API Tests', () => {
     );
     const result = await res.json();
     expect(result.brokers).toHaveLength(1);
-    expect(result.brokers[0].partitions).toHaveLength(1);
+    // Partition count is environment-dependent (single-broker clusters can be
+    // configured with 1 or more partitions). Assert health/role rather than
+    // a hard-coded count to keep the test stable across environments.
+    expect(result.brokers[0].partitions.length).toBeGreaterThanOrEqual(1);
+    for (const partition of result.brokers[0].partitions) {
+      expect(partition.health).toBe('healthy');
+      expect(partition.role).toBe('leader');
+    }
   });
 
   test('Get Cluster Topology - Unauthorized', async ({request}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-completion-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-completion-api-tests.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {test} from '@playwright/test';
+import {expect, test} from '@playwright/test';
 import {
   cancelProcessInstance,
   createInstances,
@@ -20,6 +20,7 @@ import {
   jsonHeaders,
 } from '../../../../utils/http';
 import {activateJobToObtainAValidJobKey} from '@requestHelpers';
+import {defaultAssertionOptions} from '../../../../utils/constants';
 
 // Running the job tests on the same process instance leads to conflicts
 /* eslint-disable playwright/expect-expect */
@@ -103,17 +104,21 @@ test.describe('Job Completion API Tests', () => {
     });
 
     await test.step('First completion (should succeed)', async () => {
-      const completeRes = await request.post(
-        buildUrl(`/jobs/${localState['jobKey']}/failure`),
-        {
-          headers: jsonHeaders(),
-          data: {
-            retries: 0,
-            errorMessage: 'Simulated failure',
+      // Job activation is observed before the job is fully visible to the
+      // /jobs/{jobKey}/failure endpoint. Retry on 404 until visibility catches up.
+      await expect(async () => {
+        const completeRes = await request.post(
+          buildUrl(`/jobs/${localState['jobKey']}/failure`),
+          {
+            headers: jsonHeaders(),
+            data: {
+              retries: 0,
+              errorMessage: 'Simulated failure',
+            },
           },
-        },
-      );
-      await assertStatusCode(completeRes, 204);
+        );
+        await assertStatusCode(completeRes, 204);
+      }).toPass(defaultAssertionOptions);
     });
 
     await test.step('Second completion (should conflict)', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-completion-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-completion-api-tests.spec.ts
@@ -103,7 +103,7 @@ test.describe('Job Completion API Tests', () => {
       );
     });
 
-    await test.step('First completion (should succeed)', async () => {
+    await test.step('Fail the job (drains retries to produce conflict)', async () => {
       // Job activation is observed before the job is fully visible to the
       // /jobs/{jobKey}/failure endpoint. Retry on 404 until visibility catches up.
       await expect(async () => {
@@ -121,7 +121,7 @@ test.describe('Job Completion API Tests', () => {
       }).toPass(defaultAssertionOptions);
     });
 
-    await test.step('Second completion (should conflict)', async () => {
+    await test.step('Attempt completion (should conflict 409)', async () => {
       const completeAgainRes = await request.post(
         buildUrl(`/jobs/${localState['jobKey']}/completion`),
         {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-update-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-update-api-tests.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {test} from '@playwright/test';
+import {expect, test} from '@playwright/test';
 import {
   assertBadRequest,
   assertNotFoundRequest,
@@ -18,6 +18,7 @@ import {
   activateJobToObtainAValidJobKey,
   setupProcessInstanceForTests,
 } from '@requestHelpers';
+import {defaultAssertionOptions} from '../../../../utils/constants';
 
 /* eslint-disable playwright/expect-expect */
 test.describe('Job Update API Tests', () => {
@@ -36,13 +37,17 @@ test.describe('Job Update API Tests', () => {
     );
 
     await test.step('PATCH update the job', async () => {
-      const updateRes = await request.patch(buildUrl(`/jobs/${jobKey}`), {
-        headers: jsonHeaders(),
-        data: {
-          changeset: {retries: 1, timeout: 9000},
-        },
-      });
-      await assertStatusCode(updateRes, 204);
+      // Job activation is observed before the job is fully visible to the
+      // /jobs/{jobKey} endpoint. Retry on 404 until visibility catches up.
+      await expect(async () => {
+        const updateRes = await request.patch(buildUrl(`/jobs/${jobKey}`), {
+          headers: jsonHeaders(),
+          data: {
+            changeset: {retries: 1, timeout: 9000},
+          },
+        });
+        await assertStatusCode(updateRes, 204);
+      }).toPass(defaultAssertionOptions);
     });
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-resolve-related-incident-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-resolve-related-incident-api.spec.ts
@@ -88,6 +88,10 @@ test.describe.parallel('Resolve related incidents API Tests', () => {
 
     await test.step('Search for incidents related to created process instance', async () => {
       await expect(async () => {
+        // Reset accumulators on every retry so leftover state from a prior
+        // (failed) iteration does not pollute the assertion.
+        elementInstanceKey = '';
+        incidentKeys = [];
         const incidents = await request.post(
           buildUrl(
             `/process-instances/${processInstanceKeyWithIncidentToResolve}/incidents/search`,


### PR DESCRIPTION
## Description

Stabilizes the C8 Orchestration Cluster nightly API tests on `stable/8.9`. Investigated from run [25411706244](https://github.com/camunda/camunda/actions/runs/25411706244), which produced **1 failed + 5 flaky** out of 1009 passing tests.

## Root causes & fixes

### 1. Hard failure: `Cluster API Tests › Get Cluster Topology`
The test asserted `partitions.length === 1`, but the stable/8.9 nightly cluster runs with 2 partitions (both healthy/leader). Replaced the hard-coded count with a shape-based assertion that checks each partition is `healthy` and `leader`. Cluster shape is set by docker-compose, not by the test; this keeps the contract focused on what the API guarantees.

### 2. Flaky: `Resolve related incidents of a process instance`
The retry block accumulated `incidentKeys` and `elementInstanceKey` across iterations, eventually surfacing as `Received: 53` instead of `2`. Both accumulators are now reset at the top of each `toPass` iteration.

### 3. Flaky: `Cancel active batch operation`
First cancel call could return 404 while the freshly-created batch was still propagating. Wrapped in `toPass` so the cancel retries until the batch is visible.

### 4. Flaky: `Update Job - success` and `Complete Job - conflict 409 (first failure)`
Same pattern: the first request following `activateJobToObtainAValidJobKey` could see 404 before the job was fully visible. Wrapped in `toPass`.

## Out of scope
- Usage-metrics flake (#224) is already wrapped in `toPass`; the timeout exceeded 30s, suggesting an authorization-propagation lag worth investigating separately.

## Verification
https://github.com/camunda/camunda/actions/runs/25424747367
- All edited tests passed, some other failed due to flakiness will be investigated seperately