### PR TITLE
feat: add custom CSS injection for the orchestration webapp

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -1122,6 +1122,7 @@ public class WebSecurityConfig {
                               "/tasklist/custom.css",
                               "/tasklist/favicon.ico",
                               "/webapp/assets/**",
+                              "/webapp/custom.css",
                               "/webapp/favicon.ico")
                           .permitAll()
                           .anyRequest()

--- a/webapp/client/apps/orchestration-cluster-webapp/index.prod.html
+++ b/webapp/client/apps/orchestration-cluster-webapp/index.prod.html
@@ -8,6 +8,7 @@
 		<meta name="theme-color" content="#000000" />
 		<meta name="description" content="Camunda Orchestration Cluster web application" />
 		<title>Orchestration Cluster</title>
+		<link rel="stylesheet" href="./custom.css" />
 	</head>
 	<body>
 		<noscript>You need to enable JavaScript to run this app.</noscript>

--- a/webapp/client/apps/orchestration-cluster-webapp/index.prod.html
+++ b/webapp/client/apps/orchestration-cluster-webapp/index.prod.html
@@ -8,7 +8,6 @@
 		<meta name="theme-color" content="#000000" />
 		<meta name="description" content="Camunda Orchestration Cluster web application" />
 		<title>Orchestration Cluster</title>
-		<link rel="stylesheet" href="./custom.css" />
 	</head>
 	<body>
 		<noscript>You need to enable JavaScript to run this app.</noscript>

--- a/webapp/client/apps/orchestration-cluster-webapp/vite.config.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/vite.config.ts
@@ -16,8 +16,6 @@ import viteReact from '@vitejs/plugin-react';
 import sbom from 'rollup-plugin-sbom';
 import {playwright} from '@vitest/browser-playwright';
 
