### PR TITLE
feat: add OpenAPI spec for AgentInstance command endpoints

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -172,6 +172,7 @@ components:
         - definition
         - metrics
         - limits
+        - tools
         - elementId
         - processInstanceKey
         - processDefinitionKey
@@ -198,6 +199,11 @@ components:
           description: The configured limits for this agent instance, set once at creation.
           allOf:
             - $ref: '#/components/schemas/AgentInstanceLimits'
+        tools:
+          description: The tools available to the agent.
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentTool'
         elementId:
           description: The BPMN element ID of the ad-hoc sub-process or AI agent task that owns this agent instance.
           allOf:
@@ -245,6 +251,22 @@ components:
         systemPrompt:
           type: string
           description: The system prompt configured for this agent instance.
+
+    AgentTool:
+      description: A tool available to the agent.
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          description: The tool name as visible to the LLM.
+        description:
+          type: string
+          description: A human-readable description of the tool.
+        elementId:
+          type: string
+          description: The BPMN element ID of the tool element within the ad-hoc sub-process.
 
     AgentInstanceMetrics:
       description: Aggregated metrics for an agent instance across all model calls.

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -82,6 +82,51 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.10"
 
+    patch:
+      x-eventually-consistent: false
+      tags:
+        - Agent instance
+      operationId: updateAgentInstance
+      summary: Update agent instance
+      description: |
+        Updates the mutable fields of an agent instance: status, metric counters, and
+        tools. Metric values are treated as deltas and applied immediately to the
+        aggregate counters. Tool updates replace the existing tool list. At least one of
+        status, metrics, or tools must be provided.
+      parameters:
+        - name: agentInstanceKey
+          in: path
+          required: true
+          description: The key of the agent instance to update.
+          schema:
+            $ref: 'keys.yaml#/components/schemas/AgentInstanceKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AgentInstanceUpdateRequest'
+      responses:
+        "204":
+          description: The agent instance was updated successfully.
+        "400":
+          $ref: 'common-responses.yaml#/components/responses/InvalidData'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "403":
+          $ref: 'common-responses.yaml#/components/responses/Forbidden'
+        "404":
+          description: |
+            The agent instance with the given key was not found.
+            More details are provided in the response body.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.10"
+
   /agent-instances/search:
     post:
       x-eventually-consistent: true
@@ -402,6 +447,57 @@ components:
           description: The system-generated key for the created agent instance.
           allOf:
             - $ref: 'keys.yaml#/components/schemas/AgentInstanceKey'
+
+    AgentInstanceMetricsDelta:
+      description: |
+        Metric increments to apply to the agent instance aggregate counters. The engine
+        accumulates these deltas into running totals on each UPDATED event. All fields
+        are optional; omit a field to leave the corresponding counter unchanged.
+      type: object
+      properties:
+        inputTokens:
+          type: integer
+          format: int64
+          minimum: 0
+          description: Increment to apply to the total input token counter.
+        outputTokens:
+          type: integer
+          format: int64
+          minimum: 0
+          description: Increment to apply to the total output token counter.
+        modelCalls:
+          type: integer
+          format: int64
+          minimum: 0
+          description: Increment to apply to the total model call counter.
+        toolCalls:
+          type: integer
+          format: int64
+          minimum: 0
+          description: Increment to apply to the total tool call counter.
+
+    AgentInstanceUpdateRequest:
+      description: |
+        Request to update the mutable state of an agent instance. At least one of
+        status, metrics, or tools must be provided.
+      type: object
+      properties:
+        status:
+          description: The new status of the agent instance.
+          allOf:
+            - $ref: '#/components/schemas/AgentInstanceStatusEnum'
+        metrics:
+          description: Metric increments to apply to the aggregate counters.
+          allOf:
+            - $ref: '#/components/schemas/AgentInstanceMetricsDelta'
+        tools:
+          description: |
+            The complete list of tools available to the agent, replacing any previously
+            stored tools. When provided, the engine replaces the existing tool list with
+            this value.
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentTool'
 
     ## Filters
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -40,6 +40,8 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+        "503":
+          $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
 
   /agent-instances/{agentInstanceKey}:
@@ -80,6 +82,8 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+        "503":
+          $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
 
     patch:

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -343,15 +343,19 @@ components:
       type: object
       required:
         - name
+        - description
+        - elementId
       properties:
         name:
           type: string
           description: The tool name as visible to the LLM.
         description:
           type: string
+          nullable: true
           description: A human-readable description of the tool.
         elementId:
           type: string
+          nullable: true
           description: The BPMN element ID of the tool element within the ad-hoc sub-process.
 
     AgentInstanceMetrics:

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -448,6 +448,8 @@ components:
     AgentInstanceCreationResult:
       description: Response returned after successfully creating an agent instance.
       type: object
+      x-semantic-provider:
+        - agentInstanceKey
       required:
         - agentInstanceKey
       properties:

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -1,6 +1,47 @@
 ## Endpoint definitions
 
 paths:
