### PR TITLE
feat: add reusable camunda-delete-load-test workflow

### DIFF
--- a/.github/workflows/camunda-delete-load-test.yml
+++ b/.github/workflows/camunda-delete-load-test.yml
@@ -1,0 +1,120 @@
+# description: Reusable workflow that deletes a single load test namespace by exact name.
+#              Authenticates via Teleport, validates the namespace looks like a load test
+#              (prefix `c8-` and label `camunda.io/purpose=load-test`), then runs
+#              `kubectl delete ns --wait=false --ignore-not-found`. Idempotent on missing
+#              namespaces, fails loudly on guardrail mismatches.
+# called-by: camunda-verify-and-cleanup-load-test.yml, camunda-pr-load-test.yaml
+# also: triggerable manually via workflow_dispatch for ad-hoc cleanup
+# type: CI
+# owner: @camunda/reliability-testing
+name: Delete load test
+on:
+  workflow_call:
+    inputs:
+      namespace:
+        description: 'Exact Kubernetes namespace to delete (caller must already have resolved the name)'
+        type: string
+        required: true
+  workflow_dispatch:
+    inputs:
+      namespace:
+        description: 'Exact Kubernetes namespace to delete. Must start with c8- and have label camunda.io/purpose=load-test.'
+        type: string
+        required: true
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  CLUSTER: camunda-benchmark-prod
+  TELEPORT_JOIN_TOKEN: infra-benchmark-prod-github-action-zeebe
+
+jobs:
+  delete-load-test:
+    name: Delete load test namespace
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Set up Teleport
+        uses: teleport-actions/setup@b638ff596557cc3959eb6b5287d5e58e0c8ac6a6 # v1.1.1
+        with:
+          proxy: camunda.teleport.sh:443
+          version: auto
+      - name: Authenticate to Cluster using Teleport
+        uses: teleport-actions/auth-k8s@0f46164469ae4fcd4d359d40e06bab17d4be17c9 # v2.0.6
+        with:
+          proxy: camunda.teleport.sh:443
+          token: ${{ env.TELEPORT_JOIN_TOKEN }}
+          kubernetes-cluster: ${{ env.CLUSTER }}
+      - name: Validate namespace
+        id: guardrail
+        env:
+          NAMESPACE: ${{ inputs.namespace }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$NAMESPACE" =~ ^c8- ]]; then
+            echo "::error::Refusing to delete namespace '$NAMESPACE': must start with 'c8-'."
+            exit 1
+          fi
+
+          # If the namespace doesn't exist, treat as success (idempotent).
+          if ! kubectl get namespace "$NAMESPACE" -o name >/dev/null 2>&1; then
+            echo "Namespace '$NAMESPACE' does not exist; nothing to delete."
+            echo "state=not-found" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Namespace exists — assert it's labeled as a load test before deleting.
+          purpose=$(kubectl get namespace "$NAMESPACE" \
+            -o jsonpath='{.metadata.labels.camunda\.io/purpose}')
+          if [[ "$purpose" != "load-test" ]]; then
+            echo "::error::Refusing to delete namespace '$NAMESPACE': expected label camunda.io/purpose=load-test, got '$purpose'."
+            kubectl get namespace "$NAMESPACE" --show-labels
+            exit 1
+          fi
+
+          echo "state=ready-to-delete" >> "$GITHUB_OUTPUT"
+      - name: Delete namespace
+        if: steps.guardrail.outputs.state == 'ready-to-delete'
+        env:
+          NAMESPACE: ${{ inputs.namespace }}
+        run: |
+          set -euo pipefail
+          kubectl delete namespace --wait=false --ignore-not-found "$NAMESPACE"
+      - name: Write summary
+        if: always()
+        env:
+          NAMESPACE: ${{ inputs.namespace }}
+          STATE: ${{ steps.guardrail.outputs.state }}
+        run: |
+          {
+            echo "## Delete load test"
+            echo ""
+            echo "- **Namespace:** \`$NAMESPACE\`"
+            case "$STATE" in
+              not-found)
+                echo "- **Outcome:** Namespace did not exist (no-op, idempotent)"
+                ;;
+              ready-to-delete)
+                echo "- **Outcome:** Deleted (\`kubectl delete --wait=false\`)"
+                ;;
+              *)
+                echo "- **Outcome:** Blocked by guardrail or step failure (see logs)"
+                ;;
+            esac
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/camunda-load-test-ttl-cleanup.yml
+++ b/.github/workflows/camunda-load-test-ttl-cleanup.yml
@@ -3,7 +3,7 @@
 #              one for new infra (Teleport auth). Posts deleted namespaces to Slack.
 # type: CI
 # owner: camunda/orchestration-cluster-team
