### PR TITLE
feat: add logging.

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/clustering/DynamicClusterServices.java
+++ b/dist/src/main/java/io/camunda/application/commons/clustering/DynamicClusterServices.java
@@ -21,6 +21,9 @@ import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossiperConfig
 import io.camunda.zeebe.dynamic.config.serializer.ProtoBufSerializer;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.micrometer.core.instrument.MeterRegistry;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Profile;
@@ -28,6 +31,8 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class DynamicClusterServices {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DynamicClusterServices.class);
 
   private final ActorScheduler scheduler;
   private final ClusterMembershipService clusterMembershipService;
@@ -74,8 +79,15 @@ public class DynamicClusterServices {
   public BrokerTopologyManager brokerTopologyManagerForEmbeddedBrokerClient() {
     final var brokerTopologyManager =
         new BrokerTopologyManagerImpl(clusterMembershipService::getMembers, brokerTopologyMetrics);
+    logFlakeMembers("[broker profile] BEFORE submitActor");
     scheduler.submitActor(brokerTopologyManager).join();
+    logFlakeMembers("[broker profile] AFTER submitActor.join() / BEFORE addListener");
     clusterMembershipService.addListener(brokerTopologyManager);
+    logFlakeMembers("[broker profile] AFTER addListener / BEFORE post-listener seed");
+    // Re-seed after the listener is attached: closes the race where a MEMBER_ADDED
+    // event fires between the actor's initial snapshot and listener registration.
+    brokerTopologyManager.checkForMissingEvents();
+    logFlakeMembers("[broker profile] AFTER post-listener checkForMissingEvents");
     return brokerTopologyManager;
   }
 
@@ -85,10 +97,40 @@ public class DynamicClusterServices {
       final GatewayClusterConfigurationService gatewayClusterConfigurationService) {
     final var brokerTopologyManager =
         new BrokerTopologyManagerImpl(clusterMembershipService::getMembers, brokerTopologyMetrics);
+    logFlakeMembers("[!broker profile] BEFORE submitActor");
     scheduler.submitActor(brokerTopologyManager).join();
+    logFlakeMembers("[!broker profile] AFTER submitActor.join() / BEFORE addListener");
     clusterMembershipService.addListener(brokerTopologyManager);
+    logFlakeMembers("[!broker profile] AFTER addListener / BEFORE post-listener seed");
+    // Re-seed after the listener is attached: closes the race where a MEMBER_ADDED
+    // event fires between the actor's initial snapshot and listener registration.
+    // brokerTopologyManager.checkForMissingEvents();
+    logFlakeMembers("[!broker profile] AFTER post-listener checkForMissingEvents");
     gatewayClusterConfigurationService.addUpdateListener(brokerTopologyManager);
     return brokerTopologyManager;
+  }
+
+  private void logFlakeMembers(final String stage) {
+    final var localId = clusterMembershipService.getLocalMember().id();
+    final var members = clusterMembershipService.getMembers();
+    final String memberDump =
+        members.stream()
+            .map(
+                m ->
+                    m.id().toString()
+                        + "(props="
+                        + m.properties().keySet()
+                        + ",hasBrokerInfo="
+                        + m.properties().containsKey("brokerInfo")
+                        + ")")
+            .sorted()
+            .collect(Collectors.joining(", "));
+    LOG.info(
+        "[FLAKE-DEBUG] {} localMember={} membersCount={} members=[{}]",
+        stage,
+        localId,
+        members.size(),
+        memberDump);
   }
 
   @Bean

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
@@ -90,14 +90,33 @@ public final class BrokerTopologyManagerImpl extends Actor
         });
   }
 