+  /agent-instances:
+    post:
+      x-eventually-consistent: false
+      tags:
+        - Agent instance
+      operationId: createAgentInstance
+      summary: Create agent instance
+      description: |
+        Creates a new agent instance. The returned key identifies the instance and must
+        be used in subsequent update and query calls.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AgentInstanceCreationRequest'
+      responses:
+        "200":
+          description: The agent instance was created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentInstanceCreationResult'
+        "400":
+          $ref: 'common-responses.yaml#/components/responses/InvalidData'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "403":
+          $ref: 'common-responses.yaml#/components/responses/Forbidden'
+        "404":
+          description: |
+            The elementInstanceKey does not correspond to an active element instance.
+            More details are provided in the response body.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.10"
+
   /agent-instances/{agentInstanceKey}:
     get:
       x-eventually-consistent: true
@@ -325,6 +366,42 @@ components:
         - THINKING
         - TOOL_CALLING
         - TOOL_DISCOVERY
+
+    AgentInstanceCreationRequest:
+      description: Request to create a new agent instance.
+      type: object
+      required:
+        - elementInstanceKey
+        - definition
+      properties:
+        elementInstanceKey:
+          description: |
+            The key of the AHSP or AI Agent Task element instance.
+            The engine uses this key to infer processInstanceKey, elementId,
+            processDefinitionKey, and tenantId.
+          allOf:
+            - $ref: 'keys.yaml#/components/schemas/ElementInstanceKey'
+        definition:
+          description: Static definition set once at creation.
+          allOf:
+            - $ref: '#/components/schemas/AgentInstanceDefinition'
+        limits:
+          description: |
+            Limits for the agent execution. When omitted, all limits default to -1
+            (no limit).
+          allOf:
+            - $ref: '#/components/schemas/AgentInstanceLimits'
+
+    AgentInstanceCreationResult:
+      description: Response returned after successfully creating an agent instance.
+      type: object
+      required:
+        - agentInstanceKey
+      properties:
+        agentInstanceKey:
+          description: The system-generated key for the created agent instance.
+          allOf:
+            - $ref: 'keys.yaml#/components/schemas/AgentInstanceKey'
 
     ## Filters
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
@@ -64,6 +64,8 @@ tags:
 
 paths:
   # Agent instance endpoints
+  /agent-instances:
+    $ref: 'agent-instances.yaml#/paths/~1agent-instances'
   /agent-instances/{agentInstanceKey}:
     $ref: 'agent-instances.yaml#/paths/~1agent-instances~1{agentInstanceKey}'
   /agent-instances/search:


### PR DESCRIPTION
## Description

Defines the REST API contract for the `AgentInstance` command endpoints and extends the query schema introduced in #52405 with tool visibility.

### What this PR introduces

Two new write endpoints and one query schema extension:

| Method   | Path                                        | Operation ID          |
|----------|---------------------------------------------|-----------------------|
| `POST`   | `/v2/agent-instances`                       | `createAgentInstance` |
| `PATCH`  | `/v2/agent-instances/{agentInstanceKey}`    | `updateAgentInstance` |

Both endpoints are `x-eventually-consistent: false` (synchronous, write to the engine record directly) and tagged `Agent instance`.

The query response schema (`AgentInstanceResult`) is also extended with a `tools` field, which was not yet present in #52405.

### Schema overview

- **`AgentTool`**: a tool available to the agent
  - `name` (required, as seen by the LLM)
  - `description` (optional)
  - `elementId` (optional, BPMN element ID of the tool within the ad-hoc sub-process).
- **`AgentInstanceCreationRequest`**:
  - `elementInstanceKey` (required — engine infers
  `processInstanceKey`, `elementId`, `processDefinitionKey`, `tenantId` from it)
  - `definition` (required)
  - `limits` (optional; defaults to `-1` / no limit when omitted)
- **`AgentInstanceCreationResult`**:
  - `agentInstanceKey` — the system-generated key to be used in all subsequent update and query calls.
- **`AgentInstanceMetricsDelta`**: (all optional, non-negative increments)
  - `inputTokens`
  - `outputTokens`
  - `modelCalls`
  - `toolCalls`
- **`AgentInstanceUpdateRequest`**: (at least one of the following must be provided)
  - `status` (optional)
  - `metrics` (optional delta)
  - `tools` (optional, full replacement list)

### Design decisions

#### Tools as a top-level mutable field (not part of `AgentInstanceDefinition`)
Tools known from the BPMN schema are available at job pickup, but MCP/A2A tools are only discovered during `TOOL_DISCOVERY` via network calls.
Making `tools` updatable via `PATCH` (with replace semantics) allows callers to push the tool list in two stages without requiring a separate endpoint.

#### Metric values are deltas, not absolute
The `PATCH` endpoint receives increments rather than totals. This keeps the update safe under retries: applying the same delta twice results in over-counting, but it avoids the read-modify-write race condition that absolute values would require.

#### `AgentInstanceCreationRequest` uses `elementInstanceKey` instead of explicit identity fields
The engine already has all the context it needs (process instance, element, definition, tenant) from the element instance key. Requiring callers to re-supply those fields would be redundant and error-prone.

### Scope and future work

This covers the engine-side contract only — controller, service layer, and persistence are tracked separately. The schema is intentionally minimal:

- Per-iteration/conversation-level metrics are not yet modelled
- A `FAILED` status is not included (failures are tracked as incidents on the element instance)
- `processDefinitionVersion` / `versionTag` identity fields may be added in a follow-up

## Related issues

Closes #51504
