### PR TITLE
docs: default Maven invocations to -q for AI agents

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -49,20 +49,26 @@ All builds use the Maven wrapper (`./mvnw`). Use `-T1C` (one thread per CPU core
 builds. Use `-T2` (two threads total) when running builds alongside other resource-intensive
 processes (e.g., an IDE, Docker containers, or other concurrent builds).
 
+Pass `-q` (quiet) by default when invoking Maven from an AI agent — only errors are shown, which
+keeps build progress noise out of the agent's context window. Verbose output bloats context and
+measurably degrades model performance ("context rot"); failures still surface with `-q` because
+errors are not suppressed. Drop `-q` only when actively debugging a build that succeeds but
+misbehaves.
+
 ### Module-scoped builds (preferred)
 
 ```bash
 # Build a module and its dependencies (recommended for monorepo work)
-./mvnw install -pl <module> -am -Dquickly -T1C
+./mvnw install -pl <module> -am -Dquickly -T1C -q
 
 # Build only a single module (requires dependencies to be already installed and unchanged)
-./mvnw install -pl <module> -Dquickly -T1C
+./mvnw install -pl <module> -Dquickly -T1C -q
 
 # Run a single test class in a module
-./mvnw verify -pl <module> -Dtest=MyTestClass -DskipTests=false -DskipITs -Dquickly
+./mvnw verify -pl <module> -Dtest=MyTestClass -DskipTests=false -DskipITs -Dquickly -q
 
 # Run a single integration test in a module
-./mvnw verify -pl <module> -Dit.test=MyIT -DskipTests=false -DskipUTs -Dquickly
+./mvnw verify -pl <module> -Dit.test=MyIT -DskipTests=false -DskipUTs -Dquickly -q
 ```
 
 Note: `-Dquickly` skips tests, checks, and Optimize. Add `-DskipTests=false` to re-enable tests.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -49,11 +49,11 @@ All builds use the Maven wrapper (`./mvnw`). Use `-T1C` (one thread per CPU core
 builds. Use `-T2` (two threads total) when running builds alongside other resource-intensive
 processes (e.g., an IDE, Docker containers, or other concurrent builds).
 
-Pass `-q` (quiet) by default when invoking Maven from an AI agent — only errors are shown, which
-keeps build progress noise out of the agent's context window. Verbose output bloats context and
-measurably degrades model performance ("context rot"); failures still surface with `-q` because
-errors are not suppressed. Drop `-q` only when actively debugging a build that succeeds but
-misbehaves.
+Pass `-q` (quiet) by default when invoking Maven from an AI agent — it suppresses most
+progress/info logs, which keeps build noise out of the agent's context window. Verbose output
+bloats context and measurably degrades model performance ("context rot"). Note that `-q` can also
+hide warnings, and some plugins may still print non-error output directly to stdout/stderr. Drop
+`-q` when diagnosing unexpected build behavior or when warnings and additional context may matter.
 
 ### Module-scoped builds (preferred)
 


### PR DESCRIPTION
## Summary

Adds `-q` (Maven quiet flag) to every documented Maven recipe in
`.github/copilot-instructions.md` (the file behind the `AGENTS.md` /
`CLAUDE.md` symlinks), plus a short paragraph explaining why.

## Why

Verbose Maven output measurably degrades model performance — a phenomenon
known as "context rot": as input length grows, an LLM's attention budget
gets stretched thin and accuracy drops. Tool output is a major source of
this bloat in agent workflows. Anthropic's [context engineering
guidance](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents)
explicitly calls out tool result verbosity.

`mvn -q` only suppresses progress noise — errors are not silenced — so
build failures remain fully diagnosable. The cost of the flag on a
passing build is essentially zero; the saving (thousands of `[INFO]`
/ `Downloading from ...` lines per invocation) is real.

## Scope

- Doc-only change to `.github/copilot-instructions.md`
- No build, code, or CI behavior changes

🤖 AI-assisted change.