### PR TITLE
[DO NOT MERGE] smoke test: verify check-action-pins gate fails on unpinned action

### DIFF
--- a/.github/workflows/check-action-pins.yml
+++ b/.github/workflows/check-action-pins.yml
@@ -165,8 +165,23 @@ jobs:
         run: pipx install 'zizmor==1.24.1'
 
       # -----------------------------------------------------------------------
-      # Step 4 — Run zizmor on the changed files only.
+      # Step 4 — Run zizmor once and split its output into errors + warnings.
       # -----------------------------------------------------------------------
+      # We run zizmor a single time with the full default audit set enabled,
+      # then post-process the GitHub annotations so that:
+      #   - `unpinned-uses` findings stay as `::error::` and FAIL the job
+      #     (this is the gate for issue #25934).
+      #   - Every other audit's `::error::` and `::notice::` is demoted to
+      #     `::warning::` — visible in the PR diff as a yellow annotation,
+      #     but never blocks merge.
+      #
+      # Why one run instead of two: zizmor has no flag to scope which audits
+      # contribute to the exit code, so we'd otherwise need either two
+      # invocations (gate + advisory) or per-audit `disable: true` in the
+      # config. Splitting the output is cleaner: one zizmor invocation, one
+      # config file, and the audit-id is preserved in the `title=` field of
+      # GitHub's documented workflow-command format — stable to grep/awk.
+      #
       # `xargs -a changed.txt -r zizmor ...`:
       #   `-a changed.txt` reads file paths from the file (one per line).
       #   `-r` (--no-run-if-empty) prevents xargs from invoking zizmor with
@@ -175,28 +190,35 @@ jobs:
       #         the behavior we DON'T want for this incremental check.
       #
       # `--config .github/zizmor.yml` points at our policy file, which
-      #   defines the per-org pinning rules (camunda/* and actions/* may
-      #   use tags; everyone else must hash-pin). See that file for details.
+      #   defines the per-org pinning rules for the unpinned-uses audit.
       #
-      # `--min-severity=high` filters out informational/low/medium audits.
-      #   The `unpinned-uses` rule fires at "high" severity when our policy
-      #   says hash-pin is required and a tag is used, so a `high` floor
-      #   lets only real policy violations fail the job — no noise from
-      #   zizmor's other audits (template-injection, excessive-permissions,
-      #   etc.) which we haven't tuned for this repo.
+      # `--format=github` makes zizmor emit
+      #     ::error file=PATH,line=N,title=AUDIT_ID::MESSAGE
+      #   annotations. The `title=AUDIT_ID` part is what we filter on.
       #
-      # `--format=github` makes zizmor emit `::error file=...::` annotations,
-      #   so violations show up inline in the PR's "Files changed" view —
-      #   reviewers see exactly which line is unpinned without digging
-      #   into raw logs.
-      #
-      # The exit code from zizmor (non-zero on findings >= min-severity)
-      # propagates out and fails the job — that's what makes this a gate.
+      # `set +e` (and the `|| true` after the xargs) keep this step alive
+      #   even when zizmor exits non-zero on findings — we need the captured
+      #   output for post-processing, and we run our own gate logic at the
+      #   bottom.
       - name: Run zizmor on changed files
         if: steps.changed.outputs.count != '0'
         run: |
-          set -euo pipefail
-          xargs -a changed.txt -r zizmor \
-            --config .github/zizmor.yml \
-            --min-severity=high \
-            --format=github
+          set -uo pipefail   # NOT -e — zizmor's non-zero on findings is expected
+          out=$(xargs -a changed.txt -r zizmor --config .github/zizmor.yml --format=github 2>&1) || true
+
+          # Stream the captured annotations to GitHub Actions, transforming
+          # everything that isn't unpinned-uses into a warning. Order of
+          # awk patterns matters: the unpinned-uses match must come first
+          # so it isn't caught by the broader `^::error /` rewrite below it.
+          echo "$out" | awk '
+            /^::error /  && /title=unpinned-uses/ { print; next }
+            /^::error /                           { sub(/^::error /,  "::warning "); print; next }
+            /^::notice /                          { sub(/^::notice /, "::warning "); print; next }
+                                                  { print }
+          '
+
+          # Gate: fail only if at least one unpinned-uses error appeared.
+          if echo "$out" | grep -qE '^::error.*title=unpinned-uses'; then
+            echo "::error::Unpinned 3rd-party action(s) detected — see annotations above"
+            exit 1
+          fi

--- a/.github/workflows/check-action-pins.yml
+++ b/.github/workflows/check-action-pins.yml
@@ -2,11 +2,17 @@
 # check-action-pins.yml
 #
 # Purpose:
-#   Enforce GitHub Issue #25934 — every 3rd-party GitHub Action MUST be pinned
-#   to a 40-char commit SHA, never a tag or branch. Tag/branch refs are mutable
-#   and expose us to supply-chain attacks: the upstream owner — or anyone who
-#   compromises them — can rewrite the tag to point at malicious code, and our
-#   CI will silently start running it.
+#   Enforce GitHub Issue #25934 — every external 3rd-party GitHub Action MUST
+#   be pinned to a 40-char commit SHA. Tag/branch refs are mutable and expose
+#   us to supply-chain attacks: the upstream owner — or anyone who compromises
+#   them — can rewrite the tag to point at malicious code, and our CI will
+#   silently start running it.
+#
+#   The actual enforced policy is more nuanced than "everything must be
+#   SHA-pinned" — `actions/*`, `github/*`, and `camunda/*` are allowed to use
+#   tag/branch refs because they're either GitHub-owned or our own
+#   infrastructure. Only external 3rd-party actions are required to use SHAs.
+#   See .github/zizmor.yml for the exact per-owner policy.
 #
 # Scope:
 #   This job intentionally only fails on action files that the *current PR*
@@ -35,14 +41,21 @@ name: check-action-pins
 # on `push` to main wouldn't help, since by then the violation is already in.
 #
 # `paths:` filters the PR-level trigger so this workflow is skipped entirely
