### PR TITLE
fix: restore default tool property names in exporter ToolsConfiguration

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/response/MessageSubscription.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/MessageSubscription.java
@@ -61,7 +61,7 @@ public interface MessageSubscription {
 
   Integer getProcessDefinitionVersion();
 
-  Map<String, String> getExtensionProperties();
+  Map<String, String> getToolProperties();
 
   String getToolName();
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/MessageSubscriptionImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/MessageSubscriptionImpl.java
@@ -42,7 +42,7 @@ public class MessageSubscriptionImpl implements MessageSubscription {
   private final String tenantId;
   private final String processDefinitionName;
   private final Integer processDefinitionVersion;
-  private final Map<String, String> extensionProperties;
+  private final Map<String, String> toolProperties;
   private final String toolName;
   private final String inboundConnectorType;
 
@@ -64,7 +64,7 @@ public class MessageSubscriptionImpl implements MessageSubscription {
     tenantId = item.getTenantId();
     processDefinitionName = item.getProcessDefinitionName();
     processDefinitionVersion = item.getProcessDefinitionVersion();
-    extensionProperties = item.getExtensionProperties();
+    toolProperties = item.getToolProperties();
     toolName = item.getToolName();
     inboundConnectorType = item.getInboundConnectorType();
   }
@@ -145,8 +145,8 @@ public class MessageSubscriptionImpl implements MessageSubscription {
   }
 
   @Override
-  public Map<String, String> getExtensionProperties() {
-    return extensionProperties;
+  public Map<String, String> getToolProperties() {
+    return toolProperties;
   }
 
   @Override
@@ -177,7 +177,7 @@ public class MessageSubscriptionImpl implements MessageSubscription {
         tenantId,
         processDefinitionName,
         processDefinitionVersion,
-        extensionProperties,
+        toolProperties,
         toolName,
         inboundConnectorType);
   }
@@ -206,7 +206,7 @@ public class MessageSubscriptionImpl implements MessageSubscription {
         && Objects.equals(tenantId, subscription.tenantId)
         && Objects.equals(processDefinitionName, subscription.processDefinitionName)
         && Objects.equals(processDefinitionVersion, subscription.processDefinitionVersion)
-        && Objects.equals(extensionProperties, subscription.extensionProperties)
+        && Objects.equals(toolProperties, subscription.toolProperties)
         && Objects.equals(toolName, subscription.toolName)
         && Objects.equals(inboundConnectorType, subscription.inboundConnectorType);
   }

--- a/configuration/src/main/java/io/camunda/configuration/Data.java
+++ b/configuration/src/main/java/io/camunda/configuration/Data.java
@@ -40,6 +40,9 @@ public class Data {
   /** This section allows configuring exporters */
   private Map<String, Exporter> exporters = new HashMap<>();
 
+  /** This section allows configuring tool property extension mapping. */
+  @NestedConfigurationProperty private Tools tools = new Tools();
+
   public AuditLog getAuditLog() {
     return auditLog;
   }
@@ -99,5 +102,13 @@ public class Data {
 
   public void setExporters(final Map<String, Exporter> exporters) {
     this.exporters = exporters;
+  }
+
+  public Tools getTools() {
+    return tools;
+  }
+
+  public void setTools(final Tools tools) {
+    this.tools = tools;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/Tools.java
+++ b/configuration/src/main/java/io/camunda/configuration/Tools.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+/**
+ * Configuration for which extension property names are exported as tool properties.
+ *
+ * <p>These properties control which BPMN extension properties are extracted and stored as
+ * structured attributes on entities, making them queryable without exporting all extension
+ * properties. While currently used primarily for message subscriptions, these settings are general
+ * and can be applied to other entity types in the future.
+ */
+public class Tools {
+
+  public static final String DEFAULT_EXTENSION_PROPERTY_TOOL_NAME = "io.camunda.tool:name";
+  public static final String DEFAULT_EXTENSION_PROPERTY_INBOUND_CONNECTOR_TYPE = "inbound.type";
+  public static final String DEFAULT_EXTENSION_PROPERTY_PREFIX_TOOL_PROPERTIES = "io.camunda.tool:";
+
+  /** The extension property name whose value is exported as the {@code toolName} attribute. */
+  private String extensionPropertyToolName = DEFAULT_EXTENSION_PROPERTY_TOOL_NAME;
+
+  /**
+   * The extension property name whose value is exported as the {@code inboundConnectorType}
+   * attribute.
+   */
+  private String extensionPropertyInboundConnectorType =
+      DEFAULT_EXTENSION_PROPERTY_INBOUND_CONNECTOR_TYPE;
+
+  /**
+   * The extension property name prefix for properties exported as the {@code toolProperties}
+   * key-value attribute. Only extension properties whose names start with this prefix are exported.
+   */
+  private String extensionPropertyPrefixToolProperties =
+      DEFAULT_EXTENSION_PROPERTY_PREFIX_TOOL_PROPERTIES;
+
+  public String getExtensionPropertyToolName() {
+    return extensionPropertyToolName;
+  }
+
+  public void setExtensionPropertyToolName(final String extensionPropertyToolName) {
+    this.extensionPropertyToolName = extensionPropertyToolName;
+  }
+
+  public String getExtensionPropertyInboundConnectorType() {
+    return extensionPropertyInboundConnectorType;
+  }
+
+  public void setExtensionPropertyInboundConnectorType(
+      final String extensionPropertyInboundConnectorType) {
+    this.extensionPropertyInboundConnectorType = extensionPropertyInboundConnectorType;
+  }
+
+  public String getExtensionPropertyPrefixToolProperties() {
+    return extensionPropertyPrefixToolProperties;
+  }
+
+  public void setExtensionPropertyPrefixToolProperties(
+      final String extensionPropertyPrefixToolProperties) {
+    this.extensionPropertyPrefixToolProperties = extensionPropertyPrefixToolProperties;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/Tools.java
+++ b/configuration/src/main/java/io/camunda/configuration/Tools.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.configuration;
 
+import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
+
 /**
  * Configuration for which extension property names are exported as tool properties.
  *
@@ -17,26 +19,30 @@ package io.camunda.configuration;
  */
 public class Tools {
 
-  public static final String DEFAULT_EXTENSION_PROPERTY_TOOL_NAME = "io.camunda.tool:name";
-  public static final String DEFAULT_EXTENSION_PROPERTY_INBOUND_CONNECTOR_TYPE = "inbound.type";
-  public static final String DEFAULT_EXTENSION_PROPERTY_PREFIX_TOOL_PROPERTIES = "io.camunda.tool:";
+  public static final String DEFAULT_EXTENSION_PROPERTY_TOOL_NAME =
+      ToolsConfiguration.DEFAULT_EXTENSION_PROPERTY_TOOL_NAME;
+  public static final String DEFAULT_EXTENSION_PROPERTY_INBOUND_CONNECTOR_TYPE =
+      ToolsConfiguration.DEFAULT_EXTENSION_PROPERTY_INBOUND_CONNECTOR_TYPE;
+  public static final String DEFAULT_EXTENSION_PROPERTY_PREFIX_TOOL_PROPERTIES =
+      ToolsConfiguration.DEFAULT_EXTENSION_PROPERTY_PREFIX_TOOL_PROPERTIES;
 
   /** The extension property name whose value is exported as the {@code toolName} attribute. */
-  private String extensionPropertyToolName = DEFAULT_EXTENSION_PROPERTY_TOOL_NAME;
+  private String extensionPropertyToolName =
+      ToolsConfiguration.DEFAULT_EXTENSION_PROPERTY_TOOL_NAME;
 
   /**
    * The extension property name whose value is exported as the {@code inboundConnectorType}
    * attribute.
    */
   private String extensionPropertyInboundConnectorType =
-      DEFAULT_EXTENSION_PROPERTY_INBOUND_CONNECTOR_TYPE;
+      ToolsConfiguration.DEFAULT_EXTENSION_PROPERTY_INBOUND_CONNECTOR_TYPE;
 
   /**
    * The extension property name prefix for properties exported as the {@code toolProperties}
    * key-value attribute. Only extension properties whose names start with this prefix are exported.
    */
   private String extensionPropertyPrefixToolProperties =
-      DEFAULT_EXTENSION_PROPERTY_PREFIX_TOOL_PROPERTIES;
+      ToolsConfiguration.DEFAULT_EXTENSION_PROPERTY_PREFIX_TOOL_PROPERTIES;
 
   public String getExtensionPropertyToolName() {
     return extensionPropertyToolName;

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -990,7 +990,7 @@ public class BrokerBasedPropertiesOverride {
   }
 
   private void applyRdbmsToolsConfiguration(
-      final io.camunda.exporter.rdbms.ExporterConfiguration.ToolsConfiguration tools,
+      final io.camunda.zeebe.exporter.common.tools.ToolsConfiguration tools,
       final io.camunda.configuration.Tools source) {
     tools.setExtensionPropertyToolName(source.getExtensionPropertyToolName());
     tools.setExtensionPropertyInboundConnectorType(

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -872,6 +872,7 @@ public class BrokerBasedPropertiesOverride {
                   CamundaExporterConfigurationApplier.applyIncidentNotifier(
                       config, unifiedConfiguration);
                   CamundaExporterConfigurationApplier.applyMisc(config, unifiedConfiguration);
+                  CamundaExporterConfigurationApplier.applyTools(config, unifiedConfiguration);
                 })
             .toArgs());
   }
@@ -981,6 +982,19 @@ public class BrokerBasedPropertiesOverride {
                         .getAsyncReplication()
                         .setPauseOnMaxLagExceeded(asyncReplication.isPauseOnMaxLagExceeded());
                   }
+
+                  final var toolsConfig = unifiedConfiguration.getCamunda().getData().getTools();
+                  config
+                      .getTools()
+                      .setExtensionPropertyToolName(toolsConfig.getExtensionPropertyToolName());
+                  config
+                      .getTools()
+                      .setExtensionPropertyInboundConnectorType(
+                          toolsConfig.getExtensionPropertyInboundConnectorType());
+                  config
+                      .getTools()
+                      .setExtensionPropertyPrefixToolProperties(
+                          toolsConfig.getExtensionPropertyPrefixToolProperties());
                 })
             .toArgs());
   }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -983,20 +983,20 @@ public class BrokerBasedPropertiesOverride {
                         .setPauseOnMaxLagExceeded(asyncReplication.isPauseOnMaxLagExceeded());
                   }
 
-                  final var toolsConfig = unifiedConfiguration.getCamunda().getData().getTools();
-                  config
-                      .getTools()
-                      .setExtensionPropertyToolName(toolsConfig.getExtensionPropertyToolName());
-                  config
-                      .getTools()
-                      .setExtensionPropertyInboundConnectorType(
-                          toolsConfig.getExtensionPropertyInboundConnectorType());
-                  config
-                      .getTools()
-                      .setExtensionPropertyPrefixToolProperties(
-                          toolsConfig.getExtensionPropertyPrefixToolProperties());
+                  applyRdbmsToolsConfiguration(
+                      config.getTools(), unifiedConfiguration.getCamunda().getData().getTools());
                 })
             .toArgs());
+  }
+
+  private void applyRdbmsToolsConfiguration(
+      final io.camunda.exporter.rdbms.ExporterConfiguration.ToolsConfiguration tools,
+      final io.camunda.configuration.Tools source) {
+    tools.setExtensionPropertyToolName(source.getExtensionPropertyToolName());
+    tools.setExtensionPropertyInboundConnectorType(
+        source.getExtensionPropertyInboundConnectorType());
+    tools.setExtensionPropertyPrefixToolProperties(
+        source.getExtensionPropertyPrefixToolProperties());
   }
 
   private void applyRdbmsHistoryExporterConfiguration(

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/CamundaExporterConfigurationApplier.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/CamundaExporterConfigurationApplier.java
@@ -12,12 +12,14 @@ import io.camunda.configuration.InterceptorPlugin;
 import io.camunda.configuration.Opensearch;
 import io.camunda.configuration.Retention;
 import io.camunda.configuration.SecondaryStorage;
+import io.camunda.configuration.Tools;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.config.ExporterConfiguration.BulkConfiguration;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
 import io.camunda.exporter.config.ExporterConfiguration.IncidentNotifierConfiguration;
 import io.camunda.exporter.config.ExporterConfiguration.PostExportConfiguration;
+import io.camunda.exporter.config.ExporterConfiguration.ToolsConfiguration;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.search.schema.config.IndexConfiguration;
 import io.camunda.search.schema.config.RetentionConfiguration;
@@ -243,6 +245,20 @@ public final class CamundaExporterConfigurationApplier {
         .getDecisionRequirementsCache()
         .setMaxCacheSize(source.getDecisionRequirementsCache().getMaxSize());
     exporterConfiguration.getFormCache().setMaxCacheSize(source.getFormCache().getMaxSize());
+  }
+
+  public static void applyTools(
+      final ExporterConfiguration exporterConfiguration,
+      final UnifiedConfiguration unifiedConfiguration) {
+
+    final Tools source = unifiedConfiguration.getCamunda().getData().getTools();
+    final ToolsConfiguration target = exporterConfiguration.getTools();
+
+    target.setExtensionPropertyToolName(source.getExtensionPropertyToolName());
+    target.setExtensionPropertyInboundConnectorType(
+        source.getExtensionPropertyInboundConnectorType());
+    target.setExtensionPropertyPrefixToolProperties(
+        source.getExtensionPropertyPrefixToolProperties());
   }
 
   private static DocumentBasedSecondaryStorageDatabase getDocumentBasedDatabase(

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/CamundaExporterConfigurationApplier.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/CamundaExporterConfigurationApplier.java
@@ -19,10 +19,10 @@ import io.camunda.exporter.config.ExporterConfiguration.BulkConfiguration;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
 import io.camunda.exporter.config.ExporterConfiguration.IncidentNotifierConfiguration;
 import io.camunda.exporter.config.ExporterConfiguration.PostExportConfiguration;
-import io.camunda.exporter.config.ExporterConfiguration.ToolsConfiguration;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.search.schema.config.IndexConfiguration;
 import io.camunda.search.schema.config.RetentionConfiguration;
+import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/configuration/src/test/java/io/camunda/configuration/DataToolsTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/DataToolsTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.zeebe.broker.exporter.context.ExporterConfiguration;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+class DataToolsTest {
+
+  @Test
+  void shouldHaveDefaults() {
+    final Tools tools = new Tools();
+
+    assertThat(tools.getExtensionPropertyToolName())
+        .isEqualTo(Tools.DEFAULT_EXTENSION_PROPERTY_TOOL_NAME);
+    assertThat(tools.getExtensionPropertyInboundConnectorType())
+        .isEqualTo(Tools.DEFAULT_EXTENSION_PROPERTY_INBOUND_CONNECTOR_TYPE);
+    assertThat(tools.getExtensionPropertyPrefixToolProperties())
+        .isEqualTo(Tools.DEFAULT_EXTENSION_PROPERTY_PREFIX_TOOL_PROPERTIES);
+  }
+
+  @Nested
+  @ActiveProfiles("broker")
+  @SpringJUnitConfig({
+    UnifiedConfiguration.class,
+    UnifiedConfigurationHelper.class,
+    BrokerBasedPropertiesOverride.class,
+  })
+  @TestPropertySource(
+      properties = {
+        "camunda.data.secondary-storage.type=elasticsearch",
+        "camunda.data.tools.extension-property-tool-name=custom.tool:name",
+        "camunda.data.tools.extension-property-inbound-connector-type=custom.inbound.type",
+        "camunda.data.tools.extension-property-prefix-tool-properties=custom.tool:",
+      })
+  class CamundaExporterWithCustomTools {
+    @Test
+    void shouldApplyToolsConfigToCamundaExporter(
+        @Autowired final BrokerBasedProperties brokerBasedProperties) {
+      final var exporter = brokerBasedProperties.getCamundaExporter();
+      final var config =
+          ExporterConfiguration.fromArgs(
+              io.camunda.exporter.config.ExporterConfiguration.class, exporter.getArgs());
+
+      assertThat(config.getTools().getExtensionPropertyToolName()).isEqualTo("custom.tool:name");
+      assertThat(config.getTools().getExtensionPropertyInboundConnectorType())
+          .isEqualTo("custom.inbound.type");
+      assertThat(config.getTools().getExtensionPropertyPrefixToolProperties())
+          .isEqualTo("custom.tool:");
+    }
+  }
+
+  @Nested
+  @ActiveProfiles("broker")
+  @SpringJUnitConfig({
+    UnifiedConfiguration.class,
+    UnifiedConfigurationHelper.class,
+    BrokerBasedPropertiesOverride.class,
+  })
+  @TestPropertySource(
+      properties = {
+        "camunda.data.secondary-storage.type=elasticsearch",
+      })
+  class CamundaExporterWithDefaultTools {
+    @Test
+    void shouldApplyDefaultToolsConfigToCamundaExporter(
+        @Autowired final BrokerBasedProperties brokerBasedProperties) {
+      final var exporter = brokerBasedProperties.getCamundaExporter();
+      final var config =
+          ExporterConfiguration.fromArgs(
+              io.camunda.exporter.config.ExporterConfiguration.class, exporter.getArgs());
+
+      assertThat(config.getTools().getExtensionPropertyToolName())
+          .isEqualTo(Tools.DEFAULT_EXTENSION_PROPERTY_TOOL_NAME);
+      assertThat(config.getTools().getExtensionPropertyInboundConnectorType())
+          .isEqualTo(Tools.DEFAULT_EXTENSION_PROPERTY_INBOUND_CONNECTOR_TYPE);
+      assertThat(config.getTools().getExtensionPropertyPrefixToolProperties())
+          .isEqualTo(Tools.DEFAULT_EXTENSION_PROPERTY_PREFIX_TOOL_PROPERTIES);
+    }
+  }
+
+  @Nested
+  @ActiveProfiles("broker")
+  @SpringJUnitConfig({
+    UnifiedConfiguration.class,
+    UnifiedConfigurationHelper.class,
+    BrokerBasedPropertiesOverride.class,
+  })
+  @TestPropertySource(
+      properties = {
+        "camunda.data.secondary-storage.type=rdbms",
+        "camunda.data.tools.extension-property-tool-name=custom.tool:name",
+        "camunda.data.tools.extension-property-inbound-connector-type=custom.inbound.type",
+        "camunda.data.tools.extension-property-prefix-tool-properties=custom.tool:",
+      })
+  class RdbmsExporterWithCustomTools {
+    @Test
+    void shouldApplyToolsConfigToRdbmsExporter(
+        @Autowired final BrokerBasedProperties brokerBasedProperties) {
+      final var exporter = brokerBasedProperties.getRdbmsExporter();
+      final var config =
+          ExporterConfiguration.fromArgs(
+              io.camunda.exporter.rdbms.ExporterConfiguration.class, exporter.getArgs());
+
+      assertThat(config.getTools().getExtensionPropertyToolName()).isEqualTo("custom.tool:name");
+      assertThat(config.getTools().getExtensionPropertyInboundConnectorType())
+          .isEqualTo("custom.inbound.type");
+      assertThat(config.getTools().getExtensionPropertyPrefixToolProperties())
+          .isEqualTo("custom.tool:");
+    }
+  }
+
+  @Nested
+  @ActiveProfiles("broker")
+  @SpringJUnitConfig({
+    UnifiedConfiguration.class,
+    UnifiedConfigurationHelper.class,
+    BrokerBasedPropertiesOverride.class,
+  })
+  @TestPropertySource(
+      properties = {
+        "camunda.data.secondary-storage.type=rdbms",
+      })
+  class RdbmsExporterWithDefaultTools {
+    @Test
+    void shouldApplyDefaultToolsConfigToRdbmsExporter(
+        @Autowired final BrokerBasedProperties brokerBasedProperties) {
+      final var exporter = brokerBasedProperties.getRdbmsExporter();
+      final var config =
+          ExporterConfiguration.fromArgs(
+              io.camunda.exporter.rdbms.ExporterConfiguration.class, exporter.getArgs());
+
+      assertThat(config.getTools().getExtensionPropertyToolName())
+          .isEqualTo(Tools.DEFAULT_EXTENSION_PROPERTY_TOOL_NAME);
+      assertThat(config.getTools().getExtensionPropertyInboundConnectorType())
+          .isEqualTo(Tools.DEFAULT_EXTENSION_PROPERTY_INBOUND_CONNECTOR_TYPE);
+      assertThat(config.getTools().getExtensionPropertyPrefixToolProperties())
+          .isEqualTo(Tools.DEFAULT_EXTENSION_PROPERTY_PREFIX_TOOL_PROPERTIES);
+    }
+  }
+}

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
@@ -66,14 +66,14 @@
     </addColumn>
   </changeSet>
 
-  <changeSet id="add_message_subscription_extension_properties_column" author="camunda">
+  <changeSet id="add_message_subscription_tool_properties_column" author="camunda">
     <preConditions onFail="MARK_RAN">
       <not>
-        <columnExists tableName="${prefix}MESSAGE_SUBSCRIPTION" columnName="EXTENSION_PROPERTIES"/>
+        <columnExists tableName="${prefix}MESSAGE_SUBSCRIPTION" columnName="TOOL_PROPERTIES"/>
       </not>
     </preConditions>
     <addColumn tableName="${prefix}MESSAGE_SUBSCRIPTION">
-      <column name="EXTENSION_PROPERTIES" type="CLOB"/>
+      <column name="TOOL_PROPERTIES" type="CLOB"/>
     </addColumn>
   </changeSet>
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/MessageSubscriptionEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/MessageSubscriptionEntityMapper.java
@@ -32,7 +32,7 @@ public class MessageSubscriptionEntityMapper {
         .tenantId(nullToEmpty(messageSubscriptionDbModel.tenantId()))
         .processDefinitionName(nullToEmpty(messageSubscriptionDbModel.processDefinitionName()))
         .processDefinitionVersion(messageSubscriptionDbModel.processDefinitionVersion())
-        .extensionProperties(messageSubscriptionDbModel.extensionProperties())
+        .toolProperties(messageSubscriptionDbModel.toolProperties())
         .toolName(messageSubscriptionDbModel.toolName())
         .inboundConnectorType(messageSubscriptionDbModel.inboundConnectorType())
         .build();

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/MessageSubscriptionDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/MessageSubscriptionDbModel.java
@@ -32,8 +32,8 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
   private int partitionId;
   private String processDefinitionName;
   private Integer processDefinitionVersion;
-  private String serializedExtensionProperties;
-  private Map<String, String> extensionProperties;
+  private String serializedToolProperties;
+  private Map<String, String> toolProperties;
   private String toolName;
   private String inboundConnectorType;
 
@@ -58,7 +58,7 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
       final int partitionId,
       final String processDefinitionName,
       final Integer processDefinitionVersion,
-      final Map<String, String> extensionProperties,
+      final Map<String, String> toolProperties,
       final String toolName,
       final String inboundConnectorType) {
     this.messageSubscriptionKey = messageSubscriptionKey;
@@ -77,8 +77,8 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
     this.partitionId = partitionId;
     this.processDefinitionName = processDefinitionName;
     this.processDefinitionVersion = processDefinitionVersion;
-    serializedExtensionProperties = MapSerializer.serialize(extensionProperties);
-    this.extensionProperties = extensionProperties;
+    serializedToolProperties = MapSerializer.serialize(toolProperties);
+    this.toolProperties = toolProperties;
     this.toolName = toolName;
     this.inboundConnectorType = inboundConnectorType;
   }
@@ -171,17 +171,17 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
     this.processDefinitionVersion = processDefinitionVersion;
   }
 
-  public String serializedExtensionProperties() {
-    return serializedExtensionProperties;
+  public String serializedToolProperties() {
+    return serializedToolProperties;
   }
 
-  public void setSerializedExtensionProperties(final String serializedExtensionProperties) {
-    this.serializedExtensionProperties = serializedExtensionProperties;
-    extensionProperties = MapSerializer.deserialize(serializedExtensionProperties);
+  public void setSerializedToolProperties(final String serializedToolProperties) {
+    this.serializedToolProperties = serializedToolProperties;
+    toolProperties = MapSerializer.deserialize(serializedToolProperties);
   }
 
-  public Map<String, String> extensionProperties() {
-    return extensionProperties;
+  public Map<String, String> toolProperties() {
+    return toolProperties;
   }
 
   public String toolName() {
@@ -267,7 +267,7 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
         .partitionId(partitionId)
         .processDefinitionName(processDefinitionName)
         .processDefinitionVersion(processDefinitionVersion)
-        .extensionProperties(extensionProperties)
+        .toolProperties(toolProperties)
         .toolName(toolName)
         .inboundConnectorType(inboundConnectorType);
   }
@@ -289,7 +289,7 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
     private int partitionId;
     private String processDefinitionName;
     private Integer processDefinitionVersion;
-    private Map<String, String> extensionProperties;
+    private Map<String, String> toolProperties;
     private String toolName;
     private String inboundConnectorType;
 
@@ -349,8 +349,8 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
       return this;
     }
 
-    public Builder extensionProperties(final Map<String, String> extensionProperties) {
-      this.extensionProperties = extensionProperties;
+    public Builder toolProperties(final Map<String, String> toolProperties) {
+      this.toolProperties = toolProperties;
       return this;
     }
 
@@ -408,7 +408,7 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
           partitionId,
           processDefinitionName,
           processDefinitionVersion,
-          extensionProperties,
+          toolProperties,
           toolName,
           inboundConnectorType);
     }

--- a/db/rdbms/src/main/resources/mapper/MessageSubscriptionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/MessageSubscriptionMapper.xml
@@ -43,7 +43,7 @@
     PARTITION_ID,
     PROCESS_DEFINITION_NAME,
     PROCESS_DEFINITION_VERSION,
-    EXTENSION_PROPERTIES,
+    TOOL_PROPERTIES,
     TOOL_NAME,
     INBOUND_CONNECTOR_TYPE
     FROM ${prefix}MESSAGE_SUBSCRIPTION
@@ -194,7 +194,7 @@
     <result column="PARTITION_ID" property="partitionId" javaType="java.lang.Integer" />
     <result column="PROCESS_DEFINITION_NAME" property="processDefinitionName" javaType="java.lang.String" />
     <result column="PROCESS_DEFINITION_VERSION" property="processDefinitionVersion" javaType="java.lang.Integer" />
-    <result column="EXTENSION_PROPERTIES" property="serializedExtensionProperties" javaType="java.lang.String" />
+    <result column="TOOL_PROPERTIES" property="serializedToolProperties" javaType="java.lang.String" />
     <result column="TOOL_NAME" property="toolName" javaType="java.lang.String" />
     <result column="INBOUND_CONNECTOR_TYPE" property="inboundConnectorType" javaType="java.lang.String" />
   </resultMap>
@@ -218,7 +218,7 @@
                                                PARTITION_ID,
                                                PROCESS_DEFINITION_NAME,
                                                PROCESS_DEFINITION_VERSION,
-                                               EXTENSION_PROPERTIES,
+                                               TOOL_PROPERTIES,
                                                TOOL_NAME,
                                                INBOUND_CONNECTOR_TYPE
     )
@@ -239,7 +239,7 @@
             #{partitionId},
             #{processDefinitionName},
             #{processDefinitionVersion},
-            #{serializedExtensionProperties},
+            #{serializedToolProperties},
             #{toolName},
             #{inboundConnectorType}
     )
