### PR TITLE
docs: improve c8run release process documentation

### DIFF
--- a/c8run/docs/release.md
+++ b/c8run/docs/release.md
@@ -3,8 +3,39 @@
 Releases are owned by `@camunda/distribution` and triggered manually via the
 [C8Run Release GitHub workflow](https://github.com/camunda/camunda/actions/workflows/c8run-release.yaml).
 
+---
+
+## Before You Start
+
+### 1. Check Docker Compose is released
+
 > [!WARNING]
 > Ensure the Docker Compose versions were released correctly prior to the C8Run release.
+
+The easiest place to verify this — and to look up all updated component versions at once — is the
+Renovate PR in [camunda/camunda-distributions](https://github.com/camunda/camunda-distributions/pulls)
+labelled `deps/docker-compose` and `version/8.x`. That PR shows the full version delta for
+Camunda, Connectors, and Docker Compose in one place. Wait for it to be merged before proceeding.
+
+### 2. Determine the versions to release
+
+Open the Renovate PR described above. The table at the top of the PR body lists every version
+change. Record:
+
+| `.env` variable      | Where to read it from                                |
+|----------------------|------------------------------------------------------|
+| `CAMUNDA_VERSION`    | `camunda/camunda` row in the Renovate PR             |
+| `CAMUNDA_DOCKER_VERSION` | Same as `CAMUNDA_VERSION`                        |
+| `CONNECTORS_VERSION` | `camunda/connectors-bundle` row in the Renovate PR   |
+| `ELASTICSEARCH_VERSION` | Only changes when Elasticsearch itself is bumped  |
+
+You can also cross-check that no c8run artifacts have been published yet for the target release:
+
+```bash
+gh release view <version> --repo camunda/camunda --json assets --jq '.assets[].name' | grep -i c8run
+```
+
+If there is no output, the c8run release has not been done yet.
 
 ---
 
@@ -18,14 +49,31 @@ For each version:
 2. Create a new branch from the version base branch:
    - `main` for the latest alpha.
    - `stable/8.8` for 8.8, etc.
-3. Update `./c8run/.env` with the correct versions and tags.
-   - For the Connectors version, check the [Camunda Artifacts repo](https://artifacts.camunda.com/ui/native/connectors/io/camunda/connector/connector-runtime-bundle/).
-4. Create a PR from the branch and get it merged.
+   - Branch name convention: `c8run-release-<version>` (e.g. `c8run-release-8.8.24`)
+3. Update `./c8run/.env` with the correct versions determined above.
+4. Commit with `deps: update c8run versions to <version>` and open a PR targeting the version
+   base branch (e.g. `stable/8.8`). Get it merged before triggering the workflow.
 
 ### 2. Artifact
 
-For each version, click **Run workflow** in the
-[C8Run Release GitHub workflow](https://github.com/camunda/camunda/actions/workflows/c8run-release.yaml):
+For each version, trigger the
+[C8Run Release GitHub workflow](https://github.com/camunda/camunda/actions/workflows/c8run-release.yaml)
+via the UI or the `gh` CLI:
+
+```bash
+gh workflow run c8run-release.yaml \
+  --repo camunda/camunda \
+  --ref main \
+  --field branch=stable/8.8 \
+  --field camundaVersion=8.8 \
+  --field camundaAppsRelease=8.8.24 \
+  --field publishToCamundaAppsRelease=true \
+  --field publishToCamundaDownloadCenter=false \
+  --field typePrerelease=false \
+  --field artifactVersionSuffix="-rc"
+```
+
+If using the UI instead:
 
 |                    Input                    |                            Value                            |
 |---------------------------------------------|-------------------------------------------------------------|
@@ -47,8 +95,22 @@ Then:
 
 ## Public Release
 
-For each version, click **Run workflow** in the
-[C8Run Release GitHub workflow](https://github.com/camunda/camunda/actions/workflows/c8run-release.yaml):
+For each version, trigger the workflow via the `gh` CLI:
+
+```bash
+gh workflow run c8run-release.yaml \
+  --repo camunda/camunda \
+  --ref main \
+  --field branch=stable/8.8 \
+  --field camundaVersion=8.8 \
+  --field camundaAppsRelease=8.8.24 \
+  --field publishToCamundaAppsRelease=true \
+  --field publishToCamundaDownloadCenter=true \
+  --field typePrerelease=false \
+  --field artifactVersionSuffix=""
+```
+
+If using the UI instead:
 
 |                    Input                    |                    Value                     |
 |---------------------------------------------|----------------------------------------------|

--- a/c8run/docs/release.md
+++ b/c8run/docs/release.md
@@ -22,17 +22,22 @@ Camunda, Connectors, and Docker Compose in one place. Wait for it to be merged b
 Open the Renovate PR described above. The table at the top of the PR body lists every version
 change. Record:
 
-|     `.env` variable      |               Where to read it from                |
-|--------------------------|----------------------------------------------------|
-| `CAMUNDA_VERSION`        | `camunda/camunda` row in the Renovate PR           |
-| `CAMUNDA_DOCKER_VERSION` | Same as `CAMUNDA_VERSION`                          |
-| `CONNECTORS_VERSION`     | `camunda/connectors-bundle` row in the Renovate PR |
-| `ELASTICSEARCH_VERSION`  | Only changes when Elasticsearch itself is bumped   |
+These two variables are the ones you will update in `./c8run/.env`:
+
+| `./c8run/.env` variable |               Where to read it from                |
+|-------------------------|----------------------------------------------------|
+| `CAMUNDA_VERSION`       | `camunda/camunda` row in the Renovate PR           |
+| `CONNECTORS_VERSION`    | `camunda/connectors-bundle` row in the Renovate PR |
+
+> **Note:** `CAMUNDA_DOCKER_VERSION` and `ELASTICSEARCH_VERSION` are **not** part of `./c8run/.env`
+> — they belong to the Docker Compose distribution and are managed separately in
+> `camunda/camunda-distributions`.
 
 You can also cross-check that no c8run artifacts have been published yet for the target release:
 
 ```bash
-gh release view <version> --repo camunda/camunda --json assets --jq '.assets[].name' | grep -i c8run
+gh release view <version> --repo camunda/camunda --json assets --jq '.assets[].name' 2>/dev/null \
+  | grep 'camunda8-run-' || echo "No c8run artifacts found (or release does not exist yet)"
 ```
 
 If there is no output, the c8run release has not been done yet.

--- a/c8run/docs/release.md
+++ b/c8run/docs/release.md
@@ -22,12 +22,12 @@ Camunda, Connectors, and Docker Compose in one place. Wait for it to be merged b
 Open the Renovate PR described above. The table at the top of the PR body lists every version
 change. Record:
 
-| `.env` variable      | Where to read it from                                |
-|----------------------|------------------------------------------------------|
-| `CAMUNDA_VERSION`    | `camunda/camunda` row in the Renovate PR             |
-| `CAMUNDA_DOCKER_VERSION` | Same as `CAMUNDA_VERSION`                        |
-| `CONNECTORS_VERSION` | `camunda/connectors-bundle` row in the Renovate PR   |
-| `ELASTICSEARCH_VERSION` | Only changes when Elasticsearch itself is bumped  |
+|     `.env` variable      |               Where to read it from                |
+|--------------------------|----------------------------------------------------|
+| `CAMUNDA_VERSION`        | `camunda/camunda` row in the Renovate PR           |
+| `CAMUNDA_DOCKER_VERSION` | Same as `CAMUNDA_VERSION`                          |
+| `CONNECTORS_VERSION`     | `camunda/connectors-bundle` row in the Renovate PR |
+| `ELASTICSEARCH_VERSION`  | Only changes when Elasticsearch itself is bumped   |
 
 You can also cross-check that no c8run artifacts have been published yet for the target release:
 


### PR DESCRIPTION
## Summary

Improves `c8run/docs/release.md` based on lessons learned during the 8.8.24 release:

- Add **"Before You Start"** section explaining how to find the correct versions to release via the Renovate PR in `camunda-distributions` (one-stop source for Camunda, Connectors, and Docker Compose versions)
- Add `gh` CLI snippet to check whether c8run artifacts already exist for a given release
- Add branch naming convention for version bump PRs (`c8run-release-<version>`)
- Add ready-to-run `gh workflow run` CLI commands for both RC and public release workflows, alongside the existing UI table

## Test plan

- [ ] Docs render correctly in GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)