### PR TITLE
fix: cancel flush task when exporter closed

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -61,6 +61,7 @@ import io.camunda.zeebe.exporter.api.ExporterException;
 import io.camunda.zeebe.exporter.api.context.Context;
 import io.camunda.zeebe.exporter.api.context.Context.RecordFilter;
 import io.camunda.zeebe.exporter.api.context.Controller;
+import io.camunda.zeebe.exporter.api.context.ScheduledTask;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -92,6 +93,7 @@ public class CamundaExporter implements Exporter {
   private long lastFlushTimestamp = 0L;
 
   private long flushDelayMs;
+  private ScheduledTask scheduledFlushTask;
 
   public CamundaExporter() {
     // the metadata will be initialized on open
@@ -153,6 +155,10 @@ public class CamundaExporter implements Exporter {
 
   @Override
   public void close() {
+    if (scheduledFlushTask != null) {
+      scheduledFlushTask.cancel();
+      scheduledFlushTask = null;
+    }
 
     if (writer != null) {
       try {
@@ -331,7 +337,9 @@ public class CamundaExporter implements Exporter {
       nextDelayMs = Math.max(0, flushDelayMs - (now - lastFlushTimestamp));
     }
 
-    controller.scheduleCancellableTask(Duration.ofMillis(nextDelayMs), this::flushAndReschedule);
+    scheduledFlushTask =
+        controller.scheduleCancellableTask(
+            Duration.ofMillis(nextDelayMs), this::flushAndReschedule);
   }
 
   private void flushAndReschedule() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
@@ -142,13 +142,13 @@ final class CamundaExporterTest {
     }
 
     @Override
-    public CacheLoader<String, CachedFormEntity> getFormCacheLoader(final String formIndexName) {
+    public CacheLoader<Long, CachedDecisionRequirementsEntity> getDecisionRequirementsCacheLoader(
+        final String decisionIndexName) {
       return k -> null;
     }
 
     @Override
-    public CacheLoader<Long, CachedDecisionRequirementsEntity> getDecisionRequirementsCacheLoader(
-        final String decisionIndexName) {
+    public CacheLoader<String, CachedFormEntity> getFormCacheLoader(final String formIndexName) {
       return k -> null;
     }
   }
@@ -419,6 +419,23 @@ final class CamundaExporterTest {
         final var tasks = testController.getScheduledTasks();
         assertThat(tasks.getLast().getDelay()).isEqualTo(Duration.ofMillis(1000));
       }
+    }
+
+    @Test
+    void shouldCancelScheduledFlushTaskOnClose() {
+      exporter =
+          new CamundaExporter(
+              resourceProvider, new ExporterMetadata(TestObjectMapper.objectMapper()));
+      exporter.configure(testContext);
+      exporter.open(testController);
+
+      final var tasks = testController.getScheduledTasks();
+      final var flushTask = tasks.getLast();
+      assertThat(flushTask.isCanceled()).isEqualTo(false);
+
+      exporter.close();
+
+      assertThat(flushTask.isCanceled()).isEqualTo(true);
     }
   }
 }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.exporter.api.Exporter;
 import io.camunda.zeebe.exporter.api.ExporterException;
 import io.camunda.zeebe.exporter.api.context.Context;
 import io.camunda.zeebe.exporter.api.context.Controller;
+import io.camunda.zeebe.exporter.api.context.ScheduledTask;
 import io.camunda.zeebe.exporter.filter.DefaultRecordFilter;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.util.SemanticVersion;
@@ -57,6 +58,7 @@ public class ElasticsearchExporter implements Exporter {
   private ElasticsearchExporterSchemaManager schemaManager;
 
   private long lastPosition = -1;
+  private ScheduledTask scheduledFlushTask;
 
   @Override
   public void configure(final Context context) {
@@ -105,6 +107,11 @@ public class ElasticsearchExporter implements Exporter {
 
   @Override
   public void close() {
+    if (scheduledFlushTask != null) {
+      scheduledFlushTask.cancel();
+      scheduledFlushTask = null;
+    }
+
     // the client is only created in some lifecycles, so during others (e.g. validation) it may not
     // exist, in which case there's no point flushing or doing anything
     if (client != null) {
@@ -230,8 +237,9 @@ public class ElasticsearchExporter implements Exporter {
   }
 
   private void scheduleDelayedFlush() {
-    controller.scheduleCancellableTask(
-        Duration.ofSeconds(configuration.bulk.delay), this::flushAndReschedule);
+    scheduledFlushTask =
+        controller.scheduleCancellableTask(
+            Duration.ofSeconds(configuration.bulk.delay), this::flushAndReschedule);
   }
 
   private void flush() {

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterTest.java
@@ -108,6 +108,24 @@ final class ElasticsearchExporterTest {
     verify(client).close();
   }
 
+  @Test
+  void shouldCancelScheduledFlushTaskOnClose() {
+    // given
+    final var exporter = new ElasticsearchExporter();
+    exporter.configure(context);
+    exporter.open(controller);
+
+    final var tasks = controller.getScheduledTasks();
+    final var flushTask = tasks.getLast();
+    assertThat(flushTask.isCanceled()).isEqualTo(false);
+
+    // when
+    exporter.close();
+
+    // then
+    assertThat(flushTask.isCanceled()).isEqualTo(true);
+  }
+
   @Nested
   final class RecordFilterTest {
 

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.exporter.api.Exporter;
 import io.camunda.zeebe.exporter.api.ExporterException;
 import io.camunda.zeebe.exporter.api.context.Context;
 import io.camunda.zeebe.exporter.api.context.Controller;
+import io.camunda.zeebe.exporter.api.context.ScheduledTask;
 import io.camunda.zeebe.exporter.filter.DefaultRecordFilter;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.util.SemanticVersion;
@@ -42,6 +43,7 @@ public class OpensearchExporter implements Exporter {
   private OpensearchExporterSchemaManager schemaManager;
 
   private long lastPosition = -1;
+  private ScheduledTask scheduledFlushTask;
 
   @Override
   public void configure(final Context context) {
@@ -88,6 +90,10 @@ public class OpensearchExporter implements Exporter {
 
   @Override
   public void close() {
+    if (scheduledFlushTask != null) {
+      scheduledFlushTask.cancel();
+      scheduledFlushTask = null;
+    }
     // the client is only created in some lifecycles, so during others (e.g. validation) it may not
     // exist, in which case there's no point flushing or doing anything
     if (client != null) {
@@ -209,8 +215,9 @@ public class OpensearchExporter implements Exporter {
   }
 
   private void scheduleDelayedFlush() {
-    controller.scheduleCancellableTask(
-        Duration.ofSeconds(configuration.bulk.delay), this::flushAndReschedule);
+    scheduledFlushTask =
+        controller.scheduleCancellableTask(
+            Duration.ofSeconds(configuration.bulk.delay), this::flushAndReschedule);
   }
 
   private void flush() {

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterTest.java
@@ -112,6 +112,24 @@ final class OpensearchExporterTest {
   }
 
   @Test
+  void shouldCancelScheduledFlushTaskOnClose() {
+    // given
+    final var exporter = new OpensearchExporter();
+    exporter.configure(context);
+    exporter.open(controller);
+
+    final var tasks = controller.getScheduledTasks();
+    final var flushTask = tasks.getLast();
+    assertThat(flushTask.isCanceled()).isEqualTo(false);
+
+    // when
+    exporter.close();
+
+    // then
+    assertThat(flushTask.isCanceled()).isEqualTo(true);
+  }
+
+  @Test
   void shouldCreateIndexStateManagementPolicy() {
     // given
     config.retention.setEnabled(true);


### PR DESCRIPTION
to ensure we stop trying to flush when the exporter is closed.

## Related issues

closes #52612
