### PR TITLE
fix: avoid NPE in call-hierarchy mapping when processDefinitionName is null

### DIFF
--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -1517,7 +1517,7 @@ public final class SearchQueryResponseMapper {
         .processInstanceKey(KeyUtil.keyToString(processInstanceEntity.processInstanceKey()))
         .processDefinitionKey(KeyUtil.keyToString(processInstanceEntity.processDefinitionKey()))
         .processDefinitionName(
-            processInstanceEntity.processDefinitionName().isBlank()
+            StringUtils.isBlank(processInstanceEntity.processDefinitionName())
                 ? processInstanceEntity.processDefinitionId()
                 : processInstanceEntity.processDefinitionName());
   }

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
@@ -14,6 +14,7 @@ import io.camunda.gateway.protocol.model.BatchOperationItemResponse;
 import io.camunda.gateway.protocol.model.BatchOperationItemResponse.StateEnum;
 import io.camunda.gateway.protocol.model.BatchOperationTypeEnum;
 import io.camunda.gateway.protocol.model.IncidentStateEnum;
+import io.camunda.gateway.protocol.model.ProcessInstanceCallHierarchyEntry;
 import io.camunda.search.entities.AuditLogEntity;
 import io.camunda.search.entities.AuditLogEntity.AuditLogActorType;
 import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
@@ -778,5 +779,68 @@ class SearchQueryResponseMapperTest {
     assertThat(result.getC8Links())
         .containsEntry("operate", "https://operate.example.com")
         .containsEntry("tasklist", "https://tasklist.example.com");
+  }
+
+  @Test
+  void shouldMapCallHierarchyEntryUsingProcessDefinitionNameWhenPresent() {
+    // given
+    final var entity = callHierarchyEntity("demoProcess", "Demo Process");
+
+    // when
+    final ProcessInstanceCallHierarchyEntry entry =
+        SearchQueryResponseMapper.toProcessInstanceCallHierarchyEntry(entity);
+
+    // then
+    assertThat(entry.getProcessInstanceKey()).isEqualTo("123");
+    assertThat(entry.getProcessDefinitionKey()).isEqualTo("456");
+    assertThat(entry.getProcessDefinitionName()).isEqualTo("Demo Process");
+  }
+
+  @Test
+  void shouldMapCallHierarchyEntryFallingBackToProcessDefinitionIdWhenNameIsNull() {
+    // given - regression coverage for #50011: BPMN deployed without a name
+    // attribute leaves processDefinitionName null and previously NPE'd here
+    final var entity = callHierarchyEntity("demoProcess", null);
+
+    // when
+    final ProcessInstanceCallHierarchyEntry entry =
+        SearchQueryResponseMapper.toProcessInstanceCallHierarchyEntry(entity);
+
+    // then
+    assertThat(entry.getProcessDefinitionName()).isEqualTo("demoProcess");
+  }
+
+  @Test
+  void shouldMapCallHierarchyEntryFallingBackToProcessDefinitionIdWhenNameIsBlank() {
+    // given
+    final var entity = callHierarchyEntity("demoProcess", "   ");
+
+    // when
+    final ProcessInstanceCallHierarchyEntry entry =
+        SearchQueryResponseMapper.toProcessInstanceCallHierarchyEntry(entity);
+
+    // then
+    assertThat(entry.getProcessDefinitionName()).isEqualTo("demoProcess");
+  }
+
+  private static ProcessInstanceEntity callHierarchyEntity(
+      final String processDefinitionId, final String processDefinitionName) {
+    return new ProcessInstanceEntity(
+        123L, // processInstanceKey
+        null, // rootProcessInstanceKey
+        processDefinitionId,
+        processDefinitionName,
+        1, // processDefinitionVersion
+        null, // processDefinitionVersionTag
+        456L, // processDefinitionKey
+        null, // parentProcessInstanceKey
+        null, // parentFlowNodeInstanceKey
+        OffsetDateTime.now(),
+        null, // endDate
+        ProcessInstanceState.ACTIVE,
+        false, // hasIncident
+        "tenant",
+        null, // treePath
+        null); // businessId
   }
 }


### PR DESCRIPTION
## Summary

Fixes the 500 returned by `GET /v2/process-instances/{key}/call-hierarchy` when the parent process was deployed without a `name` attribute, which is what's preventing the parent-process breadcrumb from rendering in Operate (Yulia's analysis on the issue).

Closes #50011

## Root cause

`gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java#toProcessInstanceCallHierarchyEntry` called `String.isBlank()` directly on `ProcessInstanceEntity.processDefinitionName()`:

```java
.processDefinitionName(
    processInstanceEntity.processDefinitionName().isBlank()
        ? processInstanceEntity.processDefinitionId()
        : processInstanceEntity.processDefinitionName());
```

When a BPMN process is deployed without a `<process name="…">` attribute, `processDefinitionName` is `null`, so `null.isBlank()` throws:

```
java.lang.NullPointerException: Cannot invoke "String.isBlank()" because the return value of "io.camunda.search.entities.ProcessInstanceEntity.processDefinitionName()" is null
```

The exception bubbles out of the mapper, the controller responds with HTTP 500, and the Operate UI — which builds the call-hierarchy breadcrumb from this endpoint — silently shows no link back to the parent process.

This was introduced in `b2665b5e8c7` ("feat: add PI call hierarchy endpoint for v2 API"). On `main` it was incidentally repaired by #51301 (NullAway rollout), but no targeted backport exists, so 8.9 is still affected.

## Fix

Switch to the null-safe Apache Commons `StringUtils.isBlank` (already imported in this file). Behavior preserved when name is non-blank or blank; when name is `null` we now correctly fall back to `processDefinitionId` instead of NPE'ing.

```diff
-            processInstanceEntity.processDefinitionName().isBlank()
+            StringUtils.isBlank(processInstanceEntity.processDefinitionName())
```

## Test plan

- [x] Added 3 unit tests in `SearchQueryResponseMapperTest`:
  - happy path (name present)
  - regression for #50011 (name `null` → falls back to `processDefinitionId`)
  - blank name (whitespace only → falls back)
- [x] Verified the regression test reproduces the **exact** NPE from the issue when the fix is reverted
- [x] `./mvnw verify -pl gateways/gateway-mapping-http -Dtest=SearchQueryResponseMapperTest`: 30/30 pass
- [ ] Manual verification on a cluster: deploy a parent process that calls a child process where the parent (or child) BPMN omits the `name` attribute, confirm Operate breadcrumb appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)