### PR TITLE
deps: update c8run versions to 8.9.4

### DIFF
--- a/c8run/.env
+++ b/c8run/.env
@@ -1,9 +1,9 @@
 # this is the version of camunda/ zeebe
-CAMUNDA_VERSION=8.9.2
+CAMUNDA_VERSION=8.9.4
 # docker images moved to a shortened tag, override compose with this value when using --docker
-CAMUNDA_DOCKER_VERSION=8.9.2
+CAMUNDA_DOCKER_VERSION=8.9.4
 # Look here: https://artifacts.camunda.com/ui/native/connectors/io/camunda/connector/connector-runtime-bundle/
-CONNECTORS_VERSION=8.9.2
+CONNECTORS_VERSION=8.9.3
 # version of docker compose artifact (used for --docker option)
 COMPOSE_TAG=8.9
 COMPOSE_EXTRACTED_FOLDER=docker-compose-8.9


### PR DESCRIPTION
## Summary

- `CAMUNDA_VERSION`: `8.9.2` → `8.9.4`
- `CAMUNDA_DOCKER_VERSION`: `8.9.2` → `8.9.4`
- `CONNECTORS_VERSION`: `8.9.2` → `8.9.3`

Versions sourced from the merged Renovate PR camunda/camunda-distributions#408.

Part of the 8.9.4 c8run RC release.