### PR TITLE
feat: add schema for agent metrics for the FE

### DIFF
--- a/operate/client/package-lock.json
+++ b/operate/client/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@axe-core/playwright": "4.11.1",
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
-        "@camunda/camunda-api-zod-schemas": "0.0.61",
+        "@camunda/camunda-api-zod-schemas": "0.0.63",
         "@camunda/camunda-composite-components": "0.22.6",
         "@carbon/elements": "11.87.0",
         "@carbon/react": "1.105.0",
@@ -451,9 +451,9 @@
       "license": "LicenseRef-Camunda-1.0"
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.61",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.61.tgz",
-      "integrity": "sha512-JhKykEKpoxRZAVvxaEI1jVa+EfBia12g/uhmmlYXL7veXG4OZeNsHRBQOP3dD68JMSoJLvooTi1qevnRXLQQLA==",
+      "version": "0.0.63",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.63.tgz",
+      "integrity": "sha512-q5QgxVLfELY/WOEJjZKc4waVZ6UFzVKbQNSRyPCMvZyb9Q+DFn7Wm/JNwXLCS+UxrMsj7ROHC8IuzjE+IGAoew==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@axe-core/playwright": "4.11.1",
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
-    "@camunda/camunda-api-zod-schemas": "0.0.61",
+    "@camunda/camunda-api-zod-schemas": "0.0.63",
     "@camunda/camunda-composite-components": "0.22.6",
     "@carbon/elements": "11.87.0",
     "@carbon/react": "1.105.0",

--- a/operate/client/src/modules/api/v2/agentInstances/fetchAgentInstance.ts
+++ b/operate/client/src/modules/api/v2/agentInstances/fetchAgentInstance.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {
+  endpoints,
+  type GetAgentInstanceResponseBody,
+} from '@camunda/camunda-api-zod-schemas/8.10';
+import {requestWithThrow} from 'modules/request';
+
+const fetchAgentInstance = async (agentInstanceKey: string) => {
+  return requestWithThrow<GetAgentInstanceResponseBody>({
+    url: endpoints.getAgentInstance.getUrl({agentInstanceKey}),
+    method: endpoints.getAgentInstance.method,
+  });
+};
+
+export {fetchAgentInstance};

--- a/operate/client/src/modules/api/v2/agentInstances/searchAgentInstances.ts
+++ b/operate/client/src/modules/api/v2/agentInstances/searchAgentInstances.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {
+  endpoints,
+  type QueryAgentInstancesRequestBody,
+  type QueryAgentInstancesResponseBody,
+} from '@camunda/camunda-api-zod-schemas/8.10';
+import {requestWithThrow} from 'modules/request';
+
+const searchAgentInstances = async (
+  payload: QueryAgentInstancesRequestBody,
+  signal?: AbortSignal,
+) => {
+  return requestWithThrow<QueryAgentInstancesResponseBody>({
+    url: endpoints.searchAgentInstances.getUrl(),
+    method: endpoints.searchAgentInstances.method,
+    body: payload,
+    signal,
+  });
+};
+
+export {searchAgentInstances};

