### PR TITLE
fix: relax streamInactivityTimeout vs streamTimeout validation to info log

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/worker/JobWorkerBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/worker/JobWorkerBuilderImpl.java
@@ -31,6 +31,7 @@ import io.camunda.client.api.worker.JobWorkerBuilderStep1;
 import io.camunda.client.api.worker.JobWorkerBuilderStep1.JobWorkerBuilderStep2;
 import io.camunda.client.api.worker.JobWorkerBuilderStep1.JobWorkerBuilderStep3;
 import io.camunda.client.api.worker.JobWorkerMetrics;
+import io.camunda.client.impl.Loggers;
 import java.io.Closeable;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -39,6 +40,7 @@ import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
+import org.slf4j.Logger;
 
 public final class JobWorkerBuilderImpl
     implements JobWorkerBuilderStep1, JobWorkerBuilderStep2, JobWorkerBuilderStep3 {
@@ -49,6 +51,7 @@ public final class JobWorkerBuilderImpl
       BackoffSupplier.newBackoffBuilder().maxDelay(Duration.ofMinutes(1).toMillis()).build();
   public static final Duration DEFAULT_STREAM_TIMEOUT = Duration.ofHours(8);
   public static final Duration DEFAULT_STREAM_INACTIVITY_TIMEOUT = Duration.ofMinutes(10);
+  private static final Logger LOG = Loggers.JOB_WORKER_LOGGER;
   private final JobClient jobClient;
   private final ScheduledExecutorService scheduledExecutor;
   private final ExecutorService jobHandlingExecutor;
@@ -237,12 +240,10 @@ public final class JobWorkerBuilderImpl
       if (streamInactivityTimeout != null) {
         ensurePositive("streamInactivityTimeout", streamInactivityTimeout);
         if (streamTimeout != null && streamInactivityTimeout.compareTo(streamTimeout) >= 0) {
-          throw new IllegalArgumentException(
-              "streamInactivityTimeout ("
-                  + streamInactivityTimeout
-                  + ") must be strictly less than streamTimeout ("
-                  + streamTimeout
-                  + ")");
+          LOG.info(
+              "streamInactivityTimeout ({}) is not less than streamTimeout ({}); inactivity-based stream recreation will not fire because streamTimeout will always preempt it.",
+              streamInactivityTimeout,
+              streamTimeout);
         }
       }
 

--- a/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerBuilderImplTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerBuilderImplTest.java
@@ -43,6 +43,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.stream.Collectors;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.appender.ListAppender;
 import org.awaitility.Awaitility;
 import org.awaitility.core.ThrowingRunnable;
 import org.junit.jupiter.api.AfterEach;
@@ -55,10 +61,13 @@ import org.mockito.Mockito;
 @SuppressWarnings("resource")
 class JobWorkerBuilderImplTest {
 
+  private static final String JOB_WORKER_LOGGER_NAME = "io.camunda.client.job.worker";
+
   private JobWorkerBuilderImpl jobWorkerBuilder;
   private JobClient jobClient;
   private List<Closeable> closeables;
   private CamundaClientConfiguration zeebeClientConfig;
+  private ListAppender logCapture;
 
   @BeforeEach
   void setUp() {
@@ -69,6 +78,14 @@ class JobWorkerBuilderImplTest {
     jobWorkerBuilder =
         new JobWorkerBuilderImpl(
             zeebeClientConfig, jobClient, executorService, executorService, closeables);
+
+    logCapture = new ListAppender("capture-" + JOB_WORKER_LOGGER_NAME);
+    logCapture.start();
+    final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+    ctx.getConfiguration()
+        .getLoggerConfig(JOB_WORKER_LOGGER_NAME)
+        .addAppender(logCapture, null, null);
+    ctx.updateLoggers();
   }
 
   @AfterEach
@@ -76,6 +93,21 @@ class JobWorkerBuilderImplTest {
     for (final Closeable closeable : closeables) {
       closeable.close();
     }
+    if (logCapture != null) {
+      final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+      ctx.getConfiguration()
+          .getLoggerConfig(JOB_WORKER_LOGGER_NAME)
+          .removeAppender(logCapture.getName());
+      ctx.updateLoggers();
+      logCapture.stop();
+    }
+  }
+
+  private List<LogEvent> eventsAt(final Level level) {
+    return logCapture.getEvents().stream()
+        .filter(e -> JOB_WORKER_LOGGER_NAME.equals(e.getLoggerName()))
+        .filter(e -> level.equals(e.getLevel()))
+        .collect(Collectors.toList());
   }
 
   @Test
@@ -159,21 +191,27 @@ class JobWorkerBuilderImplTest {
   }
 
   @Test
-  void shouldThrowErrorIfStreamInactivityTimeoutNotLessThanStreamTimeout() {
-    // given / when
-    assertThatThrownBy(
-            () ->
-                jobWorkerBuilder
-                    .jobType("some-type")
-                    .handler(mock())
-                    .streamEnabled(true)
-                    .streamTimeout(Duration.ofMinutes(5))
-                    .streamInactivityTimeout(Duration.ofMinutes(5))
-                    .open())
-        // then
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("streamInactivityTimeout")
-        .hasMessageContaining("streamTimeout");
+  void shouldLogInfoWhenStreamInactivityTimeoutNotLessThanStreamTimeout() {
+    // given / when - users may legitimately configure a streamTimeout below the default
+    // streamInactivityTimeout to enforce a more frequent hard cutoff. The build must succeed
+    // and the runtime must inform the operator that inactivity-based recreation will not fire.
+    jobWorkerBuilder
+        .jobType("some-type")
+        .handler(mock())
+        .streamEnabled(true)
+        .streamTimeout(Duration.ofMinutes(5))
+        .streamInactivityTimeout(Duration.ofMinutes(5))
+        .open();
+
+    // then
+    final List<LogEvent> infos = eventsAt(Level.INFO);
+    assertThat(infos)
+        .anySatisfy(
+            event ->
+                assertThat(event.getMessage().getFormattedMessage())
+                    .contains("streamInactivityTimeout")
+                    .contains("streamTimeout")
+                    .contains("preempt"));
   }
 
   @Test


### PR DESCRIPTION
## Summary

Relaxes the `JobWorkerBuilder` validation that previously threw `IllegalArgumentException` whenever `streamInactivityTimeout >= streamTimeout` (introduced in #51616) to an `INFO` log instead.

Combined with the 10-minute default for `streamInactivityTimeout`, the strict validation broke Spring application startup for users who had only configured `streamTimeout` to a value below 10 minutes — a legitimate setup when the operator wants a hard, more frequent stream cutoff and doesn't care about an inactivity-based watchdog.

The positive-value validation on `streamInactivityTimeout` itself is preserved.

Closes #52537

## Test plan

- [x] Updated `JobWorkerBuilderImplTest` — replaced the throw assertion with one that verifies the build succeeds and an `INFO` log informing the operator is emitted.
- [x] `./mvnw verify -pl clients/java -Dtest=JobWorkerBuilderImplTest -DskipTests=false -DskipITs -Dquickly` — 11/11 green.
- [x] `JobStreamImplTest` still green.
- [x] `./mvnw license:format spotless:apply -pl clients/java`.

## Backports

Labels added so automation forward-ports to `stable/8.9`, `stable/8.8`, and `stable/8.7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)