### PR TITLE
docs: add docs for generating svg components

### DIFF
--- a/docs/monorepo-docs/frontend/development-process/development-process.md
+++ b/docs/monorepo-docs/frontend/development-process/development-process.md
@@ -1,3 +1,7 @@
 # Development process
 
-_Content coming soon._
+- [Before Starting](before-starting.md): Things to consider before starting development.
+- [Creating a New Page](creating-a-new-page.md): Guide to creating a new page.
+- [Extending an Existing Page](extending-an-existing-page.md): Steps to extend an existing page.
+- [Working on a Large Feature](working-on-large-feature.md): Tips for handling large features.
+- [Generating SVG Components](generating-svg-components.md): Guide on generating React components from SVG files.

--- a/docs/monorepo-docs/frontend/development-process/generating-svg-components.md
+++ b/docs/monorepo-docs/frontend/development-process/generating-svg-components.md
@@ -1,0 +1,16 @@
+# Generating SVG components
+
+We use `@svgr/cli` to convert SVG files into reusable React components, simplifying their integration into the project.
+
+Run the following command inside an apps client directory to generate React components from the SVG source files:
+
+```sh
+npm run generate:svg
+```
+
+This command processes all SVG files in `src/assets/svg/` and generates React components from them. These components are stored in `src/modules/svg/` and are intended for use throughout the project. They must not be edited manually, as any changes will be overwritten the next time the command is run.
+
+This must be run manually in the following cases:
+
+- **A new SVG is added** to `src/assets/svg/`
+- **An existing SVG is changed** in `src/assets/svg/`


### PR DESCRIPTION
## Description

- Add index to development process section
- Add docs for generating svg components


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
