### PR TITLE
Feat/postgres lsn replication controller

### DIFF
--- a/db/docker-compose.yml
+++ b/db/docker-compose.yml
@@ -2,6 +2,8 @@ version: '3.9'
 
 networks:
   zeebe_network: { }
+  pgnet:
+    driver: bridge
 
 services:
 
@@ -141,3 +143,55 @@ services:
       - 9605:9605 # required for Performance Analyzer
     networks:
       - zeebe_network
+
+  postgres-primary:
+    image: bitnamilegacy/postgresql:17
+    container_name: pg-primary
+    ports:
+      - "5432:5432"
+    volumes:
+      - ./docker-compose-init/01-grant-pg-read-all-stats.sql:/docker-entrypoint-initdb.d/01-grant-pg-read-all-stats.sql:ro
+    environment:
+      - POSTGRESQL_POSTGRES_PASSWORD=camunda
+      - POSTGRES_USER=camunda
+      - POSTGRES_PASSWORD=camunda
+      - POSTGRESQL_DATABASE=camunda
+      - POSTGRESQL_REPLICATION_MODE=master
+      - POSTGRESQL_REPLICATION_USER=repl_user
+      - POSTGRESQL_REPLICATION_PASSWORD=repl_pass
+    networks:
+      - pgnet
+
+  postgres-replica-1:
+    image: bitnamilegacy/postgresql:17
+    container_name: pg-replica1
+    depends_on:
+      - postgres-primary
+    ports:
+      - "5433:5432"
+    environment:
+      - POSTGRES_USER=camunda
+      - POSTGRES_PASSWORD=camunda
+      - POSTGRESQL_REPLICATION_MODE=slave
+      - POSTGRESQL_MASTER_HOST=postgres-primary
+      - POSTGRESQL_REPLICATION_USER=repl_user
+      - POSTGRESQL_REPLICATION_PASSWORD=repl_pass
+    networks:
+      - pgnet
+
+  postgres-replica-2:
+    image: bitnamilegacy/postgresql:17
+    container_name: pg-replica2
+    depends_on:
+      - postgres-primary
+    ports:
+      - "5434:5432"
+    environment:
+      - POSTGRES_USER=camunda
+      - POSTGRES_PASSWORD=camunda
+      - POSTGRESQL_REPLICATION_MODE=slave
+      - POSTGRESQL_MASTER_HOST=postgres-primary
+      - POSTGRESQL_REPLICATION_USER=repl_user
+      - POSTGRESQL_REPLICATION_PASSWORD=repl_pass
+    networks:
+      - pgnet

