### PR TITLE
test: use page object model for login visual test

### DIFF
--- a/webapp/client/apps/orchestration-cluster-webapp/test/pages/Login.page.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/test/pages/Login.page.ts
@@ -6,13 +6,22 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {test, expect} from '#/pw-modules/test-extend';
-import {LoginPage} from '../pages/Login.page';
+import {type Page} from '@playwright/test';
 
-test('should match the login page snapshot', async ({page}) => {
-	const loginPage = new LoginPage(page);
-	await loginPage.goto();
-	await expect(loginPage.submitButton).toBeVisible();
+class LoginPage {
+	private page: Page;
 
-	await expect(page).toHaveScreenshot();
-});
+	constructor(page: Page) {
+		this.page = page;
+	}
+
+	async goto() {
+		await this.page.goto('/login');
+	}
+
+	get submitButton() {
+		return this.page.getByRole('button', {name: /login/i});
+	}
+}
+
+export {LoginPage};


### PR DESCRIPTION
## Description

 Use page object model for login visual test.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

related to #51319 
