### PR TITLE
feat: rename extensionProperties to toolProperties in message subscriptions

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/response/MessageSubscription.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/MessageSubscription.java
@@ -61,7 +61,7 @@ public interface MessageSubscription {
 
   Integer getProcessDefinitionVersion();
 
-  Map<String, String> getExtensionProperties();
+  Map<String, String> getToolProperties();
 
   String getToolName();
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/MessageSubscriptionImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/MessageSubscriptionImpl.java
@@ -42,7 +42,7 @@ public class MessageSubscriptionImpl implements MessageSubscription {
   private final String tenantId;
   private final String processDefinitionName;
   private final Integer processDefinitionVersion;
-  private final Map<String, String> extensionProperties;
+  private final Map<String, String> toolProperties;
   private final String toolName;
   private final String inboundConnectorType;
 
@@ -64,7 +64,7 @@ public class MessageSubscriptionImpl implements MessageSubscription {
     tenantId = item.getTenantId();
     processDefinitionName = item.getProcessDefinitionName();
     processDefinitionVersion = item.getProcessDefinitionVersion();
-    extensionProperties = item.getExtensionProperties();
+    toolProperties = item.getToolProperties();
     toolName = item.getToolName();
     inboundConnectorType = item.getInboundConnectorType();
   }
@@ -145,8 +145,8 @@ public class MessageSubscriptionImpl implements MessageSubscription {
   }
 
   @Override
-  public Map<String, String> getExtensionProperties() {
-    return extensionProperties;
+  public Map<String, String> getToolProperties() {
+    return toolProperties;
   }
 
   @Override
@@ -177,7 +177,7 @@ public class MessageSubscriptionImpl implements MessageSubscription {
         tenantId,
         processDefinitionName,
         processDefinitionVersion,
-        extensionProperties,
+        toolProperties,
         toolName,
         inboundConnectorType);
   }
@@ -206,7 +206,7 @@ public class MessageSubscriptionImpl implements MessageSubscription {
         && Objects.equals(tenantId, subscription.tenantId)
         && Objects.equals(processDefinitionName, subscription.processDefinitionName)
         && Objects.equals(processDefinitionVersion, subscription.processDefinitionVersion)
-        && Objects.equals(extensionProperties, subscription.extensionProperties)
+        && Objects.equals(toolProperties, subscription.toolProperties)
         && Objects.equals(toolName, subscription.toolName)
         && Objects.equals(inboundConnectorType, subscription.inboundConnectorType);
   }

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
@@ -66,14 +66,14 @@
     </addColumn>
   </changeSet>
 
-  <changeSet id="add_message_subscription_extension_properties_column" author="camunda">
+  <changeSet id="add_message_subscription_tool_properties_column" author="camunda">
     <preConditions onFail="MARK_RAN">
       <not>
-        <columnExists tableName="${prefix}MESSAGE_SUBSCRIPTION" columnName="EXTENSION_PROPERTIES"/>
+        <columnExists tableName="${prefix}MESSAGE_SUBSCRIPTION" columnName="TOOL_PROPERTIES"/>
       </not>
     </preConditions>
     <addColumn tableName="${prefix}MESSAGE_SUBSCRIPTION">
-      <column name="EXTENSION_PROPERTIES" type="CLOB"/>
+      <column name="TOOL_PROPERTIES" type="CLOB"/>
     </addColumn>
   </changeSet>
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/MessageSubscriptionEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/MessageSubscriptionEntityMapper.java
@@ -32,7 +32,7 @@ public class MessageSubscriptionEntityMapper {
         .tenantId(nullToEmpty(messageSubscriptionDbModel.tenantId()))
         .processDefinitionName(nullToEmpty(messageSubscriptionDbModel.processDefinitionName()))
         .processDefinitionVersion(messageSubscriptionDbModel.processDefinitionVersion())
-        .extensionProperties(messageSubscriptionDbModel.extensionProperties())
+        .toolProperties(messageSubscriptionDbModel.toolProperties())
         .toolName(messageSubscriptionDbModel.toolName())
         .inboundConnectorType(messageSubscriptionDbModel.inboundConnectorType())
         .build();

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/MessageSubscriptionDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/MessageSubscriptionDbModel.java
@@ -32,8 +32,8 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
   private int partitionId;
   private String processDefinitionName;
   private Integer processDefinitionVersion;
-  private String serializedExtensionProperties;
-  private Map<String, String> extensionProperties;
+  private String serializedToolProperties;
+  private Map<String, String> toolProperties;
   private String toolName;
   private String inboundConnectorType;
 
@@ -58,7 +58,7 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
       final int partitionId,
       final String processDefinitionName,
       final Integer processDefinitionVersion,
-      final Map<String, String> extensionProperties,
+      final Map<String, String> toolProperties,
       final String toolName,
       final String inboundConnectorType) {
     this.messageSubscriptionKey = messageSubscriptionKey;
@@ -77,8 +77,8 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
     this.partitionId = partitionId;
     this.processDefinitionName = processDefinitionName;
     this.processDefinitionVersion = processDefinitionVersion;
-    serializedExtensionProperties = MapSerializer.serialize(extensionProperties);
-    this.extensionProperties = extensionProperties;
+    serializedToolProperties = MapSerializer.serialize(toolProperties);
+    this.toolProperties = toolProperties;
     this.toolName = toolName;
     this.inboundConnectorType = inboundConnectorType;
   }
@@ -171,17 +171,17 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
     this.processDefinitionVersion = processDefinitionVersion;
   }
 
-  public String serializedExtensionProperties() {
-    return serializedExtensionProperties;
+  public String serializedToolProperties() {
+    return serializedToolProperties;
   }
 
-  public void setSerializedExtensionProperties(final String serializedExtensionProperties) {
-    this.serializedExtensionProperties = serializedExtensionProperties;
-    extensionProperties = MapSerializer.deserialize(serializedExtensionProperties);
+  public void setSerializedToolProperties(final String serializedToolProperties) {
+    this.serializedToolProperties = serializedToolProperties;
+    toolProperties = MapSerializer.deserialize(serializedToolProperties);
   }
 
-  public Map<String, String> extensionProperties() {
-    return extensionProperties;
+  public Map<String, String> toolProperties() {
+    return toolProperties;
   }
 
   public String toolName() {
@@ -267,7 +267,7 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
         .partitionId(partitionId)
         .processDefinitionName(processDefinitionName)
         .processDefinitionVersion(processDefinitionVersion)
-        .extensionProperties(extensionProperties)
+        .toolProperties(toolProperties)
         .toolName(toolName)
         .inboundConnectorType(inboundConnectorType);
   }
@@ -289,7 +289,7 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
     private int partitionId;
     private String processDefinitionName;
     private Integer processDefinitionVersion;
-    private Map<String, String> extensionProperties;
+    private Map<String, String> toolProperties;
     private String toolName;
     private String inboundConnectorType;
 
@@ -349,8 +349,8 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
       return this;
     }
 
-    public Builder extensionProperties(final Map<String, String> extensionProperties) {
-      this.extensionProperties = extensionProperties;
+    public Builder toolProperties(final Map<String, String> toolProperties) {
+      this.toolProperties = toolProperties;
       return this;
     }
 
@@ -408,7 +408,7 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
           partitionId,
           processDefinitionName,
           processDefinitionVersion,
-          extensionProperties,
+          toolProperties,
           toolName,
           inboundConnectorType);
     }

--- a/db/rdbms/src/main/resources/mapper/MessageSubscriptionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/MessageSubscriptionMapper.xml
@@ -43,7 +43,7 @@
     PARTITION_ID,
     PROCESS_DEFINITION_NAME,
     PROCESS_DEFINITION_VERSION,
-    EXTENSION_PROPERTIES,
+    TOOL_PROPERTIES,
     TOOL_NAME,
     INBOUND_CONNECTOR_TYPE
     FROM ${prefix}MESSAGE_SUBSCRIPTION
@@ -194,7 +194,7 @@
     <result column="PARTITION_ID" property="partitionId" javaType="java.lang.Integer" />
     <result column="PROCESS_DEFINITION_NAME" property="processDefinitionName" javaType="java.lang.String" />
     <result column="PROCESS_DEFINITION_VERSION" property="processDefinitionVersion" javaType="java.lang.Integer" />
-    <result column="EXTENSION_PROPERTIES" property="serializedExtensionProperties" javaType="java.lang.String" />
+    <result column="TOOL_PROPERTIES" property="serializedToolProperties" javaType="java.lang.String" />
     <result column="TOOL_NAME" property="toolName" javaType="java.lang.String" />
     <result column="INBOUND_CONNECTOR_TYPE" property="inboundConnectorType" javaType="java.lang.String" />
   </resultMap>
@@ -218,7 +218,7 @@
                                                PARTITION_ID,
                                                PROCESS_DEFINITION_NAME,
                                                PROCESS_DEFINITION_VERSION,
-                                               EXTENSION_PROPERTIES,
+                                               TOOL_PROPERTIES,
                                                TOOL_NAME,
                                                INBOUND_CONNECTOR_TYPE
     )
@@ -239,7 +239,7 @@
             #{partitionId},
             #{processDefinitionName},
             #{processDefinitionVersion},
-            #{serializedExtensionProperties},
+            #{serializedToolProperties},
             #{toolName},
             #{inboundConnectorType}
     )