-name: camunda-load-test-clean-up.yml
+name: camunda-load-test-ttl-cleanup.yml
 on:
   schedule:
     - cron: "0 4 * * *"

--- a/.github/workflows/camunda-pr-load-test.yaml
+++ b/.github/workflows/camunda-pr-load-test.yaml
@@ -204,36 +204,7 @@ jobs:
     if: >
       (github.event.action == 'unlabeled' && github.event.label.name == inputs.label) ||
       (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, inputs.label))
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      contents: 'read'
-      id-token: 'write'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Set up Teleport
-        uses: teleport-actions/setup@b638ff596557cc3959eb6b5287d5e58e0c8ac6a6 # v1.1.1
-        with:
-          proxy: camunda.teleport.sh:443
-          version: auto
-
-      - name: Authenticate to Cluster using Teleport
-        uses: teleport-actions/auth-k8s@0f46164469ae4fcd4d359d40e06bab17d4be17c9 # v2.0.6
-        with:
-          proxy: camunda.teleport.sh:443
-          token: ${{ env.TELEPORT_JOIN_TOKEN }}
-          kubernetes-cluster: ${{ env.CLUSTER }}
-
-      - name: Delete benchmarks
-        run: |
-          kubectl delete ns "${{ needs.sanitize-branch-name.outputs.sanitized-name }}" --ignore-not-found
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+    uses: ./.github/workflows/camunda-delete-load-test.yml
+    secrets: inherit
+    with:
+      namespace: ${{ needs.sanitize-branch-name.outputs.sanitized-name }}

--- a/.github/workflows/camunda-pr-load-test.yaml
+++ b/.github/workflows/camunda-pr-load-test.yaml
@@ -204,6 +204,9 @@ jobs:
     if: >
       (github.event.action == 'unlabeled' && github.event.label.name == inputs.label) ||
       (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, inputs.label))
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/camunda-delete-load-test.yml
     secrets: inherit
     with:

--- a/.github/workflows/camunda-verify-and-cleanup-load-test.yml
+++ b/.github/workflows/camunda-verify-and-cleanup-load-test.yml
@@ -1,6 +1,5 @@
-# description: Verifies a load test deployment is healthy and cleans up the namespace.
-#              Waits for all pods to be ready and checks gateway connectivity via gRPC Topology metric,
-#              then deletes the namespace regardless of verification outcome.
+# description: Verifies a load test deployment is healthy. Cleanup is delegated to
+#              camunda-delete-load-test.yml and runs regardless of verify outcome.
 # called-by: camunda-scheduled-release-load-tests.yml
 # type: CI
 # owner: @camunda/reliability-testing
@@ -18,8 +17,8 @@ env:
   TELEPORT_JOIN_TOKEN: infra-benchmark-prod-github-action-zeebe
 
 jobs:
-  verify-and-cleanup:
-    name: Verify and cleanup
+  verify:
+    name: Verify
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -39,9 +38,6 @@ jobs:
       - uses: ./.github/actions/await-load-test
         with:
           namespace: ${{ inputs.namespace }}
-      - name: Delete namespace
-        if: always()
-        run: kubectl delete ns --wait=false ${{ inputs.namespace }} --ignore-not-found || true
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -51,3 +47,12 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
+  cleanup:
+    name: Cleanup
+    needs: verify
+    if: always()
+    uses: ./.github/workflows/camunda-delete-load-test.yml
+    secrets: inherit
+    with:
+      namespace: ${{ inputs.namespace }}

--- a/.github/workflows/camunda-verify-and-cleanup-load-test.yml
+++ b/.github/workflows/camunda-verify-and-cleanup-load-test.yml
@@ -52,6 +52,9 @@ jobs:
     name: Cleanup
     needs: verify
     if: always()
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/camunda-delete-load-test.yml
     secrets: inherit
     with:

