### PR TITLE
fix: false positive warning about legacy property usage

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineConnectPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineConnectPropertiesOverride.java
@@ -143,7 +143,7 @@ public class SearchEngineConnectPropertiesOverride {
     final List<InterceptorPlugin> interceptorPlugins = resolveInterceptorPlugin(override);
 
     // Log common interceptor plugins warning instead of using UnifiedConfigurationHelper logging.
-    if (override.getInterceptorPlugins() != null) {
+    if (override.getInterceptorPlugins() != null && !override.getInterceptorPlugins().isEmpty()) {
       final String warningMessage =
           String.format(
               "The following legacy property is no longer supported and should be removed in favor of '%s': %s",


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
```
WARN  	io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride - The following legacy property is no longer supported and should be removed in favor of 'camunda.data.secondary-storage.elasticsearch.interceptor-plugins': camunda.database.interceptorPlugins
```
even when `camunda.database.interceptorPlugins` is not used

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
