### PR TITLE
fix: stabilize ControlledActorClockEndpointIT.testOffsetTime

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ControlledActorClockEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ControlledActorClockEndpointIT.java
@@ -94,21 +94,25 @@ final class ControlledActorClockEndpointIT {
     RecordingExporter.records().limit(1).await();
 
     // then - records are exported with a timestamp matching the offset time
+    // Snapshot records before sampling the upper bound so every record in the snapshot was
+    // produced before `Instant.now()` is read; otherwise async records (e.g. from the periodic
+    // job/usage metrics schedulers) can land between the sample and the assertion.
+    final var snapshot = RecordingExporter.getRecords().stream().toList();
     final var expectedUpperBound = Instant.now().plus(offset);
     final var expectedLowerBound = beforeRecords.plus(offset);
     assertThat(response.statusCode()).as("/add request was successful").isEqualTo(200);
     assertThat(response.body().instant())
         .as("returned instant is close to expected bound")
         .isCloseTo(expectedUpperBound, within(30, ChronoUnit.SECONDS));
-    assertThat(RecordingExporter.getRecords())
+    assertThat(snapshot)
         .as("all exported records after the /add request have an offset of 5 hours")
         .isNotEmpty()
         .allSatisfy(
             record ->
                 assertThat(Instant.ofEpochMilli(record.getTimestamp()))
                     .as("record has offset timestamp")
-                    .isBefore(expectedUpperBound)
-                    .isAfter(expectedLowerBound));
+                    .isBeforeOrEqualTo(expectedUpperBound)
+                    .isAfterOrEqualTo(expectedLowerBound));
   }
 
   private Builder buildRequest(final String operation) {


### PR DESCRIPTION
## Description

The test asserted that every record in `RecordingExporter.getRecords()` had a timestamp strictly before `Instant.now().plus(offset)`. Because the upper bound was sampled before the records were iterated, any record produced in the gap between the sample and the iteration — typically a periodic `JOB_METRICS_BATCH` / `USAGE_METRIC` emission from the metrics schedulers, which are not gated by `RecordingExporter.records().limit(1).await()` could legitimately carry a timestamp past the bound and fail the assertion.
                                                          
This fix snapshots the exporter records first and only then samples Instant.now() for the upper bound, guaranteeing every record in the snapshot was produced no later than the sample. Bounds are also relaxed from strict to inclusive, since equality at the boundary is now reachable and not an error.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes https://github.com/camunda/camunda/issues/51933
