### PR TITLE
fix: workaround to avoid validating locally the container config in migration ITs

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/UnifiedConfigurationHelper.java
+++ b/configuration/src/main/java/io/camunda/configuration/UnifiedConfigurationHelper.java
@@ -17,6 +17,7 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,7 +28,6 @@ import org.springframework.boot.convert.ApplicationConversionService;
 import org.springframework.core.ResolvableType;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.TypeDescriptor;
-import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
@@ -36,9 +36,10 @@ public class UnifiedConfigurationHelper {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(UnifiedConfigurationHelper.class);
   private static final ConversionService CONVERSION_SERVICE = new ApplicationConversionService();
+  private static final ThreadLocal<Integer> SKIP_VALIDATION_SEMAPHORE =
+      ThreadLocal.withInitial(() -> 0);
 
   private static Environment environment;
-  private static ConfigurableEnvironment configurableEnvironment;
 
   public UnifiedConfigurationHelper(@Autowired final Environment environment) {
     // We need to pin the environment object statically so that it can be used to perform the
@@ -165,6 +166,10 @@ public class UnifiedConfigurationHelper {
         isSensitiveData);
   }
 
+  private static boolean isValidationSkipped() {
+    return SKIP_VALIDATION_SEMAPHORE.get() > 0;
+  }
+
   private static <T> T validateLegacyConfiguration(
       final String newProperty,
       final T newValue,
@@ -172,6 +177,13 @@ public class UnifiedConfigurationHelper {
       final BackwardsCompatibilityMode backwardsCompatibilityMode,
       final Set<String> legacyProperties,
       final boolean isSensitiveData) {
+
+    // Skip validations entirely, if we're building the UC object as an artifact to pass to a test
+    // container. In these cases, as the configuration goes to a container, we do not want to
+    // validate it against the local current environment.
+    if (isValidationSkipped()) {
+      return newValue;
+    }
 
     // If the environment is not set, it is assumed that the helper is used
     // in a non-Spring context, and the validation of backward compatibility
@@ -348,6 +360,10 @@ public class UnifiedConfigurationHelper {
       final BackwardsCompatibilityMode backwardsCompatibilityMode,
       final Set<Set<String>> legacyProperties,
       final boolean isSensitiveData) {
+
+    if (isValidationSkipped()) {
+      return newValue;
+    }
 
     // If the environment is not set, it is assumed that the helper is used
     // in a non-Spring context, and the validation of backward compatibility
@@ -811,6 +827,15 @@ public class UnifiedConfigurationHelper {
 
   public static void setCustomEnvironment(final Environment environment) {
     UnifiedConfigurationHelper.environment = environment;
+  }
+
+  public static <T> T withoutValidation(final Supplier<T> block) {
+    SKIP_VALIDATION_SEMAPHORE.set(SKIP_VALIDATION_SEMAPHORE.get() + 1);
+    try {
+      return block.get();
+    } finally {
+      SKIP_VALIDATION_SEMAPHORE.set(SKIP_VALIDATION_SEMAPHORE.get() - 1);
+    }
   }
 
   public enum BackwardsCompatibilityMode {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -34,6 +34,9 @@
     <spotbugs.exclude>spotbugs/spotbugs-exclude.xml</spotbugs.exclude>
     <maven-profiler-report-directory>${project.build.directory}/profiler</maven-profiler-report-directory>
 
+    <!-- data layer nightly test exclusion flag -->
+    <failsafe.excluded.nightly>dl-nightly</failsafe.excluded.nightly>
+
     <!-- EXTERNAL LIBS -->
     <version.agrona>2.4.0</version.agrona>
     <version.animal-sniffer>1.27</version.animal-sniffer>
@@ -2453,7 +2456,7 @@
           <configuration>
             <argLine>${jvm.module.opens}</argLine>
             <!-- by default, exclude performance and strace tests -->
-            <excludedGroups>performance, strace</excludedGroups>
+            <excludedGroups>performance, strace, ${failsafe.excluded.nightly}</excludedGroups>
             <failIfNoTests>false</failIfNoTests>
             <trimStackTrace>false</trimStackTrace>
             <redirectTestOutputToFile>true</redirectTestOutputToFile>

--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -721,6 +721,9 @@
   <profiles>
     <profile>
       <id>dl-nightly</id>
+      <properties>
+        <failsafe.excluded.nightly/>
+      </properties>
       <build>
         <plugins>
           <plugin>

--- a/qa/testcontainer/src/main/java/io/camunda/container/ExtendedConfigurationBuilder.java
+++ b/qa/testcontainer/src/main/java/io/camunda/container/ExtendedConfigurationBuilder.java
@@ -30,6 +30,7 @@ import io.camunda.configuration.Monitoring;
 import io.camunda.configuration.Processing;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.configuration.Security;
+import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.configuration.Webapps;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
@@ -245,24 +246,27 @@ public class ExtendedConfigurationBuilder {
    * included, avoiding serialization bloat from eagerly initialized nested objects.
    */
   public String exportConfigAsString() {
-    try {
-      // Compute the diff between the configured Camunda bean and a pristine default instance.
-      // This avoids serializing hundreds of default properties that can interfere with the
-      // Docker image's own defaults (e.g. secondary-storage type, thread counts, etc.).
-      final Map<String, Object> defaultMap = flatten(createDefaultCamunda());
-      final Map<String, Object> configuredMap = flatten(unifiedConfig);
-      final Map<String, Object> diff = diffMaps(defaultMap, configuredMap);
+    return UnifiedConfigurationHelper.withoutValidation(
+        () -> {
+          try {
+            // Compute the diff between the configured Camunda bean and a pristine default instance.
+            // This avoids serializing hundreds of default properties that can interfere with the
+            // Docker image's own defaults (e.g. secondary-storage type, thread counts, etc.).
+            final Map<String, Object> defaultMap = flatten(createDefaultCamunda());
+            final Map<String, Object> configuredMap = flatten(unifiedConfig);
+            final Map<String, Object> diff = diffMaps(defaultMap, configuredMap);
 
-      final Map<String, Object> fullConfig = new LinkedHashMap<>();
-      if (!diff.isEmpty()) {
-        fullConfig.put(CAMUNDA_HEADER, diff);
-      }
-      mergeConfigs(fullConfig, flatten(additionalConfigs));
+            final Map<String, Object> fullConfig = new LinkedHashMap<>();
+            if (!diff.isEmpty()) {
+              fullConfig.put(CAMUNDA_HEADER, diff);
+            }
+            mergeConfigs(fullConfig, flatten(additionalConfigs));
 
-      return YAML_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(fullConfig);
-    } catch (final IOException e) {
-      throw new RuntimeException(e);
-    }
+            return YAML_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(fullConfig);
+          } catch (final IOException e) {
+            throw new RuntimeException(e);
+          }
+        });
   }
 
   /**


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

When instantiating the camunda containers, we're often building the unified configuration object with a sequence of calls to getters and setters, plus a final export. These operations are performing the configuration validation with the issue that, while the config is supposed to be injected into the container, the validation is being performed against the local JVM. This is causing a conceptual misbehavior, where test container's properties might clash with locally configured properties.

In this PR, we're using a workaround to init the container without validating the unified configuration, so that the tests can run correctly. The problem has been observed in the parameterized test `shouldCompleteUpgradeWithBacklogAndExportAllRecordsAgainstReleasePatches`, where only the first test would succeed, while the others would fail.

Before the PR:

<img width="508" height="174" alt="image" src="https://github.com/user-attachments/assets/fd7ec51a-f58a-4eb7-98ac-5cb188673af9" />

After the PR:

<img width="507" height="171" alt="image" src="https://github.com/user-attachments/assets/745ab001-bf63-4a28-9378-145aa37c0d93" />

NOTE: That test is tagged as `dl-nightly`, which is an excluded group. To verify this PR, it's enough to hit "play" with IntelliJ against the test. This PR is also fixing the exclusion mechanism, as it was not working as expected, before.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