--- a/operate/client/src/modules/queries/agentInstances/useAgentInstance.ts
+++ b/operate/client/src/modules/queries/agentInstances/useAgentInstance.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {skipToken, useQuery} from '@tanstack/react-query';
+import type {AgentInstance} from '@camunda/camunda-api-zod-schemas/8.10';
+import {fetchAgentInstance} from 'modules/api/v2/agentInstances/fetchAgentInstance';
+import {queryKeys} from '../queryKeys';
+
+const RUNNING_STATUSES: ReadonlySet<AgentInstance['status']> = new Set([
+  'INITIALIZING',
+  'TOOL_DISCOVERY',
+  'THINKING',
+  'TOOL_CALLING',
+  'IDLE',
+]);
+
+const isAgentInstanceRunning = (agentInstance: AgentInstance): boolean => {
+  return RUNNING_STATUSES.has(agentInstance.status);
+};
+
+const useAgentInstance = <T = AgentInstance>(
+  agentInstanceKey: string | undefined,
+  options?: {
+    select?: (data: AgentInstance) => T;
+    enabled?: boolean;
+  },
+) => {
+  return useQuery({
+    queryKey: queryKeys.agentInstance.get(agentInstanceKey ?? ''),
+    queryFn: agentInstanceKey
+      ? async () => {
+          const {response, error} = await fetchAgentInstance(agentInstanceKey);
+          if (response !== null) {
+            return response;
+          }
+          throw error;
+        }
+      : skipToken,
+    select: options?.select,
+    enabled: options?.enabled,
+    refetchInterval: (query) => {
+      const agentInstance = query.state.data;
+      if (
+        agentInstance !== undefined &&
+        isAgentInstanceRunning(agentInstance)
+      ) {
+        return 5000;
+      }
+      return undefined;
+    },
+  });
+};
+
+export {useAgentInstance, isAgentInstanceRunning};

--- a/operate/client/src/modules/queries/agentInstances/useAgentInstancesSearch.ts
+++ b/operate/client/src/modules/queries/agentInstances/useAgentInstancesSearch.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useQuery} from '@tanstack/react-query';
+import type {QueryAgentInstancesRequestBody} from '@camunda/camunda-api-zod-schemas/8.10';
+import {searchAgentInstances} from 'modules/api/v2/agentInstances/searchAgentInstances';
+import {queryKeys} from '../queryKeys';
+
+const useAgentInstancesSearch = (
+  payload: QueryAgentInstancesRequestBody,
+  options?: {
+    enabled?: boolean;
+    refetchInterval?: number | false;
+  },
+) => {
+  return useQuery({
+    queryKey: queryKeys.agentInstances.search(payload),
+    queryFn: async ({signal}) => {
+      const {response, error} = await searchAgentInstances(payload, signal);
+      if (response !== null) {
+        return response;
+      }
+      throw error;
+    },
+    enabled: options?.enabled,
+    refetchInterval: options?.refetchInterval,
+  });
+};
+
+export {useAgentInstancesSearch};