--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -42,7 +42,7 @@ graph TD
         DAILY["camunda-daily-load-tests.yml<br/><i>Weekdays 02:00 UTC</i>"]
         WEEKLY["camunda-weekly-load-tests.yml<br/><i>Monday 01:00 UTC</i>"]
         ROLLING["zeebe-update-long-running-<br/>migrating-benchmark.yaml<br/><i>Monday 00:00 UTC</i>"]
-        CLEANUP["camunda-load-test-clean-up.yml<br/><i>Daily 04:00 UTC</i>"]
+        CLEANUP["camunda-load-test-ttl-cleanup.yml<br/><i>Daily 04:00 UTC</i>"]
     end
 
     subgraph "Event Triggers"
@@ -93,7 +93,7 @@ graph TD
 | 01:00 UTC Monday  | `camunda-weekly-load-tests.yml`                      | Weekly    |
 | 02:00 UTC Mon-Fri | `camunda-scheduled-release-load-tests.yml`           | Weekdays  |
 | 02:00 UTC Mon-Fri | `camunda-daily-load-tests.yml`                       | Weekdays  |
-| 04:00 UTC         | `camunda-load-test-clean-up.yml`                     | Daily     |
+| 04:00 UTC         | `camunda-load-test-ttl-cleanup.yml`                  | Daily     |
 
 For detailed inputs, triggers, and job definitions, see each workflow's header comments in [`.github/workflows/`](../.github/workflows/).
 
@@ -255,7 +255,7 @@ Results are posted to the `#reliability-testing-alerts` Slack channel.
 
 ### Weekly load tests
 
