### PR TITLE
[PoC] Document reference visualization based on export handler

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/search/SearchClientConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchClientConfiguration.java
@@ -19,6 +19,7 @@ import io.camunda.search.clients.reader.BatchOperationItemReader;
 import io.camunda.search.clients.reader.BatchOperationReader;
 import io.camunda.search.clients.reader.ClusterVariableReader;
 import io.camunda.search.clients.reader.CorrelatedMessageSubscriptionReader;
+import io.camunda.search.clients.reader.DocumentReferenceReader;
 import io.camunda.search.clients.reader.DecisionDefinitionReader;
 import io.camunda.search.clients.reader.DecisionInstanceReader;
 import io.camunda.search.clients.reader.DecisionRequirementsReader;
@@ -141,6 +142,7 @@ public class SearchClientConfiguration {
       final UserTaskReader userTaskReader,
       final VariableReader variableReader,
       final ClusterVariableReader clusterVariableReader,
+      final DocumentReferenceReader documentReferenceReader,
       final AuditLogReader auditLogReader,
       final IncidentProcessInstanceStatisticsByErrorReader
           incidentProcessInstanceStatisticsByErrorReader,
@@ -184,6 +186,7 @@ public class SearchClientConfiguration {
         userTaskReader,
         variableReader,
         clusterVariableReader,
+        documentReferenceReader,
         auditLogReader,
         incidentProcessInstanceStatisticsByErrorReader,
         incidentProcessInstanceStatisticsByDefinitionReader,

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchClientReadersFactory.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchClientReadersFactory.java
@@ -15,6 +15,7 @@ import io.camunda.search.clients.reader.BatchOperationDocumentReader;
 import io.camunda.search.clients.reader.BatchOperationItemDocumentReader;
 import io.camunda.search.clients.reader.ClusterVariableDocumentReader;
 import io.camunda.search.clients.reader.CorrelatedMessageSubscriptionDocumentReader;
+import io.camunda.search.clients.reader.DocumentReferenceDocumentReader;
 import io.camunda.search.clients.reader.DecisionDefinitionDocumentReader;
 import io.camunda.search.clients.reader.DecisionInstanceDocumentReader;
 import io.camunda.search.clients.reader.DecisionRequirementsDocumentReader;
@@ -54,6 +55,7 @@ import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.camunda.webapps.schema.descriptors.index.AuthorizationIndex;
 import io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex;
 import io.camunda.webapps.schema.descriptors.index.DecisionIndex;
+import io.camunda.webapps.schema.descriptors.index.DocumentReferenceIndex;
 import io.camunda.webapps.schema.descriptors.index.DecisionRequirementsIndex;
 import io.camunda.webapps.schema.descriptors.index.DeployedResourceIndex;
 import io.camunda.webapps.schema.descriptors.index.FormIndex;
@@ -151,6 +153,8 @@ public final class SearchClientReadersFactory {
         new VariableDocumentReader(executor, descriptors.get(VariableTemplate.class));
     final var clusterVariableReader =
         new ClusterVariableDocumentReader(executor, descriptors.get(ClusterVariableIndex.class));
+    final var documentReferenceReader =
+        new DocumentReferenceDocumentReader(executor, descriptors.get(DocumentReferenceIndex.class));
     final var auditLogReader =
         new AuditLogDocumentReader(executor, descriptors.get(AuditLogTemplate.class));
     final var globalListenerReader =
@@ -240,6 +244,7 @@ public final class SearchClientReadersFactory {
         userTaskReader,
         variableReader,
         clusterVariableReader,
+        documentReferenceReader,
         auditLogReader,
         incidentProcessInstanceStatisticsByErrorReader,
         incidentProcessInstanceStatisticsByDefinitionReader,

--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -16,6 +16,7 @@ import io.camunda.search.clients.AuthorizationSearchClient;
 import io.camunda.search.clients.BatchOperationSearchClient;
 import io.camunda.search.clients.ClusterVariableSearchClient;
 import io.camunda.search.clients.DecisionDefinitionSearchClient;
+import io.camunda.search.clients.DocumentReferenceSearchClient;
 import io.camunda.search.clients.DecisionInstanceSearchClient;
 import io.camunda.search.clients.DecisionRequirementSearchClient;
 import io.camunda.search.clients.DeployedResourceSearchClient;
@@ -50,6 +51,7 @@ import io.camunda.service.ConditionalServices;
 import io.camunda.service.DecisionDefinitionServices;
 import io.camunda.service.DecisionInstanceServices;
 import io.camunda.service.DecisionRequirementsServices;
+import io.camunda.service.DocumentReferenceServices;
 import io.camunda.service.DocumentServices;
 import io.camunda.service.ElementInstanceServices;
 import io.camunda.service.ExpressionServices;
@@ -391,6 +393,21 @@ public class CamundaServicesConfiguration {
         brokerClient,
         securityContextProvider,
         clusterVariableSearchClient,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
+  }
+
+  @Bean
+  public DocumentReferenceServices documentReferenceServices(
+      final BrokerClient brokerClient,
+      final SecurityContextProvider securityContextProvider,
+      final DocumentReferenceSearchClient documentReferenceSearchClient,
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    return new DocumentReferenceServices(
+        brokerClient,
+        securityContextProvider,
+        documentReferenceSearchClient,
         executorProvider,
         brokerRequestAuthorizationConverter);
   }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -360,6 +360,9 @@ public class SearchQueryFilterMapper {
     ofNullable(filter.getProcessInstanceKey())
         .map(mapToKeyOperations("processInstanceKey", validationErrors))
         .ifPresent(builder::processInstanceKeyOperations);
+    ofNullable(filter.getScopeKey())
+        .map(mapToKeyOperations("scopeKey", validationErrors))
+        .ifPresent(builder::scopeKeyOperations);
     ofNullable(filter.getVariableKey())
         .map(mapToKeyOperations("variableKey", validationErrors))
         .ifPresent(builder::variableKeyOperations);

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -53,6 +53,7 @@ import io.camunda.search.filter.DecisionDefinitionFilter;
 import io.camunda.search.filter.DecisionInstanceFilter;
 import io.camunda.search.filter.DecisionRequirementsFilter;
 import io.camunda.search.filter.DeployedResourceFilter;
+import io.camunda.search.filter.DocumentReferenceFilter;
 import io.camunda.search.filter.FilterBuilders;
 import io.camunda.search.filter.FlowNodeInstanceFilter;
 import io.camunda.search.filter.GlobalJobStatisticsFilter;
@@ -342,6 +343,30 @@ public class SearchQueryFilterMapper {
     ofNullable(filter.getIsTruncated()).ifPresent(builder::isTruncated);
     ofNullable(filter.getName()).map(mapToStringOperations()).ifPresent(builder::nameOperations);
     ofNullable(filter.getValue()).map(mapToStringOperations()).ifPresent(builder::valueOperations);
+
+    return validationErrors.isEmpty()
+        ? Either.right(builder.build())
+        : Either.left(validationErrors);
+  }
+
+  static Either<List<String>, DocumentReferenceFilter> toDocumentReferenceFilter(
+      final io.camunda.gateway.protocol.model.@Nullable DocumentReferenceFilter filter) {
+    if (filter == null) {
+      return Either.right(FilterBuilders.documentReference().build());
+    }
+    final var builder = FilterBuilders.documentReference();
+    final List<String> validationErrors = new ArrayList<>();
+
+    ofNullable(filter.getProcessInstanceKey())
+        .map(mapToKeyOperations("processInstanceKey", validationErrors))
+        .ifPresent(builder::processInstanceKeyOperations);
+    ofNullable(filter.getVariableKey())
+        .map(mapToKeyOperations("variableKey", validationErrors))
+        .ifPresent(builder::variableKeyOperations);
+    ofNullable(filter.getDocumentId())
+        .map(mapToStringOperations())
+        .ifPresent(builder::documentIdOperations);
+    ofNullable(filter.getTenantId()).ifPresent(t -> builder.tenantIds(List.of(t)));
 
     return validationErrors.isEmpty()
         ? Either.right(builder.build())

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryRequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryRequestMapper.java
@@ -34,6 +34,7 @@ import io.camunda.search.query.DecisionDefinitionQuery;
 import io.camunda.search.query.DecisionInstanceQuery;
 import io.camunda.search.query.DecisionRequirementsQuery;
 import io.camunda.search.query.DeployedResourceQuery;
+import io.camunda.search.query.DocumentReferenceQuery;
 import io.camunda.search.query.FlowNodeInstanceQuery;
 import io.camunda.search.query.GlobalListenerQuery;
 import io.camunda.search.query.GroupMemberQuery;
@@ -617,6 +618,22 @@ public final class SearchQueryRequestMapper {
             SearchQuerySortRequestMapper::applyVariableSortField);
     final var filter = SearchQueryFilterMapper.toVariableFilter(request.getFilter());
     return buildSearchQuery(filter, sort, page, SearchQueryBuilders::variableSearchQuery);
+  }
+
+  public static Either<ProblemDetail, DocumentReferenceQuery> toDocumentReferenceQuery(
+      final @Nullable DocumentReferenceSearchQuery request) {
+    if (request == null) {
+      return Either.right(SearchQueryBuilders.documentReferenceSearchQuery().build());
+    }
+    final var page = toSearchQueryPage(request.getPage());
+    final var sort =
+        SearchQuerySortRequestMapper.toSearchQuerySort(
+            SearchQuerySortRequestMapper.fromDocumentReferenceSearchQuerySortRequest(
+                request.getSort()),
+            SortOptionBuilders::documentReference,
+            SearchQuerySortRequestMapper::applyDocumentReferenceSortField);
+    final var filter = SearchQueryFilterMapper.toDocumentReferenceFilter(request.getFilter());
+    return buildSearchQuery(filter, sort, page, SearchQueryBuilders::documentReferenceSearchQuery);
   }
 
   public static Either<ProblemDetail, ClusterVariableQuery> toClusterVariableQuery(

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -52,6 +52,8 @@ import io.camunda.gateway.protocol.model.DecisionInstanceSearchQueryResult;
 import io.camunda.gateway.protocol.model.DecisionInstanceStateEnum;
 import io.camunda.gateway.protocol.model.DecisionRequirementsResult;
 import io.camunda.gateway.protocol.model.DecisionRequirementsSearchQueryResult;
+import io.camunda.gateway.protocol.model.DocumentReferenceSearchQueryResult;
+import io.camunda.gateway.protocol.model.DocumentReferenceSearchResult;
 import io.camunda.gateway.protocol.model.ElementInstanceResult;
 import io.camunda.gateway.protocol.model.ElementInstanceSearchQueryResult;
 import io.camunda.gateway.protocol.model.ElementInstanceStateEnum;
@@ -162,6 +164,7 @@ import io.camunda.search.entities.DecisionInstanceEntity.DecisionInstanceOutputE
 import io.camunda.search.entities.DecisionInstanceEntity.DecisionInstanceState;
 import io.camunda.search.entities.DecisionRequirementsEntity;
 import io.camunda.search.entities.DeployedResourceEntity;
+import io.camunda.search.entities.DocumentReferenceEntity;
 import io.camunda.search.entities.FlowNodeInstanceEntity;
 import io.camunda.search.entities.FormEntity;
 import io.camunda.search.entities.GlobalJobStatisticsEntity;
@@ -1322,6 +1325,41 @@ public final class SearchQueryResponseMapper {
       case UNSPECIFIED -> DecisionDefinitionTypeEnum.UNSPECIFIED;
       default -> DecisionDefinitionTypeEnum.UNKNOWN;
     };
+  }
+
+  public static DocumentReferenceSearchQueryResult toDocumentReferenceSearchQueryResponse(
+      final io.camunda.search.query.SearchQueryResult<DocumentReferenceEntity> result) {
+    final var page = toSearchQueryPageResponse(result);
+    return new DocumentReferenceSearchQueryResult()
+        .page(page)
+        .items(
+            ofNullable(result.items())
+                .map(SearchQueryResponseMapper::toDocumentReferences)
+                .orElseGet(Collections::emptyList));
+  }
+
+  private static List<DocumentReferenceSearchResult> toDocumentReferences(
+      final List<DocumentReferenceEntity> entities) {
+    return entities.stream().map(SearchQueryResponseMapper::toDocumentReference).toList();
+  }
+
+  private static DocumentReferenceSearchResult toDocumentReference(
+      final DocumentReferenceEntity entity) {
+    return new DocumentReferenceSearchResult()
+        .variableKey(keyToString(entity.variableKey()))
+        .variableName(entity.variableName())
+        .processInstanceKey(keyToString(entity.processInstanceKey()))
+        .scopeKey(keyToString(entity.scopeKey()))
+        .processDefinitionKey(keyToString(entity.processDefinitionKey()))
+        .processDefinitionId(entity.processDefinitionId())
+        .tenantId(entity.tenantId())
+        .documentId(entity.documentId())
+        .storeId(entity.storeId())
+        .fileName(entity.fileName())
+        .contentType(entity.contentType())
+        .size(entity.size())
+        .expiresAt(entity.expiresAt())
+        .contentHash(entity.contentHash());
   }
 
   public static VariableSearchQueryResult toVariableSearchQueryResponse(

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -1350,7 +1350,7 @@ public final class SearchQueryResponseMapper {
         .variableName(entity.variableName())
         .processInstanceKey(keyToString(entity.processInstanceKey()))
         .scopeKey(keyToString(entity.scopeKey()))
-        .processDefinitionKey(keyToString(entity.processDefinitionKey()))
+        .processDefinitionKey(keyToStringOrNull(entity.processDefinitionKey()))
         .processDefinitionId(entity.processDefinitionId())
         .tenantId(entity.tenantId())
         .documentId(entity.documentId())

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQuerySortRequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQuerySortRequestMapper.java
@@ -766,6 +766,7 @@ public class SearchQuerySortRequestMapper {
     } else {
       switch (field) {
         case PROCESS_INSTANCE_KEY -> builder.processInstanceKey();
+        case SCOPE_KEY -> builder.scopeKey();
         case VARIABLE_KEY -> builder.variableKey();
         case DOCUMENT_ID -> builder.documentId();
         case FILE_NAME -> builder.fileName();

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQuerySortRequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQuerySortRequestMapper.java
@@ -20,6 +20,7 @@ import io.camunda.search.sort.DecisionDefinitionSort;
 import io.camunda.search.sort.DecisionInstanceSort;
 import io.camunda.search.sort.DecisionRequirementsSort;
 import io.camunda.search.sort.DeployedResourceSort;
+import io.camunda.search.sort.DocumentReferenceSort;
 import io.camunda.search.sort.FlowNodeInstanceSort;
 import io.camunda.search.sort.GlobalListenerSort;
 import io.camunda.search.sort.GroupMemberSort;
@@ -198,6 +199,12 @@ public class SearchQuerySortRequestMapper {
 
   static List<SearchQuerySortRequest<VariableSearchQuerySortRequest.FieldEnum>>
       fromVariableSearchQuerySortRequest(final List<VariableSearchQuerySortRequest> requests) {
+    return requests.stream().map(r -> createFrom(r.getField(), r.getOrder())).toList();
+  }
+
+  static List<SearchQuerySortRequest<DocumentReferenceSearchQuerySortRequest.FieldEnum>>
+      fromDocumentReferenceSearchQuerySortRequest(
+          final List<DocumentReferenceSearchQuerySortRequest> requests) {
     return requests.stream().map(r -> createFrom(r.getField(), r.getOrder())).toList();
   }
 
@@ -744,6 +751,25 @@ public class SearchQuerySortRequestMapper {
         case VARIABLE_KEY -> builder.variableKey();
         case SCOPE_KEY -> builder.scopeKey();
         case PROCESS_INSTANCE_KEY -> builder.processInstanceKey();
+        default -> validationErrors.add(ERROR_UNKNOWN_SORT_BY.formatted(field));
+      }
+    }
+    return validationErrors;
+  }
+
+  static List<String> applyDocumentReferenceSortField(
+      final DocumentReferenceSearchQuerySortRequest.FieldEnum field,
+      final DocumentReferenceSort.Builder builder) {
+    final List<String> validationErrors = new ArrayList<>();
+    if (field == null) {
+      validationErrors.add(ERROR_SORT_FIELD_MUST_NOT_BE_NULL);
+    } else {
+      switch (field) {
+        case PROCESS_INSTANCE_KEY -> builder.processInstanceKey();
+        case VARIABLE_KEY -> builder.variableKey();
+        case DOCUMENT_ID -> builder.documentId();
+        case FILE_NAME -> builder.fileName();
+        case TENANT_ID -> builder.tenantId();
         default -> validationErrors.add(ERROR_UNKNOWN_SORT_BY.formatted(field));
       }
     }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQuerySortRequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQuerySortRequestMapper.java
@@ -768,6 +768,7 @@ public class SearchQuerySortRequestMapper {
         case PROCESS_INSTANCE_KEY -> builder.processInstanceKey();
         case SCOPE_KEY -> builder.scopeKey();
         case VARIABLE_KEY -> builder.variableKey();
+        case VARIABLE_NAME -> builder.variableName();
         case DOCUMENT_ID -> builder.documentId();
         case FILE_NAME -> builder.fileName();
         case TENANT_ID -> builder.tenantId();

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DocumentsTab/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DocumentsTab/index.tsx
@@ -1,0 +1,160 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useState} from 'react';
+import {IconButton, Layer, Loading} from '@carbon/react';
+import {Download} from '@carbon/react/icons';
+import styled from 'styled-components';
+import {StructuredList} from 'modules/components/StructuredList';
+import {EmptyMessage} from 'modules/components/EmptyMessage';
+import {ErrorMessage} from 'modules/components/ErrorMessage';
+import {useDocuments} from 'modules/queries/variables/useDocuments';
+import {fetchDocument} from 'modules/api/v2/documentReferences/fetchDocument';
+import {type DocumentReferenceSearchResult} from '@camunda/camunda-api-zod-schemas/8.10';
+
+const Content = styled(Layer)`
+  position: relative;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  padding: 0 var(--cds-spacing-05);
+`;
+
+const ScrollContainer = styled.div`
+  height: 100%;
+  overflow-y: auto;
+`;
+
+const CenteredContainer = styled.div`
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  align-items: center;
+`;
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+const DocumentsTab: React.FC = () => {
+  const {
+    documents,
+    isLoading,
+    isError,
+    fetchNextPage,
+    fetchPreviousPage,
+    hasNextPage,
+    hasPreviousPage,
+  } = useDocuments();
+
+  const [downloadingId, setDownloadingId] = useState<string | null>(null);
+
+  const handleDownload = async (doc: DocumentReferenceSearchResult) => {
+    if (downloadingId !== null) return;
+    setDownloadingId(doc.documentId);
+    try {
+      const response = await fetchDocument({
+        documentId: doc.documentId,
+        storeId: doc.storeId ?? undefined,
+        contentHash: doc.contentHash ?? undefined,
+      });
+      if (response.ok) {
+        const blob = await response.blob();
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = doc.fileName ?? doc.documentId;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(url);
+      }
+    } catch {
+      // download failed silently
+    } finally {
+      setDownloadingId(null);
+    }
+  };
+
+  if (isError) {
+    return (
+      <Content>
+        <CenteredContainer>
+          <ErrorMessage
+            message="Documents could not be fetched"
+            additionalInfo="Refresh the page to try again"
+          />
+        </CenteredContainer>
+      </Content>
+    );
+  }
+
+  return (
+    <Content>
+      {!isLoading && documents.length === 0 ? (
+        <CenteredContainer>
+          <EmptyMessage message="No document references found for this process instance" />
+        </CenteredContainer>
+      ) : (
+        <ScrollContainer>
+          <StructuredList
+            dataTestId="documents-list"
+            headerColumns={[
+              {cellContent: 'Variable', width: '25%'},
+              {cellContent: 'File name', width: '35%'},
+              {cellContent: 'File type', width: '20%'},
+              {cellContent: 'Size', width: '15%'},
+              {cellContent: '', width: '5%'},
+            ]}
+            headerSize="sm"
+            verticalCellPadding="var(--cds-spacing-02)"
+            label="Documents List"
+            onVerticalScrollStartReach={() => {
+              if (hasPreviousPage) fetchPreviousPage();
+            }}
+            onVerticalScrollEndReach={() => {
+              if (hasNextPage) fetchNextPage();
+            }}
+            rows={documents.map((doc) => ({
+              key: doc.variableKey,
+              dataTestId: doc.variableKey,
+              columns: [
+                {cellContent: doc.variableName ?? '—'},
+                {cellContent: doc.fileName ?? '—'},
+                {cellContent: doc.contentType ?? '—'},
+                {cellContent: doc.size !== null ? formatSize(doc.size) : '—'},
+                {
+                  cellContent: (
+                    <IconButton
+                      kind="ghost"
+                      size="sm"
+                      label="Download"
+                      aria-label={`Download ${doc.fileName ?? doc.documentId}`}
+                      disabled={downloadingId !== null}
+                      onClick={() => handleDownload(doc)}
+                    >
+                      {downloadingId === doc.documentId ? (
+                        <Loading withOverlay={false} small />
+                      ) : (
+                        <Download />
+                      )}
+                    </IconButton>
+                  ),
+                },
+              ],
+            }))}
+          />
+        </ScrollContainer>
+      )}
+    </Content>
+  );
+};
+
+export {DocumentsTab};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DocumentsTab/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DocumentsTab/index.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {useMemo, useState} from 'react';
+import {useState} from 'react';
 import {useLocation} from 'react-router-dom';
 import {IconButton, Layer, Loading} from '@carbon/react';
 import {Download} from '@carbon/react/icons';
@@ -25,7 +25,7 @@ const Content = styled(Layer)`
 `;
 
 const HEADER_COLUMNS = [
-  {header: 'Variable', key: 'variableName'},
+  {header: 'Variable', key: 'variableName', isDisabled: true},
   {header: 'File name', key: 'fileName'},
   {header: 'File type', key: 'contentType', isDisabled: true},
   {header: 'Size', key: 'size', isDisabled: true},
@@ -38,38 +38,10 @@ function formatSize(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
-function sortDocuments(
-  docs: DocumentReferenceSearchResult[],
-  sortBy: string,
-  sortOrder: 'asc' | 'desc',
-): DocumentReferenceSearchResult[] {
-  return [...docs].sort((a, b) => {
-    let aVal: string | number | null;
-    let bVal: string | number | null;
-
-    switch (sortBy) {
-      case 'variableName':
-        aVal = a.variableName;
-        bVal = b.variableName;
-        break;
-      case 'fileName':
-        aVal = a.fileName;
-        bVal = b.fileName;
-        break;
-      default:
-        return 0;
-    }
-
-    if (aVal === null && bVal === null) return 0;
-    if (aVal === null) return 1;
-    if (bVal === null) return -1;
-
-    const cmp = String(aVal).localeCompare(String(bVal));
-    return sortOrder === 'asc' ? cmp : -cmp;
-  });
-}
-
 const DocumentsTab: React.FC = () => {
+  const location = useLocation();
+  const sortParams = getSortParams(location.search);
+
   const {
     documents,
     isLoading,
@@ -78,22 +50,17 @@ const DocumentsTab: React.FC = () => {
     fetchPreviousPage,
     hasNextPage,
     hasPreviousPage,
-  } = useDocuments();
+    isFetchingNextPage,
+    isFetchingPreviousPage,
+  } = useDocuments(sortParams ?? undefined);
 
   const [downloadingId, setDownloadingId] = useState<string | null>(null);
-  const location = useLocation();
-
-  const sortedDocuments = useMemo(() => {
-    const sortParams = getSortParams(location.search);
-    if (sortParams === null) return documents;
-    return sortDocuments(documents, sortParams.sortBy, sortParams.sortOrder);
-  }, [documents, location.search]);
 
   const tableState = isError
     ? ('error' as const)
     : isLoading
       ? ('skeleton' as const)
-      : sortedDocuments.length === 0
+      : documents.length === 0
         ? ('empty' as const)
         : ('content' as const);
 
@@ -134,13 +101,13 @@ const DocumentsTab: React.FC = () => {
         headerColumns={HEADER_COLUMNS}
         columnsWithNoContentPadding={['download']}
         onVerticalScrollStartReach={() => {
-          if (hasPreviousPage) fetchPreviousPage();
+          if (hasPreviousPage && !isFetchingPreviousPage) fetchPreviousPage();
         }}
         onVerticalScrollEndReach={() => {
-          if (hasNextPage) fetchNextPage();
+          if (hasNextPage && !isFetchingNextPage) fetchNextPage();
         }}
-        rows={sortedDocuments.map((doc) => ({
-          id: doc.variableKey,
+        rows={documents.map((doc) => ({
+          id: doc.documentId,
           variableName: doc.variableName ?? '—',
           fileName: doc.fileName ?? '—',
           contentType: doc.contentType ?? '—',

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DocumentsTab/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DocumentsTab/index.tsx
@@ -6,15 +6,15 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {useState} from 'react';
+import {useMemo, useState} from 'react';
+import {useLocation} from 'react-router-dom';
 import {IconButton, Layer, Loading} from '@carbon/react';
 import {Download} from '@carbon/react/icons';
 import styled from 'styled-components';
-import {StructuredList} from 'modules/components/StructuredList';
-import {EmptyMessage} from 'modules/components/EmptyMessage';
-import {ErrorMessage} from 'modules/components/ErrorMessage';
+import {SortableTable} from 'modules/components/SortableTable';
 import {useDocuments} from 'modules/queries/variables/useDocuments';
 import {fetchDocument} from 'modules/api/v2/documentReferences/fetchDocument';
+import {getSortParams} from 'modules/utils/filter';
 import {type DocumentReferenceSearchResult} from '@camunda/camunda-api-zod-schemas/8.10';
 
 const Content = styled(Layer)`
@@ -22,25 +22,51 @@ const Content = styled(Layer)`
   height: 100%;
   display: flex;
   flex-direction: column;
-  padding: 0 var(--cds-spacing-05);
 `;
 
-const ScrollContainer = styled.div`
-  height: 100%;
-  overflow-y: auto;
-`;
-
-const CenteredContainer = styled.div`
-  display: flex;
-  height: 100%;
-  justify-content: center;
-  align-items: center;
-`;
+const HEADER_COLUMNS = [
+  {header: 'Variable', key: 'variableName'},
+  {header: 'File name', key: 'fileName'},
+  {header: 'File type', key: 'contentType', isDisabled: true},
+  {header: 'Size', key: 'size', isDisabled: true},
+  {header: '', key: 'download', isDisabled: true},
+];
 
 function formatSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function sortDocuments(
+  docs: DocumentReferenceSearchResult[],
+  sortBy: string,
+  sortOrder: 'asc' | 'desc',
+): DocumentReferenceSearchResult[] {
+  return [...docs].sort((a, b) => {
+    let aVal: string | number | null;
+    let bVal: string | number | null;
+
+    switch (sortBy) {
+      case 'variableName':
+        aVal = a.variableName;
+        bVal = b.variableName;
+        break;
+      case 'fileName':
+        aVal = a.fileName;
+        bVal = b.fileName;
+        break;
+      default:
+        return 0;
+    }
+
+    if (aVal === null && bVal === null) return 0;
+    if (aVal === null) return 1;
+    if (bVal === null) return -1;
+
+    const cmp = String(aVal).localeCompare(String(bVal));
+    return sortOrder === 'asc' ? cmp : -cmp;
+  });
 }
 
 const DocumentsTab: React.FC = () => {
@@ -55,6 +81,21 @@ const DocumentsTab: React.FC = () => {
   } = useDocuments();
 
   const [downloadingId, setDownloadingId] = useState<string | null>(null);
+  const location = useLocation();
+
+  const sortedDocuments = useMemo(() => {
+    const sortParams = getSortParams(location.search);
+    if (sortParams === null) return documents;
+    return sortDocuments(documents, sortParams.sortBy, sortParams.sortOrder);
+  }, [documents, location.search]);
+
+  const tableState = isError
+    ? ('error' as const)
+    : isLoading
+      ? ('skeleton' as const)
+      : sortedDocuments.length === 0
+        ? ('empty' as const)
+        : ('content' as const);
 
   const handleDownload = async (doc: DocumentReferenceSearchResult) => {
     if (downloadingId !== null) return;
@@ -83,76 +124,45 @@ const DocumentsTab: React.FC = () => {
     }
   };
 
-  if (isError) {
-    return (
-      <Content>
-        <CenteredContainer>
-          <ErrorMessage
-            message="Documents could not be fetched"
-            additionalInfo="Refresh the page to try again"
-          />
-        </CenteredContainer>
-      </Content>
-    );
-  }
-
   return (
     <Content>
-      {!isLoading && documents.length === 0 ? (
-        <CenteredContainer>
-          <EmptyMessage message="No document references found for this process instance" />
-        </CenteredContainer>
-      ) : (
-        <ScrollContainer>
-          <StructuredList
-            dataTestId="documents-list"
-            headerColumns={[
-              {cellContent: 'Variable', width: '25%'},
-              {cellContent: 'File name', width: '35%'},
-              {cellContent: 'File type', width: '20%'},
-              {cellContent: 'Size', width: '15%'},
-              {cellContent: '', width: '5%'},
-            ]}
-            headerSize="sm"
-            verticalCellPadding="var(--cds-spacing-02)"
-            label="Documents List"
-            onVerticalScrollStartReach={() => {
-              if (hasPreviousPage) fetchPreviousPage();
-            }}
-            onVerticalScrollEndReach={() => {
-              if (hasNextPage) fetchNextPage();
-            }}
-            rows={documents.map((doc) => ({
-              key: doc.variableKey,
-              dataTestId: doc.variableKey,
-              columns: [
-                {cellContent: doc.variableName ?? '—'},
-                {cellContent: doc.fileName ?? '—'},
-                {cellContent: doc.contentType ?? '—'},
-                {cellContent: doc.size !== null ? formatSize(doc.size) : '—'},
-                {
-                  cellContent: (
-                    <IconButton
-                      kind="ghost"
-                      size="sm"
-                      label="Download"
-                      aria-label={`Download ${doc.fileName ?? doc.documentId}`}
-                      disabled={downloadingId !== null}
-                      onClick={() => handleDownload(doc)}
-                    >
-                      {downloadingId === doc.documentId ? (
-                        <Loading withOverlay={false} small />
-                      ) : (
-                        <Download />
-                      )}
-                    </IconButton>
-                  ),
-                },
-              ],
-            }))}
-          />
-        </ScrollContainer>
-      )}
+      <SortableTable
+        state={tableState}
+        emptyMessage={{
+          message: 'No document references found for this process instance',
+        }}
+        headerColumns={HEADER_COLUMNS}
+        columnsWithNoContentPadding={['download']}
+        onVerticalScrollStartReach={() => {
+          if (hasPreviousPage) fetchPreviousPage();
+        }}
+        onVerticalScrollEndReach={() => {
+          if (hasNextPage) fetchNextPage();
+        }}
+        rows={sortedDocuments.map((doc) => ({
+          id: doc.variableKey,
+          variableName: doc.variableName ?? '—',
+          fileName: doc.fileName ?? '—',
+          contentType: doc.contentType ?? '—',
+          size: doc.size !== null ? formatSize(doc.size) : '—',
+          download: (
+            <IconButton
+              kind="ghost"
+              size="sm"
+              label="Download"
+              aria-label={`Download ${doc.fileName ?? doc.documentId}`}
+              disabled={downloadingId !== null}
+              onClick={() => handleDownload(doc)}
+            >
+              {downloadingId === doc.documentId ? (
+                <Loading withOverlay={false} small />
+              ) : (
+                <Download />
+              )}
+            </IconButton>
+          ),
+        }))}
+      />
     </Content>
   );
 };

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/index.tsx
@@ -91,6 +91,14 @@ const BottomPanelTabs: React.FC<{isHistoryTabVisible: boolean}> = ({
       visible: true,
     },
     {
+      label: 'Documents',
+      to: {pathname: Paths.processInstanceDocuments({processInstanceId})},
+      key: 'documents',
+      selected: currentPage === 'process-details-documents',
+      title: 'Documents',
+      visible: true,
+    },
+    {
       label: 'Input Mappings',
       to: {pathname: Paths.processInstanceInputMappings({processInstanceId})},
       key: 'input-mappings',

--- a/operate/client/src/App/index.tsx
+++ b/operate/client/src/App/index.tsx
@@ -142,6 +142,14 @@ const routes = createRoutesFromElements(
           }}
         />
         <Route
+          path={Paths.processInstanceDocuments({isRelative: true})}
+          lazy={async () => {
+            const {DocumentsTab} =
+              await import('./ProcessInstance/BottomPanelTabs/DocumentsTab/index');
+            return {Component: DocumentsTab};
+          }}
+        />
+        <Route
           path={Paths.processInstanceListeners({isRelative: true})}
           lazy={async () => {
             const {ListenersTab} =

--- a/operate/client/src/modules/Routes.tsx
+++ b/operate/client/src/modules/Routes.tsx
@@ -39,6 +39,7 @@ const Paths = {
   processInstanceOutputMappings:
     getRelativeProcessInstancePathHandler('output-mappings'),
   processInstanceVariables: getRelativeProcessInstancePathHandler('variables'),
+  processInstanceDocuments: getRelativeProcessInstancePathHandler('documents'),
   processInstanceListeners: getRelativeProcessInstancePathHandler('listeners'),
   processInstanceOperationsLog:
     getRelativeProcessInstancePathHandler('operations-log'),

--- a/operate/client/src/modules/api/v2/documentReferences/fetchDocument.ts
+++ b/operate/client/src/modules/api/v2/documentReferences/fetchDocument.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {endpoints} from '@camunda/camunda-api-zod-schemas/8.10';
+import {request} from 'modules/request';
+
+const fetchDocument = async ({
+  documentId,
+  storeId,
+  contentHash,
+}: {
+  documentId: string;
+  storeId?: string;
+  contentHash?: string;
+}) => {
+  return request({
+    url: endpoints.getDocument.getUrl({documentId, storeId, contentHash}),
+    method: endpoints.getDocument.method,
+  });
+};
+
+export {fetchDocument};

--- a/operate/client/src/modules/api/v2/documentReferences/searchDocumentReferences.ts
+++ b/operate/client/src/modules/api/v2/documentReferences/searchDocumentReferences.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {
+  endpoints,
+  type SearchDocumentReferencesRequestBody,
+  type SearchDocumentReferencesResponseBody,
+} from '@camunda/camunda-api-zod-schemas/8.10';
+import {requestWithThrow} from 'modules/request';
+
+const searchDocumentReferences = async (
+  payload: SearchDocumentReferencesRequestBody,
+) => {
+  return requestWithThrow<SearchDocumentReferencesResponseBody>({
+    url: endpoints.searchDocumentReferences.getUrl(),
+    method: endpoints.searchDocumentReferences.method,
+    body: payload,
+  });
+};
+
+export {searchDocumentReferences};

--- a/operate/client/src/modules/hooks/useCurrentPage.tsx
+++ b/operate/client/src/modules/hooks/useCurrentPage.tsx
@@ -20,6 +20,7 @@ const useCurrentPage = () => {
     | 'operations-log'
     | 'process-details'
     | 'process-details-variables'
+    | 'process-details-documents'
     | 'process-details-details'
     | 'process-details-incidents'
     | 'process-details-input-mappings'
@@ -57,6 +58,12 @@ const useCurrentPage = () => {
       matchPath(Paths.processInstanceVariables(), location.pathname) !== null
     ) {
       return 'process-details-variables';
+    }
+
+    if (
+      matchPath(Paths.processInstanceDocuments(), location.pathname) !== null
+    ) {
+      return 'process-details-documents';
     }
 
     if (matchPath(Paths.processInstance(), location.pathname) !== null) {

--- a/operate/client/src/modules/queries/variables/useDocuments.ts
+++ b/operate/client/src/modules/queries/variables/useDocuments.ts
@@ -14,12 +14,17 @@ import {useVariableScopeKey} from 'modules/hooks/variables';
 
 const MAX_DOCUMENTS_PER_REQUEST = 50;
 
-function useDocuments() {
+type SortConfig = {
+  sortBy: string;
+  sortOrder: 'asc' | 'desc';
+};
+
+function useDocuments(sortConfig?: SortConfig) {
   const {processInstanceId = ''} = useProcessInstancePageParams();
   const scopeKey = useVariableScopeKey();
 
   const result = useInfiniteQuery({
-    queryKey: ['documents', processInstanceId, scopeKey],
+    queryKey: ['documents', processInstanceId, scopeKey, sortConfig?.sortBy, sortConfig?.sortOrder],
     queryFn: async ({pageParam = 0}) => {
       const {response, error} = await searchDocumentReferences({
         filter: {
@@ -30,7 +35,9 @@ function useDocuments() {
           from: pageParam,
           limit: MAX_DOCUMENTS_PER_REQUEST,
         },
-        sort: [{field: 'variableKey', order: 'asc'}],
+        ...(sortConfig !== undefined
+          ? {sort: [{field: sortConfig.sortBy, order: sortConfig.sortOrder}]}
+          : {}),
       });
 
       if (response !== null) {
@@ -42,7 +49,7 @@ function useDocuments() {
     initialPageParam: 0,
     getNextPageParam: (lastPage, _, lastPageParam) => {
       const nextPage = lastPageParam + MAX_DOCUMENTS_PER_REQUEST;
-      if (nextPage > lastPage.page.totalItems) return null;
+      if (nextPage >= lastPage.page.totalItems) return null;
       return nextPage;
     },
     getPreviousPageParam: (_, __, firstPageParam) => {

--- a/operate/client/src/modules/queries/variables/useDocuments.ts
+++ b/operate/client/src/modules/queries/variables/useDocuments.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {type SearchDocumentReferencesResponseBody} from '@camunda/camunda-api-zod-schemas/8.10';
+import {useInfiniteQuery} from '@tanstack/react-query';
+import {searchDocumentReferences} from 'modules/api/v2/documentReferences/searchDocumentReferences';
+import {useProcessInstancePageParams} from 'App/ProcessInstance/useProcessInstancePageParams';
+import {useVariableScopeKey} from 'modules/hooks/variables';
+
+const MAX_DOCUMENTS_PER_REQUEST = 50;
+
+function useDocuments() {
+  const {processInstanceId = ''} = useProcessInstancePageParams();
+  const scopeKey = useVariableScopeKey();
+
+  const result = useInfiniteQuery({
+    queryKey: ['documents', processInstanceId, scopeKey],
+    queryFn: async ({pageParam = 0}) => {
+      const {response, error} = await searchDocumentReferences({
+        filter: {
+          processInstanceKey: {$eq: processInstanceId},
+          ...(scopeKey !== null ? {scopeKey: {$eq: scopeKey}} : {}),
+        },
+        page: {
+          from: pageParam,
+          limit: MAX_DOCUMENTS_PER_REQUEST,
+        },
+        sort: [{field: 'variableKey', order: 'asc'}],
+      });
+
+      if (response !== null) {
+        return response as SearchDocumentReferencesResponseBody;
+      }
+
+      throw error;
+    },
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, _, lastPageParam) => {
+      const nextPage = lastPageParam + MAX_DOCUMENTS_PER_REQUEST;
+      if (nextPage > lastPage.page.totalItems) return null;
+      return nextPage;
+    },
+    getPreviousPageParam: (_, __, firstPageParam) => {
+      const previousPage = firstPageParam - MAX_DOCUMENTS_PER_REQUEST;
+      if (previousPage < 0) return null;
+      return previousPage;
+    },
+  });
+
+  const documents = (result.data?.pages ?? []).flatMap((page) => page.items);
+
+  return Object.assign(result, {documents});
+}
+
+export {useDocuments};

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/DocumentReferenceDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/DocumentReferenceDocumentReader.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.reader;
+
+import io.camunda.search.clients.SearchClientBasedQueryExecutor;
+import io.camunda.search.entities.DocumentReferenceEntity;
+import io.camunda.search.query.DocumentReferenceQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.reader.ResourceAccessChecks;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+
+public class DocumentReferenceDocumentReader extends DocumentBasedReader
+    implements DocumentReferenceReader {
+
+  public DocumentReferenceDocumentReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptor indexDescriptor) {
+    super(executor, indexDescriptor);
+  }
+
+  @Override
+  public SearchQueryResult<DocumentReferenceEntity> search(
+      final DocumentReferenceQuery query, final ResourceAccessChecks resourceAccessChecks) {
+    return getSearchExecutor()
+        .search(
+            query,
+            io.camunda.webapps.schema.entities.DocumentReferenceEntity.class,
+            resourceAccessChecks);
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
@@ -89,6 +89,7 @@ import io.camunda.search.clients.transformers.entity.DecisionDefinitionEntityTra
 import io.camunda.search.clients.transformers.entity.DecisionInstanceEntityTransformer;
 import io.camunda.search.clients.transformers.entity.DecisionRequirementsEntityTransformer;
 import io.camunda.search.clients.transformers.entity.DeployedResourceEntityTransformer;
+import io.camunda.search.clients.transformers.entity.DocumentReferenceEntityTransformer;
 import io.camunda.search.clients.transformers.entity.FlowNodeInstanceEntityTransformer;
 import io.camunda.search.clients.transformers.entity.FormEntityTransformer;
 import io.camunda.search.clients.transformers.entity.GlobalListenerEntityTransformer;
@@ -119,6 +120,7 @@ import io.camunda.search.clients.transformers.filter.DecisionDefinitionFilterTra
 import io.camunda.search.clients.transformers.filter.DecisionInstanceFilterTransformer;
 import io.camunda.search.clients.transformers.filter.DecisionRequirementsFilterTransformer;
 import io.camunda.search.clients.transformers.filter.DeployedResourceFilterTransformer;
+import io.camunda.search.clients.transformers.filter.DocumentReferenceFilterTransformer;
 import io.camunda.search.clients.transformers.filter.FilterTransformer;
 import io.camunda.search.clients.transformers.filter.FlownodeInstanceFilterTransformer;
 import io.camunda.search.clients.transformers.filter.FormFilterTransformer;
@@ -166,6 +168,7 @@ import io.camunda.search.clients.transformers.sort.DecisionDefinitionFieldSortin
 import io.camunda.search.clients.transformers.sort.DecisionInstanceFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.DecisionRequirementsFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.DeployedResourceFieldSortingTransformer;
+import io.camunda.search.clients.transformers.sort.DocumentReferenceFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.FieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.FlowNodeInstanceFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.FormFieldSortingTransformer;
@@ -197,6 +200,7 @@ import io.camunda.search.filter.DecisionDefinitionFilter;
 import io.camunda.search.filter.DecisionInstanceFilter;
 import io.camunda.search.filter.DecisionRequirementsFilter;
 import io.camunda.search.filter.DeployedResourceFilter;
+import io.camunda.search.filter.DocumentReferenceFilter;
 import io.camunda.search.filter.FilterBase;
 import io.camunda.search.filter.FlowNodeInstanceFilter;
 import io.camunda.search.filter.FormFilter;
@@ -238,6 +242,7 @@ import io.camunda.search.query.DecisionDefinitionQuery;
 import io.camunda.search.query.DecisionInstanceQuery;
 import io.camunda.search.query.DecisionRequirementsQuery;
 import io.camunda.search.query.DeployedResourceQuery;
+import io.camunda.search.query.DocumentReferenceQuery;
 import io.camunda.search.query.FlowNodeInstanceQuery;
 import io.camunda.search.query.FormQuery;
 import io.camunda.search.query.GlobalJobStatisticsQuery;
@@ -287,6 +292,7 @@ import io.camunda.search.sort.DecisionDefinitionSort;
 import io.camunda.search.sort.DecisionInstanceSort;
 import io.camunda.search.sort.DecisionRequirementsSort;
 import io.camunda.search.sort.DeployedResourceSort;
+import io.camunda.search.sort.DocumentReferenceSort;
 import io.camunda.search.sort.FlowNodeInstanceSort;
 import io.camunda.search.sort.FormSort;
 import io.camunda.search.sort.GlobalListenerSort;
@@ -314,6 +320,7 @@ import io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex;
 import io.camunda.webapps.schema.descriptors.index.DecisionIndex;
 import io.camunda.webapps.schema.descriptors.index.DecisionRequirementsIndex;
 import io.camunda.webapps.schema.descriptors.index.DeployedResourceIndex;
+import io.camunda.webapps.schema.descriptors.index.DocumentReferenceIndex;
 import io.camunda.webapps.schema.descriptors.index.FormIndex;
 import io.camunda.webapps.schema.descriptors.index.GlobalListenerIndex;
 import io.camunda.webapps.schema.descriptors.index.GroupIndex;
@@ -339,6 +346,7 @@ import io.camunda.webapps.schema.descriptors.template.UsageMetricTUTemplate;
 import io.camunda.webapps.schema.descriptors.template.UsageMetricTemplate;
 import io.camunda.webapps.schema.descriptors.template.VariableTemplate;
 import io.camunda.webapps.schema.entities.CorrelatedMessageSubscriptionEntity;
+import io.camunda.webapps.schema.entities.DocumentReferenceEntity;
 import io.camunda.webapps.schema.entities.JobEntity;
 import io.camunda.webapps.schema.entities.ProcessEntity;
 import io.camunda.webapps.schema.entities.SequenceFlowEntity;
@@ -466,6 +474,7 @@ public final class ServiceTransformers {
             UserQuery.class,
             VariableQuery.class,
             ClusterVariableQuery.class,
+            DocumentReferenceQuery.class,
             AuditLogQuery.class,
             IncidentProcessInstanceStatisticsByErrorQuery.class,
             IncidentProcessInstanceStatisticsByDefinitionQuery.class,
@@ -504,6 +513,7 @@ public final class ServiceTransformers {
     mappers.put(TaskEntity.class, new UserTaskEntityTransformer());
     mappers.put(VariableEntity.class, new VariableEntityTransformer());
     mappers.put(ClusterVariableEntity.class, new ClusterVariableEntityTransformer());
+    mappers.put(DocumentReferenceEntity.class, new DocumentReferenceEntityTransformer());
     mappers.put(TenantEntity.class, new TenantEntityTransformer());
     mappers.put(TenantMemberEntity.class, new TenantMemberEntityTransformer());
     mappers.put(UserEntity.class, new UserEntityTransformer());
@@ -538,6 +548,7 @@ public final class ServiceTransformers {
     mappers.put(UserTaskSort.class, new UserTaskFieldSortingTransformer());
     mappers.put(VariableSort.class, new VariableFieldSortingTransformer());
     mappers.put(ClusterVariableSort.class, new ClusterVariableFieldSortingTransformer());
+    mappers.put(DocumentReferenceSort.class, new DocumentReferenceFieldSortingTransformer());
     mappers.put(TenantSort.class, new TenantFieldSortingTransformer());
     mappers.put(UsageMetricsSort.class, new UsageMetricsFieldSortingTransformer());
     mappers.put(UserSort.class, new UserFieldSortingTransformer());
@@ -560,6 +571,9 @@ public final class ServiceTransformers {
     mappers.put(
         ClusterVariableFilter.class,
         new ClusterVariableFilterTransformer(indexDescriptors.get(ClusterVariableIndex.class)));
+    mappers.put(
+        DocumentReferenceFilter.class,
+        new DocumentReferenceFilterTransformer(indexDescriptors.get(DocumentReferenceIndex.class)));
     mappers.put(DateValueFilter.class, new DateValueFilterTransformer());
     mappers.put(
         VariableFilter.class,

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/DocumentReferenceEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/DocumentReferenceEntityTransformer.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.entity;
+
+import io.camunda.search.clients.transformers.ServiceTransformer;
+import io.camunda.search.entities.DocumentReferenceEntity;
+
+public class DocumentReferenceEntityTransformer
+    implements ServiceTransformer<
+        io.camunda.webapps.schema.entities.DocumentReferenceEntity, DocumentReferenceEntity> {
+
+  @Override
+  public DocumentReferenceEntity apply(
+      final io.camunda.webapps.schema.entities.DocumentReferenceEntity source) {
+    return new DocumentReferenceEntity(
+        source.getVariableKey(),
+        source.getVariableName(),
+        source.getScopeKey(),
+        source.getProcessInstanceKey(),
+        source.getProcessDefinitionKey(),
+        source.getProcessDefinitionId(),
+        source.getRootProcessInstanceKey(),
+        source.getTenantId(),
+        source.getDocumentId(),
+        source.getStoreId(),
+        source.getFileName(),
+        source.getContentType(),
+        source.getSize(),
+        source.getExpiresAt(),
+        source.getContentHash(),
+        source.getCustomProperties());
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/DocumentReferenceFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/DocumentReferenceFilterTransformer.java
@@ -15,6 +15,7 @@ import static io.camunda.webapps.schema.descriptors.IndexDescriptor.TENANT_ID;
 import static io.camunda.webapps.schema.descriptors.index.DocumentReferenceIndex.BPMN_PROCESS_ID;
 import static io.camunda.webapps.schema.descriptors.index.DocumentReferenceIndex.DOCUMENT_ID;
 import static io.camunda.webapps.schema.descriptors.index.DocumentReferenceIndex.PROCESS_INSTANCE_KEY;
+import static io.camunda.webapps.schema.descriptors.index.DocumentReferenceIndex.SCOPE_KEY;
 import static io.camunda.webapps.schema.descriptors.index.DocumentReferenceIndex.VARIABLE_KEY;
 import static java.util.Optional.ofNullable;
 
@@ -35,6 +36,7 @@ public class DocumentReferenceFilterTransformer
   public SearchQuery toSearchQuery(final DocumentReferenceFilter filter) {
     final var queries = new ArrayList<SearchQuery>();
     queries.addAll(longOperations(PROCESS_INSTANCE_KEY, filter.processInstanceKeyOperations()));
+    queries.addAll(longOperations(SCOPE_KEY, filter.scopeKeyOperations()));
     queries.addAll(longOperations(VARIABLE_KEY, filter.variableKeyOperations()));
     queries.addAll(stringOperations(DOCUMENT_ID, filter.documentIdOperations()));
     ofNullable(stringTerms(TENANT_ID, filter.tenantIds())).ifPresent(queries::add);

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/DocumentReferenceFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/DocumentReferenceFilterTransformer.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.filter;
+
+import static io.camunda.search.clients.query.SearchQueryBuilders.and;
+import static io.camunda.search.clients.query.SearchQueryBuilders.longOperations;
+import static io.camunda.search.clients.query.SearchQueryBuilders.stringOperations;
+import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
+import static io.camunda.webapps.schema.descriptors.IndexDescriptor.TENANT_ID;
+import static io.camunda.webapps.schema.descriptors.index.DocumentReferenceIndex.BPMN_PROCESS_ID;
+import static io.camunda.webapps.schema.descriptors.index.DocumentReferenceIndex.DOCUMENT_ID;
+import static io.camunda.webapps.schema.descriptors.index.DocumentReferenceIndex.PROCESS_INSTANCE_KEY;
+import static io.camunda.webapps.schema.descriptors.index.DocumentReferenceIndex.SCOPE_KEY;
+import static io.camunda.webapps.schema.descriptors.index.DocumentReferenceIndex.VARIABLE_KEY;
+import static java.util.Optional.ofNullable;
+
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.filter.DocumentReferenceFilter;
+import io.camunda.security.auth.Authorization;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import java.util.ArrayList;
+
+public class DocumentReferenceFilterTransformer
+    extends IndexFilterTransformer<DocumentReferenceFilter> {
+
+  public DocumentReferenceFilterTransformer(final IndexDescriptor indexDescriptor) {
+    super(indexDescriptor);
+  }
+
+  @Override
+  public SearchQuery toSearchQuery(final DocumentReferenceFilter filter) {
+    final var queries = new ArrayList<SearchQuery>();
+    queries.addAll(longOperations(PROCESS_INSTANCE_KEY, filter.processInstanceKeyOperations()));
+    queries.addAll(longOperations(SCOPE_KEY, filter.scopeKeyOperations()));
+    queries.addAll(longOperations(VARIABLE_KEY, filter.variableKeyOperations()));
+    queries.addAll(stringOperations(DOCUMENT_ID, filter.documentIdOperations()));
+    ofNullable(stringTerms(TENANT_ID, filter.tenantIds())).ifPresent(queries::add);
+    return and(queries);
+  }
+
+  @Override
+  protected SearchQuery toAuthorizationCheckSearchQuery(final Authorization<?> authorization) {
+    return stringTerms(BPMN_PROCESS_ID, authorization.resourceIds());
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/DocumentReferenceFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/DocumentReferenceFilterTransformer.java
@@ -15,7 +15,6 @@ import static io.camunda.webapps.schema.descriptors.IndexDescriptor.TENANT_ID;
 import static io.camunda.webapps.schema.descriptors.index.DocumentReferenceIndex.BPMN_PROCESS_ID;
 import static io.camunda.webapps.schema.descriptors.index.DocumentReferenceIndex.DOCUMENT_ID;
 import static io.camunda.webapps.schema.descriptors.index.DocumentReferenceIndex.PROCESS_INSTANCE_KEY;
-import static io.camunda.webapps.schema.descriptors.index.DocumentReferenceIndex.SCOPE_KEY;
 import static io.camunda.webapps.schema.descriptors.index.DocumentReferenceIndex.VARIABLE_KEY;
 import static java.util.Optional.ofNullable;
 
@@ -36,7 +35,6 @@ public class DocumentReferenceFilterTransformer
   public SearchQuery toSearchQuery(final DocumentReferenceFilter filter) {
     final var queries = new ArrayList<SearchQuery>();
     queries.addAll(longOperations(PROCESS_INSTANCE_KEY, filter.processInstanceKeyOperations()));
-    queries.addAll(longOperations(SCOPE_KEY, filter.scopeKeyOperations()));
     queries.addAll(longOperations(VARIABLE_KEY, filter.variableKeyOperations()));
     queries.addAll(stringOperations(DOCUMENT_ID, filter.documentIdOperations()));
     ofNullable(stringTerms(TENANT_ID, filter.tenantIds())).ifPresent(queries::add);

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/DocumentReferenceFieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/DocumentReferenceFieldSortingTransformer.java
@@ -11,6 +11,7 @@ import static io.camunda.webapps.schema.descriptors.IndexDescriptor.TENANT_ID;
 import static io.camunda.webapps.schema.descriptors.index.DocumentReferenceIndex.DOCUMENT_ID;
 import static io.camunda.webapps.schema.descriptors.index.DocumentReferenceIndex.FILE_NAME;
 import static io.camunda.webapps.schema.descriptors.index.DocumentReferenceIndex.PROCESS_INSTANCE_KEY;
+import static io.camunda.webapps.schema.descriptors.index.DocumentReferenceIndex.SCOPE_KEY;
 import static io.camunda.webapps.schema.descriptors.index.DocumentReferenceIndex.VARIABLE_KEY;
 
 public class DocumentReferenceFieldSortingTransformer implements FieldSortingTransformer {
@@ -19,11 +20,17 @@ public class DocumentReferenceFieldSortingTransformer implements FieldSortingTra
   public String apply(final String domainField) {
     return switch (domainField) {
       case "processInstanceKey" -> PROCESS_INSTANCE_KEY;
+      case "scopeKey" -> SCOPE_KEY;
       case "variableKey" -> VARIABLE_KEY;
       case "documentId" -> DOCUMENT_ID;
       case "fileName" -> FILE_NAME;
       case "tenantId" -> TENANT_ID;
       default -> throw new IllegalArgumentException("Unknown sortField: " + domainField);
     };
+  }
+
+  @Override
+  public String defaultSortField() {
+    return VARIABLE_KEY;
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/DocumentReferenceFieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/DocumentReferenceFieldSortingTransformer.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.sort;
+
+import static io.camunda.webapps.schema.descriptors.IndexDescriptor.TENANT_ID;
+import static io.camunda.webapps.schema.descriptors.index.DocumentReferenceIndex.DOCUMENT_ID;
+import static io.camunda.webapps.schema.descriptors.index.DocumentReferenceIndex.FILE_NAME;
+import static io.camunda.webapps.schema.descriptors.index.DocumentReferenceIndex.PROCESS_INSTANCE_KEY;
+import static io.camunda.webapps.schema.descriptors.index.DocumentReferenceIndex.VARIABLE_KEY;
+
+public class DocumentReferenceFieldSortingTransformer implements FieldSortingTransformer {
+
+  @Override
+  public String apply(final String domainField) {
+    return switch (domainField) {
+      case "processInstanceKey" -> PROCESS_INSTANCE_KEY;
+      case "variableKey" -> VARIABLE_KEY;
+      case "documentId" -> DOCUMENT_ID;
+      case "fileName" -> FILE_NAME;
+      case "tenantId" -> TENANT_ID;
+      default -> throw new IllegalArgumentException("Unknown sortField: " + domainField);
+    };
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/DocumentReferenceFieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/DocumentReferenceFieldSortingTransformer.java
@@ -13,6 +13,7 @@ import static io.camunda.webapps.schema.descriptors.index.DocumentReferenceIndex
 import static io.camunda.webapps.schema.descriptors.index.DocumentReferenceIndex.PROCESS_INSTANCE_KEY;
 import static io.camunda.webapps.schema.descriptors.index.DocumentReferenceIndex.SCOPE_KEY;
 import static io.camunda.webapps.schema.descriptors.index.DocumentReferenceIndex.VARIABLE_KEY;
+import static io.camunda.webapps.schema.descriptors.index.DocumentReferenceIndex.VARIABLE_NAME;
 
 public class DocumentReferenceFieldSortingTransformer implements FieldSortingTransformer {
 
@@ -22,6 +23,7 @@ public class DocumentReferenceFieldSortingTransformer implements FieldSortingTra
       case "processInstanceKey" -> PROCESS_INSTANCE_KEY;
       case "scopeKey" -> SCOPE_KEY;
       case "variableKey" -> VARIABLE_KEY;
+      case "variableName" -> VARIABLE_NAME;
       case "documentId" -> DOCUMENT_ID;
       case "fileName" -> FILE_NAME;
       case "tenantId" -> TENANT_ID;

--- a/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/DocumentReferenceReader.java
+++ b/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/DocumentReferenceReader.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.reader;
+
+import io.camunda.search.entities.DocumentReferenceEntity;
+import io.camunda.search.query.DocumentReferenceQuery;
+
+public interface DocumentReferenceReader
+    extends SearchEntityReader<DocumentReferenceEntity, DocumentReferenceQuery> {}

--- a/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/SearchClientReaders.java
+++ b/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/SearchClientReaders.java
@@ -45,6 +45,7 @@ public record SearchClientReaders(
     UserTaskReader userTaskReader,
     VariableReader variableReader,
     ClusterVariableReader clusterVariableReader,
+    DocumentReferenceReader documentReferenceReader,
     AuditLogReader auditLogReader,
     IncidentProcessInstanceStatisticsByErrorReader incidentProcessInstanceStatisticsByErrorReader,
     IncidentProcessInstanceStatisticsByDefinitionReader

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -24,6 +24,7 @@ import io.camunda.search.entities.DecisionDefinitionEntity;
 import io.camunda.search.entities.DecisionInstanceEntity;
 import io.camunda.search.entities.DecisionRequirementsEntity;
 import io.camunda.search.entities.DeployedResourceEntity;
+import io.camunda.search.entities.DocumentReferenceEntity;
 import io.camunda.search.entities.FlowNodeInstanceEntity;
 import io.camunda.search.entities.FormEntity;
 import io.camunda.search.entities.GlobalJobStatisticsEntity;
@@ -74,6 +75,7 @@ import io.camunda.search.query.DecisionDefinitionQuery;
 import io.camunda.search.query.DecisionInstanceQuery;
 import io.camunda.search.query.DecisionRequirementsQuery;
 import io.camunda.search.query.DeployedResourceQuery;
+import io.camunda.search.query.DocumentReferenceQuery;
 import io.camunda.search.query.FlowNodeInstanceQuery;
 import io.camunda.search.query.FormQuery;
 import io.camunda.search.query.GlobalJobStatisticsQuery;
@@ -538,6 +540,12 @@ public class CamundaSearchClients implements SearchClientsProxy {
   @Override
   public SearchQueryResult<VariableEntity> searchVariables(final VariableQuery query) {
     return doSearchWithReader(readers.variableReader(), query);
+  }
+
+  @Override
+  public SearchQueryResult<DocumentReferenceEntity> searchDocumentReferences(
+      final DocumentReferenceQuery query) {
+    return doSearchWithReader(readers.documentReferenceReader(), query);
   }
 
   @Override

--- a/search/search-client/src/main/java/io/camunda/search/clients/DocumentReferenceSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/DocumentReferenceSearchClient.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients;
+
+import io.camunda.search.entities.DocumentReferenceEntity;
+import io.camunda.search.query.DocumentReferenceQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.SecurityContext;
+
+public interface DocumentReferenceSearchClient {
+
+  SearchQueryResult<DocumentReferenceEntity> searchDocumentReferences(DocumentReferenceQuery query);
+
+  DocumentReferenceSearchClient withSecurityContext(SecurityContext securityContext);
+}

--- a/search/search-client/src/main/java/io/camunda/search/clients/SearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/SearchClientsProxy.java
@@ -18,6 +18,7 @@ public interface SearchClientsProxy
         DecisionDefinitionSearchClient,
         DecisionInstanceSearchClient,
         DecisionRequirementSearchClient,
+        DocumentReferenceSearchClient,
         FlowNodeInstanceSearchClient,
         FormSearchClient,
         GroupSearchClient,

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
@@ -18,6 +18,7 @@ import io.camunda.search.entities.DecisionDefinitionEntity;
 import io.camunda.search.entities.DecisionInstanceEntity;
 import io.camunda.search.entities.DecisionRequirementsEntity;
 import io.camunda.search.entities.DeployedResourceEntity;
+import io.camunda.search.entities.DocumentReferenceEntity;
 import io.camunda.search.entities.FlowNodeInstanceEntity;
 import io.camunda.search.entities.FormEntity;
 import io.camunda.search.entities.GlobalJobStatisticsEntity;
@@ -63,6 +64,7 @@ import io.camunda.search.query.DecisionDefinitionQuery;
 import io.camunda.search.query.DecisionInstanceQuery;
 import io.camunda.search.query.DecisionRequirementsQuery;
 import io.camunda.search.query.DeployedResourceQuery;
+import io.camunda.search.query.DocumentReferenceQuery;
 import io.camunda.search.query.FlowNodeInstanceQuery;
 import io.camunda.search.query.FormQuery;
 import io.camunda.search.query.GlobalJobStatisticsQuery;
@@ -392,6 +394,12 @@ public class NoDBSearchClientsProxy implements SearchClientsProxy {
   @Override
   public SearchQueryResult<ClusterVariableEntity> searchClusterVariables(
       final ClusterVariableQuery query) {
+    throw new NoSecondaryStorageException();
+  }
+
+  @Override
+  public SearchQueryResult<DocumentReferenceEntity> searchDocumentReferences(
+      final DocumentReferenceQuery query) {
     throw new NoSecondaryStorageException();
   }
 

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
@@ -20,6 +20,7 @@ import io.camunda.search.entities.DecisionDefinitionEntity;
 import io.camunda.search.entities.DecisionInstanceEntity;
 import io.camunda.search.entities.DecisionRequirementsEntity;
 import io.camunda.search.entities.DeployedResourceEntity;
+import io.camunda.search.entities.DocumentReferenceEntity;
 import io.camunda.search.entities.FlowNodeInstanceEntity;
 import io.camunda.search.entities.FormEntity;
 import io.camunda.search.entities.GlobalJobStatisticsEntity;
@@ -64,6 +65,7 @@ import io.camunda.search.query.DecisionDefinitionQuery;
 import io.camunda.search.query.DecisionInstanceQuery;
 import io.camunda.search.query.DecisionRequirementsQuery;
 import io.camunda.search.query.DeployedResourceQuery;
+import io.camunda.search.query.DocumentReferenceQuery;
 import io.camunda.search.query.FlowNodeInstanceQuery;
 import io.camunda.search.query.FormQuery;
 import io.camunda.search.query.GlobalJobStatisticsQuery;
@@ -394,6 +396,12 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
   @Override
   public SearchQueryResult<ClusterVariableEntity> searchClusterVariables(
       final ClusterVariableQuery query) {
+    return SearchQueryResult.empty();
+  }
+
+  @Override
+  public SearchQueryResult<DocumentReferenceEntity> searchDocumentReferences(
+      final DocumentReferenceQuery query) {
     return SearchQueryResult.empty();
   }
 

--- a/search/search-domain/src/main/java/io/camunda/search/entities/DocumentReferenceEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/DocumentReferenceEntity.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.entities;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.Objects;
+import org.jspecify.annotations.Nullable;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record DocumentReferenceEntity(
+    Long variableKey,
+    String variableName,
+    Long scopeKey,
+    Long processInstanceKey,
+    @Nullable Long processDefinitionKey,
+    String processDefinitionId,
+    @Nullable Long rootProcessInstanceKey,
+    String tenantId,
+    String documentId,
+    @Nullable String storeId,
+    @Nullable String fileName,
+    @Nullable String contentType,
+    @Nullable Long size,
+    @Nullable String expiresAt,
+    @Nullable String contentHash,
+    @Nullable String customProperties)
+    implements TenantOwnedEntity {
+
+  public DocumentReferenceEntity {
+    Objects.requireNonNull(variableKey, "variableKey");
+    Objects.requireNonNull(variableName, "variableName");
+    Objects.requireNonNull(scopeKey, "scopeKey");
+    Objects.requireNonNull(processInstanceKey, "processInstanceKey");
+    Objects.requireNonNull(processDefinitionId, "processDefinitionId");
+    Objects.requireNonNull(tenantId, "tenantId");
+    Objects.requireNonNull(documentId, "documentId");
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/filter/DocumentReferenceFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/DocumentReferenceFilter.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.filter;
+
+import static io.camunda.util.CollectionUtil.addValuesToList;
+import static io.camunda.util.CollectionUtil.collectValues;
+
+import io.camunda.util.FilterUtil;
+import io.camunda.util.ObjectBuilder;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+public record DocumentReferenceFilter(
+    List<Operation<Long>> processInstanceKeyOperations,
+    List<Operation<Long>> scopeKeyOperations,
+    List<Operation<Long>> variableKeyOperations,
+    List<String> tenantIds,
+    List<Operation<String>> documentIdOperations)
+    implements FilterBase {
+
+  public static final class Builder implements ObjectBuilder<DocumentReferenceFilter> {
+    private List<Operation<Long>> processInstanceKeyOperations;
+    private List<Operation<Long>> scopeKeyOperations;
+    private List<Operation<Long>> variableKeyOperations;
+    private List<String> tenantIds;
+    private List<Operation<String>> documentIdOperations;
+
+    public Builder processInstanceKeyOperations(final List<Operation<Long>> operations) {
+      processInstanceKeyOperations = addValuesToList(processInstanceKeyOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder processInstanceKeyOperations(
+        final Operation<Long> operation, final Operation<Long>... operations) {
+      return processInstanceKeyOperations(collectValues(operation, operations));
+    }
+
+    public Builder processInstanceKey(final long value) {
+      return processInstanceKeyOperations(FilterUtil.mapDefaultToOperation(value));
+    }
+
+    public Builder scopeKeyOperations(final List<Operation<Long>> operations) {
+      scopeKeyOperations = addValuesToList(scopeKeyOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder scopeKeyOperations(
+        final Operation<Long> operation, final Operation<Long>... operations) {
+      return scopeKeyOperations(collectValues(operation, operations));
+    }
+
+    public Builder scopeKey(final long value) {
+      return scopeKeyOperations(FilterUtil.mapDefaultToOperation(value));
+    }
+
+    public Builder variableKeyOperations(final List<Operation<Long>> operations) {
+      variableKeyOperations = addValuesToList(variableKeyOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder variableKeyOperations(
+        final Operation<Long> operation, final Operation<Long>... operations) {
+      return variableKeyOperations(collectValues(operation, operations));
+    }
+
+    public Builder variableKey(final long value) {
+      return variableKeyOperations(FilterUtil.mapDefaultToOperation(value));
+    }
+
+    public Builder tenantIds(final String value, final String... values) {
+      return tenantIds(collectValues(value, values));
+    }
+
+    public Builder tenantIds(final List<String> values) {
+      tenantIds = addValuesToList(tenantIds, values);
+      return this;
+    }
+
+    public Builder documentIdOperations(final List<Operation<String>> operations) {
+      documentIdOperations = addValuesToList(documentIdOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder documentIdOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return documentIdOperations(collectValues(operation, operations));
+    }
+
+    public Builder documentIds(final String value, final String... values) {
+      return documentIdOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    @Override
+    public DocumentReferenceFilter build() {
+      return new DocumentReferenceFilter(
+          Objects.requireNonNullElseGet(processInstanceKeyOperations, Collections::emptyList),
+          Objects.requireNonNullElseGet(scopeKeyOperations, Collections::emptyList),
+          Objects.requireNonNullElseGet(variableKeyOperations, Collections::emptyList),
+          Objects.requireNonNullElseGet(tenantIds, Collections::emptyList),
+          Objects.requireNonNullElseGet(documentIdOperations, Collections::emptyList));
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/filter/DocumentReferenceFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/DocumentReferenceFilter.java
@@ -18,7 +18,6 @@ import java.util.Objects;
 
 public record DocumentReferenceFilter(
     List<Operation<Long>> processInstanceKeyOperations,
-    List<Operation<Long>> scopeKeyOperations,
     List<Operation<Long>> variableKeyOperations,
     List<String> tenantIds,
     List<Operation<String>> documentIdOperations)
@@ -26,7 +25,6 @@ public record DocumentReferenceFilter(
 
   public static final class Builder implements ObjectBuilder<DocumentReferenceFilter> {
     private List<Operation<Long>> processInstanceKeyOperations;
-    private List<Operation<Long>> scopeKeyOperations;
     private List<Operation<Long>> variableKeyOperations;
     private List<String> tenantIds;
     private List<Operation<String>> documentIdOperations;
@@ -44,21 +42,6 @@ public record DocumentReferenceFilter(
 
     public Builder processInstanceKey(final long value) {
       return processInstanceKeyOperations(FilterUtil.mapDefaultToOperation(value));
-    }
-
-    public Builder scopeKeyOperations(final List<Operation<Long>> operations) {
-      scopeKeyOperations = addValuesToList(scopeKeyOperations, operations);
-      return this;
-    }
-
-    @SafeVarargs
-    public final Builder scopeKeyOperations(
-        final Operation<Long> operation, final Operation<Long>... operations) {
-      return scopeKeyOperations(collectValues(operation, operations));
-    }
-
-    public Builder scopeKey(final long value) {
-      return scopeKeyOperations(FilterUtil.mapDefaultToOperation(value));
     }
 
     public Builder variableKeyOperations(final List<Operation<Long>> operations) {
@@ -104,7 +87,6 @@ public record DocumentReferenceFilter(
     public DocumentReferenceFilter build() {
       return new DocumentReferenceFilter(
           Objects.requireNonNullElseGet(processInstanceKeyOperations, Collections::emptyList),
-          Objects.requireNonNullElseGet(scopeKeyOperations, Collections::emptyList),
           Objects.requireNonNullElseGet(variableKeyOperations, Collections::emptyList),
           Objects.requireNonNullElseGet(tenantIds, Collections::emptyList),
           Objects.requireNonNullElseGet(documentIdOperations, Collections::emptyList));

--- a/search/search-domain/src/main/java/io/camunda/search/filter/DocumentReferenceFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/DocumentReferenceFilter.java
@@ -18,6 +18,7 @@ import java.util.Objects;
 
 public record DocumentReferenceFilter(
     List<Operation<Long>> processInstanceKeyOperations,
+    List<Operation<Long>> scopeKeyOperations,
     List<Operation<Long>> variableKeyOperations,
     List<String> tenantIds,
     List<Operation<String>> documentIdOperations)
@@ -25,6 +26,7 @@ public record DocumentReferenceFilter(
 
   public static final class Builder implements ObjectBuilder<DocumentReferenceFilter> {
     private List<Operation<Long>> processInstanceKeyOperations;
+    private List<Operation<Long>> scopeKeyOperations;
     private List<Operation<Long>> variableKeyOperations;
     private List<String> tenantIds;
     private List<Operation<String>> documentIdOperations;
@@ -42,6 +44,21 @@ public record DocumentReferenceFilter(
 
     public Builder processInstanceKey(final long value) {
       return processInstanceKeyOperations(FilterUtil.mapDefaultToOperation(value));
+    }
+
+    public Builder scopeKeyOperations(final List<Operation<Long>> operations) {
+      scopeKeyOperations = addValuesToList(scopeKeyOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder scopeKeyOperations(
+        final Operation<Long> operation, final Operation<Long>... operations) {
+      return scopeKeyOperations(collectValues(operation, operations));
+    }
+
+    public Builder scopeKey(final long value) {
+      return scopeKeyOperations(FilterUtil.mapDefaultToOperation(value));
     }
 
     public Builder variableKeyOperations(final List<Operation<Long>> operations) {
@@ -87,6 +104,7 @@ public record DocumentReferenceFilter(
     public DocumentReferenceFilter build() {
       return new DocumentReferenceFilter(
           Objects.requireNonNullElseGet(processInstanceKeyOperations, Collections::emptyList),
+          Objects.requireNonNullElseGet(scopeKeyOperations, Collections::emptyList),
           Objects.requireNonNullElseGet(variableKeyOperations, Collections::emptyList),
           Objects.requireNonNullElseGet(tenantIds, Collections::emptyList),
           Objects.requireNonNullElseGet(documentIdOperations, Collections::emptyList));

--- a/search/search-domain/src/main/java/io/camunda/search/filter/FilterBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/FilterBuilders.java
@@ -405,4 +405,13 @@ public final class FilterBuilders {
       final Function<DeployedResourceFilter.Builder, ObjectBuilder<DeployedResourceFilter>> fn) {
     return fn.apply(deployedResource()).build();
   }
+
+  public static DocumentReferenceFilter.Builder documentReference() {
+    return new DocumentReferenceFilter.Builder();
+  }
+
+  public static DocumentReferenceFilter documentReference(
+      final Function<DocumentReferenceFilter.Builder, ObjectBuilder<DocumentReferenceFilter>> fn) {
+    return fn.apply(documentReference()).build();
+  }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/query/DocumentReferenceQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/DocumentReferenceQuery.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.query;
+
+import io.camunda.search.filter.DocumentReferenceFilter;
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.sort.DocumentReferenceSort;
+import io.camunda.search.sort.SortOptionBuilders;
+import io.camunda.util.ObjectBuilder;
+import java.util.Objects;
+import java.util.function.Function;
+
+public final record DocumentReferenceQuery(
+    DocumentReferenceFilter filter, DocumentReferenceSort sort, SearchQueryPage page)
+    implements TypedSearchQuery<DocumentReferenceFilter, DocumentReferenceSort> {
+
+  public static DocumentReferenceQuery of(
+      final Function<Builder, ObjectBuilder<DocumentReferenceQuery>> fn) {
+    return fn.apply(new Builder()).build();
+  }
+
+  public static final class Builder extends SearchQueryBase.AbstractQueryBuilder<Builder>
+      implements TypedSearchQueryBuilder<
+          DocumentReferenceQuery, Builder, DocumentReferenceFilter, DocumentReferenceSort> {
+
+    private static final DocumentReferenceFilter EMPTY_FILTER =
+        FilterBuilders.documentReference().build();
+    private static final DocumentReferenceSort EMPTY_SORT =
+        SortOptionBuilders.documentReference().build();
+
+    private DocumentReferenceFilter filter;
+    private DocumentReferenceSort sort;
+
+    @Override
+    public Builder filter(final DocumentReferenceFilter value) {
+      filter = value;
+      return this;
+    }
+
+    @Override
+    public Builder sort(final DocumentReferenceSort value) {
+      sort = value;
+      return this;
+    }
+
+    public Builder filter(
+        final Function<DocumentReferenceFilter.Builder, ObjectBuilder<DocumentReferenceFilter>>
+            fn) {
+      return filter(FilterBuilders.documentReference(fn));
+    }
+
+    public Builder sort(
+        final Function<DocumentReferenceSort.Builder, ObjectBuilder<DocumentReferenceSort>> fn) {
+      return sort(SortOptionBuilders.documentReference(fn));
+    }
+
+    @Override
+    protected Builder self() {
+      return this;
+    }
+
+    @Override
+    public DocumentReferenceQuery build() {
+      filter = Objects.requireNonNullElse(filter, EMPTY_FILTER);
+      sort = Objects.requireNonNullElse(sort, EMPTY_SORT);
+      return new DocumentReferenceQuery(filter, sort, page());
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryBuilders.java
@@ -328,4 +328,13 @@ public final class SearchQueryBuilders {
       final Function<DeployedResourceQuery.Builder, ObjectBuilder<DeployedResourceQuery>> fn) {
     return fn.apply(deployedResourceSearchQuery()).build();
   }
+
+  public static DocumentReferenceQuery.Builder documentReferenceSearchQuery() {
+    return new DocumentReferenceQuery.Builder();
+  }
+
+  public static DocumentReferenceQuery documentReferenceSearchQuery(
+      final Function<DocumentReferenceQuery.Builder, ObjectBuilder<DocumentReferenceQuery>> fn) {
+    return fn.apply(documentReferenceSearchQuery()).build();
+  }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/sort/DocumentReferenceSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/DocumentReferenceSort.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.sort;
+
+import io.camunda.util.ObjectBuilder;
+import java.util.List;
+import java.util.function.Function;
+
+public final record DocumentReferenceSort(List<FieldSorting> orderings) implements SortOption {
+
+  @Override
+  public List<FieldSorting> getFieldSortings() {
+    return orderings;
+  }
+
+  public static DocumentReferenceSort of(
+      final Function<Builder, ObjectBuilder<DocumentReferenceSort>> fn) {
+    return SortOptionBuilders.documentReference(fn);
+  }
+
+  public static final class Builder extends AbstractBuilder<Builder>
+      implements ObjectBuilder<DocumentReferenceSort> {
+
+    public Builder processInstanceKey() {
+      currentOrdering = new FieldSorting("processInstanceKey", null);
+      return this;
+    }
+
+    public Builder variableKey() {
+      currentOrdering = new FieldSorting("variableKey", null);
+      return this;
+    }
+
+    public Builder documentId() {
+      currentOrdering = new FieldSorting("documentId", null);
+      return this;
+    }
+
+    public Builder fileName() {
+      currentOrdering = new FieldSorting("fileName", null);
+      return this;
+    }
+
+    public Builder tenantId() {
+      currentOrdering = new FieldSorting("tenantId", null);
+      return this;
+    }
+
+    @Override
+    protected Builder self() {
+      return this;
+    }
+
+    @Override
+    public DocumentReferenceSort build() {
+      return new DocumentReferenceSort(orderings);
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/sort/DocumentReferenceSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/DocumentReferenceSort.java
@@ -31,6 +31,11 @@ public final record DocumentReferenceSort(List<FieldSorting> orderings) implemen
       return this;
     }
 
+    public Builder scopeKey() {
+      currentOrdering = new FieldSorting("scopeKey", null);
+      return this;
+    }
+
     public Builder variableKey() {
       currentOrdering = new FieldSorting("variableKey", null);
       return this;

--- a/search/search-domain/src/main/java/io/camunda/search/sort/DocumentReferenceSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/DocumentReferenceSort.java
@@ -46,6 +46,11 @@ public final record DocumentReferenceSort(List<FieldSorting> orderings) implemen
       return this;
     }
 
+    public Builder variableName() {
+      currentOrdering = new FieldSorting("variableName", null);
+      return this;
+    }
+
     public Builder fileName() {
       currentOrdering = new FieldSorting("fileName", null);
       return this;

--- a/search/search-domain/src/main/java/io/camunda/search/sort/SortOptionBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/SortOptionBuilders.java
@@ -380,4 +380,13 @@ public final class SortOptionBuilders {
       final Function<DeployedResourceSort.Builder, ObjectBuilder<DeployedResourceSort>> fn) {
     return fn.apply(deployedResource()).build();
   }
+
+  public static DocumentReferenceSort.Builder documentReference() {
+    return new DocumentReferenceSort.Builder();
+  }
+
+  public static DocumentReferenceSort documentReference(
+      final Function<DocumentReferenceSort.Builder, ObjectBuilder<DocumentReferenceSort>> fn) {
+    return fn.apply(documentReference()).build();
+  }
 }

--- a/service/src/main/java/io/camunda/service/DocumentReferenceServices.java
+++ b/service/src/main/java/io/camunda/service/DocumentReferenceServices.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import static io.camunda.service.authorization.Authorizations.VARIABLE_READ_AUTHORIZATION;
+
+import io.camunda.search.clients.DocumentReferenceSearchClient;
+import io.camunda.search.entities.DocumentReferenceEntity;
+import io.camunda.search.query.DocumentReferenceQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.api.model.CamundaAuthentication;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
+import io.camunda.service.search.core.SearchQueryService;
+import io.camunda.service.security.SecurityContextProvider;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+
+public final class DocumentReferenceServices
+    extends SearchQueryService<
+        DocumentReferenceServices, DocumentReferenceQuery, DocumentReferenceEntity> {
+
+  private final DocumentReferenceSearchClient documentReferenceSearchClient;
+
+  public DocumentReferenceServices(
+      final BrokerClient brokerClient,
+      final SecurityContextProvider securityContextProvider,
+      final DocumentReferenceSearchClient documentReferenceSearchClient,
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    super(
+        brokerClient,
+        securityContextProvider,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
+    this.documentReferenceSearchClient = documentReferenceSearchClient;
+  }
+
+  @Override
+  public SearchQueryResult<DocumentReferenceEntity> search(
+      final DocumentReferenceQuery query, final CamundaAuthentication authentication) {
+    return executeSearchRequest(
+        () ->
+            documentReferenceSearchClient
+                .withSecurityContext(
+                    securityContextProvider.provideSecurityContext(
+                        authentication, VARIABLE_READ_AUTHORIZATION))
+                .searchDocumentReferences(query));
+  }
+}

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/document.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/document.ts
@@ -7,7 +7,13 @@
  */
 
 import {z} from 'zod';
-import {API_VERSION, type Endpoint} from './common';
+import {
+	API_VERSION,
+	basicStringFilterSchema,
+	getQueryRequestBodySchema,
+	getQueryResponseBodySchema,
+	type Endpoint,
+} from './common';
 
 const documentMetadataSchema = z.object({
 	contentType: z.string(),
@@ -56,6 +62,50 @@ type DocumentLink = z.infer<typeof documentLinkSchema>;
 
 const getDocumentResponseBodySchema = z.string();
 type GetDocumentResponseBody = z.infer<typeof getDocumentResponseBodySchema>;
+
+const documentReferenceSearchResultSchema = z.object({
+	variableKey: z.string(),
+	variableName: z.string(),
+	processInstanceKey: z.string(),
+	scopeKey: z.string().nullable(),
+	processDefinitionKey: z.string().nullable(),
+	processDefinitionId: z.string().nullable(),
+	tenantId: z.string(),
+	documentId: z.string(),
+	storeId: z.string().nullable(),
+	fileName: z.string().nullable(),
+	contentType: z.string().nullable(),
+	size: z.number().nullable(),
+	expiresAt: z.string().nullable(),
+	contentHash: z.string().nullable(),
+});
+type DocumentReferenceSearchResult = z.infer<typeof documentReferenceSearchResultSchema>;
+
+const searchDocumentReferencesRequestBodySchema = getQueryRequestBodySchema({
+	sortFields: ['variableKey', 'variableName', 'processInstanceKey', 'scopeKey', 'documentId', 'tenantId'] as const,
+	filter: z
+		.object({
+			processInstanceKey: basicStringFilterSchema,
+			scopeKey: basicStringFilterSchema,
+			variableKey: basicStringFilterSchema,
+			documentId: basicStringFilterSchema,
+			tenantId: z.string(),
+		})
+		.partial(),
+});
+type SearchDocumentReferencesRequestBody = z.infer<typeof searchDocumentReferencesRequestBodySchema>;
+
+const searchDocumentReferencesResponseBodySchema = getQueryResponseBodySchema(
+	documentReferenceSearchResultSchema,
+);
+type SearchDocumentReferencesResponseBody = z.infer<
+	typeof searchDocumentReferencesResponseBodySchema
+>;
+
+const searchDocumentReferences: Endpoint = {
+	method: 'POST',
+	getUrl: () => `/${API_VERSION}/document-references/search`,
+};
 
 const createDocument: Endpoint<{
 	storeId?: string;
@@ -150,11 +200,15 @@ export {
 	documentLinkRequestBodySchema,
 	documentLinkSchema,
 	getDocumentResponseBodySchema,
+	documentReferenceSearchResultSchema,
+	searchDocumentReferencesRequestBodySchema,
+	searchDocumentReferencesResponseBodySchema,
 	createDocument,
 	createDocuments,
 	getDocument,
 	deleteDocument,
 	createDocumentLink,
+	searchDocumentReferences,
 };
 export type {
 	DocumentMetadata,
@@ -164,4 +218,7 @@ export type {
 	DocumentLinkRequestBody,
 	DocumentLink,
 	GetDocumentResponseBody,
+	DocumentReferenceSearchResult,
+	SearchDocumentReferencesRequestBody,
+	SearchDocumentReferencesResponseBody,
 };

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/index.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/index.ts
@@ -37,7 +37,7 @@ import {
 	createDecisionInstancesDeletionBatchOperation,
 } from './decision-instance';
 import {queryDecisionRequirements, getDecisionRequirements, getDecisionRequirementsXml} from './decision-requirements';
-import {createDocument, createDocuments, getDocument, deleteDocument, createDocumentLink} from './document';
+import {createDocument, createDocuments, getDocument, deleteDocument, createDocumentLink, searchDocumentReferences} from './document';
 import {
 	queryElementInstances,
 	getElementInstance,
@@ -217,6 +217,7 @@ const endpoints = {
 	getDocument,
 	deleteDocument,
 	createDocumentLink,
+	searchDocumentReferences,
 	queryElementInstances,
 	queryElementInstanceIncidents,
 	getElementInstance,
@@ -538,6 +539,9 @@ export {
 	documentLinkRequestBodySchema,
 	documentLinkSchema,
 	getDocumentResponseBodySchema,
+	documentReferenceSearchResultSchema,
+	searchDocumentReferencesRequestBodySchema,
+	searchDocumentReferencesResponseBodySchema,
 	type DocumentMetadata,
 	type DocumentReference,
 	type DocumentCreationFailureDetail,
@@ -545,6 +549,9 @@ export {
 	type DocumentLinkRequestBody,
 	type DocumentLink,
 	type GetDocumentResponseBody,
+	type DocumentReferenceSearchResult,
+	type SearchDocumentReferencesRequestBody,
+	type SearchDocumentReferencesResponseBody,
 } from './document';
 export {
 	queryElementInstancesRequestBodySchema,

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/IndexDescriptors.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/IndexDescriptors.java
@@ -13,6 +13,7 @@ import io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex;
 import io.camunda.webapps.schema.descriptors.index.DecisionIndex;
 import io.camunda.webapps.schema.descriptors.index.DecisionRequirementsIndex;
 import io.camunda.webapps.schema.descriptors.index.DeployedResourceIndex;
+import io.camunda.webapps.schema.descriptors.index.DocumentReferenceIndex;
 import io.camunda.webapps.schema.descriptors.index.FormIndex;
 import io.camunda.webapps.schema.descriptors.index.GlobalListenerIndex;
 import io.camunda.webapps.schema.descriptors.index.GroupIndex;
@@ -84,6 +85,7 @@ public class IndexDescriptors {
                 new UserIndex(indexPrefix, isElasticsearch),
                 new VariableTemplate(indexPrefix, isElasticsearch),
                 new ClusterVariableIndex(indexPrefix, isElasticsearch),
+                new DocumentReferenceIndex(indexPrefix, isElasticsearch),
                 new MessageTemplate(indexPrefix, isElasticsearch),
                 new UsageMetricTemplate(indexPrefix, isElasticsearch),
                 new UsageMetricTUTemplate(indexPrefix, isElasticsearch),

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/DocumentReferenceIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/DocumentReferenceIndex.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.descriptors.index;
+
+import static io.camunda.webapps.schema.descriptors.ComponentNames.CAMUNDA;
+
+import io.camunda.webapps.schema.descriptors.AbstractIndexDescriptor;
+import io.camunda.webapps.schema.descriptors.backup.Prio4Backup;
+import java.util.Optional;
+
+public class DocumentReferenceIndex extends AbstractIndexDescriptor implements Prio4Backup {
+
+  public static final String INDEX_NAME = "document-reference";
+  public static final String INDEX_VERSION = "8.9.0";
+
+  public static final String ID = "id";
+  public static final String VARIABLE_KEY = "variableKey";
+  public static final String VARIABLE_NAME = "variableName";
+  public static final String SCOPE_KEY = "scopeKey";
+  public static final String PROCESS_INSTANCE_KEY = "processInstanceKey";
+  public static final String PROCESS_DEFINITION_KEY = "processDefinitionKey";
+  public static final String BPMN_PROCESS_ID = "processDefinitionId";
+  public static final String ROOT_PROCESS_INSTANCE_KEY = "rootProcessInstanceKey";
+  public static final String TENANT_ID = "tenantId";
+  public static final String POSITION = "position";
+  public static final String PARTITION_ID = "partitionId";
+  public static final String DOCUMENT_ID = "documentId";
+  public static final String STORE_ID = "storeId";
+  public static final String FILE_NAME = "fileName";
+  public static final String CONTENT_TYPE = "contentType";
+  public static final String SIZE = "size";
+  public static final String EXPIRES_AT = "expiresAt";
+  public static final String CONTENT_HASH = "contentHash";
+  public static final String CUSTOM_PROPERTIES = "customProperties";
+
+  public DocumentReferenceIndex(final String indexPrefix, final boolean isElasticsearch) {
+    super(indexPrefix, isElasticsearch);
+  }
+
+  @Override
+  public String getIndexName() {
+    return INDEX_NAME;
+  }
+
+  @Override
+  public Optional<String> getTenantIdField() {
+    return Optional.of(TENANT_ID);
+  }
+
+  @Override
+  public String getVersion() {
+    return INDEX_VERSION;
+  }
+
+  @Override
+  public String getComponentName() {
+    return CAMUNDA.toString();
+  }
+}

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/DocumentReferenceEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/DocumentReferenceEntity.java
@@ -1,0 +1,299 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.entities;
+
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import java.util.Objects;
+
+public class DocumentReferenceEntity
+    implements ExporterEntity<DocumentReferenceEntity>,
+        PartitionedEntity<DocumentReferenceEntity>,
+        TenantOwned {
+
+  private String id;
+  private Long variableKey;
+  private String variableName;
+  private Long scopeKey;
+  private Long processInstanceKey;
+  private Long processDefinitionKey;
+  private String processDefinitionId;
+  private Long rootProcessInstanceKey;
+  private String tenantId = DEFAULT_TENANT_IDENTIFIER;
+  private Long position;
+  private int partitionId;
+  private String documentId;
+  private String storeId;
+  private String fileName;
+  private String contentType;
+  private Long size;
+  private String expiresAt;
+  private String contentHash;
+  private String customProperties;
+
+  @Override
+  public String getId() {
+    return id;
+  }
+
+  @Override
+  public DocumentReferenceEntity setId(final String id) {
+    this.id = id;
+    return this;
+  }
+
+  public Long getVariableKey() {
+    return variableKey;
+  }
+
+  public DocumentReferenceEntity setVariableKey(final Long variableKey) {
+    this.variableKey = variableKey;
+    return this;
+  }
+
+  public String getVariableName() {
+    return variableName;
+  }
+
+  public DocumentReferenceEntity setVariableName(final String variableName) {
+    this.variableName = variableName;
+    return this;
+  }
+
+  public Long getScopeKey() {
+    return scopeKey;
+  }
+
+  public DocumentReferenceEntity setScopeKey(final Long scopeKey) {
+    this.scopeKey = scopeKey;
+    return this;
+  }
+
+  public Long getProcessInstanceKey() {
+    return processInstanceKey;
+  }
+
+  public DocumentReferenceEntity setProcessInstanceKey(final Long processInstanceKey) {
+    this.processInstanceKey = processInstanceKey;
+    return this;
+  }
+
+  public Long getProcessDefinitionKey() {
+    return processDefinitionKey;
+  }
+
+  public DocumentReferenceEntity setProcessDefinitionKey(final Long processDefinitionKey) {
+    this.processDefinitionKey = processDefinitionKey;
+    return this;
+  }
+
+  public String getProcessDefinitionId() {
+    return processDefinitionId;
+  }
+
+  public DocumentReferenceEntity setProcessDefinitionId(final String processDefinitionId) {
+    this.processDefinitionId = processDefinitionId;
+    return this;
+  }
+
+  public Long getRootProcessInstanceKey() {
+    return rootProcessInstanceKey;
+  }
+
+  public DocumentReferenceEntity setRootProcessInstanceKey(final Long rootProcessInstanceKey) {
+    this.rootProcessInstanceKey = rootProcessInstanceKey;
+    return this;
+  }
+
+  @Override
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  public DocumentReferenceEntity setTenantId(final String tenantId) {
+    this.tenantId = tenantId;
+    return this;
+  }
+
+  public Long getPosition() {
+    return position;
+  }
+
+  public DocumentReferenceEntity setPosition(final Long position) {
+    this.position = position;
+    return this;
+  }
+
+  @Override
+  public int getPartitionId() {
+    return partitionId;
+  }
+
+  @Override
+  public DocumentReferenceEntity setPartitionId(final int partitionId) {
+    this.partitionId = partitionId;
+    return this;
+  }
+
+  public String getDocumentId() {
+    return documentId;
+  }
+
+  public DocumentReferenceEntity setDocumentId(final String documentId) {
+    this.documentId = documentId;
+    return this;
+  }
+
+  public String getStoreId() {
+    return storeId;
+  }
+
+  public DocumentReferenceEntity setStoreId(final String storeId) {
+    this.storeId = storeId;
+    return this;
+  }
+
+  public String getFileName() {
+    return fileName;
+  }
+
+  public DocumentReferenceEntity setFileName(final String fileName) {
+    this.fileName = fileName;
+    return this;
+  }
+
+  public String getContentType() {
+    return contentType;
+  }
+
+  public DocumentReferenceEntity setContentType(final String contentType) {
+    this.contentType = contentType;
+    return this;
+  }
+
+  public Long getSize() {
+    return size;
+  }
+
+  public DocumentReferenceEntity setSize(final Long size) {
+    this.size = size;
+    return this;
+  }
+
+  public String getExpiresAt() {
+    return expiresAt;
+  }
+
+  public DocumentReferenceEntity setExpiresAt(final String expiresAt) {
+    this.expiresAt = expiresAt;
+    return this;
+  }
+
+  public String getContentHash() {
+    return contentHash;
+  }
+
+  public DocumentReferenceEntity setContentHash(final String contentHash) {
+    this.contentHash = contentHash;
+    return this;
+  }
+
+  public String getCustomProperties() {
+    return customProperties;
+  }
+
+  public DocumentReferenceEntity setCustomProperties(final String customProperties) {
+    this.customProperties = customProperties;
+    return this;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        id,
+        variableKey,
+        variableName,
+        scopeKey,
+        processInstanceKey,
+        processDefinitionKey,
+        processDefinitionId,
+        rootProcessInstanceKey,
+        tenantId,
+        position,
+        partitionId,
+        documentId,
+        storeId,
+        fileName,
+        contentType,
+        size,
+        expiresAt,
+        contentHash,
+        customProperties);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DocumentReferenceEntity that = (DocumentReferenceEntity) o;
+    return partitionId == that.partitionId
+        && Objects.equals(id, that.id)
+        && Objects.equals(variableKey, that.variableKey)
+        && Objects.equals(variableName, that.variableName)
+        && Objects.equals(scopeKey, that.scopeKey)
+        && Objects.equals(processInstanceKey, that.processInstanceKey)
+        && Objects.equals(processDefinitionKey, that.processDefinitionKey)
+        && Objects.equals(processDefinitionId, that.processDefinitionId)
+        && Objects.equals(rootProcessInstanceKey, that.rootProcessInstanceKey)
+        && Objects.equals(tenantId, that.tenantId)
+        && Objects.equals(position, that.position)
+        && Objects.equals(documentId, that.documentId)
+        && Objects.equals(storeId, that.storeId)
+        && Objects.equals(fileName, that.fileName)
+        && Objects.equals(contentType, that.contentType)
+        && Objects.equals(size, that.size)
+        && Objects.equals(expiresAt, that.expiresAt)
+        && Objects.equals(contentHash, that.contentHash)
+        && Objects.equals(customProperties, that.customProperties);
+  }
+
+  @Override
+  public String toString() {
+    return "DocumentReferenceEntity{"
+        + "id='"
+        + id
+        + '\''
+        + ", variableKey="
+        + variableKey
+        + ", variableName='"
+        + variableName
+        + '\''
+        + ", scopeKey="
+        + scopeKey
+        + ", processInstanceKey="
+        + processInstanceKey
+        + ", processDefinitionKey="
+        + processDefinitionKey
+        + ", processDefinitionId='"
+        + processDefinitionId
+        + '\''
+        + ", tenantId='"
+        + tenantId
+        + '\''
+        + ", documentId='"
+        + documentId
+        + '\''
+        + ", storeId='"
+        + storeId
+        + '\''
+        + '}';
+  }
+}

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-document-reference.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-document-reference.json
@@ -1,0 +1,67 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "id": {
+        "type": "keyword"
+      },
+      "variableKey": {
+        "type": "long"
+      },
+      "variableName": {
+        "type": "keyword"
+      },
+      "scopeKey": {
+        "type": "long"
+      },
+      "processInstanceKey": {
+        "type": "long"
+      },
+      "processDefinitionKey": {
+        "type": "long"
+      },
+      "processDefinitionId": {
+        "type": "keyword"
+      },
+      "rootProcessInstanceKey": {
+        "type": "long"
+      },
+      "tenantId": {
+        "type": "keyword"
+      },
+      "position": {
+        "type": "long"
+      },
+      "partitionId": {
+        "type": "integer"
+      },
+      "documentId": {
+        "type": "keyword"
+      },
+      "storeId": {
+        "type": "keyword"
+      },
+      "fileName": {
+        "type": "keyword",
+        "ignore_above": 8191
+      },
+      "contentType": {
+        "type": "keyword"
+      },
+      "size": {
+        "type": "long"
+      },
+      "expiresAt": {
+        "type": "date"
+      },
+      "contentHash": {
+        "type": "keyword",
+        "ignore_above": 8191
+      },
+      "customProperties": {
+        "type": "keyword",
+        "ignore_above": 8191
+      }
+    }
+  }
+}

--- a/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-document-reference.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-document-reference.json
@@ -1,0 +1,67 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "id": {
+        "type": "keyword"
+      },
+      "variableKey": {
+        "type": "long"
+      },
+      "variableName": {
+        "type": "keyword"
+      },
+      "scopeKey": {
+        "type": "long"
+      },
+      "processInstanceKey": {
+        "type": "long"
+      },
+      "processDefinitionKey": {
+        "type": "long"
+      },
+      "processDefinitionId": {
+        "type": "keyword"
+      },
+      "rootProcessInstanceKey": {
+        "type": "long"
+      },
+      "tenantId": {
+        "type": "keyword"
+      },
+      "position": {
+        "type": "long"
+      },
+      "partitionId": {
+        "type": "integer"
+      },
+      "documentId": {
+        "type": "keyword"
+      },
+      "storeId": {
+        "type": "keyword"
+      },
+      "fileName": {
+        "type": "keyword",
+        "ignore_above": 8191
+      },
+      "contentType": {
+        "type": "keyword"
+      },
+      "size": {
+        "type": "long"
+      },
+      "expiresAt": {
+        "type": "date"
+      },
+      "contentHash": {
+        "type": "keyword",
+        "ignore_above": 8191
+      },
+      "customProperties": {
+        "type": "keyword",
+        "ignore_above": 8191
+      }
+    }
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -26,6 +26,7 @@ import io.camunda.exporter.handlers.CorrelatedMessageSubscriptionFromProcessMess
 import io.camunda.exporter.handlers.DecisionEvaluationHandler;
 import io.camunda.exporter.handlers.DecisionHandler;
 import io.camunda.exporter.handlers.DecisionRequirementsHandler;
+import io.camunda.exporter.handlers.DocumentReferenceHandler;
 import io.camunda.exporter.handlers.EmbeddedFormHandler;
 import io.camunda.exporter.handlers.ExportHandler;
 import io.camunda.exporter.handlers.FlowNodeInstanceFromIncidentHandler;
@@ -104,6 +105,7 @@ import io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex;
 import io.camunda.webapps.schema.descriptors.index.DecisionIndex;
 import io.camunda.webapps.schema.descriptors.index.DecisionRequirementsIndex;
 import io.camunda.webapps.schema.descriptors.index.DeployedResourceIndex;
+import io.camunda.webapps.schema.descriptors.index.DocumentReferenceIndex;
 import io.camunda.webapps.schema.descriptors.index.FormIndex;
 import io.camunda.webapps.schema.descriptors.index.GlobalListenerIndex;
 import io.camunda.webapps.schema.descriptors.index.GroupIndex;
@@ -261,6 +263,9 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
             new VariableHandler(
                 indexDescriptors.get(VariableTemplate.class).getFullQualifiedName(),
                 configuration.getIndex().getVariableSizeThreshold()),
+            new DocumentReferenceHandler(
+                indexDescriptors.get(DocumentReferenceIndex.class).getFullQualifiedName(),
+                objectMapper),
             new DecisionRequirementsHandler(
                 indexDescriptors.get(DecisionRequirementsIndex.class).getFullQualifiedName(),
                 decisionRequirementsCache),

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/DocumentReferenceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/DocumentReferenceHandler.java
@@ -64,7 +64,14 @@ public class DocumentReferenceHandler
     if (!SUPPORTED_INTENTS.contains(record.getIntent())) {
       return false;
     }
-    return isDocumentReference(record.getValue().getValue());
+    final String value = record.getValue().getValue();
+    // Fast-path: most variables are not document references, and many can be large JSON objects
+    // or arrays.  A substring scan is O(n) but avoids any allocation; if the discriminator is
+    // absent we can discard the record without touching the JSON parser at all.
+    if (!value.contains(DOCUMENT_TYPE_DISCRIMINATOR)) {
+      return false;
+    }
+    return isDocumentReference(value);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/DocumentReferenceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/DocumentReferenceHandler.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import static io.camunda.exporter.utils.ExporterUtil.tenantOrDefault;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.DocumentReferenceEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.VariableIntent;
+import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DocumentReferenceHandler
+    implements ExportHandler<DocumentReferenceEntity, VariableRecordValue> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DocumentReferenceHandler.class);
+
+  // The discriminator field is injected by the REST layer when a client uploads a document.
+  // Its presence as a top-level key (or as a key in every element of a top-level array) is the
+  // contract that identifies a variable as a document reference.  The value is always "camunda"
+  // for first-party document references; future third-party store adapters may use a different
+  // value, but the key itself is stable.
+  private static final String DOCUMENT_TYPE_DISCRIMINATOR = "camunda.document.type";
+
+  // MIGRATED intent carries the same value as CREATED/UPDATED but signals a process-instance
+  // migration event.  The variable content doesn't change, so re-indexing it would just produce
+  // a duplicate write with no new information.  We filter it out here to avoid that overhead.
+  private static final Set<VariableIntent> SUPPORTED_INTENTS =
+      Set.of(VariableIntent.CREATED, VariableIntent.UPDATED);
+
+  private final String indexName;
+  private final ObjectMapper objectMapper;
+
+  public DocumentReferenceHandler(final String indexName, final ObjectMapper objectMapper) {
+    this.indexName = indexName;
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public ValueType getHandledValueType() {
+    return ValueType.VARIABLE;
+  }
+
+  @Override
+  public Class<DocumentReferenceEntity> getEntityType() {
+    return DocumentReferenceEntity.class;
+  }
+
+  @Override
+  public boolean handlesRecord(final Record<VariableRecordValue> record) {
+    if (!SUPPORTED_INTENTS.contains(record.getIntent())) {
+      return false;
+    }
+    return isDocumentReference(record.getValue().getValue());
+  }
+
+  @Override
+  public List<String> generateIds(final Record<VariableRecordValue> record) {
+    final List<String> ids = new ArrayList<>();
+    try {
+      final JsonNode root = objectMapper.readTree(record.getValue().getValue());
+      if (root.isArray()) {
+        for (final JsonNode node : root) {
+          if (isDocumentReferenceNode(node) && node.has("documentId")) {
+            ids.add(generateId(record.getKey(), node.get("documentId").asText()));
+          }
+        }
+      } else if (isDocumentReferenceNode(root) && root.has("documentId")) {
+        ids.add(generateId(record.getKey(), root.get("documentId").asText()));
+      }
+    } catch (final Exception e) {
+      LOG.debug(
+          "Failed to parse document reference ids from variable record key={}: {}",
+          record.getKey(),
+          e.getMessage());
+    }
+    return ids;
+  }
+
+  @Override
+  public DocumentReferenceEntity createNewEntity(final String id) {
+    return new DocumentReferenceEntity().setId(id);
+  }
+
+  @Override
+  public void updateEntity(
+      final Record<VariableRecordValue> record, final DocumentReferenceEntity entity) {
+    final var recordValue = record.getValue();
+    entity
+        .setVariableKey(record.getKey())
+        .setVariableName(recordValue.getName())
+        .setScopeKey(recordValue.getScopeKey())
+        .setProcessInstanceKey(recordValue.getProcessInstanceKey())
+        .setProcessDefinitionKey(recordValue.getProcessDefinitionKey())
+        .setProcessDefinitionId(recordValue.getBpmnProcessId())
+        .setTenantId(tenantOrDefault(recordValue.getTenantId()))
+        .setPosition(record.getPosition())
+        .setPartitionId(record.getPartitionId());
+
+    final var rootKey = recordValue.getRootProcessInstanceKey();
+    if (rootKey > 0) {
+      entity.setRootProcessInstanceKey(rootKey);
+    }
+
+    // The entity id encodes which document to populate when the variable holds an array.
+    // Format is "{variableKey}_{documentId}" — we strip the prefix to recover the documentId.
+    final String docId = extractDocumentId(entity.getId(), record.getKey());
+
+    try {
+      final JsonNode root = objectMapper.readTree(recordValue.getValue());
+      JsonNode docNode = null;
+      if (root.isArray()) {
+        for (final JsonNode node : root) {
+          if (isDocumentReferenceNode(node)
+              && node.has("documentId")
+              && docId.equals(node.get("documentId").asText())) {
+            docNode = node;
+            break;
+          }
+        }
+      } else if (isDocumentReferenceNode(root)) {
+        docNode = root;
+      }
+      if (docNode != null) {
+        entity.setDocumentId(docNode.get("documentId").asText());
+        entity.setStoreId(getTextOrNull(docNode, "storeId"));
+        entity.setContentHash(getTextOrNull(docNode, "contentHash"));
+        final JsonNode metadata = docNode.get("metadata");
+        if (metadata != null) {
+          entity.setFileName(getTextOrNull(metadata, "fileName"));
+          entity.setContentType(getTextOrNull(metadata, "contentType"));
+          entity.setExpiresAt(getTextOrNull(metadata, "expiresAt"));
+          if (metadata.has("size") && !metadata.get("size").isNull()) {
+            entity.setSize(metadata.get("size").asLong());
+          }
+          if (metadata.has("customProperties") && !metadata.get("customProperties").isNull()) {
+            entity.setCustomProperties(metadata.get("customProperties").toString());
+          }
+        }
+      } else {
+        LOG.warn(
+            "Document reference with id='{}' not found in variable record key={}",
+            docId,
+            record.getKey());
+      }
+    } catch (final Exception e) {
+      LOG.error(
+          "Failed to parse document reference data from variable record key={}: {}",
+          record.getKey(),
+          e.getMessage());
+    }
+  }
+
+  @Override
+  public void flush(final DocumentReferenceEntity entity, final BatchRequest batchRequest) {
+    batchRequest.add(indexName, entity);
+  }
+
+  @Override
+  public String getIndexName() {
+    return indexName;
+  }
+
+  private boolean isDocumentReference(final String value) {
+    try {
+      final JsonNode root = objectMapper.readTree(value);
+      if (root.isArray()) {
+        return root.size() > 0 && isDocumentReferenceNode(root.get(0));
+      }
+      return isDocumentReferenceNode(root);
+    } catch (final Exception e) {
+      return false;
+    }
+  }
+
+  private boolean isDocumentReferenceNode(final JsonNode node) {
+    return node.isObject() && node.has(DOCUMENT_TYPE_DISCRIMINATOR);
+  }
+
+  private String generateId(final long variableKey, final String documentId) {
+    return variableKey + "_" + documentId;
+  }
+
+  private String extractDocumentId(final String entityId, final long variableKey) {
+    final String prefix = variableKey + "_";
+    return entityId.startsWith(prefix) ? entityId.substring(prefix.length()) : entityId;
+  }
+
+  private String getTextOrNull(final JsonNode node, final String field) {
+    final JsonNode f = node.get(field);
+    return (f != null && !f.isNull()) ? f.asText() : null;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/DocumentReferenceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/DocumentReferenceHandler.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import org.slf4j.Logger;
@@ -44,6 +45,14 @@ public class DocumentReferenceHandler
   private final String indexName;
   private final ObjectMapper objectMapper;
 
+  // Single-record cache: the exporter processes records strictly sequentially on one thread.
+  // handlesRecord(), generateIds(), and updateEntity() are all called for the same record in
+  // order — handlesRecord first, then generateIds, then updateEntity once per id.  Caching the
+  // parsed JsonNode list here avoids re-deserializing the same (potentially large) JSON string
+  // up to (2 + N) times for an N-document array variable.
+  private Long cachedRecordKey = null;
+  private List<JsonNode> cachedDocRefs = Collections.emptyList();
+
   public DocumentReferenceHandler(final String indexName, final ObjectMapper objectMapper) {
     this.indexName = indexName;
     this.objectMapper = objectMapper;
@@ -59,6 +68,9 @@ public class DocumentReferenceHandler
     return DocumentReferenceEntity.class;
   }
 
+  // Note: this method mutates the per-instance cache fields (cachedRecordKey, cachedDocRefs) so
+  // the parse result can be reused by generateIds() and updateEntity() during the same lifecycle
+  // pass.  Do not call it speculatively expecting predicate purity.
   @Override
   public boolean handlesRecord(final Record<VariableRecordValue> record) {
     if (!SUPPORTED_INTENTS.contains(record.getIntent())) {
@@ -71,28 +83,23 @@ public class DocumentReferenceHandler
     if (!value.contains(DOCUMENT_TYPE_DISCRIMINATOR)) {
       return false;
     }
-    return isDocumentReference(value);
+    final List<JsonNode> docRefs = parseDocumentRefs(value);
+    if (docRefs.isEmpty()) {
+      return false;
+    }
+    // Populate the cache so generateIds() and updateEntity() can reuse this parse result.
+    cachedRecordKey = record.getKey();
+    cachedDocRefs = docRefs;
+    return true;
   }
 
   @Override
   public List<String> generateIds(final Record<VariableRecordValue> record) {
     final List<String> ids = new ArrayList<>();
-    try {
-      final JsonNode root = objectMapper.readTree(record.getValue().getValue());
-      if (root.isArray()) {
-        for (final JsonNode node : root) {
-          if (isDocumentReferenceNode(node) && node.has("documentId")) {
-            ids.add(generateId(record.getKey(), node.get("documentId").asText()));
-          }
-        }
-      } else if (isDocumentReferenceNode(root) && root.has("documentId")) {
-        ids.add(generateId(record.getKey(), root.get("documentId").asText()));
+    for (final JsonNode node : getDocRefs(record)) {
+      if (node.has("documentId")) {
+        ids.add(generateId(record.getKey(), node.get("documentId").asText()));
       }
-    } catch (final Exception e) {
-      LOG.debug(
-          "Failed to parse document reference ids from variable record key={}: {}",
-          record.getKey(),
-          e.getMessage());
     }
     return ids;
   }
@@ -126,48 +133,35 @@ public class DocumentReferenceHandler
     // Format is "{variableKey}_{documentId}" — we strip the prefix to recover the documentId.
     final String docId = extractDocumentId(entity.getId(), record.getKey());
 
-    try {
-      final JsonNode root = objectMapper.readTree(recordValue.getValue());
-      JsonNode docNode = null;
-      if (root.isArray()) {
-        for (final JsonNode node : root) {
-          if (isDocumentReferenceNode(node)
-              && node.has("documentId")
-              && docId.equals(node.get("documentId").asText())) {
-            docNode = node;
-            break;
-          }
-        }
-      } else if (isDocumentReferenceNode(root)) {
-        docNode = root;
+    JsonNode docNode = null;
+    for (final JsonNode node : getDocRefs(record)) {
+      if (node.has("documentId") && docId.equals(node.get("documentId").asText())) {
+        docNode = node;
+        break;
       }
-      if (docNode != null) {
-        entity.setDocumentId(docNode.get("documentId").asText());
-        entity.setStoreId(getTextOrNull(docNode, "storeId"));
-        entity.setContentHash(getTextOrNull(docNode, "contentHash"));
-        final JsonNode metadata = docNode.get("metadata");
-        if (metadata != null) {
-          entity.setFileName(getTextOrNull(metadata, "fileName"));
-          entity.setContentType(getTextOrNull(metadata, "contentType"));
-          entity.setExpiresAt(getTextOrNull(metadata, "expiresAt"));
-          if (metadata.has("size") && !metadata.get("size").isNull()) {
-            entity.setSize(metadata.get("size").asLong());
-          }
-          if (metadata.has("customProperties") && !metadata.get("customProperties").isNull()) {
-            entity.setCustomProperties(metadata.get("customProperties").toString());
-          }
+    }
+
+    if (docNode != null) {
+      entity.setDocumentId(docNode.get("documentId").asText());
+      entity.setStoreId(getTextOrNull(docNode, "storeId"));
+      entity.setContentHash(getTextOrNull(docNode, "contentHash"));
+      final JsonNode metadata = docNode.get("metadata");
+      if (metadata != null) {
+        entity.setFileName(getTextOrNull(metadata, "fileName"));
+        entity.setContentType(getTextOrNull(metadata, "contentType"));
+        entity.setExpiresAt(getTextOrNull(metadata, "expiresAt"));
+        if (metadata.has("size") && !metadata.get("size").isNull()) {
+          entity.setSize(metadata.get("size").asLong());
         }
-      } else {
-        LOG.warn(
-            "Document reference with id='{}' not found in variable record key={}",
-            docId,
-            record.getKey());
+        if (metadata.has("customProperties") && !metadata.get("customProperties").isNull()) {
+          entity.setCustomProperties(metadata.get("customProperties").toString());
+        }
       }
-    } catch (final Exception e) {
-      LOG.error(
-          "Failed to parse document reference data from variable record key={}: {}",
-          record.getKey(),
-          e.getMessage());
+    } else {
+      LOG.warn(
+          "Document reference with id='{}' not found in variable record key={}",
+          docId,
+          record.getKey());
     }
   }
 
@@ -181,16 +175,40 @@ public class DocumentReferenceHandler
     return indexName;
   }
 
-  private boolean isDocumentReference(final String value) {
+  // Returns the cached parsed list if the key matches, otherwise re-parses and warms the cache.
+  // The re-parse path exists as a safety net: in practice handlesRecord() is always called first
+  // for every record the handler processes, so the cache will be warm.  Updating the cache on
+  // miss ensures any subsequent calls in the same lifecycle pass (e.g. updateEntity per array
+  // element) reuse the same parse result.
+  private List<JsonNode> getDocRefs(final Record<VariableRecordValue> record) {
+    if (cachedRecordKey != null && cachedRecordKey == record.getKey()) {
+      return cachedDocRefs;
+    }
+    final List<JsonNode> parsed = parseDocumentRefs(record.getValue().getValue());
+    cachedRecordKey = record.getKey();
+    cachedDocRefs = parsed;
+    return parsed;
+  }
+
+  private List<JsonNode> parseDocumentRefs(final String value) {
     try {
       final JsonNode root = objectMapper.readTree(value);
       if (root.isArray()) {
-        return root.size() > 0 && isDocumentReferenceNode(root.get(0));
+        final List<JsonNode> refs = new ArrayList<>();
+        for (final JsonNode node : root) {
+          if (isDocumentReferenceNode(node)) {
+            refs.add(node);
+          }
+        }
+        return refs;
+      } else if (isDocumentReferenceNode(root)) {
+        return List.of(root);
       }
-      return isDocumentReferenceNode(root);
     } catch (final Exception e) {
-      return false;
+      LOG.debug(
+          "Failed to parse document reference from variable record value: {}", e.getMessage());
     }
+    return Collections.emptyList();
   }
 
   private boolean isDocumentReferenceNode(final JsonNode node) {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/DocumentReferenceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/DocumentReferenceHandlerTest.java
@@ -279,6 +279,192 @@ public class DocumentReferenceHandlerTest {
     assertThat(entity.getStoreId()).isEqualTo("gcp");
     assertThat(entity.getContentHash()).isEqualTo("hash2");
     assertThat(entity.getFileName()).isEqualTo("report.docx");
+    assertThat(entity.getContentType())
+        .isEqualTo(
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document");
     assertThat(entity.getSize()).isEqualTo(2048L);
+    assertThat(entity.getExpiresAt()).isEqualTo("2025-12-31T00:00:00Z");
+  }
+
+  @Test
+  void shouldNotHandleRecordWhenDiscriminatorAppearsOnlyAsValue() {
+    // given - discriminator string appears in a value, not as a key
+    final VariableRecordValue recordValue =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withValue("{\"description\": \"we use camunda.document.type for foo\"}")
+            .build();
+    final Record<VariableRecordValue> record =
+        factory.generateRecord(
+            ValueType.VARIABLE,
+            r -> r.withIntent(VariableIntent.CREATED).withValue(recordValue));
+
+    // when - then
+    assertThat(underTest.handlesRecord(record)).isFalse();
+  }
+
+  @Test
+  void shouldNotHandleRecordWhenJsonIsMalformedButPassesFastPath() {
+    // given - contains the discriminator substring but isn't valid JSON
+    final VariableRecordValue recordValue =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withValue("{\"camunda.document.type\": \"camunda\"")
+            .build();
+    final Record<VariableRecordValue> record =
+        factory.generateRecord(
+            ValueType.VARIABLE,
+            r -> r.withIntent(VariableIntent.CREATED).withValue(recordValue));
+
+    // when - then
+    assertThat(underTest.handlesRecord(record)).isFalse();
+  }
+
+  @Test
+  void shouldFilterOutNonDocRefElementsFromMixedArray() {
+    // given - one element is a doc-ref, the other is a plain object
+    final String mixedArray =
+        """
+        [
+          {
+            "camunda.document.type": "camunda",
+            "documentId": "doc123",
+            "storeId": "aws",
+            "metadata": {"fileName": "a.pdf"}
+          },
+          {
+            "foo": "bar"
+          }
+        ]
+        """;
+    final VariableRecordValue recordValue =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withValue(mixedArray)
+            .build();
+    final Record<VariableRecordValue> record =
+        factory.generateRecord(
+            ValueType.VARIABLE,
+            r -> r.withIntent(VariableIntent.CREATED).withValue(recordValue));
+
+    // when
+    final boolean handles = underTest.handlesRecord(record);
+    final var ids = underTest.generateIds(record);
+
+    // then - only the doc-ref element produces an id
+    assertThat(handles).isTrue();
+    assertThat(ids).containsExactly(record.getKey() + "_doc123");
+  }
+
+  @Test
+  void shouldSkipArrayElementWithoutDocumentId() {
+    // given - array with one valid doc-ref and one missing documentId
+    final String arrayMissingId =
+        """
+        [
+          {
+            "camunda.document.type": "camunda",
+            "documentId": "doc123",
+            "metadata": {}
+          },
+          {
+            "camunda.document.type": "camunda",
+            "metadata": {}
+          }
+        ]
+        """;
+    final VariableRecordValue recordValue =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withValue(arrayMissingId)
+            .build();
+    final Record<VariableRecordValue> record =
+        factory.generateRecord(
+            ValueType.VARIABLE,
+            r -> r.withIntent(VariableIntent.CREATED).withValue(recordValue));
+
+    // when
+    final var ids = underTest.generateIds(record);
+
+    // then - only the element with documentId yields an id
+    assertThat(ids).containsExactly(record.getKey() + "_doc123");
+  }
+
+  @Test
+  void shouldSetRootProcessInstanceKeyWhenPositive() {
+    // given
+    final VariableRecordValue recordValue =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withValue(SINGLE_DOC_REF)
+            .withRootProcessInstanceKey(42L)
+            .build();
+    final Record<VariableRecordValue> record =
+        factory.generateRecord(
+            ValueType.VARIABLE,
+            r -> r.withIntent(VariableIntent.CREATED).withValue(recordValue));
+    final DocumentReferenceEntity entity = new DocumentReferenceEntity();
+    entity.setId(record.getKey() + "_doc123");
+
+    // when
+    underTest.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getRootProcessInstanceKey()).isEqualTo(42L);
+  }
+
+  @Test
+  void shouldFallBackToDefaultTenantWhenTenantIsEmpty() {
+    // given - empty tenantId triggers tenantOrDefault fallback
+    final VariableRecordValue recordValue =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withValue(SINGLE_DOC_REF)
+            .withTenantId("")
+            .build();
+    final Record<VariableRecordValue> record =
+        factory.generateRecord(
+            ValueType.VARIABLE,
+            r -> r.withIntent(VariableIntent.CREATED).withValue(recordValue));
+    final DocumentReferenceEntity entity = new DocumentReferenceEntity();
+    entity.setId(record.getKey() + "_doc123");
+
+    // when
+    underTest.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getTenantId()).isEqualTo("<default>");
+  }
+
+  @Test
+  void shouldRunFullLifecycleReusingTheCacheForArrayDocRefs() {
+    // given - exercise the cache happy-path: handlesRecord populates, generateIds + updateEntity
+    // both consume without re-parsing
+    final VariableRecordValue recordValue =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withValue(ARRAY_DOC_REFS)
+            .build();
+    final Record<VariableRecordValue> record =
+        factory.generateRecord(
+            ValueType.VARIABLE,
+            r -> r.withIntent(VariableIntent.CREATED).withValue(recordValue));
+
+    // when
+    final boolean handles = underTest.handlesRecord(record);
+    final var ids = underTest.generateIds(record);
+    final DocumentReferenceEntity first = new DocumentReferenceEntity();
+    first.setId(ids.get(0));
+    underTest.updateEntity(record, first);
+    final DocumentReferenceEntity second = new DocumentReferenceEntity();
+    second.setId(ids.get(1));
+    underTest.updateEntity(record, second);
+
+    // then
+    assertThat(handles).isTrue();
+    assertThat(ids).hasSize(2);
+    assertThat(first.getDocumentId()).isNotEqualTo(second.getDocumentId());
+    assertThat(first.getDocumentId()).isIn("doc123", "doc456");
+    assertThat(second.getDocumentId()).isIn("doc123", "doc456");
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/DocumentReferenceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/DocumentReferenceHandlerTest.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.DocumentReferenceEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.VariableIntent;
+import io.camunda.zeebe.protocol.record.value.ImmutableVariableRecordValue;
+import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.EnumSource.Mode;
+
+public class DocumentReferenceHandlerTest {
+
+  private static final String SINGLE_DOC_REF =
+      """
+      {
+        "camunda.document.type": "camunda",
+        "documentId": "doc123",
+        "storeId": "aws",
+        "contentHash": "hash1",
+        "metadata": {
+          "fileName": "test.pdf",
+          "contentType": "application/pdf",
+          "size": 1024,
+          "expiresAt": "2025-12-31T00:00:00Z",
+          "customProperties": {}
+        }
+      }
+      """;
+
+  private static final String ARRAY_DOC_REFS =
+      """
+      [
+        {
+          "camunda.document.type": "camunda",
+          "documentId": "doc123",
+          "storeId": "aws",
+          "contentHash": "hash1",
+          "metadata": {
+            "fileName": "test.pdf",
+            "contentType": "application/pdf",
+            "size": 1024,
+            "expiresAt": "2025-12-31T00:00:00Z",
+            "customProperties": {}
+          }
+        },
+        {
+          "camunda.document.type": "camunda",
+          "documentId": "doc456",
+          "storeId": "gcp",
+          "contentHash": "hash2",
+          "metadata": {
+            "fileName": "report.docx",
+            "contentType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "size": 2048,
+            "expiresAt": "2025-12-31T00:00:00Z",
+            "customProperties": {}
+          }
+        }
+      ]
+      """;
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final String indexName = "document-reference";
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final DocumentReferenceHandler underTest =
+      new DocumentReferenceHandler(indexName, objectMapper);
+
+  @Test
+  void shouldGetHandledValueType() {
+    assertThat(underTest.getHandledValueType()).isEqualTo(ValueType.VARIABLE);
+  }
+
+  @Test
+  void shouldGetEntityType() {
+    assertThat(underTest.getEntityType()).isEqualTo(DocumentReferenceEntity.class);
+  }
+
+  @Test
+  void shouldNotHandleRecordWithMigratedIntent() {
+    // given
+    final Record<VariableRecordValue> record =
+        factory.generateRecord(ValueType.VARIABLE, r -> r.withIntent(VariableIntent.MIGRATED));
+
+    // when - then
+    assertThat(underTest.handlesRecord(record)).isFalse();
+  }
+
+  @Test
+  void shouldNotHandleRecordWithNonDocumentReferenceValue() {
+    // given
+    final VariableRecordValue recordValue =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withValue("{\"some\": \"value\"}")
+            .build();
+    final Record<VariableRecordValue> record =
+        factory.generateRecord(
+            ValueType.VARIABLE, r -> r.withIntent(VariableIntent.CREATED).withValue(recordValue));
+
+    // when - then
+    assertThat(underTest.handlesRecord(record)).isFalse();
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = VariableIntent.class,
+      names = {"CREATED", "UPDATED"},
+      mode = Mode.INCLUDE)
+  void shouldHandleRecordWithSingleDocRef(final VariableIntent intent) {
+    // given
+    final VariableRecordValue recordValue =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withValue(SINGLE_DOC_REF)
+            .build();
+    final Record<VariableRecordValue> record =
+        factory.generateRecord(
+            ValueType.VARIABLE, r -> r.withIntent(intent).withValue(recordValue));
+
+    // when - then
+    assertThat(underTest.handlesRecord(record)).isTrue();
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = VariableIntent.class,
+      names = {"CREATED", "UPDATED"},
+      mode = Mode.INCLUDE)
+  void shouldHandleRecordWithArrayOfDocRefs(final VariableIntent intent) {
+    // given
+    final VariableRecordValue recordValue =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withValue(ARRAY_DOC_REFS)
+            .build();
+    final Record<VariableRecordValue> record =
+        factory.generateRecord(
+            ValueType.VARIABLE, r -> r.withIntent(intent).withValue(recordValue));
+
+    // when - then
+    assertThat(underTest.handlesRecord(record)).isTrue();
+  }
+
+  @Test
+  void shouldGenerateIdsForSingleDocRef() {
+    // given
+    final VariableRecordValue recordValue =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withValue(SINGLE_DOC_REF)
+            .build();
+    final Record<VariableRecordValue> record =
+        factory.generateRecord(
+            ValueType.VARIABLE, r -> r.withIntent(VariableIntent.CREATED).withValue(recordValue));
+
+    // when
+    final var ids = underTest.generateIds(record);
+
+    // then
+    assertThat(ids).hasSize(1);
+    assertThat(ids.get(0)).isEqualTo(record.getKey() + "_doc123");
+  }
+
+  @Test
+  void shouldGenerateIdsForArrayOfDocRefs() {
+    // given
+    final VariableRecordValue recordValue =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withValue(ARRAY_DOC_REFS)
+            .build();
+    final Record<VariableRecordValue> record =
+        factory.generateRecord(
+            ValueType.VARIABLE, r -> r.withIntent(VariableIntent.CREATED).withValue(recordValue));
+
+    // when
+    final var ids = underTest.generateIds(record);
+
+    // then
+    assertThat(ids).hasSize(2);
+    assertThat(ids)
+        .containsExactlyInAnyOrder(record.getKey() + "_doc123", record.getKey() + "_doc456");
+  }
+
+  @Test
+  void shouldCreateNewEntity() {
+    // when
+    final var result = underTest.createNewEntity("testId");
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo("testId");
+  }
+
+  @Test
+  void shouldAddEntityOnFlush() {
+    // given
+    final DocumentReferenceEntity entity =
+        new DocumentReferenceEntity().setId("id").setDocumentId("doc123");
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    // when
+    underTest.flush(entity, mockRequest);
+
+    // then
+    verify(mockRequest, times(1)).add(indexName, entity);
+  }
+
+  @Test
+  void shouldUpdateEntityFromSingleDocRef() {
+    // given
+    final VariableRecordValue recordValue =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withValue(SINGLE_DOC_REF)
+            .withName("myDoc")
+            .build();
+    final Record<VariableRecordValue> record =
+        factory.generateRecord(
+            ValueType.VARIABLE, r -> r.withIntent(VariableIntent.CREATED).withValue(recordValue));
+
+    final DocumentReferenceEntity entity = new DocumentReferenceEntity();
+    entity.setId(record.getKey() + "_doc123");
+
+    // when
+    underTest.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getVariableKey()).isEqualTo(record.getKey());
+    assertThat(entity.getVariableName()).isEqualTo("myDoc");
+    assertThat(entity.getDocumentId()).isEqualTo("doc123");
+    assertThat(entity.getStoreId()).isEqualTo("aws");
+    assertThat(entity.getContentHash()).isEqualTo("hash1");
+    assertThat(entity.getFileName()).isEqualTo("test.pdf");
+    assertThat(entity.getContentType()).isEqualTo("application/pdf");
+    assertThat(entity.getSize()).isEqualTo(1024L);
+    assertThat(entity.getExpiresAt()).isEqualTo("2025-12-31T00:00:00Z");
+  }
+
+  @Test
+  void shouldUpdateEntityFromArrayOfDocRefsPickingCorrectOne() {
+    // given
+    final VariableRecordValue recordValue =
+        ImmutableVariableRecordValue.builder()
+            .from(factory.generateObject(VariableRecordValue.class))
+            .withValue(ARRAY_DOC_REFS)
+            .withName("myDocs")
+            .build();
+    final Record<VariableRecordValue> record =
+        factory.generateRecord(
+            ValueType.VARIABLE, r -> r.withIntent(VariableIntent.CREATED).withValue(recordValue));
+
+    final DocumentReferenceEntity entity = new DocumentReferenceEntity();
+    entity.setId(record.getKey() + "_doc456");
+
+    // when
+    underTest.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getDocumentId()).isEqualTo("doc456");
+    assertThat(entity.getStoreId()).isEqualTo("gcp");
+    assertThat(entity.getContentHash()).isEqualTo("hash2");
+    assertThat(entity.getFileName()).isEqualTo("report.docx");
+    assertThat(entity.getSize()).isEqualTo(2048L);
+  }
+}

--- a/zeebe/gateway-protocol/src/main/proto/v2/document-references.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/document-references.yaml
@@ -49,6 +49,8 @@ components:
       properties:
         processInstanceKey:
           $ref: 'keys.yaml#/components/schemas/ProcessInstanceKeyFilterProperty'
+        scopeKey:
+          $ref: 'keys.yaml#/components/schemas/ScopeKeyFilterProperty'
         variableKey:
           $ref: 'keys.yaml#/components/schemas/VariableKeyFilterProperty'
         documentId:
@@ -66,6 +68,7 @@ components:
           type: string
           enum:
             - processInstanceKey
+            - scopeKey
             - variableKey
             - documentId
             - fileName

--- a/zeebe/gateway-protocol/src/main/proto/v2/document-references.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/document-references.yaml
@@ -70,6 +70,7 @@ components:
             - processInstanceKey
             - scopeKey
             - variableKey
+            - variableName
             - documentId
             - fileName
             - tenantId

--- a/zeebe/gateway-protocol/src/main/proto/v2/document-references.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/document-references.yaml
@@ -1,0 +1,155 @@
+paths:
+  /document-references/search:
+    post:
+      x-eventually-consistent: true
+      tags:
+        - Document reference
+      operationId: searchDocumentReferences
+      summary: Search document references
+      description: Search for document references based on given criteria.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DocumentReferenceSearchQuery'
+      responses:
+        "200":
+          description: The document reference search result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DocumentReferenceSearchQueryResult'
+        "400":
+          $ref: 'common-responses.yaml#/components/responses/InvalidData'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "403":
+          $ref: 'common-responses.yaml#/components/responses/Forbidden'
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
+
+components:
+  schemas:
+    DocumentReferenceSearchQuery:
+      type: object
+      properties:
+        filter:
+          $ref: '#/components/schemas/DocumentReferenceFilter'
+        sort:
+          type: array
+          items:
+            $ref: '#/components/schemas/DocumentReferenceSearchQuerySortRequest'
+        page:
+          $ref: 'search-models.yaml#/components/schemas/SearchQueryPageRequest'
+
+    DocumentReferenceFilter:
+      type: object
+      properties:
+        processInstanceKey:
+          $ref: 'keys.yaml#/components/schemas/ProcessInstanceKeyFilterProperty'
+        variableKey:
+          $ref: 'keys.yaml#/components/schemas/VariableKeyFilterProperty'
+        documentId:
+          allOf:
+            - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
+          description: The document ID to filter by.
+        tenantId:
+          $ref: 'identifiers.yaml#/components/schemas/TenantId'
+
+    DocumentReferenceSearchQuerySortRequest:
+      type: object
+      properties:
+        field:
+          description: The field to sort by.
+          type: string
+          enum:
+            - processInstanceKey
+            - variableKey
+            - documentId
+            - fileName
+            - tenantId
+        order:
+          $ref: 'search-models.yaml#/components/schemas/SortOrderEnum'
+      required:
+        - field
+
+    DocumentReferenceSearchQueryResult:
+      description: Document reference search query response.
+      type: object
+      required:
+        - items
+      allOf:
+        - $ref: 'search-models.yaml#/components/schemas/SearchQueryResponse'
+      properties:
+        items:
+          description: The matching document references.
+          type: array
+          items:
+            $ref: '#/components/schemas/DocumentReferenceSearchResult'
+
+    DocumentReferenceSearchResult:
+      description: Document reference result item.
+      type: object
+      required:
+        - variableKey
+        - variableName
+        - processInstanceKey
+        - tenantId
+        - documentId
+      properties:
+        variableKey:
+          description: The key of the variable holding this document reference.
+          allOf:
+            - $ref: 'keys.yaml#/components/schemas/VariableKey'
+        variableName:
+          type: string
+          description: Name of the variable holding this document reference.
+        processInstanceKey:
+          allOf:
+            - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
+          description: The key of the process instance.
+        scopeKey:
+          allOf:
+            - $ref: 'keys.yaml#/components/schemas/ScopeKey'
+          description: The key of the scope where the variable is defined.
+        processDefinitionKey:
+          allOf:
+            - $ref: 'keys.yaml#/components/schemas/ProcessDefinitionKey'
+          description: The key of the process definition.
+        processDefinitionId:
+          type: string
+          description: The BPMN process definition ID.
+        tenantId:
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/TenantId'
+          description: The tenant ID.
+        documentId:
+          type: string
+          description: The document ID.
+        storeId:
+          type: string
+          description: The document store ID.
+        fileName:
+          type: string
+          description: The file name.
+          nullable: true
+        contentType:
+          type: string
+          description: The content type of the document.
+          nullable: true
+        size:
+          type: integer
+          format: int64
+          description: The size of the document in bytes.
+          nullable: true
+        expiresAt:
+          type: string
+          format: date-time
+          description: The expiration date of the document.
+          nullable: true
+        contentHash:
+          type: string
+          description: The content hash of the document.
+          nullable: true

--- a/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
@@ -38,6 +38,7 @@ tags:
   - name: Decision instance
   - name: Decision requirements
   - name: Document
+  - name: Document reference
   - name: Element instance
   - name: Expression
   - name: Global listener
@@ -151,6 +152,10 @@ paths:
   # Deployment/Resource endpoints
   /deployments:
     $ref: 'deployments.yaml#/paths/~1deployments'
+
+  # Document reference endpoints
+  /document-references/search:
+    $ref: 'document-references.yaml#/paths/~1document-references~1search'
 
   # Document endpoints
   /documents:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DocumentReferenceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DocumentReferenceController.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import static io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper.mapErrorToResponse;
+
+import io.camunda.gateway.mapping.http.search.SearchQueryRequestMapper;
+import io.camunda.gateway.mapping.http.search.SearchQueryResponseMapper;
+import io.camunda.gateway.protocol.model.DocumentReferenceSearchQuery;
+import io.camunda.search.query.DocumentReferenceQuery;
+import io.camunda.security.api.context.CamundaAuthenticationProvider;
+import io.camunda.service.DocumentReferenceServices;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
+import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
+import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@CamundaRestController
+@RequiresSecondaryStorage
+@RequestMapping("/v2/document-references")
+public class DocumentReferenceController {
+
+  private final DocumentReferenceServices documentReferenceServices;
+  private final CamundaAuthenticationProvider authenticationProvider;
+
+  public DocumentReferenceController(
+      final DocumentReferenceServices documentReferenceServices,
+      final CamundaAuthenticationProvider authenticationProvider) {
+    this.documentReferenceServices = documentReferenceServices;
+    this.authenticationProvider = authenticationProvider;
+  }
+
+  @CamundaPostMapping(path = "/search")
+  public ResponseEntity<Object> searchDocumentReferences(
+      @RequestBody(required = false) final DocumentReferenceSearchQuery query) {
+    return SearchQueryRequestMapper.toDocumentReferenceQuery(query)
+        .fold(RestErrorMapper::mapProblemToResponse, this::search);
+  }
+
+  private ResponseEntity<Object> search(final DocumentReferenceQuery query) {
+    try {
+      final var result =
+          documentReferenceServices.search(
+              query, authenticationProvider.getCamundaAuthentication());
+      return ResponseEntity.ok(
+          SearchQueryResponseMapper.toDocumentReferenceSearchQueryResponse(result));
+    } catch (final Exception e) {
+      return mapErrorToResponse(e);
+    }
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DocumentReferenceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DocumentReferenceControllerTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+
+import io.camunda.search.entities.DocumentReferenceEntity;
+import io.camunda.search.query.DocumentReferenceQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.search.query.SearchQueryResult.Builder;
+import io.camunda.security.api.context.CamundaAuthenticationProvider;
+import io.camunda.service.DocumentReferenceServices;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
+
+@WebMvcTest(value = DocumentReferenceController.class)
+public class DocumentReferenceControllerTest extends RestControllerTest {
+
+  private static final String SEARCH_URL = "/v2/document-references/search";
+
+  private static final DocumentReferenceEntity SAMPLE_DOC_REF =
+      new DocumentReferenceEntity(
+          100L,
+          "myDoc",
+          200L,
+          300L,
+          400L,
+          "invoice-process",
+          null,
+          "<default>",
+          "doc123",
+          "aws",
+          "invoice.pdf",
+          "application/pdf",
+          1024L,
+          "2025-12-31T00:00:00Z",
+          "hash1",
+          null);
+
+  private static final SearchQueryResult<DocumentReferenceEntity> SEARCH_QUERY_RESULT =
+      new Builder<DocumentReferenceEntity>()
+          .total(1L)
+          .items(List.of(SAMPLE_DOC_REF))
+          .startCursor("0")
+          .endCursor("0")
+          .build();
+
+  private static final String EXPECTED_SEARCH_RESPONSE =
+      """
+          {
+            "items": [
+              {
+                "variableKey": "100",
+                "variableName": "myDoc",
+                "scopeKey": "200",
+                "processInstanceKey": "300",
+                "processDefinitionKey": "400",
+                "processDefinitionId": "invoice-process",
+                "tenantId": "<default>",
+                "documentId": "doc123",
+                "storeId": "aws",
+                "fileName": "invoice.pdf",
+                "contentType": "application/pdf",
+                "size": 1024,
+                "expiresAt": "2025-12-31T00:00:00Z",
+                "contentHash": "hash1"
+              }
+            ],
+            "page": {
+              "totalItems": 1,
+              "startCursor": "0",
+              "endCursor": "0",
+              "hasMoreTotalItems": false
+            }
+          }
+          """;
+
+  @MockitoBean DocumentReferenceServices documentReferenceServices;
+  @MockitoBean CamundaAuthenticationProvider authenticationProvider;
+
+  @BeforeEach
+  void setupServices() {
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
+    when(documentReferenceServices.search(any(DocumentReferenceQuery.class), any()))
+        .thenReturn(SEARCH_QUERY_RESULT);
+  }
+
+  @Test
+  void shouldSearchDocumentReferences() {
+    // when / then
+    webClient
+        .post()
+        .uri(SEARCH_URL)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(APPLICATION_JSON)
+        .expectBody()
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.LENIENT);
+
+    verify(documentReferenceServices)
+        .search(eq(new DocumentReferenceQuery.Builder().build()), any());
+  }
+
+  @Test
+  void shouldSearchDocumentReferencesWithFilter() {
+    // given
+    final var request =
+        """
+            {
+              "filter": {
+                "processInstanceKey": "300"
+              }
+            }
+            """;
+
+    // when / then
+    webClient
+        .post()
+        .uri(SEARCH_URL)
+        .accept(APPLICATION_JSON)
+        .contentType(APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(APPLICATION_JSON)
+        .expectBody()
+        .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.LENIENT);
+  }
+
+  @Test
+  void shouldReturnEmptyResultOnSearch() {
+    // given
+    when(documentReferenceServices.search(any(DocumentReferenceQuery.class), any()))
+        .thenReturn(new Builder<DocumentReferenceEntity>().total(0L).items(List.of()).build());
+
+    // when / then
+    webClient
+        .post()
+        .uri(SEARCH_URL)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.items")
+        .isArray()
+        .jsonPath("$.items.length()")
+        .isEqualTo(0);
+  }
+
+  @Test
+  void shouldReturn400OnInvalidFilter() {
+    // given - an invalid processInstanceKey (not a valid long)
+    final var request =
+        """
+            {
+              "filter": {
+                "processInstanceKey": {
+                  "$gt": "not-a-number"
+                }
+              }
+            }
+            """;
+
+    // when / then
+    webClient
+        .post()
+        .uri(SEARCH_URL)
+        .accept(APPLICATION_JSON)
+        .contentType(APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest();
+  }
+}


### PR DESCRIPTION
## Description
Proof of concept for the [document reference visualization epic](https://github.com/camunda/product-hub/issues/3465) based on a new `/v2/document-references/search` API supported by an export handler extracting document references from `VARIABLE` records and storing them as separate entities in secondary storage.

## Notes
- only document references stored in top-level variables (no nesting) and arrays are handled
- this PoC only supports ES/OS secondary storage, no RDBMS
- the UI is just a draft to test if the API work correctly