### PR TITLE
test: stabilize Operate E2E processInstanceMigration tests (#52655)

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/LoginPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/LoginPage.ts
@@ -53,23 +53,26 @@ export class LoginPage {
   async login(username: string, password: string) {
     // Camunda apps share an auth session: navigating to /<app>/login when
     // already authenticated redirects to the app home, so the login form
-    // never renders. Skip login in that case rather than hanging on a
-    // username input that will never appear.
+    // never renders. Wait briefly for any pending redirect to settle, and
+    // if the page leaves /login skip login rather than spending the full
+    // form-visibility retry budget waiting for an input that will never appear.
     try {
-      await waitForAssertion({
-        assertion: async () => {
-          await expect(this.usernameInput).toBeVisible({timeout: 30000});
-        },
-        onFailure: async () => {
-          await this.page.reload();
-        },
-      });
-    } catch (error) {
-      if (!this.page.url().includes('/login')) {
-        return;
-      }
-      throw error;
+      await this.page.waitForURL(
+        (url) => !url.pathname.includes('/login'),
+        {timeout: 5000},
+      );
+      return;
+    } catch {
+      // Still at /login — fall through to the normal login flow.
     }
+    await waitForAssertion({
+      assertion: async () => {
+        await expect(this.usernameInput).toBeVisible({timeout: 30000});
+      },
+      onFailure: async () => {
+        await this.page.reload();
+      },
+    });
     await this.clickUsername();
     await this.fillUsername(username);
     await this.fillPassword(password);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/LoginPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/LoginPage.ts
@@ -53,25 +53,21 @@ export class LoginPage {
   async login(username: string, password: string) {
     // Camunda apps share an auth session: navigating to /<app>/login when
     // already authenticated redirects to the app home, so the login form
-    // never renders. Wait briefly for any pending redirect to settle, and
-    // if the page leaves /login skip login rather than spending the full
-    // form-visibility retry budget waiting for an input that will never appear.
-    try {
-      await this.page.waitForURL((url) => !url.pathname.includes('/login'), {
-        timeout: 5000,
+    // never renders. Skip login in that case rather than waiting for a
+    // form that will never appear.
+    if (!(await this.usernameInput.isVisible())) {
+      if (!this.page.url().includes('/login')) {
+        return;
+      }
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(this.usernameInput).toBeVisible({timeout: 30000});
+        },
+        onFailure: async () => {
+          await this.page.reload();
+        },
       });
-      return;
-    } catch {
-      // Still at /login — fall through to the normal login flow.
     }
-    await waitForAssertion({
-      assertion: async () => {
-        await expect(this.usernameInput).toBeVisible({timeout: 30000});
-      },
-      onFailure: async () => {
-        await this.page.reload();
-      },
-    });
     await this.clickUsername();
     await this.fillUsername(username);
     await this.fillPassword(password);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/LoginPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/LoginPage.ts
@@ -57,10 +57,9 @@ export class LoginPage {
     // if the page leaves /login skip login rather than spending the full
     // form-visibility retry budget waiting for an input that will never appear.
     try {
-      await this.page.waitForURL(
-        (url) => !url.pathname.includes('/login'),
-        {timeout: 5000},
-      );
+      await this.page.waitForURL((url) => !url.pathname.includes('/login'), {
+        timeout: 5000,
+      });
       return;
     } catch {
       // Still at /login — fall through to the normal login flow.

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/LoginPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/LoginPage.ts
@@ -51,14 +51,25 @@ export class LoginPage {
   }
 
   async login(username: string, password: string) {
-    await waitForAssertion({
-      assertion: async () => {
-        await expect(this.usernameInput).toBeVisible({timeout: 30000});
-      },
-      onFailure: async () => {
-        await this.page.reload();
-      },
-    });
+    // Camunda apps share an auth session: navigating to /<app>/login when
+    // already authenticated redirects to the app home, so the login form
+    // never renders. Skip login in that case rather than hanging on a
+    // username input that will never appear.
+    try {
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(this.usernameInput).toBeVisible({timeout: 30000});
+        },
+        onFailure: async () => {
+          await this.page.reload();
+        },
+      });
+    } catch (error) {
+      if (!this.page.url().includes('/login')) {
+        return;
+      }
+      throw error;
+    }
     await this.clickUsername();
     await this.fillUsername(username);
     await this.fillPassword(password);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -8,6 +8,7 @@
 
 import {Page, Locator, expect} from '@playwright/test';
 import {sleep} from 'utils/sleep';
+import {waitForAssertion} from 'utils/waitForAssertion';
 
 class OperateProcessInstancePage {
   private page: Page;
@@ -1011,8 +1012,18 @@ class OperateProcessInstancePage {
   }
 
   async verifyIncidentCount(expectedCount: number): Promise<void> {
-    const actualCount = await this.getIncidentCount();
-    expect(actualCount).toBe(expectedCount);
+    // Post-migration the incident is reindexed against the new element id;
+    // poll until the incident table reflects the expected count to avoid
+    // racing against eventual-consistency propagation.
+    await waitForAssertion({
+      assertion: async () => {
+        const actualCount = await this.getIncidentCount();
+        expect(actualCount).toBe(expectedCount);
+      },
+      onFailure: async () => {
+        await this.page.reload();
+      },
+    });
   }
 
   getOperationsLogTableRowCount(): Promise<number> {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -609,7 +609,6 @@ test.describe.serial('Process Instance Migration', () => {
         'MIGRATE',
       );
       await operateProcessMigrationModePage.clickMigrationConfirmationButton();
-      await sleep(2000);
     });
 
     await test.step('Verify 3 instances migrated to target version', async () => {
@@ -619,7 +618,7 @@ test.describe.serial('Process Instance Migration', () => {
         assertion: async () => {
           await expect(
             operateProcessesPage.versionCells(targetVersion),
-          ).toHaveCount(3, {timeout: 6000});
+          ).toHaveCount(3, {timeout: 30000});
         },
         onFailure: async () => {
           await page.reload();


### PR DESCRIPTION
## Summary

Fixes the three failures from #52655 in `qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts`. Root-cause analysis: https://github.com/camunda/camunda/issues/52655#issuecomment-4397027610

- **`:797` "Migrate parallel job-based user tasks"** (persistent failure) — used the generic `LoginPage` for the Tasklist login. `LoginPage.usernameInput` selects via `getByRole('textbox',{name:'Username'})`, which does not match the Tasklist login form. Adds a `tasklistLoginPage` fixture backed by the existing `TaskListLoginPage` (which uses `getByLabel`) and uses it for the cross-app login. Subsequent `loginPage.login` calls in the same test re-enter `/operate/login` with an active session — Camunda apps share auth, so the route redirects past `/login` and the form never renders. `LoginPage.login` now skips login when the page has been redirected away from `/login` instead of hanging on a username input that will never appear.
- **`:665` "Migrated process instances"** (flaky) — `OperateProcessInstancePage.verifyIncidentCount` asserted once with no polling, racing post-migration incident reindexing. Wrapped in `waitForAssertion` with `page.reload()` on failure, matching the pattern already used elsewhere in the file (e.g. lines 637–647).
- **`:433` "Manual mapping migration"** (flaky) — replaced the brittle fixed `await sleep(2000)` after migrate-confirm with a longer (6s → 30s) `toHaveCount` timeout inside the existing `waitForAssertion` block, so the assertion waits for real propagation instead of a hard-coded delay.

## Files changed

- `pages/LoginPage.ts` — skip-if-redirected guard in `login()`
- `pages/OperateProcessInstancePage.ts` — wrap `verifyIncidentCount` in `waitForAssertion`
- `fixtures.ts` — add `tasklistLoginPage` fixture
- `tests/operate/processInstanceMigration.spec.ts` — use `tasklistLoginPage` for the Tasklist login; replace `sleep(2000)` with a longer assertion timeout

No product (frontend or backend) code changes — this is QA test stabilization only.

## Test plan

- [ ] Re-run Operate E2E suite (Legacy-Operate-E2E-Tests workflow) — the three named tests pass on initial attempt across consecutive runs
- [ ] Verify other tests still pass — `LoginPage.login` change is backwards-compatible (only kicks in when the page has been redirected away from `/login`); `verifyIncidentCount` change preserves the same final assertion semantics with added retry
- [ ] Confirm `tasklistLoginPage` fixture compiles and is wired up correctly
- [ ] Manual trace of `:797` happy path: Tasklist login (new selector) → Tasklist actions → navigate back to Operate (LoginPage skips, since already authenticated) → migration steps

Closes #52655

🤖 Generated with [Claude Code](https://claude.com/claude-code)