-# for PRs that don't touch action files. Note that `paths:` filters which
-# *workflow runs* are created — it does NOT filter which files the job
-# inspects. We do per-file filtering further down in the job itself.
+# for PRs that don't touch action files. The patterns mirror exactly what
+# the diff step (Step 2) inspects, so we don't spawn no-op runs for PRs that
+# only touch e.g. shell scripts, JSON config, or README files inside
+# `.github/workflows/` or `.github/actions/`.
+#
+# Note: `paths:` filters which *workflow runs* are created — it does NOT
+# filter which files the job inspects within a triggered run. The per-file
+# filtering further down in Step 2 is what actually scopes zizmor's input.
 on:
   pull_request:
     paths:
-      - '.github/workflows/**'
-      - '.github/actions/**'
+      - '.github/workflows/*.yml'
+      - '.github/workflows/*.yaml'
+      - '.github/actions/**/action.yml'
+      - '.github/actions/**/action.yaml'
 
 # -----------------------------------------------------------------------------
 # Permissions

--- a/.github/workflows/check-action-pins.yml
+++ b/.github/workflows/check-action-pins.yml
@@ -1,0 +1,189 @@
+# =============================================================================
+# check-action-pins.yml
+#
+# Purpose:
+#   Enforce GitHub Issue #25934 — every 3rd-party GitHub Action MUST be pinned
+#   to a 40-char commit SHA, never a tag or branch. Tag/branch refs are mutable
+#   and expose us to supply-chain attacks: the upstream owner — or anyone who
+#   compromises them — can rewrite the tag to point at malicious code, and our
+#   CI will silently start running it.
+#
+# Scope:
+#   This job intentionally only fails on action files that the *current PR*
+#   adds or modifies. It does NOT scan the whole repo. The reason is that
+#   `main` and the stable branches still carry pre-existing unpinned legacy
+#   files (e.g. older `actions/checkout@v4` references) that we don't want
+#   to block unrelated PRs on. By running zizmor only on changed files, we:
+#     - block any *new* violation that a PR is trying to introduce
+#     - force a touched legacy file to be cleaned up before merge
+#     - leave untouched legacy files alone (so the rule lands incrementally)
+#
+# Tool:
+#   We use `zizmor` (https://github.com/zizmorcore/zizmor), a security auditor
+#   for GitHub Actions. Its `unpinned-uses` rule supports per-org policies,
+#   which lets us require hash-pinning for external actions while still
+#   allowing tag/branch refs for our own org (camunda/*) and for GitHub-owned
+#   actions (actions/*, github/*) — see .github/zizmor.yml for the policy.
+# =============================================================================
+
+name: check-action-pins
+
+# -----------------------------------------------------------------------------
+# Triggers
+# -----------------------------------------------------------------------------
+# We run on `pull_request` so the check is gated *before* merge — running it
+# on `push` to main wouldn't help, since by then the violation is already in.
+#
+# `paths:` filters the PR-level trigger so this workflow is skipped entirely
+# for PRs that don't touch action files. Note that `paths:` filters which
+# *workflow runs* are created — it does NOT filter which files the job
+# inspects. We do per-file filtering further down in the job itself.
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+
+# -----------------------------------------------------------------------------
+# Permissions
+# -----------------------------------------------------------------------------
+# Principle of least privilege: this job only reads code, so we drop the
+# default GITHUB_TOKEN scopes to `contents: read` and nothing else. If
+# someone later adds a step that comments on the PR, *that* step can
+# request `pull-requests: write` explicitly at the step level rather than
+# elevating the whole job.
+permissions:
+  contents: read
+
+jobs:
+  pin-check:
+    # Standard GitHub-hosted runner — this job only reads files and runs a
+    # small static-analysis tool, no need for self-hosted.
+    runs-on: ubuntu-latest
+
+    steps:
+      # -----------------------------------------------------------------------
+      # Step 1 — Check out the PR head, with full history.
+      # -----------------------------------------------------------------------
+      # We need `fetch-depth: 0` because Step 2 calls `git diff` between
+      # the PR base SHA and the PR head SHA. The default shallow clone
+      # (fetch-depth: 1) doesn't include the base commit, so `git diff`
+      # would fail with "fatal: bad object". Full history is the simplest
+      # fix; if performance matters here later, we could fetch only the
+      # specific base SHA via `git fetch origin $base_sha --depth=1`.
+      #
+      # The action below is itself pinned to a SHA — both because this
+      # workflow has to follow the rule it enforces, and because pinning
+      # the enforcer to a SHA matters more than pinning anything else.
+      - name: Check out PR head
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      # -----------------------------------------------------------------------
+      # Step 2 — Compute the list of action files this PR adds or modifies.
+      # -----------------------------------------------------------------------
+      # `github.event.pull_request.base.sha` is the SHA of the base branch's
+      # tip at the moment the PR was opened/synchronized. `head.sha` is the
+      # tip of the PR branch. Diffing these gives us the set of files this
+      # PR is contributing.
+      #
+      # `--diff-filter=AM` keeps only **A**dded and **M**odified files:
+      #   - We don't want to flag deletions (a PR that removes an unpinned
+      #     file shouldn't be blocked by this check).
+      #   - Pure renames aren't included either; if you want to also lint
+      #     content-edited renames, add `R` here.
+      #
+      # The path globs restrict the diff to action definition files only —
+      # workflow YAMLs and composite-action YAMLs. Files outside those dirs
+      # (e.g. application code) are never inspected.
+      #
+      # We write the list to `changed.txt` instead of using a step output
+      # because step outputs have a 1MB limit and shell-quoting newline-
+      # delimited file lists across steps is fiddly. A file is simpler.
+      #
+      # `count` is exposed as a step output so later steps can short-circuit
+      # via `if: steps.changed.outputs.count != '0'`. Without that guard,
+      # running zizmor with zero files passed to it would error out and
+      # turn a no-op PR into a red check.
+      - name: List added/edited action files vs PR base
+        id: changed
+        run: |
+          set -euo pipefail
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+
+          # `mapfile` reads stdin into a bash array, one element per line.
+          # `< <(...)` is process substitution — it feeds the git output
+          # to mapfile without spawning a subshell that would lose the array.
+          mapfile -t files < <(git diff --name-only --diff-filter=AM "$base" "$head" -- \
+            '.github/workflows/*.yml' \
+            '.github/workflows/*.yaml' \
+            '.github/actions/**/action.yml' \
+            '.github/actions/**/action.yaml')
+
+          # Persist the list for the next step. `printf '%s\n'` correctly
+          # handles paths containing spaces or special chars (unlike `echo`).
+          printf '%s\n' "${files[@]}" > changed.txt
+
+          # Emit a count so downstream `if:` conditions can skip cleanly.
+          echo "count=${#files[@]}" >> "$GITHUB_OUTPUT"
+
+          # Surface the list in the job log for debugging.
+          echo "Files to lint:"
+          cat changed.txt
+
+      # -----------------------------------------------------------------------
+      # Step 3 — Install zizmor.
+      # -----------------------------------------------------------------------
+      # `pipx` installs Python apps in isolated venvs — preferred over plain
+      # `pip install` to avoid polluting the runner's system Python and to
+      # keep zizmor's deps from clashing with anything else.
+      #
+      # We pin zizmor itself to a specific version, both for reproducibility
+      # (a silent upgrade could change the rule set or severity assignments
+      # and start failing PRs that used to pass) and because this workflow's
+      # whole point is "pin your dependencies". Bump deliberately when ready.
+      #
+      # The `if:` skips the install when there are no files to lint — cheaper,
+      # and avoids a misleading green tick on a job that did nothing.
+      - name: Install zizmor
+        if: steps.changed.outputs.count != '0'
+        run: pipx install 'zizmor==1.24.1'
+
+      # -----------------------------------------------------------------------
+      # Step 4 — Run zizmor on the changed files only.
+      # -----------------------------------------------------------------------
+      # `xargs -a changed.txt -r zizmor ...`:
+      #   `-a changed.txt` reads file paths from the file (one per line).
+      #   `-r` (--no-run-if-empty) prevents xargs from invoking zizmor with
+      #         no arguments if the list happens to be empty — without this,
+      #         zizmor would run against the whole repo, which is exactly
+      #         the behavior we DON'T want for this incremental check.
+      #
+      # `--config .github/zizmor.yml` points at our policy file, which
+      #   defines the per-org pinning rules (camunda/* and actions/* may
+      #   use tags; everyone else must hash-pin). See that file for details.
+      #
+      # `--min-severity=high` filters out informational/low/medium audits.
+      #   The `unpinned-uses` rule fires at "high" severity when our policy
+      #   says hash-pin is required and a tag is used, so a `high` floor
+      #   lets only real policy violations fail the job — no noise from
+      #   zizmor's other audits (template-injection, excessive-permissions,
+      #   etc.) which we haven't tuned for this repo.
+      #
+      # `--format=github` makes zizmor emit `::error file=...::` annotations,
+      #   so violations show up inline in the PR's "Files changed" view —
+      #   reviewers see exactly which line is unpinned without digging
+      #   into raw logs.
+      #
+      # The exit code from zizmor (non-zero on findings >= min-severity)
+      # propagates out and fails the job — that's what makes this a gate.
+      - name: Run zizmor on changed files
+        if: steps.changed.outputs.count != '0'
+        run: |
+          set -euo pipefail
+          xargs -a changed.txt -r zizmor \
+            --config .github/zizmor.yml \
+            --min-severity=high \
+            --format=github

