### PR TITLE
ci: add container dump logs

### DIFF
--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/backup/BackupCompatibilityAcceptance.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/backup/BackupCompatibilityAcceptance.java
@@ -33,7 +33,9 @@ import org.agrona.collections.MutableBoolean;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.Network;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.utility.DockerImageName;
 
 /**
@@ -362,10 +364,13 @@ public interface BackupCompatibilityAcceptance {
   }
 
   private BrokerContainer createOldBroker(final String storeBasePath) {
+    final var imageName = DockerImageName.parse("camunda/zeebe").withTag(previousVersion());
     final var broker =
-        new BrokerContainer(
-                DockerImageName.parse("camunda/zeebe").withTag(VersionUtil.getPreviousVersion()))
+        new BrokerContainer(imageName)
             .withNetwork(getNetwork())
+            .withLogConsumer(
+                new Slf4jLogConsumer(LoggerFactory.getLogger(BackupCompatibilityAcceptance.class))
+                    .withPrefix(imageName.asCanonicalNameString()))
             .withEmbeddedGateway()
             .withTopologyCheck(new ZeebeTopologyWaitStrategy(1, 1, 1))
             .withEnv("CAMUNDA_DATABASE_TYPE", "NONE")


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Could not reproduce CI flake. Adding container dumper logs to tests for further investigation

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

ref #51914
