### PR TITLE
deps: update thymeleaf dependency to 3.1.5.RELEASE

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -173,7 +173,7 @@
     <version.reflections>0.10.2</version.reflections>
 
     <version.commons-io>2.21.0</version.commons-io>
-    <version.thymeleaf>3.1.4.RELEASE</version.thymeleaf>
+    <version.thymeleaf>3.1.5.RELEASE</version.thymeleaf>
     <version.unboundid-ldapsdk>7.0.4</version.unboundid-ldapsdk>
     <version.parsson>1.1.7</version.parsson>
     <version.springdoc>3.0.2</version.springdoc>
@@ -2177,14 +2177,6 @@
         <groupId>com.nimbusds</groupId>
         <artifactId>nimbus-jose-jwt</artifactId>
         <version>${version.nimbus-jose-jwt}</version>
-      </dependency>
-
-      <!-- override transitive dependency in spring-boot-starter-thymeleaf until a
-           new version using thymeleaf-spring6:3.1.4.RELEASE is released -->
-      <dependency>
-        <groupId>org.thymeleaf</groupId>
-        <artifactId>thymeleaf-spring6</artifactId>
-        <version>${version.thymeleaf}</version>
       </dependency>
 
       <!-- testcontainers and docker: see


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Update Thymeleaf dependency to fix CVE issues.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #52634
