### PR TITLE
49826 archiver repo move document tests

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryTest.java
@@ -16,11 +16,16 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
+import co.elastic.clients.elasticsearch.core.BulkRequest;
+import co.elastic.clients.elasticsearch.core.BulkResponse;
 import co.elastic.clients.elasticsearch.core.DeleteByQueryRequest;
 import co.elastic.clients.elasticsearch.core.DeleteByQueryResponse;
 import co.elastic.clients.elasticsearch.core.ReindexRequest;
+import co.elastic.clients.elasticsearch.core.ReindexResponse;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.bulk.BulkResponseItem;
+import co.elastic.clients.elasticsearch.core.bulk.OperationType;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import co.elastic.clients.elasticsearch.core.search.HitsMetadata;
 import co.elastic.clients.elasticsearch.core.search.TotalHitsRelation;
@@ -37,6 +42,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import jakarta.json.Json;
 import java.net.ConnectException;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -229,6 +235,98 @@ final class ElasticsearchArchiverRepositoryTest extends AbstractArchiverReposito
     inOrder.verify(client).reindex(any(ReindexRequest.class));
     inOrder.verify(client).deleteByQuery(any(DeleteByQueryRequest.class));
     inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  public void shouldSearchReindexThenNotBulkDeleteWhenMovingDocumentsByIdIfReindexingFails() {
+    // given
+    when(client.search(any(SearchRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(searchResponse("4", "5", "6")));
+    when(client.reindex(any(ReindexRequest.class)))
+        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("Error reindexing")));
+
+    // when
+    final var future =
+        repository.moveDocumentsById(
+            "from-index",
+            "to-index",
+            Map.of("key", List.of("1", "2", "3")),
+            Map.of(),
+            Map.of(),
+            Runnable::run);
+
+    // then
+    assertThat(future)
+        .failsWithin(Duration.ofSeconds(5))
+        .withThrowableThat()
+        .withMessageContaining("Error reindexing");
+
+    final var inOrder = Mockito.inOrder(client);
+    inOrder.verify(client).search(any(SearchRequest.class));
+    inOrder.verify(client).reindex(any(ReindexRequest.class));
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  public void shouldSearchReindexThenBulkDeleteWhenMovingDocumentsById() {
+    // given
+    when(client.search(any(SearchRequest.class)))
+        .thenReturn(
+            CompletableFuture.completedFuture(searchResponse("4", "5", "6")),
+            CompletableFuture.completedFuture(searchResponse()));
+    when(client.reindex(any(ReindexRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(ReindexResponse.of(b -> b.total(3L))));
+    when(client.bulk(any(BulkRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(bulkResponse("4", "5", "6")));
+
+    // when
+    final var future =
+        repository.moveDocumentsById(
+            "from-index",
+            "to-index",
+            Map.of("key", List.of("1", "2", "3")),
+            Map.of(),
+            Map.of(),
+            Runnable::run);
+
+    // then
+    assertThat(future).succeedsWithin(Duration.ofSeconds(5));
+
+    final var inOrder = Mockito.inOrder(client);
+    inOrder.verify(client).search(any(SearchRequest.class));
+    inOrder.verify(client).reindex(any(ReindexRequest.class));
+    inOrder.verify(client).bulk(any(BulkRequest.class));
+    inOrder.verify(client).search(any(SearchRequest.class));
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  private SearchResponse<Void> searchResponse(final String... ids) {
+    final var hits =
+        Arrays.stream(ids).map(id -> Hit.<Void>of(h -> h.id(id).index("from-index"))).toList();
+    return SearchResponse.of(
+        r ->
+            r.took(123L)
+                .timedOut(false)
+                .shards(s -> s.total(1).successful(1).failed(0))
+                .hits(
+                    h ->
+                        h.total(t -> t.value(hits.size()).relation(TotalHitsRelation.Eq))
+                            .hits(hits)));
+  }
+
+  private BulkResponse bulkResponse(final String... ids) {
+    final var items =
+        Arrays.stream(ids)
+            .map(
+                id ->
+                    BulkResponseItem.of(
+                        h ->
+                            h.id(id)
+                                .operationType(OperationType.Delete)
+                                .index("from-index")
+                                .status(200)))
+            .toList();
+    return BulkResponse.of(b -> b.took(123L).errors(false).items(items));
   }
 
   private ElasticsearchArchiverRepository createRepository(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryTest.java
@@ -12,9 +12,13 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
+import co.elastic.clients.elasticsearch.core.DeleteByQueryRequest;
+import co.elastic.clients.elasticsearch.core.DeleteByQueryResponse;
+import co.elastic.clients.elasticsearch.core.ReindexRequest;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.search.Hit;
@@ -32,6 +36,7 @@ import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEnt
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import jakarta.json.Json;
 import java.net.ConnectException;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -181,6 +186,49 @@ final class ElasticsearchArchiverRepositoryTest extends AbstractArchiverReposito
     // then - purely based on mapping logic which splits by root key presence
     assertThat(batch.processInstanceKeys()).containsExactly(1L);
     assertThat(batch.rootProcessInstanceKeys()).containsExactly(100L);
+  }
+
+  @Test
+  public void shouldNotDeleteWhenMovingIfReindexingFails() {
+    // given
+    when(client.reindex(any(ReindexRequest.class)))
+        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("Error reindexing")));
+
+    // when
+    final var future =
+        repository.moveDocuments(
+            "from-index", "to-index", Map.of("key", List.of("1", "2", "3")), Runnable::run);
+
+    // then
+    assertThat(future)
+        .failsWithin(Duration.ofSeconds(5))
+        .withThrowableThat()
+        .withMessageContaining("Error reindexing");
+
+    verify(client).reindex(any(ReindexRequest.class));
+    verifyNoMoreInteractions(client);
+  }
+
+  @Test
+  public void shouldReindexThenDeleteWhenMovingDocuments() {
+    // given
+    when(client.reindex(any(ReindexRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(ReindexResponse.of(b -> b.total(10L))));
+    when(client.deleteByQuery(any(DeleteByQueryRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(DeleteByQueryResponse.of(b -> b.total(10L))));
+
+    // when
+    final var future =
+        repository.moveDocuments(
+            "from-index", "to-index", Map.of("key", List.of("1", "2", "3")), Runnable::run);
+
+    // then
+    assertThat(future).succeedsWithin(Duration.ofSeconds(5));
+
+    final var inOrder = Mockito.inOrder(client);
+    inOrder.verify(client).reindex(any(ReindexRequest.class));
+    inOrder.verify(client).deleteByQuery(any(DeleteByQueryRequest.class));
+    inOrder.verifyNoMoreInteractions();
   }
 
   private ElasticsearchArchiverRepository createRepository(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryTest.java
@@ -12,6 +12,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
@@ -24,6 +25,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import jakarta.json.Json;
 import java.io.IOException;
 import java.net.ConnectException;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -34,6 +36,9 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.opensearch.client.json.JsonData;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
+import org.opensearch.client.opensearch.core.DeleteByQueryRequest;
+import org.opensearch.client.opensearch.core.DeleteByQueryResponse;
+import org.opensearch.client.opensearch.core.ReindexRequest;
 import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.SearchResponse;
 import org.opensearch.client.opensearch.core.search.Hit;
@@ -101,6 +106,51 @@ final class OpenSearchArchiverRepositoryTest extends AbstractArchiverRepositoryT
         Runnable::run,
         metrics,
         LOGGER);
+  }
+
+  @Test
+  public void shouldNotDeleteWhenMovingIfReindexingFails() throws IOException {
+    // given
+    when(client.reindex(any(ReindexRequest.class)))
+        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("Error reindexing")));
+
+    // when
+    final var future =
+        repository.moveDocuments(
+            "from-index", "to-index", Map.of("key", List.of("1", "2", "3")), Runnable::run);
+
+    // then
+    assertThat(future)
+        .failsWithin(Duration.ofSeconds(5))
+        .withThrowableThat()
+        .withMessageContaining("Error reindexing");
+
+    verify(client).reindex(any(ReindexRequest.class));
+    verify(client)._transport();
+    verify(client)._transportOptions();
+    verifyNoMoreInteractions(client);
+  }
+
+  @Test
+  public void shouldReindexThenDeleteWhenMovingDocuments() throws IOException {
+    // given
+    when(client.reindex(any(ReindexRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(ReindexResponse.of(b -> b.total(10L))));
+    when(client.deleteByQuery(any(DeleteByQueryRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(DeleteByQueryResponse.of(b -> b.total(10L))));
+
+    // when
+    final var future =
+        repository.moveDocuments(
+            "from-index", "to-index", Map.of("key", List.of("1", "2", "3")), Runnable::run);
+
+    // then
+    assertThat(future).succeedsWithin(Duration.ofSeconds(5));
+
+    final var inOrder = Mockito.inOrder(client);
+    inOrder.verify(client).reindex(any(ReindexRequest.class));
+    inOrder.verify(client).deleteByQuery(any(DeleteByQueryRequest.class));
+    inOrder.verifyNoMoreInteractions();
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryTest.java
@@ -26,6 +26,7 @@ import jakarta.json.Json;
 import java.io.IOException;
 import java.net.ConnectException;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -36,11 +37,16 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.opensearch.client.json.JsonData;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
+import org.opensearch.client.opensearch.core.BulkRequest;
+import org.opensearch.client.opensearch.core.BulkResponse;
 import org.opensearch.client.opensearch.core.DeleteByQueryRequest;
 import org.opensearch.client.opensearch.core.DeleteByQueryResponse;
 import org.opensearch.client.opensearch.core.ReindexRequest;
+import org.opensearch.client.opensearch.core.ReindexResponse;
 import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.bulk.BulkResponseItem;
+import org.opensearch.client.opensearch.core.bulk.OperationType;
 import org.opensearch.client.opensearch.core.search.Hit;
 import org.opensearch.client.opensearch.core.search.TotalHitsRelation;
 import org.opensearch.client.opensearch.generic.OpenSearchGenericClient;
@@ -148,9 +154,108 @@ final class OpenSearchArchiverRepositoryTest extends AbstractArchiverRepositoryT
     assertThat(future).succeedsWithin(Duration.ofSeconds(5));
 
     final var inOrder = Mockito.inOrder(client);
+    inOrder.verify(client)._transport();
+    inOrder.verify(client)._transportOptions();
     inOrder.verify(client).reindex(any(ReindexRequest.class));
     inOrder.verify(client).deleteByQuery(any(DeleteByQueryRequest.class));
     inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  public void shouldSearchReindexThenNotBulkDeleteWhenMovingDocumentsByIdIfReindexingFails()
+      throws IOException {
+    // given
+    when(client.search(any(SearchRequest.class), eq(Object.class)))
+        .thenReturn(CompletableFuture.completedFuture(searchResponse("4", "5", "6")));
+    when(client.reindex(any(ReindexRequest.class)))
+        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("Error reindexing")));
+
+    // when
+    final var future =
+        repository.moveDocumentsById(
+            "from-index",
+            "to-index",
+            Map.of("key", List.of("1", "2", "3")),
+            Map.of(),
+            Map.of(),
+            Runnable::run);
+
+    // then
+    assertThat(future)
+        .failsWithin(Duration.ofSeconds(5))
+        .withThrowableThat()
+        .withMessageContaining("Error reindexing");
+
+    final var inOrder = Mockito.inOrder(client);
+    inOrder.verify(client)._transport();
+    inOrder.verify(client)._transportOptions();
+    inOrder.verify(client).search(any(SearchRequest.class), eq(Object.class));
+    inOrder.verify(client).reindex(any(ReindexRequest.class));
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  public void shouldSearchReindexThenBulkDeleteWhenMovingDocumentsById() throws IOException {
+    // given
+    when(client.search(any(SearchRequest.class), eq(Object.class)))
+        .thenReturn(
+            CompletableFuture.completedFuture(searchResponse("4", "5", "6")),
+            CompletableFuture.completedFuture(searchResponse()));
+    when(client.reindex(any(ReindexRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(ReindexResponse.of(b -> b.total(3L))));
+    when(client.bulk(any(BulkRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(bulkResponse("4", "5", "6")));
+
+    // when
+    final var future =
+        repository.moveDocumentsById(
+            "from-index",
+            "to-index",
+            Map.of("key", List.of("1", "2", "3")),
+            Map.of(),
+            Map.of(),
+            Runnable::run);
+
+    // then
+    assertThat(future).succeedsWithin(Duration.ofSeconds(5));
+
+    final var inOrder = Mockito.inOrder(client);
+    inOrder.verify(client)._transport();
+    inOrder.verify(client)._transportOptions();
+    inOrder.verify(client).search(any(SearchRequest.class), eq(Object.class));
+    inOrder.verify(client).reindex(any(ReindexRequest.class));
+    inOrder.verify(client).bulk(any(BulkRequest.class));
+    inOrder.verify(client).search(any(SearchRequest.class), eq(Object.class));
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  private SearchResponse<Object> searchResponse(final String... ids) {
+    final var hits =
+        Arrays.stream(ids).map(id -> Hit.<Object>of(h -> h.id(id).index("from-index"))).toList();
+    return SearchResponse.searchResponseOf(
+        r ->
+            r.took(123L)
+                .timedOut(false)
+                .shards(s -> s.total(1).successful(1).failed(0))
+                .hits(
+                    h ->
+                        h.total(t -> t.value(hits.size()).relation(TotalHitsRelation.Eq))
+                            .hits(hits)));
+  }
+
+  private BulkResponse bulkResponse(final String... ids) {
+    final var items =
+        Arrays.stream(ids)
+            .map(
+                id ->
+                    BulkResponseItem.of(
+                        h ->
+                            h.id(id)
+                                .operationType(OperationType.Delete)
+                                .index("from-index")
+                                .status(200)))
+            .toList();
+    return BulkResponse.of(b -> b.took(123L).errors(false).items(items));
   }
 
   @Test


### PR DESCRIPTION
This just adds some unit tests to verify that moving documents (for the archiver(s)) has the correct behaviour (in terms of reindexing then deleting) and it works correctly when exceptions happen (e.g. disconnections/timeouts).

## Related issues

refs #49826