--- a/.github/workflows/check-action-pins.yml
+++ b/.github/workflows/check-action-pins.yml
@@ -60,13 +60,20 @@ on:
 # -----------------------------------------------------------------------------
 # Permissions
 # -----------------------------------------------------------------------------
-# Principle of least privilege: this job only reads code, so we drop the
-# default GITHUB_TOKEN scopes to `contents: read` and nothing else. If
-# someone later adds a step that comments on the PR, *that* step can
-# request `pull-requests: write` explicitly at the step level rather than
-# elevating the whole job.
+# Principle of least privilege:
+#   - contents: read         — checking out the PR head
+#   - pull-requests: write   — needed by the comment-management step (Step 5)
+#                              so the bot can create/update the markdown
+#                              summary comment with violation details.
+#
+# Note on fork PRs: GitHub's `pull_request` trigger only grants a read-only
+# token when the PR is from a fork (security policy). The comment step will
+# silently fail in that case — annotations still appear, the gate still
+# fires, but no comment is created. Camunda's contributor flow is mostly
+# branches in the same repo, so this affects very few PRs in practice.
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   pin-check:
@@ -200,7 +207,7 @@ jobs:
       #   even when zizmor exits non-zero on findings — we need the captured
       #   output for post-processing, and we run our own gate logic at the
       #   bottom.
-      - name: Run zizmor on changed files
+      - name: Run zizmor and emit annotations
         if: steps.changed.outputs.count != '0'
         run: |
           set -uo pipefail   # NOT -e — zizmor's non-zero on findings is expected
@@ -217,8 +224,172 @@ jobs:
                                                   { print }
           '
 
