### PR TITLE
fix(qa): skip/trim extensionProperties assertions while field is temporarily removed (#52514)

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/index.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/index.ts
@@ -430,6 +430,11 @@ export const RESPONSE_INDEX = {
       '200': 1,
     },
   },
+  '/resources/search': {
+    POST: {
+      '200': 1,
+    },
+  },
   '/resources/{resourceKey}': {
     GET: {
       '200': 1,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/responses.json
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/responses.json
@@ -5076,7 +5076,12 @@
                   "nullable": true
                 }
               ],
-              "optional": []
+              "optional": [
+                {
+                  "name": "extensionProperties",
+                  "type": "object"
+                }
+              ]
             }
           },
           {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/responses.json
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/responses.json
@@ -1,10 +1,10 @@
 {
   "metadata": {
     "sourceRepo": "https://github.com/camunda/camunda",
-    "commit": "b22a92d268da08532cd1b5fc86b4763b8cad9d49",
-    "generatedAt": "2026-04-27T13:36:37.463Z",
+    "commit": "304a6b608bad29c893c4597fc951ac967e9f4124",
+    "generatedAt": "2026-05-06T09:33:31.629Z",
     "specPath": "zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml",
-    "specSha256": "e1916dea8fd495e28808d5902a663aca3e629446b9d3cae8c636b5d8a840e75f"
+    "specSha256": "7b59672a1557b1183147696e37f62e5e7d56a17fceb2a30cc4ec078086b41261"
   },
   "responses": [
     {
@@ -769,7 +769,8 @@
                 },
                 {
                   "name": "processInstanceKey",
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 {
                   "name": "rootProcessInstanceKey",
@@ -6217,6 +6218,77 @@
                 },
                 {
                   "name": "incidents",
+                  "type": "number"
+                }
+              ],
+              "optional": []
+            }
+          }
+        ],
+        "optional": []
+      }
+    },
+    {
+      "path": "/resources/search",
+      "method": "POST",
+      "status": "200",
+      "schema": {
+        "required": [
+          {
+            "name": "items",
+            "type": "array<schema>",
+            "children": {
+              "required": [
+                {
+                  "name": "resourceId",
+                  "type": "string"
+                },
+                {
+                  "name": "resourceKey",
+                  "type": "string"
+                },
+                {
+                  "name": "resourceName",
+                  "type": "string"
+                },
+                {
+                  "name": "tenantId",
+                  "type": "string"
+                },
+                {
+                  "name": "version",
+                  "type": "number"
+                },
+                {
+                  "name": "versionTag",
+                  "type": "string",
+                  "nullable": true
+                }
+              ],
+              "optional": []
+            }
+          },
+          {
+            "name": "page",
+            "type": "object",
+            "children": {
+              "required": [
+                {
+                  "name": "endCursor",
+                  "type": "string",
+                  "nullable": true
+                },
+                {
+                  "name": "hasMoreTotalItems",
+                  "type": "boolean"
+                },
+                {
+                  "name": "startCursor",
+                  "type": "string",
+                  "nullable": true
+                },
+                {
+                  "name": "totalItems",
                   "type": "number"
                 }
               ],

--- a/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/responses.json
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/responses.json
@@ -2,7 +2,7 @@
   "metadata": {
     "sourceRepo": "https://github.com/camunda/camunda",
     "commit": "304a6b608bad29c893c4597fc951ac967e9f4124",
-    "generatedAt": "2026-05-06T09:33:31.629Z",
+    "generatedAt": "2026-05-06T09:43:55.169Z",
     "specPath": "zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml",
     "specSha256": "7b59672a1557b1183147696e37f62e5e7d56a17fceb2a30cc4ec078086b41261"
   },
@@ -4998,10 +4998,6 @@
                   "name": "elementInstanceKey",
                   "type": "string",
                   "nullable": true
-                },
-                {
-                  "name": "extensionProperties",
-                  "type": "object"
                 },
                 {
                   "name": "inboundConnectorType",

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message-subscriptions/mcp-message-subscription-search.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message-subscriptions/mcp-message-subscription-search.spec.ts
@@ -420,5 +420,4 @@ test.describe('MCP Message Subscription Search API Tests', () => {
       });
     });
   });
-
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message-subscriptions/mcp-message-subscription-search.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message-subscriptions/mcp-message-subscription-search.spec.ts
@@ -476,7 +476,10 @@ test.describe('MCP Message Subscription Search API Tests', () => {
   test('SC-API-04 — extensionProperties contains tool metadata', async ({
     request,
   }) => {
-    test.skip(true, 'Skipped due to bug 52514: https://github.com/camunda/camunda/issues/52514');
+    test.skip(
+      true,
+      'Skipped due to bug 52514: https://github.com/camunda/camunda/issues/52514',
+    );
     await expect(async () => {
       const res = await request.post(
         buildUrl('/message-subscriptions/search'),

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message-subscriptions/mcp-message-subscription-search.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message-subscriptions/mcp-message-subscription-search.spec.ts
@@ -282,7 +282,7 @@ test.describe('MCP Message Subscription Search API Tests', () => {
       const json = await res.json();
       expect(json.page.totalItems).toBeGreaterThanOrEqual(1);
 
-      // TODO(camunda/camunda#52534, camunda/camunda#52514): restore extensionProperties assertion below
+      // extensionProperties assertion skipped due to bug 52514: https://github.com/camunda/camunda/issues/52514
       json.items.forEach(
         (it: {processDefinitionId: string; toolName: string}) => {
           expect(it.processDefinitionId).toBe('mcpProcessAlpha');
@@ -291,6 +291,7 @@ test.describe('MCP Message Subscription Search API Tests', () => {
       );
     });
 
+<<<<<<< HEAD
     //Skipped due to bug: 52532 https://github.com/camunda/camunda/issues/52532
     await test.step.skip(
       'SC-API-08 — Filter by processDefinitionId for with-inputs process includes extensionProperties with input metadata',
@@ -304,6 +305,17 @@ test.describe('MCP Message Subscription Search API Tests', () => {
                 processDefinitionId: 'mcpProcessWithInputs',
                 messageSubscriptionType: 'START_EVENT',
               },
+=======
+    await test.step('SC-API-08 — Filter by processDefinitionId returns with-inputs process subscription', async () => {
+      const res = await request.post(
+        buildUrl('/message-subscriptions/search'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              processDefinitionId: 'mcpProcessWithInputs',
+              messageSubscriptionType: 'START_EVENT',
+>>>>>>> ec6984c42cc (fix: address Copilot review comments on extensionProperties skip PR)
             },
           },
         );
@@ -319,6 +331,7 @@ test.describe('MCP Message Subscription Search API Tests', () => {
         const json = await res.json();
         expect(json.page.totalItems).toBeGreaterThanOrEqual(1);
 
+<<<<<<< HEAD
 <<<<<<< HEAD
         json.items.forEach(
           (it: {extensionProperties: Record<string, string>}) => {
@@ -349,6 +362,9 @@ test.describe('MCP Message Subscription Search API Tests', () => {
     );
 =======
       // TODO(camunda/camunda#52534, camunda/camunda#52514): restore extensionProperties assertions below
+=======
+      // extensionProperties assertions skipped due to bug 52514: https://github.com/camunda/camunda/issues/52514
+>>>>>>> ec6984c42cc (fix: address Copilot review comments on extensionProperties skip PR)
       json.items.forEach((it: object) => {
         assertEqualsForKeys(
           it,
@@ -401,15 +417,18 @@ test.describe('MCP Message Subscription Search API Tests', () => {
     });
 
     await test.step('SC-API-10 — Sort by processDefinitionVersion descending', async () => {
-      // Deploying mcpProcessAlpha twice yields version 2; all other processes are at version 1.
-      // Sorting all START_EVENT subscriptions DESC by version must place Alpha (v2) first.
+      // mcpProcessAlpha is deployed twice (v1 via mcpProcessAlpha.bpmn, v2 via mcp-process-alpha-v2.bpmn).
+      // Filtering by processDefinitionId isolates Alpha's two versions from other processes on the cluster.
       await expect(async () => {
         const res = await request.post(
           buildUrl('/message-subscriptions/search'),
           {
             headers: jsonHeaders(),
             data: {
-              filter: {messageSubscriptionType: 'START_EVENT'},
+              filter: {
+                processDefinitionId: 'mcpProcessAlpha',
+                messageSubscriptionType: 'START_EVENT',
+              },
               sort: [{field: 'processDefinitionVersion', order: 'DESC'}],
               page: {limit: 100},
             },
@@ -427,20 +446,23 @@ test.describe('MCP Message Subscription Search API Tests', () => {
         const json = await res.json();
         expect(json.page.totalItems).toBeGreaterThanOrEqual(2);
 
-        const versions: number[] = json.items
-          .map(
-            (it: {processDefinitionVersion: number | null}) =>
-              it.processDefinitionVersion,
-          )
-          .filter((v: number | null) => v !== null);
+        const items: {
+          processDefinitionVersion: number | null;
+          processDefinitionId: string;
+        }[] = json.items.filter(
+          (it: {processDefinitionVersion: number | null}) =>
+            it.processDefinitionVersion !== null,
+        );
 
-        for (let i = 0; i < versions.length - 1; i++) {
-          expect(versions[i]).toBeGreaterThanOrEqual(versions[i + 1]);
+        for (let i = 0; i < items.length - 1; i++) {
+          expect(items[i].processDefinitionVersion).toBeGreaterThanOrEqual(
+            items[i + 1].processDefinitionVersion!,
+          );
         }
 
-        // mcpProcessAlpha v2 must appear first
-        expect(versions[0]).toBeGreaterThanOrEqual(2);
-        expect(json.items[0].processDefinitionId).toBe('mcpProcessAlpha');
+        // Alpha v2 must appear first in the sorted results
+        expect(items[0].processDefinitionVersion).toBeGreaterThanOrEqual(2);
+        expect(items[0].processDefinitionId).toBe('mcpProcessAlpha');
       }).toPass({
         intervals: [5_000, 10_000, 15_000],
         timeout: 30_000,
@@ -448,4 +470,53 @@ test.describe('MCP Message Subscription Search API Tests', () => {
     });
   });
 
+<<<<<<< HEAD
+=======
+  // Skipped due to bug 52514: https://github.com/camunda/camunda/issues/52514
+  test('SC-API-04 — extensionProperties contains tool metadata', async ({
+    request,
+  }) => {
+    test.skip(true, 'Skipped due to bug 52514: https://github.com/camunda/camunda/issues/52514');
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/message-subscriptions/search'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              processDefinitionId: 'mcpProcessAlpha',
+              messageSubscriptionType: 'START_EVENT',
+            },
+          },
+        },
+      );
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: '/message-subscriptions/search',
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+      const json = await res.json();
+      expect(json.page.totalItems).toBeGreaterThanOrEqual(1);
+
+      json.items.forEach(
+        (it: {extensionProperties: Record<string, string>}) => {
+          expect(it.extensionProperties).toBeDefined();
+          expect(it.extensionProperties['io.camunda.tool:name']).toBe(
+            'alpha-tool-name',
+          );
+          expect(
+            it.extensionProperties['io.camunda.tool:purpose'],
+          ).toBeDefined();
+        },
+      );
+    }).toPass({
+      intervals: [5_000, 10_000, 15_000],
+      timeout: 30_000,
+    });
+  });
+>>>>>>> ec6984c42cc (fix: address Copilot review comments on extensionProperties skip PR)
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message-subscriptions/mcp-message-subscription-search.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message-subscriptions/mcp-message-subscription-search.spec.ts
@@ -139,7 +139,7 @@ test.describe('MCP Message Subscription Search API Tests', () => {
       expect(types).toContain('PROCESS_EVENT');
     });
 
-    //Skipped due to bug: 52532 https://github.com/camunda/camunda/issues/52532
+    //Skipped due to bug: 52514 https://github.com/camunda/camunda/issues/52514
     await test.step.skip(
       'SC-API-04 — extensionProperties contains tool metadata',
       async () => {
@@ -282,17 +282,11 @@ test.describe('MCP Message Subscription Search API Tests', () => {
       const json = await res.json();
       expect(json.page.totalItems).toBeGreaterThanOrEqual(1);
 
+      // TODO(camunda/camunda#52534, camunda/camunda#52514): restore extensionProperties assertion below
       json.items.forEach(
-        (it: {
-          processDefinitionId: string;
-          toolName: string;
-          extensionProperties: Record<string, string>;
-        }) => {
+        (it: {processDefinitionId: string; toolName: string}) => {
           expect(it.processDefinitionId).toBe('mcpProcessAlpha');
           expect(it.toolName).toBe('alpha-tool-name');
-          expect(it.extensionProperties['io.camunda.tool:name']).toBe(
-            'alpha-tool-name',
-          );
         },
       );
     });
@@ -325,6 +319,7 @@ test.describe('MCP Message Subscription Search API Tests', () => {
         const json = await res.json();
         expect(json.page.totalItems).toBeGreaterThanOrEqual(1);
 
+<<<<<<< HEAD
         json.items.forEach(
           (it: {extensionProperties: Record<string, string>}) => {
             assertEqualsForKeys(
@@ -352,6 +347,21 @@ test.describe('MCP Message Subscription Search API Tests', () => {
         );
       },
     );
+=======
+      // TODO(camunda/camunda#52534, camunda/camunda#52514): restore extensionProperties assertions below
+      json.items.forEach((it: object) => {
+        assertEqualsForKeys(
+          it,
+          {
+            processDefinitionId: 'mcpProcessWithInputs',
+            messageSubscriptionType: 'START_EVENT',
+            tenantId: '<default>',
+          },
+          ['processDefinitionId', 'messageSubscriptionType', 'tenantId'],
+        );
+      });
+    });
+>>>>>>> 0865368c020 (fix: skip/trim extensionProperties tests while field is temporarily removed)
 
     await test.step('SC-API-09 — Sort by processDefinitionName ascending', async () => {
       const res = await request.post(
@@ -437,4 +447,5 @@ test.describe('MCP Message Subscription Search API Tests', () => {
       });
     });
   });
+
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message-subscriptions/mcp-message-subscription-search.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message-subscriptions/mcp-message-subscription-search.spec.ts
@@ -291,21 +291,6 @@ test.describe('MCP Message Subscription Search API Tests', () => {
       );
     });
 
-<<<<<<< HEAD
-    //Skipped due to bug: 52532 https://github.com/camunda/camunda/issues/52532
-    await test.step.skip(
-      'SC-API-08 — Filter by processDefinitionId for with-inputs process includes extensionProperties with input metadata',
-      async () => {
-        const res = await request.post(
-          buildUrl('/message-subscriptions/search'),
-          {
-            headers: jsonHeaders(),
-            data: {
-              filter: {
-                processDefinitionId: 'mcpProcessWithInputs',
-                messageSubscriptionType: 'START_EVENT',
-              },
-=======
     await test.step('SC-API-08 — Filter by processDefinitionId returns with-inputs process subscription', async () => {
       const res = await request.post(
         buildUrl('/message-subscriptions/search'),
@@ -315,56 +300,23 @@ test.describe('MCP Message Subscription Search API Tests', () => {
             filter: {
               processDefinitionId: 'mcpProcessWithInputs',
               messageSubscriptionType: 'START_EVENT',
->>>>>>> ec6984c42cc (fix: address Copilot review comments on extensionProperties skip PR)
             },
           },
-        );
-        await assertStatusCode(res, 200);
-        await validateResponse(
-          {
-            path: '/message-subscriptions/search',
-            method: 'POST',
-            status: '200',
-          },
-          res,
-        );
-        const json = await res.json();
-        expect(json.page.totalItems).toBeGreaterThanOrEqual(1);
+        },
+      );
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: '/message-subscriptions/search',
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+      const json = await res.json();
+      expect(json.page.totalItems).toBeGreaterThanOrEqual(1);
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-        json.items.forEach(
-          (it: {extensionProperties: Record<string, string>}) => {
-            assertEqualsForKeys(
-              it,
-              {
-                processDefinitionId: 'mcpProcessWithInputs',
-                messageSubscriptionType: 'START_EVENT',
-                tenantId: '<default>',
-              },
-              ['processDefinitionId', 'messageSubscriptionType', 'tenantId'],
-            );
-            expect(it.extensionProperties['io.camunda.tool:input_1_name']).toBe(
-              'firstName',
-            );
-            expect(it.extensionProperties['io.camunda.tool:input_1_type']).toBe(
-              'string',
-            );
-            expect(it.extensionProperties['io.camunda.tool:input_2_name']).toBe(
-              'amount',
-            );
-            expect(
-              it.extensionProperties['io.camunda.tool:input_2_required'],
-            ).toBe('true');
-          },
-        );
-      },
-    );
-=======
-      // TODO(camunda/camunda#52534, camunda/camunda#52514): restore extensionProperties assertions below
-=======
       // extensionProperties assertions skipped due to bug 52514: https://github.com/camunda/camunda/issues/52514
->>>>>>> ec6984c42cc (fix: address Copilot review comments on extensionProperties skip PR)
       json.items.forEach((it: object) => {
         assertEqualsForKeys(
           it,
@@ -377,7 +329,6 @@ test.describe('MCP Message Subscription Search API Tests', () => {
         );
       });
     });
->>>>>>> 0865368c020 (fix: skip/trim extensionProperties tests while field is temporarily removed)
 
     await test.step('SC-API-09 — Sort by processDefinitionName ascending', async () => {
       const res = await request.post(
@@ -470,56 +421,4 @@ test.describe('MCP Message Subscription Search API Tests', () => {
     });
   });
 
-<<<<<<< HEAD
-=======
-  // Skipped due to bug 52514: https://github.com/camunda/camunda/issues/52514
-  test('SC-API-04 — extensionProperties contains tool metadata', async ({
-    request,
-  }) => {
-    test.skip(
-      true,
-      'Skipped due to bug 52514: https://github.com/camunda/camunda/issues/52514',
-    );
-    await expect(async () => {
-      const res = await request.post(
-        buildUrl('/message-subscriptions/search'),
-        {
-          headers: jsonHeaders(),
-          data: {
-            filter: {
-              processDefinitionId: 'mcpProcessAlpha',
-              messageSubscriptionType: 'START_EVENT',
-            },
-          },
-        },
-      );
-      await assertStatusCode(res, 200);
-      await validateResponse(
-        {
-          path: '/message-subscriptions/search',
-          method: 'POST',
-          status: '200',
-        },
-        res,
-      );
-      const json = await res.json();
-      expect(json.page.totalItems).toBeGreaterThanOrEqual(1);
-
-      json.items.forEach(
-        (it: {extensionProperties: Record<string, string>}) => {
-          expect(it.extensionProperties).toBeDefined();
-          expect(it.extensionProperties['io.camunda.tool:name']).toBe(
-            'alpha-tool-name',
-          );
-          expect(
-            it.extensionProperties['io.camunda.tool:purpose'],
-          ).toBeDefined();
-        },
-      );
-    }).toPass({
-      intervals: [5_000, 10_000, 15_000],
-      timeout: 30_000,
-    });
-  });
->>>>>>> ec6984c42cc (fix: address Copilot review comments on extensionProperties skip PR)
 });


### PR DESCRIPTION
## Summary

- Regenerates `responses.json` from latest `main` so `validateResponse()` no longer fails when `extensionProperties` is absent from the API response
- Skips SC-API-04 ("extensionProperties contains tool metadata") with `test.skip(true, ...)` and a TODO referencing #52514
- Trims `extensionProperties`-only assertions from SC-API-07 and SC-API-08 (remaining assertions for `toolName` filter, `processDefinitionId`, `messageSubscriptionType`, `tenantId` are preserved)

All TODO comments reference both this fix issue (#52534) and the root cause (#52514) so they are easy to locate when the field is restored.

## Related

- Original test PR: #52454 (merged)
- Root cause: #52514
- Fix tracking: Closes #52534

## Test plan

- [x] CI passes — SC-API-01..03, 05..10 pass; SC-API-04 shows as skipped (https://github.com/camunda/camunda/actions/runs/25457746649)
- [ ] After #52514 restores `extensionProperties`: run `npm run responses:regenerate`, unskip SC-API-04, restore assertions in SC-API-07 and SC-API-08

🤖 Generated with [Claude Code](https://claude.com/claude-code)