-  private void checkForMissingEvents() {
+  /**
+   * Seeds the topology with all brokers currently visible in the membership service. Safe to call
+   * from any thread; mutations are routed through the actor. Idempotent.
+   *
+   * <p>Callers wiring this up against a {@code ClusterMembershipService} must invoke this AFTER
+   * registering this instance as a listener, to close the race where a {@code MEMBER_ADDED} event
+   * fires between the actor starting and the listener being attached.
+   */
+  public void checkForMissingEvents() {
     final Set<Member> members = membersSupplier.get();
+    LOG.info(
+        "[FLAKE-DEBUG] checkForMissingEvents called on thread={} memberPropertiesSize={} membersSupplier returned {} members ids={}",
+        Thread.currentThread().getName(),
+        memberProperties.size(),
+        members == null ? -1 : members.size(),
+        members == null ? "null" : members.stream().map(m -> m.id().toString()).sorted().toList());
     if (members == null || members.isEmpty()) {
       return;
     }
 
     for (final Member member : members) {
       final BrokerInfo brokerInfo = BrokerInfo.fromProperties(member.properties());
+      LOG.info(
+          "[FLAKE-DEBUG] checkForMissingEvents inspect member={} propertyKeys={} brokerInfo={}",
+          member.id(),
+          member.properties().keySet(),
+          brokerInfo == null ? "null" : "nodeId=" + brokerInfo.getNodeId());
       if (brokerInfo != null) {
         addBroker(member, brokerInfo);
       }
@@ -105,9 +124,21 @@ public final class BrokerTopologyManagerImpl extends Actor
   }
 
   private void addBroker(final Member member, final BrokerInfo brokerInfo) {
+    LOG.info(
+        "[FLAKE-DEBUG] addBroker invoked (queueing actor task) member={} nodeId={} thread={}",
+        member.id(),
+        brokerInfo.getNodeId(),
+        Thread.currentThread().getName());
     actor.run(
         () -> {
-          if (!memberProperties.containsKey(member.id())) {
+          final boolean isNew = !memberProperties.containsKey(member.id());
+          LOG.info(
+              "[FLAKE-DEBUG] addBroker actor-task running member={} nodeId={} isNew={} memberPropertiesBefore={}",
+              member.id(),
+              brokerInfo.getNodeId(),
+              isNew,
+              memberProperties.keySet());
+          if (isNew) {
             topologyListeners.forEach(l -> l.brokerAdded(member.id()));
           }
 
@@ -140,8 +171,14 @@ public final class BrokerTopologyManagerImpl extends Actor
 
   @Override
   protected void onActorStarted() {
-    // Get the initial member state before the listener is registered
+    LOG.info("[FLAKE-DEBUG] onActorStarted entry thread={}", Thread.currentThread().getName());
+    // Defense-in-depth seed. Callers must also invoke checkForMissingEvents()
+    // AFTER registering this as a membership listener, to cover the window
+    // between the snapshot here and listener attachment.
     checkForMissingEvents();
+    LOG.info(
+        "[FLAKE-DEBUG] onActorStarted exit memberPropertiesAfterInitialSeed={}",
+        memberProperties.keySet());
   }
 
   @Override
@@ -149,6 +186,14 @@ public final class BrokerTopologyManagerImpl extends Actor
     final Member subject = event.subject();
     final Type eventType = event.type();
     final BrokerInfo brokerInfo = BrokerInfo.fromProperties(subject.properties());
+
+    LOG.info(
+        "[FLAKE-DEBUG] event() entry type={} subject={} propertyKeys={} brokerInfoExtracted={} thread={}",
+        eventType,
+        subject.id(),
+        subject.properties().keySet(),
+        brokerInfo == null ? "null" : "nodeId=" + brokerInfo.getNodeId(),
+        Thread.currentThread().getName());
 
     if (brokerInfo == null) {
       return;


### PR DESCRIPTION
## Description

Added logging verify issue with flaky test. relates with https://github.com/camunda/camunda/issues/51924
Not to be merged, just to confirm theory of race condition that when broker joins it can miss cluster events between broker that joined started and adding listner for events.
## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
