### PR TITLE
deps: update c8run versions to 8.8.24

### DIFF
--- a/c8run/.env
+++ b/c8run/.env
@@ -1,10 +1,10 @@
 ELASTICSEARCH_VERSION=8.17.3
 # this is the version of camunda/ zeebe
-CAMUNDA_VERSION=8.8.23
+CAMUNDA_VERSION=8.8.24
 # docker images moved to a shortened tag, override compose with this value when using --docker
-CAMUNDA_DOCKER_VERSION=8.8.23
+CAMUNDA_DOCKER_VERSION=8.8.24
 # Look here: https://artifacts.camunda.com/ui/native/connectors/io/camunda/connector/connector-runtime-bundle/
-CONNECTORS_VERSION=8.8.10
+CONNECTORS_VERSION=8.8.11
 # version of docker compose artifact (used for --docker option)
 COMPOSE_TAG=8.8
 COMPOSE_EXTRACTED_FOLDER=docker-compose-8.8


### PR DESCRIPTION
## Summary

- Bumps `CAMUNDA_VERSION` and `CAMUNDA_DOCKER_VERSION` from `8.8.23` → `8.8.24`
- Bumps `CONNECTORS_VERSION` from `8.8.10` → `8.8.11`

Required version bump before triggering the [C8Run Release workflow](https://github.com/camunda/camunda/actions/workflows/c8run-release.yaml) for the 8.8.24 public release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)