### PR TITLE
feat: add reusable load-test metrics workflow

### DIFF
--- a/.github/workflows/camunda-load-test-metrics.yaml
+++ b/.github/workflows/camunda-load-test-metrics.yaml
@@ -1,0 +1,191 @@
+# description: Renders load-test metrics for a given namespace as a job
+#              summary. Reusable via workflow_call (returns JSON for other
+#              workflows) or runnable ad-hoc via workflow_dispatch.
+# calls: load-tests/docs/scripts/loadTestMetrics.sh
+# type: CI
+# owner: @camunda/reliability-testing
+name: Camunda Load Test Metrics
+on:
+  workflow_dispatch:
+    inputs:
+      namespace:
+        description: 'Namespace (e.g. c8-pgoyal-quicker-pr-1234 or c8-medic-daily-2026-05-08-abc1234-test)'
+        required: true
+        type: string
+      duration-seconds:
+        description: 'Duration of the load-test run window in seconds, also the PromQL range each query covers'
+        required: false
+        type: string
+        default: '600'
+  workflow_call:
+    inputs:
+      namespace:
+        description: 'Namespace passed to loadTestMetrics.sh'
+        required: true
+        type: string
+      duration-seconds:
+        description: 'Duration of the load-test run window in seconds, also the PromQL range each query covers.'
+        required: false
+        type: string
+        default: '600'
+    outputs:
+      results-json:
+        description: 'JSON object {name: number, ...} from loadTestMetrics.sh stdout (queries that scrape no data are omitted)'
+        value: ${{ jobs.query-and-summarize.outputs.results-json }}
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  PROM_URL: https://ci-monitor.benchmark.camunda.cloud
+
+jobs:
+  query-and-summarize:
+    name: Query Prometheus and render summary
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    env:
+      NAMESPACE: ${{ inputs.namespace }}
+      DURATION_SECONDS: ${{ inputs.duration-seconds }}
+    outputs:
+      results-json: ${{ steps.run-queries.outputs.results-json }}
+    steps:
+      - name: Validate namespace prefix
+        env:
+          NAMESPACE: ${{ inputs.namespace }}
+        run: |
+          if [[ ! "$NAMESPACE" =~ ^c8- ]]; then
+            echo "::error::Namespace '$NAMESPACE' must start with 'c8-' (e.g. c8-pgoyal-quicker-pr-1234)."
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Import Prometheus credentials from Vault
+        id: secrets
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/qa/ci/common LDAP_QA_USER | PROM_USER;
+            secret/data/products/qa/ci/common LDAP_QA_PASSWORD | PROM_PASS;
+
+      - name: Run PromQL queries via loadTestMetrics.sh
+        id: run-queries
+        # Reads queries.yaml, substitutes $NAMESPACE / $DURATION_S, hits
+        # $PROM_URL with HTTP basic auth, emits {name: number} JSON to stdout
+        # (queries that scrape no data are omitted).
+        run: |
+          set +e
+          bash load-tests/docs/scripts/loadTestMetrics.sh \
+            "$NAMESPACE" \
+            "$DURATION_SECONDS" \
+            "$PROM_URL" \
+            "--user $PROM_USER:$PROM_PASS" \
+            > /tmp/results-raw.json
+          rc=$?
+          if [[ $rc -ne 0 ]]; then
+            echo "::warning::loadTestMetrics.sh exited ${rc}; some metrics may be missing from the summary"
+          fi
+          # Drop entries whose value is null. Fallback to the raw file if jq
+          # chokes (defensive — script is expected to always emit valid JSON).
+          if ! jq 'with_entries(select(.value != null))' /tmp/results-raw.json > /tmp/results.json 2>/dev/null; then
+            echo "::warning::Failed to filter null entries; using raw script output"
+            cp /tmp/results-raw.json /tmp/results.json
+          fi
+          echo "--- /tmp/results.json (null entries stripped) ---"
+          cat /tmp/results.json
+          {
+            echo "results-json<<__VQ_EOF__"
+            cat /tmp/results.json
+            echo "__VQ_EOF__"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Convert queries.yaml to JSON for render step
+        run: |
+          yq -o=json '.' load-tests/docs/scripts/queries.yaml > /tmp/queries.json
+
+      - name: Render summary
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const fs = require('fs');
+
+            const namespace = process.env.NAMESPACE;
+            const durationSeconds = parseInt(process.env.DURATION_SECONDS, 10);
+
+            // queries.yaml drives row order, description, and formatting.
+            const queriesDoc = JSON.parse(
+              fs.readFileSync('/tmp/queries.json', 'utf8'),
+            );
+
+            let results = {};
+            let rawJson = '{}';
+            try {
+              rawJson = fs.readFileSync('/tmp/results.json', 'utf8');
+              results = JSON.parse(rawJson);
+            } catch (e) {
+              core.warning(`No /tmp/results.json — every metric will render as n/a (${e.message})`);
+            }
+
+            const numericOrNull = (v) =>
+              (typeof v === 'number' && Number.isFinite(v)) ? v : null;
+
+            const formatValue = (n, q) => {
+              if (n == null || !Number.isFinite(n)) return 'n/a';
+              const decimals = q.decimals ?? 2;
+              const unit = q.unit ?? '';
+              switch (q.format) {
+                case 'integer':
+                  return Math.round(n).toLocaleString();
+                case 'percent':
+                  return n.toFixed(decimals) + (unit || '%');
+                case 'float':
+                  return n.toFixed(decimals) + (unit ? ' ' + unit : '');
+                default:
+                  return String(n);
+              }
+            };
+
+            // Missing keys = "no data scraped" — skip the row entirely.
+            const tableLines = [
+              '| Metric | Value |',
+              '|---|---:|',
+            ];
+            for (const q of queriesDoc.queries) {
+              const value = numericOrNull(results[q.name]);
+              if (value == null) continue;
+              tableLines.push(`| ${q.description} | ${formatValue(value, q)} |`);
+            }
+            if (tableLines.length === 2) {
+              tableLines.push('| _no metrics scraped_ | - |');
+            }
+
+            const dashboard = `https://dashboard.benchmark.camunda.cloud/d/zeebe-dashboard/zeebe?var-namespace=${namespace}`;
+            const body = [
+              `## 🔍 Load Test Metrics`,
+              '',
+              `Namespace: \`${namespace}\` · Window: ${durationSeconds}s`,
+              '',
+              ...tableLines,
+              '',
+              '<details><summary>Raw JSON</summary>',
+              '',
+              '```json',
+              rawJson.trim(),
+              '```',
+              '',
+              '</details>',
+              '',
+              `📊 [Grafana dashboard](${dashboard}) · 🔁 [Workflow run](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
+            ].join('\n');
+
+            await core.summary.addRaw(body).write();

--- a/load-tests/docs/scripts/README.md
+++ b/load-tests/docs/scripts/README.md
@@ -60,6 +60,42 @@ Done
 **GitHub Actions Workflow:**
 You can also use the [Profile Load Test workflow](https://github.com/camunda/camunda/actions/workflows/profile-load-test.yml) to profile pods running in load tests. This workflow allows you to select the load test name, pod name, event type (cpu/wall/alloc), and optional profiler options through the GitHub UI.
 
+## loadTestMetrics.sh
+
+**Usage:**
+Runs every PromQL query defined in `queries.yaml` against a Prometheus HTTP endpoint and emits a `{name: value, ...}` JSON object on stdout. Failed/empty queries are omitted. Used by the [Camunda Load Test Metrics workflow](https://github.com/camunda/camunda/actions/workflows/camunda-load-test-metrics.yaml) and runnable locally against any reachable Prometheus.
+
+**Syntax:**
+
+```
+./loadTestMetrics.sh <namespace> [duration_seconds] [endpoint] [extra_curl_opts]
+```
+
+**Arguments:**
+- `namespace` — exact namespace label, e.g. `c8-pgoyal-quicker-pr-1234`. Required.
+- `duration_seconds` — PromQL range-vector window. Default: `600`.
+- `endpoint` — Prometheus base URL. Default: `http://localhost:9090` (assumes `kubectl port-forward` is open).
+- `extra_curl_opts` — free-form curl options string, e.g. `--user "u:p"` for HTTP basic auth.
+
+**Examples:**
+
+Local dev (port-forward already open):
+
+```
+./loadTestMetrics.sh c8-pgoyal-quicker-pr-1234
+```
+
+Against the LDAP-protected ingress:
+
+```
+./loadTestMetrics.sh \
+  c8-medic-daily-2026-05-08-abc1234-test 600 \
+  https://ci-monitor.benchmark.camunda.cloud \
+  "--user $PROM_USER:$PROM_PASS" > /tmp/results.json
+```
+
+zsh users: quote regex-looking arguments to avoid `no matches found` glob errors.
+
 ## PartitionDistribution.sh
 
 **Usage:**

--- a/load-tests/docs/scripts/loadTestMetrics.sh
+++ b/load-tests/docs/scripts/loadTestMetrics.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Run every query in queries.yaml against a Prometheus HTTP endpoint and emit
+# a JSON object on stdout: {name: value, ...} with failed/empty queries
+# omitted entirely. Run `./loadTestMetrics.sh --help` for full usage.
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: loadTestMetrics.sh <namespace> [duration_seconds] [endpoint] [extra_curl_opts]
+
+Arguments:
+  namespace          Substituted for $NAMESPACE in queries (required).
+  duration_seconds   Positive integer; substituted as ${n}s for $DURATION_S. Default: 600.
+  endpoint           Prometheus base URL. Default: http://localhost:9090
+                     (assumes a `kubectl port-forward` is open in another terminal).
+  extra_curl_opts    Free-form curl options string, e.g. `--user "u:p"`.
+                     Pass "" if not needed. Default: "".
+
+Options:
+  -h, --help         Show this help message.
+
+Examples:
+  # Local dev, port-forward already open:
+  ./loadTestMetrics.sh c8-pgoyal-quicker-pr-1234
+
+  # CI against the LDAP-protected ingress:
+  ./loadTestMetrics.sh \
+    "$NAMESPACE" "$DURATION_SECONDS" \
+    "https://ci-monitor.benchmark.camunda.cloud" \
+    "--user $PROM_USER:$PROM_PASS" > /tmp/results.json
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ -z "${1:-}" ]]; then
+  echo "Error: Missing <namespace>." >&2
+  usage >&2
+  exit 1
+fi
+
+### --- Args ---
+NAMESPACE="$1"
+DURATION_SECONDS="${2:-600}"
+ENDPOINT="${3:-http://localhost:9090}"
+EXTRA_OPTS="${4-}"
+
+if (( ${#NAMESPACE} > 63 )) || ! [[ "$NAMESPACE" =~ ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ ]]; then
+  echo "Error: namespace '$NAMESPACE' must be a valid Kubernetes DNS label (max 63 characters; lowercase alphanumeric or '-', and must start and end with an alphanumeric character)." >&2
+  exit 1
+fi
+
+if ! [[ "$DURATION_SECONDS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "Error: duration_seconds '$DURATION_SECONDS' must be a positive integer." >&2
+  exit 1
+fi
+
+DURATION_S="${DURATION_SECONDS}s"
+QUERIES_FILE="$(cd "$(dirname "$0")" && pwd)/queries.yaml"
+
+if [[ ! -f "$QUERIES_FILE" ]]; then
+  echo "Error: queries.yaml not found at $QUERIES_FILE" >&2
+  exit 1
+fi
+
+### --- Tool checks ---
+for cmd in yq jq curl; do
+  command -v "$cmd" >/dev/null 2>&1 || {
+    echo "Error: '$cmd' not in PATH." >&2
+    exit 1
+  }
+done
+
+# EXTRA_OPTS is a free-form string. Word-split into an array, then expand with
+# the `${arr[@]+"${arr[@]}"}` idiom so curl gets zero extra args when the
+# array is empty (bash 3.2 + set -u would otherwise raise "unbound variable").
+read -ra EXTRA_OPTS_ARR <<<"$EXTRA_OPTS"
+
+### --- Run queries ---
+
+count=$(yq '.queries | length' "$QUERIES_FILE")
+declare -a json_entries=()
+
+for i in $(seq 0 $((count - 1))); do
+  name=$(yq  ".queries[${i}].name" "$QUERIES_FILE")
+  query=$(yq ".queries[${i}].query" "$QUERIES_FILE")
+
+  promql=${query//\$NAMESPACE/$NAMESPACE}
+  promql=${promql//\$DURATION_S/$DURATION_S}
+
+  resp=$(curl -sf -G ${EXTRA_OPTS_ARR[@]+"${EXTRA_OPTS_ARR[@]}"} \
+        "${ENDPOINT}/api/v1/query" \
+        --data-urlencode "query=$promql" 2>/dev/null) || continue
+
+  [[ "$(jq -r '.status' <<<"$resp" 2>/dev/null || echo error)" == "success" ]] || continue
+
+  value=$(jq -r '.data.result[0].value[1] // "null"' <<<"$resp")
+  if [[ "$value" == "null" ]] || ! jq -en --argjson v "$value" 'true' >/dev/null 2>&1; then
+    continue
+  fi
+
+  json_entries+=("$(jq -n --arg k "$name" --argjson v "$value" '{($k): $v}')")
+done
+
+### --- Output ---
+if [[ ${#json_entries[@]} -eq 0 ]]; then
+  echo '{}'
+else
+  printf '%s\n' "${json_entries[@]}" | jq -s 'add'
+fi

--- a/load-tests/docs/scripts/queries.yaml
+++ b/load-tests/docs/scripts/queries.yaml
@@ -1,0 +1,161 @@
+# PromQL query definitions for key metrics of load tests.
+#
+# Each entry defines one metric scraped via the cluster's central Prometheus
+# at end-of-run. Adding a new metric = one block here.
+#
+# Template variables (substituted by the workflow before each query is sent):
+#   $NAMESPACE   the exact test namespace label, e.g. c8-bot-quicker-pr-1234.
+#                Callers that want to compare against a daily-on-main run
+#                must resolve to a concrete namespace first — regex globs are
+#                no longer supported.
+#   $DURATION_S  the run duration with `s` suffix, e.g. 600s
+#
+# Fields per entry:
+#   name              machine key — used as the JSON key in loadTestMetrics.sh
+#                     output and as the lookup key in the render step
+#   description       human label — used as the row label in the job summary
+#   query             PromQL string (multi-line OK; trailing whitespace is fine)
+#   higher_is_better  true when a larger value is better (throughput, instances);
+#                     false when a smaller value is better (backpressure)
+#   format            integer | float | percent  — controls summary cell format
+#   decimals          decimal places for float / percent (default 2)
+#   unit              optional display suffix appended to the formatted value
+
+queries:
+  - name: process-instances-started
+    description: Process instances submitted by the starter
+    query: |
+      max(starter_process_instances_started_total{namespace="$NAMESPACE"}[$DURATION_S])
+    higher_is_better: true
+    format: integer
+
+  - name: process-instances-completed
+    description: Root process instances completed by the engine
+    query: |
+      max(zeebe_executed_instances_total{
+        action="completed",
+        type="ROOT_PROCESS_INSTANCE",
+        namespace="$NAMESPACE"
+      }[$DURATION_S])
+    higher_is_better: true
+    format: integer
+
+  - name: throughput-per-second
+    description: Client Process Instance Started Rate (avg)
+    query: |
+      sum(rate(starter_process_instances_started_total{namespace="$NAMESPACE"}[$DURATION_S]))
+    higher_is_better: true
+    format: float
+    decimals: 1
+    unit: PI/s
+
+  - name: completed-pi-rate-per-second
+    description: Completion PI rate (avg)
+    query: |
+      sum(rate(zeebe_executed_instances_total{
+        action="completed",
+        type="ROOT_PROCESS_INSTANCE",
+        namespace="$NAMESPACE"
+      }[$DURATION_S]))
+    higher_is_better: true
+    format: float
+    decimals: 1
+    unit: PI/s
+
+  # Fraction of gateway-accepted submissions that completed end-to-end.
+  # Denominator picks up gRPC and/or HTTP submissions via PromQL `or`. The `!= 0`
+  # guard on the HTTP arm prevents zero-result series from contributing when the
+  # cluster is gRPC-only (or vice versa).
+  - name: completion-ratio
+    description: Completed process instances in %
+    query: |
+      100 * (
+        sum(rate(zeebe_executed_instances_total{
+          action="completed",
+          type="ROOT_PROCESS_INSTANCE",
+          namespace="$NAMESPACE"
+        }[$DURATION_S]))
+        /
+        (
+          sum(rate(grpc_server_processing_duration_seconds_count{
+            method="CreateProcessInstance",
+            namespace="$NAMESPACE"
+          }[$DURATION_S]))
+          or
+          sum(rate(http_server_requests_seconds_count{
+            method="POST",
+            uri="/v2/process-instances",
+            namespace="$NAMESPACE"
+          }[$DURATION_S]) != 0)
+        )
+      )
+    higher_is_better: true
+    format: percent
+    decimals: 2
+    unit: '%'
+
+  - name: backpressure-percent
+    description: Backpressure (rejected / received)
+    query: |
+      100 *
+      sum(increase(zeebe_dropped_request_count_total{namespace="$NAMESPACE"}[$DURATION_S]))
+      /
+      sum(increase(zeebe_received_request_count_total{namespace="$NAMESPACE"}[$DURATION_S]))
+    higher_is_better: false
+    format: percent
+    decimals: 2
+    unit: '%'
+
+  # Gateway-accepted submission rate. Denominator-side counterpart to the
+  # completion-ratio query: gRPC `or` HTTP, with `!= 0` to exclude empty series
+  # on a single-protocol cluster.
+  - name: starter-rate-per-second
+    description: Gateway-accepted submission rate (avg)
+    query: |
+      sum(rate(grpc_server_processing_duration_seconds_count{
+        namespace="$NAMESPACE",
+        method="CreateProcessInstance"
+      }[$DURATION_S]))
+      or
+      sum(rate(http_server_requests_seconds_count{
+        method="POST",
+        namespace="$NAMESPACE",
+        uri="/v2/process-instances"
+      }[$DURATION_S]) != 0)
+    higher_is_better: true
+    format: float
+    decimals: 1
+    unit: PI/s
+
+  # P99 latency from starter submission to data being durably available. Lower
+  # is better. Baseline is a placeholder until we calibrate against clean main
+  # runs.
+  - name: data-availability
+    description: Data availability latency (P99)
+    query: |
+      histogram_quantile(0.99, sum by (le) (
+        rate(starter_data_availability_latency_seconds_bucket{
+          namespace="$NAMESPACE"
+        }[$DURATION_S])
+      ))
+    higher_is_better: false
+    format: float
+    decimals: 3
+    unit: s
+
+  # P99 of round-trip request-response time as observed by the starter:
+  # client send → gateway processing (incl. processing-queue + auth/authz) →
+  # response received. Threshold per spec: p99 < 5s.
+  - name: request-response-latency
+    description: Request-response latency (P99)
+    query: |
+      histogram_quantile(0.99, sum by (le) (
+        rate(starter_response_latency_seconds_bucket{
+          namespace="$NAMESPACE"
+        }[$DURATION_S])
+      ))
+    higher_is_better: false
+    format: float
+    decimals: 3
+    unit: s
+


### PR DESCRIPTION
## Description

Adds a reusable `Camunda Load Test Metrics` workflow (`workflow_dispatch` + `workflow_call`) that runs the quicker-benchmark PromQL set against any namespace and renders the result as a job summary.

Backed by `loadTestMetrics.sh` + `queries.yaml` under `load-tests/quicker-benchmark/`. Namespace input is validated against `^c8-`.




## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [x] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #[HackDays](https://github.com/camunda/camunda/issues/43985)