### PR TITLE
Rl fix broker topology listener race

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/clustering/DynamicClusterServices.java
+++ b/dist/src/main/java/io/camunda/application/commons/clustering/DynamicClusterServices.java
@@ -76,6 +76,9 @@ public class DynamicClusterServices {
         new BrokerTopologyManagerImpl(clusterMembershipService::getMembers, brokerTopologyMetrics);
     scheduler.submitActor(brokerTopologyManager).join();
     clusterMembershipService.addListener(brokerTopologyManager);
+    // Re-seed after the listener is attached: closes the race where a MEMBER_ADDED
+    // event fires between the actor's initial snapshot and listener registration.
+    brokerTopologyManager.checkForMissingEvents();
     return brokerTopologyManager;
   }
 
@@ -87,6 +90,9 @@ public class DynamicClusterServices {
         new BrokerTopologyManagerImpl(clusterMembershipService::getMembers, brokerTopologyMetrics);
     scheduler.submitActor(brokerTopologyManager).join();
     clusterMembershipService.addListener(brokerTopologyManager);
+    // Re-seed after the listener is attached: closes the race where a MEMBER_ADDED
+    // event fires between the actor's initial snapshot and listener registration.
+    brokerTopologyManager.checkForMissingEvents();
     gatewayClusterConfigurationService.addUpdateListener(brokerTopologyManager);
     return brokerTopologyManager;
   }

--- a/dist/src/main/java/io/camunda/application/commons/clustering/DynamicClusterServices.java
+++ b/dist/src/main/java/io/camunda/application/commons/clustering/DynamicClusterServices.java
@@ -78,7 +78,7 @@ public class DynamicClusterServices {
     clusterMembershipService.addListener(brokerTopologyManager);
     // Re-seed after the listener is attached: closes the race where a MEMBER_ADDED
     // event fires between the actor's initial snapshot and listener registration.
-    brokerTopologyManager.checkForMissingEvents();
+    brokerTopologyManager.initializeTopologyFromMembership();
     return brokerTopologyManager;
   }
 
@@ -92,7 +92,7 @@ public class DynamicClusterServices {
     clusterMembershipService.addListener(brokerTopologyManager);
     // Re-seed after the listener is attached: closes the race where a MEMBER_ADDED
     // event fires between the actor's initial snapshot and listener registration.
-    brokerTopologyManager.checkForMissingEvents();
+    brokerTopologyManager.initializeTopologyFromMembership();
     gatewayClusterConfigurationService.addUpdateListener(brokerTopologyManager);
     return brokerTopologyManager;
   }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
@@ -98,7 +98,7 @@ public final class BrokerTopologyManagerImpl extends Actor
    * registering this instance as a listener, to close the race where a {@code MEMBER_ADDED} event
    * fires between the actor starting and the listener being attached.
    */
-  public void checkForMissingEvents() {
+  public void initializeTopologyFromMembership() {
     final Set<Member> members = membersSupplier.get();
     if (members == null || members.isEmpty()) {
       return;
@@ -151,7 +151,7 @@ public final class BrokerTopologyManagerImpl extends Actor
     // Get the initial member state before the listener is registered.
     // Also called AFTER registering this as a membership listener, to cover the window
     // between the snapshot here and listener attachment.
-    checkForMissingEvents();
+    initializeTopologyFromMembership();
   }
 
   @Override

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
@@ -90,7 +90,15 @@ public final class BrokerTopologyManagerImpl extends Actor
         });
   }
 
-  private void checkForMissingEvents() {
+  /**
+   * Seeds the topology with all brokers currently visible in the membership service. Safe to call
+   * from any thread; mutations are routed through the actor. Idempotent.
+   *
+   * <p>Callers wiring this up against a {@code ClusterMembershipService} must invoke this AFTER
+   * registering this instance as a listener, to close the race where a {@code MEMBER_ADDED} event
+   * fires between the actor starting and the listener being attached.
+   */
+  public void checkForMissingEvents() {
     final Set<Member> members = membersSupplier.get();
     if (members == null || members.isEmpty()) {
       return;
@@ -140,7 +148,9 @@ public final class BrokerTopologyManagerImpl extends Actor
 
   @Override
   protected void onActorStarted() {
-    // Get the initial member state before the listener is registered
+    // Get the initial member state before the listener is registered.
+    // Also called AFTER registering this as a membership listener, to cover the window
+    // between the snapshot here and listener attachment.
     checkForMissingEvents();
   }
 


### PR DESCRIPTION
## Description

Investigated the flaky logs of `io.camunda.zeebe.it.cluster.management.RebalancingEndpointIT` with claude and the reason in all the cases seems to be the same. 

`shouldRebalanceCluster` failed at `forceBadLeaderDistribution` because `awaitCompleteTopology(Duration.ofMinutes(1))` on the just-restarted broker timed out. The gateway returned only **1** or **2** brokers.

From one of the cases:

From the broker log timeline (broker 1 had been stopped and was rejoining):

```
11:46:08.474   Broker-1 SWIM:    Member added Member{id=2, ... brokerInfo=...}
11:46:08.480   Broker-1 SWIM:    Member added Member{id=0, ... brokerInfo=...}
11:46:08.528   Broker-1 gateway: "Updating topology with clusterSize 3..."
11:46:08.534   Broker-1 *internal* TopologyManager: metadata for 0 / 2 received
11:46:08.721   Broker-1 gateway:  first metadata change (for self only)
   <— ~60 s of silence on the gateway side for brokers 0 and 2 —>
11:47:09.152   Broker-1 gateway:  first metadata change for Broker 0  (test already failed)
```

- **Zero** `"Received new broker"` log lines for any broker anywhere in the failing run — i.e. the gateway-side `BrokerTopologyManagerImpl` listener never received a `MEMBER_ADDED` event.
- The test's own assertion (broker 0 missing) rules out the alternative — that the snapshot at `onActorStarted` had picked up the peers.

The broker-internal `TopologyManager` (a *different* listener on the same membership service) **did** receive metadata for peers 0 and 2 at `08.534`, so SWIM membership and Raft replication were healthy. The bug is specific to the gateway-side listener.

The wiring in `DynamicClusterServices` is:

```java
scheduler.submitActor(brokerTopologyManager).join();         // (1) onActorStarted → checkForMissingEvents()
clusterMembershipService.addListener(brokerTopologyManager); // (2) listener attached
```

This is a very short time for this race condition to happen but the high parallelism of tests in qa/integration-tests with maven-test-fork-count: 10 is probably the reason why we see this only in the CI and not locally.

So this PR closes the startup race in `BrokerTopologyManagerImpl` wiring that lets a freshly rejoined broker's embedded gateway return an incomplete topology, sometimes for tens of seconds, until a peer happens to update its properties. This is done by just checking for updates immediately after registering the listener. 

This is a potentially bug fix, but seems quite unlikely to happen in normal conditions.


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes https://github.com/camunda/camunda/issues/51924