-Weekly load tests run against the state of the **main** branch via the [Camunda load test GitHub workflow](https://github.com/camunda/camunda/actions/workflows/camunda-load-test.yml). They are automatically created every Monday and run for 4 weeks, then cleaned up by the [TTL checker](https://github.com/camunda/camunda/blob/main/.github/workflows/camunda-load-test-clean-up.yml). This results in several concurrent weekly tests (multiple variants × four weeks).
+Weekly load tests run against the state of the **main** branch via the [Camunda load test GitHub workflow](https://github.com/camunda/camunda/actions/workflows/camunda-load-test.yml). They are automatically created every Monday and run for 4 weeks, then cleaned up by the [TTL checker](https://github.com/camunda/camunda/blob/main/.github/workflows/camunda-load-test-ttl-cleanup.yml). This results in several concurrent weekly tests (multiple variants × four weeks).
 
 The weekly tests cover, for example, the [realistic load](../docs/testing/reliability-testing.md#realistic-load) variants (one with Elasticsearch, one with OpenSearch, and one with PostgreSQL) plus the [latency test](../docs/testing/reliability-testing.md#latency-load-test).
 

--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -56,6 +56,7 @@ graph TD
         ECS["camunda-ecs-weekly-load-test.yaml<br/><i>workflow_call + workflow_dispatch</i>"]
         VERIFY["camunda-verify-and-cleanup-<br/>load-test.yml<br/><i>workflow_call</i>"]
         PROFILE["profile-load-test.yml<br/><i>workflow_call + workflow_dispatch</i>"]
+        DELETE["camunda-delete-load-test.yml<br/><i>workflow_call + workflow_dispatch</i>"]
     end
 
     subgraph "Deployment Layer"
@@ -81,7 +82,10 @@ graph TD
     CORE -- "newLoadTest.sh + make install" --> MAKEFILE
     MAKEFILE -- "Helm install" --> GKE
     PROFILE -- "async-profiler" --> GKE
-    VERIFY -- "kubectl wait + delete" --> GKE
+    VERIFY -- "kubectl wait" --> GKE
+    VERIFY -- "delegate cleanup" --> DELETE
+    PR -- "delegate cleanup on label removal / PR close" --> DELETE
+    DELETE -- "kubectl delete ns" --> GKE
     CLEANUP -- "kubectl delete expired ns" --> GKE
 ```
 


### PR DESCRIPTION
## Summary

This PR adds a reusable GitHub workflow to **delete a specific load test namespace by name**. The new workflow is Teleport-authenticated, takes an exact namespace as input, applies guardrails before deletion, and is idempotent if the namespace is already gone.

In addition, this PR refactors existing cleanup paths to reuse the new workflow instead of carrying their own deletion logic, and renames the TTL-based cleanup workflow to make the distinction clearer between **delete one named load test** vs **periodic TTL cleanup**.

## Why

This came out of the recent release-thread discussion around RC / alpha load tests. The main gap was that we did not have a simple automation primitive to clean up a specific load test namespace on demand. The requested direction was to have a GitHub workflow that "just takes a load test name and cleans the related namespace," so it can be reused in release/PR related flows as needed.

My goal here is to keep this change small and explicit:
- one reusable workflow for **delete-by-name**
- existing callers delegate to it
- TTL cleanup remains separate and clearly named

Beyond the immediate Reliability Testing use cases, this primitive is also useful:
- to **users in general** running ad-hoc load tests who need a clean way to tear down a namespace by name (without needing direct kubectl access)
- as a building block for the upcoming **Claude `load-test-ops` skill** (#51886), which currently shells out to `kubectl`/`make` for cleanup and can instead call this workflow for a safer, guardrailed deletion path

## Changes

- Added reusable workflow `camunda-delete-load-test.yml`
  - accepts an exact namespace
  - authenticates via Teleport
  - deletes the namespace
  - validates that the namespace starts with `c8-`
  - validates that the namespace carries `camunda.io/purpose=load-test`
  - succeeds cleanly if the namespace is already missing

- Refactored `camunda-verify-and-cleanup-load-test.yml`
  - cleanup now delegates to the reusable delete workflow

- Refactored the cleanup path in `camunda-pr-load-test.yaml`
  - PR cleanup now delegates to the same reusable delete workflow

- Renamed the TTL cleanup workflow from `camunda-load-test-clean-up.yml` to `camunda-load-test-ttl-cleanup.yml`
  - makes it more obvious that this workflow is for deadline-based cleanup, not explicit delete-by-name

- Updated docs / README
  - adjusted references
  - updated the Mermaid diagram and workflow edges accordingly

## Motivation / Design Notes

We already had periodic TTL cleanup and some embedded cleanup logic in other workflows, but we were missing a reusable primitive for **direct deletion of one known load test**. This PR fills that gap and should make it easier to plug cleanup into other flows without duplicating Teleport / kubectl / guardrail logic again.

I feel this also gives us a better foundation for future workflow composition:
- PR load test cleanup
- release / RC cleanup steps
- manual ad-hoc cleanup
- later reuse in skills / automation around load tests (e.g. #51886)

## Test Plan / Results

`workflow_dispatch` cannot be triggered for a workflow that doesn't yet exist on the default branch, so the dispatch tests below were run via a temporary WIP alias of `camunda-load-test-clean-up.yml` (which still exists on `main`) pointing at the new code on this branch. The WIP commit was reverted before mark-ready.

| # | Scenario | Run | Outcome |
|---|---|---|---|
| 1 | Create a disposable load test (`c8-ck-cleanup-test`) via `camunda-load-test.yml` | [run 25536693973](https://github.com/camunda/camunda/actions/runs/25536693973) | ✅ deployed |
| 2 | Delete it via the new workflow | [run 25536976494](https://github.com/camunda/camunda/actions/runs/25536976494) | ✅ green — `Validate namespace` ✓, `Delete namespace` ✓, summary "Deleted" |
| 3 | Idempotency — re-dispatch with a non-existent `c8-` name | [run 25536655822](https://github.com/camunda/camunda/actions/runs/25536655822) | ✅ green — `Validate namespace` ✓ → `state=not-found`, `Delete namespace` skipped, summary "Namespace did not exist" |
| 4 | Guardrail — dispatch with `bad-prefix-test` (no `c8-` prefix) | [run 25536646999](https://github.com/camunda/camunda/actions/runs/25536646999) | ✅ red as expected — `Validate namespace` failed with the "must start with 'c8-'" error, `Delete namespace` skipped |
| 5 | PR cleanup path — `benchmark` label add+remove on this PR | [run 25502905956](https://github.com/camunda/camunda/actions/runs/25502905956) | ✅ green end-to-end — confirms Teleport auth, `id-token: write` permissions fix, and workflow-call delegation all work in real CI |

The only scenario from the spec's outcome matrix that wasn't exercised in CI is "namespace exists with a non-`load-test` value for `camunda.io/purpose`" — that path is a 3-line bash string comparison, low risk.

---

_Description drafted with help of Glean; iterated and finalized via Claude Code._