--- a/db/rdbms-schema/src/main/java/io/camunda/db/rdbms/config/VendorDatabaseProperties.java
+++ b/db/rdbms-schema/src/main/java/io/camunda/db/rdbms/config/VendorDatabaseProperties.java
@@ -11,6 +11,9 @@ import java.util.Properties;
 
 public class VendorDatabaseProperties {
 
+  /** Required property to specify the databaseId. */
+  public static final String DATABASE_ID = "databaseId";
+
   /**
    * Required property to specify the size of the variable value preview in characters. This is used
    * to truncate variable values for preview purposes.
@@ -52,6 +55,7 @@ public class VendorDatabaseProperties {
 
   private final Properties properties;
 
+  private final String databaseId;
   private final int variableValuePreviewSize;
   private final boolean disableFkBeforeTruncate;
   private final boolean supportsInsertBatching;
@@ -62,6 +66,11 @@ public class VendorDatabaseProperties {
 
   public VendorDatabaseProperties(final Properties properties) {
     this.properties = properties;
+
+    if (!properties.containsKey(DATABASE_ID)) {
+      throw new IllegalArgumentException("Property '" + DATABASE_ID + "' is missing");
+    }
+    databaseId = properties.getProperty(DATABASE_ID);
 
     if (!properties.containsKey(VARIABLE_VALUE_PREVIEW_SIZE)) {
       throw new IllegalArgumentException(
@@ -102,6 +111,10 @@ public class VendorDatabaseProperties {
     supportsInsertBatching =
         !properties.containsKey(SUPPORTS_INSERT_BATCHING)
             || Boolean.parseBoolean(properties.getProperty(SUPPORTS_INSERT_BATCHING));
+  }
+
+  public String databaseId() {
+    return databaseId;
   }
 
   public int variableValuePreviewSize() {

--- a/db/rdbms-schema/src/main/java/io/camunda/db/rdbms/config/VendorDatabasePropertiesLoader.java
+++ b/db/rdbms-schema/src/main/java/io/camunda/db/rdbms/config/VendorDatabasePropertiesLoader.java
@@ -26,6 +26,7 @@ public final class VendorDatabasePropertiesLoader {
             "No vendor properties found for databaseId " + databaseId);
       }
     }
+    properties.put(VendorDatabaseProperties.DATABASE_ID, databaseId);
 
     return new VendorDatabaseProperties(properties);
   }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsService.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.db.rdbms;
 
+import io.camunda.db.rdbms.read.replication.ReplicationLogStatusProvider;
+import io.camunda.db.rdbms.read.replication.ReplicationLogStatusProviderFactory;
 import io.camunda.db.rdbms.read.service.AuditLogDbReader;
 import io.camunda.db.rdbms.read.service.AuthorizationDbReader;
 import io.camunda.db.rdbms.read.service.BatchOperationDbReader;
@@ -49,6 +51,7 @@ import io.camunda.db.rdbms.write.RdbmsWriterConfig;
 import io.camunda.db.rdbms.write.RdbmsWriterConfig.Builder;
 import io.camunda.db.rdbms.write.RdbmsWriterFactory;
 import io.camunda.db.rdbms.write.RdbmsWriters;
+import java.util.Optional;
 import java.util.function.Consumer;
 
 /** A holder for all rdbms services */
@@ -98,6 +101,7 @@ public class RdbmsService {
       incidentProcessInstanceStatisticsByDefinitionDbReader;
   private final GlobalListenerDbReader globalListenerDbReader;
   private final DeployedResourceDbReader deployedResourceDbReader;
+  private final ReplicationLogStatusProviderFactory replicationLogStatusProviderFactory;
 
   public RdbmsService(
       final RdbmsWriterFactory rdbmsWriterFactory,
@@ -142,7 +146,8 @@ public class RdbmsService {
       final IncidentProcessInstanceStatisticsByDefinitionDbReader
           incidentProcessInstanceStatisticsByDefinitionDbReader,
       final GlobalListenerDbReader globalListenerDbReader,
-      final DeployedResourceDbReader deployedResourceDbReader) {
+      final DeployedResourceDbReader deployedResourceDbReader,
+      final ReplicationLogStatusProviderFactory replicationLogStatusProviderFactory) {
     this.rdbmsWriterFactory = rdbmsWriterFactory;
     this.auditLogReader = auditLogReader;
     this.authorizationReader = authorizationReader;
@@ -186,6 +191,7 @@ public class RdbmsService {
         incidentProcessInstanceStatisticsByDefinitionDbReader;
     this.globalListenerDbReader = globalListenerDbReader;
     this.deployedResourceDbReader = deployedResourceDbReader;
+    this.replicationLogStatusProviderFactory = replicationLogStatusProviderFactory;
   }
 
   public AuthorizationDbReader getAuthorizationReader() {
@@ -347,6 +353,10 @@ public class RdbmsService {
 
   public DeployedResourceDbReader getResourceDbReader() {
     return deployedResourceDbReader;
+  }
+
+  public Optional<ReplicationLogStatusProvider> getReplicationLogStatusProvider() {
+    return replicationLogStatusProviderFactory.create();
   }
 
   public RdbmsWriters createWriter(final RdbmsWriterConfig config) {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsService.java
@@ -51,7 +51,6 @@ import io.camunda.db.rdbms.write.RdbmsWriterConfig;
 import io.camunda.db.rdbms.write.RdbmsWriterConfig.Builder;
 import io.camunda.db.rdbms.write.RdbmsWriterFactory;
 import io.camunda.db.rdbms.write.RdbmsWriters;
-import java.util.Optional;
 import java.util.function.Consumer;
 
 /** A holder for all rdbms services */
@@ -355,7 +354,7 @@ public class RdbmsService {
     return deployedResourceDbReader;
   }
 
-  public Optional<ReplicationLogStatusProvider> getReplicationLogStatusProvider() {
+  public ReplicationLogStatusProvider getReplicationLogStatusProvider() {
     return replicationLogStatusProviderFactory.create();
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/replication/PostgresReplicationLogStatusProvider.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/replication/PostgresReplicationLogStatusProvider.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.replication;
+
+import io.camunda.db.rdbms.sql.ReplicationStatusMapper;
+import java.util.List;
+
+/**
+ * PostgreSQL implementation using {@code pg_current_wal_lsn()} and {@code pg_stat_replication}.
+ *
+ * <p>Per-replica lag is read from {@code pg_stat_replication.replay_lag} — the elapsed time between
+ * flushing WAL locally and the standby acknowledging it has been replayed (applied). Disconnected
+ * replicas simply do not appear in the view and therefore do not contribute a row; the caller is
+ * expected to combine the row count with a configured {@code minSyncReplicas} quorum to detect
+ * broken replication.
+ *
+ * <p>Note: the {@code replay_lag} column is restricted to superusers by default. The exporter user
+ * needs the {@code pg_monitor} or {@code pg_read_all_stats} role to observe it; otherwise the lag
+ * reads as 0.
+ */
+public final class PostgresReplicationLogStatusProvider implements ReplicationLogStatusProvider {
+
+  private final ReplicationStatusMapper mapper;
+
+  public PostgresReplicationLogStatusProvider(final ReplicationStatusMapper mapper) {
+    this.mapper = mapper;
+  }
+
+  @Override
+  public long getCurrent() {
+    return mapper.getCurrentLogStatus();
+  }
+
+  @Override
+  public List<ReplicationLogStatus> getReplicationStatuses() {
+    return mapper.getReplicationStatus();
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/replication/ReplicationLogStatus.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/replication/ReplicationLogStatus.java
@@ -7,4 +7,4 @@
  */
 package io.camunda.db.rdbms.read.replication;
 
-public record ReplicationLogStatus(long logStatus, String replicaId, long replicationLagMs) {}
+public record ReplicationLogStatus(Long logStatus, String replicaId, Long replicationLagMs) {}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/replication/ReplicationLogStatus.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/replication/ReplicationLogStatus.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.replication;
+
+public record ReplicationLogStatus(long logStatus, String replicaId, long replicationLagMs) {}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/replication/ReplicationLogStatusProvider.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/replication/ReplicationLogStatusProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.replication;
+
+import java.util.List;
+
+/**
+ * Provides replication log status for tracking async replication state. The primary's current
+ * position is captured after each flush to know what has been committed. Replica statuses are
+ * polled periodically to determine what each replica has applied, together with the DB-reported
+ * replication lag per replica.
+ *
+ * <p>The position can represent different metrics depending on the database: a WAL LSN
+ * (PostgreSQL), a durable LSN (Aurora), or a timestamp (Azure SQL). Implementations are
+ * database-specific.
+ */
+public interface ReplicationLogStatusProvider {
+
+  /** Returns the primary's current replication position after the last commit. */
+  long getCurrent();
+
+  /**
+   * Returns per-replica state: last replayed position/timestamp, a stable unique identifier, and
+   * the DB-reported replication lag in milliseconds. Returning one row per replica lets the caller
+   * apply quorum-aware aggregation instead of collapsing to a single worst-case value in SQL.
+   */
+  List<ReplicationLogStatus> getReplicationStatuses();
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/replication/ReplicationLogStatusProviderFactory.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/replication/ReplicationLogStatusProviderFactory.java
@@ -9,7 +9,6 @@ package io.camunda.db.rdbms.read.replication;
 
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.sql.ReplicationStatusMapper;
-import java.util.Optional;
 
 public final class ReplicationLogStatusProviderFactory {
 
@@ -25,11 +24,17 @@ public final class ReplicationLogStatusProviderFactory {
     this.replicationStatusMapper = replicationStatusMapper;
   }
 
-  public Optional<ReplicationLogStatusProvider> create() {
+  public ReplicationLogStatusProvider create() {
     return switch (vendorDatabaseProperties.databaseId()) {
       case POSTGRESQL_DATABASE_ID ->
-          Optional.of(new PostgresReplicationLogStatusProvider(replicationStatusMapper));
-      case null, default -> Optional.empty();
+          new PostgresReplicationLogStatusProvider(replicationStatusMapper);
+      case null ->
+          throw new IllegalArgumentException(
+              "Cannot create ReplicationLogStatusProvider for null database id");
+      default ->
+          throw new IllegalArgumentException(
+              "Cannot create ReplicationLogStatusProvider for unknown database id "
+                  + vendorDatabaseProperties.databaseId());
     };
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/replication/ReplicationLogStatusProviderFactory.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/replication/ReplicationLogStatusProviderFactory.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.replication;
+
+import io.camunda.db.rdbms.config.VendorDatabaseProperties;
+import io.camunda.db.rdbms.sql.ReplicationStatusMapper;
+import java.util.Optional;
+
+public final class ReplicationLogStatusProviderFactory {
+
+  public static final String POSTGRESQL_DATABASE_ID = "postgresql";
+
+  private final VendorDatabaseProperties vendorDatabaseProperties;
+  private final ReplicationStatusMapper replicationStatusMapper;
+
+  public ReplicationLogStatusProviderFactory(
+      final VendorDatabaseProperties vendorDatabaseProperties,
+      final ReplicationStatusMapper replicationStatusMapper) {
+    this.vendorDatabaseProperties = vendorDatabaseProperties;
+    this.replicationStatusMapper = replicationStatusMapper;
+  }
+
+  public Optional<ReplicationLogStatusProvider> create() {
+    return switch (vendorDatabaseProperties.databaseId()) {
+      case POSTGRESQL_DATABASE_ID ->
+          Optional.of(new PostgresReplicationLogStatusProvider(replicationStatusMapper));
+      case null, default -> Optional.empty();
+    };
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/ReplicationStatusMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/ReplicationStatusMapper.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql;
+
+import io.camunda.db.rdbms.read.replication.ReplicationLogStatus;
+import java.util.List;
+
+public interface ReplicationStatusMapper {
+
+  long getCurrentLogStatus();
+
+  List<ReplicationLogStatus> getReplicationStatus();
+}

--- a/db/rdbms/src/main/resources/mapper/ReplicationStatusMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ReplicationStatusMapper.xml
@@ -10,11 +10,19 @@
   "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="io.camunda.db.rdbms.sql.ReplicationStatusMapper">
 
+  <resultMap id="replicationLogStatusResultMap" type="io.camunda.db.rdbms.read.replication.ReplicationLogStatus">
+    <constructor>
+      <arg column="logStatus" javaType="java.lang.Long"/>
+      <arg column="replicaId" javaType="java.lang.String"/>
+      <arg column="replicationLagMs" javaType="java.lang.Long"/>
+    </constructor>
+  </resultMap>
+
   <select id="getCurrentLogStatus" resultType="java.lang.Long" databaseId="postgresql">
     SELECT pg_wal_lsn_diff(pg_current_wal_lsn(), '0/0')::bigint last_lsn
   </select>
 
-  <select id="getReplicationStatus" resultType="io.camunda.db.rdbms.read.replication.ReplicationLogStatus" databaseId="postgresql">
+  <select id="getReplicationStatus" resultMap="replicationLogStatusResultMap" databaseId="postgresql">
     SELECT
       COALESCE(pg_wal_lsn_diff(replay_lsn, '0/0'), 0)::bigint AS logStatus,
       pid::text AS replicaId,

--- a/db/rdbms/src/main/resources/mapper/ReplicationStatusMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ReplicationStatusMapper.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="io.camunda.db.rdbms.sql.ReplicationStatusMapper">
+
+  <select id="getCurrentLogStatus" resultType="java.lang.Long" databaseId="postgresql">
+    SELECT pg_wal_lsn_diff(pg_current_wal_lsn(), '0/0')::bigint last_lsn
+  </select>
+
+  <select id="getReplicationStatus" resultType="io.camunda.db.rdbms.read.replication.ReplicationLogStatus" databaseId="postgresql">
+    SELECT
+      COALESCE(pg_wal_lsn_diff(replay_lsn, '0/0'), 0)::bigint AS logStatus,
+      pid::text AS replicaId,
+      COALESCE((EXTRACT(EPOCH FROM replay_lag) * 1000)::bigint, 0) AS replicationLagMs
+    FROM pg_stat_replication
+    WHERE pid IS NOT NULL;
+  </select>
+
+</mapper>
+

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/replication/ReplicationLogStatusProviderFactoryTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/replication/ReplicationLogStatusProviderFactoryTest.java
@@ -67,4 +67,3 @@ class ReplicationLogStatusProviderFactoryTest {
     assertThat(provider).isEmpty();
   }
 }
-

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/replication/ReplicationLogStatusProviderFactoryTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/replication/ReplicationLogStatusProviderFactoryTest.java
@@ -8,6 +8,7 @@
 package io.camunda.db.rdbms.read.replication;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -30,9 +31,7 @@ class ReplicationLogStatusProviderFactoryTest {
     final var provider = factory.create();
 
     // then
-    assertThat(provider)
-        .hasValueSatisfying(
-            value -> assertThat(value).isInstanceOf(PostgresReplicationLogStatusProvider.class));
+    assertThat(provider).isInstanceOf(PostgresReplicationLogStatusProvider.class);
   }
 
   @Test
@@ -45,10 +44,9 @@ class ReplicationLogStatusProviderFactoryTest {
             vendorDatabaseProperties, mock(ReplicationStatusMapper.class));
 
     // when
-    final var provider = factory.create();
-
-    // then
-    assertThat(provider).isEmpty();
+    assertThatThrownBy(factory::create)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot create ReplicationLogStatusProvider for unknown database id oracle");
   }
 
   @Test
@@ -61,9 +59,8 @@ class ReplicationLogStatusProviderFactoryTest {
             vendorDatabaseProperties, mock(ReplicationStatusMapper.class));
 
     // when
-    final var provider = factory.create();
-
-    // then
-    assertThat(provider).isEmpty();
+    assertThatThrownBy(factory::create)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot create ReplicationLogStatusProvider for null database id");
   }
 }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/replication/ReplicationLogStatusProviderFactoryTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/replication/ReplicationLogStatusProviderFactoryTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.replication;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.db.rdbms.config.VendorDatabaseProperties;
+import io.camunda.db.rdbms.sql.ReplicationStatusMapper;
+import org.junit.jupiter.api.Test;
+
+class ReplicationLogStatusProviderFactoryTest {
+
+  @Test
+  void shouldCreatePostgresReplicationLogStatusProvider() {
+    // given
+    final var vendorDatabaseProperties = mock(VendorDatabaseProperties.class);
+    when(vendorDatabaseProperties.databaseId()).thenReturn("postgresql");
+    final var factory =
+        new ReplicationLogStatusProviderFactory(
+            vendorDatabaseProperties, mock(ReplicationStatusMapper.class));
+
+    // when
+    final var provider = factory.create();
+
+    // then
+    assertThat(provider)
+        .hasValueSatisfying(
+            value -> assertThat(value).isInstanceOf(PostgresReplicationLogStatusProvider.class));
+  }
+
+  @Test
+  void shouldNotCreateReplicationLogStatusProviderForUnsupportedDatabase() {
+    // given
+    final var vendorDatabaseProperties = mock(VendorDatabaseProperties.class);
+    when(vendorDatabaseProperties.databaseId()).thenReturn("oracle");
+    final var factory =
+        new ReplicationLogStatusProviderFactory(
+            vendorDatabaseProperties, mock(ReplicationStatusMapper.class));
+
+    // when
+    final var provider = factory.create();
+
+    // then
+    assertThat(provider).isEmpty();
+  }
+
+  @Test
+  void shouldNotCreateReplicationLogStatusProviderWhenDatabaseIdIsNull() {
+    // given
+    final var vendorDatabaseProperties = mock(VendorDatabaseProperties.class);
+    when(vendorDatabaseProperties.databaseId()).thenReturn(null);
+    final var factory =
+        new ReplicationLogStatusProviderFactory(
+            vendorDatabaseProperties, mock(ReplicationStatusMapper.class));
+
+    // when
+    final var provider = factory.create();
+
+    // then
+    assertThat(provider).isEmpty();
+  }
+}
+

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
@@ -36,6 +36,7 @@ import io.camunda.db.rdbms.sql.PersistentWebSessionMapper;
 import io.camunda.db.rdbms.sql.ProcessDefinitionMapper;
 import io.camunda.db.rdbms.sql.ProcessInstanceMapper;
 import io.camunda.db.rdbms.sql.PurgeMapper;
+import io.camunda.db.rdbms.sql.ReplicationStatusMapper;
 import io.camunda.db.rdbms.sql.RoleMapper;
 import io.camunda.db.rdbms.sql.SequenceFlowMapper;
 import io.camunda.db.rdbms.sql.TableMetricsMapper;
@@ -330,6 +331,12 @@ public class MyBatisConfiguration {
   MapperFactoryBean<HistoryDeletionMapper> historyDeletionMapper(
       final SqlSessionFactory sqlSessionFactory) {
     return createMapperFactoryBean(sqlSessionFactory, HistoryDeletionMapper.class);
+  }
+
+  @Bean
+  MapperFactoryBean<ReplicationStatusMapper> replicationStatusMapper(
+      final SqlSessionFactory sqlSessionFactory) {
+    return createMapperFactoryBean(sqlSessionFactory, ReplicationStatusMapper.class);
   }
 
   @Bean

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
@@ -13,6 +13,7 @@ import io.camunda.configuration.conditions.ConditionalOnSecondaryStorageType;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.read.RdbmsReaderConfig;
+import io.camunda.db.rdbms.read.replication.ReplicationLogStatusProviderFactory;
 import io.camunda.db.rdbms.read.service.AuditLogDbReader;
 import io.camunda.db.rdbms.read.service.AuthorizationDbReader;
 import io.camunda.db.rdbms.read.service.BatchOperationDbReader;
@@ -79,6 +80,7 @@ import io.camunda.db.rdbms.sql.PersistentWebSessionMapper;
 import io.camunda.db.rdbms.sql.ProcessDefinitionMapper;
 import io.camunda.db.rdbms.sql.ProcessInstanceMapper;
 import io.camunda.db.rdbms.sql.PurgeMapper;
+import io.camunda.db.rdbms.sql.ReplicationStatusMapper;
 import io.camunda.db.rdbms.sql.RoleMapper;
 import io.camunda.db.rdbms.sql.SequenceFlowMapper;
 import io.camunda.db.rdbms.sql.TableMetricsMapper;
@@ -389,6 +391,14 @@ public class RdbmsConfiguration {
   }
 
   @Bean
+  public ReplicationLogStatusProviderFactory replicationLogStatusProviderFactory(
+      final VendorDatabaseProperties vendorDatabaseProperties,
+      final ReplicationStatusMapper replicationStatusMapper) {
+    return new ReplicationLogStatusProviderFactory(
+        vendorDatabaseProperties, replicationStatusMapper);
+  }
+
+  @Bean
   public GlobalListenerDbReader globalListenerRdbmsReader(
       final GlobalListenerMapper globalListenerMapper, final RdbmsReaderConfig readerConfig) {
     return new GlobalListenerDbReader(globalListenerMapper, readerConfig);
@@ -514,7 +524,8 @@ public class RdbmsConfiguration {
       final IncidentProcessInstanceStatisticsByDefinitionDbReader
           incidentProcessInstanceStatisticsByDefinitionReader,
       final GlobalListenerDbReader globalListenerDbReader,
-      final DeployedResourceDbReader deployedResourceDbReader) {
+      final DeployedResourceDbReader deployedResourceDbReader,
+      final ReplicationLogStatusProviderFactory replicationLogStatusProviderFactory) {
     return new RdbmsService(
         rdbmsWriterFactory,
         auditLogReader,
@@ -554,7 +565,8 @@ public class RdbmsConfiguration {
         incidentProcessInstanceStatisticsByErrorReader,
         incidentProcessInstanceStatisticsByDefinitionReader,
         globalListenerDbReader,
-        deployedResourceDbReader);
+        deployedResourceDbReader,
+        replicationLogStatusProviderFactory);
   }
 
   @Bean

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/asyncreplication/AsyncReplicationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/asyncreplication/AsyncReplicationIT.java
@@ -28,11 +28,7 @@ public class AsyncReplicationIT {
   @TestTemplate
   public void shouldQueryReplicationStatus(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
-    final var oReplicationStatusProvider = rdbmsService.getReplicationLogStatusProvider();
-
-    assertThat(oReplicationStatusProvider).isPresent();
-
-    final var replicationStatusProvider = oReplicationStatusProvider.get();
+    final var replicationStatusProvider = rdbmsService.getReplicationLogStatusProvider();
 
     final var currentLsn = replicationStatusProvider.getCurrent();
     final var replicationStatuses = replicationStatusProvider.getReplicationStatuses();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/asyncreplication/AsyncReplicationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/asyncreplication/AsyncReplicationIT.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.asyncreplication;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+@Tag("rdbms")
+public class AsyncReplicationIT {
+
+  @RegisterExtension
+  static final CamundaRdbmsInvocationContextProviderExtension TEST_APPLICATION =
+      new CamundaRdbmsInvocationContextProviderExtension(
+          "camundaWithPostgresSQL" // currently we only support PostgreSQL
+          );
+
+  @TestTemplate
+  public void shouldQueryReplicationStatus(final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final var oReplicationStatusProvider = rdbmsService.getReplicationLogStatusProvider();
+
+    assertThat(oReplicationStatusProvider).isPresent();
+
+    final var replicationStatusProvider = oReplicationStatusProvider.get();
+
+    final var currentLsn = replicationStatusProvider.getCurrent();
+    final var replicationStatuses = replicationStatusProvider.getReplicationStatuses();
+
+    assertThat(currentLsn).isGreaterThan(0);
+    assertThat(replicationStatuses).isNotNull();
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterBatchOperationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterBatchOperationsIT.java
@@ -51,6 +51,7 @@ class RdbmsExporterBatchOperationsIT {
       new VendorDatabaseProperties(
           new Properties() {
             {
+              setProperty("databaseId", "h2");
               setProperty("variableValue.previewSize", "100");
               setProperty("userCharColumn.size", "50");
               setProperty("errorMessage.size", "500");

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
@@ -142,6 +142,7 @@ class RdbmsExporterIT {
       new VendorDatabaseProperties(
           new Properties() {
             {
+              setProperty("databaseId", "h2");
               setProperty("variableValue.previewSize", "100");
               setProperty("userCharColumn.size", "50");
               setProperty("errorMessage.size", "500");

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -131,13 +131,7 @@ public class RdbmsExporterWrapper implements Exporter {
     builder.historyDeletionService(historyDeletionService);
     if (config.getAsyncReplication().isEnabled()) {
       final ReplicationLogStatusProvider replicationLogStatusProvider =
-          rdbmsService
-              .getReplicationLogStatusProvider()
-              .orElseThrow(
-                  () ->
-                      new IllegalStateException(
-                          "No LSN provider found for configured databaseId "
-                              + vendorDatabaseProperties.databaseId()));
+          rdbmsService.getReplicationLogStatusProvider();
       builder.replicationControllerFactory(
           new LsnReplicationControllerFactory(
               replicationLogStatusProvider,

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -135,7 +135,9 @@ public class RdbmsExporterWrapper implements Exporter {
               .getReplicationLogStatusProvider()
               .orElseThrow(
                   () ->
-                      new IllegalStateException("Not LSN provider found for configured database"));
+                      new IllegalStateException(
+                          "No LSN provider found for configured databaseId "
+                              + vendorDatabaseProperties.databaseId()));
       builder.replicationControllerFactory(
           new LsnReplicationControllerFactory(
               replicationLogStatusProvider,

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.rdbms;
 import io.camunda.db.rdbms.RdbmsSchemaManager;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
+import io.camunda.db.rdbms.read.replication.ReplicationLogStatusProvider;
 import io.camunda.db.rdbms.write.RdbmsWriterConfig.HistoryDeletionConfig;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.db.rdbms.write.service.HistoryCleanupService;
@@ -56,6 +57,7 @@ import io.camunda.exporter.rdbms.handlers.batchoperation.ProcessInstanceCancella
 import io.camunda.exporter.rdbms.handlers.batchoperation.ProcessInstanceHistoryDeletionBatchOperationExportHandler;
 import io.camunda.exporter.rdbms.handlers.batchoperation.ProcessInstanceMigrationBatchOperationExportHandler;
 import io.camunda.exporter.rdbms.handlers.batchoperation.ProcessInstanceModificationBatchOperationExportHandler;
+import io.camunda.exporter.rdbms.replication.LsnReplicationControllerFactory;
 import io.camunda.exporter.rdbms.replication.ReplicationControllerFactory;
 import io.camunda.search.entities.BatchOperationType;
 import io.camunda.zeebe.exporter.api.Exporter;
@@ -127,7 +129,22 @@ public class RdbmsExporterWrapper implements Exporter {
                 config.getHistoryDeletion().getDependentRowLimit()),
             context.clock());
     builder.historyDeletionService(historyDeletionService);
-    builder.replicationControllerFactory(ReplicationControllerFactory.noop());
+    if (config.getAsyncReplication().isEnabled()) {
+      final ReplicationLogStatusProvider replicationLogStatusProvider =
+          rdbmsService
+              .getReplicationLogStatusProvider()
+              .orElseThrow(
+                  () ->
+                      new IllegalStateException("Not LSN provider found for configured database"));
+      builder.replicationControllerFactory(
+          new LsnReplicationControllerFactory(
+              replicationLogStatusProvider,
+              config.getAsyncReplication(),
+              partitionId,
+              context.clock()));
+    } else {
+      builder.replicationControllerFactory(ReplicationControllerFactory.noop());
+    }
 
     createHandlers(partitionId, rdbmsWriters, builder, config, historyCleanupService);
     createBatchOperationHandlers(rdbmsWriters, builder, historyCleanupService);

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/replication/LsnReplicationController.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/replication/LsnReplicationController.java
@@ -75,22 +75,28 @@ public class LsnReplicationController implements ReplicationController {
   @Override
   public void onFlush(final long exporterPosition) {
     flushedPosition.set(exporterPosition);
-    final long currentLsn = lsnProvider.getCurrent();
-    final long now = clock.millis();
-    LOG.debug(
-        "[RDBMS Exporter P{}] Flushed position {}, current LSN is {}, enqueueing for replication check",
-        partitionId,
-        exporterPosition,
-        currentLsn);
-    if (!pendingEntries.offer(new LsnPositionEntry(exporterPosition, currentLsn, now))) {
-      // it's fine to just drop. When we are able to compact, when we export a new entry it will be
-      // added. If the queue is not full for too much it's not a problem, otherwise we will just hit
-      // the max_lag bound.
-      LOG.warn(
-          "[RDBMS Exporter P{}] Replication queue is full, dropping LSN entry (lsn={}, position={})",
+    try {
+      final long currentLsn = lsnProvider.getCurrent();
+      final long now = clock.millis();
+      LOG.debug(
+          "[RDBMS Exporter P{}] Flushed position {}, current LSN is {}, enqueueing for replication check",
           partitionId,
-          currentLsn,
-          exporterPosition);
+          exporterPosition,
+          currentLsn);
+      if (!pendingEntries.offer(new LsnPositionEntry(exporterPosition, currentLsn, now))) {
+        // it's fine to just drop. When we are able to compact, when we export a new entry it will
+        // be
+        // added. If the queue is not full for too much it's not a problem, otherwise we will just
+        // hit
+        // the max_lag bound.
+        LOG.warn(
+            "[RDBMS Exporter P{}] Replication queue is full, dropping LSN entry (lsn={}, position={})",
+            partitionId,
+            currentLsn,
+            exporterPosition);
+      }
+    } catch (final Exception e) {
+      pauseOnFlushFailure(exporterPosition, e);
     }
   }
 
@@ -184,6 +190,16 @@ public class LsnReplicationController implements ReplicationController {
     }
 
     return null;
+  }
+
+  private void pauseOnFlushFailure(final long exporterPosition, final Exception e) {
+    paused.set(true);
+    LOG.error(
+        "[RDBMS Exporter P{}] Failed to capture replication state after flushing exporter "
+            + "position {}. Exporting will remain paused until replication checks recover.",
+        partitionId,
+        exporterPosition,
+        e);
   }
 
   private void updatePausedState(

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/replication/LsnReplicationController.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/replication/LsnReplicationController.java
@@ -43,10 +43,11 @@ public class LsnReplicationController implements ReplicationController {
   private final AtomicReference<Instant> lastConfirmedReplication;
   private final AtomicBoolean paused = new AtomicBoolean(false);
 
-  private final ScheduledTask replicationCheckTask;
   private final int minSyncReplicas;
   private final Duration maxLag;
   private final boolean pauseOnMaxLagExceeded;
+
+  private ScheduledTask replicationCheckTask;
 
   public LsnReplicationController(
       final Controller controller,
@@ -131,8 +132,9 @@ public class LsnReplicationController implements ReplicationController {
           replicationConfiguration.getPollingInterval(),
           e);
     } finally {
-      controller.scheduleCancellableTask(
-          replicationConfiguration.getPollingInterval(), this::checkReplication);
+      replicationCheckTask =
+          controller.scheduleCancellableTask(
+              replicationConfiguration.getPollingInterval(), this::checkReplication);
     }
   }
 

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/replication/LsnReplicationController.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/replication/LsnReplicationController.java
@@ -26,6 +26,24 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * The LsnReplicationController uses the log sequence number (LSN) of the database to compare the
+ * replication status of the primary and all linked replicas with each other. We only
+ * acknowledge/commit exporter positions to the ExporterController if the LSN of the replicas has
+ * reached the LSN of the primary at the time of the flush. <br>
+ * <br>
+ * This ensures that the exporter will only acknowledge positions to the ExporterController if they
+ * have been replicated to all replicas, which guarantees that no data will be lost in case of a
+ * failover. The replication status is checked periodically by polling the database for the current
+ * LSN of the primary and all replicas and comparing them with each other. If the replication lag
+ * exceeds a configured threshold of <code>maxLag</code>, the replication is considered out-of-sync
+ * and the exporter is paused until it is back in sync.<br>
+ * <br>
+ * Note: While the exporter position is a sequential offset per partition, the LSN is a global,
+ * monotonically increasing value representing the commit order of transactions in the database. The
+ * used LSN is never the actual LSN of the last exporter transaction, but it is still guaranteed
+ * that it is higher, so we still can use that LSN as a guarantee for replication.
+ */
 public class LsnReplicationController implements ReplicationController {
   public static final int DEFAULT_QUEUE_CAPACITY = 8192;
 
@@ -33,7 +51,7 @@ public class LsnReplicationController implements ReplicationController {
 
   private final ReplicationLogStatusProvider lsnProvider;
   private final Controller controller;
-  private final ReplicationConfiguration replicationConfiguration;
+  private final ReplicationConfiguration config;
   private final int partitionId;
   private final InstantSource clock;
 
@@ -43,11 +61,7 @@ public class LsnReplicationController implements ReplicationController {
   private final AtomicReference<Instant> lastConfirmedReplication;
   private final AtomicBoolean paused = new AtomicBoolean(false);
 
-  private final int minSyncReplicas;
-  private final Duration maxLag;
-  private final boolean pauseOnMaxLagExceeded;
-
-  private ScheduledTask replicationCheckTask;
+  private volatile ScheduledTask replicationCheckTask;
 
   public LsnReplicationController(
       final Controller controller,
@@ -57,7 +71,7 @@ public class LsnReplicationController implements ReplicationController {
       final InstantSource clock) {
     this.lsnProvider = lsnProvider;
     this.controller = controller;
-    this.replicationConfiguration = replicationConfiguration;
+    config = replicationConfiguration;
     this.partitionId = partitionId;
     this.clock = clock;
 
@@ -65,13 +79,16 @@ public class LsnReplicationController implements ReplicationController {
     replicationCheckTask =
         controller.scheduleCancellableTask(
             replicationConfiguration.getPollingInterval(), this::checkReplication);
-    minSyncReplicas = this.replicationConfiguration.getMinSyncReplicas();
-    maxLag = this.replicationConfiguration.getMaxLag();
-    pauseOnMaxLagExceeded = this.replicationConfiguration.isPauseOnMaxLagExceeded();
 
-    lastConfirmedReplication = new AtomicReference<>(this.clock.instant());
+    lastConfirmedReplication = new AtomicReference<>(Instant.MIN);
   }
 
+  /**
+   * Tracks the current LSN and link it to the current exporter position. This pair is remembered in
+   * a list until it is confirmed by the connected replicas.
+   *
+   * @param exporterPosition current exported position
+   */
   @Override
   public void onFlush(final long exporterPosition) {
     flushedPosition.set(exporterPosition);
@@ -85,10 +102,8 @@ public class LsnReplicationController implements ReplicationController {
           currentLsn);
       if (!pendingEntries.offer(new LsnPositionEntry(exporterPosition, currentLsn, now))) {
         // it's fine to just drop. When we are able to compact, when we export a new entry it will
-        // be
-        // added. If the queue is not full for too much it's not a problem, otherwise we will just
-        // hit
-        // the max_lag bound.
+        // be added. If the queue is not full for too much it's not a problem, otherwise we will
+        // just hit the max_lag bound.
         LOG.warn(
             "[RDBMS Exporter P{}] Replication queue is full, dropping LSN entry (lsn={}, position={})",
             partitionId,
@@ -105,6 +120,13 @@ public class LsnReplicationController implements ReplicationController {
     return !paused.get();
   }
 
+  /**
+   * Retrieve the replication status from the connected replicas and confirm all older pairs of
+   * LSN+position to the exporter controller.<br>
+   * <br>
+   * If the oldest still not replicated position is older than the configured <code>maxLag</code>,
+   * the replication is marked as <i>out-of-sync</i>.
+   */
   @VisibleForTesting
   void checkReplication() {
     try {
@@ -122,18 +144,20 @@ public class LsnReplicationController implements ReplicationController {
           dbReplicationLag);
 
       final boolean dbLagExceeded = isMaxLagExceeded(dbReplicationLag);
-      final boolean quorumNotMet = pendingEntries.isEmpty() && connectedReplicas < minSyncReplicas;
+      final boolean quorumNotMet =
+          pendingEntries.isEmpty() && connectedReplicas < config.getMinSyncReplicas();
 
       // pause when:
       // - pauseOnMaxLagExceeded is true
       // - either the replicas have not confirmed for long time
       // - or there are no pending entries and there are not enough replicas connected
       updatePausedState(
-          pauseOnMaxLagExceeded && (dbLagExceeded || quorumNotMet),
+          config.isPauseOnMaxLagExceeded() && (dbLagExceeded || quorumNotMet),
           dbReplicationLag,
           connectedReplicas);
 
       if (confirmedEntry != null) {
+        replicatedPosition.set(confirmedEntry.position);
         LOG.info(
             "[RDBMS Exporter P{}] Updating replicated position to {}",
             partitionId,
@@ -144,14 +168,13 @@ public class LsnReplicationController implements ReplicationController {
       LOG.error(
           "[RDBMS Exporter P{}] Error while checking replication status, will retry after {}",
           partitionId,
-          replicationConfiguration.getPollingInterval(),
+          config.getPollingInterval(),
           e);
     } finally {
       // if null, controller was closed during check
       if (replicationCheckTask != null) {
         replicationCheckTask =
-            controller.scheduleCancellableTask(
-                replicationConfiguration.getPollingInterval(), this::checkReplication);
+            controller.scheduleCancellableTask(config.getPollingInterval(), this::checkReplication);
       }
     }
   }
@@ -166,7 +189,7 @@ public class LsnReplicationController implements ReplicationController {
 
   @VisibleForTesting
   boolean isMaxLagExceeded(final Duration dbLag) {
-    return dbLag.compareTo(maxLag) > 0;
+    return dbLag.compareTo(config.getMaxLag()) > 0;
   }
 
   /**
@@ -197,7 +220,6 @@ public class LsnReplicationController implements ReplicationController {
       lastConfirmedEntry = pendingEntries.poll();
     }
     if (newReplicatedPosition > replicatedPosition.get()) {
-      replicatedPosition.set(newReplicatedPosition);
       return lastConfirmedEntry;
     }
 
@@ -222,36 +244,42 @@ public class LsnReplicationController implements ReplicationController {
           "[RDBMS Exporter P{}] Pausing exporter: replication lag ({}) exceeded maxLag ({})",
           partitionId,
           dbReportedLag,
-          maxLag);
+          config.getMaxLag());
     } else if (!shouldPause && wasPaused) {
       LOG.info(
           "[RDBMS Exporter P{}] Resuming exporter: replication quorum met ({}/{} replicas) and lag ({}) within maxLag ({})",
           partitionId,
           connectedReplicas,
-          minSyncReplicas,
+          config.getMinSyncReplicas(),
           dbReportedLag,
-          maxLag);
+          config.getMaxLag());
     }
   }
 
+  /**
+   * Calculates the lowest LSN which is confirmed by at least the configured <code>minSyncReplicas
+   * </code> connected replicas.<br>
+   * The number of entries in <code>statuses</code> may vary over time since replicas may disconnect
+   * on network failure or when new, optional replicas are connected. The <code>minSyncReplicas
+   * </code> configuration property defines a minimal quorum of replicas in sync.
+   *
+   * @param statuses the replication status read from all connected replicas.
+   * @return the lowest LSN confirmed.
+   */
   @VisibleForTesting
   long computeConfirmedLsn(final List<ReplicationLogStatus> statuses) {
     if (lsnProvider.getCurrent() < 0) {
       return Long.MIN_VALUE;
     }
 
-    if (minSyncReplicas == 0) {
-      return Long.MAX_VALUE;
-    }
-
-    if (statuses.size() < minSyncReplicas) {
+    if (statuses.size() < config.getMinSyncReplicas()) {
       return -1;
     }
 
     return statuses.stream()
         .map(ReplicationLogStatus::logStatus)
         .sorted(Comparator.<Long>naturalOrder().reversed())
-        .limit(minSyncReplicas)
+        .limit(config.getMinSyncReplicas())
         .min(Comparator.naturalOrder())
         .orElse(-1L);
   }
@@ -262,5 +290,12 @@ public class LsnReplicationController implements ReplicationController {
     replicationCheckTask = null;
   }
 
+  /**
+   * An entry linking an LSN to an exporter position.
+   *
+   * @param position the exporter position
+   * @param lsn the LSN
+   * @param enqueueTimeMs the instant in ms when the LSN was queried
+   */
   record LsnPositionEntry(long position, long lsn, long enqueueTimeMs) {}
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/replication/LsnReplicationController.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/replication/LsnReplicationController.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.replication;
+
+import io.camunda.db.rdbms.read.replication.ReplicationLogStatus;
+import io.camunda.db.rdbms.read.replication.ReplicationLogStatusProvider;
+import io.camunda.exporter.rdbms.ExporterConfiguration.ReplicationConfiguration;
+import io.camunda.zeebe.exporter.api.context.Controller;
+import io.camunda.zeebe.exporter.api.context.ScheduledTask;
+import io.camunda.zeebe.util.VisibleForTesting;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.InstantSource;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LsnReplicationController implements ReplicationController {
+  public static final int DEFAULT_QUEUE_CAPACITY = 8192;
+
+  private static final Logger LOG = LoggerFactory.getLogger(LsnReplicationController.class);
+
+  private final ReplicationLogStatusProvider lsnProvider;
+  private final Controller controller;
+  private final ReplicationConfiguration replicationConfiguration;
+  private final int partitionId;
+  private final InstantSource clock;
+
+  private final BlockingQueue<LsnPositionEntry> pendingEntries;
+  private final AtomicLong flushedPosition = new AtomicLong(-1);
+  private final AtomicLong replicatedPosition = new AtomicLong(-1);
+  private final AtomicReference<Instant> lastConfirmedReplication;
+  private final AtomicBoolean paused = new AtomicBoolean(false);
+
+  private final ScheduledTask replicationCheckTask;
+  private final int minSyncReplicas;
+  private final Duration maxLag;
+  private final boolean pauseOnMaxLagExceeded;
+
+  public LsnReplicationController(
+      final Controller controller,
+      final ReplicationLogStatusProvider lsnProvider,
+      final ReplicationConfiguration replicationConfiguration,
+      final int partitionId,
+      final InstantSource clock) {
+    this.lsnProvider = lsnProvider;
+    this.controller = controller;
+    this.replicationConfiguration = replicationConfiguration;
+    this.partitionId = partitionId;
+    this.clock = clock;
+
+    pendingEntries = new ArrayBlockingQueue<>(DEFAULT_QUEUE_CAPACITY);
+    replicationCheckTask =
+        controller.scheduleCancellableTask(
+            replicationConfiguration.getPollingInterval(), this::checkReplication);
+    minSyncReplicas = this.replicationConfiguration.getMinSyncReplicas();
+    maxLag = this.replicationConfiguration.getMaxLag();
+    pauseOnMaxLagExceeded = this.replicationConfiguration.isPauseOnMaxLagExceeded();
+
+    lastConfirmedReplication = new AtomicReference<>(this.clock.instant());
+  }
+
+  @Override
+  public void onFlush(final long exporterPosition) {
+    flushedPosition.set(exporterPosition);
+    final long currentLsn = lsnProvider.getCurrent();
+    final long now = clock.millis();
+    if (!pendingEntries.offer(new LsnPositionEntry(exporterPosition, currentLsn, now))) {
+      // it's fine to just drop. When we are able to compact, when we export a new entry it will be
+      // added. If the queue is not full for too much it's not a problem, otherwise we will just hit
+      // the max_lag bound.
+      LOG.warn(
+          "[RDBMS Exporter P{}] Replication queue is full, dropping LSN entry (lsn={}, position={})",
+          partitionId,
+          currentLsn,
+          exporterPosition);
+    }
+  }
+
+  @Override
+  public boolean isReplicationInSync() {
+    return !paused.get();
+  }
+
+  @VisibleForTesting
+  void checkReplication() {
+    try {
+      final var statuses = lsnProvider.getReplicationStatuses();
+      final int connectedReplicas = statuses.size();
+
+      final long confirmedLsn = computeConfirmedLsn(statuses);
+      final var confirmedEntry = removeConfirmedLsnEntries(confirmedLsn);
+      final Duration dbReportedLag = getCurrentDbLag();
+      final boolean dbLagExceeded = isMaxLagExceeded(dbReportedLag);
+
+      updatePausedState(pauseOnMaxLagExceeded && dbLagExceeded, dbReportedLag, connectedReplicas);
+
+      if (confirmedEntry != null) {
+        LOG.info(
+            "[RDBMS Exporter P{}] Updating replicated position to {}",
+            partitionId,
+            replicatedPosition.get());
+        controller.updateLastExportedRecordPosition(replicatedPosition.get());
+      }
+    } catch (final Exception e) {
+      LOG.error(
+          "[RDBMS Exporter P{}] Error while checking replication status, will retry after {}",
+          partitionId,
+          replicationConfiguration.getPollingInterval(),
+          e);
+    } finally {
+      controller.scheduleCancellableTask(
+          replicationConfiguration.getPollingInterval(), this::checkReplication);
+    }
+  }
+
+  @VisibleForTesting
+  Duration getCurrentDbLag() {
+    if (pendingEntries.isEmpty()) {
+      return Duration.ZERO;
+    }
+    return Duration.ofMillis(clock.millis() - pendingEntries.peek().enqueueTimeMs);
+  }
+
+  @VisibleForTesting
+  boolean isMaxLagExceeded(final Duration dbLag) {
+    return dbLag.compareTo(maxLag) > 0;
+  }
+
+  /**
+   * Removes entries from the queue which have been confirmed based on the confirmedLsn.
+   *
+   * @param confirmedLsn the confirmed LSN based on the database
+   * @return the highest confirmed entry
+   */
+  @VisibleForTesting
+  LsnPositionEntry removeConfirmedLsnEntries(final long confirmedLsn) {
+    LsnPositionEntry lastConfirmedEntry = null;
+    LsnPositionEntry entry;
+    long newReplicatedPosition = replicatedPosition.get();
+    while ((entry = pendingEntries.peek()) != null) {
+      if (entry.lsn() > confirmedLsn) {
+        break;
+      }
+
+      lastConfirmedReplication.set(Instant.ofEpochMilli(entry.enqueueTimeMs()));
+      newReplicatedPosition = entry.position();
+      lastConfirmedEntry = pendingEntries.poll();
+    }
+    if (newReplicatedPosition > replicatedPosition.get()) {
+      replicatedPosition.set(newReplicatedPosition);
+      return lastConfirmedEntry;
+    }
+
+    return null;
+  }
+
+  private void updatePausedState(
+      final boolean shouldPause, final Duration dbReportedLag, final int connectedReplicas) {
+    final boolean wasPaused = paused.getAndSet(shouldPause);
+    if (shouldPause && !wasPaused) {
+      LOG.warn(
+          "[RDBMS Exporter P{}] Pausing exporter: DB-reported replication lag ({}) exceeded maxLag ({})",
+          partitionId,
+          dbReportedLag,
+          maxLag);
+    } else if (!shouldPause && wasPaused) {
+      LOG.info(
+          "[RDBMS Exporter P{}] Resuming exporter: replication quorum met ({}/{} replicas) and DB-reported lag ({}) within maxLag ({})",
+          partitionId,
+          connectedReplicas,
+          minSyncReplicas,
+          dbReportedLag,
+          maxLag);
+    }
+  }
+
+  @VisibleForTesting
+  long computeConfirmedLsn(final List<ReplicationLogStatus> statuses) {
+    if (lsnProvider.getCurrent() < 0) {
+      return Long.MIN_VALUE;
+    }
+
+    if (minSyncReplicas == 0) {
+      return Long.MAX_VALUE;
+    }
+
+    if (statuses.size() < minSyncReplicas) {
+      return -1;
+    }
+
+    return statuses.stream()
+        .map(ReplicationLogStatus::logStatus)
+        .sorted(Comparator.<Long>naturalOrder().reversed())
+        .limit(minSyncReplicas)
+        .min(Comparator.naturalOrder())
+        .orElse(-1L);
+  }
+
+  @Override
+  public void close() throws Exception {
+    replicationCheckTask.cancel();
+  }
+
+  record LsnPositionEntry(long position, long lsn, long enqueueTimeMs) {}
+}

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/replication/LsnReplicationController.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/replication/LsnReplicationController.java
@@ -76,6 +76,11 @@ public class LsnReplicationController implements ReplicationController {
     flushedPosition.set(exporterPosition);
     final long currentLsn = lsnProvider.getCurrent();
     final long now = clock.millis();
+    LOG.debug(
+        "[RDBMS Exporter P{}] Flushed position {}, current LSN is {}, enqueueing for replication check",
+        partitionId,
+        exporterPosition,
+        currentLsn);
     if (!pendingEntries.offer(new LsnPositionEntry(exporterPosition, currentLsn, now))) {
       // it's fine to just drop. When we are able to compact, when we export a new entry it will be
       // added. If the queue is not full for too much it's not a problem, otherwise we will just hit
@@ -103,6 +108,12 @@ public class LsnReplicationController implements ReplicationController {
       final var confirmedEntry = removeConfirmedLsnEntries(confirmedLsn);
       final Duration dbReportedLag = getCurrentDbLag();
       final boolean dbLagExceeded = isMaxLagExceeded(dbReportedLag);
+
+      LOG.debug(
+          "[RDBMS Exporter P{}] Confirmed LSN {}, current lag is {}",
+          partitionId,
+          confirmedLsn,
+          dbReportedLag);
 
       updatePausedState(pauseOnMaxLagExceeded && dbLagExceeded, dbReportedLag, connectedReplicas);
 
@@ -153,6 +164,13 @@ public class LsnReplicationController implements ReplicationController {
       if (entry.lsn() > confirmedLsn) {
         break;
       }
+
+      LOG.trace(
+          "[RDBMS Exporter P{}] Removing pending LSN {} for position {}, as it is lower than confirmed lsn {}",
+          partitionId,
+          entry.lsn(),
+          entry.position(),
+          confirmedLsn);
 
       lastConfirmedReplication.set(Instant.ofEpochMilli(entry.enqueueTimeMs()));
       newReplicatedPosition = entry.position();

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/replication/LsnReplicationController.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/replication/LsnReplicationController.java
@@ -113,16 +113,25 @@ public class LsnReplicationController implements ReplicationController {
 
       final long confirmedLsn = computeConfirmedLsn(statuses);
       final var confirmedEntry = removeConfirmedLsnEntries(confirmedLsn);
-      final Duration dbReportedLag = getCurrentDbLag();
-      final boolean dbLagExceeded = isMaxLagExceeded(dbReportedLag);
+      final Duration dbReplicationLag = getCurrentDbLag();
 
       LOG.debug(
           "[RDBMS Exporter P{}] Confirmed LSN {}, current lag is {}",
           partitionId,
           confirmedLsn,
-          dbReportedLag);
+          dbReplicationLag);
 
-      updatePausedState(pauseOnMaxLagExceeded && dbLagExceeded, dbReportedLag, connectedReplicas);
+      final boolean dbLagExceeded = isMaxLagExceeded(dbReplicationLag);
+      final boolean quorumNotMet = pendingEntries.isEmpty() && connectedReplicas < minSyncReplicas;
+
+      // pause when:
+      // - pauseOnMaxLagExceeded is true
+      // - either the replicas have not confirmed for long time
+      // - or there are no pending entries and there are not enough replicas connected
+      updatePausedState(
+          pauseOnMaxLagExceeded && (dbLagExceeded || quorumNotMet),
+          dbReplicationLag,
+          connectedReplicas);
 
       if (confirmedEntry != null) {
         LOG.info(
@@ -138,9 +147,12 @@ public class LsnReplicationController implements ReplicationController {
           replicationConfiguration.getPollingInterval(),
           e);
     } finally {
-      replicationCheckTask =
-          controller.scheduleCancellableTask(
-              replicationConfiguration.getPollingInterval(), this::checkReplication);
+      // if null, controller was closed during check
+      if (replicationCheckTask != null) {
+        replicationCheckTask =
+            controller.scheduleCancellableTask(
+                replicationConfiguration.getPollingInterval(), this::checkReplication);
+      }
     }
   }
 
@@ -207,13 +219,13 @@ public class LsnReplicationController implements ReplicationController {
     final boolean wasPaused = paused.getAndSet(shouldPause);
     if (shouldPause && !wasPaused) {
       LOG.warn(
-          "[RDBMS Exporter P{}] Pausing exporter: DB-reported replication lag ({}) exceeded maxLag ({})",
+          "[RDBMS Exporter P{}] Pausing exporter: replication lag ({}) exceeded maxLag ({})",
           partitionId,
           dbReportedLag,
           maxLag);
     } else if (!shouldPause && wasPaused) {
       LOG.info(
-          "[RDBMS Exporter P{}] Resuming exporter: replication quorum met ({}/{} replicas) and DB-reported lag ({}) within maxLag ({})",
+          "[RDBMS Exporter P{}] Resuming exporter: replication quorum met ({}/{} replicas) and lag ({}) within maxLag ({})",
           partitionId,
           connectedReplicas,
           minSyncReplicas,
@@ -247,6 +259,7 @@ public class LsnReplicationController implements ReplicationController {
   @Override
   public void close() throws Exception {
     replicationCheckTask.cancel();
+    replicationCheckTask = null;
   }
 
   record LsnPositionEntry(long position, long lsn, long enqueueTimeMs) {}

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/replication/LsnReplicationControllerFactory.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/replication/LsnReplicationControllerFactory.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.replication;
+
+import io.camunda.db.rdbms.read.replication.ReplicationLogStatusProvider;
+import io.camunda.exporter.rdbms.ExporterConfiguration.ReplicationConfiguration;
+import io.camunda.zeebe.exporter.api.context.Controller;
+import java.time.InstantSource;
+
+public class LsnReplicationControllerFactory implements ReplicationControllerFactory {
+
+  private final int partitionId;
+  private final ReplicationLogStatusProvider replicationLagProvider;
+  private final ReplicationConfiguration replicationConfiguration;
+  private final InstantSource clock;
+
+  public LsnReplicationControllerFactory(
+      final ReplicationLogStatusProvider lsnProvider,
+      final ReplicationConfiguration replicationConfiguration,
+      final int partitionId,
+      final InstantSource clock) {
+    replicationLagProvider = lsnProvider;
+    this.replicationConfiguration = replicationConfiguration;
+    this.partitionId = partitionId;
+    this.clock = clock;
+  }
+
+  @Override
+  public ReplicationController createReplicationController(final Controller controller) {
+    return new LsnReplicationController(
+        controller, replicationLagProvider, replicationConfiguration, partitionId, clock);
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/replication/LsnReplicationControllerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/replication/LsnReplicationControllerTest.java
@@ -251,6 +251,19 @@ class LsnReplicationControllerTest {
   }
 
   @Test
+  void shouldPauseWhenEmptyQueueButQuorumNotMetOnCheck() {
+    // given – no entries enqueued at all
+    final var sut = createController();
+    when(lsnProvider.getReplicationStatuses()).thenReturn(List.of());
+
+    // when
+    sut.checkReplication();
+
+    // then – empty queue → lag = ZERO → no pause
+    assertThat(sut.isReplicationInSync()).isFalse();
+  }
+
+  @Test
   void shouldRescheduleAfterCheck() {
     // given
     final var sut = createController();

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/replication/LsnReplicationControllerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/replication/LsnReplicationControllerTest.java
@@ -82,18 +82,18 @@ class LsnReplicationControllerTest {
   @Test
   void shouldEnqueueEntryOnFlush() {
     // given
-    final var sut = createController();
+    final var replicationController = createController();
     when(lsnProvider.getCurrent()).thenReturn(42L);
     when(clock.millis()).thenReturn(1000L);
 
     // when
-    sut.onFlush(10L);
+    replicationController.onFlush(10L);
 
     // then – queue should contain the entry; verify by checking that a subsequent
     // checkReplication with confirmed LSN 42 updates the exported position
     when(lsnProvider.getReplicationStatuses())
         .thenReturn(List.of(new ReplicationLogStatus(42L, "replica-1", 0L)));
-    sut.checkReplication();
+    replicationController.checkReplication();
 
     verify(controller, atLeastOnce()).updateLastExportedRecordPosition(10L);
   }
@@ -101,58 +101,58 @@ class LsnReplicationControllerTest {
   @Test
   void shouldDropEntryOnFullQueue() {
     // given – create a controller with queue that is already full
-    final var sut = createController();
+    final var replicationController = createController();
     when(lsnProvider.getCurrent()).thenReturn(1L);
     when(clock.millis()).thenReturn(0L);
 
     // fill the queue completely
     for (int i = 0; i < LsnReplicationController.DEFAULT_QUEUE_CAPACITY; i++) {
-      sut.onFlush(i);
+      replicationController.onFlush(i);
     }
 
     // when – one more flush that should be silently dropped
-    sut.onFlush(LsnReplicationController.DEFAULT_QUEUE_CAPACITY + 1);
+    replicationController.onFlush(LsnReplicationController.DEFAULT_QUEUE_CAPACITY + 1);
 
     // then – isReplicationInSync still returns true (no exception, no crash)
-    assertThat(sut.isReplicationInSync()).isTrue();
+    assertThat(replicationController.isReplicationInSync()).isTrue();
   }
 
   @Test
   void shouldPauseWhenLsnQueryExceptionalOnFullQueue() {
     // given – create a controller with queue that is already full
-    final var sut = createController();
+    final var replicationController = createController();
     when(lsnProvider.getCurrent()).thenThrow(new RuntimeException("db error"));
     when(clock.millis()).thenReturn(0L);
 
     // fill the queue completely
-    sut.onFlush(1);
+    replicationController.onFlush(1);
 
     // then – isReplicationInSync returns false due to DB problems
-    assertThat(sut.isReplicationInSync()).isFalse();
+    assertThat(replicationController.isReplicationInSync()).isFalse();
   }
 
   @Test
   void shouldRemoveConfirmedEntriesOnCheck() {
     // given – 5 entries with lsn 1..5; replica has confirmed up to lsn 2
-    final var sut = createController();
+    final var replicationController = createController();
     when(lsnProvider.getCurrent()).thenReturn(10L);
     when(clock.millis()).thenReturn(0L);
-    sut.onFlush(100L); // lsn=10 at enqueue time
+    replicationController.onFlush(100L); // lsn=10 at enqueue time
     when(lsnProvider.getCurrent()).thenReturn(20L);
-    sut.onFlush(200L);
+    replicationController.onFlush(200L);
     when(lsnProvider.getCurrent()).thenReturn(30L);
-    sut.onFlush(300L);
+    replicationController.onFlush(300L);
     when(lsnProvider.getCurrent()).thenReturn(40L);
-    sut.onFlush(400L);
+    replicationController.onFlush(400L);
     when(lsnProvider.getCurrent()).thenReturn(50L);
-    sut.onFlush(500L);
+    replicationController.onFlush(500L);
 
     // replica has confirmed up to lsn=20 → first 2 entries should be removed
     when(lsnProvider.getReplicationStatuses())
         .thenReturn(List.of(new ReplicationLogStatus(20L, "replica-1", 0L)));
 
     // when
-    sut.checkReplication();
+    replicationController.checkReplication();
 
     // then – last exported position updated to the highest confirmed position (200)
     verify(controller).updateLastExportedRecordPosition(200L);
@@ -161,11 +161,11 @@ class LsnReplicationControllerTest {
   @Test
   void shouldNotPauseWhenNoLagExceededOnCheck() {
     // given – 5 entries all enqueued "now"; lag is 0, well within maxLag
-    final var sut = createController();
+    final var replicationController = createController();
     when(lsnProvider.getCurrent()).thenReturn(10L);
     when(clock.millis()).thenReturn(0L);
     for (int i = 1; i <= 5; i++) {
-      sut.onFlush(i * 100L);
+      replicationController.onFlush(i * 100L);
     }
 
     // current time is 0, so lag = 0
@@ -174,27 +174,26 @@ class LsnReplicationControllerTest {
         .thenReturn(List.of(new ReplicationLogStatus(10L, "replica-1", 0L)));
 
     // when
-    sut.checkReplication();
+    replicationController.checkReplication();
 
     // then
-    assertThat(sut.isReplicationInSync()).isTrue();
+    assertThat(replicationController.isReplicationInSync()).isTrue();
   }
 
   @Test
   void shouldPauseWhenLagExceededOnCheck() {
     // given – 5 entries. The first 2 are enqueued at time 0, the rest at time 0 as well.
     // After enqueue the clock advances beyond maxLag so the head of the queue is stale.
-    final var sut = createController();
+    final var replicationController = createController();
     when(lsnProvider.getCurrent()).thenReturn(10L);
     when(clock.millis()).thenReturn(0L);
 
     // two entries with lsn=10, enqueued early
-    sut.onFlush(100L);
-    sut.onFlush(200L);
-    // three more entries, same lsn
-    sut.onFlush(300L);
-    sut.onFlush(400L);
-    sut.onFlush(500L);
+    for (int i = 1; i <= 5; i++) {
+      when(lsnProvider.getCurrent()).thenReturn(i * 10L);
+      when(clock.millis()).thenReturn(i * 10L);
+      replicationController.onFlush(i * 100L);
+    }
 
     // advance clock past maxLag (maxLag = 10 s = 10_000 ms)
     when(clock.millis()).thenReturn(MAX_LAG.toMillis() + 1_000L);
@@ -203,74 +202,73 @@ class LsnReplicationControllerTest {
         .thenReturn(List.of(new ReplicationLogStatus(0L, "replica-1", 0L)));
 
     // when
-    sut.checkReplication();
+    replicationController.checkReplication();
 
     // then
-    assertThat(sut.isReplicationInSync()).isFalse();
+    assertThat(replicationController.isReplicationInSync()).isFalse();
   }
 
   @Test
   void shouldResumeWhenOnNoLagExceededOnCheck() {
     // given – first trigger a pause
-    final var sut = createController();
-    when(lsnProvider.getCurrent()).thenReturn(10L);
-    when(clock.millis()).thenReturn(0L);
+    final var replicationController = createController();
     for (int i = 1; i <= 5; i++) {
-      sut.onFlush(i * 100L);
+      when(lsnProvider.getCurrent()).thenReturn(i * 10L);
+      when(clock.millis()).thenReturn(i * 10L);
+      replicationController.onFlush(i * 100L);
     }
 
     // pause: advance clock past maxLag, replica not up-to-date
     when(clock.millis()).thenReturn(MAX_LAG.toMillis() + 1_000L);
     when(lsnProvider.getReplicationStatuses())
         .thenReturn(List.of(new ReplicationLogStatus(0L, "replica-1", 0L)));
-    sut.checkReplication();
-    assertThat(sut.isReplicationInSync()).isFalse();
+    replicationController.checkReplication();
+    assertThat(replicationController.isReplicationInSync()).isFalse();
 
     // resume: replica catches up and clock is back within maxLag
-    when(clock.millis()).thenReturn(MAX_LAG.toMillis() + 1_000L);
     when(lsnProvider.getReplicationStatuses())
-        .thenReturn(List.of(new ReplicationLogStatus(10L, "replica-1", 0L)));
-    sut.checkReplication();
+        .thenReturn(List.of(new ReplicationLogStatus(50L, "replica-1", 0L)));
+    replicationController.checkReplication();
 
     // then
-    assertThat(sut.isReplicationInSync()).isTrue();
+    assertThat(replicationController.isReplicationInSync()).isTrue();
   }
 
   @Test
   void shouldNotPauseWhenEmptyQueueOnCheck() {
     // given – no entries enqueued at all
-    final var sut = createController();
+    final var replicationController = createController();
     when(lsnProvider.getReplicationStatuses())
         .thenReturn(List.of(new ReplicationLogStatus(0L, "replica-1", 0L)));
 
     // when
-    sut.checkReplication();
+    replicationController.checkReplication();
 
     // then – empty queue → lag = ZERO → no pause
-    assertThat(sut.isReplicationInSync()).isTrue();
+    assertThat(replicationController.isReplicationInSync()).isTrue();
   }
 
   @Test
   void shouldPauseWhenEmptyQueueButQuorumNotMetOnCheck() {
     // given – no entries enqueued at all
-    final var sut = createController();
+    final var replicationController = createController();
     when(lsnProvider.getReplicationStatuses()).thenReturn(List.of());
 
     // when
-    sut.checkReplication();
+    replicationController.checkReplication();
 
     // then – empty queue → lag = ZERO → no pause
-    assertThat(sut.isReplicationInSync()).isFalse();
+    assertThat(replicationController.isReplicationInSync()).isFalse();
   }
 
   @Test
   void shouldRescheduleAfterCheck() {
     // given
-    final var sut = createController();
+    final var replicationController = createController();
     when(lsnProvider.getReplicationStatuses()).thenReturn(List.of());
 
     // when
-    sut.checkReplication();
+    replicationController.checkReplication();
 
     // then – one schedule during construction + one after checkReplication
     verify(controller, times(2)).scheduleCancellableTask(eq(POLLING_INTERVAL), any());
@@ -279,11 +277,11 @@ class LsnReplicationControllerTest {
   @Test
   void shouldRescheduleAfterExceptionalCheck() {
     // given – lsnProvider throws
-    final var sut = createController();
+    final var replicationController = createController();
     when(lsnProvider.getReplicationStatuses()).thenThrow(new RuntimeException("db error"));
 
     // when
-    sut.checkReplication();
+    replicationController.checkReplication();
 
     // then – reschedule must still happen even after an exception
     verify(controller, times(2)).scheduleCancellableTask(eq(POLLING_INTERVAL), any());
@@ -292,11 +290,11 @@ class LsnReplicationControllerTest {
   @Test
   void shouldCancelTaskAfterClose() throws Exception {
     // given
-    final var sut = createController();
+    final var replicationController = createController();
     when(lsnProvider.getReplicationStatuses()).thenReturn(List.of());
 
     // when
-    sut.close();
+    replicationController.close();
 
     // then – one schedule during construction + one after checkReplication
     verify(scheduledTask).cancel();
@@ -305,14 +303,14 @@ class LsnReplicationControllerTest {
   @Test
   void shouldCancelRescheduledTaskAfterClose() throws Exception {
     // given
-    final var sut = createController();
+    final var replicationController = createController();
     when(lsnProvider.getReplicationStatuses()).thenReturn(List.of());
     final var rescheduledTask = mock(ScheduledTask.class);
     when(controller.scheduleCancellableTask(any(), any())).thenReturn(rescheduledTask);
 
     // when
-    sut.checkReplication();
-    sut.close();
+    replicationController.checkReplication();
+    replicationController.close();
 
     // then – one schedule during construction + one after checkReplication
     verify(rescheduledTask).cancel();
@@ -329,29 +327,13 @@ class LsnReplicationControllerTest {
     void shouldReturnMinValueWhenCurrentLsnIsNegative() {
       // given
       when(lsnProvider.getCurrent()).thenReturn(-1L);
-      final var sut = createController();
+      final var replicationController = createController();
 
       // when
-      final long result = sut.computeConfirmedLsn(List.of());
+      final long result = replicationController.computeConfirmedLsn(List.of());
 
       // then
       assertThat(result).isEqualTo(Long.MIN_VALUE);
-    }
-
-    @Test
-    void shouldReturnMaxValueWhenMinSyncReplicasIsZero() {
-      // given
-      replicationConfig.setMinSyncReplicas(0);
-      when(lsnProvider.getCurrent()).thenReturn(50L);
-      // Note: validate() would reject 0, but the constructor still accepts it and
-      // computeConfirmedLsn() returns MAX_VALUE in this case.
-      final var sut = createController();
-
-      // when
-      final long result = sut.computeConfirmedLsn(List.of());
-
-      // then
-      assertThat(result).isEqualTo(Long.MAX_VALUE);
     }
 
     @Test
@@ -359,11 +341,12 @@ class LsnReplicationControllerTest {
       // given
       replicationConfig.setMinSyncReplicas(2);
       when(lsnProvider.getCurrent()).thenReturn(50L);
-      final var sut = createController();
+      final var replicationController = createController();
 
       // when – only 1 replica but 2 required
       final long result =
-          sut.computeConfirmedLsn(List.of(new ReplicationLogStatus(100L, "replica-1", 0L)));
+          replicationController.computeConfirmedLsn(
+              List.of(new ReplicationLogStatus(100L, "replica-1", 0L)));
 
       // then
       assertThat(result).isEqualTo(-1L);
@@ -374,7 +357,7 @@ class LsnReplicationControllerTest {
       // given – minSyncReplicas = 2, 3 replicas with lsn 10, 30, 50
       replicationConfig.setMinSyncReplicas(2);
       when(lsnProvider.getCurrent()).thenReturn(50L);
-      final var sut = createController();
+      final var replicationController = createController();
 
       final var statuses =
           List.of(
@@ -383,7 +366,7 @@ class LsnReplicationControllerTest {
               new ReplicationLogStatus(50L, "replica-3", 0L));
 
       // when
-      final long result = sut.computeConfirmedLsn(statuses);
+      final long result = replicationController.computeConfirmedLsn(statuses);
 
       // then – top 2 by lsn are 30 and 50; min of those is 30
       assertThat(result).isEqualTo(30L);
@@ -393,12 +376,12 @@ class LsnReplicationControllerTest {
     void shouldReturnReplicaLsnWhenExactlyMinSyncReplicas() {
       // given
       when(lsnProvider.getCurrent()).thenReturn(50L);
-      final var sut = createController();
+      final var replicationController = createController();
 
       final var statuses = List.of(new ReplicationLogStatus(40L, "replica-1", 0L));
 
       // when
-      final long result = sut.computeConfirmedLsn(statuses);
+      final long result = replicationController.computeConfirmedLsn(statuses);
 
       // then
       assertThat(result).isEqualTo(40L);
@@ -415,10 +398,10 @@ class LsnReplicationControllerTest {
     @Test
     void shouldReturnNullWhenQueueIsEmpty() {
       // given
-      final var sut = createController();
+      final var replicationController = createController();
 
       // when
-      final var result = sut.removeConfirmedLsnEntries(100L);
+      final var result = replicationController.removeConfirmedLsnEntries(100L);
 
       // then
       assertThat(result).isNull();
@@ -427,15 +410,15 @@ class LsnReplicationControllerTest {
     @Test
     void shouldNotRemoveEntriesWhenConfirmedLsnBelowAll() {
       // given
-      final var sut = createController();
+      final var replicationController = createController();
       when(lsnProvider.getCurrent()).thenReturn(10L);
       when(clock.millis()).thenReturn(0L);
-      sut.onFlush(100L); // lsn=10
+      replicationController.onFlush(100L); // lsn=10
       when(lsnProvider.getCurrent()).thenReturn(20L);
-      sut.onFlush(200L); // lsn=20
+      replicationController.onFlush(200L); // lsn=20
 
       // when – confirmedLsn=5 is below all entries
-      final var result = sut.removeConfirmedLsnEntries(5L);
+      final var result = replicationController.removeConfirmedLsnEntries(5L);
 
       // then
       assertThat(result).isNull();
@@ -444,15 +427,15 @@ class LsnReplicationControllerTest {
     @Test
     void shouldRemoveOnlyEntriesUpToConfirmedLsn() {
       // given – 5 entries with lsn 10, 20, 30, 40, 50
-      final var sut = createController();
+      final var replicationController = createController();
       when(clock.millis()).thenReturn(0L);
       for (int i = 1; i <= 5; i++) {
         when(lsnProvider.getCurrent()).thenReturn((long) (i * 10));
-        sut.onFlush(i * 100L);
+        replicationController.onFlush(i * 100L);
       }
 
       // when – confirm up to lsn=30 → removes entries with lsn 10, 20, 30
-      final var result = sut.removeConfirmedLsnEntries(30L);
+      final var result = replicationController.removeConfirmedLsnEntries(30L);
 
       // then – the returned entry is the last confirmed one (lsn=30, position=300)
       assertThat(result).isNotNull();
@@ -463,15 +446,15 @@ class LsnReplicationControllerTest {
     @Test
     void shouldRemoveAllEntriesWhenConfirmedLsnExceedsAll() {
       // given – 5 entries
-      final var sut = createController();
+      final var replicationController = createController();
       when(clock.millis()).thenReturn(0L);
       for (int i = 1; i <= 5; i++) {
         when(lsnProvider.getCurrent()).thenReturn((long) (i * 10));
-        sut.onFlush(i * 100L);
+        replicationController.onFlush(i * 100L);
       }
 
       // when – confirmedLsn exceeds max lsn (50)
-      final var result = sut.removeConfirmedLsnEntries(9999L);
+      final var result = replicationController.removeConfirmedLsnEntries(9999L);
 
       // then
       assertThat(result).isNotNull();
@@ -490,10 +473,10 @@ class LsnReplicationControllerTest {
     @Test
     void shouldReturnZeroWhenQueueIsEmpty() {
       // given
-      final var sut = createController();
+      final var replicationController = createController();
 
       // when
-      final var lag = sut.getCurrentDbLag();
+      final var lag = replicationController.getCurrentDbLag();
 
       // then
       assertThat(lag).isEqualTo(Duration.ZERO);
@@ -502,15 +485,15 @@ class LsnReplicationControllerTest {
     @Test
     void shouldReturnElapsedTimeSinceOldestEntry() {
       // given – entry enqueued at t=0, current time is t=3000
-      final var sut = createController();
+      final var replicationController = createController();
       when(lsnProvider.getCurrent()).thenReturn(1L);
       when(clock.millis()).thenReturn(0L);
-      sut.onFlush(100L);
+      replicationController.onFlush(100L);
 
       when(clock.millis()).thenReturn(3_000L);
 
       // when
-      final var lag = sut.getCurrentDbLag();
+      final var lag = replicationController.getCurrentDbLag();
 
       // then
       assertThat(lag).isEqualTo(Duration.ofMillis(3_000));
@@ -519,17 +502,17 @@ class LsnReplicationControllerTest {
     @Test
     void shouldAlwaysUseHeadOfQueueForLag() {
       // given – two entries at times 0 and 5000; current time is 6000
-      final var sut = createController();
+      final var replicationController = createController();
       when(lsnProvider.getCurrent()).thenReturn(1L);
       when(clock.millis()).thenReturn(0L);
-      sut.onFlush(100L);
+      replicationController.onFlush(100L);
       when(clock.millis()).thenReturn(5_000L);
-      sut.onFlush(200L);
+      replicationController.onFlush(200L);
 
       when(clock.millis()).thenReturn(6_000L);
 
       // when
-      final var lag = sut.getCurrentDbLag();
+      final var lag = replicationController.getCurrentDbLag();
 
       // then – lag is measured from head (t=0), not tail (t=5000)
       assertThat(lag).isEqualTo(Duration.ofMillis(6_000));
@@ -546,10 +529,11 @@ class LsnReplicationControllerTest {
     @Test
     void shouldReturnFalseWhenLagIsLessThanMaxLag() {
       // given
-      final var sut = createController();
+      final var replicationController = createController();
 
       // when
-      final boolean exceeded = sut.isMaxLagExceeded(MAX_LAG.minus(Duration.ofMillis(1)));
+      final boolean exceeded =
+          replicationController.isMaxLagExceeded(MAX_LAG.minus(Duration.ofMillis(1)));
 
       // then
       assertThat(exceeded).isFalse();
@@ -558,10 +542,10 @@ class LsnReplicationControllerTest {
     @Test
     void shouldReturnFalseWhenLagEqualsMaxLag() {
       // given
-      final var sut = createController();
+      final var replicationController = createController();
 
       // when
-      final boolean exceeded = sut.isMaxLagExceeded(MAX_LAG);
+      final boolean exceeded = replicationController.isMaxLagExceeded(MAX_LAG);
 
       // then
       assertThat(exceeded).isFalse();
@@ -570,10 +554,11 @@ class LsnReplicationControllerTest {
     @Test
     void shouldReturnTrueWhenLagExceedsMaxLag() {
       // given
-      final var sut = createController();
+      final var replicationController = createController();
 
       // when
-      final boolean exceeded = sut.isMaxLagExceeded(MAX_LAG.plus(Duration.ofMillis(1)));
+      final boolean exceeded =
+          replicationController.isMaxLagExceeded(MAX_LAG.plus(Duration.ofMillis(1)));
 
       // then
       assertThat(exceeded).isTrue();
@@ -582,10 +567,10 @@ class LsnReplicationControllerTest {
     @Test
     void shouldReturnFalseForZeroLag() {
       // given
-      final var sut = createController();
+      final var replicationController = createController();
 
       // when
-      final boolean exceeded = sut.isMaxLagExceeded(Duration.ZERO);
+      final boolean exceeded = replicationController.isMaxLagExceeded(Duration.ZERO);
 
       // then
       assertThat(exceeded).isFalse();

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/replication/LsnReplicationControllerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/replication/LsnReplicationControllerTest.java
@@ -1,0 +1,538 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.replication;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.db.rdbms.read.replication.ReplicationLogStatus;
+import io.camunda.db.rdbms.read.replication.ReplicationLogStatusProvider;
+import io.camunda.exporter.rdbms.ExporterConfiguration.ReplicationConfiguration;
+import io.camunda.zeebe.exporter.api.context.Controller;
+import io.camunda.zeebe.exporter.api.context.ScheduledTask;
+import java.time.Duration;
+import java.time.InstantSource;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class LsnReplicationControllerTest {
+
+  private static final int PARTITION_ID = 1;
+  private static final Duration POLLING_INTERVAL = Duration.ofSeconds(5);
+  private static final Duration MAX_LAG = Duration.ofSeconds(10);
+  private static final int MIN_SYNC_REPLICAS = 1;
+
+  private Controller controller;
+  private ReplicationLogStatusProvider lsnProvider;
+  private ReplicationConfiguration replicationConfig;
+  private InstantSource clock;
+  private ScheduledTask scheduledTask;
+
+  @BeforeEach
+  void setUp() {
+    controller = mock(Controller.class);
+    lsnProvider = mock(ReplicationLogStatusProvider.class);
+    replicationConfig = new ReplicationConfiguration();
+    replicationConfig.setPollingInterval(POLLING_INTERVAL);
+    replicationConfig.setMaxLag(MAX_LAG);
+    replicationConfig.setMinSyncReplicas(MIN_SYNC_REPLICAS);
+    replicationConfig.setPauseOnMaxLagExceeded(true);
+
+    scheduledTask = mock(ScheduledTask.class);
+    clock = mock(InstantSource.class);
+
+    when(clock.millis()).thenReturn(0L);
+    when(clock.instant()).thenReturn(java.time.Instant.EPOCH);
+    when(controller.scheduleCancellableTask(any(), any())).thenReturn(scheduledTask);
+    when(lsnProvider.getCurrent()).thenReturn(100L);
+    when(lsnProvider.getReplicationStatuses()).thenReturn(List.of());
+  }
+
+  private LsnReplicationController createController() {
+    return new LsnReplicationController(
+        controller, lsnProvider, replicationConfig, PARTITION_ID, clock);
+  }
+
+  // -----------------------------------------------------------------------
+  // Integration-style tests (checkReplication flow)
+  // -----------------------------------------------------------------------
+
+  @Test
+  void shouldScheduleCheckTaskOnConstruct() {
+    // when
+    createController();
+
+    // then
+    verify(controller, times(1)).scheduleCancellableTask(eq(POLLING_INTERVAL), any());
+  }
+
+  @Test
+  void shouldEnqueueEntryOnFlush() {
+    // given
+    final var sut = createController();
+    when(lsnProvider.getCurrent()).thenReturn(42L);
+    when(clock.millis()).thenReturn(1000L);
+
+    // when
+    sut.onFlush(10L);
+
+    // then – queue should contain the entry; verify by checking that a subsequent
+    // checkReplication with confirmed LSN 42 updates the exported position
+    when(lsnProvider.getReplicationStatuses())
+        .thenReturn(List.of(new ReplicationLogStatus(42L, "replica-1", 0L)));
+    sut.checkReplication();
+
+    verify(controller, atLeastOnce()).updateLastExportedRecordPosition(10L);
+  }
+
+  @Test
+  void shouldDropEntryOnFullQueue() {
+    // given – create a controller with queue that is already full
+    final var sut = createController();
+    when(lsnProvider.getCurrent()).thenReturn(1L);
+    when(clock.millis()).thenReturn(0L);
+
+    // fill the queue completely
+    for (int i = 0; i < LsnReplicationController.DEFAULT_QUEUE_CAPACITY; i++) {
+      sut.onFlush(i);
+    }
+
+    // when – one more flush that should be silently dropped
+    sut.onFlush(LsnReplicationController.DEFAULT_QUEUE_CAPACITY + 1);
+
+    // then – isReplicationInSync still returns true (no exception, no crash)
+    assertThat(sut.isReplicationInSync()).isTrue();
+  }
+
+  @Test
+  void shouldRemoveConfirmedEntriesOnCheck() {
+    // given – 5 entries with lsn 1..5; replica has confirmed up to lsn 2
+    final var sut = createController();
+    when(lsnProvider.getCurrent()).thenReturn(10L);
+    when(clock.millis()).thenReturn(0L);
+    sut.onFlush(100L); // lsn=10 at enqueue time
+    when(lsnProvider.getCurrent()).thenReturn(20L);
+    sut.onFlush(200L);
+    when(lsnProvider.getCurrent()).thenReturn(30L);
+    sut.onFlush(300L);
+    when(lsnProvider.getCurrent()).thenReturn(40L);
+    sut.onFlush(400L);
+    when(lsnProvider.getCurrent()).thenReturn(50L);
+    sut.onFlush(500L);
+
+    // replica has confirmed up to lsn=20 → first 2 entries should be removed
+    when(lsnProvider.getReplicationStatuses())
+        .thenReturn(List.of(new ReplicationLogStatus(20L, "replica-1", 0L)));
+
+    // when
+    sut.checkReplication();
+
+    // then – last exported position updated to the highest confirmed position (200)
+    verify(controller).updateLastExportedRecordPosition(200L);
+  }
+
+  @Test
+  void shouldNotPauseWhenNoLagExceededOnCheck() {
+    // given – 5 entries all enqueued "now"; lag is 0, well within maxLag
+    final var sut = createController();
+    when(lsnProvider.getCurrent()).thenReturn(10L);
+    when(clock.millis()).thenReturn(0L);
+    for (int i = 1; i <= 5; i++) {
+      sut.onFlush(i * 100L);
+    }
+
+    // current time is 0, so lag = 0
+    when(clock.millis()).thenReturn(0L);
+    when(lsnProvider.getReplicationStatuses())
+        .thenReturn(List.of(new ReplicationLogStatus(10L, "replica-1", 0L)));
+
+    // when
+    sut.checkReplication();
+
+    // then
+    assertThat(sut.isReplicationInSync()).isTrue();
+  }
+
+  @Test
+  void shouldPauseWhenLagExceededOnCheck() {
+    // given – 5 entries. The first 2 are enqueued at time 0, the rest at time 0 as well.
+    // After enqueue the clock advances beyond maxLag so the head of the queue is stale.
+    final var sut = createController();
+    when(lsnProvider.getCurrent()).thenReturn(10L);
+    when(clock.millis()).thenReturn(0L);
+
+    // two entries with lsn=10, enqueued early
+    sut.onFlush(100L);
+    sut.onFlush(200L);
+    // three more entries, same lsn
+    sut.onFlush(300L);
+    sut.onFlush(400L);
+    sut.onFlush(500L);
+
+    // advance clock past maxLag (maxLag = 10 s = 10_000 ms)
+    when(clock.millis()).thenReturn(MAX_LAG.toMillis() + 1_000L);
+    // replica has NOT confirmed anything yet
+    when(lsnProvider.getReplicationStatuses())
+        .thenReturn(List.of(new ReplicationLogStatus(0L, "replica-1", 0L)));
+
+    // when
+    sut.checkReplication();
+
+    // then
+    assertThat(sut.isReplicationInSync()).isFalse();
+  }
+
+  @Test
+  void shouldResumeWhenOnNoLagExceededOnCheck() {
+    // given – first trigger a pause
+    final var sut = createController();
+    when(lsnProvider.getCurrent()).thenReturn(10L);
+    when(clock.millis()).thenReturn(0L);
+    for (int i = 1; i <= 5; i++) {
+      sut.onFlush(i * 100L);
+    }
+
+    // pause: advance clock past maxLag, replica not up-to-date
+    when(clock.millis()).thenReturn(MAX_LAG.toMillis() + 1_000L);
+    when(lsnProvider.getReplicationStatuses())
+        .thenReturn(List.of(new ReplicationLogStatus(0L, "replica-1", 0L)));
+    sut.checkReplication();
+    assertThat(sut.isReplicationInSync()).isFalse();
+
+    // resume: replica catches up and clock is back within maxLag
+    when(clock.millis()).thenReturn(MAX_LAG.toMillis() + 1_000L);
+    when(lsnProvider.getReplicationStatuses())
+        .thenReturn(List.of(new ReplicationLogStatus(10L, "replica-1", 0L)));
+    sut.checkReplication();
+
+    // then
+    assertThat(sut.isReplicationInSync()).isTrue();
+  }
+
+  @Test
+  void shouldNotPauseWhenEmptyQueueOnCheck() {
+    // given – no entries enqueued at all
+    final var sut = createController();
+    when(lsnProvider.getReplicationStatuses())
+        .thenReturn(List.of(new ReplicationLogStatus(0L, "replica-1", 0L)));
+
+    // when
+    sut.checkReplication();
+
+    // then – empty queue → lag = ZERO → no pause
+    assertThat(sut.isReplicationInSync()).isTrue();
+  }
+
+  @Test
+  void shouldRescheduleAfterCheck() {
+    // given
+    final var sut = createController();
+    when(lsnProvider.getReplicationStatuses()).thenReturn(List.of());
+
+    // when
+    sut.checkReplication();
+
+    // then – one schedule during construction + one after checkReplication
+    verify(controller, times(2)).scheduleCancellableTask(eq(POLLING_INTERVAL), any());
+  }
+
+  @Test
+  void shouldRescheduleAfterExceptionalCheck() {
+    // given – lsnProvider throws
+    final var sut = createController();
+    when(lsnProvider.getReplicationStatuses()).thenThrow(new RuntimeException("db error"));
+
+    // when
+    sut.checkReplication();
+
+    // then – reschedule must still happen even after an exception
+    verify(controller, times(2)).scheduleCancellableTask(eq(POLLING_INTERVAL), any());
+  }
+
+  // -----------------------------------------------------------------------
+  // Unit tests for computeConfirmedLsn()
+  // -----------------------------------------------------------------------
+
+  @Nested
+  class ComputeConfirmedLsnTest {
+
+    @Test
+    void shouldReturnMinValueWhenCurrentLsnIsNegative() {
+      // given
+      when(lsnProvider.getCurrent()).thenReturn(-1L);
+      final var sut = createController();
+
+      // when
+      final long result = sut.computeConfirmedLsn(List.of());
+
+      // then
+      assertThat(result).isEqualTo(Long.MIN_VALUE);
+    }
+
+    @Test
+    void shouldReturnMaxValueWhenMinSyncReplicasIsZero() {
+      // given
+      replicationConfig.setMinSyncReplicas(0);
+      when(lsnProvider.getCurrent()).thenReturn(50L);
+      // Note: validate() would reject 0, but the constructor still accepts it and
+      // computeConfirmedLsn() returns MAX_VALUE in this case.
+      final var sut = createController();
+
+      // when
+      final long result = sut.computeConfirmedLsn(List.of());
+
+      // then
+      assertThat(result).isEqualTo(Long.MAX_VALUE);
+    }
+
+    @Test
+    void shouldReturnNegativeOneWhenNotEnoughReplicas() {
+      // given
+      replicationConfig.setMinSyncReplicas(2);
+      when(lsnProvider.getCurrent()).thenReturn(50L);
+      final var sut = createController();
+
+      // when – only 1 replica but 2 required
+      final long result =
+          sut.computeConfirmedLsn(List.of(new ReplicationLogStatus(100L, "replica-1", 0L)));
+
+      // then
+      assertThat(result).isEqualTo(-1L);
+    }
+
+    @Test
+    void shouldReturnLowestOfTopNReplicaLsns() {
+      // given – minSyncReplicas = 2, 3 replicas with lsn 10, 30, 50
+      replicationConfig.setMinSyncReplicas(2);
+      when(lsnProvider.getCurrent()).thenReturn(50L);
+      final var sut = createController();
+
+      final var statuses =
+          List.of(
+              new ReplicationLogStatus(10L, "replica-1", 0L),
+              new ReplicationLogStatus(30L, "replica-2", 0L),
+              new ReplicationLogStatus(50L, "replica-3", 0L));
+
+      // when
+      final long result = sut.computeConfirmedLsn(statuses);
+
+      // then – top 2 by lsn are 30 and 50; min of those is 30
+      assertThat(result).isEqualTo(30L);
+    }
+
+    @Test
+    void shouldReturnReplicaLsnWhenExactlyMinSyncReplicas() {
+      // given
+      when(lsnProvider.getCurrent()).thenReturn(50L);
+      final var sut = createController();
+
+      final var statuses = List.of(new ReplicationLogStatus(40L, "replica-1", 0L));
+
+      // when
+      final long result = sut.computeConfirmedLsn(statuses);
+
+      // then
+      assertThat(result).isEqualTo(40L);
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Unit tests for removeConfirmedLsnEntries()
+  // -----------------------------------------------------------------------
+
+  @Nested
+  class RemoveConfirmedLsnEntriesTest {
+
+    @Test
+    void shouldReturnNullWhenQueueIsEmpty() {
+      // given
+      final var sut = createController();
+
+      // when
+      final var result = sut.removeConfirmedLsnEntries(100L);
+
+      // then
+      assertThat(result).isNull();
+    }
+
+    @Test
+    void shouldNotRemoveEntriesWhenConfirmedLsnBelowAll() {
+      // given
+      final var sut = createController();
+      when(lsnProvider.getCurrent()).thenReturn(10L);
+      when(clock.millis()).thenReturn(0L);
+      sut.onFlush(100L); // lsn=10
+      when(lsnProvider.getCurrent()).thenReturn(20L);
+      sut.onFlush(200L); // lsn=20
+
+      // when – confirmedLsn=5 is below all entries
+      final var result = sut.removeConfirmedLsnEntries(5L);
+
+      // then
+      assertThat(result).isNull();
+    }
+
+    @Test
+    void shouldRemoveOnlyEntriesUpToConfirmedLsn() {
+      // given – 5 entries with lsn 10, 20, 30, 40, 50
+      final var sut = createController();
+      when(clock.millis()).thenReturn(0L);
+      for (int i = 1; i <= 5; i++) {
+        when(lsnProvider.getCurrent()).thenReturn((long) (i * 10));
+        sut.onFlush(i * 100L);
+      }
+
+      // when – confirm up to lsn=30 → removes entries with lsn 10, 20, 30
+      final var result = sut.removeConfirmedLsnEntries(30L);
+
+      // then – the returned entry is the last confirmed one (lsn=30, position=300)
+      assertThat(result).isNotNull();
+      assertThat(result.lsn()).isEqualTo(30L);
+      assertThat(result.position()).isEqualTo(300L);
+    }
+
+    @Test
+    void shouldRemoveAllEntriesWhenConfirmedLsnExceedsAll() {
+      // given – 5 entries
+      final var sut = createController();
+      when(clock.millis()).thenReturn(0L);
+      for (int i = 1; i <= 5; i++) {
+        when(lsnProvider.getCurrent()).thenReturn((long) (i * 10));
+        sut.onFlush(i * 100L);
+      }
+
+      // when – confirmedLsn exceeds max lsn (50)
+      final var result = sut.removeConfirmedLsnEntries(9999L);
+
+      // then
+      assertThat(result).isNotNull();
+      assertThat(result.lsn()).isEqualTo(50L);
+      assertThat(result.position()).isEqualTo(500L);
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Unit tests for getCurrentDbLag()
+  // -----------------------------------------------------------------------
+
+  @Nested
+  class GetCurrentDbLagTest {
+
+    @Test
+    void shouldReturnZeroWhenQueueIsEmpty() {
+      // given
+      final var sut = createController();
+
+      // when
+      final var lag = sut.getCurrentDbLag();
+
+      // then
+      assertThat(lag).isEqualTo(Duration.ZERO);
+    }
+
+    @Test
+    void shouldReturnElapsedTimeSinceOldestEntry() {
+      // given – entry enqueued at t=0, current time is t=3000
+      final var sut = createController();
+      when(lsnProvider.getCurrent()).thenReturn(1L);
+      when(clock.millis()).thenReturn(0L);
+      sut.onFlush(100L);
+
+      when(clock.millis()).thenReturn(3_000L);
+
+      // when
+      final var lag = sut.getCurrentDbLag();
+
+      // then
+      assertThat(lag).isEqualTo(Duration.ofMillis(3_000));
+    }
+
+    @Test
+    void shouldAlwaysUseHeadOfQueueForLag() {
+      // given – two entries at times 0 and 5000; current time is 6000
+      final var sut = createController();
+      when(lsnProvider.getCurrent()).thenReturn(1L);
+      when(clock.millis()).thenReturn(0L);
+      sut.onFlush(100L);
+      when(clock.millis()).thenReturn(5_000L);
+      sut.onFlush(200L);
+
+      when(clock.millis()).thenReturn(6_000L);
+
+      // when
+      final var lag = sut.getCurrentDbLag();
+
+      // then – lag is measured from head (t=0), not tail (t=5000)
+      assertThat(lag).isEqualTo(Duration.ofMillis(6_000));
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Unit tests for isMaxLagExceeded()
+  // -----------------------------------------------------------------------
+
+  @Nested
+  class IsMaxLagExceededTest {
+
+    @Test
+    void shouldReturnFalseWhenLagIsLessThanMaxLag() {
+      // given
+      final var sut = createController();
+
+      // when
+      final boolean exceeded = sut.isMaxLagExceeded(MAX_LAG.minus(Duration.ofMillis(1)));
+
+      // then
+      assertThat(exceeded).isFalse();
+    }
+
+    @Test
+    void shouldReturnFalseWhenLagEqualsMaxLag() {
+      // given
+      final var sut = createController();
+
+      // when
+      final boolean exceeded = sut.isMaxLagExceeded(MAX_LAG);
+
+      // then
+      assertThat(exceeded).isFalse();
+    }
+
+    @Test
+    void shouldReturnTrueWhenLagExceedsMaxLag() {
+      // given
+      final var sut = createController();
+
+      // when
+      final boolean exceeded = sut.isMaxLagExceeded(MAX_LAG.plus(Duration.ofMillis(1)));
+
+      // then
+      assertThat(exceeded).isTrue();
+    }
+
+    @Test
+    void shouldReturnFalseForZeroLag() {
+      // given
+      final var sut = createController();
+
+      // when
+      final boolean exceeded = sut.isMaxLagExceeded(Duration.ZERO);
+
+      // then
+      assertThat(exceeded).isFalse();
+    }
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/replication/LsnReplicationControllerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/replication/LsnReplicationControllerTest.java
@@ -262,6 +262,35 @@ class LsnReplicationControllerTest {
     verify(controller, times(2)).scheduleCancellableTask(eq(POLLING_INTERVAL), any());
   }
 
+  @Test
+  void shouldCancelTaskAfterClose() throws Exception {
+    // given
+    final var sut = createController();
+    when(lsnProvider.getReplicationStatuses()).thenReturn(List.of());
+
+    // when
+    sut.close();
+
+    // then – one schedule during construction + one after checkReplication
+    verify(scheduledTask).cancel();
+  }
+
+  @Test
+  void shouldCancelRescheduledTaskAfterClose() throws Exception {
+    // given
+    final var sut = createController();
+    when(lsnProvider.getReplicationStatuses()).thenReturn(List.of());
+    final var rescheduledTask = mock(ScheduledTask.class);
+    when(controller.scheduleCancellableTask(any(), any())).thenReturn(rescheduledTask);
+
+    // when
+    sut.checkReplication();
+    sut.close();
+
+    // then – one schedule during construction + one after checkReplication
+    verify(rescheduledTask).cancel();
+  }
+
   // -----------------------------------------------------------------------
   // Unit tests for computeConfirmedLsn()
   // -----------------------------------------------------------------------

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/replication/LsnReplicationControllerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/replication/LsnReplicationControllerTest.java
@@ -118,6 +118,20 @@ class LsnReplicationControllerTest {
   }
 
   @Test
+  void shouldPauseWhenLsnQueryExceptionalOnFullQueue() {
+    // given – create a controller with queue that is already full
+    final var sut = createController();
+    when(lsnProvider.getCurrent()).thenThrow(new RuntimeException("db error"));
+    when(clock.millis()).thenReturn(0L);
+
+    // fill the queue completely
+    sut.onFlush(1);
+
+    // then – isReplicationInSync returns false due to DB problems
+    assertThat(sut.isReplicationInSync()).isFalse();
+  }
+
+  @Test
   void shouldRemoveConfirmedEntriesOnCheck() {
     // given – 5 entries with lsn 1..5; replica has confirmed up to lsn 2
     final var sut = createController();


### PR DESCRIPTION
This pull request adds support for monitoring the database replication status by the LSN, a sequential (not gap-free) byte-offset of the write-ahead-log of the database. With this, the new `LsnReplicationController` can link every exporterPosition to a LSN and can compare the committed LSN of the connected replicas. The goal is, that we only commit/acknowledge exporterPositions to the ExporterController, which have reached a configured minimal quorum in the DB cluster.

Features:
- only acknowledge replicated exporter positions to the `ExporterController`. We configure a minReplicas quorum, so we also can connect more replicas than needed, but we can compensate loosing one
- when the quorum is not reached for a certain amount of time, the exporter pauses processing and only continues, when the quorum is reached in the future

Refactorings:
- added a databaseId property to the `VendorDatabaseProperties` to instantiate the correct LSN provider

Future extension points:
- we can add more LSN providers in the future for other database vendors

Not implemented in this PR:
- a full integration test with a running Camunda against a cluster of PostgreSQL instances

## Related issues

closes #51463 
