### PR TITLE
docs: create orchestration cluster docs

### DIFF
--- a/docs/monorepo-docs/frontend/adr/adr.md
+++ b/docs/monorepo-docs/frontend/adr/adr.md
@@ -1,3 +1,17 @@
 # Architecture Decision Records
 
-_Content coming soon._
+An Architecture Decision Record (ADR) is a short document that
+captures a single architectural decision, the context behind it, the
+alternatives that were considered, and the consequences that follow.
+The goal is to give future engineers a clear answer to "why was this
+built this way?" without having to dig through Slack threads or old
+Google Docs. ADRs live in `webapp/client/adrs/`. Only write an ADR
+when the decision is final.
+
+## Creating an ADR
+
+Use the Camunda
+[create-architecture-decision](https://github.com/camunda/.github/blob/main/skills/create-architecture-decision/SKILL.md)
+AI skill. It guides you through the full workflow: source review,
+decision framing, drafting, file naming, and cross-referencing. Use it
+as the default way to create ADRs.

--- a/docs/monorepo-docs/frontend/adr/adr.md
+++ b/docs/monorepo-docs/frontend/adr/adr.md
@@ -1,0 +1,3 @@
+# Architecture Decision Records
+
+_Content coming soon._

--- a/docs/monorepo-docs/frontend/camunda-api-zod-schemas.md
+++ b/docs/monorepo-docs/frontend/camunda-api-zod-schemas.md
@@ -1,0 +1,50 @@
+# Camunda API Zod schemas
+
+`@camunda/camunda-api-zod-schemas` is a community-driven open-source
+package that provides [Zod](https://zod.dev/) schemas and TypeScript
+types for the Camunda 8 REST API. It helps developers build robust,
+type-safe applications when interacting with Camunda 8.
+
+Official Camunda 8 REST API reference:
+[docs.camunda.io](https://docs.camunda.io/docs/next/apis-tools/camunda-api-rest/camunda-api-rest-overview/).
+
+Inside this monorepo, the package is consumed directly via the npm
+workspace by `@camunda/orchestration-cluster-webapp`, and via published
+versions by the legacy `operate/client`, `tasklist/client`, and
+`identity/client` frontends.
+
+## Installation
+
+```bash
+# pnpm
+pnpm add @camunda/camunda-api-zod-schemas
+
+# npm
+npm install @camunda/camunda-api-zod-schemas
+
+# yarn
+yarn add @camunda/camunda-api-zod-schemas
+```
+
+## Usage
+
+The library exports modules that correspond to the different parts of
+the Camunda API. Import schemas and types from the main package or from
+a specific version sub-module — `@camunda/camunda-api-zod-schemas/8.8`,
+`/8.9`, or `/8.10`.
+
+For the full list of exported schemas and types, refer to the source
+under `packages/camunda-api-zod-schemas/lib/` — for example
+`packages/camunda-api-zod-schemas/lib/8.8/index.ts`.
+
+## Publishing a new version
+
+1. Increment the version in `package.json`, update the dependency
+   version in any consumer npm workspace packages, run `npm i`, and
+   push the changes to `main`.
+2. Run the [Publish Zod Schemas to npm](https://github.com/camunda/camunda/actions/workflows/publish-zod-schemas.yml)
+   GitHub Action.
+   - The dry-run option is enabled by default. Uncheck it to publish
+     the new version.
+3. Update the `@camunda/camunda-api-zod-schemas` dependency version in
+   Operate, Admin, and Tasklist.

--- a/docs/monorepo-docs/frontend/camunda-api-zod-schemas.md
+++ b/docs/monorepo-docs/frontend/camunda-api-zod-schemas.md
@@ -49,3 +49,14 @@ under `packages/camunda-api-zod-schemas/lib/` — for example
      the new version.
 3. Update the `@camunda/camunda-api-zod-schemas` dependency version in
    Operate, Admin, and Tasklist.
+
+### When the schema update is part of a new feature
+
+1. Update the schema and changelog, increment the version in
+   `package.json`, and open a PR.
+2. Merge the PR to `main`.
+3. Immediately publish the new version from `main` using the GitHub
+   Action above.
+4. Open follow-up PRs in Operate, Tasklist, and Admin bumping
+   `@camunda/camunda-api-zod-schemas` to the new version.
+5. Use the updated schema in the feature PR.

--- a/docs/monorepo-docs/frontend/camunda-api-zod-schemas.md
+++ b/docs/monorepo-docs/frontend/camunda-api-zod-schemas.md
@@ -39,7 +39,8 @@ under `packages/camunda-api-zod-schemas/lib/` — for example
 
 ## Publishing a new version
 
-1. Increment the version in `package.json`, update the dependency
+1. Increment the version in the `camunda-api-zod-schemas` `package.json`
+   (this is manual for now; we plan to automate it in the future), update the dependency
    version in any consumer npm workspace packages, run `npm i`, and
    push the changes to `main`.
 2. Run the [Publish Zod Schemas to npm](https://github.com/camunda/camunda/actions/workflows/publish-zod-schemas.yml)

--- a/docs/monorepo-docs/frontend/code-reviews.md
+++ b/docs/monorepo-docs/frontend/code-reviews.md
@@ -1,0 +1,3 @@
+# Code reviews
+
+_Content coming soon._

--- a/docs/monorepo-docs/frontend/code-reviews.md
+++ b/docs/monorepo-docs/frontend/code-reviews.md
@@ -1,3 +1,37 @@
 # Code reviews
 
-_Content coming soon._
+Our baseline is the Camunda-wide review guide in
+[CONTRIBUTING.md](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#reviewing-a-pull-request)
+and the
+[Pull Requests and Code Reviews wiki](https://github.com/camunda/camunda/wiki/Pull-Requests-and-Code-Reviews).
+This page adds frontend-specific expectations.
+
+## Reviewer responsibility
+
+You share ownership of the code you approve. Approving a PR means you
+are confident it meets our standards and does what the PR and issue
+description say it does.
+
+## What to check
+
+- Code follows project conventions: data loading, routing, modules,
+  forms, and testing patterns from the sibling docs in this section.
+- The PR does what the issue and PR description describe. The PR might contain small unrelated improvements but the reviewer should ensure they are minor and do not overwhelm the PR.
+- No leftover AI artifacts: redundant comments, unnecessary
+  abstractions, dead code.
+- Tests cover the change meaningfully.
+
+## Manual testing
+
+Before approving, run the feature locally:
+
+- Check the happy path end to end.
+- Try 1-2 error cases (network failure, invalid input, 403, empty
+  state).
+
+## Emoji code
+
+We use the emoji code documented in
+[CONTRIBUTING.md](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#review-emoji-code)
+to express the intent of review comments (required change, suggestion,
+question, etc.).

--- a/docs/monorepo-docs/frontend/code-style.md
+++ b/docs/monorepo-docs/frontend/code-style.md
@@ -1,3 +1,49 @@
 # Code style
 
-_Content coming soon._
+General style conventions for the orchestration-cluster webapp
+codebase. Linting and formatting are enforced by the shared
+`@camunda/lint-config` package.
+
+## YAGNI
+
+Don't build what you don't need yet. No abstractions for hypothetical
+future use. Wait until a real requirement forces the shape. Three
+similar lines beat a premature wrapper.
+
+## Naming
+
+- **Booleans**: prefix with `is` (e.g. `isLoading`, `isVisible`).
+- **Constants**: `SCREAMING_SNAKE_CASE` (e.g. `MAX_RETRY_COUNT`).
+- **Components**: `PascalCase` (e.g. `DashboardHeader`).
+
+## Exports
+
+Use a single export block at the end of the file. Do not use inline
+`export` on declarations.
+
+```ts
+// good
+function parseInput(raw: string) { ... }
+function formatOutput(data: Data) { ... }
+
+export {parseInput, formatOutput};
+
+// avoid
+export function parseInput(raw: string) { ... }
+export function formatOutput(data: Data) { ... }
+```
+
+## Comments
+
+Avoid comments. The code should be readable enough to explain itself.
+When a comment is necessary, explain why, not how.
+
+```ts
+// good
+// The API returns dates as Unix seconds, not milliseconds.
+const timestamp = raw * 1000;
+
+// bad
+// Multiply raw by 1000.
+const timestamp = raw * 1000;
+```

--- a/docs/monorepo-docs/frontend/code-style.md
+++ b/docs/monorepo-docs/frontend/code-style.md
@@ -1,0 +1,3 @@
+# Code style
+
+_Content coming soon._

--- a/docs/monorepo-docs/frontend/code-style.md
+++ b/docs/monorepo-docs/frontend/code-style.md
@@ -12,7 +12,7 @@ similar lines beat a premature wrapper.
 
 ## Naming
 
-- **Booleans**: prefix with `is` (e.g. `isLoading`, `isVisible`).
+- **Booleans**: prefix with `is` or `has` (e.g. `isLoading`, `isVisible`, `hasIncident`).
 - **Constants**: `SCREAMING_SNAKE_CASE` (e.g. `MAX_RETRY_COUNT`).
 - **Components**: `PascalCase` (e.g. `DashboardHeader`).
 

--- a/docs/monorepo-docs/frontend/data-loading.md
+++ b/docs/monorepo-docs/frontend/data-loading.md
@@ -1,3 +1,177 @@
 # Data loading
 
-_Content coming soon._
+Data fetching in `@camunda/orchestration-cluster-webapp` uses
+[TanStack Router](https://tanstack.com/router/latest) for route-level
+loaders and [TanStack Query](https://tanstack.com/query/latest) for
+server-state caching. This page defines the order of preference for
+data-loading patterns in the app. For background, see the
+[TanStack Router data-loading guide](https://tanstack.com/router/latest/docs/framework/react/guide/data-loading).
+
+## Stack
+
+- **TanStack Router** — route loaders, link preloading, suspense integration.
+- **TanStack Query** — server-state cache, suspense queries, mutations.
+
+## Order of preference
+
+The tiers below are listed in descending order of preference. Pick the
+highest option that fits the page; drop a tier only when a constraint
+forces it.
+
+### 1. Route loader + suspense queries
+
+The route loader prefetches via `queryClient.ensureQueryData`; the
+component reads the same options via `useSuspenseQuery`.
+
+```tsx
+// src/routes/_auth/profile.tsx
+import { createFileRoute } from "@tanstack/react-router";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { currentUserQueryOptions } from "#/modules/http/queries";
+import { MyUserComponent } from "#/modules/my-account/components/MyUserComponent";
+
+export const Route = createFileRoute("/_auth/profile")({
+  loader: ({ context: { queryClient } }) => {
+    // route will only render once this promise resolves, so we can await or return it
+    return queryClient.ensureQueryData(currentUserQueryOptions);
+  },
+  component: Profile,
+});
+
+function Profile() {
+  const { data: user } = useSuspenseQuery(currentUserQueryOptions);
+  return <MyUserComponent user={user} />;
+}
+```
+
+`queryOptions` constants live in `#/modules/http/queries.ts` (or
+co-located with the owning module). Loader and component import the
+same reference so the cache key and fetcher stay in sync.
+
+### 2. Route loader + `pendingComponent`
+
+Same shape as Tier 1, plus `pendingComponent` so the router falls back
+to a placeholder instead of freezing the previous page when the loader
+takes too long.
+
+```tsx
+// src/routes/_auth/dashboard.tsx
+import { createFileRoute } from "@tanstack/react-router";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { dashboardQueryOptions } from "#/modules/http/queries";
+import { DashboardSkeleton } from "#/modules/dashboard/components/DashboardSkeleton";
+import { MyDashboard } from "#/modules/dashboard/components/MyDashboard";
+
+export const Route = createFileRoute("/_auth/dashboard")({
+  loader: ({ context: { queryClient } }) => {
+    queryClient.ensureQueryData(dashboardQueryOptions);
+  },
+  pendingComponent: DashboardSkeleton,
+  component: Dashboard,
+});
+
+function Dashboard() {
+  const { data } = useSuspenseQuery(dashboardQueryOptions);
+  return <MyDashboard data={data} />;
+}
+```
+
+Tune `pendingMs` (default 1000ms) and `pendingMinMs` per route, or set
+`defaultPendingComponent` and `defaultPendingMs` on `createRouter` to
+apply globally.
+
+### 3. Route loader + streamed promises + granular skeletons
+
+The loader awaits the fast slice via `ensureQueryData` and
+fires-and-forgets the slow one via `prefetchQuery`. The slow slice is
+wrapped in its own `<Suspense>` so the fast content paints immediately
+and a skeleton stands in for the slow part until it resolves.
+
+```tsx
+// src/routes/_auth/dashboard.tsx
+import { Suspense } from "react";
+import { createFileRoute } from "@tanstack/react-router";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import {
+  dashboardSummaryQueryOptions,
+  dashboardMetricsQueryOptions,
+} from "#/modules/http/queries";
+import { MetricsPanelSkeleton } from "#/modules/dashboard/components/MetricsPanelSkeleton";
+import { Metrics } from "#/modules/dashboard/components/Metrics";
+
+export const Route = createFileRoute("/_auth/dashboard")({
+  loader: async ({ context: { queryClient } }) => {
+    // await the fast query
+    await queryClient.prefetchQuery(dashboardSummaryQueryOptions);
+
+    // fire-and-forget the slow query
+    queryClient.ensureQueryData(dashboardMetricsQueryOptions);
+  },
+  component: Dashboard,
+});
+
+function Dashboard() {
+  const { data: summary } = useSuspenseQuery(dashboardSummaryQueryOptions);
+  return (
+    <main>
+      <h1>{summary.title}</h1>
+      <Suspense fallback={<MetricsPanelSkeleton />}>
+        {/*.Consumes dashboardMetricsQueryOptions */}
+        <Metrics />
+      </Suspense>
+    </main>
+  );
+}
+```
+
+Pick this over Tier 2 only when the slow slice is isolated and the rest
+of the page renders fast — otherwise Tier 2 is simpler.
+
+## Error handling
+
+The default is `errorComponent` on the route. The `queryFn` throws on
+failure, so Query rejects, the loader rejects, and the router renders
+`errorComponent` in place of the route component.
+
+```tsx
+// src/routes/_auth/profile.tsx
+import {
+  createFileRoute,
+  type ErrorComponentProps,
+} from "@tanstack/react-router";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { currentUserQueryOptions } from "#/modules/http/queries";
+
+export const Route = createFileRoute("/_auth/profile")({
+  loader: ({ context: { queryClient } }) =>
+    queryClient.ensureQueryData(currentUserQueryOptions),
+  errorComponent: ProfileError,
+  component: Profile,
+});
+
+function ProfileError({ error, reset }: ErrorComponentProps) {
+  return (
+    <main>
+      <h1>Could not load profile</h1>
+      <p>{error.message}</p>
+      <button onClick={reset}>Retry</button>
+    </main>
+  );
+}
+
+function Profile() {
+  const { data: user } = useSuspenseQuery(currentUserQueryOptions);
+  return <h1>Hello, {user.displayName}</h1>;
+}
+```
+
+Set `defaultErrorComponent` on `createRouter` for a global fallback.
+Reach for a component-level `<ErrorBoundary>` only when the rest of
+the page should keep rendering. 401s are handled centrally by the
+`request()` wrapper (cache clear + login redirect), so `errorComponent`
+covers everything else.
+
+## References
+
+- [TanStack Router — Data Loading](https://tanstack.com/router/latest/docs/guide/data-loading)
+- [TanStack Query — Suspense](https://tanstack.com/query/latest/docs/framework/react/guides/suspense)

--- a/docs/monorepo-docs/frontend/data-loading.md
+++ b/docs/monorepo-docs/frontend/data-loading.md
@@ -1,0 +1,3 @@
+# Data loading
+
+_Content coming soon._

--- a/docs/monorepo-docs/frontend/development-process/before-starting.md
+++ b/docs/monorepo-docs/frontend/development-process/before-starting.md
@@ -56,6 +56,16 @@ Default to pessimistic UI. Reach for optimistic updates only with an
 explicit reconciliation plan, because the next read may not show your write
 yet.
 
+## Does the page need live data?
+
+Not every page needs to poll. Default to static loads — fetch once on
+mount. Add `refetchInterval` on the `useSuspenseQuery` only when the
+page must reflect server-side changes without user interaction (e.g., a
+running process instance view, a task inbox). Polling adds complexity
+to tests because assertions must account for ongoing background
+requests. Keep the interval as slow as acceptable. See
+[Data loading](../data-loading.md) for the query patterns.
+
 ## Does it trigger a long-running operation?
 
 Batch operations don't complete inline. The POST returns a

--- a/docs/monorepo-docs/frontend/development-process/before-starting.md
+++ b/docs/monorepo-docs/frontend/development-process/before-starting.md
@@ -1,3 +1,78 @@
 # Things to consider before starting
 
-_Content coming soon._
+Before planning a feature in `@camunda/orchestration-cluster-webapp`,
+work through the questions below. Each one touches a Camunda-specific
+behavior that shapes the page architecture. The answers below are our
+defaults. Deviate only with a good reason.
+
+## Are the endpoints already in `@camunda/camunda-api-zod-schemas`?
+
+The orchestration-cluster webapp consumes the API through
+`@camunda/camunda-api-zod-schemas`, which is currently hand-written.
+Generation from the OpenAPI spec is on the roadmap but not in place
+yet. Before you start, check whether the endpoints your feature needs
+are already exported. If they aren't, add them to the package as part
+of your work. See
+[Camunda API Zod schemas](../camunda-api-zod-schemas.md) for the
+package layout and conventions.
+
+## Does the data paginate?
+
+Most list endpoints in the Camunda API paginate. Check the OpenAPI spec
+for the endpoints you'll consume. If they do, our default is infinite
+scrolling with `useSuspenseInfiniteQuery` from TanStack Query, and virtualized
+rows when the list can grow unbounded. For other styles of pagination we must consult with the design team. The
+API supports three cursor shapes: offset (`from` / `limit`),
+cursor-forward (`after`), and cursor-backward (`before`). The default
+`limit` is 100, with a max of `10000`. Trust `hasMoreTotalItems`, not
+`totalItems`. Prefer cusror-based pagination when possible, as it's more robust due to performance reasons.
+
+## Does the feature need permission handling?
+
+Authorization is enforced server-side. Our convention splits
+by interaction type:
+
+- **Actions**: leave the button visible. If the call returns 403,
+  surface a toast and re-enable the control.
+- **Data loads**: render a forbidden state. Use a page-level forbidden
+  view when the entire page is gated; use a section-level forbidden
+  view when only one panel is.
+
+A 403 can also mean the feature is disabled for this deployment
+(secondary storage off, license missing, OIDC-managed users). The
+forbidden state handles both shapes equally well.
+
+## Is the read eventually consistent?
+
+Commands (Zeebe) are strongly consistent. Reads from secondary storage
+(Elasticsearch, OpenSearch, RDBMS) are eventually consistent. The
+OpenAPI spec flags each operation with `x-eventually-consistent`. If
+yours does, plan to poll: there is no SSE or WebSocket today. Use
+`refetchInterval` on the relevant query and tune the cadence to the
+endpoint (~1s for fresh-task polling, ~5s for batch progress, slower
+otherwise).
+
+Default to pessimistic UI. Reach for optimistic updates only with an
+explicit reconciliation plan, because the next read may not show your write
+yet.
+
+## Does it trigger a long-running operation?
+
+Batch operations don't complete inline. The POST returns a
+`batchOperationKey`, and the FE polls
+`GET /v2/batch-operations/{key}` for the state (`PENDING`,
+`PROCESSING`, `COMPLETED`, `FAILED`, `CANCELED`). Cancellation is a
+separate `POST /v2/batch-operations/{key}/cancellation`. Our default
+is to show a toast confirming the action has been submitted, poll the
+backend in the background, and surface the final result via toast or
+inline once it lands. Never block the page on the poll. Reach for
+optimistic updates to the list or page only when necessary. The poll
+is the source of truth.
+
+## Is the feature tenant-aware?
+
+Multi-tenancy is a deployment-level toggle. The default tenant is
+`<default>`, and every list endpoint accepts a tenant filter. Branch
+your UI on based on the cluster configuration: render the tenant
+picker, columns, and filters only when it's on. Always pass the active
+tenant in requests when it is.

--- a/docs/monorepo-docs/frontend/development-process/before-starting.md
+++ b/docs/monorepo-docs/frontend/development-process/before-starting.md
@@ -1,0 +1,3 @@
+# Things to consider before starting
+
+_Content coming soon._

--- a/docs/monorepo-docs/frontend/development-process/creating-a-new-page.md
+++ b/docs/monorepo-docs/frontend/development-process/creating-a-new-page.md
@@ -8,9 +8,9 @@ live in [Data loading](../data-loading.md).
 
 A page spans three folders in `apps/orchestration-cluster-webapp/src/`:
 
-- `modules/` — components, hooks, stores, utilities.
-- `pages/` — one file per page, wires modules together.
-- `routes/` — [TanStack Router](https://tanstack.com/router/latest)
+- `modules/`: components, hooks, stores, utilities.
+- `pages/`: one file per page, wires modules together.
+- `routes/`: [TanStack Router](https://tanstack.com/router/latest)
   mount points. Owns the loader, `pendingComponent`, and
   `errorComponent`.
 
@@ -25,30 +25,30 @@ intent.
 
 Skip a route only for:
 
-- Transient overlays — toasts, snackbars, command palette, hover
+- Transient overlays such as toasts, snackbars, command palette, and hover
   cards.
-- Modals that should not be linkable — confirmations, inline edit
+- Modals that should not be linkable, like confirmations and inline edit
   dialogs.
-- In-page tabs on a page already gated by the same data — encode the
+- In-page tabs on a page already gated by the same data. Encode the
   active tab as a search param (`/_auth/processes?tab=completed`).
 
 Anything else, justify it in the PR description.
 
-## Step 1 — Build the modules
+## Step 1: Build the modules
 
 Modules live in `src/modules/<thing>/`. Each owns one focused concern
-— `http`, `errors`, `theme`, `login`.
+(`http`, `errors`, `theme`, `login`).
 
 Layout:
 
-- `components/` — React components, optionally a subfolder per
+- `components/`: React components, optionally a subfolder per
   component for co-located styles and tests.
-- Module root — hooks, stores, utilities, types.
+- Module root: hooks, stores, utilities, types.
 
 Reuse before building. For what counts as a module, see the
 [Modules section](../orchestration-cluster-webapp.md#modules).
 
-## Step 2 — Compose the page
+## Step 2: Compose the page
 
 Page lives at `src/pages/<page>.tsx` with co-located styles and tests:
 
@@ -83,7 +83,7 @@ export function DashboardPage({ data }: { data: Dashboard }) {
 }
 ```
 
-## Step 3 — Plug into the router
+## Step 3: Plug into the router
 
 Route lives at `src/routes/<path>.tsx`. File path = URL path. Place
 under `_auth/` when auth is required.
@@ -117,11 +117,11 @@ applies. Full tier breakdown in [Data loading](../data-loading.md).
 The URL holds the page's state. Components read from it, not from each
 other.
 
-- **Route params** — entity identity (`/_auth/processes/$processKey`).
-- **Search params** — view state: filters, sort, cursor, selection,
-  active tab, modal-open flag.
-- **Local React state** — ephemeral UI only: open menu, input draft,
-  hover, focus.
+- **Route params**: entity identity (`/_auth/processes/$processKey`).
+- **Search params**: view state including filters, sort, cursor, selection,
+  active tab, and modal-open flag.
+- **Local React state**: ephemeral UI only, such as open menu, input draft,
+  hover, and focus.
 
 Payoff: deep-linkable, refresh preserves intent, back/forward work,
 siblings stay decoupled.

--- a/docs/monorepo-docs/frontend/development-process/creating-a-new-page.md
+++ b/docs/monorepo-docs/frontend/development-process/creating-a-new-page.md
@@ -1,3 +1,213 @@
 # Creating a new page
 
-_Content coming soon._
+How to build a new page in `@camunda/orchestration-cluster-webapp`.
+Read [Before starting](./before-starting.md) first; loader patterns
+live in [Data loading](../data-loading.md).
+
+## Overview
+
+A page spans three folders in `apps/orchestration-cluster-webapp/src/`:
+
+- `modules/` — components, hooks, stores, utilities.
+- `pages/` — one file per page, wires modules together.
+- `routes/` — [TanStack Router](https://tanstack.com/router/latest)
+  mount points. Owns the loader, `pendingComponent`, and
+  `errorComponent`.
+
+Build modules, compose a page, plug it into a route.
+
+## Default to a new route
+
+If a user can navigate to it, it gets its own URL. Routes are cheap,
+the payoff is large: deep-linkable views, working back/forward,
+shareable filter state, decoupled components, refresh that preserves
+intent.
+
+Skip a route only for:
+
+- Transient overlays — toasts, snackbars, command palette, hover
+  cards.
+- Modals that should not be linkable — confirmations, inline edit
+  dialogs.
+- In-page tabs on a page already gated by the same data — encode the
+  active tab as a search param (`/_auth/processes?tab=completed`).
+
+Anything else, justify it in the PR description.
+
+## Step 1 — Build the modules
+
+Modules live in `src/modules/<thing>/`. Each owns one focused concern
+— `http`, `errors`, `theme`, `login`.
+
+Layout:
+
+- `components/` — React components, optionally a subfolder per
+  component for co-located styles and tests.
+- Module root — hooks, stores, utilities, types.
+
+Reuse before building. For what counts as a module, see the
+[Modules section](../orchestration-cluster-webapp.md#modules).
+
+## Step 2 — Compose the page
+
+Page lives at `src/pages/<page>.tsx` with co-located styles and tests:
+
+```
+src/pages/
+├── dashboard.tsx
+├── dashboard.module.scss
+└── dashboard.test.tsx
+```
+
+Pages are glue: receive data as props, orchestrate module components.
+No `fetch`, no business logic. Prefer prop-passing — the route reads
+the loader query and passes data down. Reach for `useSuspenseQuery`
+inside the page only when prop drilling through a deep tree hurts more
+than it helps. See [Data loading](../data-loading.md) for the
+loader/query patterns.
+
+```tsx
+// src/pages/dashboard.tsx
+import { DashboardHeader } from "#/modules/dashboard/components/DashboardHeader";
+import { Metrics } from "#/modules/dashboard/components/Metrics";
+import type { Dashboard } from "#/modules/http/queries";
+import styles from "./dashboard.module.scss";
+
+export function DashboardPage({ data }: { data: Dashboard }) {
+  return (
+    <main className={styles.page}>
+      <DashboardHeader title={data.title} />
+      <Metrics metrics={data.metrics} />
+    </main>
+  );
+}
+```
+
+## Step 3 — Plug into the router
+
+Route lives at `src/routes/<path>.tsx`. File path = URL path. Place
+under `_auth/` when auth is required.
+
+```tsx
+// src/routes/_auth/dashboard.tsx
+import { createFileRoute } from "@tanstack/react-router";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { dashboardQueryOptions } from "#/modules/http/queries";
+import { DashboardPage } from "#/pages/dashboard";
+
+export const Route = createFileRoute("/_auth/dashboard")({
+  loader: ({ context: { queryClient } }) => {
+    queryClient.ensureQueryData(dashboardQueryOptions);
+  },
+  component: Dashboard,
+});
+
+function Dashboard() {
+  const { data } = useSuspenseQuery(dashboardQueryOptions);
+  return <DashboardPage data={data} />;
+}
+```
+
+`queryClient.ensureQueryData` is the preferred loader. Skip
+`pendingComponent` / `errorComponent` only when a router-level default
+applies. Full tier breakdown in [Data loading](../data-loading.md).
+
+## Use the URL as state
+
+The URL holds the page's state. Components read from it, not from each
+other.
+
+- **Route params** — entity identity (`/_auth/processes/$processKey`).
+- **Search params** — view state: filters, sort, cursor, selection,
+  active tab, modal-open flag.
+- **Local React state** — ephemeral UI only: open menu, input draft,
+  hover, focus.
+
+Payoff: deep-linkable, refresh preserves intent, back/forward work,
+siblings stay decoupled.
+
+```tsx
+function StateFilter() {
+  const { state } = useSearch({ from: "/some-router" });
+  const navigate = useNavigate();
+
+  return (
+    <select
+      value={state}
+      onChange={(e) =>
+        navigate({
+          search: (prev) => ({ ...prev, state: e.target.value || undefined }),
+        })
+      }
+    >
+      <option value="">All</option>
+      <option value="active">Active</option>
+      <option value="completed">Completed</option>
+    </select>
+  );
+}
+```
+
+Lifting state to a common parent? Route it through the URL first.
+
+## Validate URL inputs with Zod
+
+URLs are user input. Pin every search-param and path-param shape with
+[Zod](https://zod.dev/).
+
+```tsx
+// src/routes/_auth/processes.tsx
+import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
+
+const searchSchema = z.object({
+  state: z.enum(["active", "completed", "canceled"]).optional(),
+  cursor: z.string().optional(),
+  limit: z.number().int().min(1).max(100).default(50),
+});
+
+export const Route = createFileRoute("/_auth/processes")({
+  validateSearch: searchSchema,
+  // loader, component, ...
+});
+```
+
+`validateSearch` for search params, `parseParams` for path params.
+Reuse schemas from `@camunda/camunda-api-zod-schemas` when the URL
+slice maps to an API contract
+([Camunda API Zod schemas](../camunda-api-zod-schemas.md)). Otherwise
+co-locate the schema in the route file.
+
+`useSearch()` and `useParams()` return the validated,
+typed output.
+
+## Keep it flat
+
+Three layers is the budget. Don't nest.
+
+- **No page-shaped modules.** A `modules/<page>/` mirroring a whole
+  page means page logic leaked.
+- **No deep module trees.** Cap depth at
+  `modules/<thing>/components/<Component>/`.
+- **No parent → child state plumbing.** Push it to the URL; children
+  read directly.
+- **No abstractions for hypothetical use.** Wait until the shape is forced.
+
+Three similar lines beats a premature wrapper.
+
+## Checklist
+
+Before opening the PR:
+
+- [ ] Modules created or existing ones reused; no business logic in
+      `src/pages/`.
+- [ ] Page in `src/pages/<name>.tsx`; styles + tests co-located.
+- [ ] Route in `src/routes/<path>.tsx`; URL matches file path;
+      auth-gated routes under `_auth/`.
+- [ ] Loader uses `queryClient.ensureQueryData`; `pendingComponent` +
+      `errorComponent` wired or a router-level default applies.
+- [ ] Search params validated via `validateSearch` + Zod; path params
+      via `parseParams`.
+- [ ] View state lives in the URL.
+- [ ] No deeply-nested module folders.
+- [ ] Dev server boots the new route (`npm run dev:oc`).

--- a/docs/monorepo-docs/frontend/development-process/creating-a-new-page.md
+++ b/docs/monorepo-docs/frontend/development-process/creating-a-new-page.md
@@ -8,7 +8,8 @@ live in [Data loading](../data-loading.md).
 
 A page spans three folders in `apps/orchestration-cluster-webapp/src/`:
 
-- `modules/`: components, hooks, stores, utilities.
+- `modules/`: components, hooks, stores, utilities
+  (see [Modules](../orchestration-cluster-webapp.md#modules)).
 - `pages/`: one file per page, wires modules together.
 - `routes/`: [TanStack Router](https://tanstack.com/router/latest)
   mount points. Owns the loader, `pendingComponent`, and

--- a/docs/monorepo-docs/frontend/development-process/creating-a-new-page.md
+++ b/docs/monorepo-docs/frontend/development-process/creating-a-new-page.md
@@ -186,13 +186,22 @@ typed output.
 
 Three layers is the budget. Don't nest.
 
-- **No page-shaped modules.** A `modules/<page>/` mirroring a whole
-  page means page logic leaked.
+- **No page-shaped modules** — unless the page is small and
+  self-contained. A `modules/<page>/` mirroring a large page means
+  page logic leaked. A tiny feature that fits in one module folder
+  is fine (e.g. `login`).
 - **No deep module trees.** Cap depth at
   `modules/<thing>/components/<Component>/`.
-- **No parent → child state plumbing.** Push it to the URL; children
-  read directly.
 - **No abstractions for hypothetical use.** Wait until the shape is forced.
+
+Two data-flow rules:
+
+- **API data → props.** The route reads the loader query and passes
+  data down through props. This keeps pages testable and dependencies
+  explicit.
+- **View state → URL.** Filters, sort, cursor, selection live in
+  search params. Children read the URL directly via `useSearch` —
+  no parent → child plumbing for view state.
 
 Three similar lines beats a premature wrapper.
 

--- a/docs/monorepo-docs/frontend/development-process/creating-a-new-page.md
+++ b/docs/monorepo-docs/frontend/development-process/creating-a-new-page.md
@@ -1,0 +1,3 @@
+# Creating a new page
+
+_Content coming soon._

--- a/docs/monorepo-docs/frontend/development-process/development-process.md
+++ b/docs/monorepo-docs/frontend/development-process/development-process.md
@@ -1,3 +1,7 @@
 # Development process
 
-_Content coming soon._
+- [Before Starting](before-starting.md): Things to consider before starting development.
+- [Creating a New Page](creating-a-new-page.md): Guide to creating a new page.
+- [Extending an Existing Page](extending-an-existing-page.md): Steps to extend an existing page.
+- [Working on a Large Feature](working-on-large-feature.md): Tips for handling large features.
+- [Generating SVG Components](generating-svg-components.md): Guide on generating React components from SVG files.

--- a/docs/monorepo-docs/frontend/development-process/development-process.md
+++ b/docs/monorepo-docs/frontend/development-process/development-process.md
@@ -1,0 +1,3 @@
+# Development process
+
+_Content coming soon._

--- a/docs/monorepo-docs/frontend/development-process/extending-an-existing-page.md
+++ b/docs/monorepo-docs/frontend/development-process/extending-an-existing-page.md
@@ -1,0 +1,3 @@
+# Extending an existing page
+
+_Content coming soon._

--- a/docs/monorepo-docs/frontend/development-process/extending-an-existing-page.md
+++ b/docs/monorepo-docs/frontend/development-process/extending-an-existing-page.md
@@ -1,3 +1,46 @@
 # Extending an existing page
 
-_Content coming soon._
+Incremental work on a page that already ships. For greenfield pages
+see [Creating a new page](./creating-a-new-page.md); for multi-page
+initiatives see [Working on a large feature](./working-on-large-feature.md).
+
+## Overview
+
+You're adding to a page that already ships: a new column, filter,
+panel, drill-down, or flow. Two things to settle before writing code:
+whether the addition really belongs on this page, and where the new
+code lives if it does.
+
+## First, can it be a new route?
+
+Default: yes. If the addition is navigable, has its own state, or
+users would deep-link to it, it gets its own route. That can be a nested route or
+a search-param-encoded view on the existing one.
+
+Common splits:
+
+- **Tabs**: nested child route, or `?tab=...` when the parent already
+  loads the same data.
+- **Drill-downs** (list to row, instance to details): nested route,
+  e.g. `/_auth/processes/$processKey`.
+- **Side panels with shareable state**: search-param flag or nested
+  route.
+
+Anything else, justify staying on the existing page in the PR. Full
+heuristic in
+[Default to a new route](./creating-a-new-page.md#default-to-a-new-route).
+
+## If it stays on the existing page
+
+Build new pieces as modules
+([Step 1](./creating-a-new-page.md#step-1-build-the-modules)) and
+compose them into the existing page file
+([Step 2](./creating-a-new-page.md#step-2-compose-the-page)). No new
+abstraction layers, no wrapper-of-wrappers, no parent-feature state
+plumbed through new children.
+
+If the addition introduces branching view state (open/closed,
+expanded section, selected sub-view), push it to the URL via search
+params, validated with Zod
+([URL as state](./creating-a-new-page.md#use-the-url-as-state),
+[Zod validation](./creating-a-new-page.md#validate-url-inputs-with-zod)).

--- a/docs/monorepo-docs/frontend/development-process/generating-svg-components.md
+++ b/docs/monorepo-docs/frontend/development-process/generating-svg-components.md
@@ -2,15 +2,15 @@
 
 We use `@svgr/cli` to convert SVG files into reusable React components, simplifying their integration into the project.
 
-Run the following command inside an apps client directory to generate React components from the SVG source files:
+Run the following command inside the `@camunda/orchestration-cluster-webapp` app directory to generate React components from the SVG source files:
 
 ```sh
 npm run generate:svg
 ```
 
-This command processes all SVG files in `src/assets/svg/` and generates React components from them. These components are stored in `src/modules/svg/` and are intended for use throughout the project. They must not be edited manually, as any changes will be overwritten the next time the command is run.
+This command processes all SVG files in `apps/orchestration-cluster-webapp/src/assets/svg/` and generates React components from them. These components are stored in `apps/orchestration-cluster-webapp/src/modules/svg/` and are intended for use throughout the project. They must not be edited manually, as any changes will be overwritten the next time the command is run.
 
 This must be run manually in the following cases:
 
-- **A new SVG is added** to `src/assets/svg/`
-- **An existing SVG is changed** in `src/assets/svg/`
+- **A new SVG is added** to `apps/orchestration-cluster-webapp/src/assets/svg/`
+- **An existing SVG is changed** in `apps/orchestration-cluster-webapp/src/assets/svg/`

--- a/docs/monorepo-docs/frontend/development-process/generating-svg-components.md
+++ b/docs/monorepo-docs/frontend/development-process/generating-svg-components.md
@@ -1,0 +1,16 @@
+# Generating SVG components
+
+We use `@svgr/cli` to convert SVG files into reusable React components, simplifying their integration into the project.
+
+Run the following command inside an apps client directory to generate React components from the SVG source files:
+
+```sh
+npm run generate:svg
+```
+
+This command processes all SVG files in `src/assets/svg/` and generates React components from them. These components are stored in `src/modules/svg/` and are intended for use throughout the project. They must not be edited manually, as any changes will be overwritten the next time the command is run.
+
+This must be run manually in the following cases:
+
+- **A new SVG is added** to `src/assets/svg/`
+- **An existing SVG is changed** in `src/assets/svg/`

--- a/docs/monorepo-docs/frontend/development-process/working-on-large-feature.md
+++ b/docs/monorepo-docs/frontend/development-process/working-on-large-feature.md
@@ -1,0 +1,3 @@
+# Working on a large feature
+
+_Content coming soon._

--- a/docs/monorepo-docs/frontend/development-process/working-on-large-feature.md
+++ b/docs/monorepo-docs/frontend/development-process/working-on-large-feature.md
@@ -1,3 +1,99 @@
 # Working on a large feature
 
-_Content coming soon._
+How to ship a feature that spans multiple pages, modules, or weeks of
+work. The per-PR mechanics still follow
+[Creating a new page](./creating-a-new-page.md) and
+[Extending an existing page](./extending-an-existing-page.md); this
+page covers how to break the work down and keep unfinished features
+off for users.
+
+## Overview
+
+Large features merged as a single PR are hard to review for both
+humans and agents, risky to merge, and delay value delivery. Split the
+work into smaller PRs that each stand on their own.
+
+## Split into smaller PRs
+
+Each PR should be a meaningful, self-contained unit, not "part 1 of 5"
+but a slice that adds value or lays necessary groundwork. It should
+build, pass tests, and be reviewable in isolation.
+
+How to slice:
+
+- **By layer**: schemas/types first, then modules, then page, then
+  route wiring.
+- **By user-visible unit**: one filter, one column, one panel, one
+  flow per PR.
+- **By dependency order**: shared modules before consumers.
+
+When in doubt, err on the side of smaller. A PR that is too small is
+still easy to review. A PR that is too large is not.
+
+## Feature flags
+
+When the feature is not ready to be enabled for users but code needs
+to merge to `main`, gate it behind a feature flag.
+
+### Creating a flag
+
+Export a boolean `const` from
+`src/modules/feature-flags.ts`. Use `SCREAMING_SNAKE_CASE` and
+default to `false`.
+
+```ts
+// src/modules/feature-flags.ts
+export const ENABLE_PROCESS_MIGRATION = false;
+```
+
+### Using a flag
+
+Gate at the highest possible level: route registration, page
+component, or navigation item. Do not scatter flag checks deep inside
+modules.
+
+```tsx
+import { ENABLE_PROCESS_MIGRATION } from "#/modules/feature-flags";
+
+function ProcessActions() {
+  return (
+    <>
+      {ENABLE_PROCESS_MIGRATION && <MigrateButton />}
+    </>
+  );
+}
+```
+
+### Large refactors behind a flag
+
+When a feature rewrites a significant portion of an existing page or
+module, copy the affected code and build the new version alongside the
+old one. Toggle between them with the feature flag. This keeps PRs
+small and focused: reviewers see only the new code, not a giant diff
+of interleaved changes. The cleanup PR that removes the flag also
+deletes the old copy.
+
+### Removing a flag
+
+Once the feature ships and is validated, remove the flag in a
+dedicated cleanup PR:
+
+1. Set the flag to `true` and verify everything works.
+2. Remove the `const` from `feature-flags.ts`.
+3. Remove all conditional branches that read it.
+4. Delete any dead code that was behind the negative branch.
+
+Do not leave flags lingering. If removal is deferred, file a tracking
+issue and link it from a comment next to the flag.
+
+## Checklist
+
+Before opening each PR in a large feature:
+
+- [ ] PR is a self-contained slice, not a partial dump.
+- [ ] Feature flag added in `src/modules/feature-flags.ts` if the
+      feature is not ready to enable.
+- [ ] Flag gating lives at route or page level, not deep in modules.
+- [ ] No leftover flags without a tracking issue for removal.
+- [ ] PR follows the per-PR checklist from
+      [Creating a new page](./creating-a-new-page.md#checklist).

--- a/docs/monorepo-docs/frontend/forms.md
+++ b/docs/monorepo-docs/frontend/forms.md
@@ -1,0 +1,3 @@
+# Forms
+
+_Content coming soon._

--- a/docs/monorepo-docs/frontend/forms.md
+++ b/docs/monorepo-docs/frontend/forms.md
@@ -1,3 +1,60 @@
 # Forms
 
-_Content coming soon._
+This page covers the form library landscape across the Camunda
+frontends today and the best practices to follow when picking and
+writing forms in `@camunda/orchestration-cluster-webapp`.
+
+## Current state
+
+| App                                     | Library          |
+| --------------------------------------- | ---------------- |
+| `@camunda/orchestration-cluster-webapp` | react-final-form |
+| Tasklist (`tasklist/client`)            | react-final-form |
+| Operate (`operate/client`)              | react-final-form |
+| Identity (`identity/client`)            | react-hook-form  |
+
+## Future direction
+
+We plan to unify on a single form library across the unified webapp.
+The candidates are [react-hook-form](https://react-hook-form.com/) and
+[@tanstack/react-form](https://tanstack.com/form/latest). No decision
+has been made yet.
+
+Until the unification lands, new forms in
+`@camunda/orchestration-cluster-webapp` follow the guidance in the
+sections below.
+
+## When to reach for a form library
+
+Decision rule:
+
+- **Simple form** → plain HTML `<form>` with native validation. No
+  library needed.
+- **Reach for a library** when the form needs either of:
+  - schema-based validation (cross-field, async, or otherwise complex
+    rules), or
+  - form / field meta state — `dirty`, `touched`, `pristine`, blur
+    tracking, submission state, field arrays, etc.
+
+Concrete examples:
+
+- A single-input search box → plain HTML.
+- A multi-step creation form with conditional fields and per-field
+  errors → form library.
+
+## Validation strategy
+
+- **On submit** → validate the whole form.
+- **On blur** → validate only the field that lost focus.
+- Do **not** validate on every keystroke — it's noisy and disruptive
+  to users still typing.
+
+Reuse Zod schemas from `@camunda/camunda-api-zod-schemas` where the
+form maps to an API contract; otherwise co-locate a Zod schema next
+to the form that uses it.
+
+## References
+
+- [react-final-form](https://final-form.org/react)
+- [react-hook-form](https://react-hook-form.com/)
+- [Camunda API Zod schemas](./camunda-api-zod-schemas.md)

--- a/docs/monorepo-docs/frontend/frontend.md
+++ b/docs/monorepo-docs/frontend/frontend.md
@@ -11,6 +11,8 @@ Anyone working on the orchestration cluster frontend components.
 
 - **[Getting started](./getting-started.md)** — clone, prerequisites, run backend + frontend locally.
 - **[Project outline](./project-outline.md)** — packages and apps inside `webapp/client` and what each owns.
+- **[Orchestration cluster webapp](./orchestration-cluster-webapp.md)** — deeper intro to the unified app: tech stack, layout, scripts, dev-server proxy, testing.
+- **[Camunda API Zod schemas](./camunda-api-zod-schemas.md)** — installation, usage, and publishing for the `@camunda/camunda-api-zod-schemas` package.
 - **[Data loading](./data-loading.md)** — TanStack Query + Zod schema patterns.
 - **[Forms](./forms.md)** — form library choice and shared form-agnostic patterns.
 - **[Development process](./development-process/development-process.md)** — pre-flight checklist plus playbooks for new pages, extending pages, and large features.

--- a/docs/monorepo-docs/frontend/frontend.md
+++ b/docs/monorepo-docs/frontend/frontend.md
@@ -19,6 +19,7 @@ Anyone working on the orchestration cluster frontend components.
 - **[Code reviews](./code-reviews.md)** — what we look for.
 - **[ADRs](./adr/adr.md)** — recorded architecture decisions.
 - **[Code style](./code-style.md)** — formatting and naming conventions.
+- **[Legacy components](./legacy-components.md)** — pointers to components still living outside `webapp/client`.
 
 ## Status
 

--- a/docs/monorepo-docs/frontend/frontend.md
+++ b/docs/monorepo-docs/frontend/frontend.md
@@ -1,0 +1,6 @@
+# Frontend
+
+Source of truth for frontend development of the orchestration cluster components
+(Admin, Operate and Tasklist) hosted in `webapp/client`.
+
+_Content coming soon._

--- a/docs/monorepo-docs/frontend/frontend.md
+++ b/docs/monorepo-docs/frontend/frontend.md
@@ -31,6 +31,11 @@ For the latest status, check the unification epic
 ([camunda/camunda#51305](https://github.com/camunda/camunda/issues/51305)) or the
 Slack channel `#prj-pdp-3456-frontend-application-unification`.
 
+## Get in touch
+
+- Slack: `#team-core-features-frontend` — day-to-day questions and discussion.
+- Bi-weekly team sync — ask in the Slack channel for the invite.
+
 ## Related references
 
 - [`.github/instructions/frontend.instructions.md`](https://github.com/camunda/camunda/blob/main/.github/instructions/frontend.instructions.md) — scoped instructions auto-loaded by editors and AI agents.

--- a/docs/monorepo-docs/frontend/frontend.md
+++ b/docs/monorepo-docs/frontend/frontend.md
@@ -3,4 +3,38 @@
 Source of truth for frontend development of the orchestration cluster components
 (Admin, Operate and Tasklist) hosted in `webapp/client`.
 
-_Content coming soon._
+## Who this is for
+
+Anyone working on the orchestration cluster frontend components.
+
+## What you'll find here
+
+- **[Getting started](./getting-started.md)** — clone, prerequisites, run backend + frontend locally.
+- **[Project outline](./project-outline.md)** — packages and apps inside `webapp/client` and what each owns.
+- **[Data loading](./data-loading.md)** — TanStack Query + Zod schema patterns.
+- **[Forms](./forms.md)** — form library choice and shared form-agnostic patterns.
+- **[Development process](./development-process/development-process.md)** — pre-flight checklist plus playbooks for new pages, extending pages, and large features.
+- **[Testing](./testing.md)** — unit (Vitest browser), integration (Playwright + MSW), a11y, and visual regression.
+- **[Using AI](./using-ai.md)** — guidelines for AI-assisted frontend work.
+- **[Code reviews](./code-reviews.md)** — what we look for.
+- **[ADRs](./adr/adr.md)** — recorded architecture decisions.
+- **[Code style](./code-style.md)** — formatting and naming conventions.
+
+## Status
+
+No component lives in `webapp/client` yet — we're currently laying the foundations.
+The legacy components still ship from `identity/client`, `tasklist/client`,
+`operate/client`, and `optimize/client`.
+
+For the latest status, check the unification epic
+([camunda/camunda#51305](https://github.com/camunda/camunda/issues/51305)) or the
+Slack channel `#prj-pdp-3456-frontend-application-unification`.
+
+## Related references
+
+- [`.github/instructions/frontend.instructions.md`](https://github.com/camunda/camunda/blob/main/.github/instructions/frontend.instructions.md) — scoped instructions auto-loaded by editors and AI agents.
+- [docs.camunda.io](https://docs.camunda.io) — product documentation.
+- Per-app READMEs that still apply until folded in:
+  - [`operate/client/README.md`](https://github.com/camunda/camunda/blob/main/operate/client/README.md)
+  - [`tasklist/client/README.md`](https://github.com/camunda/camunda/blob/main/tasklist/client/README.md)
+  - [`identity/client/README.md`](https://github.com/camunda/camunda/blob/main/identity/client/README.md)

--- a/docs/monorepo-docs/frontend/getting-started.md
+++ b/docs/monorepo-docs/frontend/getting-started.md
@@ -8,8 +8,8 @@ talking to the orchestration-cluster backend on `http://localhost:8080`.
 - **Node.js** via [`fnm`](https://github.com/Schniz/fnm) (recommended) or
   [`nvm`](https://github.com/nvm-sh/nvm). The repo pins Node in
   `webapp/client/.nvmrc` — `fnm use` / `nvm use` reads it for you.
-- **Java 21** — the backend builds and runs with Maven. Install via
-  [SDKMAN](https://sdkman.io) or Homebrew (`brew install openjdk@21`).
+- **Java** — the backend builds and runs with Maven. Install via
+  [SDKMAN](https://sdkman.io) or Homebrew (`brew install openjdk@21`). Check the current version on the project.
 - **Docker** — used by `make env-up` to run Elasticsearch, and by Playwright's
   containerized browser for visual-regression tests.
 - **make** — wraps backend startup (`make env-up` / `make env-down`) and VS Code

--- a/docs/monorepo-docs/frontend/getting-started.md
+++ b/docs/monorepo-docs/frontend/getting-started.md
@@ -29,7 +29,7 @@ The workspace install covers all `packages/*` and `apps/*`.
 
 ## Run the backend
 
-From `webapp/client`:
+From `webapp`:
 
 ```sh
 make env-up

--- a/docs/monorepo-docs/frontend/getting-started.md
+++ b/docs/monorepo-docs/frontend/getting-started.md
@@ -1,0 +1,3 @@
+# Getting started
+
+_Content coming soon._

--- a/docs/monorepo-docs/frontend/getting-started.md
+++ b/docs/monorepo-docs/frontend/getting-started.md
@@ -1,3 +1,70 @@
 # Getting started
 
-_Content coming soon._
+This guide gets you to a running `webapp/client` on `http://localhost:3000`,
+talking to the orchestration-cluster backend on `http://localhost:8080`.
+
+## Prerequisites
+
+- **Node.js** via [`fnm`](https://github.com/Schniz/fnm) (recommended) or
+  [`nvm`](https://github.com/nvm-sh/nvm). The repo pins Node in
+  `webapp/client/.nvmrc` — `fnm use` / `nvm use` reads it for you.
+- **Java 21** — the backend builds and runs with Maven. Install via
+  [SDKMAN](https://sdkman.io) or Homebrew (`brew install openjdk@21`).
+- **Docker** — used by `make env-up` to run Elasticsearch, and by Playwright's
+  containerized browser for visual-regression tests.
+- **make** — wraps backend startup (`make env-up` / `make env-down`) and VS Code
+  config sync (`make vscode-sync-all`). Pre-installed on macOS and most Linux;
+  Windows users install via WSL or `choco install make`.
+
+## Clone & install
+
+```sh
+git clone https://github.com/camunda/camunda.git
+cd camunda/webapp/client
+fnm use            # or: nvm use
+npm ci
+```
+
+The workspace install covers all `packages/*` and `apps/*`.
+
+## Run the backend
+
+From `webapp/client`:
+
+```sh
+make env-up
+```
+
+This boots Elasticsearch (Docker) and the orchestration-cluster backend on
+`http://localhost:8080`, seeded with a `demo` / `demo` user. Tear it down with:
+
+```sh
+make env-down
+```
+
+## Run the frontend
+
+From `webapp/client`:
+
+```sh
+npm run dev:oc
+```
+
+The dev server opens `http://localhost:3000`. Vite proxies `/v2`, `/login`, and
+`/logout` to `:8080`, so the frontend talks to the backend you started above.
+
+## Verify
+
+- The dev page renders in the browser.
+- `npm run lint` exits clean.
+- `npm run typecheck` exits clean.
+
+## Optional: VS Code setup
+
+From the repo root:
+
+```sh
+make vscode-sync-all
+```
+
+Merges the repository's MCP and editor settings into your VS Code config.

--- a/docs/monorepo-docs/frontend/legacy-components.md
+++ b/docs/monorepo-docs/frontend/legacy-components.md
@@ -1,3 +1,22 @@
 # Legacy components
 
-_Content coming soon._
+The legacy frontends still ship independently and will eventually be
+integrated into the unified orchestration-cluster webapp.
+
+## Projects
+
+- **`operate/client`**: process monitoring.
+- **`tasklist/client`**: user task management.
+- **`identity/client`** (also known as Admin): authentication,
+  authorization and general cluster admin features.
+
+Each project has its own standards, tooling, and conventions. When
+working on them, follow the conventions already established in that
+project, not the ones documented in this section.
+
+## Migration
+
+These components will be progressively migrated into
+`@camunda/orchestration-cluster-webapp`. For the current status, see
+the unification epic
+([camunda/camunda#51305](https://github.com/camunda/camunda/issues/51305)).

--- a/docs/monorepo-docs/frontend/legacy-components.md
+++ b/docs/monorepo-docs/frontend/legacy-components.md
@@ -1,0 +1,3 @@
+# Legacy components
+
+_Content coming soon._

--- a/docs/monorepo-docs/frontend/orchestration-cluster-webapp.md
+++ b/docs/monorepo-docs/frontend/orchestration-cluster-webapp.md
@@ -1,0 +1,86 @@
+# Orchestration cluster webapp
+
+`@camunda/orchestration-cluster-webapp` is the unified React webapp that
+will replace the Operate, Tasklist, and Admin frontends shipped today
+from `operate/client`, `tasklist/client`, and `identity/client`.
+
+## Tech stack
+
+| Concern         | Library                                                 | Notes                                         |
+| --------------- | ------------------------------------------------------- | --------------------------------------------- |
+| Framework       | React 19, TypeScript                                    | Strict mode                                   |
+| Bundler         | Vite                                                    | Dev on `:3000`, preview on `:3003`            |
+| Routing         | TanStack Router (+ Vite plugin)                         | File-based; `routeTree.gen.ts` auto-generated |
+| Server state    | TanStack Query                                          | See [Data loading](./data-loading.md)         |
+| Client state    | MobX                                                    | Used for theme + session                      |
+| Forms           | react-final-form + Zod                                  | See [Forms](./forms.md)                       |
+| API contracts   | `@camunda/camunda-api-zod-schemas`                      | Runtime-validated                             |
+| Design system   | Carbon (`@carbon/react`) + Camunda composite components | Sass for styles                               |
+| Telemetry       | Mixpanel + Osano consent                                |                                               |
+| Unit tests      | Vitest browser mode (Playwright provider)               | See [Testing](./testing.md)                   |
+| E2E / a11y / VR | Playwright + Axe + MSW                                  |                                               |
+
+## Directory layout
+
+```
+apps/orchestration-cluster-webapp/
+├── src/
+│   ├── assets/svg/         # SVG sources (see Generating SVG components)
+│   ├── modules/            # This folders contains all app parts separated by feature (e.g. login, http, errors, etc.)
+│   ├── pages/              # Standalone pages. Each file assembles all compponents of a page. Like main page content, error, loading, etc.
+│   ├── routes/             # TanStack Router file-based routes. Each page is plugged into a route here.
+│   ├── vitest-modules/     # Unit test utils
+│   └── main.tsx            # App entry
+├── test/                   # Playwright based tests
+│   ├── a11y/               # accessibility (Axe)
+│   ├── integration/        # MSW-mocked integration
+│   ├── visual/             # visual regression
+│   ├── pw-modules/         # shared fixtures (MSW + Axe)
+│   └── pages/              # page objects
+├── shared-test-modules/    # Test utils shared between unit and Playwright tests
+└── vite.config.ts
+```
+
+## Scripts
+
+| Script                    | What it does                                                                                                                        |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `dev`                     | Vite dev server on `:3000`, opens the browser                                                                                       |
+| `build`                   | Production bundle, then `renameProdIndex.mjs` post-build                                                                            |
+| `build:visual-regression` | Production build with the visual-regression entry point                                                                             |
+| `preview`                 | Serve the production build on `:3003`. Used for visual regression tests.                                                            |
+| `typecheck`               | Run `tsc` against `tsconfig.browser.json`, `tsconfig.vitest.json`, `tsconfig.node.json`                                             |
+| `extract-sbom`            | Vite build with the SBOM Rollup plugin                                                                                              |
+| `test:unit`               | Vitest in headless Chromium                                                                                                         |
+| `test:unit:ui`            | Vitest with a visible browser                                                                                                       |
+| `test:a11y`               | Playwright a11y projects (light + dark)                                                                                             |
+| `test:visual`             | Playwright visual-regression projects (light/dark × desktop/tablet)                                                                 |
+| `test:integration`        | Playwright integration project (MSW-mocked)                                                                                         |
+| `generate:svg`            | Convert `src/assets/svg/` to React components (see [Generating SVG components](./development-process/generating-svg-components.md)) |
+
+## Dev server & backend integration
+
+- Vite dev server on `:3000`, with proxies to the orchestration-cluster
+  backend on `:8080`:
+  - `/v2` → `http://localhost:8080`
+  - `/login` (POST only) → `http://localhost:8080`
+  - `/logout` (POST only) → `http://localhost:8080`
+- Auth is session-cookie based with a CSRF token: the `request()` wrapper
+  appends `X-CSRF-TOKEN` (read from `sessionStorage`) to mutating
+  requests, and a `401` clears the React Query cache.
+- Endpoint shapes come from `@camunda/camunda-api-zod-schemas`, so
+  responses are validated at runtime.
+
+## Testing approach
+
+- **Unit** — Vitest browser mode (Playwright provider, headless
+  Chromium). HTTP mocks are done via MSW.
+- **Integration** — Playwright project, MSW via `@msw/playwright` for
+  request interception.
+- **Accessibility** — Playwright + `@axe-core/playwright`, in light and
+  dark themes.
+- **Visual regression** — Playwright; uses a containerized browser
+  (`CONTAINERIZED_BROWSER=true` runs the official `mcr.microsoft.com/playwright`
+  image) for stable rendering across machines.
+
+See [Testing](./testing.md) for the full guide.

--- a/docs/monorepo-docs/frontend/orchestration-cluster-webapp.md
+++ b/docs/monorepo-docs/frontend/orchestration-cluster-webapp.md
@@ -62,6 +62,18 @@ Keep each module's internal structure flat. React components live in a
 `components/` subfolder; everything else (hooks, utilities, stores,
 etc.) sits at the module root.
 
+### Filename conventions
+
+Keep filenames consistent so the role of each file is obvious at a
+glance:
+
+| Kind      | Pattern          | Example              |
+| --------- | ---------------- | -------------------- |
+| Hook      | `use*.ts(x)`     | `useAuth.ts`         |
+| Store     | `*.store.ts`     | `session.store.ts`   |
+| Component | `PascalCase.tsx` | `LoadingSpinner.tsx` |
+| Unit test | `*.test.ts(x)`   | `request.test.ts`    |
+
 There is **no** `modules/process-instances/` covering an entire large page;
 pages are assembled in `src/pages/` from these building blocks.
 

--- a/docs/monorepo-docs/frontend/orchestration-cluster-webapp.md
+++ b/docs/monorepo-docs/frontend/orchestration-cluster-webapp.md
@@ -26,7 +26,7 @@ from `operate/client`, `tasklist/client`, and `identity/client`.
 apps/orchestration-cluster-webapp/
 ├── src/
 │   ├── assets/svg/         # SVG sources (see Generating SVG components)
-│   ├── modules/            # This folders contains all app parts separated by feature (e.g. login, http, errors, etc.)
+│   ├── modules/            # Building blocks the app is assembled from (see Modules below)
 │   ├── pages/              # Standalone pages. Each file assembles all compponents of a page. Like main page content, error, loading, etc.
 │   ├── routes/             # TanStack Router file-based routes. Each page is plugged into a route here.
 │   ├── vitest-modules/     # Unit test utils
@@ -40,6 +40,30 @@ apps/orchestration-cluster-webapp/
 ├── shared-test-modules/    # Test utils shared between unit and Playwright tests
 └── vite.config.ts
 ```
+
+## Modules
+
+`src/modules/` holds the building blocks the app is assembled from,
+split by **meaningful unit** — not by feature. A module owns one small
+concern that one or more pages reuse.
+
+Two common shapes:
+
+- **Cross-cutting** — `http` for requests, `errors` for generic error
+  UI, `theme`, `tracking`, etc.
+- **Shared between related pages** — e.g., a layout module shared by
+  the process instances and decision instances pages, or a filters module
+  those pages share.
+
+Small, self-contained pages can live entirely inside a single module
+folder. The `login` module is an example.
+
+Keep each module's internal structure flat. React components live in a
+`components/` subfolder; everything else (hooks, utilities, stores,
+etc.) sits at the module root.
+
+There is **no** `modules/process-instances/` covering an entire large page;
+pages are assembled in `src/pages/` from these building blocks.
 
 ## Scripts
 

--- a/docs/monorepo-docs/frontend/project-outline.md
+++ b/docs/monorepo-docs/frontend/project-outline.md
@@ -1,3 +1,53 @@
 # Project outline
 
-_Content coming soon._
+`webapp/client` is an npm workspaces monorepo that holds the unified
+orchestration-cluster frontend and the shared libraries that support it.
+
+## Layout
+
+```
+webapp/client/
+├── apps/
+│   └── orchestration-cluster-webapp/
+└── packages/
+    ├── camunda-api-zod-schemas/
+    ├── c8-mocks/
+    └── lint-config/
+```
+
+## Packages
+
+### `@camunda/camunda-api-zod-schemas`
+
+Published to npm. Provides Zod schemas and TypeScript types for
+the Camunda 8 REST API, versioned per release line (8.8 / 8.9 / 8.10).
+Consumed by
+`@camunda/orchestration-cluster-webapp` and legacy frontend components for type-safe API calls and
+runtime validation.
+
+Currently this package is manually written. We plan to automate generation from the OpenAPI spec in the future.
+
+See [Camunda API Zod schemas](./camunda-api-zod-schemas.md) for
+installation, usage, and publishing.
+
+### `@camunda/c8-mocks`
+
+Shared mock data fixtures (e.g., current user, license) for
+use in webapp tests.
+
+### `@camunda/lint-config`
+
+ESLint and Prettier configuration shared across
+the Camunda frontends — also consumed outside this workspace by
+`operate/client`, `tasklist/client`, and `identity/client`. Consumers
+compose only the eslint variants they need (`base`, `typescript`,
+`react`, `testing`, `license`, `tanstack-query`).
+
+## Apps
+
+### `@camunda/orchestration-cluster-webapp`
+
+The unified React webapp that will replace the legacy Operate, Tasklist,
+and Admin frontends. See
+[Orchestration cluster webapp](./orchestration-cluster-webapp.md) for
+the full introduction.

--- a/docs/monorepo-docs/frontend/project-outline.md
+++ b/docs/monorepo-docs/frontend/project-outline.md
@@ -1,0 +1,3 @@
+# Project outline
+
+_Content coming soon._

--- a/docs/monorepo-docs/frontend/testing.md
+++ b/docs/monorepo-docs/frontend/testing.md
@@ -1,0 +1,3 @@
+# Testing
+
+_Content coming soon._

--- a/docs/monorepo-docs/frontend/testing.md
+++ b/docs/monorepo-docs/frontend/testing.md
@@ -1,3 +1,141 @@
 # Testing
 
-_Content coming soon._
+Testing in `@camunda/orchestration-cluster-webapp`. For the scripts
+that run each suite, see the
+[Scripts table](./orchestration-cluster-webapp.md#scripts).
+
+## Stack
+
+| Type              | Tool                                 | Location              | Script                     |
+| ----------------- | ------------------------------------ | --------------------- | -------------------------- |
+| Unit              | Vitest browser mode (Playwright)     | `src/**/*.test.ts(x)` | `npm run test:unit`        |
+| Integration       | Playwright + MSW (`@msw/playwright`) | `test/integration/`   | `npm run test:integration` |
+| Accessibility     | Playwright + `@axe-core/playwright`  | `test/a11y/`          | `npm run test:a11y`        |
+| Visual regression | Playwright + containerized browser   | `test/visual/`        | `npm run test:visual`      |
+
+## Mocking the backend
+
+[MSW](https://mswjs.io/) is the only backend mock layer. Two
+entrypoints depending on the test type:
+
+- **Unit tests**: MSW `setupWorker` (browser mode), auto-started by
+  the custom `it` fixture from `#/vitest-modules/test-extend`.
+- **Playwright tests**: MSW via `@msw/playwright`, auto-started by
+  the `network` fixture from `#/pw-modules/test-extend`.
+
+Both use `createEndpointMock` from
+`#/shared-test-modules/mock-endpoint` to build typed request handlers.
+All endpoint mocks are defined in `#/shared-test-modules/endpoints` as
+a shared dictionary, so every test (unit and Playwright) reuses the
+same mock definitions.
+
+Unit test example:
+
+```ts
+import { it } from "#/vitest-modules/test-extend";
+import { endpoints } from "#/shared-test-modules/endpoints";
+import { HttpResponse } from "msw";
+
+it("should render users", async ({ worker }) => {
+  worker.use(
+    endpoints.users({
+      successResponse: HttpResponse.json([{ name: "Alice" }]),
+    }),
+  );
+  // render and assert...
+});
+```
+
+Playwright test example:
+
+```ts
+import { test, expect } from "#/pw-modules/test-extend";
+import { endpoints } from "#/shared-test-modules/endpoints";
+import { HttpResponse } from "msw";
+
+test("should render users", async ({ network, page }) => {
+  network.use(
+    endpoints.users({
+      successResponse: HttpResponse.json([{ name: "Alice" }]),
+    }),
+  );
+  await page.goto("/users");
+  await expect(page.getByText("Alice")).toBeVisible();
+});
+```
+
+## Prefer testing library selectors
+
+Both Vitest browser mode and Playwright include testing library
+selectors out of the box. Use `getByRole`, `getByLabelText`, and
+`getByText` over raw DOM queries like `querySelector` or `getByTestId`.
+They enforce accessible markup and make tests resilient to structural
+changes.
+
+```ts
+// good
+screen.getByRole("button", { name: /submit/i });
+screen.getByLabelText(/username/i);
+
+// avoid
+screen.querySelector("button.submit-btn");
+screen.getByTestId("submit-button");
+```
+
+## Avoid vitest mocks
+
+Prefer MSW and real implementations over `vi.mock` and
+module mocks. Vitest mocks couple tests to implementation details and
+break on refactors. Reach for them only when there is no practical
+alternative, such as faking time with `vi.useFakeTimers`.
+
+## Unit vs. integration tests
+
+### Unit tests
+
+Test a single component, hook, or utility in isolation. Render with
+`vitest-browser-react` `render()`. Use MSW to mock HTTP when the
+component fetches data.
+
+Do not mock the router. The only exception is when the component uses
+`<Link>`, `useNavigate`, or another router hook that fails without a
+provider. In that case wrap in a minimal router provider, nothing more.
+
+### Integration tests
+
+Test a feature across UI sections and pages: navigation, data loading,
+error states, user flows that span multiple components. Run against the
+built app via Playwright. Always mock the backend with MSW via the
+`network` fixture.
+
+## Accessibility tests
+
+Playwright + `@axe-core/playwright`. Two Playwright projects run every
+a11y test in both light and dark themes. Use the `makeAxeBuilder`
+fixture and assert that `violations` is empty.
+
+```ts
+import { test, expect } from "#/pw-modules/test-extend";
+
+test("should have no a11y violations", async ({ makeAxeBuilder, page }) => {
+  await page.goto("/some-page");
+  const results = await makeAxeBuilder().analyze();
+  expect(results.violations).toEqual([]);
+});
+```
+
+## Visual regression tests
+
+Playwright `toHaveScreenshot`. Four projects cover light/dark and
+desktop/tablet combinations. Set `CONTAINERIZED_BROWSER=true` to run
+inside the official `mcr.microsoft.com/playwright` Docker image for
+stable cross-machine rendering.
+
+```ts
+import { test, expect } from "#/pw-modules/test-extend";
+
+test("should match snapshot", async ({ page }) => {
+  await page.goto("/some-page");
+  await expect(page).toHaveScreenshot("some-page.png", { fullPage: true });
+});
+```

--- a/docs/monorepo-docs/frontend/using-ai.md
+++ b/docs/monorepo-docs/frontend/using-ai.md
@@ -19,7 +19,8 @@ automated agents reviewing your PRs.
   the orchestration-cluster webapp and knows our conventions. The agent
   is currently being developed and will be available soon.
 - Break the problem down before prompting. Smaller, well-scoped
-  prompts produce better results than "implement this feature."
+  prompts produce better results than "implement this feature." Use
+  plan mode to get the agent's help with the breakdown.
 - Review each response critically. Check for unnecessary abstractions,
   dead code, wrong patterns, and deviations from project conventions.
 - Iterate. Push back on the agent when the solution is not good

--- a/docs/monorepo-docs/frontend/using-ai.md
+++ b/docs/monorepo-docs/frontend/using-ai.md
@@ -1,0 +1,3 @@
+# Using AI
+
+_Content coming soon._

--- a/docs/monorepo-docs/frontend/using-ai.md
+++ b/docs/monorepo-docs/frontend/using-ai.md
@@ -1,3 +1,39 @@
 # Using AI
 
-_Content coming soon._
+Camunda follows an AI-first approach. Follow the company AI policies
+and apply the guidelines below when using AI for frontend work.
+
+## Your responsibility
+
+AI writes code, you own the result. Your job is to steer agents toward
+a good solution, not accept the first thing that compiles. Apply
+critical thinking, iterate, and refine.
+
+A PR should look as if AI was not involved. If it doesn't, you are
+shifting review burden to other engineers and wasting cycles from
+automated agents reviewing your PRs.
+
+## Working with agents
+
+- Use the frontend agent for frontend work. It is purpose-built for
+  the orchestration-cluster webapp and knows our conventions. The agent
+  is currently being developed and will be available soon.
+- Break the problem down before prompting. Smaller, well-scoped
+  prompts produce better results than "implement this feature."
+- Review each response critically. Check for unnecessary abstractions,
+  dead code, wrong patterns, and deviations from project conventions.
+- Iterate. Push back on the agent when the solution is not good
+  enough. Ask it to simplify, restructure, or try a different
+  approach.
+- Use the project docs (this site) as context for the agent so it
+  follows our conventions.
+
+## Before opening a PR
+
+- Code follows project conventions (see sibling docs).
+- No leftover boilerplate, redundant comments, or over-engineered
+  abstractions typical of AI output.
+- You can explain what your code does.
+- Tests are meaningful, not just "make the build pass."
+- The diff is clean and reviewable, same standard as hand-written
+  code.

--- a/monorepo-docs-site/sidebars.js
+++ b/monorepo-docs-site/sidebars.js
@@ -127,6 +127,7 @@ const sidebars = {
             'frontend/development-process/creating-a-new-page',
             'frontend/development-process/extending-an-existing-page',
             'frontend/development-process/working-on-large-feature',
+            'frontend/development-process/generating-svg-components',
           ],
         },
         'frontend/testing',

--- a/monorepo-docs-site/sidebars.js
+++ b/monorepo-docs-site/sidebars.js
@@ -139,6 +139,7 @@ const sidebars = {
           items: [],
         },
         'frontend/code-style',
+        'frontend/legacy-components',
       ],
     },
   ],

--- a/monorepo-docs-site/sidebars.js
+++ b/monorepo-docs-site/sidebars.js
@@ -113,6 +113,8 @@ const sidebars = {
       items: [
         'frontend/getting-started',
         'frontend/project-outline',
+        'frontend/orchestration-cluster-webapp',
+        'frontend/camunda-api-zod-schemas',
         'frontend/data-loading',
         'frontend/forms',
         {

--- a/monorepo-docs-site/sidebars.js
+++ b/monorepo-docs-site/sidebars.js
@@ -106,6 +106,41 @@ const sidebars = {
         },
       ],
     },
+    {
+      type: 'category',
+      label: 'Frontend',
+      link: { type: 'doc', id: 'frontend/frontend' },
+      items: [
+        'frontend/getting-started',
+        'frontend/project-outline',
+        'frontend/data-loading',
+        'frontend/forms',
+        {
+          type: 'category',
+          label: 'Development process',
+          link: {
+            type: 'doc',
+            id: 'frontend/development-process/development-process',
+          },
+          items: [
+            'frontend/development-process/before-starting',
+            'frontend/development-process/creating-a-new-page',
+            'frontend/development-process/extending-an-existing-page',
+            'frontend/development-process/working-on-large-feature',
+          ],
+        },
+        'frontend/testing',
+        'frontend/using-ai',
+        'frontend/code-reviews',
+        {
+          type: 'category',
+          label: 'ADRs',
+          link: { type: 'doc', id: 'frontend/adr/adr' },
+          items: [],
+        },
+        'frontend/code-style',
+      ],
+    },
   ],
 };
 

--- a/webapp/client/README.md
+++ b/webapp/client/README.md
@@ -1,0 +1,8 @@
+# webapp/client
+
+The unified frontend for Camunda 8 orchestration cluster components.
+
+For development documentation, see the **Frontend** section of the monorepo docs:
+[`docs/monorepo-docs/frontend/`](../../docs/monorepo-docs/frontend/frontend.md).
+
+Start with [Getting started](../../docs/monorepo-docs/frontend/getting-started.md).

--- a/webapp/client/packages/camunda-api-zod-schemas/README.md
+++ b/webapp/client/packages/camunda-api-zod-schemas/README.md
@@ -1,35 +1,8 @@
 # @camunda/camunda-api-zod-schemas
 
-This is a community-driven open-source project that provides [Zod](https://zod.dev/) schemas and TypeScript type definitions for the Camunda 8 REST API.
+[Zod](https://zod.dev/) schemas and TypeScript types for the Camunda 8
+REST API.
 
-It aims to help developers build robust and type-safe applications when interacting with Camunda 8.
-
-The official Camunda 8 REST API documentation can be found here: [https://docs.camunda.io/docs/next/apis-tools/camunda-api-rest/camunda-api-rest-overview/](https://docs.camunda.io/docs/next/apis-tools/camunda-api-rest/camunda-api-rest-overview/)
-
-## Installation
-
-You can install the package using your favorite package manager:
-
-```bash
-# pnpm
-pnpm add @camunda/camunda-api-zod-schemas
-
-# npm
-npm install @camunda/camunda-api-zod-schemas
-
-# yarn
-yarn add @camunda/camunda-api-zod-schemas
-```
-
-## Usage
-
-The library exports modules that correspond to the different parts of the Camunda API. You can import the schemas and types you need from the main package or specific version sub-modules like `@camunda/camunda-api-zod-schemas/8.8`.
-
-Refer to the exported members from `lib/8.8/index.ts` and other files in the `lib` directory for available schemas and types.
-
-## Publishing a new version
-
-1. Increment the version in `package.json`, dependency-versions in the npm workspace packages, run `npm i`, and push changes to `main`.
-2. Run the [Publish Zod Schemas to npm](https://github.com/camunda/camunda/actions/workflows/publish-zod-schemas.yml) GitHub action.
-   - By default, the dry-run option is enabled. Uncheck it to publish the new version.
-3. Update the `@camunda/camunda-api-zod-schemas` package versions in Operate, Admin and Tasklist.
+Full documentation — installation, usage, and publishing — lives in
+the Camunda Platform Developer Documentation:
+[Camunda API Zod schemas](https://camunda.github.io/camunda/frontend/camunda-api-zod-schemas/).


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR setups the basic structure of the frontend docs.

@pedesen Please review this one. I'll keep it open and open other PRs that will merge into this one. On these other docs I'll ask for review of the other frontend engineers too since it will involve the architecture.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #51327
