### PR TITLE
test: stabilize flaky processInstanceModifications E2E – 'modifications persist after reloading'

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceModifications.spec.ts
@@ -659,6 +659,7 @@ test.describe('Process Instance Modifications', () => {
       });
 
       test('Applied modifications persist after reloading', async ({
+        page,
         operateProcessInstancePage,
         operateProcessInstanceViewModificationModePage,
       }) => {
@@ -697,39 +698,51 @@ test.describe('Process Instance Modifications', () => {
           operateProcessInstanceViewModificationModePage.modificationModeText,
         ).toBeHidden();
 
-        await operateProcessInstancePage.expandTreeItemInHistory(
-          activityFirstSubprocess,
-        );
-        await operateProcessInstancePage.clickInstanceHistoryElement(
-          activityCollectMoney,
-        );
-        await expect(
-          operateProcessInstancePage.existingVariableByName('testLocalVariable')
-            .name,
-        ).toBeVisible();
-        expect(
-          await operateProcessInstancePage
-            .existingVariableByName('testLocalVariable')
-            .value.innerText(),
-        ).toContain('"addedValue"');
+        await page.reload();
+        await hideHelperModals(page);
 
-        await operateProcessInstancePage.navigateToRootScope();
-        await expect(
-          operateProcessInstancePage.existingVariableByName(
-            'testNewMeowVariable',
-          ).name,
-        ).toBeVisible();
-        expect(
-          await operateProcessInstancePage
-            .existingVariableByName('testNewMeowVariable')
-            .value.innerText(),
-        ).toContain('7');
-        await assertJsonEqual(
-          operateProcessInstancePage.existingVariableByName(
-            'testVariableString',
-          ).value,
-          validJSONValue2,
-        );
+        await waitForAssertion({
+          assertion: async () => {
+            await operateProcessInstancePage.expandTreeItemInHistory(
+              activityFirstSubprocess,
+            );
+            await operateProcessInstancePage.clickInstanceHistoryElement(
+              activityCollectMoney,
+            );
+            await expect(
+              operateProcessInstancePage.existingVariableByName(
+                'testLocalVariable',
+              ).name,
+            ).toBeVisible();
+            expect(
+              await operateProcessInstancePage
+                .existingVariableByName('testLocalVariable')
+                .value.innerText(),
+            ).toContain('"addedValue"');
+
+            await operateProcessInstancePage.navigateToRootScope();
+            await expect(
+              operateProcessInstancePage.existingVariableByName(
+                'testNewMeowVariable',
+              ).name,
+            ).toBeVisible();
+            expect(
+              await operateProcessInstancePage
+                .existingVariableByName('testNewMeowVariable')
+                .value.innerText(),
+            ).toContain('7');
+            await assertJsonEqual(
+              operateProcessInstancePage.existingVariableByName(
+                'testVariableString',
+              ).value,
+              validJSONValue2,
+            );
+          },
+          onFailure: async () => {
+            await page.reload();
+            await hideHelperModals(page);
+          },
+        });
       });
     });
   });


### PR DESCRIPTION
## Summary

Fixes the flaky test `processInstanceModifications.spec.ts:661` — "Applied modifications persist after reloading" — reported in #52657.

**Root cause:** After clicking Apply in the modifications dialog, the test waited only for the modification-mode UI to exit (`modificationModeText` hidden), then immediately asserted on variables. That UI state change happens when the API call is dispatched — not when the backend commits it — so on slower runs the variables weren't visible yet.

Additionally, despite the test title saying "after reloading", there was no `page.reload()` call at all.

**Fix:**
- Add an explicit `page.reload()` + `hideHelperModals(page)` after modification mode exits, fulfilling the test's stated intent
- Wrap all post-reload assertions in `waitForAssertion` with `onFailure: page.reload() + hideHelperModals(page)`, matching the retry-with-reload pattern used throughout `miSubprocessModifications.spec.ts` and `batchMoveModification.spec.ts`

Closes #52657

## Test plan

- [ ] Run on-demand E2E workflow against this branch: https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
- [ ] Locally: `npx playwright test --project=operate-e2e --grep "Applied modifications persist after reloading" --repeat-each=5`