### PR TITLE
refactor: remove ts-check from operate and tasklist client build scripts

### DIFF
--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -46,7 +46,7 @@
   },
   "scripts": {
     "start": "vite",
-    "build": "npm run ts-check && vite build && node ./renameProdIndex.js && node license-build.js",
+    "build": "vite build && node ./renameProdIndex.js && node license-build.js",
     "build:visual-regression": "cross-env VITE_VERSION=0.0.0-SNAPSHOT vite build --mode visual-regression",
     "test": "vitest run --project=unit",
     "test:browser": "vitest run --project=browser",

--- a/tasklist/client/package.json
+++ b/tasklist/client/package.json
@@ -42,7 +42,7 @@
   },
   "scripts": {
     "start": "vite",
-    "build": "npm run ts-check && vite build && node ./renameProdIndex.mjs",
+    "build": "vite build && node ./renameProdIndex.mjs",
     "build:visual-regression": "VITE_VERSION=0.0.0-SNAPSHOT vite build --mode visual-regression",
     "test": "TZ=utc vitest run",
     "test:ci": "CI=true npm run test",


### PR DESCRIPTION
## Description

Removes the TS check from both Operate's and Tasklist's build scripts. This will improve the build performance in various CI jobs. Their main CI job still run a type check so the static analysis guarantees should not be lost.