-          # Gate: fail only if at least one unpinned-uses error appeared.
-          if echo "$out" | grep -qE '^::error.*title=unpinned-uses'; then
-            echo "::error::Unpinned 3rd-party action(s) detected — see annotations above"
+          # Capture unpinned-uses violations as JSON for the comment step.
+          # `jq -R . | jq -s` reads the raw lines and wraps them into an array;
+          # the inner sed extracts {path,line} objects from the github-format
+          # error annotations. Empty file == "[]" so downstream steps see a
+          # well-formed JSON array regardless of whether anything fired.
+          echo "$out" | grep -E '^::error.*title=unpinned-uses' \
+            | sed -E 's|^::error file=([^,]+),line=([0-9]+),title=unpinned-uses::.*$|{"path":"\1","line":\2}|' \
+            | jq -s '.' > unpinned-violations.json
+          echo "Captured violations:"
+          cat unpinned-violations.json
+
+      # -----------------------------------------------------------------------
+      # Step 5 — PR comment state machine.
+      # -----------------------------------------------------------------------
+      # We render a markdown summary as a single bot comment on the PR so
+      # the author sees, in the conversation tab, *which* `uses:` lines are
+      # unpinned and how to fix them — without scrolling the Files tab to
+      # find the inline annotations.
+      #   prev state               | current run    | action
+      #   ─────────────────────────┼────────────────┼────────────────────
+      #   no comment               | clean          | noop
+      #   no comment               | violations     | create violation comment
+      #   has same violations      | same set       | noop  (no spam on rebase)
+      #   has different violations | different set  | update violation comment
+      #   has violations           | clean          | update to "resolved"
+      #   already-resolved         | clean          | noop  (don't churn)
+      #   already-resolved         | violations     | update to violation comment (regression)
+
+      - name: Manage PR comment
+        if: steps.changed.outputs.count != '0' && github.event_name == 'pull_request'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const fs = require('fs');
+
+            const MARKER = '<!-- check-action-pins-bot -->';
+            const STATE_RE = /<!--\s*state:\s*(.*?)\s*-->/;
+            const stateLine = (state) => `<!-- state: ${JSON.stringify(state)} -->`;
+
+            // Read the current violation set the previous step captured.
+            const current = fs.existsSync('unpinned-violations.json')
+              ? JSON.parse(fs.readFileSync('unpinned-violations.json', 'utf8'))
+              : [];
+
+            // List the PR's existing comments and find ours (if any).
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(MARKER));
+
+            // Recover previous state from the existing comment, if any. We
+            // tolerate parse failures (manual edits, schema drift) by
+            // treating them as "no prior state".
+            let prev = { violations: [], resolved: false };
+            if (existing) {
+              const m = existing.body.match(STATE_RE);
+              if (m) { try { prev = JSON.parse(m[1]); } catch (_) {} }
+            }
+
+            // Stable key for comparing violations. Path+line is enough; we
+            // don't track which action repo because zizmor's annotation
+            // doesn't expose it without re-parsing the workflow file.
+            const key = v => `${v.path}:${v.line}`;
+            const sameSet = (a, b) => {
+              const A = a.map(key).sort().join('|');
+              const B = b.map(key).sort().join('|');
+              return A === B;
+            };
+
+            // Decide the action.
+            let action;
+            if (current.length === 0) {
+              if (prev.violations.length === 0 || prev.resolved) {
+                action = 'noop';                 // already clean OR already marked resolved
+              } else {
+                action = 'resolve';              // newly resolved
+              }
+            } else {
+              if (!prev.resolved && sameSet(prev.violations, current)) {
+                action = 'noop';                 // no churn on rebase/sync
+              } else {
+                action = 'update';               // new set, or regression after resolve
+              }
+            }
+
+            console.log(`Decision: ${action} (prev=${JSON.stringify(prev)}, current=${current.length} violations)`);
+
+            // Body builders — kept as small helpers for readability.
+            const violationBody = (violations) => [
+              MARKER,
+              stateLine({ violations, resolved: false }),
+              '',
+              '## ❌ Unpinned 3rd-party GitHub Action(s) detected',
+              '',
+              'This PR introduces or modifies one or more `uses:` lines that reference an external 3rd-party action by tag or branch instead of a 40-character commit SHA. Per [issue #25934](https://github.com/camunda/camunda/issues/25934), all external actions must be SHA-pinned to mitigate supply-chain attacks (mutable tag refs can be silently rewritten by a compromised upstream).',
+              '',
+              '### Offending lines',
+              ...violations.map(v => `- \`${v.path}:${v.line}\``),
+              '',
+              '### How to fix',
+              'Replace each `@<tag>` with `@<sha> # <tag>` so the version is recorded in the comment but the binary identity is locked to a SHA. Look up the SHA via:',
+              '```bash',
+              'gh api repos/<owner>/<repo>/git/refs/tags/<tag> --jq .object.sha',
+              '```',
+              'Example:',
+              '```yaml',
+              '- uses: foo/bar@a1b2c3d4e5f60123456789abcdef0123456789ab # v1.2.3',
+              '```',
+              '',
+              '### Escape hatches',
+              '- Inline ignore on a single line — `# zizmor: ignore[unpinned-uses] <reason>`',
+              '- Per-file ignore in `.github/zizmor.yml` under `rules.unpinned-uses.ignore`',
+              '',
+              'Full per-org policy in [`.github/zizmor.yml`](../blob/main/.github/zizmor.yml) — `actions/*`, `github/*`, and `camunda/*` are exempt at `ref-pin`.',
+            ].join('\n');
+
+            const resolvedBody = () => [
+              MARKER,
+              stateLine({ violations: [], resolved: true }),
+              '',
+              '## ✅ Pinning issue resolved',
+              '',
+              'All previously detected unpinned 3rd-party action references in this PR have been fixed. Compliant with the SHA-pinning policy ([issue #25934](https://github.com/camunda/camunda/issues/25934)).',
+            ].join('\n');
+
+            // Execute the chosen action.
+            const common = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            };
+
+            if (action === 'noop') {
+              return;
+            }
+
+            const body = action === 'resolve' ? resolvedBody() : violationBody(current);
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                ...common,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({ ...common, body });
+            }
+
+      # -----------------------------------------------------------------------
+      # Step 6 — Gate.
+      # -----------------------------------------------------------------------
+      # Final, deterministic check: if any unpinned-uses violations were
+      # captured, fail the job. We do this as a separate step (rather than
+      # exiting from Step 4) so that Step 5 always runs first and the PR
+      # comment is up-to-date *before* the red check appears — otherwise
+      # a fast reviewer could see the failure annotation without the
+      # actionable comment yet.
+      - name: Gate on unpinned-uses violations
+        if: steps.changed.outputs.count != '0'
+        run: |
+          set -euo pipefail
+          if [ "$(jq 'length' unpinned-violations.json)" -gt 0 ]; then
+            echo "::error::Unpinned 3rd-party action(s) detected — see PR comment and annotations above"
             exit 1
           fi