@@ -260,7 +260,7 @@
         TENANT_ID = #{tenantId},
         PROCESS_DEFINITION_NAME = #{processDefinitionName},
         PROCESS_DEFINITION_VERSION = #{processDefinitionVersion},
-        EXTENSION_PROPERTIES = #{serializedExtensionProperties},
+        TOOL_PROPERTIES = #{serializedToolProperties},
         TOOL_NAME = #{toolName},
         INBOUND_CONNECTOR_TYPE = #{inboundConnectorType}
     WHERE MESSAGE_SUBSCRIPTION_KEY = #{messageSubscriptionKey}

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/MessageSubscriptionEntityMapperTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/MessageSubscriptionEntityMapperTest.java
@@ -37,7 +37,7 @@ public class MessageSubscriptionEntityMapperTest {
             .tenantId("tenantId")
             .processDefinitionName("My Process")
             .processDefinitionVersion(2)
-            .extensionProperties(Map.of("key1", "value1"))
+            .toolProperties(Map.of("key1", "value1"))
             .build();
 
     // When
@@ -66,7 +66,7 @@ public class MessageSubscriptionEntityMapperTest {
             .tenantId(null)
             .processDefinitionName(null)
             .processDefinitionVersion(null)
-            .extensionProperties(null)
+            .toolProperties(null)
             .build();
 
     // When
@@ -88,6 +88,6 @@ public class MessageSubscriptionEntityMapperTest {
     assertThat(entity.processDefinitionName())
         .isEqualTo(""); // Oracle treats empty strings as NULL, mapper converts back to ""
     assertThat(entity.processDefinitionVersion()).isNull();
-    assertThat(entity.extensionProperties()).isEqualTo(Map.of());
+    assertThat(entity.toolProperties()).isEqualTo(Map.of());
   }
 }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -1095,7 +1095,7 @@ public final class SearchQueryResponseMapper {
         .tenantId(messageSubscription.tenantId())
         .processDefinitionName(messageSubscription.processDefinitionName())
         .processDefinitionVersion(messageSubscription.processDefinitionVersion())
-        .extensionProperties(messageSubscription.extensionProperties())
+        .toolProperties(messageSubscription.toolProperties())
         .toolName(messageSubscription.toolName())
         .inboundConnectorType(messageSubscription.inboundConnectorType());
   }

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/processes/ProcessesToolRepository.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/processes/ProcessesToolRepository.java
@@ -136,7 +136,7 @@ public class ProcessesToolRepository implements ToolRepository {
 
   private Tool buildTool(final MessageSubscriptionEntity entity) {
     final String name = entity.toolName() + "_" + entity.messageSubscriptionKey();
-    final String description = buildDescription(entity.extensionProperties());
+    final String description = buildDescription(entity.toolProperties());
     return Tool.builder()
         .name(name)
         .title(entity.toolName())

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/processes/ProcessesToolRepositoryTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/processes/ProcessesToolRepositoryTest.java
@@ -59,14 +59,14 @@ class ProcessesToolRepositoryTest {
   private static MessageSubscriptionEntity buildStartSubscriptionEntity(
       final Long key,
       final String toolName,
-      final Map<String, String> extensionProperties,
+      final Map<String, String> toolProperties,
       final String messageName,
       final String tenantId,
       final MessageSubscriptionState state) {
     return MessageSubscriptionEntity.builder()
         .messageSubscriptionKey(key)
         .toolName(toolName)
-        .extensionProperties(extensionProperties)
+        .toolProperties(toolProperties)
         .messageName(messageName)
         .tenantId(tenantId)
         .messageSubscriptionState(state)

--- a/identity/client/src/pages/mcp-processes/useMcpProcessTools.ts
+++ b/identity/client/src/pages/mcp-processes/useMcpProcessTools.ts
@@ -51,7 +51,7 @@ const mapSubscriptionToProcessTool = (
   // `toolName` is expected to exist based on the filter supplied to the backend.
   if (!sub.toolName) return null;
 
-  const toolData = toolDataSchema.parse(sub.extensionProperties ?? {});
+  const toolData = toolDataSchema.parse(sub.toolProperties ?? {});
   return {
     id: sub.messageSubscriptionKey,
     toolName: sub.toolName,

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/MessageSubscriptionSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/MessageSubscriptionSearchIT.java
@@ -24,7 +24,6 @@ import io.camunda.qa.util.multidb.MultiDbTest;
 import java.util.Comparator;
 import java.util.List;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 @MultiDbTest
@@ -225,8 +224,7 @@ public class MessageSubscriptionSearchIT {
   }
 
   @Test
-  @Disabled("Will be re-eavaluated once we start exporting extensionProperties again")
-  void shouldReturnExtensionPropertiesForStartEventSubscription() {
+  void shouldReturnToolPropertiesForStartEventSubscription() {
     // when
     final var result =
         camundaClient
@@ -238,9 +236,9 @@ public class MessageSubscriptionSearchIT {
     // then
     assertThat(result.items()).hasSize(1);
     final var sub = result.items().getFirst();
-    assertThat(sub.getExtensionProperties())
-        .containsEntry("customKey", "customValue")
-        .containsEntry("env", "test");
+    // toolProperties only includes keys prefixed with "io.camunda.tool:";
+    // the test process has no such keys, so the map is empty.
+    assertThat(sub.getToolProperties()).isEmpty();
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/MessageSubscriptionSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/MessageSubscriptionSearchIT.java
@@ -236,9 +236,49 @@ public class MessageSubscriptionSearchIT {
     // then
     assertThat(result.items()).hasSize(1);
     final var sub = result.items().getFirst();
-    // toolProperties only includes keys prefixed with "io.camunda.tool:";
-    // the test process has no such keys, so the map is empty.
-    assertThat(sub.getToolProperties()).isEmpty();
+    // toolProperties only includes keys prefixed with "io.camunda.tool:"; "inbound.type" is
+    // excluded
+    assertThat(sub.getToolProperties())
+        .containsEntry("io.camunda.tool:name", "myWebhookTool")
+        .doesNotContainKey("inbound.type")
+        .doesNotContainKey("customKey");
+    assertThat(sub.getToolName()).isEqualTo("myWebhookTool");
+    assertThat(sub.getInboundConnectorType()).isEqualTo("io.camunda:http-webhook:1");
+  }
+
+  @Test
+  void shouldFilterByToolName() {
+    // when
+    final var result =
+        camundaClient
+            .newMessageSubscriptionSearchRequest()
+            .filter(f -> f.toolName("myWebhookTool"))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().getFirst().getMessageSubscriptionType())
+        .isEqualTo(MessageSubscriptionType.START_EVENT);
+    assertThat(result.items().getFirst().getToolName()).isEqualTo("myWebhookTool");
+  }
+
+  @Test
+  void shouldFilterByInboundConnectorType() {
+    // when
+    final var result =
+        camundaClient
+            .newMessageSubscriptionSearchRequest()
+            .filter(f -> f.inboundConnectorType("io.camunda:http-webhook:1"))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().getFirst().getMessageSubscriptionType())
+        .isEqualTo(MessageSubscriptionType.START_EVENT);
+    assertThat(result.items().getFirst().getInboundConnectorType())
+        .isEqualTo("io.camunda:http-webhook:1");
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/MessageSubscriptionFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/MessageSubscriptionFixtures.java
@@ -41,7 +41,7 @@ public final class MessageSubscriptionFixtures extends CommonFixtures {
             .processDefinitionVersion((int) (Math.random() * 50))
             .messageSubscriptionType(randomEnum(MessageSubscriptionType.class))
             .messageSubscriptionState(randomEnum(MessageSubscriptionState.class))
-            .extensionProperties(Map.of("key-" + UUID.randomUUID(), "value-" + UUID.randomUUID()));
+            .toolProperties(Map.of("key-" + UUID.randomUUID(), "value-" + UUID.randomUUID()));
 
     return builderFunction.apply(builder).build();
   }

--- a/qa/acceptance-tests/src/test/resources/process/process_with_message_start_zeebe_properties.bpmn
+++ b/qa/acceptance-tests/src/test/resources/process/process_with_message_start_zeebe_properties.bpmn
@@ -11,8 +11,9 @@
     <bpmn:startEvent id="StartEvent_msg">
       <bpmn:extensionElements>
         <zeebe:properties>
+          <zeebe:property name="io.camunda.tool:name" value="myWebhookTool" />
+          <zeebe:property name="inbound.type" value="io.camunda:http-webhook:1" />
           <zeebe:property name="customKey" value="customValue" />
-          <zeebe:property name="env" value="test" />
         </zeebe:properties>
       </bpmn:extensionElements>
       <bpmn:outgoing>Flow_1</bpmn:outgoing>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/responses.json
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/responses.json
@@ -4999,7 +4999,7 @@
                   "nullable": true
                 },
                 {
-                  "name": "extensionProperties",
+                  "name": "toolProperties",
                   "type": "object"
                 },
                 {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message-subscriptions/mcp-message-subscription-search.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message-subscriptions/mcp-message-subscription-search.spec.ts
@@ -6,8 +6,6 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-/* eslint-disable playwright/no-skipped-test */
-
 import {test, expect} from '@playwright/test';
 import {
   buildUrl,
@@ -139,47 +137,43 @@ test.describe('MCP Message Subscription Search API Tests', () => {
       expect(types).toContain('PROCESS_EVENT');
     });
 
-    //Skipped due to bug: 52532 https://github.com/camunda/camunda/issues/52532
-    await test.step.skip(
-      'SC-API-04 — extensionProperties contains tool metadata',
-      async () => {
-        const res = await request.post(
-          buildUrl('/message-subscriptions/search'),
-          {
-            headers: jsonHeaders(),
-            data: {
-              filter: {
-                processDefinitionId: 'mcpProcessAlpha',
-                messageSubscriptionType: 'START_EVENT',
-              },
+    await test.step('SC-API-04 — toolProperties contains tool metadata', async () => {
+      const res = await request.post(
+        buildUrl('/message-subscriptions/search'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              processDefinitionId: 'mcpProcessAlpha',
+              messageSubscriptionType: 'START_EVENT',
             },
           },
-        );
-        await assertStatusCode(res, 200);
-        await validateResponse(
-          {
-            path: '/message-subscriptions/search',
-            method: 'POST',
-            status: '200',
-          },
-          res,
-        );
-        const json = await res.json();
-        expect(json.page.totalItems).toBeGreaterThanOrEqual(1);
+        },
+      );
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: '/message-subscriptions/search',
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+      const json = await res.json();
+      expect(json.page.totalItems).toBeGreaterThanOrEqual(1);
 
-        json.items.forEach(
-          (it: {extensionProperties: Record<string, string>}) => {
-            expect(it.extensionProperties).toBeDefined();
-            expect(it.extensionProperties['io.camunda.tool:name']).toBe(
-              'alpha-tool-name',
-            );
-            expect(
-              it.extensionProperties['io.camunda.tool:purpose'],
-            ).toBeDefined();
-          },
-        );
-      },
-    );
+      json.items.forEach(
+        (it: {toolProperties: Record<string, string>}) => {
+          expect(it.toolProperties).toBeDefined();
+          expect(it.toolProperties['io.camunda.tool:name']).toBe(
+            'alpha-tool-name',
+          );
+          expect(
+            it.toolProperties['io.camunda.tool:purpose'],
+          ).toBeDefined();
+        },
+      );
+    });
 
     await test.step('SC-API-05 — processDefinitionName and processDefinitionVersion returned', async () => {
       const res = await request.post(
@@ -257,8 +251,7 @@ test.describe('MCP Message Subscription Search API Tests', () => {
       );
     });
 
-    //Skipped due to bug: 52532 https://github.com/camunda/camunda/issues/52532
-    await test.step.skip('SC-API-07 — Filter by toolName', async () => {
+    await test.step('SC-API-07 — Filter by toolName', async () => {
       const res = await request.post(
         buildUrl('/message-subscriptions/search'),
         {
@@ -286,72 +279,68 @@ test.describe('MCP Message Subscription Search API Tests', () => {
         (it: {
           processDefinitionId: string;
           toolName: string;
-          extensionProperties: Record<string, string>;
+          toolProperties: Record<string, string>;
         }) => {
           expect(it.processDefinitionId).toBe('mcpProcessAlpha');
           expect(it.toolName).toBe('alpha-tool-name');
-          expect(it.extensionProperties['io.camunda.tool:name']).toBe(
+          expect(it.toolProperties['io.camunda.tool:name']).toBe(
             'alpha-tool-name',
           );
         },
       );
     });
 
-    //Skipped due to bug: 52532 https://github.com/camunda/camunda/issues/52532
-    await test.step.skip(
-      'SC-API-08 — Filter by processDefinitionId for with-inputs process includes extensionProperties with input metadata',
-      async () => {
-        const res = await request.post(
-          buildUrl('/message-subscriptions/search'),
-          {
-            headers: jsonHeaders(),
-            data: {
-              filter: {
-                processDefinitionId: 'mcpProcessWithInputs',
-                messageSubscriptionType: 'START_EVENT',
-              },
+    await test.step('SC-API-08 — Filter by processDefinitionId for with-inputs process includes toolProperties with input metadata', async () => {
+      const res = await request.post(
+        buildUrl('/message-subscriptions/search'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              processDefinitionId: 'mcpProcessWithInputs',
+              messageSubscriptionType: 'START_EVENT',
             },
           },
-        );
-        await assertStatusCode(res, 200);
-        await validateResponse(
-          {
-            path: '/message-subscriptions/search',
-            method: 'POST',
-            status: '200',
-          },
-          res,
-        );
-        const json = await res.json();
-        expect(json.page.totalItems).toBeGreaterThanOrEqual(1);
+        },
+      );
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: '/message-subscriptions/search',
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+      const json = await res.json();
+      expect(json.page.totalItems).toBeGreaterThanOrEqual(1);
 
-        json.items.forEach(
-          (it: {extensionProperties: Record<string, string>}) => {
-            assertEqualsForKeys(
-              it,
-              {
-                processDefinitionId: 'mcpProcessWithInputs',
-                messageSubscriptionType: 'START_EVENT',
-                tenantId: '<default>',
-              },
-              ['processDefinitionId', 'messageSubscriptionType', 'tenantId'],
-            );
-            expect(it.extensionProperties['io.camunda.tool:input_1_name']).toBe(
-              'firstName',
-            );
-            expect(it.extensionProperties['io.camunda.tool:input_1_type']).toBe(
-              'string',
-            );
-            expect(it.extensionProperties['io.camunda.tool:input_2_name']).toBe(
-              'amount',
-            );
-            expect(
-              it.extensionProperties['io.camunda.tool:input_2_required'],
-            ).toBe('true');
-          },
-        );
-      },
-    );
+      json.items.forEach(
+        (it: {toolProperties: Record<string, string>}) => {
+          assertEqualsForKeys(
+            it,
+            {
+              processDefinitionId: 'mcpProcessWithInputs',
+              messageSubscriptionType: 'START_EVENT',
+              tenantId: '<default>',
+            },
+            ['processDefinitionId', 'messageSubscriptionType', 'tenantId'],
+          );
+          expect(it.toolProperties['io.camunda.tool:input_1_name']).toBe(
+            'firstName',
+          );
+          expect(it.toolProperties['io.camunda.tool:input_1_type']).toBe(
+            'string',
+          );
+          expect(it.toolProperties['io.camunda.tool:input_2_name']).toBe(
+            'amount',
+          );
+          expect(
+            it.toolProperties['io.camunda.tool:input_2_required'],
+          ).toBe('true');
+        },
+      );
+    });
 
     await test.step('SC-API-09 — Sort by processDefinitionName ascending', async () => {
       const res = await request.post(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message-subscriptions/mcp-message-subscription-search.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message-subscriptions/mcp-message-subscription-search.spec.ts
@@ -162,17 +162,13 @@ test.describe('MCP Message Subscription Search API Tests', () => {
       const json = await res.json();
       expect(json.page.totalItems).toBeGreaterThanOrEqual(1);
 
-      json.items.forEach(
-        (it: {toolProperties: Record<string, string>}) => {
-          expect(it.toolProperties).toBeDefined();
-          expect(it.toolProperties['io.camunda.tool:name']).toBe(
-            'alpha-tool-name',
-          );
-          expect(
-            it.toolProperties['io.camunda.tool:purpose'],
-          ).toBeDefined();
-        },
-      );
+      json.items.forEach((it: {toolProperties: Record<string, string>}) => {
+        expect(it.toolProperties).toBeDefined();
+        expect(it.toolProperties['io.camunda.tool:name']).toBe(
+          'alpha-tool-name',
+        );
+        expect(it.toolProperties['io.camunda.tool:purpose']).toBeDefined();
+      });
     });
 
     await test.step('SC-API-05 — processDefinitionName and processDefinitionVersion returned', async () => {
@@ -315,31 +311,29 @@ test.describe('MCP Message Subscription Search API Tests', () => {
       const json = await res.json();
       expect(json.page.totalItems).toBeGreaterThanOrEqual(1);
 
-      json.items.forEach(
-        (it: {toolProperties: Record<string, string>}) => {
-          assertEqualsForKeys(
-            it,
-            {
-              processDefinitionId: 'mcpProcessWithInputs',
-              messageSubscriptionType: 'START_EVENT',
-              tenantId: '<default>',
-            },
-            ['processDefinitionId', 'messageSubscriptionType', 'tenantId'],
-          );
-          expect(it.toolProperties['io.camunda.tool:input_1_name']).toBe(
-            'firstName',
-          );
-          expect(it.toolProperties['io.camunda.tool:input_1_type']).toBe(
-            'string',
-          );
-          expect(it.toolProperties['io.camunda.tool:input_2_name']).toBe(
-            'amount',
-          );
-          expect(
-            it.toolProperties['io.camunda.tool:input_2_required'],
-          ).toBe('true');
-        },
-      );
+      json.items.forEach((it: {toolProperties: Record<string, string>}) => {
+        assertEqualsForKeys(
+          it,
+          {
+            processDefinitionId: 'mcpProcessWithInputs',
+            messageSubscriptionType: 'START_EVENT',
+            tenantId: '<default>',
+          },
+          ['processDefinitionId', 'messageSubscriptionType', 'tenantId'],
+        );
+        expect(it.toolProperties['io.camunda.tool:input_1_name']).toBe(
+          'firstName',
+        );
+        expect(it.toolProperties['io.camunda.tool:input_1_type']).toBe(
+          'string',
+        );
+        expect(it.toolProperties['io.camunda.tool:input_2_name']).toBe(
+          'amount',
+        );
+        expect(it.toolProperties['io.camunda.tool:input_2_required']).toBe(
+          'true',
+        );
+      });
     });
 
     await test.step('SC-API-09 — Sort by processDefinitionName ascending', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/mcp-processes.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/identity/mcp-processes.spec.ts
@@ -164,8 +164,7 @@ test.describe('Identity MCP Processes', () => {
     });
   });
 
-  // TODO: Re-evaluate once extensionProperties are exported again
-  test.skip('MCP Processes rows can be expanded to show more tool information', async ({
+  test('MCP Processes rows can be expanded to show more tool information', async ({
     identityMcpProcessesPage,
   }) => {
     await identityMcpProcessesPage.navigateToMcpProcesses();

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/MessageSubscriptionEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/MessageSubscriptionEntityTransformer.java
@@ -36,7 +36,7 @@ public class MessageSubscriptionEntityTransformer
         value.getTenantId(),
         value.getProcessDefinitionName(),
         value.getProcessDefinitionVersion(),
-        value.getExtensionProperties(),
+        value.getToolProperties(),
         value.getToolName(),
         value.getInboundConnectorType());
   }

--- a/search/search-domain/src/main/java/io/camunda/search/entities/MessageSubscriptionEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/MessageSubscriptionEntity.java
@@ -32,7 +32,7 @@ public record MessageSubscriptionEntity(
     String tenantId,
     @Nullable String processDefinitionName,
     @Nullable Integer processDefinitionVersion,
-    Map<String, String> extensionProperties,
+    Map<String, String> toolProperties,
     @Nullable String toolName,
     @Nullable String inboundConnectorType)
     implements TenantOwnedEntity {
@@ -47,7 +47,7 @@ public record MessageSubscriptionEntity(
     // Mutable collections are required: MyBatis hydrates collection-mapped fields (e.g. from a
     // <collection> result map or a LEFT JOIN) by calling .add() on the existing instance.
     // Immutable defaults (e.g. Map.of()) would cause UnsupportedOperationException at runtime.
-    extensionProperties = extensionProperties != null ? extensionProperties : new HashMap<>();
+    toolProperties = toolProperties != null ? toolProperties : new HashMap<>();
     // Pre-8.10 rows have no messageSubscriptionType stored; default them to PROCESS_EVENT.
     messageSubscriptionType =
         messageSubscriptionType != null
@@ -75,7 +75,7 @@ public record MessageSubscriptionEntity(
     private @Nullable String tenantId;
     private @Nullable String processDefinitionName;
     private @Nullable Integer processDefinitionVersion;
-    private @Nullable Map<String, String> extensionProperties;
+    private @Nullable Map<String, String> toolProperties;
     private @Nullable String toolName;
     private @Nullable String inboundConnectorType;
 
@@ -135,8 +135,8 @@ public record MessageSubscriptionEntity(
       return this;
     }
 
-    public Builder extensionProperties(final Map<String, String> extensionProperties) {
-      this.extensionProperties = extensionProperties;
+    public Builder toolProperties(final Map<String, String> toolProperties) {
+      this.toolProperties = toolProperties;
       return this;
     }
 
@@ -188,7 +188,7 @@ public record MessageSubscriptionEntity(
           tenantId,
           processDefinitionName,
           processDefinitionVersion,
-          extensionProperties,
+          toolProperties,
           toolName,
           inboundConnectorType);
     }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/MessageSubscriptionBuilder.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/utils/MessageSubscriptionBuilder.java
@@ -38,7 +38,7 @@ public class MessageSubscriptionBuilder implements MessageSubscription {
   private MessageSubscriptionType messageSubscriptionType;
   private String processDefinitionName;
   private Integer processDefinitionVersion;
-  private Map<String, String> extensionProperties;
+  private Map<String, String> toolProperties;
   private String toolName;
   private String inboundConnectorType;
 
@@ -118,8 +118,8 @@ public class MessageSubscriptionBuilder implements MessageSubscription {
   }
 
   @Override
-  public Map<String, String> getExtensionProperties() {
-    return extensionProperties;
+  public Map<String, String> getToolProperties() {
+    return toolProperties;
   }
 
   @Override
@@ -132,9 +132,8 @@ public class MessageSubscriptionBuilder implements MessageSubscription {
     return inboundConnectorType;
   }
 
-  public MessageSubscriptionBuilder setExtensionProperties(
-      final Map<String, String> extensionProperties) {
-    this.extensionProperties = extensionProperties;
+  public MessageSubscriptionBuilder setToolProperties(final Map<String, String> toolProperties) {
+    this.toolProperties = toolProperties;
     return this;
   }
 

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/message-subscriptions.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/message-subscriptions.ts
@@ -38,7 +38,7 @@ const messageSubscriptionSchema = z.object({
 	correlationKey: z.string().nullable(),
 	tenantId: z.string(),
 	rootProcessInstanceKey: z.string().nullable(),
-	extensionProperties: z.record(z.string(), z.string()),
+	toolProperties: z.record(z.string(), z.string()),
 	processDefinitionName: z.string().nullable(),
 	processDefinitionVersion: z.number().int().nullable(),
 	toolName: z.string().nullable(),

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/MessageSubscriptionTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/MessageSubscriptionTemplate.java
@@ -108,7 +108,7 @@ public class MessageSubscriptionTemplate extends AbstractTemplateDescriptor
 
   public static final String PROCESS_DEFINITION_NAME = "processDefinitionName";
   public static final String PROCESS_DEFINITION_VERSION = "processDefinitionVersion";
-  public static final String EXTENSION_PROPERTIES = "extensionProperties";
+  public static final String TOOL_PROPERTIES = "toolProperties";
   public static final String MESSAGE_SUBSCRIPTION_TYPE = "messageSubscriptionType";
   public static final String TOOL_NAME = "toolName";
   public static final String INBOUND_CONNECTOR_TYPE = "inboundConnectorType";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/messagesubscription/MessageSubscriptionEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/messagesubscription/MessageSubscriptionEntity.java
@@ -61,7 +61,7 @@ public class MessageSubscriptionEntity
   private Integer processDefinitionVersion;
 
   @SinceVersion(value = "8.10.0", requireDefault = false)
-  private Map<String, String> extensionProperties;
+  private Map<String, String> toolProperties;
 
   @SinceVersion(value = "8.10.0", requireDefault = false)
   private String messageSubscriptionType;
@@ -238,13 +238,12 @@ public class MessageSubscriptionEntity
     return this;
   }
 
-  public Map<String, String> getExtensionProperties() {
-    return extensionProperties;
+  public Map<String, String> getToolProperties() {
+    return toolProperties;
   }
 
-  public MessageSubscriptionEntity setExtensionProperties(
-      final Map<String, String> extensionProperties) {
-    this.extensionProperties = extensionProperties;
+  public MessageSubscriptionEntity setToolProperties(final Map<String, String> toolProperties) {
+    this.toolProperties = toolProperties;
     return this;
   }
 
@@ -367,7 +366,7 @@ public class MessageSubscriptionEntity
         rootProcessInstanceKey,
         processDefinitionName,
         processDefinitionVersion,
-        extensionProperties,
+        toolProperties,
         messageSubscriptionType,
         toolName,
         inboundConnectorType);
@@ -403,7 +402,7 @@ public class MessageSubscriptionEntity
         && Objects.equals(rootProcessInstanceKey, that.rootProcessInstanceKey)
         && Objects.equals(processDefinitionName, that.processDefinitionName)
         && Objects.equals(processDefinitionVersion, that.processDefinitionVersion)
-        && Objects.equals(extensionProperties, that.extensionProperties)
+        && Objects.equals(toolProperties, that.toolProperties)
         && Objects.equals(messageSubscriptionType, that.messageSubscriptionType)
         && Objects.equals(toolName, that.toolName)
         && Objects.equals(inboundConnectorType, that.inboundConnectorType);

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-event.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-event.json
@@ -100,7 +100,7 @@
       "processDefinitionVersion": {
         "type": "integer"
       },
-      "extensionProperties": {
+      "toolProperties": {
         "type": "object",
         "enabled": false
       },

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-event.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-event.json
@@ -100,7 +100,7 @@
       "processDefinitionVersion": {
         "type": "integer"
       },
-      "extensionProperties": {
+      "toolProperties": {
         "type": "object",
         "enabled": false
       },

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/tools/ToolsConfiguration.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/tools/ToolsConfiguration.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.common.tools;
+
+/** Exporter-side configuration for which BPMN extension properties map to tool attributes. */
+public class ToolsConfiguration {
+
+  public static final String DEFAULT_EXTENSION_PROPERTY_TOOL_NAME = "io.camunda.tool:name";
+  public static final String DEFAULT_EXTENSION_PROPERTY_INBOUND_CONNECTOR_TYPE = "inbound.type";
+  public static final String DEFAULT_EXTENSION_PROPERTY_PREFIX_TOOL_PROPERTIES = "io.camunda.tool:";
+
+  private String extensionPropertyToolName = DEFAULT_EXTENSION_PROPERTY_TOOL_NAME;
+  private String extensionPropertyInboundConnectorType =
+      DEFAULT_EXTENSION_PROPERTY_INBOUND_CONNECTOR_TYPE;
+  private String extensionPropertyPrefixToolProperties =
+      DEFAULT_EXTENSION_PROPERTY_PREFIX_TOOL_PROPERTIES;
+
+  public String getExtensionPropertyToolName() {
+    return extensionPropertyToolName;
+  }
+
+  public void setExtensionPropertyToolName(final String extensionPropertyToolName) {
+    this.extensionPropertyToolName = extensionPropertyToolName;
+  }
+
+  public String getExtensionPropertyInboundConnectorType() {
+    return extensionPropertyInboundConnectorType;
+  }
+
+  public void setExtensionPropertyInboundConnectorType(
+      final String extensionPropertyInboundConnectorType) {
+    this.extensionPropertyInboundConnectorType = extensionPropertyInboundConnectorType;
+  }
+
+  public String getExtensionPropertyPrefixToolProperties() {
+    return extensionPropertyPrefixToolProperties;
+  }
+
+  public void setExtensionPropertyPrefixToolProperties(
+      final String extensionPropertyPrefixToolProperties) {
+    this.extensionPropertyPrefixToolProperties = extensionPropertyPrefixToolProperties;
+  }
+}

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/utils/ProcessCacheUtil.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/utils/ProcessCacheUtil.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.model.bpmn.instance.FlowNode;
 import io.camunda.zeebe.util.modelreader.ProcessModelReader;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -171,5 +172,15 @@ public final class ProcessCacheUtil {
       return null;
     }
     return extensionProperties.get(EXTENSION_PROPERTY_INBOUND_TYPE);
+  }
+
+  public static Map<String, String> getToolProperties(
+      final Map<String, String> extensionProperties) {
+    if (extensionProperties == null) {
+      return Map.of();
+    }
+    return extensionProperties.entrySet().stream()
+        .filter(e -> e.getKey().startsWith("io.camunda.tool:"))
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/utils/ProcessCacheUtil.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/utils/ProcessCacheUtil.java
@@ -23,8 +23,6 @@ import org.slf4j.LoggerFactory;
 
 public final class ProcessCacheUtil {
 
-  public static final String EXTENSION_PROPERTY_CAMUNDA_TOOL_NAME = "io.camunda.tool:name";
-  public static final String EXTENSION_PROPERTY_INBOUND_TYPE = "inbound.type";
   private static final Logger LOGGER = LoggerFactory.getLogger(ProcessCacheUtil.class);
 
   private ProcessCacheUtil() {
@@ -160,18 +158,34 @@ public final class ProcessCacheUtil {
         .collect(HashMap::new, (map, fn) -> map.put(fn.getId(), fn.getName()), HashMap::putAll);
   }
 
-  public static String getToolName(final Map<String, String> extensionProperties) {
-    if (extensionProperties == null) {
+  public static String getToolName(
+      final Map<String, String> extensionProperties, final String toolNameProperty) {
+    if (extensionProperties == null || toolNameProperty == null) {
       return null;
     }
-    return extensionProperties.get(EXTENSION_PROPERTY_CAMUNDA_TOOL_NAME);
+    return extensionProperties.get(toolNameProperty);
   }
 
-  public static String getInboundConnectorType(final Map<String, String> extensionProperties) {
-    if (extensionProperties == null) {
+  public static String getInboundConnectorType(
+      final Map<String, String> extensionProperties, final String inboundTypeProperty) {
+    if (extensionProperties == null || inboundTypeProperty == null) {
       return null;
     }
-    return extensionProperties.get(EXTENSION_PROPERTY_INBOUND_TYPE);
+    return extensionProperties.get(inboundTypeProperty);
+  }
+
+  /**
+   * Returns a map of extension properties whose keys start with the given prefix. Returns an empty
+   * map if {@code extensionProperties} is null or the prefix is null/blank.
+   */
+  public static Map<String, String> getToolProperties(
+      final Map<String, String> extensionProperties, final String prefix) {
+    if (extensionProperties == null || prefix == null || prefix.isBlank()) {
+      return Map.of();
+    }
+    return extensionProperties.entrySet().stream()
+        .filter(e -> e.getKey().startsWith(prefix))
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
   public static Map<String, String> getToolProperties(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -289,10 +289,12 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
             new MessageSubscriptionFromProcessMessageSubscriptionHandler(
                 indexDescriptors.get(MessageSubscriptionTemplate.class).getFullQualifiedName(),
                 exporterMetadata,
-                processCache),
+                processCache,
+                configuration.getTools()),
             new MessageSubscriptionFromMessageStartEventSubscriptionHandler(
                 indexDescriptors.get(MessageSubscriptionTemplate.class).getFullQualifiedName(),
-                processCache),
+                processCache,
+                configuration.getTools()),
             new UserTaskCreatingHandler(
                 indexDescriptors.get(TaskTemplate.class).getFullQualifiedName(),
                 formCache,

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -592,9 +592,9 @@ public class ExporterConfiguration {
   }
 
   public static class ToolsConfiguration {
-    private String extensionPropertyToolName;
-    private String extensionPropertyInboundConnectorType;
-    private String extensionPropertyPrefixToolProperties;
+    private String extensionPropertyToolName = "io.camunda.tool:name";
+    private String extensionPropertyInboundConnectorType = "inbound.type";
+    private String extensionPropertyPrefixToolProperties = "io.camunda.tool:";
 
     public String getExtensionPropertyToolName() {
       return extensionPropertyToolName;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -30,6 +30,7 @@ public class ExporterConfiguration {
   private HistoryDeletionConfiguration historyDeletion = new HistoryDeletionConfiguration();
   private boolean createSchema = true;
   private boolean skipVariableWriteWithoutUserTasks = false;
+  private ToolsConfiguration tools = new ToolsConfiguration();
 
   public AuditLogConfiguration getAuditLog() {
     return auditLog;
@@ -150,6 +151,14 @@ public class ExporterConfiguration {
 
   public void setBatchOperation(final BatchOperationConfiguration batchOperation) {
     this.batchOperation = batchOperation;
+  }
+
+  public ToolsConfiguration getTools() {
+    return tools;
+  }
+
+  public void setTools(final ToolsConfiguration tools) {
+    this.tools = tools;
   }
 
   @Override
@@ -579,6 +588,38 @@ public class ExporterConfiguration {
           + "exportItemsOnCreation="
           + exportItemsOnCreation
           + '}';
+    }
+  }
+
+  public static class ToolsConfiguration {
+    private String extensionPropertyToolName;
+    private String extensionPropertyInboundConnectorType;
+    private String extensionPropertyPrefixToolProperties;
+
+    public String getExtensionPropertyToolName() {
+      return extensionPropertyToolName;
+    }
+
+    public void setExtensionPropertyToolName(final String extensionPropertyToolName) {
+      this.extensionPropertyToolName = extensionPropertyToolName;
+    }
+
+    public String getExtensionPropertyInboundConnectorType() {
+      return extensionPropertyInboundConnectorType;
+    }
+
+    public void setExtensionPropertyInboundConnectorType(
+        final String extensionPropertyInboundConnectorType) {
+      this.extensionPropertyInboundConnectorType = extensionPropertyInboundConnectorType;
+    }
+
+    public String getExtensionPropertyPrefixToolProperties() {
+      return extensionPropertyPrefixToolProperties;
+    }
+
+    public void setExtensionPropertyPrefixToolProperties(
+        final String extensionPropertyPrefixToolProperties) {
+      this.extensionPropertyPrefixToolProperties = extensionPropertyPrefixToolProperties;
     }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -12,6 +12,7 @@ import io.camunda.search.schema.config.IndexConfiguration;
 import io.camunda.search.schema.config.RetentionConfiguration;
 import io.camunda.zeebe.exporter.common.auditlog.AuditLogConfiguration;
 import io.camunda.zeebe.exporter.common.historydeletion.HistoryDeletionConfiguration;
+import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
 
 public class ExporterConfiguration {
 
@@ -588,38 +589,6 @@ public class ExporterConfiguration {
           + "exportItemsOnCreation="
           + exportItemsOnCreation
           + '}';
-    }
-  }
-
-  public static class ToolsConfiguration {
-    private String extensionPropertyToolName = "io.camunda.tool:name";
-    private String extensionPropertyInboundConnectorType = "inbound.type";
-    private String extensionPropertyPrefixToolProperties = "io.camunda.tool:";
-
-    public String getExtensionPropertyToolName() {
-      return extensionPropertyToolName;
-    }
-
-    public void setExtensionPropertyToolName(final String extensionPropertyToolName) {
-      this.extensionPropertyToolName = extensionPropertyToolName;
-    }
-
-    public String getExtensionPropertyInboundConnectorType() {
-      return extensionPropertyInboundConnectorType;
-    }
-
-    public void setExtensionPropertyInboundConnectorType(
-        final String extensionPropertyInboundConnectorType) {
-      this.extensionPropertyInboundConnectorType = extensionPropertyInboundConnectorType;
-    }
-
-    public String getExtensionPropertyPrefixToolProperties() {
-      return extensionPropertyPrefixToolProperties;
-    }
-
-    public void setExtensionPropertyPrefixToolProperties(
-        final String extensionPropertyPrefixToolProperties) {
-      this.extensionPropertyPrefixToolProperties = extensionPropertyPrefixToolProperties;
     }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AbstractEventHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AbstractEventHandler.java
@@ -32,6 +32,7 @@ import static io.camunda.webapps.schema.descriptors.template.MessageSubscription
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.TOOL_NAME;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.TOOL_PROPERTIES;
 
+import io.camunda.exporter.config.ExporterConfiguration.ToolsConfiguration;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.messagesubscription.EventSourceType;
 import io.camunda.webapps.schema.entities.messagesubscription.MessageSubscriptionEntity;
@@ -49,9 +50,15 @@ public abstract class AbstractEventHandler<R extends RecordValue>
     implements ExportHandler<MessageSubscriptionEntity, R> {
   protected static final String ID_PATTERN = "%s_%s";
   protected final String indexName;
+  protected final ToolsConfiguration toolConfig;
 
   public AbstractEventHandler(final String indexName) {
+    this(indexName, new ToolsConfiguration());
+  }
+
+  public AbstractEventHandler(final String indexName, final ToolsConfiguration toolConfig) {
     this.indexName = indexName;
+    this.toolConfig = toolConfig;
   }
 
   @Override
@@ -148,9 +155,13 @@ public abstract class AbstractEventHandler<R extends RecordValue>
               .map(p -> p.get(elementId))
               .orElse(Map.of());
       entity
-          .setToolName(ProcessCacheUtil.getToolName(ext))
-          .setInboundConnectorType(ProcessCacheUtil.getInboundConnectorType(ext))
-          .setToolProperties(ProcessCacheUtil.getToolProperties(ext));
+          .setToolName(ProcessCacheUtil.getToolName(ext, toolConfig.getExtensionPropertyToolName()))
+          .setInboundConnectorType(
+              ProcessCacheUtil.getInboundConnectorType(
+                  ext, toolConfig.getExtensionPropertyInboundConnectorType()))
+          .setToolProperties(
+              ProcessCacheUtil.getToolProperties(
+                  ext, toolConfig.getExtensionPropertyPrefixToolProperties()));
     }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AbstractEventHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AbstractEventHandler.java
@@ -30,6 +30,7 @@ import static io.camunda.webapps.schema.descriptors.template.MessageSubscription
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.PROCESS_DEFINITION_VERSION;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.PROCESS_KEY;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.TOOL_NAME;
+import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.TOOL_PROPERTIES;
 
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.messagesubscription.EventSourceType;
@@ -98,6 +99,7 @@ public abstract class AbstractEventHandler<R extends RecordValue>
     jsonMap.put(FLOW_NODE_ID, entity.getFlowNodeId());
     jsonMap.put(PROCESS_DEFINITION_NAME, entity.getProcessDefinitionName());
     jsonMap.put(PROCESS_DEFINITION_VERSION, entity.getProcessDefinitionVersion());
+    jsonMap.put(TOOL_PROPERTIES, entity.getToolProperties());
     jsonMap.put(TOOL_NAME, entity.getToolName());
     jsonMap.put(INBOUND_CONNECTOR_TYPE, entity.getInboundConnectorType());
     jsonMap.put(positionFieldName, positionFieldValue);
@@ -147,7 +149,8 @@ public abstract class AbstractEventHandler<R extends RecordValue>
               .orElse(Map.of());
       entity
           .setToolName(ProcessCacheUtil.getToolName(ext))
-          .setInboundConnectorType(ProcessCacheUtil.getInboundConnectorType(ext));
+          .setInboundConnectorType(ProcessCacheUtil.getInboundConnectorType(ext))
+          .setToolProperties(ProcessCacheUtil.getToolProperties(ext));
     }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AbstractEventHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AbstractEventHandler.java
@@ -32,13 +32,13 @@ import static io.camunda.webapps.schema.descriptors.template.MessageSubscription
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.TOOL_NAME;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.TOOL_PROPERTIES;
 
-import io.camunda.exporter.config.ExporterConfiguration.ToolsConfiguration;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.messagesubscription.EventSourceType;
 import io.camunda.webapps.schema.entities.messagesubscription.MessageSubscriptionEntity;
 import io.camunda.webapps.schema.entities.messagesubscription.MessageSubscriptionState;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
+import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
 import io.camunda.zeebe.exporter.common.utils.ProcessCacheUtil;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MessageSubscriptionFromMessageStartEventSubscriptionHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MessageSubscriptionFromMessageStartEventSubscriptionHandler.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.handlers;
 
 import static io.camunda.exporter.utils.ExporterUtil.tenantOrDefault;
 
+import io.camunda.exporter.config.ExporterConfiguration.ToolsConfiguration;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate;
 import io.camunda.webapps.schema.entities.messagesubscription.MessageSubscriptionEntity;
@@ -36,7 +37,14 @@ public class MessageSubscriptionFromMessageStartEventSubscriptionHandler
 
   public MessageSubscriptionFromMessageStartEventSubscriptionHandler(
       final String indexName, final ExporterEntityCache<Long, CachedProcessEntity> processCache) {
-    super(indexName);
+    this(indexName, processCache, new ToolsConfiguration());
+  }
+
+  public MessageSubscriptionFromMessageStartEventSubscriptionHandler(
+      final String indexName,
+      final ExporterEntityCache<Long, CachedProcessEntity> processCache,
+      final ToolsConfiguration toolConfig) {
+    super(indexName, toolConfig);
     this.processCache = processCache;
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MessageSubscriptionFromMessageStartEventSubscriptionHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MessageSubscriptionFromMessageStartEventSubscriptionHandler.java
@@ -9,13 +9,13 @@ package io.camunda.exporter.handlers;
 
 import static io.camunda.exporter.utils.ExporterUtil.tenantOrDefault;
 
-import io.camunda.exporter.config.ExporterConfiguration.ToolsConfiguration;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate;
 import io.camunda.webapps.schema.entities.messagesubscription.MessageSubscriptionEntity;
 import io.camunda.webapps.schema.entities.messagesubscription.MessageSubscriptionMetadataEntity;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
+import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MessageSubscriptionFromProcessMessageSubscriptionHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MessageSubscriptionFromProcessMessageSubscriptionHandler.java
@@ -10,13 +10,13 @@ package io.camunda.exporter.handlers;
 import static io.camunda.exporter.utils.ExporterUtil.tenantOrDefault;
 
 import io.camunda.exporter.ExporterMetadata;
-import io.camunda.exporter.config.ExporterConfiguration.ToolsConfiguration;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate;
 import io.camunda.webapps.schema.entities.messagesubscription.MessageSubscriptionEntity;
 import io.camunda.webapps.schema.entities.messagesubscription.MessageSubscriptionMetadataEntity;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
+import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MessageSubscriptionFromProcessMessageSubscriptionHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MessageSubscriptionFromProcessMessageSubscriptionHandler.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.handlers;
 import static io.camunda.exporter.utils.ExporterUtil.tenantOrDefault;
 
 import io.camunda.exporter.ExporterMetadata;
+import io.camunda.exporter.config.ExporterConfiguration.ToolsConfiguration;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate;
 import io.camunda.webapps.schema.entities.messagesubscription.MessageSubscriptionEntity;
@@ -41,7 +42,15 @@ public class MessageSubscriptionFromProcessMessageSubscriptionHandler
       final String indexName,
       final ExporterMetadata exporterMetadata,
       final ExporterEntityCache<Long, CachedProcessEntity> processCache) {
-    super(indexName);
+    this(indexName, exporterMetadata, processCache, new ToolsConfiguration());
+  }
+
+  public MessageSubscriptionFromProcessMessageSubscriptionHandler(
+      final String indexName,
+      final ExporterMetadata exporterMetadata,
+      final ExporterEntityCache<Long, CachedProcessEntity> processCache,
+      final ToolsConfiguration toolConfig) {
+    super(indexName, toolConfig);
     this.exporterMetadata = exporterMetadata;
     this.processCache = processCache;
   }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromMessageStartEventSubscriptionHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromMessageStartEventSubscriptionHandlerTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import io.camunda.exporter.config.ExporterConfiguration.ToolsConfiguration;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate;
 import io.camunda.webapps.schema.entities.messagesubscription.EventSourceType;
@@ -209,6 +210,14 @@ final class MessageSubscriptionFromMessageStartEventSubscriptionHandlerTest {
                     false,
                     Map.of(startEventId, extProps))));
 
+    final ToolsConfiguration toolsConfig = new ToolsConfiguration();
+    toolsConfig.setExtensionPropertyToolName("io.camunda.tool:name");
+    toolsConfig.setExtensionPropertyInboundConnectorType("inbound.type");
+    toolsConfig.setExtensionPropertyPrefixToolProperties("io.camunda.tool:");
+    final var handlerWithConfig =
+        new MessageSubscriptionFromMessageStartEventSubscriptionHandler(
+            indexName, processCache, toolsConfig);
+
     final ImmutableMessageStartEventSubscriptionRecordValue value =
         ImmutableMessageStartEventSubscriptionRecordValue.builder()
             .withProcessDefinitionKey(processDefinitionKey)
@@ -229,7 +238,7 @@ final class MessageSubscriptionFromMessageStartEventSubscriptionHandlerTest {
     final MessageSubscriptionEntity entity = new MessageSubscriptionEntity();
 
     // when
-    underTest.updateEntity(record, entity);
+    handlerWithConfig.updateEntity(record, entity);
 
     // then
     assertThat(entity.getToolName()).isEqualTo("myTool");

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromMessageStartEventSubscriptionHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromMessageStartEventSubscriptionHandlerTest.java
@@ -234,7 +234,9 @@ final class MessageSubscriptionFromMessageStartEventSubscriptionHandlerTest {
     // then
     assertThat(entity.getToolName()).isEqualTo("myTool");
     assertThat(entity.getInboundConnectorType()).isEqualTo("io.camunda:http-webhook:1");
-    // TODO: Add an assertion for the extension properties once they are included in the entity
+    assertThat(entity.getToolProperties())
+        .containsEntry("io.camunda.tool:name", "myTool")
+        .doesNotContainKey("inbound.type");
   }
 
   @Test
@@ -305,6 +307,7 @@ final class MessageSubscriptionFromMessageStartEventSubscriptionHandlerTest {
     expectedUpdateFields.put("processDefinitionVersion", null);
     expectedUpdateFields.put("toolName", null);
     expectedUpdateFields.put("inboundConnectorType", null);
+    expectedUpdateFields.put("toolProperties", null);
     expectedUpdateFields.put("metadata", metadataMap);
     final BatchRequest mockRequest = Mockito.mock(BatchRequest.class);
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromMessageStartEventSubscriptionHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromMessageStartEventSubscriptionHandlerTest.java
@@ -13,7 +13,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import io.camunda.exporter.config.ExporterConfiguration.ToolsConfiguration;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate;
 import io.camunda.webapps.schema.entities.messagesubscription.EventSourceType;
@@ -22,6 +21,7 @@ import io.camunda.webapps.schema.entities.messagesubscription.MessageSubscriptio
 import io.camunda.webapps.schema.entities.messagesubscription.MessageSubscriptionState;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
+import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromProcessMessageSubscriptionHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromProcessMessageSubscriptionHandlerTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.ExporterMetadata;
+import io.camunda.exporter.config.ExporterConfiguration.ToolsConfiguration;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.search.test.utils.TestObjectMapper;
 import io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate;
@@ -347,6 +348,14 @@ final class MessageSubscriptionFromProcessMessageSubscriptionHandlerTest {
                 new CachedProcessEntity(
                     "Process", 1, null, List.of(), Map.of(), false, Map.of(elementId, extProps))));
 
+    final ToolsConfiguration toolsConfig = new ToolsConfiguration();
+    toolsConfig.setExtensionPropertyToolName("io.camunda.tool:name");
+    toolsConfig.setExtensionPropertyInboundConnectorType("inbound.type");
+    toolsConfig.setExtensionPropertyPrefixToolProperties("io.camunda.tool:");
+    final var handlerWithConfig =
+        new MessageSubscriptionFromProcessMessageSubscriptionHandler(
+            indexName, exporterMetadata, processCache, toolsConfig);
+
     final ImmutableProcessMessageSubscriptionRecordValue value =
         ImmutableProcessMessageSubscriptionRecordValue.builder()
             .withProcessDefinitionKey(processDefinitionKey)
@@ -367,7 +376,7 @@ final class MessageSubscriptionFromProcessMessageSubscriptionHandlerTest {
     final MessageSubscriptionEntity entity = new MessageSubscriptionEntity();
 
     // when
-    underTest.updateEntity(record, entity);
+    handlerWithConfig.updateEntity(record, entity);
 
     // then
     assertThat(entity.getToolName()).isEqualTo("myTool");

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromProcessMessageSubscriptionHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromProcessMessageSubscriptionHandlerTest.java
@@ -15,7 +15,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.ExporterMetadata;
-import io.camunda.exporter.config.ExporterConfiguration.ToolsConfiguration;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.search.test.utils.TestObjectMapper;
 import io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate;
@@ -25,6 +24,7 @@ import io.camunda.webapps.schema.entities.messagesubscription.MessageSubscriptio
 import io.camunda.webapps.schema.entities.messagesubscription.MessageSubscriptionState;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
+import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromProcessMessageSubscriptionHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromProcessMessageSubscriptionHandlerTest.java
@@ -372,7 +372,9 @@ final class MessageSubscriptionFromProcessMessageSubscriptionHandlerTest {
     // then
     assertThat(entity.getToolName()).isEqualTo("myTool");
     assertThat(entity.getInboundConnectorType()).isEqualTo("io.camunda:http-webhook:1");
-    // TODO: Add an assertion for the extension properties once they are included in the entity
+    assertThat(entity.getToolProperties())
+        .containsEntry("io.camunda.tool:name", "myTool")
+        .doesNotContainKey("inbound.type");
   }
 
   @Test
@@ -443,6 +445,7 @@ final class MessageSubscriptionFromProcessMessageSubscriptionHandlerTest {
     expectedUpdateFields.put("processDefinitionVersion", null);
     expectedUpdateFields.put("toolName", null);
     expectedUpdateFields.put("inboundConnectorType", null);
+    expectedUpdateFields.put("toolProperties", null);
     expectedUpdateFields.put("metadata", metadataMap);
 
     final BatchRequest mockRequest = Mockito.mock(BatchRequest.class);

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
@@ -44,6 +44,7 @@ public class ExporterConfiguration {
   private CacheConfiguration decisionRequirementsCache = new CacheConfiguration();
   private CacheConfiguration batchOperationCache = new CacheConfiguration();
   private ReplicationConfiguration asyncReplication = new ReplicationConfiguration();
+  private ToolsConfiguration tools = new ToolsConfiguration();
 
   public AuditLogConfiguration getAuditLog() {
     return auditLog;
@@ -148,6 +149,14 @@ public class ExporterConfiguration {
 
   public void setAsyncReplication(final ReplicationConfiguration asyncReplication) {
     this.asyncReplication = asyncReplication;
+  }
+
+  public ToolsConfiguration getTools() {
+    return tools;
+  }
+
+  public void setTools(final ToolsConfiguration tools) {
+    this.tools = tools;
   }
 
   public void validate() {
@@ -695,6 +704,38 @@ public class ExporterConfiguration {
                 "asyncReplication.maxLag must be a positive duration but was %s", maxLag));
       }
       return errors;
+    }
+  }
+
+  public static class ToolsConfiguration {
+    private String extensionPropertyToolName;
+    private String extensionPropertyInboundConnectorType;
+    private String extensionPropertyPrefixToolProperties;
+
+    public String getExtensionPropertyToolName() {
+      return extensionPropertyToolName;
+    }
+
+    public void setExtensionPropertyToolName(final String extensionPropertyToolName) {
+      this.extensionPropertyToolName = extensionPropertyToolName;
+    }
+
+    public String getExtensionPropertyInboundConnectorType() {
+      return extensionPropertyInboundConnectorType;
+    }
+
+    public void setExtensionPropertyInboundConnectorType(
+        final String extensionPropertyInboundConnectorType) {
+      this.extensionPropertyInboundConnectorType = extensionPropertyInboundConnectorType;
+    }
+
+    public String getExtensionPropertyPrefixToolProperties() {
+      return extensionPropertyPrefixToolProperties;
+    }
+
+    public void setExtensionPropertyPrefixToolProperties(
+        final String extensionPropertyPrefixToolProperties) {
+      this.extensionPropertyPrefixToolProperties = extensionPropertyPrefixToolProperties;
     }
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
@@ -14,6 +14,7 @@ import io.camunda.db.rdbms.write.RdbmsWriterConfig.InsertBatchingConfig;
 import io.camunda.zeebe.exporter.api.ExporterException;
 import io.camunda.zeebe.exporter.common.auditlog.AuditLogConfiguration;
 import io.camunda.zeebe.exporter.common.historydeletion.HistoryDeletionConfiguration;
+import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
 import java.time.Duration;
 import java.time.InstantSource;
 import java.util.ArrayList;
@@ -704,38 +705,6 @@ public class ExporterConfiguration {
                 "asyncReplication.maxLag must be a positive duration but was %s", maxLag));
       }
       return errors;
-    }
-  }
-
-  public static class ToolsConfiguration {
-    private String extensionPropertyToolName = "io.camunda.tool:name";
-    private String extensionPropertyInboundConnectorType = "inbound.type";
-    private String extensionPropertyPrefixToolProperties = "io.camunda.tool:";
-
-    public String getExtensionPropertyToolName() {
-      return extensionPropertyToolName;
-    }
-
-    public void setExtensionPropertyToolName(final String extensionPropertyToolName) {
-      this.extensionPropertyToolName = extensionPropertyToolName;
-    }
-
-    public String getExtensionPropertyInboundConnectorType() {
-      return extensionPropertyInboundConnectorType;
-    }
-
-    public void setExtensionPropertyInboundConnectorType(
-        final String extensionPropertyInboundConnectorType) {
-      this.extensionPropertyInboundConnectorType = extensionPropertyInboundConnectorType;
-    }
-
-    public String getExtensionPropertyPrefixToolProperties() {
-      return extensionPropertyPrefixToolProperties;
-    }
-
-    public void setExtensionPropertyPrefixToolProperties(
-        final String extensionPropertyPrefixToolProperties) {
-      this.extensionPropertyPrefixToolProperties = extensionPropertyPrefixToolProperties;
     }
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
@@ -708,9 +708,9 @@ public class ExporterConfiguration {
   }
 
   public static class ToolsConfiguration {
-    private String extensionPropertyToolName;
-    private String extensionPropertyInboundConnectorType;
-    private String extensionPropertyPrefixToolProperties;
+    private String extensionPropertyToolName = "io.camunda.tool:name";
+    private String extensionPropertyInboundConnectorType = "inbound.type";
+    private String extensionPropertyPrefixToolProperties = "io.camunda.tool:";
 
     public String getExtensionPropertyToolName() {
       return extensionPropertyToolName;

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -248,7 +248,9 @@ public class RdbmsExporterWrapper implements Exporter {
     builder.withHandler(
         ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
         new MessageSubscriptionExportHandler(
-            rdbmsWriters.getMessageSubscriptionWriter(), cacheRegistry.processCache()));
+            rdbmsWriters.getMessageSubscriptionWriter(),
+            cacheRegistry.processCache(),
+            config.getTools()));
     builder.withHandler(
         ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
         new CorrelatedMessageSubscriptionFromProcessMessageSubscriptionExportHandler(
@@ -260,7 +262,9 @@ public class RdbmsExporterWrapper implements Exporter {
     builder.withHandler(
         ValueType.MESSAGE_START_EVENT_SUBSCRIPTION,
         new MessageSubscriptionFromMessageStartEventSubscriptionExportHandler(
-            rdbmsWriters.getMessageSubscriptionWriter(), cacheRegistry.processCache()));
+            rdbmsWriters.getMessageSubscriptionWriter(),
+            cacheRegistry.processCache(),
+            config.getTools()));
     builder.withHandler(
         ValueType.HISTORY_DELETION,
         new HistoryDeletionDeletedHandler(rdbmsWriters.getHistoryDeletionWriter()));

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionExportHandler.java
@@ -94,7 +94,7 @@ public class MessageSubscriptionExportHandler
         .processDefinitionName(
             cached.map(CachedProcessEntity::name).filter(s -> !s.isBlank()).orElse(null))
         .processDefinitionVersion(cached.map(CachedProcessEntity::version).orElse(null))
-        .extensionProperties(Map.of())
+        .toolProperties(ProcessCacheUtil.getToolProperties(ext))
         .toolName(ProcessCacheUtil.getToolName(ext))
         .inboundConnectorType(ProcessCacheUtil.getInboundConnectorType(ext))
         .build();

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionExportHandler.java
@@ -11,12 +11,12 @@ import static io.camunda.exporter.rdbms.utils.DateUtil.toOffsetDateTime;
 
 import io.camunda.db.rdbms.write.domain.MessageSubscriptionDbModel;
 import io.camunda.db.rdbms.write.service.MessageSubscriptionWriter;
-import io.camunda.exporter.rdbms.ExporterConfiguration.ToolsConfiguration;
 import io.camunda.exporter.rdbms.RdbmsExportHandler;
 import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionState;
 import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionType;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
+import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
 import io.camunda.zeebe.exporter.common.utils.ProcessCacheUtil;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.Intent;

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionExportHandler.java
@@ -11,6 +11,7 @@ import static io.camunda.exporter.rdbms.utils.DateUtil.toOffsetDateTime;
 
 import io.camunda.db.rdbms.write.domain.MessageSubscriptionDbModel;
 import io.camunda.db.rdbms.write.service.MessageSubscriptionWriter;
+import io.camunda.exporter.rdbms.ExporterConfiguration.ToolsConfiguration;
 import io.camunda.exporter.rdbms.RdbmsExportHandler;
 import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionState;
 import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionType;
@@ -37,12 +38,15 @@ public class MessageSubscriptionExportHandler
           ProcessMessageSubscriptionIntent.MIGRATED);
   private final MessageSubscriptionWriter messageSubscriptionWriter;
   private final ExporterEntityCache<Long, CachedProcessEntity> processCache;
+  private final ToolsConfiguration toolConfig;
 
   public MessageSubscriptionExportHandler(
       final MessageSubscriptionWriter messageSubscriptionWriter,
-      final ExporterEntityCache<Long, CachedProcessEntity> processCache) {
+      final ExporterEntityCache<Long, CachedProcessEntity> processCache,
+      final ToolsConfiguration toolConfig) {
     this.messageSubscriptionWriter = messageSubscriptionWriter;
     this.processCache = processCache;
+    this.toolConfig = toolConfig;
   }
 
   @Override
@@ -94,9 +98,13 @@ public class MessageSubscriptionExportHandler
         .processDefinitionName(
             cached.map(CachedProcessEntity::name).filter(s -> !s.isBlank()).orElse(null))
         .processDefinitionVersion(cached.map(CachedProcessEntity::version).orElse(null))
-        .toolProperties(ProcessCacheUtil.getToolProperties(ext))
-        .toolName(ProcessCacheUtil.getToolName(ext))
-        .inboundConnectorType(ProcessCacheUtil.getInboundConnectorType(ext))
+        .toolProperties(
+            ProcessCacheUtil.getToolProperties(
+                ext, toolConfig.getExtensionPropertyPrefixToolProperties()))
+        .toolName(ProcessCacheUtil.getToolName(ext, toolConfig.getExtensionPropertyToolName()))
+        .inboundConnectorType(
+            ProcessCacheUtil.getInboundConnectorType(
+                ext, toolConfig.getExtensionPropertyInboundConnectorType()))
         .build();
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionFromMessageStartEventSubscriptionExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionFromMessageStartEventSubscriptionExportHandler.java
@@ -11,6 +11,7 @@ import static io.camunda.exporter.rdbms.utils.DateUtil.toOffsetDateTime;
 
 import io.camunda.db.rdbms.write.domain.MessageSubscriptionDbModel;
 import io.camunda.db.rdbms.write.service.MessageSubscriptionWriter;
+import io.camunda.exporter.rdbms.ExporterConfiguration.ToolsConfiguration;
 import io.camunda.exporter.rdbms.RdbmsExportHandler;
 import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionState;
 import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionType;
@@ -37,12 +38,15 @@ public class MessageSubscriptionFromMessageStartEventSubscriptionExportHandler
 
   private final MessageSubscriptionWriter messageSubscriptionWriter;
   private final ExporterEntityCache<Long, CachedProcessEntity> processCache;
+  private final ToolsConfiguration toolConfig;
 
   public MessageSubscriptionFromMessageStartEventSubscriptionExportHandler(
       final MessageSubscriptionWriter messageSubscriptionWriter,
-      final ExporterEntityCache<Long, CachedProcessEntity> processCache) {
+      final ExporterEntityCache<Long, CachedProcessEntity> processCache,
+      final ToolsConfiguration toolConfig) {
     this.messageSubscriptionWriter = messageSubscriptionWriter;
     this.processCache = processCache;
+    this.toolConfig = toolConfig;
   }
 
   @Override
@@ -93,9 +97,13 @@ public class MessageSubscriptionFromMessageStartEventSubscriptionExportHandler
         .processDefinitionName(
             cached.map(CachedProcessEntity::name).filter(s -> !s.isBlank()).orElse(null))
         .processDefinitionVersion(cached.map(CachedProcessEntity::version).orElse(null))
-        .toolProperties(ProcessCacheUtil.getToolProperties(ext))
-        .toolName(ProcessCacheUtil.getToolName(ext))
-        .inboundConnectorType(ProcessCacheUtil.getInboundConnectorType(ext))
+        .toolProperties(
+            ProcessCacheUtil.getToolProperties(
+                ext, toolConfig.getExtensionPropertyPrefixToolProperties()))
+        .toolName(ProcessCacheUtil.getToolName(ext, toolConfig.getExtensionPropertyToolName()))
+        .inboundConnectorType(
+            ProcessCacheUtil.getInboundConnectorType(
+                ext, toolConfig.getExtensionPropertyInboundConnectorType()))
         .build();
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionFromMessageStartEventSubscriptionExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionFromMessageStartEventSubscriptionExportHandler.java
@@ -93,7 +93,7 @@ public class MessageSubscriptionFromMessageStartEventSubscriptionExportHandler
         .processDefinitionName(
             cached.map(CachedProcessEntity::name).filter(s -> !s.isBlank()).orElse(null))
         .processDefinitionVersion(cached.map(CachedProcessEntity::version).orElse(null))
-        .extensionProperties(Map.of())
+        .toolProperties(ProcessCacheUtil.getToolProperties(ext))
         .toolName(ProcessCacheUtil.getToolName(ext))
         .inboundConnectorType(ProcessCacheUtil.getInboundConnectorType(ext))
         .build();

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionFromMessageStartEventSubscriptionExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionFromMessageStartEventSubscriptionExportHandler.java
@@ -11,12 +11,12 @@ import static io.camunda.exporter.rdbms.utils.DateUtil.toOffsetDateTime;
 
 import io.camunda.db.rdbms.write.domain.MessageSubscriptionDbModel;
 import io.camunda.db.rdbms.write.service.MessageSubscriptionWriter;
-import io.camunda.exporter.rdbms.ExporterConfiguration.ToolsConfiguration;
 import io.camunda.exporter.rdbms.RdbmsExportHandler;
 import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionState;
 import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionType;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
+import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
 import io.camunda.zeebe.exporter.common.utils.ProcessCacheUtil;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.Intent;

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/message/MessageSubscriptionExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/message/MessageSubscriptionExportHandlerTest.java
@@ -195,7 +195,7 @@ final class MessageSubscriptionExportHandlerTest {
         .isEqualTo(DateUtil.toOffsetDateTime(Instant.ofEpochMilli(timestamp)));
     assertThat(model.processDefinitionName()).isEqualTo(processName);
     assertThat(model.processDefinitionVersion()).isEqualTo(processVersion);
-    assertThat(model.extensionProperties()).isEqualTo(Map.of());
+    assertThat(model.toolProperties()).isEqualTo(Map.of("io.camunda.tool:name", "myTool"));
     assertThat(model.toolName()).isEqualTo("myTool");
     assertThat(model.inboundConnectorType()).isEqualTo("io.camunda:http-webhook:1");
   }
@@ -245,7 +245,7 @@ final class MessageSubscriptionExportHandlerTest {
     final MessageSubscriptionDbModel model = captor.getValue();
     assertThat(model.processDefinitionName()).isNull();
     assertThat(model.processDefinitionVersion()).isNull();
-    assertThat(model.extensionProperties()).isEqualTo(Map.of());
+    assertThat(model.toolProperties()).isEqualTo(Map.of());
     assertThat(model.toolName()).isNull();
     assertThat(model.inboundConnectorType()).isNull();
   }

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/message/MessageSubscriptionExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/message/MessageSubscriptionExportHandlerTest.java
@@ -15,13 +15,13 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.db.rdbms.write.domain.MessageSubscriptionDbModel;
 import io.camunda.db.rdbms.write.service.MessageSubscriptionWriter;
-import io.camunda.exporter.rdbms.ExporterConfiguration.ToolsConfiguration;
 import io.camunda.exporter.rdbms.handlers.MessageSubscriptionExportHandler;
 import io.camunda.exporter.rdbms.utils.DateUtil;
 import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionState;
 import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionType;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
+import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/message/MessageSubscriptionExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/message/MessageSubscriptionExportHandlerTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.db.rdbms.write.domain.MessageSubscriptionDbModel;
 import io.camunda.db.rdbms.write.service.MessageSubscriptionWriter;
+import io.camunda.exporter.rdbms.ExporterConfiguration.ToolsConfiguration;
 import io.camunda.exporter.rdbms.handlers.MessageSubscriptionExportHandler;
 import io.camunda.exporter.rdbms.utils.DateUtil;
 import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionState;
@@ -51,7 +52,15 @@ final class MessageSubscriptionExportHandlerTest {
       mock(ExporterEntityCache.class);
 
   private final MessageSubscriptionExportHandler underTest =
-      new MessageSubscriptionExportHandler(writer, processCache);
+      new MessageSubscriptionExportHandler(writer, processCache, buildToolsConfig());
+
+  private static ToolsConfiguration buildToolsConfig() {
+    final var config = new ToolsConfiguration();
+    config.setExtensionPropertyToolName("io.camunda.tool:name");
+    config.setExtensionPropertyInboundConnectorType("inbound.type");
+    config.setExtensionPropertyPrefixToolProperties("io.camunda.tool:");
+    return config;
+  }
 
   @ParameterizedTest
   @EnumSource(

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/message/MessageSubscriptionFromMessageStartEventSubscriptionExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/message/MessageSubscriptionFromMessageStartEventSubscriptionExportHandlerTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.db.rdbms.write.domain.MessageSubscriptionDbModel;
 import io.camunda.db.rdbms.write.service.MessageSubscriptionWriter;
+import io.camunda.exporter.rdbms.ExporterConfiguration.ToolsConfiguration;
 import io.camunda.exporter.rdbms.handlers.MessageSubscriptionFromMessageStartEventSubscriptionExportHandler;
 import io.camunda.exporter.rdbms.utils.DateUtil;
 import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionState;
@@ -50,7 +51,16 @@ final class MessageSubscriptionFromMessageStartEventSubscriptionExportHandlerTes
       mock(ExporterEntityCache.class);
 
   private final MessageSubscriptionFromMessageStartEventSubscriptionExportHandler underTest =
-      new MessageSubscriptionFromMessageStartEventSubscriptionExportHandler(writer, processCache);
+      new MessageSubscriptionFromMessageStartEventSubscriptionExportHandler(
+          writer, processCache, buildToolsConfig());
+
+  private static ToolsConfiguration buildToolsConfig() {
+    final var config = new ToolsConfiguration();
+    config.setExtensionPropertyToolName("io.camunda.tool:name");
+    config.setExtensionPropertyInboundConnectorType("inbound.type");
+    config.setExtensionPropertyPrefixToolProperties("io.camunda.tool:");
+    return config;
+  }
 
   @ParameterizedTest
   @EnumSource(MessageStartEventSubscriptionIntent.class)

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/message/MessageSubscriptionFromMessageStartEventSubscriptionExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/message/MessageSubscriptionFromMessageStartEventSubscriptionExportHandlerTest.java
@@ -15,13 +15,13 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.db.rdbms.write.domain.MessageSubscriptionDbModel;
 import io.camunda.db.rdbms.write.service.MessageSubscriptionWriter;
-import io.camunda.exporter.rdbms.ExporterConfiguration.ToolsConfiguration;
 import io.camunda.exporter.rdbms.handlers.MessageSubscriptionFromMessageStartEventSubscriptionExportHandler;
 import io.camunda.exporter.rdbms.utils.DateUtil;
 import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionState;
 import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionType;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
+import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/message/MessageSubscriptionFromMessageStartEventSubscriptionExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/message/MessageSubscriptionFromMessageStartEventSubscriptionExportHandlerTest.java
@@ -187,7 +187,7 @@ final class MessageSubscriptionFromMessageStartEventSubscriptionExportHandlerTes
         .isEqualTo(DateUtil.toOffsetDateTime(Instant.ofEpochMilli(timestamp)));
     assertThat(model.processDefinitionName()).isEqualTo(processName);
     assertThat(model.processDefinitionVersion()).isEqualTo(processVersion);
-    assertThat(model.extensionProperties()).isEqualTo(Map.of());
+    assertThat(model.toolProperties()).isEqualTo(Map.of("io.camunda.tool:name", "myTool"));
     assertThat(model.toolName()).isEqualTo("myTool");
     assertThat(model.inboundConnectorType()).isEqualTo("io.camunda:http-webhook:1");
   }
@@ -226,13 +226,13 @@ final class MessageSubscriptionFromMessageStartEventSubscriptionExportHandlerTes
     // when
     underTest.export(record);
 
-    // then — no exception, name/version/extensionProperties are absent
+    // then — no exception, name/version/toolProperties are absent
     final var captor = ArgumentCaptor.forClass(MessageSubscriptionDbModel.class);
     verify(writer).create(captor.capture());
     final MessageSubscriptionDbModel model = captor.getValue();
     assertThat(model.processDefinitionName()).isNull();
     assertThat(model.processDefinitionVersion()).isNull();
-    assertThat(model.extensionProperties()).isEqualTo(Map.of());
+    assertThat(model.toolProperties()).isEqualTo(Map.of());
     assertThat(model.toolName()).isNull();
     assertThat(model.inboundConnectorType()).isNull();
   }

--- a/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
@@ -275,7 +275,7 @@ components:
         - correlationKey
         - elementId
         - elementInstanceKey
-        - extensionProperties
+        - toolProperties
         - inboundConnectorType
         - lastUpdatedDate
         - messageName
@@ -344,7 +344,7 @@ components:
           description: The correlation key of the message subscription.
         messageSubscriptionType:
           $ref: '#/components/schemas/MessageSubscriptionTypeEnum'
-        extensionProperties:
+        toolProperties:
           type: object
           additionalProperties:
             type: string

--- a/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
@@ -349,8 +349,9 @@ components:
           additionalProperties:
             type: string
           description: |
-            The `zeebe:properties` extension properties extracted from the BPMN element associated
-            with this subscription. Empty object when no properties are defined.
+            The subset of `zeebe:properties` extension properties whose keys start with the
+            `io.camunda.tool:` prefix, extracted from the BPMN element associated with this
+            subscription. Empty object when no matching properties are defined.
         processDefinitionName:
           type: string
           nullable: true

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/MessageSubscriptionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/MessageSubscriptionQueryControllerTest.java
@@ -50,7 +50,7 @@ public class MessageSubscriptionQueryControllerTest extends RestControllerTest {
                   "tenantId": "test-tenant",
                   "processDefinitionKey": null,
                   "rootProcessInstanceKey": null,
-                  "extensionProperties": {},
+                  "toolProperties": {},
                   "processDefinitionName": null,
                   "processDefinitionVersion": null,
                   "toolName": null,


### PR DESCRIPTION
## Summary

Fixes the CI failures and addresses all four Copilot review comments on #52551.

### Root cause

Both `ExporterConfiguration.ToolsConfiguration` classes (camunda-exporter and rdbms-exporter) had `null` defaults for `extensionPropertyToolName`, `extensionPropertyInboundConnectorType`, and `extensionPropertyPrefixToolProperties`. `ProcessCacheUtil` returns `null`/empty when these are `null`, so tool attributes (`toolName`, `inboundConnectorType`, `toolProperties`) were silently dropped at runtime — including via `AbstractEventHandler`'s 1-arg constructor and any deployment where the tools section was absent from exporter args.

This caused the acceptance-test failures across all backends:
- `shouldFilterByToolName`
- `shouldFilterByInboundConnectorType`
- `shouldReturnToolPropertiesForStartEventSubscription`

### Changes

- **`ExporterConfiguration.ToolsConfiguration` (camunda-exporter)** — initialize fields with the same defaults as `Tools.java` (`"io.camunda.tool:name"`, `"inbound.type"`, `"io.camunda.tool:"`)
- **`ExporterConfiguration.ToolsConfiguration` (rdbms-exporter)** — same defaults
- **`BrokerBasedPropertiesOverride`** — extract the inline RDBMS tools mapping into a `applyRdbmsToolsConfiguration()` helper, eliminating the duplication flagged in review (mirrors `CamundaExporterConfigurationApplier.applyTools()`)

### Tests

- `DataToolsTest` (5 tests) — all green
- `MessageSubscriptionFromMessageStartEventSubscriptionHandlerTest` (11 tests) — all green

https://claude.ai/code/session_01PoPMYihhqcjezt7mqXF3Q9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PoPMYihhqcjezt7mqXF3Q9)_