--- a/operate/client/src/modules/queries/queryKeys.ts
+++ b/operate/client/src/modules/queries/queryKeys.ts
@@ -14,6 +14,7 @@ import type {
   GetProcessDefinitionInstanceVersionStatisticsRequestBody,
   GetProcessDefinitionStatisticsRequestBody,
   ProcessInstance,
+  QueryAgentInstancesRequestBody,
   QueryAuditLogsRequestBody,
   QueryBatchOperationItemsRequestBody,
   QueryBatchOperationsRequestBody,
@@ -28,6 +29,15 @@ import type {
 } from '@camunda/camunda-api-zod-schemas/8.10';
 
 const queryKeys = {
+  agentInstance: {
+    get: (agentInstanceKey: string) => ['agentInstance', agentInstanceKey],
+  },
+  agentInstances: {
+    search: (payload?: QueryAgentInstancesRequestBody) => [
+      'agentInstancesSearch',
+      payload,
+    ],
+  },
   variables: {
     search: () => ['searchVariables'],
     searchWithFilter: (params: {

--- a/webapp/client/apps/orchestration-cluster-webapp/package.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/package.json
@@ -17,7 +17,7 @@
 		"generate:svg": "svgr --typescript --no-index --out-dir src/modules/svg src/assets/svg"
 	},
 	"dependencies": {
-		"@camunda/camunda-api-zod-schemas": "0.0.62",
+		"@camunda/camunda-api-zod-schemas": "0.0.63",
 		"@camunda/camunda-composite-components": "0.23.1",
 		"@carbon/react": "1.106.0",
 		"@tanstack/react-query": "5.100.5",

--- a/webapp/client/package-lock.json
+++ b/webapp/client/package-lock.json
@@ -56,7 +56,7 @@
 		"apps/orchestration-cluster-webapp": {
 			"name": "@camunda/orchestration-cluster-webapp",
 			"dependencies": {
-				"@camunda/camunda-api-zod-schemas": "0.0.62",
+				"@camunda/camunda-api-zod-schemas": "0.0.63",
 				"@camunda/camunda-composite-components": "0.23.1",
 				"@carbon/react": "1.106.0",
 				"@tanstack/react-query": "5.100.5",
@@ -2134,9 +2134,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@rollup/pluginutils": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
-			"integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.2.0.tgz",
+			"integrity": "sha512-qWJ2ZTbmumwiLFomfzTyt5Kng4hwPi9rwCYN4SHb6eaRU1KNO4ccxINHr/VhH4GgPlt1XfSTLX2LBTme8ne4Zw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -9773,13 +9773,13 @@
 			"version": "0.0.1",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
-				"@camunda/camunda-api-zod-schemas": "0.0.62",
+				"@camunda/camunda-api-zod-schemas": "0.0.63",
 				"typescript": "6.0.3"
 			}
 		},
 		"packages/camunda-api-zod-schemas": {
 			"name": "@camunda/camunda-api-zod-schemas",
-			"version": "0.0.62",
+			"version": "0.0.63",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
 				"@types/node": "25.6.0",

--- a/webapp/client/packages/c8-mocks/package.json
+++ b/webapp/client/packages/c8-mocks/package.json
@@ -18,7 +18,7 @@
 		"typecheck": "tsc"
 	},
 	"devDependencies": {
-		"@camunda/camunda-api-zod-schemas": "0.0.62",
+		"@camunda/camunda-api-zod-schemas": "0.0.63",
 		"typescript": "6.0.3"
 	}
 }

--- a/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
+++ b/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v0.0.63
+
+### 🚀 Enhancements
+
+- Add Agent Instance schemas and endpoints for 8.10 ([#51919](https://github.com/camunda/camunda/issues/51919))
+  - `agentInstanceSchema` with status, definition, metrics, limits, and timestamps
+  - `agentInstanceFilterSchema` for search filtering
+  - `GET /v2/agent-instances/{agentInstanceKey}` endpoint
+  - `POST /v2/agent-instances/search` endpoint
+
+### ❤️ Contributors
+
+- Omran Abazid ([@OmranAbazid](https://github.com/OmranAbazid))
+
 ## v0.0.62
 
 ### 🚀 Enhancements

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/agent-instance.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/agent-instance.ts
@@ -35,17 +35,17 @@ const agentInstanceDefinitionSchema = z.object({
 type AgentInstanceDefinition = z.infer<typeof agentInstanceDefinitionSchema>;
 
 const agentInstanceMetricsSchema = z.object({
-	inputTokens: z.number().int(),
-	outputTokens: z.number().int(),
-	modelCalls: z.number().int(),
-	toolCalls: z.number().int(),
+	inputTokens: z.number(),
+	outputTokens: z.number(),
+	modelCalls: z.number(),
+	toolCalls: z.number(),
 });
 type AgentInstanceMetrics = z.infer<typeof agentInstanceMetricsSchema>;
 
 const agentInstanceLimitsSchema = z.object({
-	maxModelCalls: z.number().int(),
-	maxToolCalls: z.number().int(),
-	maxTokens: z.number().int(),
+	maxModelCalls: z.number(),
+	maxToolCalls: z.number(),
+	maxTokens: z.number(),
 });
 type AgentInstanceLimits = z.infer<typeof agentInstanceLimitsSchema>;
 
@@ -81,7 +81,7 @@ const agentInstanceFilterSchema = z
 type AgentInstanceFilter = z.infer<typeof agentInstanceFilterSchema>;
 
 const queryAgentInstancesRequestBodySchema = getQueryRequestBodySchema({
-	sortFields: ['creationDate', 'lastUpdatedDate', 'completionDate', 'status'],
+	sortFields: ['creationDate', 'lastUpdatedDate', 'completionDate', 'status'] as const,
 	filter: agentInstanceFilterSchema,
 });
 type QueryAgentInstancesRequestBody = z.infer<typeof queryAgentInstancesRequestBodySchema>;

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/agent-instance.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/agent-instance.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {z} from 'zod';
+import {
+	API_VERSION,
+	advancedDateTimeFilterSchema,
+	basicStringFilterSchema,
+	getEnumFilterSchema,
+	getQueryRequestBodySchema,
+	getQueryResponseBodySchema,
+	type Endpoint,
+} from './common';
+
+const agentInstanceStatusSchema = z.enum([
+	'COMPLETED',
+	'IDLE',
+	'INITIALIZING',
+	'THINKING',
+	'TOOL_CALLING',
+	'TOOL_DISCOVERY',
+]);
+type AgentInstanceStatus = z.infer<typeof agentInstanceStatusSchema>;
+
+const agentInstanceDefinitionSchema = z.object({
+	model: z.string(),
+	provider: z.string(),
+	systemPrompt: z.string(),
+});
+type AgentInstanceDefinition = z.infer<typeof agentInstanceDefinitionSchema>;
+
+const agentInstanceMetricsSchema = z.object({
+	inputTokens: z.number().int(),
+	outputTokens: z.number().int(),
+	modelCalls: z.number().int(),
+	toolCalls: z.number().int(),
+});
+type AgentInstanceMetrics = z.infer<typeof agentInstanceMetricsSchema>;
+
+const agentInstanceLimitsSchema = z.object({
+	maxModelCalls: z.number().int(),
+	maxToolCalls: z.number().int(),
+	maxTokens: z.number().int(),
+});
+type AgentInstanceLimits = z.infer<typeof agentInstanceLimitsSchema>;
+
+const agentInstanceSchema = z.object({
+	agentInstanceKey: z.string(),
+	status: agentInstanceStatusSchema,
+	definition: agentInstanceDefinitionSchema,
+	metrics: agentInstanceMetricsSchema,
+	limits: agentInstanceLimitsSchema,
+	elementId: z.string(),
+	processInstanceKey: z.string(),
+	processDefinitionKey: z.string(),
+	tenantId: z.string(),
+	creationDate: z.string(),
+	lastUpdatedDate: z.string(),
+	completionDate: z.string().nullable(),
+});
+type AgentInstance = z.infer<typeof agentInstanceSchema>;
+
+const agentInstanceFilterSchema = z
+	.object({
+		agentInstanceKey: basicStringFilterSchema,
+		status: getEnumFilterSchema(agentInstanceStatusSchema),
+		elementId: basicStringFilterSchema,
+		processInstanceKey: basicStringFilterSchema,
+		processDefinitionKey: basicStringFilterSchema,
+		tenantId: basicStringFilterSchema,
+		creationDate: advancedDateTimeFilterSchema,
+		lastUpdatedDate: advancedDateTimeFilterSchema,
+		completionDate: advancedDateTimeFilterSchema,
+	})
+	.partial();
+type AgentInstanceFilter = z.infer<typeof agentInstanceFilterSchema>;
+
+const queryAgentInstancesRequestBodySchema = getQueryRequestBodySchema({
+	sortFields: ['creationDate', 'lastUpdatedDate', 'completionDate', 'status'],
+	filter: agentInstanceFilterSchema,
+});
+type QueryAgentInstancesRequestBody = z.infer<typeof queryAgentInstancesRequestBodySchema>;
+
+const queryAgentInstancesResponseBodySchema = getQueryResponseBodySchema(agentInstanceSchema);
+type QueryAgentInstancesResponseBody = z.infer<typeof queryAgentInstancesResponseBodySchema>;
+
+const getAgentInstanceResponseBodySchema = agentInstanceSchema;
+type GetAgentInstanceResponseBody = z.infer<typeof getAgentInstanceResponseBodySchema>;
+
+const getAgentInstance: Endpoint<{agentInstanceKey: string}> = {
+	method: 'GET',
+	getUrl: ({agentInstanceKey}) => `/${API_VERSION}/agent-instances/${agentInstanceKey}`,
+};
+
+const searchAgentInstances: Endpoint = {
+	method: 'POST',
+	getUrl: () => `/${API_VERSION}/agent-instances/search`,
+};
+
+export {
+	agentInstanceStatusSchema,
+	agentInstanceDefinitionSchema,
+	agentInstanceMetricsSchema,
+	agentInstanceLimitsSchema,
+	agentInstanceSchema,
+	agentInstanceFilterSchema,
+	queryAgentInstancesRequestBodySchema,
+	queryAgentInstancesResponseBodySchema,
+	getAgentInstanceResponseBodySchema,
+	getAgentInstance,
+	searchAgentInstances,
+};
+export type {
+	AgentInstanceStatus,
+	AgentInstanceDefinition,
+	AgentInstanceMetrics,
+	AgentInstanceLimits,
+	AgentInstance,
+	AgentInstanceFilter,
+	QueryAgentInstancesRequestBody,
+	QueryAgentInstancesResponseBody,
+	GetAgentInstanceResponseBody,
+};

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/index.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/index.ts
@@ -8,6 +8,7 @@
 
 import {getCurrentUser} from './authentication';
 import {activateAdHocSubProcessActivities} from './ad-hoc-sub-process';
+import {getAgentInstance, searchAgentInstances} from './agent-instance';
 import {
 	createAuthorization,
 	updateAuthorization,
@@ -188,6 +189,8 @@ const endpoints = {
 	getCurrentUser,
 
 	activateAdHocSubProcessActivities,
+	getAgentInstance,
+	searchAgentInstances,
 	createAuthorization,
 	updateAuthorization,
 	getAuthorization,
@@ -410,6 +413,26 @@ export {
 	type GetIncidentProcessInstanceStatisticsByDefinitionResponseBody,
 } from './incident-statistics';
 export {currentUserSchema, getCurrentUser, type CurrentUser} from './authentication';
+export {
+	agentInstanceStatusSchema,
+	agentInstanceDefinitionSchema,
+	agentInstanceMetricsSchema,
+	agentInstanceLimitsSchema,
+	agentInstanceSchema,
+	agentInstanceFilterSchema,
+	queryAgentInstancesRequestBodySchema,
+	queryAgentInstancesResponseBodySchema,
+	getAgentInstanceResponseBodySchema,
+	type AgentInstanceStatus,
+	type AgentInstanceDefinition,
+	type AgentInstanceMetrics,
+	type AgentInstanceLimits,
+	type AgentInstance,
+	type AgentInstanceFilter,
+	type QueryAgentInstancesRequestBody,
+	type QueryAgentInstancesResponseBody,
+	type GetAgentInstanceResponseBody,
+} from './agent-instance';
 export {
 	activityTypeSchema,
 	queryActivatableActivitiesRequestBodySchema,

--- a/webapp/client/packages/camunda-api-zod-schemas/package.json
+++ b/webapp/client/packages/camunda-api-zod-schemas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda/camunda-api-zod-schemas",
-	"version": "0.0.62",
+	"version": "0.0.63",
 	"license": "LicenseRef-Camunda-1.0",
 	"description": "Zod schemas and TypeScript types for Camunda 8 unified API",
 	"author": "Vinicius Goulart <vinicius.goulart@camunda.com>",


### PR DESCRIPTION
## Description
<!-- Describe the goal and purpose of this PR. -->
Adds frontend-facing Zod schemas and Operate client query utilities to support the Agent Instance Query API (agent instance detail + search).

Note: once reviewed, i will publish a new version of the zod schema with the new types. This should fix the failing operate build in the CI


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #51919