+          echo "✓ no unpinned 3rd-party actions in this PR's diff"

--- a/.github/workflows/check-action-pins.yml
+++ b/.github/workflows/check-action-pins.yml
@@ -225,11 +225,18 @@ jobs:
           '
 
           # Capture unpinned-uses violations as JSON for the comment step.
-          # `jq -R . | jq -s` reads the raw lines and wraps them into an array;
-          # the inner sed extracts {path,line} objects from the github-format
-          # error annotations. Empty file == "[]" so downstream steps see a
-          # well-formed JSON array regardless of whether anything fired.
-          echo "$out" | grep -E '^::error.*title=unpinned-uses' \
+          # The inner sed extracts {path,line} objects from the github-format
+          # error annotations; jq -s wraps them into an array. Empty input to
+          # jq -s yields `[]`, so downstream steps always see a well-formed
+          # JSON array regardless of whether anything fired.
+          #
+          # The brace group `{ ... || true; }` is critical: when there are
+          # no unpinned-uses violations, grep exits 1 (no match), and the
+          # GitHub Actions default `bash -e` would abort the whole step
+          # before the JSON file is written. The `|| true` shield makes
+          # "no match" indistinguishable from "match with zero results"
+          # from the pipeline's exit-code perspective.
+          { echo "$out" | grep -E '^::error.*title=unpinned-uses' || true; } \
             | sed -E 's|^::error file=([^,]+),line=([0-9]+),title=unpinned-uses::.*$|{"path":"\1","line":\2}|' \
             | jq -s '.' > unpinned-violations.json
           echo "Captured violations:"

--- a/.github/workflows/check-action-pins.yml
+++ b/.github/workflows/check-action-pins.yml
@@ -336,11 +336,8 @@ jobs:
               '- uses: foo/bar@a1b2c3d4e5f60123456789abcdef0123456789ab # v1.2.3',
               '```',
               '',
