### PR TITLE
test: stabilize UsageMetricAuthorizationIT by waiting for tenant assignment propagation

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UsageMetricAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UsageMetricAuthorizationIT.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.DeploymentEvent;
+import io.camunda.client.api.search.response.TenantUser;
 import io.camunda.client.api.statistics.response.UsageMetricsStatistics;
 import io.camunda.client.impl.basicauth.BasicAuthCredentialsProviderBuilder;
 import io.camunda.client.impl.statistics.response.UsageMetricsStatisticsImpl;
@@ -33,6 +34,7 @@ import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.time.Duration;
 import java.time.OffsetDateTime;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -99,7 +101,7 @@ public class UsageMetricAuthorizationIT {
   private static void waitForUsageMetrics(
       final CamundaClient camundaClient, final Consumer<UsageMetricsStatistics> fnRequirements) {
     Awaitility.await("should export metrics to secondary storage")
-        .atMost(EXPORT_INTERVAL.multipliedBy(2))
+        .atMost(Duration.ofSeconds(30))
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
             () ->
@@ -111,6 +113,27 @@ public class UsageMetricAuthorizationIT {
                     .satisfies(fnRequirements));
   }
 
+  // Tenant assignments are exported asynchronously to secondary storage and used at request time
+  // to resolve a user's authenticated tenants. Without this wait, basic-auth requests can race
+  // and see an empty tenant list, causing tenant-scoped queries to return 0 results.
+  private static void waitForUsersAssignedToTenant(
+      final CamundaClient camundaClient, final String tenant, final String... usernames) {
+    Awaitility.await("users " + Arrays.asList(usernames) + " assigned to tenant " + tenant)
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newUsersByTenantSearchRequest(tenant)
+                            .send()
+                            .join()
+                            .items()
+                            .stream()
+                            .map(TenantUser::getUsername))
+                    .contains(usernames));
+  }
+
   @BeforeAll
   static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
     createTenant(adminClient, TENANT_A);
@@ -118,6 +141,8 @@ public class UsageMetricAuthorizationIT {
     assignUserToTenant(adminClient, ADMIN, TENANT_A);
     assignUserToTenant(adminClient, ADMIN, TENANT_B);
     assignUserToTenant(adminClient, RESTRICTED, TENANT_A);
+    waitForUsersAssignedToTenant(adminClient, TENANT_A, ADMIN, RESTRICTED);
+    waitForUsersAssignedToTenant(adminClient, TENANT_B, ADMIN);
 
     // Create PIs & wait for metrics to be exported
     deployResource(adminClient, "process/service_tasks_v1.bpmn", TENANT_A);


### PR DESCRIPTION
## Description

Attempt to fix the flakiness reported in #50862 for `UsageMetricAuthorizationIT.searchShouldReturnAssignedAndAuthorizedTenantMetricsOnly` on `stable/8.8`. CI artifacts for the most recent failures had already expired, so this is a best-guess based on code reading — not empirically validated against a failing run.

### Failure mode

> [2] testUser=restrictedUser, expected processInstances=1
    expected: 1L
    but was: 0L
        at [UsageMetricAuthorizationIT.java:142](https://github.com/camunda/camunda/blob/a017c052018a71d29911b0284fbd87a5e4360d5a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/UsageMetricAuthorizationIT.java#L142)
> 

### Hypothesis

On every basic-auth REST call, `UsernamePasswordAuthenticationTokenConverter#convert` resolves the user's tenants from secondary storage and populates `CamundaAuthentication#authenticatedTenantIds`; tenant-scoped queries (`DefaultTenantAccessProvider`) constrain results to that list, so an empty list returns 0 docs.

`@BeforeAll` waits for admin's metric view to land but never waits for the `RESTRICTED → TENANT_A` membership to propagate to ES/OS. When the `restrictedUser` parameterized run fires, the converter can still see an empty tenant list — producing exactly the observed `expected: 1L but was: 0L`. Admin doesn't hit this because its assignments happen earlier and the subsequent PI commits buy extra wall-clock time.

The relevant production code (`UsageMetricsServices`, filter/aggregation transformers, document reader, export handler) is identical across `stable/8.8`, `stable/8.9`, and `main`. The race exists in all three; 8.8 just exposes it more often, which also means this hardening is worth porting to 8.9 / main as a follow-up.

### Changes

- Add `waitForUsersAssignedToTenant`, called after the three `assignUserToTenant` calls in `@BeforeAll` — same pattern as `DecisionRequirementsTenancyIT` / `TenantAuthorizationIT`.
- Raise the `waitForUsageMetrics` awaitility budget from `EXPORT_INTERVAL × 2` (4s) to 30s. Broker export cadence is unchanged.

### Follow-up if it still flakes

Capture broker + ES logs from a fresh failure to confirm the empty-tenant-list theory or rule it out.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #50862