@@ -260,7 +260,7 @@
         TENANT_ID = #{tenantId},
         PROCESS_DEFINITION_NAME = #{processDefinitionName},
         PROCESS_DEFINITION_VERSION = #{processDefinitionVersion},
-        EXTENSION_PROPERTIES = #{serializedExtensionProperties},
+        TOOL_PROPERTIES = #{serializedToolProperties},
         TOOL_NAME = #{toolName},
         INBOUND_CONNECTOR_TYPE = #{inboundConnectorType}
     WHERE MESSAGE_SUBSCRIPTION_KEY = #{messageSubscriptionKey}

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/MessageSubscriptionEntityMapperTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/MessageSubscriptionEntityMapperTest.java
@@ -37,7 +37,7 @@ public class MessageSubscriptionEntityMapperTest {
             .tenantId("tenantId")
             .processDefinitionName("My Process")
             .processDefinitionVersion(2)
-            .extensionProperties(Map.of("key1", "value1"))
+            .toolProperties(Map.of("key1", "value1"))
             .build();
 
     // When
@@ -66,7 +66,7 @@ public class MessageSubscriptionEntityMapperTest {
             .tenantId(null)
             .processDefinitionName(null)
             .processDefinitionVersion(null)
-            .extensionProperties(null)
+            .toolProperties(null)
             .build();
 
     // When
@@ -88,6 +88,6 @@ public class MessageSubscriptionEntityMapperTest {
     assertThat(entity.processDefinitionName())
         .isEqualTo(""); // Oracle treats empty strings as NULL, mapper converts back to ""
     assertThat(entity.processDefinitionVersion()).isNull();
-    assertThat(entity.extensionProperties()).isEqualTo(Map.of());
+    assertThat(entity.toolProperties()).isEqualTo(Map.of());
   }
 }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -1135,7 +1135,7 @@ public final class SearchQueryResponseMapper {
         .correlationKey(messageSubscription.correlationKey())
         .elementId(messageSubscription.flowNodeId())
         .elementInstanceKey(keyToStringOrNull(messageSubscription.flowNodeInstanceKey()))
-        .extensionProperties(messageSubscription.extensionProperties())
+        .toolProperties(messageSubscription.toolProperties())
         .inboundConnectorType(messageSubscription.inboundConnectorType())
         // `dateTime` can be absent on subscriptions that predate the field being populated;
         // fall back to the epoch sentinel (see EPOCH_DATE_SENTINEL) rather than 500.

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/processes/ProcessesToolRepository.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/processes/ProcessesToolRepository.java
@@ -136,7 +136,7 @@ public class ProcessesToolRepository implements ToolRepository {
 
   private Tool buildTool(final MessageSubscriptionEntity entity) {
     final String name = entity.toolName() + "_" + entity.messageSubscriptionKey();
-    final String description = buildDescription(entity.extensionProperties());
+    final String description = buildDescription(entity.toolProperties());
     return Tool.builder()
         .name(name)
         .title(entity.toolName())

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/processes/ProcessesToolRepositoryTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/processes/ProcessesToolRepositoryTest.java
@@ -59,14 +59,14 @@ class ProcessesToolRepositoryTest {
   private static MessageSubscriptionEntity buildStartSubscriptionEntity(
       final Long key,
       final String toolName,
-      final Map<String, String> extensionProperties,
+      final Map<String, String> toolProperties,
       final String messageName,
       final String tenantId,
       final MessageSubscriptionState state) {
     return MessageSubscriptionEntity.builder()
         .messageSubscriptionKey(key)
         .toolName(toolName)
-        .extensionProperties(extensionProperties)
+        .toolProperties(toolProperties)
         .messageName(messageName)
         .tenantId(tenantId)
         .messageSubscriptionState(state)

--- a/identity/client/package-lock.json
+++ b/identity/client/package-lock.json
@@ -8,7 +8,7 @@
       "name": "identity-frontend",
       "version": "8.10.0-SNAPSHOT",
       "dependencies": {
-        "@camunda/camunda-api-zod-schemas": "0.0.60",
+        "@camunda/camunda-api-zod-schemas": "0.0.62",
         "@camunda/camunda-composite-components": "0.22.6",
         "@carbon/elements": "11.87.0",
         "@carbon/react": "1.105.0",
@@ -326,9 +326,9 @@
       }
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.60",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.60.tgz",
-      "integrity": "sha512-A1tAjBmTrs7CVBkZNQAFXPnC6NOCKqFJk7COtWnyjj1jMSgEk3CPsXaTYrN6UhNKKheWqTbLQGp5bxN5phbpsw==",
+      "version": "0.0.62",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.62.tgz",
+      "integrity": "sha512-GRY+fGSAJnn7ez0a1gOD/uSd6L7z7eEljhSkW1Jr70Hudel97xo2hldh0snydZ7hjXqrSkQRX/daW3BE99/gFg==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/identity/client/package.json
+++ b/identity/client/package.json
@@ -18,7 +18,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@camunda/camunda-api-zod-schemas": "0.0.60",
+    "@camunda/camunda-api-zod-schemas": "0.0.62",
     "@camunda/camunda-composite-components": "0.22.6",
     "@carbon/elements": "11.87.0",
     "@carbon/react": "1.105.0",

--- a/identity/client/src/pages/mcp-processes/components/ExpandedToolDetails.tsx
+++ b/identity/client/src/pages/mcp-processes/components/ExpandedToolDetails.tsx
@@ -36,28 +36,28 @@ const SectionBody = styled.p`
 
 export const ExpandedToolDetails: FC<{ tool: McpProcessTool }> = ({ tool }) => {
   const { t } = useTranslate("mcpProcesses");
-  const data = tool.toolData;
+  const properties = tool.toolProperties;
 
   return (
     <>
       <SectionHeading>{t("toolPurpose")}</SectionHeading>
-      <SectionBody data-fallback={!data.purpose}>
-        {data.purpose ?? t("informationMissing")}
+      <SectionBody data-fallback={!properties.purpose}>
+        {properties.purpose ?? t("informationMissing")}
       </SectionBody>
 
       <SectionHeading>{t("toolResults")}</SectionHeading>
-      <SectionBody data-fallback={!data.results}>
-        {data.results ?? t("informationMissing")}
+      <SectionBody data-fallback={!properties.results}>
+        {properties.results ?? t("informationMissing")}
       </SectionBody>
 
       <SectionHeading>{t("toolWhenToUse")}</SectionHeading>
-      <SectionBody data-fallback={!data.whenToUse}>
-        {data.whenToUse ?? t("informationMissing")}
+      <SectionBody data-fallback={!properties.whenToUse}>
+        {properties.whenToUse ?? t("informationMissing")}
       </SectionBody>
 
       <SectionHeading>{t("toolWhenNotToUse")}</SectionHeading>
-      <SectionBody data-fallback={!data.whenNotToUse}>
-        {data.whenNotToUse ?? t("informationMissing")}
+      <SectionBody data-fallback={!properties.whenNotToUse}>
+        {properties.whenNotToUse ?? t("informationMissing")}
       </SectionBody>
     </>
   );

--- a/identity/client/src/pages/mcp-processes/useMcpProcessTools.ts
+++ b/identity/client/src/pages/mcp-processes/useMcpProcessTools.ts
@@ -19,7 +19,7 @@ type Sort = NonNullable<QueryMessageSubscriptionsRequestBody["sort"]>;
 const DEFAULT_SORT: Sort = [{ field: "toolName", order: "asc" }];
 
 const toolString = z.string().trim().min(1).nullable().default(null);
-const toolDataSchema = z
+const toolPropertiesSchema = z
   .looseObject({
     "io.camunda.tool:purpose": toolString,
     "io.camunda.tool:results": toolString,
@@ -37,7 +37,7 @@ export type McpProcessTool = {
   id: string;
   toolName: string;
   toolDescription: string;
-  toolData: z.output<typeof toolDataSchema>;
+  toolProperties: z.output<typeof toolPropertiesSchema>;
   processDefinitionKey: string | null;
   processDefinitionId: string;
   processDefinitionName: string;
@@ -51,12 +51,12 @@ const mapSubscriptionToProcessTool = (
   // `toolName` is expected to exist based on the filter supplied to the backend.
   if (!sub.toolName) return null;
 
-  const toolData = toolDataSchema.parse(sub.toolProperties ?? {});
+  const toolProperties = toolPropertiesSchema.parse(sub.toolProperties ?? {});
   return {
     id: sub.messageSubscriptionKey,
     toolName: sub.toolName,
-    toolDescription: toolData.purpose ?? "-",
-    toolData,
+    toolDescription: toolProperties.purpose ?? "-",
+    toolProperties,
     processDefinitionKey: sub.processDefinitionKey,
     processDefinitionId: sub.processDefinitionId,
     processDefinitionName: sub.processDefinitionName ?? sub.processDefinitionId,

--- a/identity/client/src/pages/mcp-processes/useMcpProcessTools.ts
+++ b/identity/client/src/pages/mcp-processes/useMcpProcessTools.ts
@@ -51,7 +51,7 @@ const mapSubscriptionToProcessTool = (
   // `toolName` is expected to exist based on the filter supplied to the backend.
   if (!sub.toolName) return null;
 
-  const toolData = toolDataSchema.parse(sub.extensionProperties ?? {});
+  const toolData = toolDataSchema.parse(sub.toolProperties ?? {});
   return {
     id: sub.messageSubscriptionKey,
     toolName: sub.toolName,

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/MessageSubscriptionSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/MessageSubscriptionSearchIT.java
@@ -14,6 +14,7 @@ import static io.camunda.it.util.TestHelper.waitForMessageSubscriptions;
 import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
 import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.search.enums.MessageSubscriptionState;
@@ -239,9 +240,7 @@ public class MessageSubscriptionSearchIT {
     // toolProperties only includes keys prefixed with "io.camunda.tool:"; "inbound.type" is
     // excluded
     assertThat(sub.getToolProperties())
-        .containsEntry("io.camunda.tool:name", "myWebhookTool")
-        .doesNotContainKey("inbound.type")
-        .doesNotContainKey("customKey");
+        .containsExactly(entry("io.camunda.tool:name", "myWebhookTool"));
     assertThat(sub.getToolName()).isEqualTo("myWebhookTool");
     assertThat(sub.getInboundConnectorType()).isEqualTo("io.camunda:http-webhook:1");
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/MessageSubscriptionSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/MessageSubscriptionSearchIT.java
@@ -24,7 +24,6 @@ import io.camunda.qa.util.multidb.MultiDbTest;
 import java.util.Comparator;
 import java.util.List;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 @MultiDbTest
@@ -225,8 +224,7 @@ public class MessageSubscriptionSearchIT {
   }
 
   @Test
-  @Disabled("Will be re-eavaluated once we start exporting extensionProperties again")
-  void shouldReturnExtensionPropertiesForStartEventSubscription() {
+  void shouldReturnToolPropertiesForStartEventSubscription() {
     // when
     final var result =
         camundaClient
@@ -238,9 +236,9 @@ public class MessageSubscriptionSearchIT {
     // then
     assertThat(result.items()).hasSize(1);
     final var sub = result.items().getFirst();
-    assertThat(sub.getExtensionProperties())
-        .containsEntry("customKey", "customValue")
-        .containsEntry("env", "test");
+    // toolProperties only includes keys prefixed with "io.camunda.tool:";
+    // the test process has no such keys, so the map is empty.
+    assertThat(sub.getToolProperties()).isEmpty();
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/MessageSubscriptionSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/MessageSubscriptionSearchIT.java
@@ -236,9 +236,49 @@ public class MessageSubscriptionSearchIT {
     // then
     assertThat(result.items()).hasSize(1);
     final var sub = result.items().getFirst();
-    // toolProperties only includes keys prefixed with "io.camunda.tool:";
-    // the test process has no such keys, so the map is empty.
-    assertThat(sub.getToolProperties()).isEmpty();
+    // toolProperties only includes keys prefixed with "io.camunda.tool:"; "inbound.type" is
+    // excluded
+    assertThat(sub.getToolProperties())
+        .containsEntry("io.camunda.tool:name", "myWebhookTool")
+        .doesNotContainKey("inbound.type")
+        .doesNotContainKey("customKey");
+    assertThat(sub.getToolName()).isEqualTo("myWebhookTool");
+    assertThat(sub.getInboundConnectorType()).isEqualTo("io.camunda:http-webhook:1");
+  }
+
+  @Test
+  void shouldFilterByToolName() {
+    // when
+    final var result =
+        camundaClient
+            .newMessageSubscriptionSearchRequest()
+            .filter(f -> f.toolName("myWebhookTool"))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().getFirst().getMessageSubscriptionType())
+        .isEqualTo(MessageSubscriptionType.START_EVENT);
+    assertThat(result.items().getFirst().getToolName()).isEqualTo("myWebhookTool");
+  }
+
+  @Test
+  void shouldFilterByInboundConnectorType() {
+    // when
+    final var result =
+        camundaClient
+            .newMessageSubscriptionSearchRequest()
+            .filter(f -> f.inboundConnectorType("io.camunda:http-webhook:1"))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().getFirst().getMessageSubscriptionType())
+        .isEqualTo(MessageSubscriptionType.START_EVENT);
+    assertThat(result.items().getFirst().getInboundConnectorType())
+        .isEqualTo("io.camunda:http-webhook:1");
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/MessageSubscriptionFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/MessageSubscriptionFixtures.java
@@ -41,7 +41,7 @@ public final class MessageSubscriptionFixtures extends CommonFixtures {
             .processDefinitionVersion((int) (Math.random() * 50))
             .messageSubscriptionType(randomEnum(MessageSubscriptionType.class))
             .messageSubscriptionState(randomEnum(MessageSubscriptionState.class))
-            .extensionProperties(Map.of("key-" + UUID.randomUUID(), "value-" + UUID.randomUUID()));
+            .toolProperties(Map.of("key-" + UUID.randomUUID(), "value-" + UUID.randomUUID()));
 
     return builderFunction.apply(builder).build();
   }

--- a/qa/acceptance-tests/src/test/resources/process/process_with_message_start_zeebe_properties.bpmn
+++ b/qa/acceptance-tests/src/test/resources/process/process_with_message_start_zeebe_properties.bpmn
@@ -11,8 +11,9 @@
     <bpmn:startEvent id="StartEvent_msg">
       <bpmn:extensionElements>
         <zeebe:properties>
+          <zeebe:property name="io.camunda.tool:name" value="myWebhookTool" />
+          <zeebe:property name="inbound.type" value="io.camunda:http-webhook:1" />
           <zeebe:property name="customKey" value="customValue" />
-          <zeebe:property name="env" value="test" />
         </zeebe:properties>
       </bpmn:extensionElements>
       <bpmn:outgoing>Flow_1</bpmn:outgoing>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/responses.json
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/responses.json
@@ -5000,6 +5000,10 @@
                   "nullable": true
                 },
                 {
+                  "name": "toolProperties",
+                  "type": "object"
+                },
+                {
                   "name": "inboundConnectorType",
                   "type": "string",
                   "nullable": true
@@ -5076,12 +5080,7 @@
                   "nullable": true
                 }
               ],
-              "optional": [
-                {
-                  "name": "extensionProperties",
-                  "type": "object"
-                }
-              ]
+              "optional": []
             }
           },
           {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message-subscriptions/mcp-message-subscription-search.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message-subscriptions/mcp-message-subscription-search.spec.ts
@@ -6,8 +6,6 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-/* eslint-disable playwright/no-skipped-test */
-
 import {test, expect} from '@playwright/test';
 import {
   buildUrl,
@@ -139,47 +137,43 @@ test.describe('MCP Message Subscription Search API Tests', () => {
       expect(types).toContain('PROCESS_EVENT');
     });
 
-    //Skipped due to bug: 52514 https://github.com/camunda/camunda/issues/52514
-    await test.step.skip(
-      'SC-API-04 — extensionProperties contains tool metadata',
-      async () => {
-        const res = await request.post(
-          buildUrl('/message-subscriptions/search'),
-          {
-            headers: jsonHeaders(),
-            data: {
-              filter: {
-                processDefinitionId: 'mcpProcessAlpha',
-                messageSubscriptionType: 'START_EVENT',
-              },
+    await test.step('SC-API-04 — toolProperties contains tool metadata', async () => {
+      const res = await request.post(
+        buildUrl('/message-subscriptions/search'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              processDefinitionId: 'mcpProcessAlpha',
+              messageSubscriptionType: 'START_EVENT',
             },
           },
-        );
-        await assertStatusCode(res, 200);
-        await validateResponse(
-          {
-            path: '/message-subscriptions/search',
-            method: 'POST',
-            status: '200',
-          },
-          res,
-        );
-        const json = await res.json();
-        expect(json.page.totalItems).toBeGreaterThanOrEqual(1);
+        },
+      );
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: '/message-subscriptions/search',
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+      const json = await res.json();
+      expect(json.page.totalItems).toBeGreaterThanOrEqual(1);
 
-        json.items.forEach(
-          (it: {extensionProperties: Record<string, string>}) => {
-            expect(it.extensionProperties).toBeDefined();
-            expect(it.extensionProperties['io.camunda.tool:name']).toBe(
-              'alpha-tool-name',
-            );
-            expect(
-              it.extensionProperties['io.camunda.tool:purpose'],
-            ).toBeDefined();
-          },
-        );
-      },
-    );
+      json.items.forEach(
+        (it: {toolProperties: Record<string, string>}) => {
+          expect(it.toolProperties).toBeDefined();
+          expect(it.toolProperties['io.camunda.tool:name']).toBe(
+            'alpha-tool-name',
+          );
+          expect(
+            it.toolProperties['io.camunda.tool:purpose'],
+          ).toBeDefined();
+        },
+      );
+    });
 
     await test.step('SC-API-05 — processDefinitionName and processDefinitionVersion returned', async () => {
       const res = await request.post(
@@ -257,8 +251,7 @@ test.describe('MCP Message Subscription Search API Tests', () => {
       );
     });
 
-    //Skipped due to bug: 52532 https://github.com/camunda/camunda/issues/52532
-    await test.step.skip('SC-API-07 — Filter by toolName', async () => {
+    await test.step('SC-API-07 — Filter by toolName', async () => {
       const res = await request.post(
         buildUrl('/message-subscriptions/search'),
         {
@@ -282,11 +275,17 @@ test.describe('MCP Message Subscription Search API Tests', () => {
       const json = await res.json();
       expect(json.page.totalItems).toBeGreaterThanOrEqual(1);
 
-      // extensionProperties assertion skipped due to bug 52514: https://github.com/camunda/camunda/issues/52514
       json.items.forEach(
-        (it: {processDefinitionId: string; toolName: string}) => {
+        (it: {
+          processDefinitionId: string;
+          toolName: string;
+          toolProperties: Record<string, string>;
+        }) => {
           expect(it.processDefinitionId).toBe('mcpProcessAlpha');
           expect(it.toolName).toBe('alpha-tool-name');
+          expect(it.toolProperties['io.camunda.tool:name']).toBe(
+            'alpha-tool-name',
+          );
         },
       );
     });
@@ -316,18 +315,31 @@ test.describe('MCP Message Subscription Search API Tests', () => {
       const json = await res.json();
       expect(json.page.totalItems).toBeGreaterThanOrEqual(1);
 
-      // extensionProperties assertions skipped due to bug 52514: https://github.com/camunda/camunda/issues/52514
-      json.items.forEach((it: object) => {
-        assertEqualsForKeys(
-          it,
-          {
-            processDefinitionId: 'mcpProcessWithInputs',
-            messageSubscriptionType: 'START_EVENT',
-            tenantId: '<default>',
-          },
-          ['processDefinitionId', 'messageSubscriptionType', 'tenantId'],
-        );
-      });
+      json.items.forEach(
+        (it: {toolProperties: Record<string, string>}) => {
+          assertEqualsForKeys(
+            it,
+            {
+              processDefinitionId: 'mcpProcessWithInputs',
+              messageSubscriptionType: 'START_EVENT',
+              tenantId: '<default>',
+            },
+            ['processDefinitionId', 'messageSubscriptionType', 'tenantId'],
+          );
+          expect(it.toolProperties['io.camunda.tool:input_1_name']).toBe(
+            'firstName',
+          );
+          expect(it.toolProperties['io.camunda.tool:input_1_type']).toBe(
+            'string',
+          );
+          expect(it.toolProperties['io.camunda.tool:input_2_name']).toBe(
+            'amount',
+          );
+          expect(
+            it.toolProperties['io.camunda.tool:input_2_required'],
+          ).toBe('true');
+        },
+      );
     });
 
     await test.step('SC-API-09 — Sort by processDefinitionName ascending', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message-subscriptions/mcp-message-subscription-search.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message-subscriptions/mcp-message-subscription-search.spec.ts
@@ -162,17 +162,13 @@ test.describe('MCP Message Subscription Search API Tests', () => {
       const json = await res.json();
       expect(json.page.totalItems).toBeGreaterThanOrEqual(1);
 
-      json.items.forEach(
-        (it: {toolProperties: Record<string, string>}) => {
-          expect(it.toolProperties).toBeDefined();
-          expect(it.toolProperties['io.camunda.tool:name']).toBe(
-            'alpha-tool-name',
-          );
-          expect(
-            it.toolProperties['io.camunda.tool:purpose'],
-          ).toBeDefined();
-        },
-      );
+      json.items.forEach((it: {toolProperties: Record<string, string>}) => {
+        expect(it.toolProperties).toBeDefined();
+        expect(it.toolProperties['io.camunda.tool:name']).toBe(
+          'alpha-tool-name',
+        );
+        expect(it.toolProperties['io.camunda.tool:purpose']).toBeDefined();
+      });
     });
 
     await test.step('SC-API-05 — processDefinitionName and processDefinitionVersion returned', async () => {
@@ -315,31 +311,29 @@ test.describe('MCP Message Subscription Search API Tests', () => {
       const json = await res.json();
       expect(json.page.totalItems).toBeGreaterThanOrEqual(1);
 
-      json.items.forEach(
-        (it: {toolProperties: Record<string, string>}) => {
-          assertEqualsForKeys(
-            it,
-            {
-              processDefinitionId: 'mcpProcessWithInputs',
-              messageSubscriptionType: 'START_EVENT',
-              tenantId: '<default>',
-            },
-            ['processDefinitionId', 'messageSubscriptionType', 'tenantId'],
-          );
-          expect(it.toolProperties['io.camunda.tool:input_1_name']).toBe(
-            'firstName',
-          );
-          expect(it.toolProperties['io.camunda.tool:input_1_type']).toBe(
-            'string',
-          );
-          expect(it.toolProperties['io.camunda.tool:input_2_name']).toBe(
-            'amount',
-          );
-          expect(
-            it.toolProperties['io.camunda.tool:input_2_required'],
-          ).toBe('true');
-        },
-      );
+      json.items.forEach((it: {toolProperties: Record<string, string>}) => {
+        assertEqualsForKeys(
+          it,
+          {
+            processDefinitionId: 'mcpProcessWithInputs',
+            messageSubscriptionType: 'START_EVENT',
+            tenantId: '<default>',
+          },
+          ['processDefinitionId', 'messageSubscriptionType', 'tenantId'],
+        );
+        expect(it.toolProperties['io.camunda.tool:input_1_name']).toBe(
+          'firstName',
+        );
+        expect(it.toolProperties['io.camunda.tool:input_1_type']).toBe(
+          'string',
+        );
+        expect(it.toolProperties['io.camunda.tool:input_2_name']).toBe(
+          'amount',
+        );
+        expect(it.toolProperties['io.camunda.tool:input_2_required']).toBe(
+          'true',
+        );
+      });
     });
 
     await test.step('SC-API-09 — Sort by processDefinitionName ascending', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/mcp-processes.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/mcp-processes.spec.ts
@@ -164,8 +164,7 @@ test.describe('Identity MCP Processes', () => {
     });
   });
 
-  // TODO: Re-evaluate once extensionProperties are exported again
-  test.skip('MCP Processes rows can be expanded to show more tool information', async ({
+  test('MCP Processes rows can be expanded to show more tool information', async ({
     identityMcpProcessesPage,
   }) => {
     await identityMcpProcessesPage.navigateToMcpProcesses();

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/MessageSubscriptionEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/MessageSubscriptionEntityTransformer.java
@@ -36,7 +36,7 @@ public class MessageSubscriptionEntityTransformer
         value.getTenantId(),
         value.getProcessDefinitionName(),
         value.getProcessDefinitionVersion(),
-        value.getExtensionProperties(),
+        value.getToolProperties(),
         value.getToolName(),
         value.getInboundConnectorType());
   }

--- a/search/search-domain/src/main/java/io/camunda/search/entities/MessageSubscriptionEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/MessageSubscriptionEntity.java
@@ -32,7 +32,7 @@ public record MessageSubscriptionEntity(
     String tenantId,
     @Nullable String processDefinitionName,
     @Nullable Integer processDefinitionVersion,
-    Map<String, String> extensionProperties,
+    Map<String, String> toolProperties,
     @Nullable String toolName,
     @Nullable String inboundConnectorType)
     implements TenantOwnedEntity {
@@ -47,7 +47,7 @@ public record MessageSubscriptionEntity(
     // Mutable collections are required: MyBatis hydrates collection-mapped fields (e.g. from a
     // <collection> result map or a LEFT JOIN) by calling .add() on the existing instance.
     // Immutable defaults (e.g. Map.of()) would cause UnsupportedOperationException at runtime.
-    extensionProperties = extensionProperties != null ? extensionProperties : new HashMap<>();
+    toolProperties = toolProperties != null ? toolProperties : new HashMap<>();
     // Pre-8.10 rows have no messageSubscriptionType stored; default them to PROCESS_EVENT.
     messageSubscriptionType =
         messageSubscriptionType != null
@@ -75,7 +75,7 @@ public record MessageSubscriptionEntity(
     private @Nullable String tenantId;
     private @Nullable String processDefinitionName;
     private @Nullable Integer processDefinitionVersion;
-    private @Nullable Map<String, String> extensionProperties;
+    private @Nullable Map<String, String> toolProperties;
     private @Nullable String toolName;
     private @Nullable String inboundConnectorType;
 
@@ -135,8 +135,8 @@ public record MessageSubscriptionEntity(
       return this;
     }
 
-    public Builder extensionProperties(final Map<String, String> extensionProperties) {
-      this.extensionProperties = extensionProperties;
+    public Builder toolProperties(final Map<String, String> toolProperties) {
+      this.toolProperties = toolProperties;
       return this;
     }
 
@@ -188,7 +188,7 @@ public record MessageSubscriptionEntity(
           tenantId,
           processDefinitionName,
           processDefinitionVersion,
-          extensionProperties,
+          toolProperties,
           toolName,
           inboundConnectorType);
     }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/MessageSubscriptionBuilder.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/MessageSubscriptionBuilder.java
@@ -38,7 +38,7 @@ public class MessageSubscriptionBuilder implements MessageSubscription {
   private MessageSubscriptionType messageSubscriptionType;
   private String processDefinitionName;
   private Integer processDefinitionVersion;
-  private Map<String, String> extensionProperties;
+  private Map<String, String> toolProperties;
   private String toolName;
   private String inboundConnectorType;
 
@@ -118,8 +118,8 @@ public class MessageSubscriptionBuilder implements MessageSubscription {
   }
 
   @Override
-  public Map<String, String> getExtensionProperties() {
-    return extensionProperties;
+  public Map<String, String> getToolProperties() {
+    return toolProperties;
   }
 
   @Override
@@ -132,9 +132,8 @@ public class MessageSubscriptionBuilder implements MessageSubscription {
     return inboundConnectorType;
   }
 
-  public MessageSubscriptionBuilder setExtensionProperties(
-      final Map<String, String> extensionProperties) {
-    this.extensionProperties = extensionProperties;
+  public MessageSubscriptionBuilder setToolProperties(final Map<String, String> toolProperties) {
+    this.toolProperties = toolProperties;
     return this;
   }
 

--- a/webapp/client/apps/orchestration-cluster-webapp/package.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/package.json
@@ -17,7 +17,7 @@
 		"generate:svg": "svgr --typescript --no-index --out-dir src/modules/svg src/assets/svg"
 	},
 	"dependencies": {
-		"@camunda/camunda-api-zod-schemas": "0.0.61",
+		"@camunda/camunda-api-zod-schemas": "0.0.62",
 		"@camunda/camunda-composite-components": "0.23.1",
 		"@carbon/react": "1.106.0",
 		"@tanstack/react-query": "5.100.5",

--- a/webapp/client/apps/orchestration-cluster-webapp/src/modules/svg/CamundaLogo.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/modules/svg/CamundaLogo.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import type { SVGProps } from "react";
 const SvgCamundaLogo = (props: SVGProps<SVGSVGElement>) => (
   <svg xmlns="http://www.w3.org/2000/svg" width={96} height={33} {...props}>

--- a/webapp/client/package-lock.json
+++ b/webapp/client/package-lock.json
@@ -56,7 +56,7 @@
 		"apps/orchestration-cluster-webapp": {
 			"name": "@camunda/orchestration-cluster-webapp",
 			"dependencies": {
-				"@camunda/camunda-api-zod-schemas": "0.0.61",
+				"@camunda/camunda-api-zod-schemas": "0.0.62",
 				"@camunda/camunda-composite-components": "0.23.1",
 				"@carbon/react": "1.106.0",
 				"@tanstack/react-query": "5.100.5",
@@ -9773,13 +9773,13 @@
 			"version": "0.0.1",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
-				"@camunda/camunda-api-zod-schemas": "0.0.61",
+				"@camunda/camunda-api-zod-schemas": "0.0.62",
 				"typescript": "6.0.3"
 			}
 		},
 		"packages/camunda-api-zod-schemas": {
 			"name": "@camunda/camunda-api-zod-schemas",
-			"version": "0.0.61",
+			"version": "0.0.62",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
 				"@types/node": "25.6.0",

--- a/webapp/client/packages/c8-mocks/package.json
+++ b/webapp/client/packages/c8-mocks/package.json
@@ -18,7 +18,7 @@
 		"typecheck": "tsc"
 	},
 	"devDependencies": {
-		"@camunda/camunda-api-zod-schemas": "0.0.61",
+		"@camunda/camunda-api-zod-schemas": "0.0.62",
 		"typescript": "6.0.3"
 	}
 }

--- a/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
+++ b/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.0.62
+
+### 🚀 Enhancements
+
+- Rename `extensionProperties` to `toolProperties` in message subscriptions ([#52526](https://github.com/camunda/camunda/issues/52526))
+
+### ❤️ Contributors
+
+- Christoph Fricke ([@christoph-fricke](https://github.com/christoph-fricke))
+
 ## v0.0.61
 
 ### 🚀 Enhancements

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/message-subscriptions.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/message-subscriptions.ts
@@ -38,7 +38,7 @@ const messageSubscriptionSchema = z.object({
 	correlationKey: z.string().nullable(),
 	tenantId: z.string(),
 	rootProcessInstanceKey: z.string().nullable(),
-	extensionProperties: z.record(z.string(), z.string()),
+	toolProperties: z.record(z.string(), z.string()),
 	processDefinitionName: z.string().nullable(),
 	processDefinitionVersion: z.number().int().nullable(),
 	toolName: z.string().nullable(),

--- a/webapp/client/packages/camunda-api-zod-schemas/package.json
+++ b/webapp/client/packages/camunda-api-zod-schemas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda/camunda-api-zod-schemas",
-	"version": "0.0.61",
+	"version": "0.0.62",
 	"license": "LicenseRef-Camunda-1.0",
 	"description": "Zod schemas and TypeScript types for Camunda 8 unified API",
 	"author": "Vinicius Goulart <vinicius.goulart@camunda.com>",

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/MessageSubscriptionTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/MessageSubscriptionTemplate.java
@@ -108,7 +108,7 @@ public class MessageSubscriptionTemplate extends AbstractTemplateDescriptor
 
   public static final String PROCESS_DEFINITION_NAME = "processDefinitionName";
   public static final String PROCESS_DEFINITION_VERSION = "processDefinitionVersion";
-  public static final String EXTENSION_PROPERTIES = "extensionProperties";
+  public static final String TOOL_PROPERTIES = "toolProperties";
   public static final String MESSAGE_SUBSCRIPTION_TYPE = "messageSubscriptionType";
   public static final String TOOL_NAME = "toolName";
   public static final String INBOUND_CONNECTOR_TYPE = "inboundConnectorType";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/messagesubscription/MessageSubscriptionEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/messagesubscription/MessageSubscriptionEntity.java
@@ -61,7 +61,7 @@ public class MessageSubscriptionEntity
   private Integer processDefinitionVersion;
 
   @SinceVersion(value = "8.10.0", requireDefault = false)
-  private Map<String, String> extensionProperties;
+  private Map<String, String> toolProperties;
 
   @SinceVersion(value = "8.10.0", requireDefault = false)
   private String messageSubscriptionType;
@@ -238,13 +238,12 @@ public class MessageSubscriptionEntity
     return this;
   }
 
-  public Map<String, String> getExtensionProperties() {
-    return extensionProperties;
+  public Map<String, String> getToolProperties() {
+    return toolProperties;
   }
 
-  public MessageSubscriptionEntity setExtensionProperties(
-      final Map<String, String> extensionProperties) {
-    this.extensionProperties = extensionProperties;
+  public MessageSubscriptionEntity setToolProperties(final Map<String, String> toolProperties) {
+    this.toolProperties = toolProperties;
     return this;
   }
 
@@ -367,7 +366,7 @@ public class MessageSubscriptionEntity
         rootProcessInstanceKey,
         processDefinitionName,
         processDefinitionVersion,
-        extensionProperties,
+        toolProperties,
         messageSubscriptionType,
         toolName,
         inboundConnectorType);
@@ -403,7 +402,7 @@ public class MessageSubscriptionEntity
         && Objects.equals(rootProcessInstanceKey, that.rootProcessInstanceKey)
         && Objects.equals(processDefinitionName, that.processDefinitionName)
         && Objects.equals(processDefinitionVersion, that.processDefinitionVersion)
-        && Objects.equals(extensionProperties, that.extensionProperties)
+        && Objects.equals(toolProperties, that.toolProperties)
         && Objects.equals(messageSubscriptionType, that.messageSubscriptionType)
         && Objects.equals(toolName, that.toolName)
         && Objects.equals(inboundConnectorType, that.inboundConnectorType);

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-event.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-event.json
@@ -100,7 +100,7 @@
       "processDefinitionVersion": {
         "type": "integer"
       },
-      "extensionProperties": {
+      "toolProperties": {
         "type": "object",
         "enabled": false
       },

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-event.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-event.json
@@ -100,7 +100,7 @@
       "processDefinitionVersion": {
         "type": "integer"
       },
-      "extensionProperties": {
+      "toolProperties": {
         "type": "object",
         "enabled": false
       },

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/utils/ProcessCacheUtil.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/utils/ProcessCacheUtil.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.model.bpmn.instance.FlowNode;
 import io.camunda.zeebe.util.modelreader.ProcessModelReader;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -171,5 +172,15 @@ public final class ProcessCacheUtil {
       return null;
     }
     return extensionProperties.get(EXTENSION_PROPERTY_INBOUND_TYPE);
+  }
+
+  public static Map<String, String> getToolProperties(
+      final Map<String, String> extensionProperties) {
+    if (extensionProperties == null) {
+      return Map.of();
+    }
+    return extensionProperties.entrySet().stream()
+        .filter(e -> e.getKey().startsWith("io.camunda.tool:"))
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AbstractEventHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AbstractEventHandler.java
@@ -30,6 +30,7 @@ import static io.camunda.webapps.schema.descriptors.template.MessageSubscription
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.PROCESS_DEFINITION_VERSION;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.PROCESS_KEY;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.TOOL_NAME;
+import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.TOOL_PROPERTIES;
 
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.messagesubscription.EventSourceType;
@@ -98,6 +99,7 @@ public abstract class AbstractEventHandler<R extends RecordValue>
     jsonMap.put(FLOW_NODE_ID, entity.getFlowNodeId());
     jsonMap.put(PROCESS_DEFINITION_NAME, entity.getProcessDefinitionName());
     jsonMap.put(PROCESS_DEFINITION_VERSION, entity.getProcessDefinitionVersion());
+    jsonMap.put(TOOL_PROPERTIES, entity.getToolProperties());
     jsonMap.put(TOOL_NAME, entity.getToolName());
     jsonMap.put(INBOUND_CONNECTOR_TYPE, entity.getInboundConnectorType());
     jsonMap.put(positionFieldName, positionFieldValue);
@@ -147,7 +149,8 @@ public abstract class AbstractEventHandler<R extends RecordValue>
               .orElse(Map.of());
       entity
           .setToolName(ProcessCacheUtil.getToolName(ext))
-          .setInboundConnectorType(ProcessCacheUtil.getInboundConnectorType(ext));
+          .setInboundConnectorType(ProcessCacheUtil.getInboundConnectorType(ext))
+          .setToolProperties(ProcessCacheUtil.getToolProperties(ext));
     }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromMessageStartEventSubscriptionHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromMessageStartEventSubscriptionHandlerTest.java
@@ -234,7 +234,9 @@ final class MessageSubscriptionFromMessageStartEventSubscriptionHandlerTest {
     // then
     assertThat(entity.getToolName()).isEqualTo("myTool");
     assertThat(entity.getInboundConnectorType()).isEqualTo("io.camunda:http-webhook:1");
-    // TODO: Add an assertion for the extension properties once they are included in the entity
+    assertThat(entity.getToolProperties())
+        .containsEntry("io.camunda.tool:name", "myTool")
+        .doesNotContainKey("inbound.type");
   }
 
   @Test
@@ -305,6 +307,7 @@ final class MessageSubscriptionFromMessageStartEventSubscriptionHandlerTest {
     expectedUpdateFields.put("processDefinitionVersion", null);
     expectedUpdateFields.put("toolName", null);
     expectedUpdateFields.put("inboundConnectorType", null);
+    expectedUpdateFields.put("toolProperties", null);
     expectedUpdateFields.put("metadata", metadataMap);
     final BatchRequest mockRequest = Mockito.mock(BatchRequest.class);
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromMessageStartEventSubscriptionHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromMessageStartEventSubscriptionHandlerTest.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.handlers;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.CORRELATION_KEY;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.MESSAGE_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -234,9 +235,7 @@ final class MessageSubscriptionFromMessageStartEventSubscriptionHandlerTest {
     // then
     assertThat(entity.getToolName()).isEqualTo("myTool");
     assertThat(entity.getInboundConnectorType()).isEqualTo("io.camunda:http-webhook:1");
-    assertThat(entity.getToolProperties())
-        .containsEntry("io.camunda.tool:name", "myTool")
-        .doesNotContainKey("inbound.type");
+    assertThat(entity.getToolProperties()).containsExactly(entry("io.camunda.tool:name", "myTool"));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromProcessMessageSubscriptionHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromProcessMessageSubscriptionHandlerTest.java
@@ -11,6 +11,7 @@ import static io.camunda.exporter.handlers.MessageSubscriptionFromProcessMessage
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.CORRELATION_KEY;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.MESSAGE_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -372,9 +373,7 @@ final class MessageSubscriptionFromProcessMessageSubscriptionHandlerTest {
     // then
     assertThat(entity.getToolName()).isEqualTo("myTool");
     assertThat(entity.getInboundConnectorType()).isEqualTo("io.camunda:http-webhook:1");
-    assertThat(entity.getToolProperties())
-        .containsEntry("io.camunda.tool:name", "myTool")
-        .doesNotContainKey("inbound.type");
+    assertThat(entity.getToolProperties()).containsExactly(entry("io.camunda.tool:name", "myTool"));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromProcessMessageSubscriptionHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromProcessMessageSubscriptionHandlerTest.java
@@ -372,7 +372,9 @@ final class MessageSubscriptionFromProcessMessageSubscriptionHandlerTest {
     // then
     assertThat(entity.getToolName()).isEqualTo("myTool");
     assertThat(entity.getInboundConnectorType()).isEqualTo("io.camunda:http-webhook:1");
-    // TODO: Add an assertion for the extension properties once they are included in the entity
+    assertThat(entity.getToolProperties())
+        .containsEntry("io.camunda.tool:name", "myTool")
+        .doesNotContainKey("inbound.type");
   }
 
   @Test
@@ -443,6 +445,7 @@ final class MessageSubscriptionFromProcessMessageSubscriptionHandlerTest {
     expectedUpdateFields.put("processDefinitionVersion", null);
     expectedUpdateFields.put("toolName", null);
     expectedUpdateFields.put("inboundConnectorType", null);
+    expectedUpdateFields.put("toolProperties", null);
     expectedUpdateFields.put("metadata", metadataMap);
 
     final BatchRequest mockRequest = Mockito.mock(BatchRequest.class);

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionExportHandler.java
@@ -94,7 +94,7 @@ public class MessageSubscriptionExportHandler
         .processDefinitionName(
             cached.map(CachedProcessEntity::name).filter(s -> !s.isBlank()).orElse(null))
         .processDefinitionVersion(cached.map(CachedProcessEntity::version).orElse(null))
-        .extensionProperties(Map.of())
+        .toolProperties(ProcessCacheUtil.getToolProperties(ext))
         .toolName(ProcessCacheUtil.getToolName(ext))
         .inboundConnectorType(ProcessCacheUtil.getInboundConnectorType(ext))
         .build();

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionFromMessageStartEventSubscriptionExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionFromMessageStartEventSubscriptionExportHandler.java
@@ -93,7 +93,7 @@ public class MessageSubscriptionFromMessageStartEventSubscriptionExportHandler
         .processDefinitionName(
             cached.map(CachedProcessEntity::name).filter(s -> !s.isBlank()).orElse(null))
         .processDefinitionVersion(cached.map(CachedProcessEntity::version).orElse(null))
-        .extensionProperties(Map.of())
+        .toolProperties(ProcessCacheUtil.getToolProperties(ext))
         .toolName(ProcessCacheUtil.getToolName(ext))
         .inboundConnectorType(ProcessCacheUtil.getInboundConnectorType(ext))
         .build();

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/message/MessageSubscriptionExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/message/MessageSubscriptionExportHandlerTest.java
@@ -195,7 +195,7 @@ final class MessageSubscriptionExportHandlerTest {
         .isEqualTo(DateUtil.toOffsetDateTime(Instant.ofEpochMilli(timestamp)));
     assertThat(model.processDefinitionName()).isEqualTo(processName);
     assertThat(model.processDefinitionVersion()).isEqualTo(processVersion);
-    assertThat(model.extensionProperties()).isEqualTo(Map.of());
+    assertThat(model.toolProperties()).isEqualTo(Map.of("io.camunda.tool:name", "myTool"));
     assertThat(model.toolName()).isEqualTo("myTool");
     assertThat(model.inboundConnectorType()).isEqualTo("io.camunda:http-webhook:1");
   }
@@ -245,7 +245,7 @@ final class MessageSubscriptionExportHandlerTest {
     final MessageSubscriptionDbModel model = captor.getValue();
     assertThat(model.processDefinitionName()).isNull();
     assertThat(model.processDefinitionVersion()).isNull();
-    assertThat(model.extensionProperties()).isEqualTo(Map.of());
+    assertThat(model.toolProperties()).isEqualTo(Map.of());
     assertThat(model.toolName()).isNull();
     assertThat(model.inboundConnectorType()).isNull();
   }

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/message/MessageSubscriptionFromMessageStartEventSubscriptionExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/message/MessageSubscriptionFromMessageStartEventSubscriptionExportHandlerTest.java
@@ -187,7 +187,7 @@ final class MessageSubscriptionFromMessageStartEventSubscriptionExportHandlerTes
         .isEqualTo(DateUtil.toOffsetDateTime(Instant.ofEpochMilli(timestamp)));
     assertThat(model.processDefinitionName()).isEqualTo(processName);
     assertThat(model.processDefinitionVersion()).isEqualTo(processVersion);
-    assertThat(model.extensionProperties()).isEqualTo(Map.of());
+    assertThat(model.toolProperties()).isEqualTo(Map.of("io.camunda.tool:name", "myTool"));
     assertThat(model.toolName()).isEqualTo("myTool");
     assertThat(model.inboundConnectorType()).isEqualTo("io.camunda:http-webhook:1");
   }
@@ -226,13 +226,13 @@ final class MessageSubscriptionFromMessageStartEventSubscriptionExportHandlerTes
     // when
     underTest.export(record);
 
-    // then — no exception, name/version/extensionProperties are absent
+    // then — no exception, name/version/toolProperties are absent
     final var captor = ArgumentCaptor.forClass(MessageSubscriptionDbModel.class);
     verify(writer).create(captor.capture());
     final MessageSubscriptionDbModel model = captor.getValue();
     assertThat(model.processDefinitionName()).isNull();
     assertThat(model.processDefinitionVersion()).isNull();
-    assertThat(model.extensionProperties()).isEqualTo(Map.of());
+    assertThat(model.toolProperties()).isEqualTo(Map.of());
     assertThat(model.toolName()).isNull();
     assertThat(model.inboundConnectorType()).isNull();
   }

--- a/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
@@ -275,7 +275,7 @@ components:
         - correlationKey
         - elementId
         - elementInstanceKey
-        - extensionProperties
+        - toolProperties
         - inboundConnectorType
         - lastUpdatedDate
         - messageName
@@ -344,7 +344,7 @@ components:
           description: The correlation key of the message subscription.
         messageSubscriptionType:
           $ref: '#/components/schemas/MessageSubscriptionTypeEnum'
-        extensionProperties:
+        toolProperties:
           type: object
           additionalProperties:
             type: string

--- a/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
@@ -349,8 +349,9 @@ components:
           additionalProperties:
             type: string
           description: |
-            The `zeebe:properties` extension properties extracted from the BPMN element associated
-            with this subscription. Empty object when no properties are defined.
+            The subset of `zeebe:properties` extension properties whose keys start with the
+            `io.camunda.tool:` prefix, extracted from the BPMN element associated with this
+            subscription. Empty object when no matching properties are defined.
         processDefinitionName:
           type: string
           nullable: true

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/MessageSubscriptionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/MessageSubscriptionQueryControllerTest.java
@@ -50,7 +50,7 @@ public class MessageSubscriptionQueryControllerTest extends RestControllerTest {
                   "tenantId": "test-tenant",
                   "processDefinitionKey": null,
                   "rootProcessInstanceKey": null,
-                  "extensionProperties": {},
+                  "toolProperties": {},
                   "processDefinitionName": null,
                   "processDefinitionVersion": null,
                   "toolName": null,


### PR DESCRIPTION
## Summary

- Restores tool-related extension property export dropped in #52498, and renames the field to `toolProperties` to better reflect its purpose
- Only extension properties with the `io.camunda.tool:` prefix are included in `toolProperties` (filtered via `ProcessCacheUtil.getToolProperties()`)
- Renames `extensionProperties` → `toolProperties` across all layers: RDBMS db model/schema/mapper, search domain entity, ES/OS index templates, REST protocol YAML, Java client, gateway mappers, MCP gateway, and all tests
- Re-enables the E2E test for MCP tool information that was skipped in #52498

## Test plan

- [x] Unit tests for `MessageSubscriptionExportHandler` and `MessageSubscriptionFromMessageStartEventSubscriptionExportHandler` pass (verify filtered `toolProperties` is populated)
- [x] Unit tests for `MessageSubscriptionEntityMapper` pass
- [x] Camunda exporter handler tests pass (verify `toolProperties` is written to ES/OS index)
- [x] E2E test `mcp-processes.spec.ts` re-enabled and passing
- [x] RDBMS ITs pass with renamed `TOOL_PROPERTIES` column

Closes #52526
Closes #52606

Co-authored-by: Tobias Metzke-Bernstein <586643+tmetzke@users.noreply.github.com>
https://claude.ai/code/session_0185Ni6d5SiP9KipqEjPWSHd

---
_Generated by [Claude Code](https://claude.ai/code/session_0185Ni6d5SiP9KipqEjPWSHd)_