### PR TITLE
docs: document case-insensitive enum value handling on REST API

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
@@ -17,7 +17,7 @@ info:
     all accepted on input). Responses always use the canonical casing
     shown in this specification.
 
-    This permissive request behaviour is a server-side convenience and
+    This permissive request behavior is a server-side convenience and
     is **not** part of the OpenAPI enum contract — SDKs generated from
     this specification by strict generators may reject non-canonical
     casing on the client side. For portability across SDKs, always

--- a/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
@@ -5,7 +5,23 @@ info:
   contact:
     name: Camunda Engineering
     url: https://github.com/camunda/camunda/issues
-  description: API for communicating with a Camunda 8 cluster.
+  description: |
+    API for communicating with a Camunda 8 cluster.
+
+    ## Conventions
+
+    ### Enum value casing
+
+    Server-side, enum-typed request fields accept any casing of a
+    documented value (for example `ACTIVE`, `active`, and `Active` are
+    all accepted on input). Responses always use the canonical casing
+    shown in this specification.
+
+    This permissive request behaviour is a server-side convenience and
+    is **not** part of the OpenAPI enum contract — SDKs generated from
+    this specification by strict generators may reject non-canonical
+    casing on the client side. For portability across SDKs, always
+    send the canonical casing shown in this document.
   license:
     name: Camunda License Version 1.0
     url: https://github.com/camunda/camunda/blob/main/licenses/CAMUNDA-LICENSE-1.0.txt


### PR DESCRIPTION
## Summary

Documents an existing server-side behaviour on the Orchestration Cluster REST API: enum-typed request fields accept any casing of a documented value (e.g. `ACTIVE`, `active`, `Active` are all accepted on input), while responses always use the canonical casing shown in the spec.

The behaviour is enforced by the `useEnumCaseInsensitive=true` flag on the `gateway-model` OpenAPI codegen execution (`gateways/gateway-model/pom.xml`), which generates `equalsIgnoreCase` matchers in each enum's `@JsonCreator fromValue(...)`. It is **not** part of the OpenAPI enum contract — SDKs generated from the spec by strict generators (TypeScript, Python, C#) may still enforce case-sensitive values on the client side.

The added `info.description` text states both the server behaviour and the portability guidance: send canonical casing.

## Why

The behaviour is observable today (and relied on in some places) but is undocumented. SDK consumers and integration-test authors hit it asymmetrically — server tolerates anything, generated SDK clients reject non-canonical casing — with no contract to point at.

## Surfaces

The change lands in `zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml`, which is the bundled spec consumed by:

- `@camunda8/orchestration-cluster-api` (TypeScript SDK)
- `Camunda.Orchestration.Sdk` (C# SDK)
- `camunda_orchestration_sdk` (Python SDK)
- `camunda/api-test-generator`
- Swagger UI / Redoc renderings
- docs.camunda.io's API reference (via `docusaurus-plugin-openapi-docs`)

## Related

- #52353 (open) refactors `gateway-model` to a hand-rolled `ModelGenerator.java` and removes the `useEnumCaseInsensitive=true` Maven flag, but re-implements the same `equalsIgnoreCase` matcher inside the new `fromValue` template. The documented behaviour is preserved across that refactor; this docs change is independent of merge order. I left a comment on #52353 suggesting a small unit test to lock the case-insensitive contract in now that there's no Maven flag to point to.

## Alternatives considered

- A separate `## Conventions` section page in docs.camunda.io: rejected because it lives away from the spec and is easy to miss when reading the API reference.
- Per-enum description suffix: rejected as noisy (~50+ enums) and easy to drift.
