### PR TITLE
Fix/rdbms stabilise batch operation create

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/BatchOperationWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/BatchOperationWriter.java
@@ -58,10 +58,6 @@ public class BatchOperationWriter implements RdbmsWriter {
   }
 
   public void create(final BatchOperationDbModel batchOperation) {
-    // flush before to make the following insert flush as small as possible to prevent an
-    // ORA-00001 merge into conflict
-    executionQueue.flush();
-
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.BATCH_OPERATION,
@@ -69,10 +65,6 @@ public class BatchOperationWriter implements RdbmsWriter {
             batchOperation.batchOperationKey(),
             "io.camunda.db.rdbms.sql.BatchOperationMapper.createIfNotExists",
             batchOperation));
-
-    // to have this for available for following batch operation item inserts, we directly flush here
-    LOGGER.trace("Force flush to directly create batch operation: {}", batchOperation);
-    executionQueue.flush();
   }
 
   public void activate(final String batchOperationKey, final OffsetDateTime startDate) {

--- a/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
@@ -122,6 +122,9 @@
     ON DUPLICATE KEY UPDATE BATCH_OPERATION_KEY = BATCH_OPERATION_KEY
   </insert>
 
+  <!-- The batch operation insert can happen concurrently on multiple partitions.
+  The more common MERGE INTO of MSSQL is not safe here and still can cause a PK violation.
+  This is what we want to avoid. This try-catch will explicitly ignore the PK violation. -->
   <insert id="createIfNotExists"
     parameterType="io.camunda.db.rdbms.write.domain.BatchOperationDbModel"
     databaseId="mssql">
@@ -153,6 +156,9 @@
     END CATCH
   </insert>
 
+  <!-- The batch operation insert can happen concurrently on multiple partitions.
+  The more common MERGE INTO of MSSQL is not safe here and still can cause a PK violation.
+  This is what we want to avoid. This IGNORE_ROW_ON_DUPKEY_INDEX hint will explicitly ignore the PK violation. -->
   <insert id="createIfNotExists"
     parameterType="io.camunda.db.rdbms.write.domain.BatchOperationDbModel"
     databaseId="oracle">

--- a/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
@@ -125,48 +125,51 @@
   <insert id="createIfNotExists"
     parameterType="io.camunda.db.rdbms.write.domain.BatchOperationDbModel"
     databaseId="mssql">
-    MERGE ${prefix}BATCH_OPERATION AS target
-    USING (SELECT #{batchOperationKey} AS BATCH_OPERATION_KEY,
-                  #{state} AS STATE,
-                  #{operationType} AS OPERATION_TYPE,
-                  #{startDate, jdbcType=TIMESTAMP} AS START_DATE,
-                  #{endDate, jdbcType=TIMESTAMP} AS END_DATE,
-                  #{actorType} AS ACTOR_TYPE,
-                  #{actorId} AS ACTOR_ID,
-                  #{operationsTotalCount} AS OPERATIONS_TOTAL_COUNT,
-                  #{operationsFailedCount} AS OPERATIONS_FAILED_COUNT,
-                  #{operationsCompletedCount} AS OPERATIONS_COMPLETED_COUNT) AS source
-    ON (target.BATCH_OPERATION_KEY = source.BATCH_OPERATION_KEY)
-    WHEN NOT MATCHED THEN
-      INSERT (BATCH_OPERATION_KEY, STATE, OPERATION_TYPE, START_DATE, END_DATE, ACTOR_TYPE, ACTOR_ID,
-              OPERATIONS_TOTAL_COUNT, OPERATIONS_FAILED_COUNT, OPERATIONS_COMPLETED_COUNT)
-      VALUES (source.BATCH_OPERATION_KEY, source.STATE, source.OPERATION_TYPE, source.START_DATE,
-              source.END_DATE, source.ACTOR_TYPE, source.ACTOR_ID, source.OPERATIONS_TOTAL_COUNT,
-              source.OPERATIONS_FAILED_COUNT, source.OPERATIONS_COMPLETED_COUNT);
+    BEGIN TRY
+      INSERT INTO ${prefix}BATCH_OPERATION (BATCH_OPERATION_KEY,
+      STATE,
+      OPERATION_TYPE,
+      START_DATE,
+      END_DATE,
+      ACTOR_TYPE,
+      ACTOR_ID,
+      OPERATIONS_TOTAL_COUNT,
+      OPERATIONS_FAILED_COUNT,
+      OPERATIONS_COMPLETED_COUNT)
+      VALUES (#{batchOperationKey},
+      #{state},
+      #{operationType},
+      #{startDate, jdbcType=TIMESTAMP},
+      #{endDate, jdbcType=TIMESTAMP},
+      #{actorType},
+      #{actorId},
+      #{operationsTotalCount},
+      #{operationsFailedCount},
+      #{operationsCompletedCount});
+    END TRY
+    BEGIN CATCH
+      IF ERROR_NUMBER() != 2627 -- Violation of primary key (duplicate key)
+        THROW;
+    END CATCH
   </insert>
 
   <insert id="createIfNotExists"
     parameterType="io.camunda.db.rdbms.write.domain.BatchOperationDbModel"
     databaseId="oracle">
-    MERGE INTO ${prefix}BATCH_OPERATION target
-    USING (SELECT #{batchOperationKey} AS BATCH_OPERATION_KEY,
-                  #{state} AS STATE,
-                  #{operationType} AS OPERATION_TYPE,
-                  #{startDate} AS START_DATE,
-                  #{endDate} AS END_DATE,
-                  #{actorType} AS ACTOR_TYPE,
-                  #{actorId} AS ACTOR_ID,
-                  #{operationsTotalCount} AS OPERATIONS_TOTAL_COUNT,
-                  #{operationsFailedCount} AS OPERATIONS_FAILED_COUNT,
-                  #{operationsCompletedCount} AS OPERATIONS_COMPLETED_COUNT
-           FROM dual) source
-    ON (target.BATCH_OPERATION_KEY = source.BATCH_OPERATION_KEY)
-    WHEN NOT MATCHED THEN
-    INSERT (BATCH_OPERATION_KEY, STATE, OPERATION_TYPE, START_DATE, END_DATE, ACTOR_TYPE, ACTOR_ID,
+    INSERT /*+ IGNORE_ROW_ON_DUPKEY_INDEX(${prefix}BATCH_OPERATION (BATCH_OPERATION_KEY)) */
+    INTO ${prefix}BATCH_OPERATION
+    (BATCH_OPERATION_KEY, STATE, OPERATION_TYPE, START_DATE, END_DATE, ACTOR_TYPE, ACTOR_ID,
     OPERATIONS_TOTAL_COUNT, OPERATIONS_FAILED_COUNT, OPERATIONS_COMPLETED_COUNT)
-    VALUES (source.BATCH_OPERATION_KEY, source.STATE, source.OPERATION_TYPE, source.START_DATE,
-    source.END_DATE, source.ACTOR_TYPE, source.ACTOR_ID, source.OPERATIONS_TOTAL_COUNT,
-    source.OPERATIONS_FAILED_COUNT, source.OPERATIONS_COMPLETED_COUNT)
+    VALUES (#{batchOperationKey},
+    #{state},
+    #{operationType},
+    #{startDate},
+    #{endDate},
+    #{actorType},
+    #{actorId},
+    #{operationsTotalCount},
+    #{operationsFailedCount},
+    #{operationsCompletedCount})
   </insert>
 
   <insert id="createIfNotExists"

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/ClusterMultiplePartitionsBatchOperationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/ClusterMultiplePartitionsBatchOperationIT.java
@@ -53,9 +53,10 @@ public class ClusterMultiplePartitionsBatchOperationIT {
           .withUnauthenticatedAccess()
           .withUnifiedConfig(
               b -> {
-                final var cluster = b.getCluster();
-                cluster.setPartitionCount(3);
-                b.setCluster(cluster);
+                // We want to test multiple partitions and concurrency. To make the test potentially
+                // flaky we increase the partitions and exporter threads
+                b.getCluster().setPartitionCount(9);
+                b.getSystem().setIoThreadCount(9);
               });
 
   private static CamundaClient camundaClient;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationIT.java
@@ -63,7 +63,14 @@ public class BatchOperationIT {
     final var batchOperation = BatchOperationFixtures.createRandomized(b -> b);
 
     rdbmsWriters.getBatchOperationWriter().create(batchOperation);
+    rdbmsWriters.flush();
+
     rdbmsWriters.getBatchOperationWriter().create(batchOperation);
+    rdbmsWriters.flush();
+
+    // then
+    final var updatedBatchOperation = getBatchOperation(rdbmsService, batchOperation);
+    assertThat(updatedBatchOperation).isNotNull();
   }
 
   @TestTemplate

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExportHandler.java
@@ -15,4 +15,8 @@ public interface RdbmsExportHandler<T extends RecordValue> {
   boolean canExport(Record<T> record);
 
   void export(Record<T> record);
+
+  default boolean shouldFlushAfterRecordProcessed() {
+    return false;
+  }
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
@@ -225,6 +225,7 @@ public final class RdbmsExporter {
         record.getIntent());
 
     boolean exported = false;
+    boolean shouldFlushAfterRecordProcessed = false;
     if (registeredHandlers.containsKey(record.getValueType())) {
       for (final var handler : registeredHandlers.get(record.getValueType())) {
         if (handler.canExport(record)) {
@@ -235,6 +236,7 @@ public final class RdbmsExporter {
               handler.getClass());
           handler.export(record);
           exported = true;
+          shouldFlushAfterRecordProcessed |= handler.shouldFlushAfterRecordProcessed();
         } else {
           LOG.trace(
               "[RDBMS Exporter P{}] Handler {} can not export record {}",
@@ -263,7 +265,8 @@ public final class RdbmsExporter {
       // causes a flush check after each processed record. Depending on the queue size and
       // configuration, the writers ExecutionQueue may or may not flush here.
       try {
-        final boolean flushed = rdbmsWriters.flush(flushAfterEachRecord());
+        final boolean shouldFlush = flushAfterEachRecord() || shouldFlushAfterRecordProcessed;
+        final boolean flushed = rdbmsWriters.flush(shouldFlush);
         if (flushed) {
           resetIntervalFlush();
         }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationCreatedExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/batchoperation/BatchOperationCreatedExportHandler.java
@@ -56,6 +56,12 @@ public class BatchOperationCreatedExportHandler
             BatchOperationType.valueOf(record.getValue().getBatchOperationType().name())));
   }
 
+  @Override
+  public boolean shouldFlushAfterRecordProcessed() {
+    // to minimize the risk of PK violations during MERGE INTO we want to flush fast here
+    return true;
+  }
+
   private BatchOperationDbModel map(final Record<BatchOperationCreationRecordValue> record) {
     final var value = record.getValue();
     final var actorInfo = actorInfoExtractor.extract(record);

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterTest.java
@@ -168,6 +168,22 @@ class RdbmsExporterTest {
   }
 
   @Test
+  void shouldCheckForFlushOnFlushAfterHandlerTrue() {
+    // given
+    final var jobHandler = mockHandler(ValueType.JOB);
+    when(jobHandler.shouldFlushAfterRecordProcessed()).thenReturn(true);
+    final var record = mockRecord(ValueType.JOB, 1);
+
+    createExporter(b -> b.withHandler(ValueType.JOB, jobHandler));
+
+    // when
+    exporter.export(record);
+
+    // then
+    verify(rdbmsWriters).flush(true);
+  }
+
+  @Test
   void shouldRegisterFlushListeners() {
     // given
     createExporter(b -> b);


### PR DESCRIPTION
## Description

This PR fixes a concurrency problem when creating a batch operation. The BatchOperationCreation.CREATE record is processed on each partition and a `MERGE` or `INSERT ON CONFLICT` is used to only insert the entity when it does not exist. The problem now is, that the `MERGE INTO` of Oracle and MSSQL is unstable and still can fail with a PK violation. The statement itself is then retryable but due to a flush() in the `BatchOperationWriter` the exporter was then in an inconsistent state (flush was called in the middle of processing a record) and caused PK violations elsewhere in the audit log `INSERT`.

Fixes:
- extract the double flush() from `BatchOperationWriter` to a `shouldFlushAfterRecordProcessed`() in the exporter. The flush will now happen after all handlers processed. Any PK violation will result in an error but now the whole record will be retried.
- harden the Oracle and MSSQL statements to simply ignore PK violations when inserting batch operations. With this we also will not have an error in the log

## Checklist

<!--- Please delete options that are not relevant. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
