### PR TITLE
test: remove println leftover in test

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/BrokerAdminServiceEndpointTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/BrokerAdminServiceEndpointTest.java
@@ -94,7 +94,6 @@ public class BrokerAdminServiceEndpointTest {
     assertThat(response.statusCode()).isEqualTo(200);
 
     final var partitions = readPartitions(response);
-    System.out.println(partitions);
     assertThat(partitions).containsOnlyKeys(1);
     assertPartitionStatus(partitions.get(1));
   }


### PR DESCRIPTION
## Description
Removes a leftover println introduce only in this branch in PR #52548

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