-              '### Escape hatches',
-              '- Inline ignore on a single line — `# zizmor: ignore[unpinned-uses] <reason>`',
-              '- Per-file ignore in `.github/zizmor.yml` under `rules.unpinned-uses.ignore`',
-              '',
-              'Full per-org policy in [`.github/zizmor.yml`](../blob/main/.github/zizmor.yml) — `actions/*`, `github/*`, and `camunda/*` are exempt at `ref-pin`.',
+              '### Need an exception?',
+              'If this action genuinely cannot be SHA-pinned (e.g. the vendor publishes only tags, or there is a policy reason), please contact the **monorepo-devops team on Slack**. The team owns the pinning policy and can apply the right exception centrally.',
             ].join('\n');
 
             const resolvedBody = () => [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1460,7 +1460,7 @@ jobs:
 
       - name: Delete matrix job generated artifacts
         if: always()
-        uses: geekyeggo/delete-artifact@v6
+        uses: geekyeggo/delete-artifact@176a747ab7e287e3ff4787bf8a148716375ca118 # v6.0.0
         with:
           name: |
             zeebe-unit-tests-*

--- a/.github/workflows/operate-ci-build-reusable.yml
+++ b/.github/workflows/operate-ci-build-reusable.yml
@@ -83,7 +83,7 @@ jobs:
       # Setup: import secrets from vault
       - name: Import Secrets
         id: secrets # important to refer to it in later steps
-        uses: hashicorp/vault-action@v3
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
         with:
           url: ${{ secrets.VAULT_ADDR }}
           method: approle

--- a/.github/workflows/operate-ci-test-reusable.yml
+++ b/.github/workflows/operate-ci-test-reusable.yml
@@ -82,7 +82,7 @@ jobs:
       # Setup: import secrets from vault
       - name: Import Secrets
         id: secrets  # important to refer to it in later steps
-        uses: hashicorp/vault-action@v3
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
         with:
           url: ${{ secrets.VAULT_ADDR }}
           method: approle

--- a/.github/workflows/operate-docker-tests.yml
+++ b/.github/workflows/operate-docker-tests.yml
@@ -54,13 +54,13 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: hadolint/hadolint-action@v3.3.0
+      - uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
         with:
           ignore: DL3018 # redundant when pinning the base image
           dockerfile: operate.Dockerfile
       - name: Import Secrets
         id: secrets
-        uses: hashicorp/vault-action@v3.4.0
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
         with:
           url: ${{ secrets.VAULT_ADDR }}
           method: approle
@@ -71,7 +71,7 @@ jobs:
             secret/data/github.com/organizations/camunda NEXUS_PSW;
             secret/data/products/camunda/ci/github-actions REGISTRY_MINIMUS_PSW | minimus-token
       - name: Login to Minimus
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: reg.mini.dev
           username: minimus
@@ -83,7 +83,7 @@ jobs:
           java-version: "21"
       # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
       - name: 'Create settings.xml'
-        uses: s4u/maven-settings-action@v4.0.0
+        uses: s4u/maven-settings-action@894661b3ddae382f1ae8edbeab60987e08cf0788 # v4.0.0
         with:
           githubServer: false
           servers: |
@@ -96,11 +96,11 @@ jobs:
       - name: Build backend
         run: ./mvnw clean install -B -T1C -DskipChecks -P -docker,skipFrontendBuild -DskipTests=true -DskipRemoteStaging=true -Dmaven.deploy.skip=true
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
         with:
           driver-opts: network=host
       - name: Build and push to local registry
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         env:
           DOCKER_BUILD_SUMMARY: false
           DOCKER_BUILD_RECORD_UPLOAD: false

--- a/.github/workflows/operate-e2e-tests.yml
+++ b/.github/workflows/operate-e2e-tests.yml
@@ -60,7 +60,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Import Secrets
         id: secrets
-        uses: hashicorp/vault-action@v3.4.0
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
         with:
           url: ${{ secrets.VAULT_ADDR }}
           method: approle
@@ -101,7 +101,7 @@ jobs:
 
       # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
       - name: "Create settings.xml"
-        uses: s4u/maven-settings-action@v4.0.0
+        uses: s4u/maven-settings-action@894661b3ddae382f1ae8edbeab60987e08cf0788 # v4.0.0
         with:
           githubServer: false
           servers: |
@@ -186,7 +186,7 @@ jobs:
 
       - name: Collect docker logs on failure
         if: failure()
-        uses: jwalton/gh-docker-logs@v2
+        uses: jwalton/gh-docker-logs@2741064ab9d7af54b0b1ffb6076cf64c16f0220e # v2.2.2
         with:
           dest: "./logs"
       - name: Tar logs

--- a/.github/workflows/tasklist-e2e-tests.yml
+++ b/.github/workflows/tasklist-e2e-tests.yml
@@ -102,7 +102,7 @@ jobs:
 
       # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
       - name: "Create settings.xml"
-        uses: s4u/maven-settings-action@v4.0.0
+        uses: s4u/maven-settings-action@894661b3ddae382f1ae8edbeab60987e08cf0788 # v4.0.0
         with:
           githubServer: false
           servers: |

--- a/.github/workflows/zzz-smoke-test-pin-gate.yml
+++ b/.github/workflows/zzz-smoke-test-pin-gate.yml
@@ -1,0 +1,15 @@
+# DO NOT MERGE — smoke-test fixture for PR #52554
+#
+# Introduces a deliberately unpinned external action (foo/bar@v1) so the
+# `check-action-pins` gate can be observed firing in CI. The workflow itself
+# never runs (manual `workflow_dispatch` trigger only, on a non-existent action).
+# This file is created on a throwaway branch and is meant to be deleted along
+# with that branch once the smoke test is confirmed.
+name: zzz-smoke-test-pin-gate
+on: workflow_dispatch
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: foo/bar@v1

--- a/.github/workflows/zzz-smoke-test-pin-gate.yml
+++ b/.github/workflows/zzz-smoke-test-pin-gate.yml
@@ -1,10 +1,11 @@
 # DO NOT MERGE — smoke-test fixture for PR #52554
 #
-# Introduces a deliberately unpinned external action (foo/bar@v1) so the
-# `check-action-pins` gate can be observed firing in CI. The workflow itself
-# never runs (manual `workflow_dispatch` trigger only, on a non-existent action).
-# This file is created on a throwaway branch and is meant to be deleted along
-# with that branch once the smoke test is confirmed.
+# Originally introduced an unpinned `foo/bar@v1` to exercise the gate's
+# violation comment. Now SHA-pinned (with a placeholder SHA that satisfies
+# the 40-char hex format the policy requires) to exercise the gate's
+# "resolved" transition — the bot comment on this PR should update from
+# "❌ Unpinned 3rd-party GitHub Action(s) detected" to "✅ Pinning issue
+# resolved". This branch will be deleted once the parent PR (#52554) merges.
 name: zzz-smoke-test-pin-gate
 on: workflow_dispatch
 
@@ -12,4 +13,6 @@ jobs:
   smoke:
     runs-on: ubuntu-latest
     steps:
-      - uses: foo/bar@v1
+      - uses: geekyeggo/delete-artifact@176a747ab7e287e3ff4787bf8a148716375ca118 # v6.0.0
+        with:
+          name: smoke-test-fixture-not-real

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -3,11 +3,14 @@
 #
 # Consumed by `zizmor --config .github/zizmor.yml`.
 #
-# Only the `unpinned-uses` rule is configured here — everything else zizmor
-# offers (template-injection, excessive-permissions, dangerous-triggers, etc.)
-# is intentionally left at default to keep this gate narrowly focused on
-# issue #25934. Add more rules under `rules:` later if you want zizmor to
-# do broader security review.
+# This gate is INTENTIONALLY scoped to one audit: `unpinned-uses`.
+# All other zizmor audits are explicitly disabled below. The rationale:
+# many legacy workflow files in this repo trip zizmor's other audits
+# (cache-poisoning, template-injection, excessive-permissions, etc.) —
+# valid findings, but unrelated to issue #25934 and out of scope for
+# this PR. Re-enabling them is a one-line delete (remove the
+# `disable: true` for the audit you want to turn on); doing them as
+# separate, focused PRs lets each finding be triaged on its own merits.
 # =============================================================================
 
 rules:
@@ -71,6 +74,49 @@ rules:
       # (`.github/actions/*/action.yml`) are NOT supported here — use
       # the inline-comment escape hatch (#2 below) for those.
     ignore: []
+
+  # ---------------------------------------------------------------------------
+  # All other audits explicitly disabled.
+  #
+  # Listed alphabetically. To re-enable any of these, delete the line — that's
+  # the only change needed; zizmor will run the audit at its default settings.
+  # The comment after each name is a one-line summary of what the audit checks.
+  # ---------------------------------------------------------------------------
+  anonymous-definition: { disable: true }              # composite action without owning repo
+  archived-uses: { disable: true }                     # uses: refs to archived repos
+  artipacked: { disable: true }                        # credentials persisted in artifacts
+  bot-conditions: { disable: true }                    # GitHub Actions bot detection bypasses
+  cache-poisoning: { disable: true }                   # cache writes from PR runs poisoning trusted runs
+  concurrency-limits: { disable: true }                # missing concurrency: groups
+  dangerous-triggers: { disable: true }                # pull_request_target with checkout, etc.
+  dependabot-cooldown: { disable: true }               # dependabot config without cooldown
+  dependabot-execution: { disable: true }              # dependabot PRs running with secrets
+  excessive-permissions: { disable: true }             # GITHUB_TOKEN scopes wider than needed
+  forbidden-uses: { disable: true }                    # explicit allow/deny list of action repos
+  github-app: { disable: true }                        # GitHub App token misuse
+  github-env: { disable: true }                        # writes to $GITHUB_ENV from untrusted input
+  hardcoded-container-credentials: { disable: true }   # plaintext registry creds
+  impostor-commit: { disable: true }                   # commit not reachable from any branch/tag
+  insecure-commands: { disable: true }                 # ACTIONS_ALLOW_UNSECURE_COMMANDS=true
+  known-vulnerable-actions: { disable: true }          # actions with published CVEs
+  misfeature: { disable: true }                        # use of deprecated/discouraged features
+  obfuscation: { disable: true }                       # obfuscated shell/JS in run: blocks
+  overprovisioned-secrets: { disable: true }           # secrets passed to steps that don't use them
+  ref-confusion: { disable: true }                     # ref shadowed by tag with same name
+  ref-version-mismatch: { disable: true }              # @ref's version comment doesn't match the SHA
+  secrets-inherit: { disable: true }                   # `secrets: inherit` in reusable workflow calls
+  secrets-outside-env: { disable: true }               # secrets used outside `env:` blocks
+  self-hosted-runner: { disable: true }                # self-hosted runner usage on public repos
+  stale-action-refs: { disable: true }                 # uses: refs that are no longer maintained
+  superfluous-actions: { disable: true }               # action wraps a single trivial command
+  template-injection: { disable: true }                # ${{ }} expansion of attacker-controlled input
+  undocumented-permissions: { disable: true }          # permissions: blocks without comments
+  unpinned-images: { disable: true }                   # docker:// images using mutable tags
+  unpinned-tools: { disable: true }                    # asdf/mise/etc. tool versions not pinned
+  unredacted-secrets: { disable: true }                # secrets potentially printed in logs
+  unsound-condition: { disable: true }                 # if: conditions that always evaluate same way
+  unsound-contains: { disable: true }                  # contains() called with non-array
+  use-trusted-publishing: { disable: true }            # PyPI/npm trusted publishing missing
 
 # =============================================================================
 # Escape hatch #2 — inline comment on a single `uses:` line:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -3,14 +3,18 @@
 #
 # Consumed by `zizmor --config .github/zizmor.yml`.
 #
-# This gate is INTENTIONALLY scoped to one audit: `unpinned-uses`.
-# All other zizmor audits are explicitly disabled below. The rationale:
-# many legacy workflow files in this repo trip zizmor's other audits
-# (cache-poisoning, template-injection, excessive-permissions, etc.) —
-# valid findings, but unrelated to issue #25934 and out of scope for
-# this PR. Re-enabling them is a one-line delete (remove the
-# `disable: true` for the audit you want to turn on); doing them as
-# separate, focused PRs lets each finding be triaged on its own merits.
+# Audit scope:
+#   The default zizmor audit set is enabled. The workflow that consumes this
+#   config (`.github/workflows/check-action-pins.yml`) does the gating logic:
+#   it runs zizmor once, then post-processes the GitHub annotations so that
+#   only `unpinned-uses` findings fail the PR. All other audits surface as
+#   `::warning::` annotations — visible to reviewers but non-blocking.
+#
+#   The split is enforced by the workflow, not this file, because zizmor has
+#   no built-in "only this audit gates" mode. Keeping all audits enabled here
+#   means future PRs touching legacy files get advisory feedback (template
+#   injection, cache poisoning, excessive permissions, etc.) without being
+#   blocked by them.
 # =============================================================================
 
 rules:
@@ -74,49 +78,6 @@ rules:
       # (`.github/actions/*/action.yml`) are NOT supported here — use
       # the inline-comment escape hatch (#2 below) for those.
     ignore: []
-
-  # ---------------------------------------------------------------------------
-  # All other audits explicitly disabled.
-  #
-  # Listed alphabetically. To re-enable any of these, delete the line — that's
-  # the only change needed; zizmor will run the audit at its default settings.
-  # The comment after each name is a one-line summary of what the audit checks.
-  # ---------------------------------------------------------------------------
-  anonymous-definition: { disable: true }              # composite action without owning repo
-  archived-uses: { disable: true }                     # uses: refs to archived repos
-  artipacked: { disable: true }                        # credentials persisted in artifacts
-  bot-conditions: { disable: true }                    # GitHub Actions bot detection bypasses
-  cache-poisoning: { disable: true }                   # cache writes from PR runs poisoning trusted runs
-  concurrency-limits: { disable: true }                # missing concurrency: groups
-  dangerous-triggers: { disable: true }                # pull_request_target with checkout, etc.
-  dependabot-cooldown: { disable: true }               # dependabot config without cooldown
-  dependabot-execution: { disable: true }              # dependabot PRs running with secrets
-  excessive-permissions: { disable: true }             # GITHUB_TOKEN scopes wider than needed
-  forbidden-uses: { disable: true }                    # explicit allow/deny list of action repos
-  github-app: { disable: true }                        # GitHub App token misuse
-  github-env: { disable: true }                        # writes to $GITHUB_ENV from untrusted input
-  hardcoded-container-credentials: { disable: true }   # plaintext registry creds
-  impostor-commit: { disable: true }                   # commit not reachable from any branch/tag
-  insecure-commands: { disable: true }                 # ACTIONS_ALLOW_UNSECURE_COMMANDS=true
-  known-vulnerable-actions: { disable: true }          # actions with published CVEs
-  misfeature: { disable: true }                        # use of deprecated/discouraged features
-  obfuscation: { disable: true }                       # obfuscated shell/JS in run: blocks
-  overprovisioned-secrets: { disable: true }           # secrets passed to steps that don't use them
-  ref-confusion: { disable: true }                     # ref shadowed by tag with same name
-  ref-version-mismatch: { disable: true }              # @ref's version comment doesn't match the SHA
-  secrets-inherit: { disable: true }                   # `secrets: inherit` in reusable workflow calls
-  secrets-outside-env: { disable: true }               # secrets used outside `env:` blocks
-  self-hosted-runner: { disable: true }                # self-hosted runner usage on public repos
-  stale-action-refs: { disable: true }                 # uses: refs that are no longer maintained
-  superfluous-actions: { disable: true }               # action wraps a single trivial command
-  template-injection: { disable: true }                # ${{ }} expansion of attacker-controlled input
-  undocumented-permissions: { disable: true }          # permissions: blocks without comments
-  unpinned-images: { disable: true }                   # docker:// images using mutable tags
-  unpinned-tools: { disable: true }                    # asdf/mise/etc. tool versions not pinned
-  unredacted-secrets: { disable: true }                # secrets potentially printed in logs
-  unsound-condition: { disable: true }                 # if: conditions that always evaluate same way
-  unsound-contains: { disable: true }                  # contains() called with non-array
-  use-trusted-publishing: { disable: true }            # PyPI/npm trusted publishing missing
 
 # =============================================================================
 # Escape hatch #2 — inline comment on a single `uses:` line:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,90 @@
+# =============================================================================
+# zizmor.yml — pinning policy for the check-action-pins workflow
+#
+# Consumed by `zizmor --config .github/zizmor.yml`.
+#
+# Only the `unpinned-uses` rule is configured here — everything else zizmor
+# offers (template-injection, excessive-permissions, dangerous-triggers, etc.)
+# is intentionally left at default to keep this gate narrowly focused on
+# issue #25934. Add more rules under `rules:` later if you want zizmor to
+# do broader security review.
+# =============================================================================
+
+rules:
+  unpinned-uses:
+    config:
+      # `policies` maps action-owner globs to one of three pinning levels.
+      # Globs are matched in declared order; the FIRST match wins, so put
+      # specific patterns above general ones.
+      #
+      #   any       — no constraint; any ref (SHA, tag, branch) accepted.
+      #               Use for orgs you trust as much as your own source code.
+      #
+      #   ref-pin   — must have ANY explicit ref (SHA, tag, OR branch).
+      #               This is more permissive than it sounds: `@main` is
+      #               accepted because a branch is a "symbolic reference".
+      #               The only thing it rejects is a `uses:` with no `@ref`
+      #               at all (which is rare and usually a mistake anyway).
+      #
+      #   hash-pin  — must be a 40-char commit SHA. Tags AND branches both
+      #               fail. This is the strict, supply-chain-safe setting
+      #               and is what GitHub recommends for 3rd-party actions.
+      #
+      # Note: zizmor automatically skips local references (`uses: ./...`)
+      # for this rule — they're same-repo and outside the supply-chain
+      # threat model. So lines like `uses: ./.github/workflows/foo.yml`
+      # need no policy entry and never trigger this rule.
+      policies:
+        # GitHub-owned actions. Owned by GitHub, treated as platform.
+        # Tag refs (`@v6`) are accepted; tighten to `hash-pin` later
+        # once the rest of the repo is clean.
+        actions/*: ref-pin
+        github/*: ref-pin
+
+        # Camunda-owned actions and reusable workflows. Includes:
+        #   - camunda/infra-global-github-actions/* (maintained by infra
+        #     team; intentionally consumed at @main)
+        #   - camunda/camunda/.github/workflows/* (cross-branch reusable
+        #     workflow refs from this repo to itself)
+        #   - any other camunda/* repo
+        # `ref-pin` permits both `@main` and `@v1.2.3` here, which is
+        # what the infra team's contract requires. No exception entry
+        # needed for `camunda/infra-global-github-actions/setup-yarn-cache@main`
+        # — it's already covered.
+        camunda/*: ref-pin
+
+        # Catch-all: every external 3rd-party action MUST be SHA-pinned.
+        # This is the rule that issue #25934 is about. Any PR adding
+        # `geekyeggo/delete-artifact@v6` or `YunaBraska/java-info-action@main`
+        # will fail the check on the line that introduced it.
+        "*": hash-pin
+
+      # ---------------------------------------------------------------------
+      # Per-file ignores — escape hatch #1
+      # ---------------------------------------------------------------------
+      # If a *whole file* needs to be exempted (e.g. a vendor-provided
+      # workflow that we can't touch), list it here. Format:
+      #   - "path/to/workflow.yml"           # ignore every finding in file
+      #   - "path/to/workflow.yml:42"        # ignore line 42 only
+      #   - "path/to/workflow.yml:42:10"     # ignore line 42 col 10 only
+      # Paths are relative to the repo root. Composite-action files
+      # (`.github/actions/*/action.yml`) are NOT supported here — use
+      # the inline-comment escape hatch (#2 below) for those.
+    ignore: []
+
+# =============================================================================
+# Escape hatch #2 — inline comment on a single `uses:` line:
+#
+#   - uses: peter-evans/create-or-update-comment@v4 # zizmor: ignore[unpinned-uses]
+#
+# Optional trailing explanation is encouraged so reviewers know WHY:
+#
+#   - uses: vendor/action@v3 # zizmor: ignore[unpinned-uses] vendor only ships tags
+#
+# Multiple rules can be ignored with one comment by comma-separating:
+#
+#   - uses: foo/bar@v1 # zizmor: ignore[unpinned-uses,artipacked]
+#
+# Use sparingly — the inline form survives review better than a config
+# entry because the justification sits next to the offending line.
+# =============================================================================


### PR DESCRIPTION
**Throwaway PR — do not merge or review.**

Smoke-tests the `check-action-pins` gate added in #52554 by introducing a deliberately unpinned external action (`foo/bar@v1`) in a new workflow file. The workflow itself never runs (`workflow_dispatch` only, against a non-existent action) — its sole purpose is to exercise the gate's annotation pipeline.

Expected behavior:
- ✅ `check-action-pins` job runs (the new file matches `paths:`)
- ❌ It fails with a `::error::` annotation on the `uses: foo/bar@v1` line, citing `unpinned-uses`
- The PR shows a red required check

Once the failure is observed and screenshotted in #52554, this PR will be closed and the branch deleted.