### PR TITLE
CI: Demo for speedup-bigquery-insert2 branch

### DIFF
--- a/.github/actions/observe-aborted-jobs/action.yml
+++ b/.github/actions/observe-aborted-jobs/action.yml
@@ -41,7 +41,7 @@ runs:
         secrets: |
           secret/data/products/zeebe/ci/ci-analytics gcloud_sa_key;
 
-    - uses: camunda/infra-global-github-actions/submit-aborted-gha-status@main
+    - uses: camunda/infra-global-github-actions/submit-aborted-gha-status@speedup-bigquery-insert2
       if: ${{ always() && steps.secrets.outputs.gcloud_sa_key != '' }}
       with:
         gcp_credentials_json: "${{ steps.secrets.outputs.gcloud_sa_key }}"


### PR DESCRIPTION
## Description

DON'T MERGE, just a demo for https://github.com/camunda/infra-global-github-actions/pull/680

Runtime of `submit-aborted-gha-status` on `main`: [15 seconds](https://github.com/camunda/camunda/actions/runs/25503079322/job/74845826123#step:3:1)

Runtime of `submit-aborted-gha-status` on here (can ignore previous failures): [5 seconds](https://github.com/camunda/camunda/actions/runs/25505812906/job/74852576744?pr=52686#step:3:1)

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
