### PR TITLE
feat: add API layer for authentication

### DIFF
--- a/webapp/client/apps/orchestration-cluster-webapp/src/main.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/main.tsx
@@ -9,12 +9,11 @@
 import ReactDOM from 'react-dom/client';
 import {RouterProvider, createRouter} from '@tanstack/react-router';
 import {routeTree} from './routeTree.gen';
-import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {QueryClientProvider} from '@tanstack/react-query';
 import './index.scss';
 import {ThemeProvider} from './modules/theme/ThemeProvider';
 import {tracking} from '#/modules/tracking';
-
-const queryClient = new QueryClient();
+import {reactQueryClient} from '#/modules/http/reactQueryClient';
 
 const router = createRouter({
 	routeTree,
@@ -22,7 +21,7 @@ const router = createRouter({
 	defaultPreloadStaleTime: 0,
 	scrollRestoration: true,
 	context: {
-		queryClient,
+		queryClient: reactQueryClient,
 	},
 });
 
@@ -40,7 +39,7 @@ if (!rootElement.innerHTML) {
 	tracking.loadAnalyticsToWillingUsers().finally(() => {
 		root.render(
 			<ThemeProvider>
-				<QueryClientProvider client={queryClient}>
+				<QueryClientProvider client={reactQueryClient}>
 					<RouterProvider router={router} />
 				</QueryClientProvider>
 			</ThemeProvider>,

--- a/webapp/client/apps/orchestration-cluster-webapp/src/modules/http/endpoints.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/modules/http/endpoints.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {getCurrentUser} from '@camunda/camunda-api-zod-schemas/8.10';
+
+const BASE_REQUEST_OPTIONS: RequestInit = {
+	credentials: 'include',
+	mode: 'cors',
+};
+
+// TODO: prepend getClientConfig().contextPath once getClientConfig is supported https://github.com/camunda/camunda/issues/51322
+function getFullURL(path: string) {
+	return new URL(path, window.location.origin);
+}
+
+const endpoints = {
+	login: (body: {username: string; password: string}) =>
+		new Request(getFullURL('/login'), {
+			...BASE_REQUEST_OPTIONS,
+			method: 'POST',
+			body: new URLSearchParams(body).toString(),
+			headers: {
+				'Content-Type': 'application/x-www-form-urlencoded',
+			},
+		}),
+
+	logout: () =>
+		new Request(getFullURL('/logout'), {
+			...BASE_REQUEST_OPTIONS,
+			method: 'POST',
+		}),
+
+	getCurrentUser: () =>
+		new Request(getFullURL(getCurrentUser.getUrl()), {
+			...BASE_REQUEST_OPTIONS,
+			method: getCurrentUser.method,
+			headers: {'Content-Type': 'application/json'},
+		}),
+};
+
+export {endpoints};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/modules/http/reactQueryClient.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/modules/http/reactQueryClient.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {QueryClient} from '@tanstack/react-query';
+
+const reactQueryClient = new QueryClient();
+
+export {reactQueryClient};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/modules/http/request.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/modules/http/request.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {reactQueryClient} from '#/modules/http/reactQueryClient';
+// TODO: uncomment when authenticationStore is available
+// import {authenticationStore} from '#/modules/auth/authentication';
+import {z} from 'zod';
+
+type RequestError =
+	| {
+			variant: 'network-error';
+			response: null;
+			networkError: unknown;
+	  }
+	| {
+			variant: 'failed-response';
+			response: Response;
+			networkError: null;
+	  };
+
+function getCsrfTokenFromStorage() {
+	return sessionStorage.getItem('X-CSRF-TOKEN');
+}
+
+async function request(
+	input: RequestInfo,
+	{skipSessionCheck} = {skipSessionCheck: false},
+): Promise<
+	| {
+			response: Response;
+			error: null;
+	  }
+	| {
+			response: null;
+			error: RequestError;
+	  }
+> {
+	try {
+		const csrfToken = getCsrfTokenFromStorage();
+		if (input instanceof Request) {
+			const method = input.method;
+
+			if (csrfToken && method && ['POST', 'PUT', 'PATCH', 'DELETE'].includes(method.toUpperCase())) {
+				input.headers.append('X-CSRF-TOKEN', csrfToken);
+			}
+		}
+
+		const response = await fetch(input);
+
+		if (response.ok) {
+			// TODO: uncomment when authenticationStore is available
+			// authenticationStore.activateSession();
+		}
+
+		const tokenFromResponse = response.headers.get('X-CSRF-TOKEN');
+
+		if (tokenFromResponse) {
+			sessionStorage.setItem('X-CSRF-TOKEN', tokenFromResponse);
+		}
+
+		if (!skipSessionCheck && response.status === 401) {
+			// TODO: uncomment when authenticationStore is available
+			// authenticationStore.disableSession();
+			reactQueryClient.clear();
+		}
+
+		if (response.ok) {
+			return {
+				response,
+				error: null,
+			};
+		}
+
+		return {
+			response: null,
+			error: {
+				response,
+				networkError: null,
+				variant: 'failed-response',
+			},
+		};
+	} catch (error) {
+		return {
+			response: null,
+			error: {
+				response: null,
+				networkError: error,
+				variant: 'network-error',
+			},
+		};
+	}
+}
+
+const requestErrorSchema = z.union([
+	z.object({
+		variant: z.literal('network-error'),
+		response: z.literal(null),
+		networkError: z.instanceof(Error),
+	}),
+	z.object({
+		variant: z.literal('failed-response'),
+		response: z.instanceof(Response),
+		networkError: z.literal(null),
+	}),
+]);
+
+export {request, requestErrorSchema};
+export type {RequestError};


### PR DESCRIPTION
## Description

This is only the first PR related to #51318 to keep PR size small, more PRs to follow.

- Add API layer for `/login`, `/logout` and `/authentication/me` API endpoints
- Copy `request.ts` from Tasklist

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

related to #51318 
