### PR TITLE
feat: local grafana dev setup with generated dev data

### DIFF
--- a/monitor/Makefile
+++ b/monitor/Makefile
@@ -1,32 +1,29 @@
-COMMAND_STUB_ZEEBE := docker-compose --project-directory ./ -f docker-compose.yml -f ../docker/compose/docker-compose.yaml
-COMMAND_STUB_OPE := docker-compose --project-directory ./ -f docker-compose.yml -f docker-compose.ope-ztl.yml
+COMPOSE     := docker compose --project-directory ./
+COMPOSE_DEV := $(COMPOSE) -f docker-compose.yml -f docker-compose.dev.yml
+COMPOSE     := $(COMPOSE) -f docker-compose.yml
 
 .DEFAULT_GOAL := up
-.PHONY: up
+.PHONY: up down clean up-dev down-dev clean-dev
+
 up:
-	$(COMMAND_STUB_ZEEBE) up -d
+	$(COMPOSE) up -d
 
-.PHONY: down
 down:
-	$(COMMAND_STUB_ZEEBE) down
+	$(COMPOSE) down
 
-.PHONY: up-ope
-up-ope:
-	$(COMMAND_STUB_OPE) up -d --force-recreate
-
-.PHONY: down-ope
-down-ope:
-	$(COMMAND_STUB_OPE) down
-
-
-.PHONY: clean
 clean:
-	$(COMMAND_STUB_ZEEBE) down -v
+	$(COMPOSE) down -v
 
-.PHONY: clean-ope
-clean-ope:
-	$(COMMAND_STUB_OPE) down -v
+up-dev:
+	$(COMPOSE_DEV) up -d
 
+down-dev:
+	$(COMPOSE_DEV) down
+
+clean-dev:
+	$(COMPOSE_DEV) down -v
+
+# Deprecated: Grizzly is archived and has no Windows support. Use make up-dev instead.
 .PHONY: grizzly
 grizzly:
 	@set -o allexport && source .env && \

--- a/monitor/README.md
+++ b/monitor/README.md
@@ -2,53 +2,102 @@
 
 ## Metrics
 
