### PR TITLE
fix: skip error message assertion in forward-compat not-found tests

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/http.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/http.ts
@@ -158,9 +158,8 @@ export async function assertNotFoundRequest(
   assertRequiredFields(json, ['detail', 'title']);
   expect(json.title).toBe('NOT_FOUND');
   if (process.env.FORWARD_COMPAT_MODE === 'true') {
-    // In forward-compat runs the server may use a different error message
-    // format. Only verify that the detail mentions "not found".
-    expect(String(json.detail).toLowerCase()).toContain('not_found');
+    // In forward-compat runs we only care about the endpoint behaviour
+    // (correct status code and error structure), not the exact message wording.
   } else {
     expect(json.detail).toContain(detail);
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

In forward compatibility test runs, the exact wording of error messages may change between server versions. The important contract is the endpoint behaviour (404 status, correct error structure with title NOT_FOUND), not the specific detail message. Remove the detail string assertion in FORWARD_COMPAT_MODE to avoid false failures when the server changes its error message format.

## Related issues

related to https://camunda.slack.com/archives/C0A2AGG2Q2E/p1778124600065369
