### PR TITLE
Improve Intent.from(value) coverage

### DIFF
--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/GlobalListenerIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/GlobalListenerIntent.java
@@ -40,4 +40,23 @@ public enum GlobalListenerIntent implements Intent {
   public boolean isEvent() {
     return event;
   }
+
+  public static Intent from(final short value) {
+    switch (value) {
+      case 0:
+        return CREATE;
+      case 1:
+        return CREATED;
+      case 2:
+        return UPDATE;
+      case 3:
+        return UPDATED;
+      case 4:
+        return DELETE;
+      case 5:
+        return DELETED;
+      default:
+        return UNKNOWN;
+    }
+  }
 }

--- a/zeebe/protocol/src/test/java/io/camunda/zeebe/protocol/record/intent/IntentEncodingDecodingTest.java
+++ b/zeebe/protocol/src/test/java/io/camunda/zeebe/protocol/record/intent/IntentEncodingDecodingTest.java
@@ -33,7 +33,7 @@ final class IntentEncodingDecodingTest {
 
   @ParameterizedTest
   @MethodSource("parameters")
-  void shouldEncodeAndDecodeTimerIntent(final ParameterSet parameterSet) {
+  void shouldEncodeAndDecodeIntent(final ParameterSet parameterSet) {
     final short value = parameterSet.intent.value();
 
     final Intent decoded = parameterSet.decoder.apply(value);
@@ -55,45 +55,98 @@ final class IntentEncodingDecodingTest {
   private static Stream<ParameterSet> parameters() {
     final List<ParameterSet> result = new ArrayList<>();
     result.addAll(
-        buildParameterSets(DecisionEvaluationIntent.class, DecisionEvaluationIntent::from));
+        buildParameterSets(
+            AdHocSubProcessInstructionIntent.class, AdHocSubProcessInstructionIntent::from));
+    result.addAll(buildParameterSets(AsyncRequestIntent.class, AsyncRequestIntent::from));
+    result.addAll(buildParameterSets(AuthorizationIntent.class, AuthorizationIntent::from));
+    result.addAll(
+        buildParameterSets(BatchOperationChunkIntent.class, BatchOperationChunkIntent::from));
+    result.addAll(buildParameterSets(BatchOperationIntent.class, BatchOperationIntent::from));
+    result.addAll(
+        buildParameterSets(
+            BatchOperationExecutionIntent.class, BatchOperationExecutionIntent::from));
+    result.addAll(buildParameterSets(CheckpointIntent.class, CheckpointIntent::from));
+    result.addAll(buildParameterSets(ClockIntent.class, ClockIntent::from));
+    result.addAll(buildParameterSets(ClusterVariableIntent.class, ClusterVariableIntent::from));
+    result.addAll(
+        buildParameterSets(CommandDistributionIntent.class, CommandDistributionIntent::from));
+    result.addAll(
+        buildParameterSets(
+            CompensationSubscriptionIntent.class, CompensationSubscriptionIntent::from));
+    result.addAll(
+        buildParameterSets(ConditionalEvaluationIntent.class, ConditionalEvaluationIntent::from));
+    result.addAll(
+        buildParameterSets(
+            ConditionalSubscriptionIntent.class, ConditionalSubscriptionIntent::from));
     result.addAll(buildParameterSets(DecisionIntent.class, DecisionIntent::from));
     result.addAll(
+        buildParameterSets(DecisionEvaluationIntent.class, DecisionEvaluationIntent::from));
+    result.addAll(
         buildParameterSets(DecisionRequirementsIntent.class, DecisionRequirementsIntent::from));
+    result.addAll(buildParameterSets(DeploymentIntent.class, DeploymentIntent::from));
     result.addAll(
         buildParameterSets(DeploymentDistributionIntent.class, DeploymentDistributionIntent::from));
-    result.addAll(buildParameterSets(DeploymentIntent.class, DeploymentIntent::from));
     result.addAll(buildParameterSets(ErrorIntent.class, ErrorIntent::from));
+    result.addAll(buildParameterSets(EscalationIntent.class, EscalationIntent::from));
+    result.addAll(buildParameterSets(ExpressionIntent.class, ExpressionIntent::from));
+    result.addAll(buildParameterSets(FormIntent.class, FormIntent::from));
+    result.addAll(buildParameterSets(GlobalListenerIntent.class, GlobalListenerIntent::from));
+    result.addAll(
+        buildParameterSets(GlobalListenerBatchIntent.class, GlobalListenerBatchIntent::from));
+    result.addAll(buildParameterSets(GroupIntent.class, GroupIntent::from));
+    result.addAll(buildParameterSets(HistoryDeletionIntent.class, HistoryDeletionIntent::from));
+    result.addAll(buildParameterSets(IdentitySetupIntent.class, IdentitySetupIntent::from));
     result.addAll(buildParameterSets(IncidentIntent.class, IncidentIntent::from));
-    result.addAll(buildParameterSets(JobBatchIntent.class, JobBatchIntent::from));
     result.addAll(buildParameterSets(JobIntent.class, JobIntent::from));
+    result.addAll(buildParameterSets(JobBatchIntent.class, JobBatchIntent::from));
+    result.addAll(buildParameterSets(JobMetricsBatchIntent.class, JobMetricsBatchIntent::from));
+    result.addAll(buildParameterSets(MappingRuleIntent.class, MappingRuleIntent::from));
     result.addAll(buildParameterSets(MessageIntent.class, MessageIntent::from));
+    result.addAll(buildParameterSets(MessageBatchIntent.class, MessageBatchIntent::from));
+    result.addAll(
+        buildParameterSets(MessageCorrelationIntent.class, MessageCorrelationIntent::from));
     result.addAll(
         buildParameterSets(
             MessageStartEventSubscriptionIntent.class, MessageStartEventSubscriptionIntent::from));
     result.addAll(
         buildParameterSets(MessageSubscriptionIntent.class, MessageSubscriptionIntent::from));
+    result.addAll(buildParameterSets(MultiInstanceIntent.class, MultiInstanceIntent::from));
+    result.addAll(buildParameterSets(ProcessIntent.class, ProcessIntent::from));
     result.addAll(buildParameterSets(ProcessEventIntent.class, ProcessEventIntent::from));
+    result.addAll(buildParameterSets(ProcessInstanceIntent.class, ProcessInstanceIntent::from));
+    result.addAll(
+        buildParameterSets(ProcessInstanceBatchIntent.class, ProcessInstanceBatchIntent::from));
     result.addAll(
         buildParameterSets(
             ProcessInstanceCreationIntent.class, ProcessInstanceCreationIntent::from));
-    result.addAll(buildParameterSets(ProcessInstanceIntent.class, ProcessInstanceIntent::from));
+    result.addAll(
+        buildParameterSets(
+            ProcessInstanceMigrationIntent.class, ProcessInstanceMigrationIntent::from));
+    result.addAll(
+        buildParameterSets(
+            ProcessInstanceModificationIntent.class, ProcessInstanceModificationIntent::from));
     result.addAll(
         buildParameterSets(ProcessInstanceResultIntent.class, ProcessInstanceResultIntent::from));
-    result.addAll(buildParameterSets(ProcessIntent.class, ProcessIntent::from));
     result.addAll(
         buildParameterSets(
             ProcessMessageSubscriptionIntent.class, ProcessMessageSubscriptionIntent::from));
-    result.addAll(buildParameterSets(TimerIntent.class, TimerIntent::from));
-    result.addAll(buildParameterSets(VariableDocumentIntent.class, VariableDocumentIntent::from));
-    result.addAll(buildParameterSets(VariableIntent.class, VariableIntent::from));
-    result.addAll(buildParameterSets(CheckpointIntent.class, CheckpointIntent::from));
-    result.addAll(buildParameterSets(EscalationIntent.class, EscalationIntent::from));
+    result.addAll(buildParameterSets(ResourceIntent.class, ResourceIntent::from));
+    result.addAll(buildParameterSets(ResourceDeletionIntent.class, ResourceDeletionIntent::from));
+    result.addAll(buildParameterSets(ResourceReexportIntent.class, ResourceReexportIntent::from));
+    result.addAll(buildParameterSets(RoleIntent.class, RoleIntent::from));
+    result.addAll(
+        buildParameterSets(RuntimeInstructionIntent.class, RuntimeInstructionIntent::from));
+    result.addAll(buildParameterSets(ScaleIntent.class, ScaleIntent::from));
     result.addAll(buildParameterSets(SignalIntent.class, SignalIntent::from));
     result.addAll(
         buildParameterSets(SignalSubscriptionIntent.class, SignalSubscriptionIntent::from));
-    result.addAll(buildParameterSets(ClockIntent.class, ClockIntent::from));
     result.addAll(buildParameterSets(TenantIntent.class, TenantIntent::from));
-    result.addAll(buildParameterSets(ScaleIntent.class, ScaleIntent::from));
+    result.addAll(buildParameterSets(TimerIntent.class, TimerIntent::from));
+    result.addAll(buildParameterSets(UsageMetricIntent.class, UsageMetricIntent::from));
+    result.addAll(buildParameterSets(UserIntent.class, UserIntent::from));
+    result.addAll(buildParameterSets(UserTaskIntent.class, UserTaskIntent::from));
+    result.addAll(buildParameterSets(VariableDocumentIntent.class, VariableDocumentIntent::from));
+    result.addAll(buildParameterSets(VariableIntent.class, VariableIntent::from));
 
     return result.stream();
   }

--- a/zeebe/protocol/src/test/java/io/camunda/zeebe/protocol/record/intent/IntentEncodingDecodingTest.java
+++ b/zeebe/protocol/src/test/java/io/camunda/zeebe/protocol/record/intent/IntentEncodingDecodingTest.java
@@ -21,8 +21,11 @@ import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
 import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -36,6 +39,17 @@ final class IntentEncodingDecodingTest {
     final Intent decoded = parameterSet.decoder.apply(value);
 
     assertThat(decoded).isSameAs(parameterSet.intent);
+  }
+
+  @Test
+  void shouldCoverAllIntentsInThisTest() {
+    // when
+    final Stream<ParameterSet> parameters = parameters();
+
+    // then
+    final Set<Class<? extends Intent>> actualIntentClasses =
+        parameters.map(parameterSet -> parameterSet.intent.getClass()).collect(Collectors.toSet());
+    assertThat(actualIntentClasses).containsAll(new ArrayList<>(Intent.INTENT_CLASSES));
   }
 
   private static Stream<ParameterSet> parameters() {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

It's important that all intents have a correct implementation of this method, but the test itself was old and unmaintained.

This adds a test that ensures the test coverage is complete and adds one missing from method for `GlobalListenerIntent`.

## Checklist

<!--- Please delete options that are not relevant. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Found while working on #51505