-Zeebe and other Camunda components export several metrics to facilitate monitoring a cluster.
-Currently, metrics are exported using Prometheus. You can find
-documentation about the different Zeebe metrics
-[here](https://docs.camunda.io/docs/product-manuals/zeebe/deployment-guide/operations/metrics).
-
-### Testing
-
-You can easily test metrics locally by using the standard provided [docker compose
-file](../docker/compose/docker-compose.yaml) in combination with the one [here](docker-compose.yml), e.g.:
-
-```sh
-docker-compose --project-directory ./ -f docker-compose.yml -f ../docker/compose/docker-compose.yaml up -d
-```
-
-This will start the usual 3 brokers cluster, as well as a Grafana [instance](http://localhost:3000/) (on port 3000; login: u `admin`, p `camunda`) and a Prometheus instance on
-port 9090. The Prometheus instance is configured to scrape the brokers every 5 seconds, and pre-assigns them the
-namespace and pod label as `local` and `broker-*`.
-
-> Remember that docker-compose does not remove volumes on the down command, so if you are completely done with it you
-> will need to run either `docker-compose --project-directory ./ -f docker-compose.yml -f ../docker/compose/docker-compose.yaml down -v`
-> or `docker volume prune`
-
-### Testing with local Zeebe
-
-When you want to use a local Zeebe Broker, you need to locally modify the config:
-- enable Prometheus Docker container to access localhost ports:
-
-```yaml
-# add to the prometheus service
-extra_hosts:
-- "host.docker.internal:host-gateway"
-```
-
-- add the local Zeebe broker to Prometheus config:
-
-  ```yaml
-  # add to scrape_configs
-  - job_name: 'zeebe_local'
-    metrics_path: /actuator/prometheus
-    static_configs:
-         - targets: ['host.docker.internal:9600']
-
-  ```
+Zeebe and other Camunda components export metrics to facilitate monitoring a cluster using Prometheus. Documentation for the available metrics can be found [here](https://docs.camunda.io/docs/product-manuals/zeebe/deployment-guide/operations/metrics).
 
 ## Grafana
 
-We use Grafana to visualize our metrics in dashboards for  monitoring and troubleshooting purposes. You can find general information about Grafana [here](https://grafana.com/docs/grafana/latest/fundamentals/).
+We use Grafana to visualize our metrics in dashboards for monitoring and troubleshooting purposes. You can find general information about Grafana [here](https://grafana.com/docs/grafana/latest/fundamentals/).
+
+### Running Grafana locally
+
+Start the Grafana and Prometheus stack with Docker Compose. Requires [Docker Desktop](https://docs.docker.com/desktop/) on Windows and macOS, or Docker with the Compose plugin on Linux.
+
+Run the following from the `monitor/` directory:
+
+```sh
+# Start
+docker compose --project-directory ./ -f docker-compose.yml up -d
+
+# Stop
+docker compose --project-directory ./ -f docker-compose.yml down
+
+# Stop and remove volumes
+docker compose --project-directory ./ -f docker-compose.yml down -v
+```
+
+On **macOS and Linux** you can also use the Makefile shortcuts: `make up`, `make down`, `make clean`.
+
+On **Windows** the `make` command is not available by default — use the `docker compose` commands above directly in PowerShell.
+
+Grafana is available at http://localhost:3000 (admin / camunda), Prometheus at http://localhost:9090.
+
+Once the stack is running, open http://localhost:3000 to access Grafana. Dashboards are loaded from the JSON files under `grafana/dashboards/` and are editable in the UI without restrictions.
+
+#### Dashboard file sync
+
+The dev overlay (`docker-compose.dev.yml`) includes a `dashboard-sync` sidecar that polls the Grafana API every 10 seconds and writes any UI edits back to the corresponding JSON file on disk. Start it alongside the main stack:
+
+```sh
+docker compose --project-directory ./ -f docker-compose.yml -f docker-compose.dev.yml up -d
+```
+
+With this running, the edit loop is: open `grafana/dashboards/core-features/overview.json` (or any dashboard), save changes in the Grafana UI, and the JSON file is updated within ~10 seconds. Changes are then visible in your editor and ready to commit.
+
+The sidecar matches files to Grafana dashboards by the `uid` field. When writing synced content back to disk it preserves the `id` and `version` values from the local file rather than overwriting them with Grafana's internal values, and excludes both fields from the comparison so they never trigger a spurious sync.
+
+**Grafana-managed fields** — Grafana automatically modifies certain fields in dashboard JSON that have no meaning outside the running instance and should not be manually edited:
+
+- `id` — a numeric internal DB ID assigned per Grafana installation. Preserved from the local file by the sync; do not set it manually.
+- `version` — a save counter incremented on every edit. Preserved from the local file by the sync; do not set it manually.
+- `pluginVersion` inside panel objects — updated to the running Grafana version on load. After a Grafana version upgrade the first sync will rewrite these values throughout the file; commit the resulting changes so subsequent startups produce no diff.
+
+#### Generating test data
+
+The Camunda container (Zeebe, Operate, and Tasklist unified) exposes JVM, broker, Operate, and Tasklist metrics immediately on startup. For process- and job-level metrics you need actual workload running.
+
+The dev overlay also includes a `traffic-generator` that deploys a simple process and creates one instance every 10 seconds (see above for the start command). The test process (`processes/test-process.bpmn`) has a single service task of type `test-job`; because no worker completes the job, instances accumulate at the task — making job backlog and active instance metrics visible in the dashboards. Requires Zeebe 8.3 or later for the REST API.
+
+The dev overlay also runs a **`metrics-generator`** — a small Node.js service built from `metrics-generator/` that exposes synthetic Prometheus metrics on port 9400. It generates realistic metrics across three synthetic environments (`local`, `staging`, `production`) with the full label schema the dashboards expect (`namespace`, `cluster`, `pod`, `partition`, `application`, etc.), including counters that increase over time so `rate()` and `increase()` panels render correctly. This makes dashboard template variables (e.g. the `namespace`, `cluster`, `geo_area`, `provider` dropdowns) populate immediately with multiple selectable values. The image is built locally on first `docker compose up`; if you modify `metrics-generator/generator.js` you must rebuild it explicitly:
+
+```sh
+docker compose --project-directory ./ -f docker-compose.yml -f docker-compose.dev.yml up -d --build metrics-generator
+```
+
+The synthetic data covers all sections of the `core-features/overview` dashboard (except Legacy Operate/Tasklist and Optimize), including `kube_namespace_labels` for the template variable dropdowns (`namespace`, `geo_area`, `cloud_provider`, `generation`, `sales_plan_type`) and the `node_namespace_pod_container:*` infrastructure metrics via the recording rules in `prometheus/recording_rules.yml`. No real Kubernetes cluster is needed.
+
+For **realistic, diverse test data** across all dashboards (process instances in various states, incidents, decisions, user tasks, multiple tenants), activate the `dev-data` Spring profile. The unified Camunda image already bundles the Operate and Tasklist data generators, so enabling the profile is a one-line change in `docker-compose.yml`:
+
+```yaml
+environment:
+  - SPRING_PROFILES_ACTIVE=consolidated-auth,tasklist,broker,operate,dev-data
+```
+
+Restart the stack after making this change. The data generators run on startup and populate Elasticsearch with representative process and task data.
+
+#### Keeping generator metrics in sync
+
+The `metrics-generator` only produces metrics the real Camunda container does not — mainly Kubernetes infrastructure metrics. Run `scripts/check-metrics.js` to verify the split is clean:
+
+```sh
+node scripts/check-metrics.js
+```
+
+The script scrapes both `http://localhost:9600/actuator/prometheus` (Camunda) and `http://localhost:9400/metrics` (generator) and reports three categories:
+
+- **OVERLAPS** — Both the real container and the generator expose this metric family; Grafana will double-count it.
+  Remove the metric from `generator.js`, then rebuild with `--build metrics-generator`.
+- **LABEL GAPS** — The generator produces the metric but is missing labels that the real service uses.
+  Extend the `labelNames` array for that metric in `generator.js` and rebuild.
+- **MISSING FAMILIES** — The real container exposes a metric family the generator does not.
+  Usually no action needed — the generator is intentionally supplemental. Only add a metric to `generator.js` if a dashboard panel needs it **and** the real container cannot provide it (e.g. Kubernetes-level infrastructure metrics).
+
+**When to run this script:**
+
+- After bumping `CAMUNDA_VERSION` in `docker-compose.yml` — a new release may add metrics that overlap with what the generator already produces.
+- When a Grafana panel shows unexpectedly high values, which is a symptom of double-counting from an overlap.
+- When adding new application metrics to the Camunda codebase, to confirm the real container covers them without generator duplication.
+
+New application metrics added to Camunda generally do **not** require generator changes — the real container exposes them directly. Generator changes are only needed when the metric lives outside the application (Kubernetes, Elasticsearch cluster health, etc.) and a dashboard panel depends on it.
 
 ### Creating a new dashboard (Camunda internal)
 
@@ -63,7 +112,9 @@ If you want to learn how to add new metrics, a good starting point can be found 
 
 *or*
 
-A **local Grafana** instance (e.g. using [Grizzly](https://grafana.com/blog/2024/10/29/edit-your-git-based-grafana-dashboards-locally/) to run Grafana locally, which can be started through the `make grizzly` command (see [Makefile](Makefile)) and instead make the modifications directly in the codebase.
+A **local Grafana** instance via the local stack described above. Use `make up-dev` (macOS/Linux) or the equivalent `docker compose` command with both compose files. The `dashboard-sync` sidecar writes UI saves back to the JSON files automatically — no manual export needed.
+
+> **Deprecated (macOS/Linux only):** [Grizzly](https://grafana.com/blog/2024/10/29/edit-your-git-based-grafana-dashboards-locally/) was previously used to serve dashboards locally via `make grizzly`. It is archived and no longer maintained (August 2025) and has no Windows support. Use the local stack above instead.
 
 For this guide the assumption is that you are using a shared Grafana instance.
 
@@ -87,10 +138,14 @@ This guide does not go into details about creating visualizations, but these are
 
 #### Exporting the dashboard
 
+**If you used the local stack with `dashboard-sync`:** the JSON file is already written back to `grafana/dashboards/` within ~10 seconds of each UI save. No manual export is needed — just commit the file.
+
+**If you used a shared Grafana instance:**
+
 1) Save your modifications (if you are editing an already deployed dashboard, save it as a copy to ensure it does not get overwritten by a new deployment from code)
-2) Exit edit mode and make sure to export as described [here](https://grafana.com/docs/grafana/latest/dashboards/share-dashboards-panels/#export-a-dashboard-as-json), checking `Export the dashboard to use in another instance` as you do.
-3) Save the dashboard JSON in the codebase under [grafana/dashboards](grafana/dashboards) - create a folder for your team if it does not exist yet. Ensure that the filename, dashboard name and UID are correct if you saved it as a copy (they should reflect the original dashboard's values since the goal is to overwrite it).
-4) Delete the copied dashboard (if one was created)
+2) Exit edit mode and export as described [here](https://grafana.com/docs/grafana/latest/dashboards/share-dashboards-panels/#export-a-dashboard-as-json), checking `Export the dashboard to use in another instance`.
+3) Save the dashboard JSON in the codebase under [grafana/dashboards](grafana/dashboards) — create a folder for your team if it does not exist yet. Ensure the filename, dashboard name, and UID are correct.
+4) Delete the copied dashboard (if one was created).
 
 **Note**: If you edit an already existing dashboard, keep in mind that it may get automatically deployed once it was merged into the code base (see next section).
 

--- a/monitor/docker-compose.dev.yml
+++ b/monitor/docker-compose.dev.yml
@@ -1,0 +1,74 @@
+services:
+  grafana:
+    environment:
+      - GF_PATHS_DATA=/tmp/grafana-data
+
+  traffic-generator:
+    image: alpine:latest
+    depends_on:
+      - camunda
+    volumes:
+      - ./processes:/processes:ro
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        apk add --no-cache curl -q
+        echo "Waiting for Camunda to be ready..."
+        until curl -sf http://camunda:9600/actuator/health/readiness > /dev/null; do
+          sleep 3
+        done
+        sleep 5
+        echo "Deploying test process..."
+        curl -sf -X POST http://camunda:8080/v2/deployments \
+          -F "resources=@/processes/test-process.bpmn" \
+          -H "Accept: application/json"
+        echo "Generating traffic (one instance every 10s)..."
+        while true; do
+          curl -s -X POST http://camunda:8080/v2/process-instances \
+            -H "Content-Type: application/json" \
+            -H "Accept: application/json" \
+            -d '{"bpmnProcessId":"test-process","version":-1}'
+          sleep 10
+        done
+    restart: on-failure
+
+  metrics-generator:
+    build: ./metrics-generator
+    container_name: metrics-generator
+    ports:
+      - 9400:9400
+    environment:
+      - CAMUNDA_URL=http://camunda:8080
+    restart: unless-stopped
+
+  dashboard-sync:
+    image: alpine:latest
+    depends_on:
+      - grafana
+    volumes:
+      - ./grafana/dashboards:/dashboards
+    environment:
+      - GRAFANA_URL=http://grafana:3000
+      - GRAFANA_USER=admin
+      - GRAFANA_TOKEN=camunda
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        apk add --no-cache curl jq -q
+        echo "Dashboard sync started — writing Grafana UI saves back to JSON files..."
+        while true; do
+          sleep 10
+          for file in $$(find /dashboards -name "*.json" 2>/dev/null); do
+            uid=$$(jq -r '.uid // empty' "$$file" 2>/dev/null)
+            [ -z "$$uid" ] && continue
+            remote=$$(curl -sf -u "$$GRAFANA_USER:$$GRAFANA_TOKEN" \
+              "$$GRAFANA_URL/api/dashboards/uid/$$uid" 2>/dev/null) || continue
+            remote_content=$$(echo "$$remote" | jq -cS '.dashboard | del(.id, .version)' 2>/dev/null)
+            local_content=$$(jq -cS 'del(.id, .version)' "$$file" 2>/dev/null)
+            if [ "$$remote_content" != "$$local_content" ]; then
+              echo "Syncing $$(basename $$file)"
+              echo "$$remote" | jq --slurpfile local "$$file" '.dashboard | if ($$local[0] | has("id")) then .id = $$local[0].id else del(.id) end | if ($$local[0] | has("version")) then .version = $$local[0].version else del(.version) end' > "$${file}.tmp" && mv "$${file}.tmp" "$$file"
+            fi
+          done
+        done
+    restart: unless-stopped

--- a/monitor/docker-compose.yml
+++ b/monitor/docker-compose.yml
@@ -1,8 +1,7 @@
-version: '3'
-
 volumes:
     grafana: {}
     prometheus: {}
+    elasticsearch: {}
 
 services:
   prometheus:
@@ -16,6 +15,7 @@ services:
       - '--storage.tsdb.path=/prometheus'
       - '--web.console.libraries=/usr/share/prometheus/console_libraries'
       - '--web.console.templates=/usr/share/prometheus/consoles'
+      - '--web.enable-lifecycle'
     ports:
       - 9090:9090
 
@@ -29,17 +29,37 @@ services:
     volumes:
       - grafana:/var/lib/grafana
       - ./grafana/dashboards/:/var/lib/grafana/dashboards/
-      - ./grafana/zeebe.json/:/var/lib/grafana/dashboards/zeebe.json
-      - ./grafana/zeebe-overview.json/:/var/lib/grafana/dashboards/zeebe-overview.json
-      - ./grafana/dashboards/core-features/overview.json:/var/lib/grafana/dashboards/overview.json
-      - ./grafana/dashboards/core-features/rest.json:/var/lib/grafana/dashboards/rest.json
       - ./grafana/provisioning/:/etc/grafana/provisioning/
     environment:
       - GF_SECURITY_ADMIN_PASSWORD=camunda
       - GF_USERS_ALLOW_SIGN_UP=false
 
-  zeebe:
-    image: camunda/zeebe:${ZEEBE_VERSION:-SNAPSHOT}
-    container_name: zeebe
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.17.0
+    container_name: elasticsearch
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - ES_JAVA_OPTS=-Xms512m -Xmx512m
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:9200/_cluster/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    volumes:
+      - elasticsearch:/usr/share/elasticsearch/data
+
+  camunda:
+    image: camunda/camunda:${CAMUNDA_VERSION:-SNAPSHOT}
+    container_name: camunda
+    environment:
+      - SPRING_PROFILES_ACTIVE=consolidated-auth,tasklist,broker,operate
+      - CAMUNDA_DATA_SECONDARY_STORAGE_TYPE=elasticsearch
+      - CAMUNDA_DATA_SECONDARY_STORAGE_ELASTICSEARCH_URL=http://elasticsearch:9200
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
     ports:
       - 9600:9600
+      - 8080:8080
+      - 26500:26500

--- a/monitor/grafana/provisioning/dashboards/dashboard.yml
+++ b/monitor/grafana/provisioning/dashboards/dashboard.yml
@@ -5,5 +5,6 @@ providers:
   orgId: 1
   folder: ''
   type: file
+  allowUiUpdates: true
   options:
     path: /var/lib/grafana/dashboards

--- a/monitor/metrics-generator/Dockerfile
+++ b/monitor/metrics-generator/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:22-alpine
+WORKDIR /app
+COPY package.json .
+RUN npm install --omit=dev
+COPY generator.js .
+EXPOSE 9400
+CMD ["node", "generator.js"]

--- a/monitor/metrics-generator/generator.js
+++ b/monitor/metrics-generator/generator.js
@@ -1,0 +1,464 @@
+'use strict';
+/**
+ * Synthetic Prometheus metrics for local Camunda development.
+ *
+ * Only produces metrics the real Camunda container (camunda:9600) does NOT
+ * expose — namely Kubernetes/infrastructure metrics and dashboard template
+ * variable seeds. Application metrics (JVM, Zeebe engine, Operate, Tasklist)
+ * that the real container already emits are intentionally absent here to
+ * avoid double-counting in Grafana panels.
+ *
+ * Run scripts/check-metrics.js after starting the stack to verify coverage.
+ *
+ * Exposes on :9400/metrics.
+ */
+const client = require('prom-client');
+const http   = require('http');
+
+const PORT    = 9400;
+const TICK_MS = 5_000;
+
+const ENVIRONMENTS = [
+  { namespace: 'local',      cluster: 'local',       region: 'eu-west-1',      geoArea: 'eu', provider: 'gcp',   generation: 'stable', salesPlan: 'enterprise', _esBytes: 8  * (1 << 30) },
+  { namespace: 'staging',    cluster: 'staging-eu',  region: 'us-east-1',      geoArea: 'us', provider: 'aws',   generation: 'alpha',  salesPlan: 'trial',      _esBytes: 4  * (1 << 30) },
+  { namespace: 'production', cluster: 'prod-apac',   region: 'ap-southeast-1', geoArea: 'ap', provider: 'azure', generation: 'stable', salesPlan: 'enterprise', _esBytes: 20 * (1 << 30) },
+];
+
+const register = new client.Registry();
+
+// ── Static configuration ──────────────────────────────────────────────────────
+
+const SERVICES = [
+  { pod: 'zeebe-0',    application: 'zeebe',         container: 'zeebe',    image: 'camunda/zeebe:latest',    cpuLimit: 2,   memLimit: 2 * (1 << 30) },
+  { pod: 'operate-0',  application: 'operate',       container: 'operate',  image: 'camunda/operate:latest',  cpuLimit: 1,   memLimit: 1 * (1 << 30) },
+  { pod: 'tasklist-0', application: 'tasklist',      container: 'tasklist', image: 'camunda/tasklist:latest', cpuLimit: 1,   memLimit: 1 * (1 << 30) },
+  { pod: 'gateway-0',  application: 'zeebe-gateway', container: 'gateway',  image: 'camunda/zeebe:latest',    cpuLimit: 0.5, memLimit: 512 * (1 << 20) },
+];
+
+const PARTITIONS = ['1', '2', '3'];
+
+const GRPC_METHODS = [
+  'DeployResource', 'CreateProcessInstance', 'ActivateJobs',
+  'CompleteJob', 'FailJob', 'PublishMessage', 'SetVariables',
+  'ResolveIncident', 'CancelProcessInstance', 'StreamActivatedJobs',
+];
+
+const ELEMENT_TYPES   = ['PROCESS', 'SERVICE_TASK', 'START_EVENT', 'END_EVENT'];
+const ELEMENT_INTENTS = ['ELEMENT_ACTIVATING', 'ELEMENT_ACTIVATED', 'ELEMENT_COMPLETING', 'ELEMENT_COMPLETED'];
+
+// ── Metric factory helpers ────────────────────────────────────────────────────
+
+const g = (name, help, labelNames) =>
+  new client.Gauge({ name, help, labelNames, registers: [register] });
+const c = (name, help, labelNames) =>
+  new client.Counter({ name, help, labelNames, registers: [register] });
+const histo = (name, help, labelNames, buckets) =>
+  new client.Histogram({ name, help, labelNames, buckets: buckets || client.exponentialBuckets(0.001, 2, 14), registers: [register] });
+
+// ── Template variable seed ────────────────────────────────────────────────────
+// The namespace/geo_area/cloud_provider/generation/sales_plan_type variable
+// chain in the core-features dashboard cascades through kube_namespace_labels.
+
+const kubeNamespaceLabels = g('kube_namespace_labels',
+  'Kubernetes namespace labels (synthetic)',
+  ['namespace', 'camunda_geo_area', 'camunda_provider',
+   'label_cloud_camunda_io_generation', 'label_cloud_camunda_io_sales_plan_type']);
+
+// ── gRPC — Histogram so _bucket/_count/_sum are present ──────────────────────
+
+const grpcDuration = histo('grpc_server_processing_duration_seconds',
+  'gRPC server processing duration',
+  ['namespace', 'cluster', 'pod', 'method', 'statusCode', 'camunda_region'],
+  [0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5]);
+
+// ── Infrastructure base metrics ───────────────────────────────────────────────
+// container_* feed the Prometheus recording rules (recording_rules.yml) that
+// produce node_namespace_pod_container:* metrics for infrastructure panels.
+// image label must be non-empty for the {image!=""} recording rule filter.
+
+const containerCpuUsage = c('container_cpu_usage_seconds_total', 'Container CPU seconds',
+  ['cluster', 'namespace', 'pod', 'container', 'image']);
+
+const containerMemWorkingSet = g('container_memory_working_set_bytes', 'Container memory working set',
+  ['cluster', 'namespace', 'pod', 'container', 'image']);
+
+const kubePodContainerStatusReady = g('kube_pod_container_status_ready', 'Pod container ready',
+  ['namespace', 'pod', 'container', 'camunda_region']);
+
+const kubePodContainerResourceLimits = g('kube_pod_container_resource_limits', 'Pod container resource limits',
+  ['namespace', 'pod', 'container', 'resource', 'unit', 'cluster', 'camunda_geo_area', 'camunda_provider']);
+
+const kubeletVolumeStatsUsed     = g('kubelet_volume_stats_used_bytes',     'PVC used bytes',
+  ['namespace', 'persistentvolumeclaim', 'camunda_geo_area', 'camunda_provider']);
+const kubeletVolumeStatsCapacity = g('kubelet_volume_stats_capacity_bytes', 'PVC capacity bytes',
+  ['namespace', 'persistentvolumeclaim', 'camunda_geo_area', 'camunda_provider']);
+
+// ── Elasticsearch cluster health ──────────────────────────────────────────────
+
+const esActiveShards   = g('elasticsearch_cluster_health_active_shards',    'ES active shards',
+  ['cluster', 'namespace', 'camunda_geo_area', 'camunda_provider']);
+const esNumberOfNodes  = g('elasticsearch_cluster_health_number_of_nodes',  'ES node count',
+  ['cluster', 'namespace', 'camunda_geo_area', 'camunda_provider']);
+const esIndexStoreSize = g('elasticsearch_indices_store_size_bytes_primary', 'ES index store size',
+  ['namespace', 'camunda_geo_area', 'camunda_provider']);
+
+// ── Zeebe — metrics NOT produced by the real Camunda container ────────────────
+
+const zeebePartitionLoad  = g('zeebe_partition_load', 'Partition load',
+  ['namespace', 'cluster', 'pod', 'partition']);
+const zeebeRaftQueueDepth = g('zeebe_raft_append_entries_batch_queue_depth', 'Raft batch queue depth',
+  ['namespace', 'cluster', 'pod', 'partition']);
+const zeebeElementEvents  = c('zeebe_element_instance_events_total', 'Element events',
+  ['namespace', 'cluster', 'pod', 'partition', 'type', 'intent']);
+const zeebeCommandPending = g('zeebe_command_distributions_pending', 'Pending command distributions',
+  ['namespace', 'cluster', 'pod', 'partition']);
+const zeebeCommandRetries = c('zeebe_command_distributions_inflight_retries_total', 'Command distribution retries',
+  ['namespace', 'cluster', 'pod', 'partition', 'camunda_geo_area', 'camunda_provider']);
+
+// Legacy naming variants — some dashboard panels query both the _seconds and
+// the bare name depending on the Zeebe version the dashboard was written for.
+const zeebeSpLatencyLegacy  = histo('zeebe_stream_processor_latency', 'Stream processor latency (legacy name)',
+  ['namespace', 'cluster', 'pod', 'partition'],
+  [0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1]);
+const zeebeJobActivation       = histo('zeebe_job_activation_time_seconds', 'Job activation time',
+  ['namespace', 'cluster', 'pod', 'partition'],
+  [0.001, 0.01, 0.1, 1, 10, 30, 60]);
+const zeebeJobActivationLegacy = histo('zeebe_job_activation_time', 'Job activation time (legacy name)',
+  ['namespace', 'cluster', 'pod', 'partition'],
+  [0.001, 0.01, 0.1, 1, 10, 30, 60]);
+const zeebePiExecTime       = histo('zeebe_process_instance_execution_time_seconds', 'Process instance execution time',
+  ['namespace', 'cluster', 'pod', 'partition'],
+  [0.01, 0.1, 1, 10, 60, 300, 1800, 3600]);
+const zeebePiExecTimeLegacy = histo('zeebe_process_instance_execution_time', 'Process instance execution time (legacy name)',
+  ['namespace', 'cluster', 'pod', 'partition'],
+  [0.01, 0.1, 1, 10, 60, 300, 1800, 3600]);
+
+// ── Camunda exporter — flush/RDBMS metrics not in real container ──────────────
+
+const zeebeCamundaFlushSum   = c('zeebe_camunda_exporter_flush_latency_seconds_sum',   'Flush latency sum',
+  ['namespace', 'cluster', 'pod', 'partition']);
+const zeebeCamundaFlushCount = c('zeebe_camunda_exporter_flush_latency_seconds_count', 'Flush latency count',
+  ['namespace', 'cluster', 'pod', 'partition']);
+const zeebeEsFlushDuration   = histo('zeebe_elasticsearch_exporter_flush_duration_seconds', 'ES exporter flush duration',
+  ['namespace', 'cluster', 'pod', 'partition', 'camunda_geo_area', 'camunda_provider'],
+  [0.005, 0.01, 0.05, 0.1, 0.5, 1, 5]);
+const zeebeRdbmsFlushSum     = c('zeebe_rdbms_exporter_flush_latency_seconds_sum',   'RDBMS flush latency sum',
+  ['namespace', 'cluster', 'pod', 'partition']);
+const zeebeRdbmsFlushCount   = c('zeebe_rdbms_exporter_flush_latency_seconds_count', 'RDBMS flush latency count',
+  ['namespace', 'cluster', 'pod', 'partition']);
+
+// ── Operate metrics not in real container ─────────────────────────────────────
+
+const operateEvents       = c('operate_events_processed_total',           'Events processed',
+  ['namespace', 'pod', 'partition', 'type', 'intent']);
+const operateImportQueue  = g('operate_import_queue_size',                'Import queue size',
+  ['namespace', 'pod', 'partition', 'camunda_geo_area', 'camunda_provider']);
+const operateArchivedPi   = c('operate_archived_process_instances_total', 'Archived PIs',
+  ['namespace', 'pod']);
+const operatePostImporter = g('operate_post_importer_queue_size',         'Post importer queue size',
+  ['namespace', 'pod', 'camunda_geo_area', 'camunda_provider']);
+const operateImportTimeCount  = c('operate_import_time_seconds_count', 'Import time count',
+  ['namespace', 'pod', 'camunda_geo_area', 'camunda_provider']);
+const operateImportTimeSum    = c('operate_import_time_seconds_sum',   'Import time sum',
+  ['namespace', 'pod', 'camunda_geo_area', 'camunda_provider']);
+const operateArchiverQueryCount   = c('operate_archiver_query_seconds_count',         'Archiver query count',   ['namespace', 'pod']);
+const operateArchiverQuerySum     = c('operate_archiver_query_seconds_sum',           'Archiver query sum',     ['namespace', 'pod']);
+const operateArchiverReindexCount = c('operate_archiver_reindex_query_seconds_count', 'Archiver reindex count', ['namespace', 'pod']);
+const operateArchiverReindexSum   = c('operate_archiver_reindex_query_seconds_sum',   'Archiver reindex sum',   ['namespace', 'pod']);
+const operateArchiverDeleteCount  = c('operate_archiver_delete_query_seconds_count',  'Archiver delete count',  ['namespace', 'pod']);
+const operateArchiverDeleteSum    = c('operate_archiver_delete_query_seconds_sum',    'Archiver delete sum',    ['namespace', 'pod']);
+
+// ── Tasklist metrics not in real container ────────────────────────────────────
+
+const tasklistEvents          = c('tasklist_events_processed_total',           'Events processed',
+  ['namespace', 'pod', 'partition', 'type', 'intent']);
+const tasklistArchivedPi      = c('tasklist_archived_process_instances_total', 'Archived PIs',
+  ['namespace', 'pod']);
+const tasklistImportTimeCount = c('tasklist_import_time_seconds_count', 'Import time count',
+  ['namespace', 'pod', 'camunda_geo_area', 'camunda_provider']);
+const tasklistImportTimeSum   = c('tasklist_import_time_seconds_sum',   'Import time sum',
+  ['namespace', 'pod', 'camunda_geo_area', 'camunda_provider']);
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const randInt = (lo, hi) => Math.floor(Math.random() * (hi - lo + 1)) + lo;
+const strHash = (s) => s.split('').reduce((a, ch) => a + ch.charCodeAt(0), 0);
+
+// ── Seed all label combinations ───────────────────────────────────────────────
+
+function seed() {
+  for (const env of ENVIRONMENTS) {
+    const { namespace, cluster, region, geoArea: geo, provider, generation, salesPlan } = env;
+
+    kubeNamespaceLabels.set({
+      namespace,
+      camunda_geo_area:                       geo,
+      camunda_provider:                       provider,
+      label_cloud_camunda_io_generation:      generation,
+      label_cloud_camunda_io_sales_plan_type: salesPlan,
+    }, 1);
+
+    for (const { pod, container, image, cpuLimit, memLimit } of SERVICES) {
+      const cLbl = { cluster, namespace, pod, container, image };
+      containerCpuUsage.inc(cLbl, 0);
+      containerMemWorkingSet.set(cLbl, Math.floor(memLimit * 0.4));
+      kubePodContainerStatusReady.set({ namespace, pod, container, camunda_region: region }, 1);
+      kubePodContainerResourceLimits.set(
+        { namespace, pod, container, resource: 'cpu',    unit: 'core', cluster, camunda_geo_area: geo, camunda_provider: provider },
+        cpuLimit);
+      kubePodContainerResourceLimits.set(
+        { namespace, pod, container, resource: 'memory', unit: 'byte', cluster, camunda_geo_area: geo, camunda_provider: provider },
+        memLimit);
+    }
+
+    // gRPC
+    const gwLbl = { namespace, cluster, pod: 'gateway-0', camunda_region: region };
+    for (const method of GRPC_METHODS) {
+      grpcDuration.observe({ ...gwLbl, method, statusCode: 'OK' }, 0.002);
+    }
+
+    // Elasticsearch PVC
+    const pvcLbl = { namespace, persistentvolumeclaim: 'elasticsearch-0', camunda_geo_area: geo, camunda_provider: provider };
+    kubeletVolumeStatsCapacity.set(pvcLbl, 32 * (1 << 30));
+    kubeletVolumeStatsUsed.set(pvcLbl, env._esBytes);
+
+    // Elasticsearch cluster health
+    const esLbl = { cluster, namespace, camunda_geo_area: geo, camunda_provider: provider };
+    esActiveShards.set(esLbl, 30);
+    esNumberOfNodes.set(esLbl, 3);
+    esIndexStoreSize.set({ namespace, camunda_geo_area: geo, camunda_provider: provider }, env._esBytes);
+
+    // Zeebe per-partition
+    const zBase = { namespace, cluster, pod: 'zeebe-0' };
+    for (const partition of PARTITIONS) {
+      const zp    = { ...zBase, partition };
+      const zpGeo = { ...zp, camunda_geo_area: geo, camunda_provider: provider };
+
+      zeebePartitionLoad.set(zp, 0);
+      zeebeRaftQueueDepth.set(zp, 0);
+      zeebeCommandPending.set(zp, 0);
+      zeebeCommandRetries.inc(zpGeo, 0);
+      zeebeCamundaFlushSum.inc(zp, 0);
+      zeebeCamundaFlushCount.inc(zp, 0);
+      zeebeRdbmsFlushSum.inc(zp, 0);
+      zeebeRdbmsFlushCount.inc(zp, 0);
+
+      for (const type of ELEMENT_TYPES) {
+        for (const intent of ELEMENT_INTENTS) {
+          zeebeElementEvents.inc({ ...zp, type, intent }, 0);
+        }
+      }
+    }
+
+    // Operate
+    const oPod  = 'operate-0';
+    const oBase = { namespace, pod: oPod };
+    const oGeo  = { ...oBase, camunda_geo_area: geo, camunda_provider: provider };
+    operateArchivedPi.inc(oBase, 0);
+    operatePostImporter.set(oGeo, 0);
+    operateImportTimeCount.inc(oGeo, 0);
+    operateImportTimeSum.inc(oGeo, 0);
+    operateArchiverQueryCount.inc(oBase, 0);
+    operateArchiverQuerySum.inc(oBase, 0);
+    operateArchiverReindexCount.inc(oBase, 0);
+    operateArchiverReindexSum.inc(oBase, 0);
+    operateArchiverDeleteCount.inc(oBase, 0);
+    operateArchiverDeleteSum.inc(oBase, 0);
+    for (const partition of PARTITIONS) {
+      const op = { ...oBase, partition };
+      operateImportQueue.set({ ...op, camunda_geo_area: geo, camunda_provider: provider }, 0);
+      for (const type of ELEMENT_TYPES) {
+        for (const intent of ELEMENT_INTENTS) {
+          operateEvents.inc({ ...op, type, intent }, 0);
+        }
+      }
+    }
+
+    // Tasklist
+    const tPod  = 'tasklist-0';
+    const tBase = { namespace, pod: tPod };
+    const tGeo  = { ...tBase, camunda_geo_area: geo, camunda_provider: provider };
+    tasklistArchivedPi.inc(tBase, 0);
+    tasklistImportTimeCount.inc(tGeo, 0);
+    tasklistImportTimeSum.inc(tGeo, 0);
+    for (const partition of PARTITIONS) {
+      for (const type of ELEMENT_TYPES) {
+        for (const intent of ELEMENT_INTENTS) {
+          tasklistEvents.inc({ namespace, pod: tPod, partition, type, intent }, 0);
+        }
+      }
+    }
+  }
+}
+
+// ── Periodic update ───────────────────────────────────────────────────────────
+
+function tick() {
+  const now = Date.now() / 1000;
+
+  for (const env of ENVIRONMENTS) {
+    const { namespace, cluster, region, geoArea: geo, provider } = env;
+
+    for (const { pod, container, image, memLimit } of SERVICES) {
+      const cLbl = { cluster, namespace, pod, container, image };
+      const cpu   = 0.06 + 0.04 * Math.sin(now / 47);
+      containerCpuUsage.inc(cLbl, cpu * TICK_MS / 1000);
+      const memPhase = Math.sin(now / 30 + strHash(pod) % 5) * 0.1;
+      containerMemWorkingSet.set(cLbl, Math.max(0, memLimit * (0.4 + memPhase)));
+    }
+
+    // gRPC
+    const gwLbl = { namespace, cluster, pod: 'gateway-0', camunda_region: region };
+    for (const method of GRPC_METHODS) {
+      const n = randInt(1, 15);
+      for (let i = 0; i < n; i++) {
+        grpcDuration.observe({ ...gwLbl, method, statusCode: 'OK' }, -Math.log(Math.random()) / 5);
+      }
+      if (Math.random() < 0.02) {
+        grpcDuration.observe({ ...gwLbl, method, statusCode: 'RESOURCE_EXHAUSTED' }, 0.5);
+      }
+    }
+
+    // Elasticsearch PVC + cluster health
+    env._esBytes = Math.min(env._esBytes + randInt(100_000, 500_000), 28 * (1 << 30));
+    const pvcLbl = { namespace, persistentvolumeclaim: 'elasticsearch-0', camunda_geo_area: geo, camunda_provider: provider };
+    kubeletVolumeStatsUsed.set(pvcLbl, env._esBytes);
+    const esLbl = { cluster, namespace, camunda_geo_area: geo, camunda_provider: provider };
+    esActiveShards.set(esLbl, 30 + randInt(-2, 2));
+    esNumberOfNodes.set(esLbl, 3);
+    esIndexStoreSize.set({ namespace, camunda_geo_area: geo, camunda_provider: provider }, env._esBytes * 1.2);
+
+    // Zeebe per-partition
+    const zBase = { namespace, cluster, pod: 'zeebe-0' };
+    for (const partition of PARTITIONS) {
+      const zp    = { ...zBase, partition };
+      const zpGeo = { ...zp, camunda_geo_area: geo, camunda_provider: provider };
+
+      zeebePartitionLoad.set(zp, 0.1 + Math.random() * 0.3);
+      zeebeRaftQueueDepth.set(zp, randInt(0, 5));
+      zeebeCommandPending.set(zp, randInt(0, 3));
+      zeebeCommandRetries.inc(zpGeo, randInt(0, 1));
+
+      const flushMs = 0.001 + Math.random() * 0.05;
+      zeebeCamundaFlushSum.inc(zp, flushMs);
+      zeebeCamundaFlushCount.inc(zp, 1);
+      zeebeEsFlushDuration.observe(zpGeo, 0.005 + Math.random() * 0.02);
+      zeebeRdbmsFlushSum.inc(zp, 0.001 + Math.random() * 0.005);
+      zeebeRdbmsFlushCount.inc(zp, 1);
+
+      zeebeSpLatencyLegacy.observe(zp, Math.random() * 0.02);
+      zeebeJobActivation.observe(zp, Math.random() * 0.5);
+      zeebeJobActivationLegacy.observe(zp, Math.random() * 0.5);
+      if (Math.random() < 0.5) {
+        zeebePiExecTime.observe(zp, 1 + Math.random() * 60);
+        zeebePiExecTimeLegacy.observe(zp, 1 + Math.random() * 60);
+      }
+
+      for (const type of ELEMENT_TYPES) {
+        for (const intent of ELEMENT_INTENTS) {
+          zeebeElementEvents.inc({ ...zp, type, intent }, randInt(0, 3));
+        }
+      }
+    }
+
+    // Operate
+    const oPod  = 'operate-0';
+    const oBase = { namespace, pod: oPod };
+    const oGeo  = { ...oBase, camunda_geo_area: geo, camunda_provider: provider };
+    for (const partition of PARTITIONS) {
+      const op = { ...oBase, partition };
+      operateImportQueue.set({ ...op, camunda_geo_area: geo, camunda_provider: provider }, randInt(0, 10));
+      operateEvents.inc({ ...op, type: 'PROCESS', intent: 'ELEMENT_COMPLETED' }, randInt(1, 5));
+    }
+    if (Math.random() < 0.3) operateArchivedPi.inc(oBase, 1);
+    operatePostImporter.set(oGeo, randInt(0, 5));
+    operateImportTimeCount.inc(oGeo, randInt(1, 5));
+    operateImportTimeSum.inc(oGeo, Math.random() * 0.5);
+    const archiverLat = 0.01 + Math.random() * 0.1;
+    operateArchiverQueryCount.inc(oBase, 1);
+    operateArchiverQuerySum.inc(oBase, archiverLat);
+    if (Math.random() < 0.3) {
+      operateArchiverReindexCount.inc(oBase, 1);
+      operateArchiverReindexSum.inc(oBase, archiverLat * 3);
+      operateArchiverDeleteCount.inc(oBase, 1);
+      operateArchiverDeleteSum.inc(oBase, archiverLat);
+    }
+
+    // Tasklist
+    const tPod  = 'tasklist-0';
+    const tBase = { namespace, pod: tPod };
+    const tGeo  = { ...tBase, camunda_geo_area: geo, camunda_provider: provider };
+    for (const partition of PARTITIONS) {
+      tasklistEvents.inc({ namespace, pod: tPod, partition, type: 'PROCESS', intent: 'ELEMENT_COMPLETED' }, randInt(1, 4));
+    }
+    if (Math.random() < 0.3) tasklistArchivedPi.inc(tBase, 1);
+    tasklistImportTimeCount.inc(tGeo, randInt(1, 5));
+    tasklistImportTimeSum.inc(tGeo, Math.random() * 0.5);
+  }
+}
+
+// ── V2 REST API traffic ───────────────────────────────────────────────────────
+// Makes real requests to Camunda's V2 REST API so the container emits
+// http_server_requests_seconds metrics for each endpoint.
+// Camunda unavailability is silently ignored — the loop retries every tick.
+
+const CAMUNDA_URL = process.env.CAMUNDA_URL || 'http://localhost:8080';
+const API_TICK_MS = 15_000;
+
+async function postSearch(path, filter = {}) {
+  try {
+    await fetch(`${CAMUNDA_URL}${path}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+      body: JSON.stringify({ filter, page: { limit: 20 } }),
+      signal: AbortSignal.timeout(5000),
+    });
+  } catch { /* not ready yet */ }
+}
+
+async function get(path) {
+  try {
+    await fetch(`${CAMUNDA_URL}${path}`, {
+      headers: { 'Accept': 'application/json' },
+      signal: AbortSignal.timeout(5000),
+    });
+  } catch { /* not ready yet */ }
+}
+
+async function apiTrafficTick() {
+  // GET endpoints (no path params)
+  await get('/v2/topology');
+  await get('/v2/license');
+  await get('/v2/status');
+  await get('/v2/system/configuration');
+
+  // POST search endpoints
+  await postSearch('/v2/process-instances/search');
+  await postSearch('/v2/process-instances/search', { state: 'ACTIVE' });
+  await postSearch('/v2/process-instances/search', { state: 'INCIDENT' });
+  await postSearch('/v2/process-definitions/search');
+  await postSearch('/v2/incidents/search');
+  await postSearch('/v2/user-tasks/search');
+  await postSearch('/v2/user-tasks/search', { state: 'CREATED' });
+  await postSearch('/v2/jobs/search');
+  await postSearch('/v2/variables/search');
+}
+
+// ── HTTP server ───────────────────────────────────────────────────────────────
+
+http.createServer(async (req, res) => {
+  if (req.url === '/metrics') {
+    res.setHeader('Content-Type', register.contentType);
+    res.end(await register.metrics());
+  } else {
+    res.writeHead(200);
+    res.end('metrics-generator ok\n');
+  }
+}).listen(PORT, () => {
+  console.log(`Synthetic metrics generator listening on :${PORT}`);
+  seed();
+  console.log('Seeded. Entering update loop...');
+  setInterval(tick, TICK_MS);
+  setInterval(() => { apiTrafficTick().catch(() => {}); }, API_TICK_MS);
+  apiTrafficTick().catch(() => {});
+});

--- a/monitor/metrics-generator/package.json
+++ b/monitor/metrics-generator/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "metrics-generator",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "prom-client": "^15.1.3"
+  }
+}

--- a/monitor/processes/test-process.bpmn
+++ b/monitor/processes/test-process.bpmn
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+             targetNamespace="http://bpmn.io/schema/bpmn">
+  <process id="test-process" isExecutable="true">
+    <startEvent id="start">
+      <outgoing>to-task</outgoing>
+    </startEvent>
+    <sequenceFlow id="to-task" sourceRef="start" targetRef="task" />
+    <serviceTask id="task" name="Test Job">
+      <extensionElements>
+        <zeebe:taskDefinition type="test-job" />
+      </extensionElements>
+      <incoming>to-task</incoming>
+      <outgoing>to-end</outgoing>
+    </serviceTask>
+    <sequenceFlow id="to-end" sourceRef="task" targetRef="end" />
+    <endEvent id="end">
+      <incoming>to-end</incoming>
+    </endEvent>
+  </process>
+</definitions>

--- a/monitor/prometheus/prometheus.yml
+++ b/monitor/prometheus/prometheus.yml
@@ -2,57 +2,28 @@ global:
   scrape_interval:     5s
   evaluation_interval: 5s
 
+# Recording rules that derive node_namespace_pod_container:* metrics from the
+# synthetic container metrics produced by the metrics-generator container.
+rule_files:
+  - 'recording_rules.yml'
+
 scrape_configs:
   - job_name: 'prometheus'
     static_configs:
-         - targets: ['localhost:9090']
+      - targets: ['localhost:9090']
 
-  - job_name: 'zeebe'
+  - job_name: 'camunda'
     metrics_path: /actuator/prometheus
     static_configs:
-      - targets: ['zeebe:9600']
+      - targets: ['camunda:9600']
         labels:
           namespace: 'local'
-          pod: 'zeebe'
+          pod: 'camunda'
+          container: 'camunda'
+          cluster: 'local'
+          camunda_region: 'eu-west-1'
 
-  - job_name: 'broker-1'
+  - job_name: 'metrics-generator'
+    honor_labels: true
     static_configs:
-      - targets: ['broker-1:9600']
-        labels:
-          namespace: 'local'
-          pod: 'broker-1'
-
-  - job_name: 'broker-2'
-    static_configs:
-      - targets: ['broker-2:9600']
-        labels:
-          namespace: 'local'
-          pod: 'broker-2'
-
-  - job_name: 'broker-3'
-    static_configs:
-      - targets: ['broker-3:9600']
-        labels:
-          namespace: 'local'
-          pod: 'broker-3'
-
-  - job_name: "tasklist"
-    metrics_path: /actuator/prometheus
-    static_configs:
-      - targets: ["tasklist:8090"]
-        labels:
-          namespace: 'local'
-          pod: 'tasklist'
-
-  - job_name: "operate"
-    metrics_path: /actuator/prometheus
-    static_configs:
-      - targets: ["operate:8080"]
-        labels:
-          namespace: 'local'
-          pod: 'operate'
-
-  - job_name: "elasticsearch"
-    metrics_path: /metrics
-    static_configs:
-      - targets: ["elasticsearch_exporter:9114"]
+      - targets: ['metrics-generator:9400']

--- a/monitor/prometheus/recording_rules.yml
+++ b/monitor/prometheus/recording_rules.yml
@@ -1,0 +1,19 @@
+groups:
+  - name: local-recording-rules
+    rules:
+      # These mirror the recording rules that kube-prometheus-stack defines in a
+      # real cluster. Here they are computed from the synthetic container metrics
+      # produced by the metrics-generator, making infrastructure dashboard panels
+      # work locally without a full Kubernetes node metrics pipeline.
+
+      - record: node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate
+        expr: |
+          sum by (cluster, namespace, pod, container) (
+            irate(container_cpu_usage_seconds_total{image!=""}[5m])
+          )
+
+      - record: node_namespace_pod_container:container_memory_working_set_bytes
+        expr: |
+          sum by (cluster, namespace, pod, container) (
+            container_memory_working_set_bytes{image!=""}
+          )

--- a/monitor/scripts/check-metrics.js
+++ b/monitor/scripts/check-metrics.js
@@ -1,0 +1,313 @@
+#!/usr/bin/env node
+'use strict';
+/**
+ * Compares what the metrics-generator exposes against what real Camunda
+ * services expose at their /actuator/prometheus endpoints.
+ *
+ * Reports metric families that are present in the real services but missing
+ * from the generator, and any metrics where the generator is missing labels
+ * that the real service uses. Exits with code 1 when gaps are found.
+ *
+ * Usage:
+ *   node scripts/check-metrics.js [url ...] [--generator <url>]
+ *
+ * Default service URL:
+ *   http://localhost:9600/actuator/prometheus  (Camunda — Zeebe, Operate, Tasklist unified)
+ *
+ * Default generator URL:
+ *   http://localhost:9400/metrics
+ *
+ * Start the dev stack before running:
+ *   docker compose --project-directory ./ -f docker-compose.yml -f docker-compose.dev.yml up -d
+ */
+
+const http  = require('http');
+const https = require('https');
+
+const DEFAULT_SERVICES = [
+  'http://localhost:9600/actuator/prometheus',  // Camunda (Zeebe + Operate + Tasklist)
+];
+const DEFAULT_GENERATOR = 'http://localhost:9400/metrics';
+
+// Labels that belong to the Prometheus exposition mechanism, not the metric itself
+const INTERNAL_LABELS = new Set(['le', 'quantile']);
+
+// Suffixes Prometheus appends to histogram/counter base names in sample lines
+const SAMPLE_SUFFIXES = ['_bucket', '_sum', '_count', '_total', '_created', '_max', '_gmax'];
+
+// ── CLI ───────────────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+
+if (args.includes('--help') || args.includes('-h')) {
+  console.log([
+    'Usage: node scripts/check-metrics.js [url ...] [--generator <url>]',
+    '',
+    'Options:',
+    '  --generator <url>   URL of the metrics-generator /metrics endpoint',
+    `                      (default: ${DEFAULT_GENERATOR})`,
+    '',
+    'Positional args: one or more Prometheus-format scrape endpoints to check.',
+    `Default: ${DEFAULT_SERVICES.join(', ')}`,
+    '         (unreachable URLs are skipped automatically)',
+  ].join('\n'));
+  process.exit(0);
+}
+
+const serviceUrls = [];
+let generatorUrl  = DEFAULT_GENERATOR;
+
+for (let i = 0; i < args.length; i++) {
+  if ((args[i] === '--generator' || args[i] === '-g') && args[i + 1]) {
+    generatorUrl = args[++i];
+  } else {
+    serviceUrls.push(args[i]);
+  }
+}
+
+if (serviceUrls.length === 0) serviceUrls.push(...DEFAULT_SERVICES);
+
+// ── HTTP fetch ────────────────────────────────────────────────────────────────
+
+function fetch(url, timeoutMs = 8_000) {
+  return new Promise((resolve, reject) => {
+    const lib = url.startsWith('https') ? https : http;
+    const req = lib.get(url, { timeout: timeoutMs }, res => {
+      const chunks = [];
+      res.on('data', c => chunks.push(c));
+      res.on('end', () => {
+        if (res.statusCode >= 400) {
+          return reject(new Error(`HTTP ${res.statusCode}`));
+        }
+        resolve(Buffer.concat(chunks).toString('utf8'));
+      });
+    });
+    req.on('error', reject);
+    req.on('timeout', () => { req.destroy(); reject(new Error('timeout')); });
+  });
+}
+
+// ── Prometheus text-format parser ─────────────────────────────────────────────
+//
+// Returns Map<familyName, { type: string, labels: Set<string> }>
+//
+// Handles both legacy format (TYPE uses base name, samples may have _total)
+// and OpenMetrics-influenced format (TYPE declaration already includes _total).
+
+function parseMetrics(text) {
+  const families = new Map();
+
+  for (const raw of text.split('\n')) {
+    const line = raw.trim();
+    if (!line || line === '# EOF') continue;
+
+    if (line.startsWith('# TYPE ')) {
+      const parts = line.split(/\s+/);
+      // Strip _total from counter TYPE declarations so families are keyed
+      // by the canonical base name without the suffix.
+      const declared = parts[2];
+      const type     = parts[3] ?? 'untyped';
+      const name     = (type === 'counter' && declared.endsWith('_total'))
+        ? declared.slice(0, -6)
+        : declared;
+      if (!families.has(name)) {
+        families.set(name, { type, labels: new Set() });
+      }
+      continue;
+    }
+
+    if (line.startsWith('#')) continue;
+
+    // Extract the metric name and label string from a sample line.
+    // Format: metric_name{k="v",...} value [timestamp]
+    const braceAt = line.indexOf('{');
+    const spaceAt = line.indexOf(' ');
+    if (spaceAt < 0) continue;
+
+    const rawName  = (braceAt > 0 && braceAt < spaceAt)
+      ? line.slice(0, braceAt)
+      : line.slice(0, spaceAt);
+    const labelStr = (braceAt > 0 && braceAt < spaceAt)
+      ? line.slice(braceAt + 1, line.indexOf('}', braceAt))
+      : '';
+
+    const family = findFamily(rawName, families);
+    if (!family || !labelStr) continue;
+
+    for (const key of extractLabelKeys(labelStr)) {
+      if (!INTERNAL_LABELS.has(key)) family.labels.add(key);
+    }
+  }
+
+  return families;
+}
+
+// Look up which family a sample's metric name belongs to, stripping common
+// suffixes that Prometheus appends to the base family name.
+function findFamily(metricName, families) {
+  if (families.has(metricName)) return families.get(metricName);
+  for (const suffix of SAMPLE_SUFFIXES) {
+    if (metricName.endsWith(suffix)) {
+      const base = metricName.slice(0, -suffix.length);
+      if (families.has(base)) return families.get(base);
+    }
+  }
+  return null;
+}
+
+// Split a label string like `k1="v1",k2="v2"` on commas that are outside
+// quoted values, then return just the key portion of each pair.
+function extractLabelKeys(labelStr) {
+  const keys = [];
+  let start = 0, inQuote = false;
+  for (let i = 0; i < labelStr.length; i++) {
+    const ch = labelStr[i];
+    if (ch === '"' && labelStr[i - 1] !== '\\') inQuote = !inQuote;
+    if (!inQuote && ch === ',') {
+      pushKey(labelStr.slice(start, i), keys);
+      start = i + 1;
+    }
+  }
+  if (start < labelStr.length) pushKey(labelStr.slice(start), keys);
+  return keys;
+}
+
+function pushKey(pair, out) {
+  const eq = pair.indexOf('=');
+  if (eq > 0) out.push(pair.slice(0, eq).trim());
+}
+
+// ── prom-client declaration stub ──────────────────────────────────────────────
+
+function stub(name, type, labels) {
+  const fn      = (type === 'histogram' || type === 'summary') ? 'histo' : type === 'counter' ? 'c' : 'g';
+  const varName = name.replace(/[^a-zA-Z0-9]+/g, '_').replace(/^_+|_+$/g, '');
+  return `const ${varName} = ${fn}('${name}', '...', ${JSON.stringify(labels)});`;
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+async function main() {
+  // ── Scrape real services ──────────────────────────────────────────────────
+
+  const real    = new Map(); // familyName → { type, labels: Set, sources: string[] }
+  const reached = [];
+
+  console.log('Scraping services:');
+  for (const url of serviceUrls) {
+    try {
+      const text = await fetch(url);
+      const fams = parseMetrics(text);
+      reached.push(url);
+      console.log(`  ✓  ${url}  (${fams.size} families)`);
+      for (const [name, info] of fams) {
+        if (!real.has(name)) {
+          real.set(name, { type: info.type, labels: new Set(info.labels), sources: [url] });
+        } else {
+          const e = real.get(name);
+          for (const l of info.labels) e.labels.add(l);
+          e.sources.push(url);
+        }
+      }
+    } catch (err) {
+      console.log(`  -  ${url}  (${err.message} — skipped)`);
+    }
+  }
+
+  if (real.size === 0) {
+    console.error('\nNo metrics collected. Is the stack running?');
+    console.error('  docker compose --project-directory ./ -f docker-compose.yml -f docker-compose.dev.yml up -d');
+    process.exit(1);
+  }
+
+  // ── Scrape generator ──────────────────────────────────────────────────────
+
+  console.log('\nScraping generator:');
+  let gen;
+  try {
+    const text = await fetch(generatorUrl);
+    gen = parseMetrics(text);
+    console.log(`  ✓  ${generatorUrl}  (${gen.size} families)`);
+  } catch (err) {
+    console.error(`  ✗  ${generatorUrl}  (${err.message})`);
+    console.error('     Start the dev stack first — the generator must be running.');
+    process.exit(1);
+  }
+
+  // ── Diff ──────────────────────────────────────────────────────────────────
+
+  const missing   = []; // in real, not in gen at all
+  const labelGaps = []; // in gen, but real exposes extra labels
+
+  for (const [name, info] of real) {
+    if (!gen.has(name)) {
+      missing.push({ name, type: info.type, labels: [...info.labels].sort() });
+    } else {
+      const genLabels = gen.get(name).labels;
+      const extra     = [...info.labels].filter(l => !genLabels.has(l)).sort();
+      if (extra.length) {
+        labelGaps.push({ name, type: info.type, extra, allLabels: [...gen.get(name).labels, ...extra].sort() });
+      }
+    }
+  }
+
+  // ── Report ────────────────────────────────────────────────────────────────
+
+  console.log('\n' + '═'.repeat(64));
+  console.log(`Services reached    : ${reached.length} / ${serviceUrls.length}`);
+  console.log(`Real families total : ${real.size}`);
+  console.log(`Generator families  : ${gen.size}`);
+  console.log(`Covered             : ${real.size - missing.length}`);
+  console.log(`Missing families    : ${missing.length}`);
+  console.log(`Label gaps          : ${labelGaps.length}`);
+  console.log('═'.repeat(64));
+
+  // Overlaps: in both real and generator — these can be removed from the generator
+  const overlaps = [...real.keys()].filter(n => gen.has(n)).sort();
+
+  if (overlaps.length) {
+    console.log('\nOVERLAPS  (real service + generator both expose these — remove from generator):\n');
+    for (const name of overlaps) {
+      console.log(`  ${name}`);
+    }
+  }
+
+  if (labelGaps.length) {
+    console.log('\nLABEL GAPS  (metric exists in generator but is missing labels the real service uses):\n');
+    for (const { name, type, extra, allLabels } of labelGaps) {
+      console.log(`  ${name}  (${type})`);
+      console.log(`    missing labels : ${extra.join(', ')}`);
+      console.log(`    fix            : ${stub(name, type, allLabels)}`);
+    }
+  }
+
+  if (!missing.length) {
+    console.log('\n✓  Generator covers all metrics from the reached services.\n');
+    process.exit(0);
+  }
+
+  // Group missing by type for readability
+  const byType = {};
+  for (const m of missing) (byType[m.type] ??= []).push(m);
+
+  console.log('\nMISSING FAMILIES:\n');
+  for (const type of Object.keys(byType).sort()) {
+    const list = byType[type].sort((a, b) => a.name.localeCompare(b.name));
+    console.log(`  [${type.toUpperCase()}]`);
+    for (const m of list) {
+      console.log(`    ${m.name}`);
+      if (m.labels.length) console.log(`      labels: ${m.labels.join(', ')}`);
+    }
+    console.log();
+  }
+
+  console.log('SUGGESTED DECLARATIONS FOR generator.js:\n');
+  for (const m of missing.sort((a, b) => a.name.localeCompare(b.name))) {
+    console.log(`  ${stub(m.name, m.type, m.labels)}`);
+  }
+  console.log();
+
+  process.exit(1);
+}
+
+main().catch(e => { console.error(e.message); process.exit(1); });


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Hackdays project to simplify a local Grafana dev setup.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
