### PR TITLE
fix: defer transition completion until snapshot director is published

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotDirectorPartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotDirectorPartitionTransitionStep.java
@@ -69,31 +69,34 @@ public final class SnapshotDirectorPartitionTransitionStep implements PartitionT
               flushLog,
               new DbPositionSupplier(zeebeDb, continuousBackup));
 
-      final var future =
-          context.getActorSchedulingService().submitActor(director, SchedulingHints.cpuBound());
-      future.onComplete(
-          (ok, error) -> {
-            if (error == null) {
-              context.setSnapshotDirector(director);
-              context.getComponentHealthMonitor().registerComponent(director);
-              if (targetRole == Role.LEADER) {
-                server.addCommittedEntryListener(director);
+      // The returned future must not complete until the director has been published on the
+      // context. Otherwise the next transition step (SnapshotAfterMigrationTransitionStep) can
+      // race the submitActor callback and construct a MigrationSnapshotDirector with a null
+      // snapshot director, which then NPEs on its first scheduled forceSnapshot.
+      return context
+          .getActorSchedulingService()
+          .submitActor(director, SchedulingHints.cpuBound())
+          .thenApply(
+              ignored -> {
+                context.setSnapshotDirector(director);
+                context.getComponentHealthMonitor().registerComponent(director);
+                if (targetRole == Role.LEADER) {
+                  server.addCommittedEntryListener(director);
 
-                // Raft server will only notify if there is a new entry commited. If the node has
-                // just restarted or transitioned to leader, but there are no new processing records
-                // written or committed, the listener is not triggered. As a result the
-                // commitPosition in the snapshotDirector remain 0, thus preventing snapshots even
-                // if the state has changed after replaying previously committed events. Hence, set
-                // the commit position from the last record in the log stream.
-                try (final LogStreamReader logStreamReader =
-                    context.getLogStream().newLogStreamReader()) {
-                  final var commitPosition = logStreamReader.seekToEnd();
-                  director.onCommit(commitPosition);
+                  // Raft server will only notify if there is a new entry commited. If the node has
+                  // just restarted or transitioned to leader, but there are no new processing
+                  // records written or committed, the listener is not triggered. As a result the
+                  // commitPosition in the snapshotDirector remain 0, thus preventing snapshots
+                  // even if the state has changed after replaying previously committed events.
+                  // Hence, set the commit position from the last record in the log stream.
+                  try (final LogStreamReader logStreamReader =
+                      context.getLogStream().newLogStreamReader()) {
+                    final var commitPosition = logStreamReader.seekToEnd();
+                    director.onCommit(commitPosition);
+                  }
                 }
-              }
-            }
-          });
-      return future;
+                return null;
+              });
 
     } else {
       return CompletableActorFuture.completed(null);

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotDirectorPartitionTransitionStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotDirectorPartitionTransitionStepTest.java
@@ -115,6 +115,26 @@ class SnapshotDirectorPartitionTransitionStepTest {
   }
 
   @ParameterizedTest
+  @ArgumentsSource(TransitionsThatShouldInstallService.class)
+  void shouldPublishSnapshotDirectorBeforeFutureCompletes(
+      final Role currentRole, final Role targetRole) {
+    // regression for #43421: by the time the transition future completes, the snapshot director
+    // must be visible on the context. Otherwise the next transition step can read null and
+    // construct a MigrationSnapshotDirector that NPEs on its first forceSnapshot.
+    // given
+    initializeContext(currentRole);
+    step.prepareTransition(transitionContext, 1, targetRole).join();
+    final ActorFuture<Void> transition = step.transitionTo(transitionContext, 1, targetRole);
+
+    // when
+    schedulerExtension.workUntilDone();
+
+    // then
+    assertThat(transition.isDone()).isTrue();
+    assertThat(transitionContext.getSnapshotDirector()).isNotNull();
+  }
+
+  @ParameterizedTest
   @ArgumentsSource(TransitionsThatShouldDoNothing.class)
   void shouldNotReInstallSnapshotDirector(final Role currentRole, final Role targetRole) {
     // given


### PR DESCRIPTION
## Summary

`SnapshotDirectorPartitionTransitionStep` previously returned the `submitActor` future directly and set the director on the context inside that future's `onComplete` callback. That made the step's future contract dishonest: the future could complete before the director was actually published, letting `SnapshotAfterMigrationTransitionStep` read `context.getSnapshotDirector()` as null and construct a `MigrationSnapshotDirector` that NPEs on its first scheduled `forceSnapshot`. The affected partition then transitioned to INACTIVE on that broker.

In `RollingUpdateTest.shouldReplicateSnapshotAcrossVersions` this race was enough to break quorum: one broker is deliberately stopped, and if any other broker hit the race at startup the cluster lost its only usable replica for partition 1. That's the root cause of the flakiness in #51930.

The step now returns a fresh future that completes only after the director has been submitted *and* registered on the context (and, for leaders, after the committed-entry listener is wired up). Callers that chain on this future are guaranteed to see a fully-installed director. Submission failure completes the returned future exceptionally instead of leaving a half-installed director behind.

The new `shouldPublishSnapshotDirectorBeforeFutureCompletes` test pins the contract.

Closes #43421
Closes #51930