-// Inject custom.css as the last stylesheet in <head> so operator overrides win over
-// the bundled Carbon theme.
 const injectCustomCss: PluginOption = {
 	name: 'inject-custom-css',
 	apply: 'build',

--- a/webapp/client/apps/orchestration-cluster-webapp/vite.config.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/vite.config.ts
@@ -20,6 +20,7 @@ import {playwright} from '@vitest/browser-playwright';
 // the bundled Carbon theme.
 const injectCustomCss: PluginOption = {
 	name: 'inject-custom-css',
+	apply: 'build',
 	transformIndexHtml: {
 		order: 'post',
 		handler: () => [

--- a/webapp/client/apps/orchestration-cluster-webapp/vite.config.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/vite.config.ts
@@ -16,6 +16,22 @@ import viteReact from '@vitejs/plugin-react';
 import sbom from 'rollup-plugin-sbom';
 import {playwright} from '@vitest/browser-playwright';
 
+// Inject custom.css as the last stylesheet in <head> so operator overrides win over
+// the bundled Carbon theme.
+const injectCustomCss: PluginOption = {
+	name: 'inject-custom-css',
+	transformIndexHtml: {
+		order: 'post',
+		handler: () => [
+			{
+				tag: 'link',
+				attrs: {rel: 'stylesheet', href: './custom.css'},
+				injectTo: 'head',
+			},
+		],
+	},
+};
+
 const basePlugins: PluginOption[] = [
 	devtools(),
 	tanstackRouter({
@@ -23,6 +39,7 @@ const basePlugins: PluginOption[] = [
 		autoCodeSplitting: true,
 	}),
 	viteReact(),
+	injectCustomCss,
 ];
 
 const config = defineConfig(({mode}) => ({

--- a/webapp/server/pom.xml
+++ b/webapp/server/pom.xml
@@ -52,6 +52,11 @@
     <!-- Spring -->
     <dependency>
       <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
       <artifactId>spring-beans</artifactId>
     </dependency>
 

--- a/webapp/server/src/main/java/io/camunda/webapp/rest/CustomCssController.java
+++ b/webapp/server/src/main/java/io/camunda/webapp/rest/CustomCssController.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapp.rest;
+
+import io.camunda.spring.utils.ConditionalOnWebappUiEnabled;
+import jakarta.annotation.PostConstruct;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.CacheControl;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@ConditionalOnWebappUiEnabled("tmp-webapp")
+public class CustomCssController {
+
+  static final String PATH = "/webapp/custom.css";
+
+  static final String CLASSPATH_LOCATION = "custom.css";
+
+  private static final Logger LOG = LoggerFactory.getLogger(CustomCssController.class);
+
+  private String customCssContent;
+
+  @PostConstruct
+  public void init() {
+    try {
+      final Resource resource = loadResource(CLASSPATH_LOCATION);
+      customCssContent = resource.getContentAsString(StandardCharsets.UTF_8);
+    } catch (final IOException e) {
+      LOG.error("Error when reading custom css file {}", CLASSPATH_LOCATION, e);
+      customCssContent = "";
+    }
+  }
+
+  @GetMapping(path = PATH, produces = "text/css")
+  public ResponseEntity<String> getCustomCss() {
+    return ResponseEntity.ok().cacheControl(CacheControl.noCache()).body(customCssContent);
+  }
+
+  public Resource loadResource(final String path) {
+    return new ClassPathResource(path);
+  }
+
+  public String getCustomCssContent() {
+    return customCssContent;
+  }
+}

--- a/webapp/server/src/main/java/io/camunda/webapp/rest/CustomCssController.java
+++ b/webapp/server/src/main/java/io/camunda/webapp/rest/CustomCssController.java
@@ -43,7 +43,7 @@ public class CustomCssController {
     try {
       customCssContent = resource.getContentAsString(StandardCharsets.UTF_8);
     } catch (final IOException e) {
-      LOG.error("Failed to read custom css file {}", CLASSPATH_LOCATION, e);
+      LOG.warn("Failed to read custom css file {}, custom styles disabled", CLASSPATH_LOCATION, e);
       customCssContent = "";
     }
   }

--- a/webapp/server/src/main/java/io/camunda/webapp/rest/CustomCssController.java
+++ b/webapp/server/src/main/java/io/camunda/webapp/rest/CustomCssController.java
@@ -34,11 +34,16 @@ public class CustomCssController {
 
   @PostConstruct
   public void init() {
+    final Resource resource = loadResource(CLASSPATH_LOCATION);
+    if (!resource.exists()) {
+      LOG.debug("No custom.css found on classpath — custom styles disabled");
+      customCssContent = "";
+      return;
+    }
     try {
-      final Resource resource = loadResource(CLASSPATH_LOCATION);
       customCssContent = resource.getContentAsString(StandardCharsets.UTF_8);
     } catch (final IOException e) {
-      LOG.error("Error when reading custom css file {}", CLASSPATH_LOCATION, e);
+      LOG.error("Failed to read custom css file {}", CLASSPATH_LOCATION, e);
       customCssContent = "";
     }
   }

--- a/webapp/server/src/test/java/io/camunda/webapp/rest/CustomCssControllerIT.java
+++ b/webapp/server/src/test/java/io/camunda/webapp/rest/CustomCssControllerIT.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapp.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.webapptest.TestWebappApplication;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.resttestclient.TestRestTemplate;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+/** Integration test for {@link CustomCssController}. */
+@SpringBootTest(classes = TestWebappApplication.class, webEnvironment = WebEnvironment.RANDOM_PORT)
+@AutoConfigureTestRestTemplate
+@ActiveProfiles("tmp-webapp")
+class CustomCssControllerIT {
+
+  @Autowired private TestRestTemplate restTemplate;
+
+  @Test
+  void shouldReturn200() {
+    // when
+    final ResponseEntity<String> response =
+        restTemplate.getForEntity(CustomCssController.PATH, String.class);
+
+    // then
+    assertThat(response.getStatusCode().value()).isEqualTo(200);
+  }
+
+  @Test
+  void shouldReturnTextCssContentType() {
+    // when
+    final ResponseEntity<String> response =
+        restTemplate.getForEntity(CustomCssController.PATH, String.class);
+
+    // then
+    final var contentType = response.getHeaders().getContentType();
+    assertThat(contentType).isNotNull();
+    assertThat(contentType.getType()).isEqualTo("text");
+    assertThat(contentType.getSubtype()).isEqualTo("css");
+  }
+
+  @Test
+  void shouldReturnNoCacheHeader() {
+    // when
+    final ResponseEntity<String> response =
+        restTemplate.getForEntity(CustomCssController.PATH, String.class);
+
+    // then — operators may swap custom.css between deployments; stale caches must not persist
+    assertThat(response.getHeaders().getCacheControl()).isEqualTo("no-cache");
+  }
+
+  @Test
+  void shouldReturnEmptyBodyWhenNoFilePresent() {
+    // when
+    final ResponseEntity<String> response =
+        restTemplate.getForEntity(CustomCssController.PATH, String.class);
+
+    // then — no custom.css on test classpath → body is empty/null, never a 404 error payload
+    assertThat(response.getBody()).isNullOrEmpty();
+  }
+}

--- a/webapp/server/src/test/java/io/camunda/webapp/rest/CustomCssControllerTest.java
+++ b/webapp/server/src/test/java/io/camunda/webapp/rest/CustomCssControllerTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapp.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.HttpStatus;
+
+@ExtendWith(MockitoExtension.class)
+class CustomCssControllerTest {
+
+  private CustomCssController controller;
+
+  @Mock private ClassPathResource mockResource;
+
+  @BeforeEach
+  void setUp() {
+    controller = spy(new CustomCssController());
+  }
+
+  @Test
+  void shouldLoadCustomCssOnInit() throws IOException {
+    // given
+    final String cssContent = "body { background-color: #f3f3f3; }";
+    doReturn(mockResource).when(controller).loadResource(CustomCssController.CLASSPATH_LOCATION);
+    when(mockResource.getContentAsString(any())).thenReturn(cssContent);
+
+    // when
+    controller.init();
+
+    // then
+    assertThat(controller.getCustomCssContent()).isEqualTo(cssContent);
+  }
+
+  @Test
+  void shouldFallbackToEmptyStringOnReadError() throws IOException {
+    // given
+    doReturn(mockResource).when(controller).loadResource(CustomCssController.CLASSPATH_LOCATION);
+    doThrow(new IOException("file not found")).when(mockResource).getContentAsString(any());
+
+    // when
+    controller.init();
+
+    // then — bean init must not throw; content degrades to empty
+    assertThat(controller.getCustomCssContent()).isEmpty();
+  }
+
+  @Test
+  void shouldReturn200WithCssContent() throws IOException {
+    // given
+    final String cssContent = "h1 { color: red; }";
+    doReturn(mockResource).when(controller).loadResource(any());
+    when(mockResource.getContentAsString(any())).thenReturn(cssContent);
+    controller.init();
+
+    // when
+    final var response = controller.getCustomCss();
+
+    // then
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isEqualTo(cssContent);
+  }
+
+  @Test
+  void shouldSetNoCacheHeader() throws IOException {
+    // given
+    doReturn(mockResource).when(controller).loadResource(any());
+    when(mockResource.getContentAsString(any())).thenReturn("");
+    controller.init();
+
+    // when
+    final var response = controller.getCustomCss();
+
+    // then — operators may swap the file between deployments; stale caches must not persist
+    assertThat(response.getHeaders().getCacheControl()).isEqualTo("no-cache");
+  }
+}

--- a/webapp/server/src/test/java/io/camunda/webapp/rest/CustomCssControllerTest.java
+++ b/webapp/server/src/test/java/io/camunda/webapp/rest/CustomCssControllerTest.java
@@ -40,6 +40,7 @@ class CustomCssControllerTest {
     // given
     final String cssContent = "body { background-color: #f3f3f3; }";
     doReturn(mockResource).when(controller).loadResource(CustomCssController.CLASSPATH_LOCATION);
+    when(mockResource.exists()).thenReturn(true);
     when(mockResource.getContentAsString(any())).thenReturn(cssContent);
 
     // when
@@ -50,15 +51,29 @@ class CustomCssControllerTest {
   }
 
   @Test
-  void shouldFallbackToEmptyStringOnReadError() throws IOException {
+  void shouldReturnEmptyStringWhenFileNotPresent() {
     // given
     doReturn(mockResource).when(controller).loadResource(CustomCssController.CLASSPATH_LOCATION);
-    doThrow(new IOException("file not found")).when(mockResource).getContentAsString(any());
+    when(mockResource.exists()).thenReturn(false);
 
     // when
     controller.init();
 
-    // then — bean init must not throw; content degrades to empty
+    // then — missing file is expected in most deployments; must not throw or log ERROR
+    assertThat(controller.getCustomCssContent()).isEmpty();
+  }
+
+  @Test
+  void shouldFallbackToEmptyStringOnReadError() throws IOException {
+    // given
+    doReturn(mockResource).when(controller).loadResource(CustomCssController.CLASSPATH_LOCATION);
+    when(mockResource.exists()).thenReturn(true);
+    doThrow(new IOException("disk error")).when(mockResource).getContentAsString(any());
+
+    // when
+    controller.init();
+
+    // then — genuine read failure degrades gracefully
     assertThat(controller.getCustomCssContent()).isEmpty();
   }
 
@@ -67,6 +82,7 @@ class CustomCssControllerTest {
     // given
     final String cssContent = "h1 { color: red; }";
     doReturn(mockResource).when(controller).loadResource(any());
+    when(mockResource.exists()).thenReturn(true);
     when(mockResource.getContentAsString(any())).thenReturn(cssContent);
     controller.init();
 
@@ -82,6 +98,7 @@ class CustomCssControllerTest {
   void shouldSetNoCacheHeader() throws IOException {
     // given
     doReturn(mockResource).when(controller).loadResource(any());
+    when(mockResource.exists()).thenReturn(true);
     when(mockResource.getContentAsString(any())).thenReturn("");
     controller.init();
 


### PR DESCRIPTION
## Description

Mirrors the custom CSS injection mechanism from Tasklist into the new unified orchestration webapp BFF. Adds a `GET /webapp/custom.css` endpoint that loads a classpath-mounted `custom.css` file at startup and serves it with `Cache-Control: no-cache`. A `<link rel="stylesheet" href="./custom.css" />` is added to the production HTML template.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #51314