### PR TITLE
feat: add session watcher

### DIFF
--- a/webapp/client/apps/orchestration-cluster-webapp/src/modules/auth/components/SessionWatcher.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/modules/auth/components/SessionWatcher.test.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {createRoot} from 'react-dom/client';
+import {act} from 'react';
+import {vi, describe, it, expect, beforeEach, afterEach} from 'vitest';
+import {authenticationStore} from '../stores/authentication';
+import {SessionWatcher} from './SessionWatcher';
+
+const mockNavigate = vi.fn();
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+	const original = await importOriginal<typeof import('@tanstack/react-router')>();
+	return {
+		...original,
+		useNavigate: () => mockNavigate,
+	};
+});
+
+describe('SessionWatcher', () => {
+	let container: HTMLDivElement;
+	let root: ReturnType<typeof createRoot>;
+
+	beforeEach(() => {
+		container = document.createElement('div');
+		document.body.appendChild(container);
+
+		act(() => {
+			root = createRoot(container);
+			root.render(<SessionWatcher />);
+		});
+
+		authenticationStore.reset();
+		mockNavigate.mockReset();
+	});
+
+	afterEach(() => {
+		act(() => {
+			root.unmount();
+		});
+		document.body.removeChild(container);
+		authenticationStore.reset();
+	});
+
+	it('should navigate to /login when session expires', () => {
+		act(() => {
+			authenticationStore.setStatus('session-expired');
+		});
+
+		expect(mockNavigate).toHaveBeenCalledWith({to: '/login', replace: true});
+	});
+
+	it('should navigate to /login when session is invalid', () => {
+		act(() => {
+			authenticationStore.setStatus('session-invalid');
+		});
+
+		expect(mockNavigate).toHaveBeenCalledWith({to: '/login', replace: true});
+	});
+
+	it('should not navigate when status is initial', () => {
+		act(() => {
+			authenticationStore.reset();
+		});
+
+		expect(mockNavigate).toHaveBeenCalledTimes(0);
+	});
+
+	it('should not navigate when status is logged-in', () => {
+		act(() => {
+			authenticationStore.setStatus('logged-in');
+		});
+
+		expect(mockNavigate).toHaveBeenCalledTimes(0);
+	});
+
+	it('should not navigate when status is logged-out', () => {
+		act(() => {
+			authenticationStore.setStatus('logged-out');
+		});
+
+		expect(mockNavigate).toHaveBeenCalledTimes(0);
+	});
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/modules/auth/components/SessionWatcher.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/modules/auth/components/SessionWatcher.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useEffect} from 'react';
+import {observer} from 'mobx-react-lite';
+import {useNavigate} from '@tanstack/react-router';
+import {authenticationStore} from '#/modules/auth/stores/authentication';
+
+const SessionWatcher: React.FC = observer(() => {
+	const navigate = useNavigate();
+	const {status} = authenticationStore;
+
+	useEffect(() => {
+		if (status === 'session-expired' || status === 'session-invalid') {
+			// TODO: display a session expired notification once a notification store is available
+			navigate({to: '/login', replace: true});
+		}
+	}, [status, navigate]);
+
+	return null;
+});
+
+export {SessionWatcher};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/modules/auth/stores/authentication.test.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/modules/auth/stores/authentication.test.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {http, HttpResponse} from 'msw';
+import {describe, it, expect, beforeEach} from 'vitest';
+import {authenticationStore} from './authentication';
+import {it as itWithWorker} from '#/vitest-modules/test-extend';
+
+describe('authentication store', () => {
+	beforeEach(() => {
+		authenticationStore.reset();
+	});
+
+	it('should assume that there is an existing session', () => {
+		expect(authenticationStore.status).toBe('initial');
+	});
+
+	itWithWorker('should login', async ({worker}) => {
+		worker.use(http.post('/login', () => new HttpResponse(''), {once: true}));
+
+		authenticationStore.setStatus('session-invalid');
+
+		await authenticationStore.handleLogin('demo', 'demo');
+
+		expect(authenticationStore.status).toBe('logged-in');
+	});
+
+	itWithWorker('should handle login failure', async ({worker}) => {
+		worker.use(http.post('/login', () => new HttpResponse('', {status: 401}), {once: true}));
+
+		const result = await authenticationStore.handleLogin('demo', 'demo');
+
+		expect(result).toStrictEqual({
+			error: {
+				variant: 'failed-response',
+				response: expect.objectContaining({status: 401}),
+				networkError: null,
+			},
+		});
+		expect(authenticationStore.status).toBe('initial');
+	});
+
+	itWithWorker('should logout', async ({worker}) => {
+		worker.use(http.post('/logout', () => new HttpResponse(''), {once: true}));
+
+		authenticationStore.setStatus('logged-in');
+
+		await authenticationStore.handleLogout();
+
+		expect(authenticationStore.status).toBe('logged-out');
+	});
+
+	itWithWorker('should return an error on logout failure', async ({worker}) => {
+		worker.use(http.post('/logout', () => new HttpResponse('', {status: 500}), {once: true}));
+
+		expect(await authenticationStore.handleLogout()).toBeDefined();
+	});
+
+	it('should set status to session-invalid when disabling session from initial state', () => {
+		authenticationStore.disableSession();
+
+		expect(authenticationStore.status).toBe('session-invalid');
+	});
+
+	it('should set status to session-expired when disabling session from logged-in state', () => {
+		authenticationStore.setStatus('logged-in');
+
+		authenticationStore.disableSession();
+
+		expect(authenticationStore.status).toBe('session-expired');
+	});
+
+	it('should not change status when session is already disabled', () => {
+		authenticationStore.setStatus('session-invalid');
+		authenticationStore.disableSession();
+		expect(authenticationStore.status).toBe('session-invalid');
+
+		authenticationStore.setStatus('session-expired');
+		authenticationStore.disableSession();
+		expect(authenticationStore.status).toBe('session-expired');
+	});
+
+	// TODO: add tests for third-party session handling (canLogout / isLoginDelegated) once getClientConfig is supported
+	// https://github.com/camunda/camunda/issues/51322
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/modules/auth/stores/authentication.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/modules/auth/stores/authentication.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {makeObservable, observable, action} from 'mobx';
+import {endpoints} from '#/modules/http/endpoints';
+import {reactQueryClient} from '#/modules/http/reactQueryClient';
+import {request} from '#/modules/http/request';
+
+type Status =
+	| 'initial'
+	| 'logged-in'
+	| 'logged-out'
+	| 'session-expired'
+	| 'session-invalid'
+	// TODO: handle invalid-third-party-session once getClientConfig is supported https://github.com/camunda/camunda/issues/51322
+	| 'invalid-third-party-session';
+
+const DEFAULT_STATUS: Status = 'initial';
+
+class Authentication {
+	status: Status = DEFAULT_STATUS;
+
+	constructor() {
+		makeObservable(this, {
+			status: observable,
+			setStatus: action,
+			reset: action,
+		});
+	}
+
+	handleLogin = async (username: string, password: string) => {
+		const {error} = await request(endpoints.login({username, password}), {
+			skipSessionCheck: true,
+		});
+
+		return {error};
+	};
+
+	setStatus = (status: Status) => {
+		this.status = status;
+	};
+
+	handleLogout = async () => {
+		const {error} = await request(endpoints.logout(), {
+			skipSessionCheck: true,
+		});
+
+		if (error !== null) {
+			return error;
+		}
+
+		reactQueryClient.clear();
+
+		// TODO: handle IdP RP-initiated logout (canLogout / isLoginDelegated) once getClientConfig is supported
+		// https://github.com/camunda/camunda/issues/51322
+
+		this.setStatus('logged-out');
+		return;
+	};
+
+	activateSession = () => {
+		this.setStatus('logged-in');
+	};
+
+	disableSession = () => {
+		// TODO: handle third-party session expiration (canLogout / isLoginDelegated) once getClientConfig is supported
+		// https://github.com/camunda/camunda/issues/51322
+
+		if (['session-invalid', 'session-expired'].includes(this.status)) {
+			return;
+		}
+
+		if (this.status === 'initial') {
+			this.setStatus('session-invalid');
+		} else {
+			this.setStatus('session-expired');
+		}
+	};
+
+	reset = () => {
+		this.status = DEFAULT_STATUS;
+	};
+}
+
+const authenticationStore = new Authentication();
+
+export {authenticationStore};
+export type {Status};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/modules/queries.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/modules/queries.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {queryOptions} from '@tanstack/react-query';
+import {type CurrentUser} from '@camunda/camunda-api-zod-schemas/8.10';
+import {endpoints} from '#/modules/http/endpoints';
+import {request} from '#/modules/http/request';
+import {queryKeys} from '#/modules/queryKeys';
+
+const queries = {
+	currentUser: queryOptions({
+		queryKey: queryKeys.currentUser(),
+		queryFn: async () => {
+			const {response, error} = await request(endpoints.getCurrentUser());
+
+			if (response !== null) {
+				return response.json() as Promise<CurrentUser>;
+			}
+
+			throw error;
+		},
+		gcTime: Infinity,
+		staleTime: Infinity,
+		retry: false,
+		refetchIntervalInBackground: false,
+		refetchOnWindowFocus: false,
+	}),
+};
+
+export {queries};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/modules/queryKeys.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/modules/queryKeys.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+const queryKeys = {
+	currentUser: () => ['currentUser'],
+};
+
+export {queryKeys};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/pages/login.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/pages/login.tsx
@@ -6,13 +6,15 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import {useNavigate, useSearch} from '@tanstack/react-router';
 import {Form, Field} from 'react-final-form';
 import {FORM_ERROR} from 'final-form';
 import {TextInput, PasswordInput, Column, Grid, Stack, InlineNotification, Button} from '@carbon/react';
-import {LoadingSpinner} from '../modules/login/components/LoadingSpinner';
+import {LoadingSpinner} from '#/modules/login/components/LoadingSpinner';
 import {CamundaLogo} from '#/modules/components/CamundaLogo';
-import {getCurrentCopyrightNoticeText} from '../modules/login/getCurrentCopyrightNoticeText';
-import {Disclaimer} from '../modules/login/components/Disclaimer';
+import {getCurrentCopyrightNoticeText} from '#/modules/login/getCurrentCopyrightNoticeText';
+import {Disclaimer} from '#/modules/login/components/Disclaimer';
+import {authenticationStore} from '#/modules/auth/stores/authentication';
 import styles from './login.module.scss';
 
 type FormValues = {
@@ -21,13 +23,32 @@ type FormValues = {
 };
 
 const Login: React.FC = () => {
+	const navigate = useNavigate();
+	const {redirect: redirectTarget} = useSearch({from: '/login'});
+	const {handleLogin} = authenticationStore;
+
 	return (
 		<Grid as="main" condensed className={styles['container']!}>
 			<Form<FormValues>
-				onSubmit={async () => {
-					// TODO: call authentication API, navigate on success, return FORM_ERROR on failure
-					// https://github.com/camunda/camunda/issues/51318
-					return {[FORM_ERROR]: 'Login not yet implemented.'};
+				onSubmit={async ({username, password}) => {
+					try {
+						const {error} = await handleLogin(username, password);
+
+						if (error === null) {
+							return navigate({to: (redirectTarget ?? '/') as never, replace: true});
+						}
+
+						if (error.response?.status === 401) {
+							// TODO: replace with i18n: https://github.com/camunda/camunda/issues/51325
+							return {[FORM_ERROR]: 'Username or password is incorrect.'};
+						}
+
+						// TODO: replace with i18n: https://github.com/camunda/camunda/issues/51325
+						return {[FORM_ERROR]: 'Credentials could not be verified.'};
+					} catch {
+						// TODO: replace with i18n: https://github.com/camunda/camunda/issues/51325
+						return {[FORM_ERROR]: 'Credentials could not be verified.'};
+					}
 				}}
 				validate={({username, password}) => {
 					const errors: {username?: string; password?: string} = {};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/routes/_auth/route.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/routes/_auth/route.tsx
@@ -8,6 +8,7 @@
 
 import {createFileRoute, Outlet, redirect} from '@tanstack/react-router';
 import {queries} from '#/modules/queries';
+import {SessionWatcher} from '../../modules/auth/components/SessionWatcher';
 
 export const Route = createFileRoute('/_auth')({
 	beforeLoad: async ({context, location}) => {
@@ -21,5 +22,10 @@ export const Route = createFileRoute('/_auth')({
 });
 
 function RouteComponent() {
-	return <Outlet />;
+	return (
+		<>
+			<SessionWatcher />
+			<Outlet />
+		</>
+	);
 }

--- a/webapp/client/apps/orchestration-cluster-webapp/src/routes/_auth/route.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/routes/_auth/route.tsx
@@ -6,9 +6,17 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {createFileRoute, Outlet} from '@tanstack/react-router';
+import {createFileRoute, Outlet, redirect} from '@tanstack/react-router';
+import {queries} from '#/modules/queries';
 
 export const Route = createFileRoute('/_auth')({
+	beforeLoad: async ({context, location}) => {
+		try {
+			await context.queryClient.ensureQueryData(queries.currentUser);
+		} catch {
+			throw redirect({to: '/login', search: {redirect: location.href}});
+		}
+	},
 	component: RouteComponent,
 });
 

--- a/webapp/client/apps/orchestration-cluster-webapp/src/routes/login.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/routes/login.tsx
@@ -6,9 +6,24 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {createFileRoute} from '@tanstack/react-router';
+import {createFileRoute, isRedirect, redirect} from '@tanstack/react-router';
+import {z} from 'zod';
+import {queries} from '#/modules/queries';
 import {Login} from '../pages/login';
 
+const searchSchema = z.object({
+	redirect: z.string().optional(),
+});
+
 export const Route = createFileRoute('/login')({
+	validateSearch: searchSchema.parse,
+	beforeLoad: async ({context, search}) => {
+		try {
+			await context.queryClient.ensureQueryData(queries.currentUser);
+			throw redirect({to: (search.redirect ?? '/') as never});
+		} catch (e) {
+			if (isRedirect(e)) throw e;
+		}
+	},
 	component: Login,
 });


### PR DESCRIPTION
## Description

- add session watcher + test coverage
- include session watcher in authenticated routes

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
