### PR TITLE
fix: pin Spring Session filter to webapp paths

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/identity/WebSessionRepositoryConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/identity/WebSessionRepositoryConfiguration.java
@@ -27,12 +27,16 @@ import io.camunda.webapps.schema.descriptors.index.PersistentWebSessionIndexDesc
 import io.camunda.zeebe.gateway.rest.ConditionalOnRestGatewayEnabled;
 import io.camunda.zeebe.util.error.FatalErrorHandler;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.support.GenericConversionService;
 import org.springframework.session.config.annotation.web.http.EnableSpringHttpSession;
+import org.springframework.session.web.http.SessionRepositoryFilter;
 
 @Configuration
 @EnableSpringHttpSession
@@ -91,6 +95,46 @@ public class WebSessionRepositoryConfiguration {
         new SpringBasedWebSessionAttributeConverter(conversionService);
     final var webSessionMapper = new WebSessionMapper(webSessionAttributeConverter);
     return new WebSessionRepository(persistentWebSessionClient, webSessionMapper, request);
+  }
+
+  /**
+   * Pin {@link SessionRepositoryFilter} to webapp paths only.
+   *
+   * <p>{@link EnableSpringHttpSession} auto-registers the filter against {@code /*}, so it runs on
+   * every servlet request — including stateless Bearer-token API calls under {@code /v1/**}, {@code
+   * /v2/**}, {@code /api/**}, {@code /mcp/**}. The filter wraps the request and triggers a session
+   * lookup via {@link PersistentWebSessionClient}, which on the API hot path means a per-request
+   * I/O hit against secondary storage that the request does not need.
+   *
+   * <p>Sessions are only meaningful on webapp endpoints (login, the bundled UIs, OAuth2
+   * redirection). Restricting the filter to those URL patterns removes the per-request session
+   * lookup from the API request path while keeping webapp session behavior unchanged. Spring Boot
+   * suppresses the default global registration when a {@link FilterRegistrationBean} wrapping the
+   * same filter bean is present.
+   *
+   * <p>The patterns are intentionally a strict subset of {@code WebSecurityConfig.WEBAPP_PATHS}
+   * (translated from Spring's {@code /**} matchers to servlet {@code /*} prefix mappings). Any
+   * webapp path not listed here will lose session support; if a new webapp path is added, this list
+   * must be updated.
+   */
+  @Bean
+  public FilterRegistrationBean<SessionRepositoryFilter<?>> sessionRepositoryFilterRegistration(
+      @Qualifier("springSessionRepositoryFilter") final SessionRepositoryFilter<?> filter) {
+    final FilterRegistrationBean<SessionRepositoryFilter<?>> registration =
+        new FilterRegistrationBean<>(filter);
+    registration.setOrder(SessionRepositoryFilter.DEFAULT_ORDER);
+    registration.setUrlPatterns(
+        List.of(
+            "/operate/*",
+            "/tasklist/*",
+            "/admin/*",
+            "/webapp/*",
+            "/login/*",
+            "/logout",
+            "/sso-callback/*",
+            "/oauth2/*",
+            "/"));
+    return registration;
   }
 
   @Bean("persistentWebSessionDeletionTaskExecutor")


### PR DESCRIPTION
## Summary

`@EnableSpringHttpSession` auto-registers `SessionRepositoryFilter` against `/*`, so it ran on every servlet request — including stateless Bearer-token API calls under `/v1/**`, `/v2/**`, `/api/**`, `/mcp/**`. The filter wraps the request and triggers a session lookup via `PersistentWebSessionClient`, which on the API hot path means a per-request I/O hit against secondary storage that the request does not need.

This change wraps the existing `springSessionRepositoryFilter` bean in a `FilterRegistrationBean` with explicit URL patterns, scoped to webapp endpoints only. Spring Boot suppresses the default global registration when a `FilterRegistrationBean` wraps the same filter bean.

Refs camunda/camunda#35067

## Why this is the suspected throughput bottleneck

CPU flame graph comparison between 8.8 (no bottleneck) and 8.9 (bottleneck) showed two filters newly present on 8.9's API hot path that did not appear on 8.8:

| Frame | 8.8 | 8.9 |
| --- | --- | --- |
| `SessionRepositoryFilter.doFilterInternal` | 0% | 4.6% |
| `DisableEncodeUrlFilter.doFilterInternal` | 0% | 4.4% |

The visible CPU cost is modest. The bigger cost is invisible: `SessionRepositoryFilter` triggers a per-request lookup against `PersistentWebSessionClient` (Elasticsearch / OpenSearch / RDBMS depending on `SecondaryStorageType`). That blocking I/O lands Tomcat threads in socket-read wait — exactly the shape of the observed cap (low CPU usage, high latency, throughput cliff).

Both `SessionRepositoryFilter` and `DisableEncodeUrlFilter` (a Spring Security session-related filter) are expected to be inactive on a stateless Bearer-token request path. With this change they only run on the webapp paths where sessions are actually established (login, the Operate / Tasklist UIs, OAuth2 redirection).

## Path selection

Patterns are a strict subset of `WebSecurityConfig.WEBAPP_PATHS`, translated from Spring's `/**` matchers to servlet `/*` prefix mappings:

```
/operate/*, /tasklist/*, /admin/*, /webapp/*,
/login/*, /logout, /sso-callback/*, /oauth2/*, /
```

Any webapp path not listed will lose session support; if a new webapp path is added, this list must be updated. Worth a comment in the file (added).

## Test plan

- [ ] Manual: hit `/v2/jobs` (or any `/v2/**` endpoint) with persistent web sessions enabled and confirm `PersistentWebSessionClient` is not consulted (logs / metrics).
- [ ] Manual: log in via the Operate UI (`/login` → `/operate/...`) and confirm session establishment + persistence still work.
- [ ] Cluster benchmark: re-run the REST + OIDC load test that previously bottlenecked on 8.9 and compare throughput to the 8.8 baseline.

## Risk

- New webapp routes added later without updating the URL pattern list will silently lose session support. Mitigation: docstring on the bean calls this out explicitly; longer term, a constant shared with `WebSecurityConfig.WEBAPP_PATHS` would prevent drift.
- If anything currently relies on a session being available on an API endpoint, this will break it. None of the documented API endpoints depend on a session — they use the Bearer token chain — but worth a focused review on `WebComponentAuthorizationCheckFilter` and any non-OIDC API paths.