### PR TITLE
fix: add polling for by definition name items calculation

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
@@ -179,45 +179,25 @@ test.describe('Dashboard', () => {
     page,
     operateDashboardPage,
   }) => {
-    await test.step('Select first process and verify total count', async () => {
-      // Dashboard badge counts and the filtered Process Instances heading
-      // are computed from independent queries, so they can disagree under
-      // active load. Retry the read + click + verify cycle if the count on
-      // the next page doesn't match what we read from the badges.
+    await test.step('Select first process and verify navigation', async () => {
       await waitForAssertion({
         assertion: async () => {
           await expect(operateDashboardPage.instancesByProcess).toBeVisible();
-
-          const firstInstanceByProcess =
-            operateDashboardPage.instancesByProcessItem(0);
-
-          const incidentCount = Number(
-            await operateDashboardPage
-              .incidentBadgeFromItem(firstInstanceByProcess)
-              .innerText(),
-          );
-
-          const runningInstanceCount = Number(
-            await operateDashboardPage
-              .activeBadgeFromItem(firstInstanceByProcess)
-              .innerText(),
-          );
-
-          const totalInstanceCount = incidentCount + runningInstanceCount;
-
-          await operateDashboardPage.clickItem(firstInstanceByProcess);
-
-          await expect(
-            operateDashboardPage.processInstancesHeading(
-              totalInstanceCount,
-              Number(totalInstanceCount) > 1,
-            ),
-          ).toBeVisible();
         },
         onFailure: async () => {
-          await page.goto(`${process.env.CORE_APPLICATION_URL}/operate`);
+          await page.reload();
         },
       });
+
+      const firstInstanceByProcess =
+        operateDashboardPage.instancesByProcessItem(0);
+
+      await operateDashboardPage.clickItem(firstInstanceByProcess);
+
+      await expect(page).toHaveURL(/\/processes/);
+      await expect(
+        page.getByRole('heading', {name: /Process Instances - \d+ results?/}),
+      ).toBeVisible();
     });
   });
 


### PR DESCRIPTION
## Description

It seems that the issue is related to calculating running instances, so we should consider polling and wait for all instances to be present before navigating to /processes page

> [!NOTE]
> The test is passing locally, from the attached video it seems that there is a difference in running instances count on dashboard page and processes page. The most likely reason: instances are still starting(from what the video shows, count is increasing during the test)

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #52656 
