### PR TITLE
truncate tool attributes and filter process cache extension properties

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Data.java
+++ b/configuration/src/main/java/io/camunda/configuration/Data.java
@@ -40,8 +40,9 @@ public class Data {
   /** This section allows configuring exporters */
   private Map<String, Exporter> exporters = new HashMap<>();
 
-  /** This section allows configuring tool property extension mapping. */
-  @NestedConfigurationProperty private Tools tools = new Tools();
+  /** This section allows configuring extension property mapping. */
+  @NestedConfigurationProperty
+  private ExtensionProperties extensionProperties = new ExtensionProperties();
 
   public AuditLog getAuditLog() {
     return auditLog;
@@ -104,11 +105,11 @@ public class Data {
     this.exporters = exporters;
   }
 
-  public Tools getTools() {
-    return tools;
+  public ExtensionProperties getExtensionProperties() {
+    return extensionProperties;
   }
 
-  public void setTools(final Tools tools) {
-    this.tools = tools;
+  public void setExtensionProperties(final ExtensionProperties extensionProperties) {
+    this.extensionProperties = extensionProperties;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/ExtensionProperties.java
+++ b/configuration/src/main/java/io/camunda/configuration/ExtensionProperties.java
@@ -19,54 +19,51 @@ import io.camunda.zeebe.exporter.common.extensionproperty.ExtensionPropertyConfi
  */
 public class ExtensionProperties {
 
-  public static final String DEFAULT_EXTENSION_PROPERTY_TOOL_NAME =
-      ExtensionPropertyConfiguration.DEFAULT_EXTENSION_PROPERTY_TOOL_NAME;
-  public static final String DEFAULT_EXTENSION_PROPERTY_INBOUND_CONNECTOR_TYPE =
-      ExtensionPropertyConfiguration.DEFAULT_EXTENSION_PROPERTY_INBOUND_CONNECTOR_TYPE;
-  public static final String DEFAULT_EXTENSION_PROPERTY_PREFIX_TOOL_PROPERTIES =
-      ExtensionPropertyConfiguration.DEFAULT_EXTENSION_PROPERTY_PREFIX_TOOL_PROPERTIES;
+  public static final String DEFAULT_TOOL_NAME_PROPERTY =
+      ExtensionPropertyConfiguration.DEFAULT_TOOL_NAME_PROPERTY;
+  public static final String DEFAULT_INBOUND_CONNECTOR_TYPE_PROPERTY =
+      ExtensionPropertyConfiguration.DEFAULT_INBOUND_CONNECTOR_TYPE_PROPERTY;
+  public static final String DEFAULT_TOOL_PROPERTIES_PREFIX =
+      ExtensionPropertyConfiguration.DEFAULT_TOOL_PROPERTIES_PREFIX;
 
   /** The extension property name whose value is exported as the {@code toolName} attribute. */
-  private String extensionPropertyToolName =
-      ExtensionPropertyConfiguration.DEFAULT_EXTENSION_PROPERTY_TOOL_NAME;
+  private String toolNameProperty = ExtensionPropertyConfiguration.DEFAULT_TOOL_NAME_PROPERTY;
 
   /**
    * The extension property name whose value is exported as the {@code inboundConnectorType}
    * attribute.
    */
-  private String extensionPropertyInboundConnectorType =
-      ExtensionPropertyConfiguration.DEFAULT_EXTENSION_PROPERTY_INBOUND_CONNECTOR_TYPE;
+  private String inboundConnectorTypeProperty =
+      ExtensionPropertyConfiguration.DEFAULT_INBOUND_CONNECTOR_TYPE_PROPERTY;
 
   /**
    * The extension property name prefix for properties exported as the {@code toolProperties}
    * key-value attribute. Only extension properties whose names start with this prefix are exported.
    */
-  private String extensionPropertyPrefixToolProperties =
-      ExtensionPropertyConfiguration.DEFAULT_EXTENSION_PROPERTY_PREFIX_TOOL_PROPERTIES;
+  private String toolPropertiesPrefix =
+      ExtensionPropertyConfiguration.DEFAULT_TOOL_PROPERTIES_PREFIX;
 
-  public String getExtensionPropertyToolName() {
-    return extensionPropertyToolName;
+  public String getToolNameProperty() {
+    return toolNameProperty;
   }
 
-  public void setExtensionPropertyToolName(final String extensionPropertyToolName) {
-    this.extensionPropertyToolName = extensionPropertyToolName;
+  public void setToolNameProperty(final String toolNameProperty) {
+    this.toolNameProperty = toolNameProperty;
   }
 
-  public String getExtensionPropertyInboundConnectorType() {
-    return extensionPropertyInboundConnectorType;
+  public String getInboundConnectorTypeProperty() {
+    return inboundConnectorTypeProperty;
   }
 
-  public void setExtensionPropertyInboundConnectorType(
-      final String extensionPropertyInboundConnectorType) {
-    this.extensionPropertyInboundConnectorType = extensionPropertyInboundConnectorType;
+  public void setInboundConnectorTypeProperty(final String inboundConnectorTypeProperty) {
+    this.inboundConnectorTypeProperty = inboundConnectorTypeProperty;
   }
 
-  public String getExtensionPropertyPrefixToolProperties() {
-    return extensionPropertyPrefixToolProperties;
+  public String getToolPropertiesPrefix() {
+    return toolPropertiesPrefix;
   }
 
-  public void setExtensionPropertyPrefixToolProperties(
-      final String extensionPropertyPrefixToolProperties) {
-    this.extensionPropertyPrefixToolProperties = extensionPropertyPrefixToolProperties;
+  public void setToolPropertiesPrefix(final String toolPropertiesPrefix) {
+    this.toolPropertiesPrefix = toolPropertiesPrefix;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/ExtensionProperties.java
+++ b/configuration/src/main/java/io/camunda/configuration/ExtensionProperties.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.configuration;
 
-import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
+import io.camunda.zeebe.exporter.common.extensionproperty.ExtensionPropertyConfiguration;
 
 /**
  * Configuration for which extension property names are exported as tool properties.
@@ -17,32 +17,32 @@ import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
  * properties. While currently used primarily for message subscriptions, these settings are general
  * and can be applied to other entity types in the future.
  */
-public class Tools {
+public class ExtensionProperties {
 
   public static final String DEFAULT_EXTENSION_PROPERTY_TOOL_NAME =
-      ToolsConfiguration.DEFAULT_EXTENSION_PROPERTY_TOOL_NAME;
+      ExtensionPropertyConfiguration.DEFAULT_EXTENSION_PROPERTY_TOOL_NAME;
   public static final String DEFAULT_EXTENSION_PROPERTY_INBOUND_CONNECTOR_TYPE =
-      ToolsConfiguration.DEFAULT_EXTENSION_PROPERTY_INBOUND_CONNECTOR_TYPE;
+      ExtensionPropertyConfiguration.DEFAULT_EXTENSION_PROPERTY_INBOUND_CONNECTOR_TYPE;
   public static final String DEFAULT_EXTENSION_PROPERTY_PREFIX_TOOL_PROPERTIES =
-      ToolsConfiguration.DEFAULT_EXTENSION_PROPERTY_PREFIX_TOOL_PROPERTIES;
+      ExtensionPropertyConfiguration.DEFAULT_EXTENSION_PROPERTY_PREFIX_TOOL_PROPERTIES;
 
   /** The extension property name whose value is exported as the {@code toolName} attribute. */
   private String extensionPropertyToolName =
-      ToolsConfiguration.DEFAULT_EXTENSION_PROPERTY_TOOL_NAME;
+      ExtensionPropertyConfiguration.DEFAULT_EXTENSION_PROPERTY_TOOL_NAME;
 
   /**
    * The extension property name whose value is exported as the {@code inboundConnectorType}
    * attribute.
    */
   private String extensionPropertyInboundConnectorType =
-      ToolsConfiguration.DEFAULT_EXTENSION_PROPERTY_INBOUND_CONNECTOR_TYPE;
+      ExtensionPropertyConfiguration.DEFAULT_EXTENSION_PROPERTY_INBOUND_CONNECTOR_TYPE;
 
   /**
    * The extension property name prefix for properties exported as the {@code toolProperties}
    * key-value attribute. Only extension properties whose names start with this prefix are exported.
    */
   private String extensionPropertyPrefixToolProperties =
-      ToolsConfiguration.DEFAULT_EXTENSION_PROPERTY_PREFIX_TOOL_PROPERTIES;
+      ExtensionPropertyConfiguration.DEFAULT_EXTENSION_PROPERTY_PREFIX_TOOL_PROPERTIES;
 
   public String getExtensionPropertyToolName() {
     return extensionPropertyToolName;

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -995,11 +995,9 @@ public class BrokerBasedPropertiesOverride {
       final io.camunda.zeebe.exporter.common.extensionproperty.ExtensionPropertyConfiguration
           extensionProperties,
       final io.camunda.configuration.ExtensionProperties source) {
-    extensionProperties.setExtensionPropertyToolName(source.getExtensionPropertyToolName());
-    extensionProperties.setExtensionPropertyInboundConnectorType(
-        source.getExtensionPropertyInboundConnectorType());
-    extensionProperties.setExtensionPropertyPrefixToolProperties(
-        source.getExtensionPropertyPrefixToolProperties());
+    extensionProperties.setToolNameProperty(source.getToolNameProperty());
+    extensionProperties.setInboundConnectorTypeProperty(source.getInboundConnectorTypeProperty());
+    extensionProperties.setToolPropertiesPrefix(source.getToolPropertiesPrefix());
   }
 
   private void applyRdbmsHistoryExporterConfiguration(

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -872,7 +872,8 @@ public class BrokerBasedPropertiesOverride {
                   CamundaExporterConfigurationApplier.applyIncidentNotifier(
                       config, unifiedConfiguration);
                   CamundaExporterConfigurationApplier.applyMisc(config, unifiedConfiguration);
-                  CamundaExporterConfigurationApplier.applyTools(config, unifiedConfiguration);
+                  CamundaExporterConfigurationApplier.applyExtensionProperties(
+                      config, unifiedConfiguration);
                 })
             .toArgs());
   }
@@ -983,19 +984,21 @@ public class BrokerBasedPropertiesOverride {
                         .setPauseOnMaxLagExceeded(asyncReplication.isPauseOnMaxLagExceeded());
                   }
 
-                  applyRdbmsToolsConfiguration(
-                      config.getTools(), unifiedConfiguration.getCamunda().getData().getTools());
+                  applyRdbmsExtensionPropertyConfiguration(
+                      config.getExtensionProperties(),
+                      unifiedConfiguration.getCamunda().getData().getExtensionProperties());
                 })
             .toArgs());
   }
 
-  private void applyRdbmsToolsConfiguration(
-      final io.camunda.zeebe.exporter.common.tools.ToolsConfiguration tools,
-      final io.camunda.configuration.Tools source) {
-    tools.setExtensionPropertyToolName(source.getExtensionPropertyToolName());
-    tools.setExtensionPropertyInboundConnectorType(
+  private void applyRdbmsExtensionPropertyConfiguration(
+      final io.camunda.zeebe.exporter.common.extensionproperty.ExtensionPropertyConfiguration
+          extensionProperties,
+      final io.camunda.configuration.ExtensionProperties source) {
+    extensionProperties.setExtensionPropertyToolName(source.getExtensionPropertyToolName());
+    extensionProperties.setExtensionPropertyInboundConnectorType(
         source.getExtensionPropertyInboundConnectorType());
-    tools.setExtensionPropertyPrefixToolProperties(
+    extensionProperties.setExtensionPropertyPrefixToolProperties(
         source.getExtensionPropertyPrefixToolProperties());
   }
 

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/CamundaExporterConfigurationApplier.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/CamundaExporterConfigurationApplier.java
@@ -255,11 +255,9 @@ public final class CamundaExporterConfigurationApplier {
         unifiedConfiguration.getCamunda().getData().getExtensionProperties();
     final ExtensionPropertyConfiguration target = exporterConfiguration.getExtensionProperties();
 
-    target.setExtensionPropertyToolName(source.getExtensionPropertyToolName());
-    target.setExtensionPropertyInboundConnectorType(
-        source.getExtensionPropertyInboundConnectorType());
-    target.setExtensionPropertyPrefixToolProperties(
-        source.getExtensionPropertyPrefixToolProperties());
+    target.setToolNameProperty(source.getToolNameProperty());
+    target.setInboundConnectorTypeProperty(source.getInboundConnectorTypeProperty());
+    target.setToolPropertiesPrefix(source.getToolPropertiesPrefix());
   }
 
   private static DocumentBasedSecondaryStorageDatabase getDocumentBasedDatabase(

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/CamundaExporterConfigurationApplier.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/CamundaExporterConfigurationApplier.java
@@ -8,11 +8,11 @@
 package io.camunda.configuration.beanoverrides;
 
 import io.camunda.configuration.DocumentBasedSecondaryStorageDatabase;
+import io.camunda.configuration.ExtensionProperties;
 import io.camunda.configuration.InterceptorPlugin;
 import io.camunda.configuration.Opensearch;
 import io.camunda.configuration.Retention;
 import io.camunda.configuration.SecondaryStorage;
-import io.camunda.configuration.Tools;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.config.ExporterConfiguration.BulkConfiguration;
@@ -22,7 +22,7 @@ import io.camunda.exporter.config.ExporterConfiguration.PostExportConfiguration;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.search.schema.config.IndexConfiguration;
 import io.camunda.search.schema.config.RetentionConfiguration;
-import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
+import io.camunda.zeebe.exporter.common.extensionproperty.ExtensionPropertyConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -247,12 +247,13 @@ public final class CamundaExporterConfigurationApplier {
     exporterConfiguration.getFormCache().setMaxCacheSize(source.getFormCache().getMaxSize());
   }
 
-  public static void applyTools(
+  public static void applyExtensionProperties(
       final ExporterConfiguration exporterConfiguration,
       final UnifiedConfiguration unifiedConfiguration) {
 
-    final Tools source = unifiedConfiguration.getCamunda().getData().getTools();
-    final ToolsConfiguration target = exporterConfiguration.getTools();
+    final ExtensionProperties source =
+        unifiedConfiguration.getCamunda().getData().getExtensionProperties();
+    final ExtensionPropertyConfiguration target = exporterConfiguration.getExtensionProperties();
 
     target.setExtensionPropertyToolName(source.getExtensionPropertyToolName());
     target.setExtensionPropertyInboundConnectorType(

--- a/configuration/src/test/java/io/camunda/configuration/DataExtensionPropertiesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/DataExtensionPropertiesTest.java
@@ -19,18 +19,18 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
-class DataToolsTest {
+class DataExtensionPropertiesTest {
 
   @Test
   void shouldHaveDefaults() {
     final ExtensionProperties extensionProperties = new ExtensionProperties();
 
-    assertThat(extensionProperties.getExtensionPropertyToolName())
-        .isEqualTo(ExtensionProperties.DEFAULT_EXTENSION_PROPERTY_TOOL_NAME);
-    assertThat(extensionProperties.getExtensionPropertyInboundConnectorType())
-        .isEqualTo(ExtensionProperties.DEFAULT_EXTENSION_PROPERTY_INBOUND_CONNECTOR_TYPE);
-    assertThat(extensionProperties.getExtensionPropertyPrefixToolProperties())
-        .isEqualTo(ExtensionProperties.DEFAULT_EXTENSION_PROPERTY_PREFIX_TOOL_PROPERTIES);
+    assertThat(extensionProperties.getToolNameProperty())
+        .isEqualTo(ExtensionProperties.DEFAULT_TOOL_NAME_PROPERTY);
+    assertThat(extensionProperties.getInboundConnectorTypeProperty())
+        .isEqualTo(ExtensionProperties.DEFAULT_INBOUND_CONNECTOR_TYPE_PROPERTY);
+    assertThat(extensionProperties.getToolPropertiesPrefix())
+        .isEqualTo(ExtensionProperties.DEFAULT_TOOL_PROPERTIES_PREFIX);
   }
 
   @Nested
@@ -43,24 +43,24 @@ class DataToolsTest {
   @TestPropertySource(
       properties = {
         "camunda.data.secondary-storage.type=elasticsearch",
-        "camunda.data.extension-properties.extension-property-tool-name=custom.tool:name",
-        "camunda.data.extension-properties.extension-property-inbound-connector-type=custom.inbound.type",
-        "camunda.data.extension-properties.extension-property-prefix-tool-properties=custom.tool:",
+        "camunda.data.extension-properties.tool-name-property=custom.tool:name",
+        "camunda.data.extension-properties.inbound-connector-type-property=custom.inbound.type",
+        "camunda.data.extension-properties.tool-properties-prefix=custom.tool:",
       })
-  class CamundaExporterWithCustomTools {
+  class CamundaExporterWithCustomExtensionProperties {
     @Test
-    void shouldApplyToolsConfigToCamundaExporter(
+    void shouldApplyExtensionPropertiesConfigToCamundaExporter(
         @Autowired final BrokerBasedProperties brokerBasedProperties) {
       final var exporter = brokerBasedProperties.getCamundaExporter();
       final var config =
           ExporterConfiguration.fromArgs(
               io.camunda.exporter.config.ExporterConfiguration.class, exporter.getArgs());
 
-      assertThat(config.getExtensionProperties().getExtensionPropertyToolName())
+      assertThat(config.getExtensionProperties().getToolNameProperty())
           .isEqualTo("custom.tool:name");
-      assertThat(config.getExtensionProperties().getExtensionPropertyInboundConnectorType())
+      assertThat(config.getExtensionProperties().getInboundConnectorTypeProperty())
           .isEqualTo("custom.inbound.type");
-      assertThat(config.getExtensionProperties().getExtensionPropertyPrefixToolProperties())
+      assertThat(config.getExtensionProperties().getToolPropertiesPrefix())
           .isEqualTo("custom.tool:");
     }
   }
@@ -76,21 +76,21 @@ class DataToolsTest {
       properties = {
         "camunda.data.secondary-storage.type=elasticsearch",
       })
-  class CamundaExporterWithDefaultTools {
+  class CamundaExporterWithDefaultExtensionProperties {
     @Test
-    void shouldApplyDefaultToolsConfigToCamundaExporter(
+    void shouldApplyDefaultExtensionPropertiesConfigToCamundaExporter(
         @Autowired final BrokerBasedProperties brokerBasedProperties) {
       final var exporter = brokerBasedProperties.getCamundaExporter();
       final var config =
           ExporterConfiguration.fromArgs(
               io.camunda.exporter.config.ExporterConfiguration.class, exporter.getArgs());
 
-      assertThat(config.getExtensionProperties().getExtensionPropertyToolName())
-          .isEqualTo(ExtensionProperties.DEFAULT_EXTENSION_PROPERTY_TOOL_NAME);
-      assertThat(config.getExtensionProperties().getExtensionPropertyInboundConnectorType())
-          .isEqualTo(ExtensionProperties.DEFAULT_EXTENSION_PROPERTY_INBOUND_CONNECTOR_TYPE);
-      assertThat(config.getExtensionProperties().getExtensionPropertyPrefixToolProperties())
-          .isEqualTo(ExtensionProperties.DEFAULT_EXTENSION_PROPERTY_PREFIX_TOOL_PROPERTIES);
+      assertThat(config.getExtensionProperties().getToolNameProperty())
+          .isEqualTo(ExtensionProperties.DEFAULT_TOOL_NAME_PROPERTY);
+      assertThat(config.getExtensionProperties().getInboundConnectorTypeProperty())
+          .isEqualTo(ExtensionProperties.DEFAULT_INBOUND_CONNECTOR_TYPE_PROPERTY);
+      assertThat(config.getExtensionProperties().getToolPropertiesPrefix())
+          .isEqualTo(ExtensionProperties.DEFAULT_TOOL_PROPERTIES_PREFIX);
     }
   }
 
@@ -104,24 +104,24 @@ class DataToolsTest {
   @TestPropertySource(
       properties = {
         "camunda.data.secondary-storage.type=rdbms",
-        "camunda.data.extension-properties.extension-property-tool-name=custom.tool:name",
-        "camunda.data.extension-properties.extension-property-inbound-connector-type=custom.inbound.type",
-        "camunda.data.extension-properties.extension-property-prefix-tool-properties=custom.tool:",
+        "camunda.data.extension-properties.tool-name-property=custom.tool:name",
+        "camunda.data.extension-properties.inbound-connector-type-property=custom.inbound.type",
+        "camunda.data.extension-properties.tool-properties-prefix=custom.tool:",
       })
-  class RdbmsExporterWithCustomTools {
+  class RdbmsExporterWithCustomExtensionProperties {
     @Test
-    void shouldApplyToolsConfigToRdbmsExporter(
+    void shouldApplyExtensionPropertiesConfigToRdbmsExporter(
         @Autowired final BrokerBasedProperties brokerBasedProperties) {
       final var exporter = brokerBasedProperties.getRdbmsExporter();
       final var config =
           ExporterConfiguration.fromArgs(
               io.camunda.exporter.rdbms.ExporterConfiguration.class, exporter.getArgs());
 
-      assertThat(config.getExtensionProperties().getExtensionPropertyToolName())
+      assertThat(config.getExtensionProperties().getToolNameProperty())
           .isEqualTo("custom.tool:name");
-      assertThat(config.getExtensionProperties().getExtensionPropertyInboundConnectorType())
+      assertThat(config.getExtensionProperties().getInboundConnectorTypeProperty())
           .isEqualTo("custom.inbound.type");
-      assertThat(config.getExtensionProperties().getExtensionPropertyPrefixToolProperties())
+      assertThat(config.getExtensionProperties().getToolPropertiesPrefix())
           .isEqualTo("custom.tool:");
     }
   }
@@ -137,21 +137,21 @@ class DataToolsTest {
       properties = {
         "camunda.data.secondary-storage.type=rdbms",
       })
-  class RdbmsExporterWithDefaultTools {
+  class RdbmsExporterWithDefaultExtensionProperties {
     @Test
-    void shouldApplyDefaultToolsConfigToRdbmsExporter(
+    void shouldApplyDefaultExtensionPropertiesConfigToRdbmsExporter(
         @Autowired final BrokerBasedProperties brokerBasedProperties) {
       final var exporter = brokerBasedProperties.getRdbmsExporter();
       final var config =
           ExporterConfiguration.fromArgs(
               io.camunda.exporter.rdbms.ExporterConfiguration.class, exporter.getArgs());
 
-      assertThat(config.getExtensionProperties().getExtensionPropertyToolName())
-          .isEqualTo(ExtensionProperties.DEFAULT_EXTENSION_PROPERTY_TOOL_NAME);
-      assertThat(config.getExtensionProperties().getExtensionPropertyInboundConnectorType())
-          .isEqualTo(ExtensionProperties.DEFAULT_EXTENSION_PROPERTY_INBOUND_CONNECTOR_TYPE);
-      assertThat(config.getExtensionProperties().getExtensionPropertyPrefixToolProperties())
-          .isEqualTo(ExtensionProperties.DEFAULT_EXTENSION_PROPERTY_PREFIX_TOOL_PROPERTIES);
+      assertThat(config.getExtensionProperties().getToolNameProperty())
+          .isEqualTo(ExtensionProperties.DEFAULT_TOOL_NAME_PROPERTY);
+      assertThat(config.getExtensionProperties().getInboundConnectorTypeProperty())
+          .isEqualTo(ExtensionProperties.DEFAULT_INBOUND_CONNECTOR_TYPE_PROPERTY);
+      assertThat(config.getExtensionProperties().getToolPropertiesPrefix())
+          .isEqualTo(ExtensionProperties.DEFAULT_TOOL_PROPERTIES_PREFIX);
     }
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/DataToolsTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/DataToolsTest.java
@@ -23,14 +23,14 @@ class DataToolsTest {
 
   @Test
   void shouldHaveDefaults() {
-    final Tools tools = new Tools();
+    final ExtensionProperties extensionProperties = new ExtensionProperties();
 
-    assertThat(tools.getExtensionPropertyToolName())
-        .isEqualTo(Tools.DEFAULT_EXTENSION_PROPERTY_TOOL_NAME);
-    assertThat(tools.getExtensionPropertyInboundConnectorType())
-        .isEqualTo(Tools.DEFAULT_EXTENSION_PROPERTY_INBOUND_CONNECTOR_TYPE);
-    assertThat(tools.getExtensionPropertyPrefixToolProperties())
-        .isEqualTo(Tools.DEFAULT_EXTENSION_PROPERTY_PREFIX_TOOL_PROPERTIES);
+    assertThat(extensionProperties.getExtensionPropertyToolName())
+        .isEqualTo(ExtensionProperties.DEFAULT_EXTENSION_PROPERTY_TOOL_NAME);
+    assertThat(extensionProperties.getExtensionPropertyInboundConnectorType())
+        .isEqualTo(ExtensionProperties.DEFAULT_EXTENSION_PROPERTY_INBOUND_CONNECTOR_TYPE);
+    assertThat(extensionProperties.getExtensionPropertyPrefixToolProperties())
+        .isEqualTo(ExtensionProperties.DEFAULT_EXTENSION_PROPERTY_PREFIX_TOOL_PROPERTIES);
   }
 
   @Nested
@@ -43,9 +43,9 @@ class DataToolsTest {
   @TestPropertySource(
       properties = {
         "camunda.data.secondary-storage.type=elasticsearch",
-        "camunda.data.tools.extension-property-tool-name=custom.tool:name",
-        "camunda.data.tools.extension-property-inbound-connector-type=custom.inbound.type",
-        "camunda.data.tools.extension-property-prefix-tool-properties=custom.tool:",
+        "camunda.data.extension-properties.extension-property-tool-name=custom.tool:name",
+        "camunda.data.extension-properties.extension-property-inbound-connector-type=custom.inbound.type",
+        "camunda.data.extension-properties.extension-property-prefix-tool-properties=custom.tool:",
       })
   class CamundaExporterWithCustomTools {
     @Test
@@ -56,10 +56,11 @@ class DataToolsTest {
           ExporterConfiguration.fromArgs(
               io.camunda.exporter.config.ExporterConfiguration.class, exporter.getArgs());
 
-      assertThat(config.getTools().getExtensionPropertyToolName()).isEqualTo("custom.tool:name");
-      assertThat(config.getTools().getExtensionPropertyInboundConnectorType())
+      assertThat(config.getExtensionProperties().getExtensionPropertyToolName())
+          .isEqualTo("custom.tool:name");
+      assertThat(config.getExtensionProperties().getExtensionPropertyInboundConnectorType())
           .isEqualTo("custom.inbound.type");
-      assertThat(config.getTools().getExtensionPropertyPrefixToolProperties())
+      assertThat(config.getExtensionProperties().getExtensionPropertyPrefixToolProperties())
           .isEqualTo("custom.tool:");
     }
   }
@@ -84,12 +85,12 @@ class DataToolsTest {
           ExporterConfiguration.fromArgs(
               io.camunda.exporter.config.ExporterConfiguration.class, exporter.getArgs());
 
-      assertThat(config.getTools().getExtensionPropertyToolName())
-          .isEqualTo(Tools.DEFAULT_EXTENSION_PROPERTY_TOOL_NAME);
-      assertThat(config.getTools().getExtensionPropertyInboundConnectorType())
-          .isEqualTo(Tools.DEFAULT_EXTENSION_PROPERTY_INBOUND_CONNECTOR_TYPE);
-      assertThat(config.getTools().getExtensionPropertyPrefixToolProperties())
-          .isEqualTo(Tools.DEFAULT_EXTENSION_PROPERTY_PREFIX_TOOL_PROPERTIES);
+      assertThat(config.getExtensionProperties().getExtensionPropertyToolName())
+          .isEqualTo(ExtensionProperties.DEFAULT_EXTENSION_PROPERTY_TOOL_NAME);
+      assertThat(config.getExtensionProperties().getExtensionPropertyInboundConnectorType())
+          .isEqualTo(ExtensionProperties.DEFAULT_EXTENSION_PROPERTY_INBOUND_CONNECTOR_TYPE);
+      assertThat(config.getExtensionProperties().getExtensionPropertyPrefixToolProperties())
+          .isEqualTo(ExtensionProperties.DEFAULT_EXTENSION_PROPERTY_PREFIX_TOOL_PROPERTIES);
     }
   }
 
@@ -103,9 +104,9 @@ class DataToolsTest {
   @TestPropertySource(
       properties = {
         "camunda.data.secondary-storage.type=rdbms",
-        "camunda.data.tools.extension-property-tool-name=custom.tool:name",
-        "camunda.data.tools.extension-property-inbound-connector-type=custom.inbound.type",
-        "camunda.data.tools.extension-property-prefix-tool-properties=custom.tool:",
+        "camunda.data.extension-properties.extension-property-tool-name=custom.tool:name",
+        "camunda.data.extension-properties.extension-property-inbound-connector-type=custom.inbound.type",
+        "camunda.data.extension-properties.extension-property-prefix-tool-properties=custom.tool:",
       })
   class RdbmsExporterWithCustomTools {
     @Test
@@ -116,10 +117,11 @@ class DataToolsTest {
           ExporterConfiguration.fromArgs(
               io.camunda.exporter.rdbms.ExporterConfiguration.class, exporter.getArgs());
 
-      assertThat(config.getTools().getExtensionPropertyToolName()).isEqualTo("custom.tool:name");
-      assertThat(config.getTools().getExtensionPropertyInboundConnectorType())
+      assertThat(config.getExtensionProperties().getExtensionPropertyToolName())
+          .isEqualTo("custom.tool:name");
+      assertThat(config.getExtensionProperties().getExtensionPropertyInboundConnectorType())
           .isEqualTo("custom.inbound.type");
-      assertThat(config.getTools().getExtensionPropertyPrefixToolProperties())
+      assertThat(config.getExtensionProperties().getExtensionPropertyPrefixToolProperties())
           .isEqualTo("custom.tool:");
     }
   }
@@ -144,12 +146,12 @@ class DataToolsTest {
           ExporterConfiguration.fromArgs(
               io.camunda.exporter.rdbms.ExporterConfiguration.class, exporter.getArgs());
 
-      assertThat(config.getTools().getExtensionPropertyToolName())
-          .isEqualTo(Tools.DEFAULT_EXTENSION_PROPERTY_TOOL_NAME);
-      assertThat(config.getTools().getExtensionPropertyInboundConnectorType())
-          .isEqualTo(Tools.DEFAULT_EXTENSION_PROPERTY_INBOUND_CONNECTOR_TYPE);
-      assertThat(config.getTools().getExtensionPropertyPrefixToolProperties())
-          .isEqualTo(Tools.DEFAULT_EXTENSION_PROPERTY_PREFIX_TOOL_PROPERTIES);
+      assertThat(config.getExtensionProperties().getExtensionPropertyToolName())
+          .isEqualTo(ExtensionProperties.DEFAULT_EXTENSION_PROPERTY_TOOL_NAME);
+      assertThat(config.getExtensionProperties().getExtensionPropertyInboundConnectorType())
+          .isEqualTo(ExtensionProperties.DEFAULT_EXTENSION_PROPERTY_INBOUND_CONNECTOR_TYPE);
+      assertThat(config.getExtensionProperties().getExtensionPropertyPrefixToolProperties())
+          .isEqualTo(ExtensionProperties.DEFAULT_EXTENSION_PROPERTY_PREFIX_TOOL_PROPERTIES);
     }
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriters.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriters.java
@@ -164,7 +164,8 @@ public class RdbmsWriters {
         UsageMetricTUWriter.class, new UsageMetricTUWriter(executionQueue, usageMetricTUMapper));
     writers.put(
         MessageSubscriptionWriter.class,
-        new MessageSubscriptionWriter(executionQueue, messageSubscriptionMapper));
+        new MessageSubscriptionWriter(
+            executionQueue, messageSubscriptionMapper, vendorDatabaseProperties));
     writers.put(
         CorrelatedMessageSubscriptionWriter.class,
         new CorrelatedMessageSubscriptionWriter(

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/MessageSubscriptionDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/MessageSubscriptionDbModel.java
@@ -8,6 +8,7 @@
 package io.camunda.db.rdbms.write.domain;
 
 import io.camunda.db.rdbms.write.util.MapSerializer;
+import io.camunda.db.rdbms.write.util.TruncateUtil;
 import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionState;
 import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionType;
 import io.camunda.util.ObjectBuilder;
@@ -239,6 +240,15 @@ public class MessageSubscriptionDbModel implements Copyable<MessageSubscriptionD
   public MessageSubscriptionDbModel partitionId(final int partitionId) {
     this.partitionId = partitionId;
     return this;
+  }
+
+  public void truncateToolFields(final int sizeLimit, final Integer byteLimit) {
+    if (TruncateUtil.shouldTruncate(toolName, sizeLimit, byteLimit)) {
+      toolName = TruncateUtil.truncateValue(toolName, sizeLimit, byteLimit);
+    }
+    if (TruncateUtil.shouldTruncate(inboundConnectorType, sizeLimit, byteLimit)) {
+      inboundConnectorType = TruncateUtil.truncateValue(inboundConnectorType, sizeLimit, byteLimit);
+    }
   }
 
   @Override

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/MessageSubscriptionWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/MessageSubscriptionWriter.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.write.service;
 
+import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.sql.MessageSubscriptionMapper;
 import io.camunda.db.rdbms.write.domain.MessageSubscriptionDbModel;
 import io.camunda.db.rdbms.write.queue.ContextType;
@@ -17,14 +18,21 @@ import io.camunda.db.rdbms.write.queue.WriteStatementType;
 public class MessageSubscriptionWriter extends ProcessInstanceDependant implements RdbmsWriter {
 
   private final ExecutionQueue executionQueue;
+  private final VendorDatabaseProperties vendorDatabaseProperties;
 
   public MessageSubscriptionWriter(
-      final ExecutionQueue executionQueue, final MessageSubscriptionMapper mapper) {
+      final ExecutionQueue executionQueue,
+      final MessageSubscriptionMapper mapper,
+      final VendorDatabaseProperties vendorDatabaseProperties) {
     super(mapper);
     this.executionQueue = executionQueue;
+    this.vendorDatabaseProperties = vendorDatabaseProperties;
   }
 
   public void create(final MessageSubscriptionDbModel messageSubscription) {
+    messageSubscription.truncateToolFields(
+        vendorDatabaseProperties.userCharColumnSize(),
+        vendorDatabaseProperties.charColumnMaxBytes());
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.MESSAGE_SUBSCRIPTION,
@@ -35,6 +43,9 @@ public class MessageSubscriptionWriter extends ProcessInstanceDependant implemen
   }
 
   public void update(final MessageSubscriptionDbModel messageSubscription) {
+    messageSubscription.truncateToolFields(
+        vendorDatabaseProperties.userCharColumnSize(),
+        vendorDatabaseProperties.charColumnMaxBytes());
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.MESSAGE_SUBSCRIPTION,

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/MessageSubscriptionWriterTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/MessageSubscriptionWriterTest.java
@@ -7,10 +7,13 @@
  */
 package io.camunda.db.rdbms.write.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.sql.MessageSubscriptionMapper;
 import io.camunda.db.rdbms.write.domain.MessageSubscriptionDbModel;
 import io.camunda.db.rdbms.write.queue.ContextType;
@@ -23,8 +26,15 @@ class MessageSubscriptionWriterTest {
 
   private final ExecutionQueue executionQueue = mock(ExecutionQueue.class);
   private final MessageSubscriptionMapper mapper = mock(MessageSubscriptionMapper.class);
+  private final VendorDatabaseProperties vendorDatabaseProperties =
+      mock(VendorDatabaseProperties.class);
   private final MessageSubscriptionWriter writer =
-      new MessageSubscriptionWriter(executionQueue, mapper);
+      new MessageSubscriptionWriter(executionQueue, mapper, vendorDatabaseProperties);
+
+  MessageSubscriptionWriterTest() {
+    when(vendorDatabaseProperties.userCharColumnSize()).thenReturn(Integer.MAX_VALUE);
+    when(vendorDatabaseProperties.charColumnMaxBytes()).thenReturn(null);
+  }
 
   @Test
   void shouldCreateMessageSubscription() {
@@ -58,5 +68,62 @@ class MessageSubscriptionWriterTest {
                     model.messageSubscriptionKey(),
                     "io.camunda.db.rdbms.sql.MessageSubscriptionMapper.update",
                     model)));
+  }
+
+  @Test
+  void shouldNotTruncateToolFieldsWhenWithinLimit() {
+    // given
+    when(vendorDatabaseProperties.userCharColumnSize()).thenReturn(100);
+    final var model =
+        new MessageSubscriptionDbModel.Builder()
+            .messageSubscriptionKey(1L)
+            .toolName("short")
+            .inboundConnectorType("short")
+            .build();
+
+    // when
+    writer.create(model);
+
+    // then
+    assertThat(model.toolName()).isEqualTo("short");
+    assertThat(model.inboundConnectorType()).isEqualTo("short");
+  }
+
+  @Test
+  void shouldTruncateToolNameAndInboundConnectorTypeOnCreateWhenExceedingCharLimit() {
+    // given
+    when(vendorDatabaseProperties.userCharColumnSize()).thenReturn(5);
+    final var model =
+        new MessageSubscriptionDbModel.Builder()
+            .messageSubscriptionKey(1L)
+            .toolName("toolname-exceeds-limit")
+            .inboundConnectorType("connector-exceeds-limit")
+            .build();
+
+    // when
+    writer.create(model);
+
+    // then
+    assertThat(model.toolName()).hasSize(5);
+    assertThat(model.inboundConnectorType()).hasSize(5);
+  }
+
+  @Test
+  void shouldTruncateToolFieldsOnUpdateWhenExceedingCharLimit() {
+    // given
+    when(vendorDatabaseProperties.userCharColumnSize()).thenReturn(5);
+    final var model =
+        new MessageSubscriptionDbModel.Builder()
+            .messageSubscriptionKey(1L)
+            .toolName("toolname-exceeds-limit")
+            .inboundConnectorType("connector-exceeds-limit")
+            .build();
+
+    // when
+    writer.update(model);
+
+    // then
+    assertThat(model.toolName()).hasSize(5);
+    assertThat(model.inboundConnectorType()).hasSize(5);
   }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/extensionproperty/ExtensionPropertyConfiguration.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/extensionproperty/ExtensionPropertyConfiguration.java
@@ -12,48 +12,44 @@ import java.util.function.Predicate;
 /** Exporter-side configuration for which BPMN extension properties map to tool attributes. */
 public class ExtensionPropertyConfiguration {
 
-  public static final String DEFAULT_EXTENSION_PROPERTY_TOOL_NAME = "io.camunda.tool:name";
-  public static final String DEFAULT_EXTENSION_PROPERTY_INBOUND_CONNECTOR_TYPE = "inbound.type";
-  public static final String DEFAULT_EXTENSION_PROPERTY_PREFIX_TOOL_PROPERTIES = "io.camunda.tool:";
+  public static final String DEFAULT_TOOL_NAME_PROPERTY = "io.camunda.tool:name";
+  public static final String DEFAULT_INBOUND_CONNECTOR_TYPE_PROPERTY = "inbound.type";
+  public static final String DEFAULT_TOOL_PROPERTIES_PREFIX = "io.camunda.tool:";
 
-  private String extensionPropertyToolName = DEFAULT_EXTENSION_PROPERTY_TOOL_NAME;
-  private String extensionPropertyInboundConnectorType =
-      DEFAULT_EXTENSION_PROPERTY_INBOUND_CONNECTOR_TYPE;
-  private String extensionPropertyPrefixToolProperties =
-      DEFAULT_EXTENSION_PROPERTY_PREFIX_TOOL_PROPERTIES;
+  private String toolNameProperty = DEFAULT_TOOL_NAME_PROPERTY;
+  private String inboundConnectorTypeProperty = DEFAULT_INBOUND_CONNECTOR_TYPE_PROPERTY;
+  private String toolPropertiesPrefix = DEFAULT_TOOL_PROPERTIES_PREFIX;
 
-  public String getExtensionPropertyToolName() {
-    return extensionPropertyToolName;
+  public String getToolNameProperty() {
+    return toolNameProperty;
   }
 
-  public void setExtensionPropertyToolName(final String extensionPropertyToolName) {
-    this.extensionPropertyToolName = extensionPropertyToolName;
+  public void setToolNameProperty(final String toolNameProperty) {
+    this.toolNameProperty = toolNameProperty;
   }
 
-  public String getExtensionPropertyInboundConnectorType() {
-    return extensionPropertyInboundConnectorType;
+  public String getInboundConnectorTypeProperty() {
+    return inboundConnectorTypeProperty;
   }
 
-  public void setExtensionPropertyInboundConnectorType(
-      final String extensionPropertyInboundConnectorType) {
-    this.extensionPropertyInboundConnectorType = extensionPropertyInboundConnectorType;
+  public void setInboundConnectorTypeProperty(final String inboundConnectorTypeProperty) {
+    this.inboundConnectorTypeProperty = inboundConnectorTypeProperty;
   }
 
-  public String getExtensionPropertyPrefixToolProperties() {
-    return extensionPropertyPrefixToolProperties;
+  public String getToolPropertiesPrefix() {
+    return toolPropertiesPrefix;
   }
 
-  public void setExtensionPropertyPrefixToolProperties(
-      final String extensionPropertyPrefixToolProperties) {
-    this.extensionPropertyPrefixToolProperties = extensionPropertyPrefixToolProperties;
+  public void setToolPropertiesPrefix(final String toolPropertiesPrefix) {
+    this.toolPropertiesPrefix = toolPropertiesPrefix;
   }
 
   public Predicate<String> extensionPropertyFilter() {
     return name ->
-        name.equals(extensionPropertyToolName)
-            || name.equals(extensionPropertyInboundConnectorType)
-            || (extensionPropertyPrefixToolProperties != null
-                && !extensionPropertyPrefixToolProperties.isBlank()
-                && name.startsWith(extensionPropertyPrefixToolProperties));
+        name.equals(toolNameProperty)
+            || name.equals(inboundConnectorTypeProperty)
+            || (toolPropertiesPrefix != null
+                && !toolPropertiesPrefix.isBlank()
+                && name.startsWith(toolPropertiesPrefix));
   }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/extensionproperty/ExtensionPropertyConfiguration.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/extensionproperty/ExtensionPropertyConfiguration.java
@@ -5,12 +5,12 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.zeebe.exporter.common.tools;
+package io.camunda.zeebe.exporter.common.extensionproperty;
 
 import java.util.function.Predicate;
 
 /** Exporter-side configuration for which BPMN extension properties map to tool attributes. */
-public class ToolsConfiguration {
+public class ExtensionPropertyConfiguration {
 
   public static final String DEFAULT_EXTENSION_PROPERTY_TOOL_NAME = "io.camunda.tool:name";
   public static final String DEFAULT_EXTENSION_PROPERTY_INBOUND_CONNECTOR_TYPE = "inbound.type";

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/tools/ToolsConfiguration.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/tools/ToolsConfiguration.java
@@ -52,6 +52,8 @@ public class ToolsConfiguration {
     return name ->
         name.equals(extensionPropertyToolName)
             || name.equals(extensionPropertyInboundConnectorType)
-            || name.startsWith(extensionPropertyPrefixToolProperties);
+            || (extensionPropertyPrefixToolProperties != null
+                && !extensionPropertyPrefixToolProperties.isBlank()
+                && name.startsWith(extensionPropertyPrefixToolProperties));
   }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/tools/ToolsConfiguration.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/tools/ToolsConfiguration.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.exporter.common.tools;
 
+import java.util.function.Predicate;
+
 /** Exporter-side configuration for which BPMN extension properties map to tool attributes. */
 public class ToolsConfiguration {
 
@@ -44,5 +46,12 @@ public class ToolsConfiguration {
   public void setExtensionPropertyPrefixToolProperties(
       final String extensionPropertyPrefixToolProperties) {
     this.extensionPropertyPrefixToolProperties = extensionPropertyPrefixToolProperties;
+  }
+
+  public Predicate<String> extensionPropertyFilter() {
+    return name ->
+        name.equals(extensionPropertyToolName)
+            || name.equals(extensionPropertyInboundConnectorType)
+            || name.startsWith(extensionPropertyPrefixToolProperties);
   }
 }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/utils/ProcessCacheUtil.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/utils/ProcessCacheUtil.java
@@ -92,16 +92,16 @@ public final class ProcessCacheUtil {
    * Returns relevant data from process diagram
    *
    * @param processDefinitionEntity
-   * @param toolsConfiguration configured tool extension property names
+   * @param extensionPropertiesConfiguration configured tool extension property names
    * @return ProcessDiagramData
    */
   public static ProcessDiagramData extractProcessDiagramData(
       final ProcessDefinitionEntity processDefinitionEntity,
-      final ExtensionPropertyConfiguration toolsConfiguration) {
+      final ExtensionPropertyConfiguration extensionPropertiesConfiguration) {
     return extractProcessDiagramData(
         processDefinitionEntity.bpmnXml(),
         processDefinitionEntity.processDefinitionId(),
-        toolsConfiguration);
+        extensionPropertiesConfiguration);
   }
 
   /**
@@ -109,13 +109,13 @@ public final class ProcessCacheUtil {
    *
    * @param bpmnXml
    * @param bpmnProcessId
-   * @param toolsConfiguration configured tool extension property names
+   * @param extensionPropertiesConfiguration configured tool extension property names
    * @return ProcessDiagramData
    */
   public static ProcessDiagramData extractProcessDiagramData(
       final String bpmnXml,
       final String bpmnProcessId,
-      final ExtensionPropertyConfiguration toolsConfiguration) {
+      final ExtensionPropertyConfiguration extensionPropertiesConfiguration) {
 
     final ProcessModelReader reader =
         ProcessModelReader.of(bpmnXml.getBytes(StandardCharsets.UTF_8), bpmnProcessId).orElse(null);
@@ -127,7 +127,7 @@ public final class ProcessCacheUtil {
       final boolean hasUserTasks = ProcessModelReader.hasUserTasks(flowNodes);
       final Map<String, Map<String, String>> elementExtensionProperties =
           ProcessModelReader.extractExtensionProperties(
-              flowNodes, toolsConfiguration.extensionPropertyFilter());
+              flowNodes, extensionPropertiesConfiguration.extensionPropertyFilter());
       return new ProcessDiagramData(
           callActivityIds, flowNodesMap, hasUserTasks, elementExtensionProperties);
     }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/utils/ProcessCacheUtil.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/utils/ProcessCacheUtil.java
@@ -11,6 +11,7 @@ import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
 import io.camunda.zeebe.exporter.common.cache.process.ProcessDiagramData;
+import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
 import io.camunda.zeebe.model.bpmn.instance.BaseElement;
 import io.camunda.zeebe.model.bpmn.instance.CallActivity;
 import io.camunda.zeebe.model.bpmn.instance.FlowNode;
@@ -91,12 +92,16 @@ public final class ProcessCacheUtil {
    * Returns relevant data from process diagram
    *
    * @param processDefinitionEntity
+   * @param toolsConfiguration configured tool extension property names
    * @return ProcessDiagramData
    */
   public static ProcessDiagramData extractProcessDiagramData(
-      final ProcessDefinitionEntity processDefinitionEntity) {
+      final ProcessDefinitionEntity processDefinitionEntity,
+      final ToolsConfiguration toolsConfiguration) {
     return extractProcessDiagramData(
-        processDefinitionEntity.bpmnXml(), processDefinitionEntity.processDefinitionId());
+        processDefinitionEntity.bpmnXml(),
+        processDefinitionEntity.processDefinitionId(),
+        toolsConfiguration);
   }
 
   /**
@@ -104,10 +109,13 @@ public final class ProcessCacheUtil {
    *
    * @param bpmnXml
    * @param bpmnProcessId
+   * @param toolsConfiguration configured tool extension property names
    * @return ProcessDiagramData
    */
   public static ProcessDiagramData extractProcessDiagramData(
-      final String bpmnXml, final String bpmnProcessId) {
+      final String bpmnXml,
+      final String bpmnProcessId,
+      final ToolsConfiguration toolsConfiguration) {
 
     final ProcessModelReader reader =
         ProcessModelReader.of(bpmnXml.getBytes(StandardCharsets.UTF_8), bpmnProcessId).orElse(null);
@@ -118,7 +126,8 @@ public final class ProcessCacheUtil {
       final Map<String, String> flowNodesMap = getFlowNodesMap(flowNodes);
       final boolean hasUserTasks = ProcessModelReader.hasUserTasks(flowNodes);
       final Map<String, Map<String, String>> elementExtensionProperties =
-          ProcessModelReader.extractExtensionProperties(flowNodes);
+          ProcessModelReader.extractExtensionProperties(
+              flowNodes, toolsConfiguration.extensionPropertyFilter());
       return new ProcessDiagramData(
           callActivityIds, flowNodesMap, hasUserTasks, elementExtensionProperties);
     }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/utils/ProcessCacheUtil.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/utils/ProcessCacheUtil.java
@@ -11,7 +11,7 @@ import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
 import io.camunda.zeebe.exporter.common.cache.process.ProcessDiagramData;
-import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
+import io.camunda.zeebe.exporter.common.extensionproperty.ExtensionPropertyConfiguration;
 import io.camunda.zeebe.model.bpmn.instance.BaseElement;
 import io.camunda.zeebe.model.bpmn.instance.CallActivity;
 import io.camunda.zeebe.model.bpmn.instance.FlowNode;
@@ -97,7 +97,7 @@ public final class ProcessCacheUtil {
    */
   public static ProcessDiagramData extractProcessDiagramData(
       final ProcessDefinitionEntity processDefinitionEntity,
-      final ToolsConfiguration toolsConfiguration) {
+      final ExtensionPropertyConfiguration toolsConfiguration) {
     return extractProcessDiagramData(
         processDefinitionEntity.bpmnXml(),
         processDefinitionEntity.processDefinitionId(),
@@ -115,7 +115,7 @@ public final class ProcessCacheUtil {
   public static ProcessDiagramData extractProcessDiagramData(
       final String bpmnXml,
       final String bpmnProcessId,
-      final ToolsConfiguration toolsConfiguration) {
+      final ExtensionPropertyConfiguration toolsConfiguration) {
 
     final ProcessModelReader reader =
         ProcessModelReader.of(bpmnXml.getBytes(StandardCharsets.UTF_8), bpmnProcessId).orElse(null);

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/utils/ProcessCacheUtilTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/utils/ProcessCacheUtilTest.java
@@ -102,11 +102,61 @@ public class ProcessCacheUtilTest {
 
     // then — only tool-related keys are retained
     assertThat(task1Props)
-        .containsKey(config.getExtensionPropertyToolName())
-        .containsKey("io.camunda.tool:description")
-        .containsKey(config.getExtensionPropertyInboundConnectorType())
-        .doesNotContainKey("unrelated.property")
-        .doesNotContainKey("another.unrelated");
+        .containsOnlyKeys(
+            config.getExtensionPropertyToolName(),
+            "io.camunda.tool:description",
+            config.getExtensionPropertyInboundConnectorType());
+  }
+
+  @Test
+  void shouldNotMatchAnyPropertyWhenPrefixIsNull() {
+    // given — prefix set to null; only exact-match keys should be retained
+    final String processId = "nullPrefixProcess";
+    final var config = new ToolsConfiguration();
+    config.setExtensionPropertyPrefixToolProperties(null);
+    final BpmnModelInstance model =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .serviceTask("task1")
+            .zeebeJobType("worker")
+            .zeebeProperty(config.getExtensionPropertyToolName(), "myTool")
+            .zeebeProperty("io.camunda.tool:description", "wouldMatchDefaultPrefix")
+            .zeebeProperty("unrelated.property", "filtered")
+            .endEvent()
+            .done();
+
+    // when
+    final var diagramData =
+        ProcessCacheUtil.extractProcessDiagramData(Bpmn.convertToString(model), processId, config);
+    final var task1Props = diagramData.elementExtensionProperties().get("task1");
+
+    // then — only the exact toolName key is retained; prefix-based match is skipped
+    assertThat(task1Props).containsOnlyKeys(config.getExtensionPropertyToolName());
+  }
+
+  @Test
+  void shouldNotMatchAnyPropertyWhenPrefixIsBlank() {
+    // given — blank prefix would match every property name via startsWith(""), guard against it
+    final String processId = "blankPrefixProcess";
+    final var config = new ToolsConfiguration();
+    config.setExtensionPropertyPrefixToolProperties("  ");
+    final BpmnModelInstance model =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .serviceTask("task1")
+            .zeebeJobType("worker")
+            .zeebeProperty(config.getExtensionPropertyToolName(), "myTool")
+            .zeebeProperty("unrelated.property", "filtered")
+            .endEvent()
+            .done();
+
+    // when
+    final var diagramData =
+        ProcessCacheUtil.extractProcessDiagramData(Bpmn.convertToString(model), processId, config);
+    final var task1Props = diagramData.elementExtensionProperties().get("task1");
+
+    // then — only the exact toolName key is retained; blank prefix does not match everything
+    assertThat(task1Props).containsOnlyKeys(config.getExtensionPropertyToolName());
   }
 
   private BpmnModelInstance buildModel(final String processId, final List<String> callActivities) {

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/utils/ProcessCacheUtilTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/utils/ProcessCacheUtilTest.java
@@ -88,9 +88,9 @@ public class ProcessCacheUtilTest {
             .startEvent()
             .serviceTask("task1")
             .zeebeJobType("worker")
-            .zeebeProperty(config.getExtensionPropertyToolName(), "myTool")
+            .zeebeProperty(config.getToolNameProperty(), "myTool")
             .zeebeProperty("io.camunda.tool:description", "toolDesc")
-            .zeebeProperty(config.getExtensionPropertyInboundConnectorType(), "connector")
+            .zeebeProperty(config.getInboundConnectorTypeProperty(), "connector")
             .zeebeProperty("unrelated.property", "shouldBeFiltered")
             .zeebeProperty("another.unrelated", "alsoFiltered")
             .endEvent()
@@ -104,9 +104,9 @@ public class ProcessCacheUtilTest {
     // then — only tool-related keys are retained
     assertThat(task1Props)
         .containsOnlyKeys(
-            config.getExtensionPropertyToolName(),
+            config.getToolNameProperty(),
             "io.camunda.tool:description",
-            config.getExtensionPropertyInboundConnectorType());
+            config.getInboundConnectorTypeProperty());
   }
 
   @Test
@@ -114,13 +114,13 @@ public class ProcessCacheUtilTest {
     // given — prefix set to null; only exact-match keys should be retained
     final String processId = "nullPrefixProcess";
     final var config = new ExtensionPropertyConfiguration();
-    config.setExtensionPropertyPrefixToolProperties(null);
+    config.setToolPropertiesPrefix(null);
     final BpmnModelInstance model =
         Bpmn.createExecutableProcess(processId)
             .startEvent()
             .serviceTask("task1")
             .zeebeJobType("worker")
-            .zeebeProperty(config.getExtensionPropertyToolName(), "myTool")
+            .zeebeProperty(config.getToolNameProperty(), "myTool")
             .zeebeProperty("io.camunda.tool:description", "wouldMatchDefaultPrefix")
             .zeebeProperty("unrelated.property", "filtered")
             .endEvent()
@@ -132,7 +132,7 @@ public class ProcessCacheUtilTest {
     final var task1Props = diagramData.elementExtensionProperties().get("task1");
 
     // then — only the exact toolName key is retained; prefix-based match is skipped
-    assertThat(task1Props).containsOnlyKeys(config.getExtensionPropertyToolName());
+    assertThat(task1Props).containsOnlyKeys(config.getToolNameProperty());
   }
 
   @Test
@@ -140,13 +140,13 @@ public class ProcessCacheUtilTest {
     // given — blank prefix would match every property name via startsWith(""), guard against it
     final String processId = "blankPrefixProcess";
     final var config = new ExtensionPropertyConfiguration();
-    config.setExtensionPropertyPrefixToolProperties("  ");
+    config.setToolPropertiesPrefix("  ");
     final BpmnModelInstance model =
         Bpmn.createExecutableProcess(processId)
             .startEvent()
             .serviceTask("task1")
             .zeebeJobType("worker")
-            .zeebeProperty(config.getExtensionPropertyToolName(), "myTool")
+            .zeebeProperty(config.getToolNameProperty(), "myTool")
             .zeebeProperty("unrelated.property", "filtered")
             .endEvent()
             .done();
@@ -157,7 +157,7 @@ public class ProcessCacheUtilTest {
     final var task1Props = diagramData.elementExtensionProperties().get("task1");
 
     // then — only the exact toolName key is retained; blank prefix does not match everything
-    assertThat(task1Props).containsOnlyKeys(config.getExtensionPropertyToolName());
+    assertThat(task1Props).containsOnlyKeys(config.getToolNameProperty());
   }
 
   private BpmnModelInstance buildModel(final String processId, final List<String> callActivities) {

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/utils/ProcessCacheUtilTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/utils/ProcessCacheUtilTest.java
@@ -13,7 +13,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
-import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
+import io.camunda.zeebe.exporter.common.extensionproperty.ExtensionPropertyConfiguration;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.CallActivity;
@@ -59,7 +59,8 @@ public class ProcessCacheUtilTest {
     final var bpmnXml = Bpmn.convertToString(model);
     // when
     final var callActivities =
-        ProcessCacheUtil.extractProcessDiagramData(bpmnXml, processId, new ToolsConfiguration())
+        ProcessCacheUtil.extractProcessDiagramData(
+                bpmnXml, processId, new ExtensionPropertyConfiguration())
             .callActivityIds();
     // then
     assertThat(callActivities).containsExactly("A_Activity", "C_Activity", "D_Activity");
@@ -81,7 +82,7 @@ public class ProcessCacheUtilTest {
   void shouldOnlyRetainKnownToolPropertiesInProcessCache() {
     // given — a service task with both tool-related and unrelated zeebe:properties
     final String processId = "mixedPropsProcess";
-    final var config = new ToolsConfiguration();
+    final var config = new ExtensionPropertyConfiguration();
     final BpmnModelInstance model =
         Bpmn.createExecutableProcess(processId)
             .startEvent()
@@ -112,7 +113,7 @@ public class ProcessCacheUtilTest {
   void shouldNotMatchAnyPropertyWhenPrefixIsNull() {
     // given — prefix set to null; only exact-match keys should be retained
     final String processId = "nullPrefixProcess";
-    final var config = new ToolsConfiguration();
+    final var config = new ExtensionPropertyConfiguration();
     config.setExtensionPropertyPrefixToolProperties(null);
     final BpmnModelInstance model =
         Bpmn.createExecutableProcess(processId)
@@ -138,7 +139,7 @@ public class ProcessCacheUtilTest {
   void shouldNotMatchAnyPropertyWhenPrefixIsBlank() {
     // given — blank prefix would match every property name via startsWith(""), guard against it
     final String processId = "blankPrefixProcess";
-    final var config = new ToolsConfiguration();
+    final var config = new ExtensionPropertyConfiguration();
     config.setExtensionPropertyPrefixToolProperties("  ");
     final BpmnModelInstance model =
         Bpmn.createExecutableProcess(processId)

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/utils/ProcessCacheUtilTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/utils/ProcessCacheUtilTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
+import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.CallActivity;
@@ -58,7 +59,8 @@ public class ProcessCacheUtilTest {
     final var bpmnXml = Bpmn.convertToString(model);
     // when
     final var callActivities =
-        ProcessCacheUtil.extractProcessDiagramData(bpmnXml, processId).callActivityIds();
+        ProcessCacheUtil.extractProcessDiagramData(bpmnXml, processId, new ToolsConfiguration())
+            .callActivityIds();
     // then
     assertThat(callActivities).containsExactly("A_Activity", "C_Activity", "D_Activity");
   }
@@ -73,6 +75,38 @@ public class ProcessCacheUtilTest {
     final var ids = ProcessCacheUtil.sortedCallActivityIds(callActivities);
     // then
     assertThat(ids).containsExactly("A_Activity", "C_Activity", "D_Activity");
+  }
+
+  @Test
+  void shouldOnlyRetainKnownToolPropertiesInProcessCache() {
+    // given — a service task with both tool-related and unrelated zeebe:properties
+    final String processId = "mixedPropsProcess";
+    final var config = new ToolsConfiguration();
+    final BpmnModelInstance model =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .serviceTask("task1")
+            .zeebeJobType("worker")
+            .zeebeProperty(config.getExtensionPropertyToolName(), "myTool")
+            .zeebeProperty("io.camunda.tool:description", "toolDesc")
+            .zeebeProperty(config.getExtensionPropertyInboundConnectorType(), "connector")
+            .zeebeProperty("unrelated.property", "shouldBeFiltered")
+            .zeebeProperty("another.unrelated", "alsoFiltered")
+            .endEvent()
+            .done();
+
+    // when
+    final var diagramData =
+        ProcessCacheUtil.extractProcessDiagramData(Bpmn.convertToString(model), processId, config);
+    final var task1Props = diagramData.elementExtensionProperties().get("task1");
+
+    // then — only tool-related keys are retained
+    assertThat(task1Props)
+        .containsKey(config.getExtensionPropertyToolName())
+        .containsKey("io.camunda.tool:description")
+        .containsKey(config.getExtensionPropertyInboundConnectorType())
+        .doesNotContainKey("unrelated.property")
+        .doesNotContainKey("another.unrelated");
   }
 
   private BpmnModelInstance buildModel(final String processId, final List<String> callActivities) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -191,7 +191,7 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
             configuration.getProcessCache().getMaxCacheSize(),
             entityCacheProvider.getProcessCacheLoader(
                 indexDescriptors.get(ProcessIndex.class).getFullQualifiedName(),
-                configuration.getTools()),
+                configuration.getExtensionProperties()),
             new CaffeineCacheStatsCounter(NAMESPACE, "process", meterRegistry));
 
     decisionRequirementsCache =
@@ -283,7 +283,7 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
             new ProcessHandler(
                 indexDescriptors.get(ProcessIndex.class).getFullQualifiedName(),
                 processCache,
-                configuration.getTools()),
+                configuration.getExtensionProperties()),
             new EmbeddedFormHandler(indexDescriptors.get(FormIndex.class).getFullQualifiedName()),
             new FormHandler(
                 indexDescriptors.get(FormIndex.class).getFullQualifiedName(), formCache),
@@ -293,11 +293,11 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
                 indexDescriptors.get(MessageSubscriptionTemplate.class).getFullQualifiedName(),
                 exporterMetadata,
                 processCache,
-                configuration.getTools()),
+                configuration.getExtensionProperties()),
             new MessageSubscriptionFromMessageStartEventSubscriptionHandler(
                 indexDescriptors.get(MessageSubscriptionTemplate.class).getFullQualifiedName(),
                 processCache,
-                configuration.getTools()),
+                configuration.getExtensionProperties()),
             new UserTaskCreatingHandler(
                 indexDescriptors.get(TaskTemplate.class).getFullQualifiedName(),
                 formCache,

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -190,7 +190,8 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
         new ExporterEntityCacheImpl<>(
             configuration.getProcessCache().getMaxCacheSize(),
             entityCacheProvider.getProcessCacheLoader(
-                indexDescriptors.get(ProcessIndex.class).getFullQualifiedName()),
+                indexDescriptors.get(ProcessIndex.class).getFullQualifiedName(),
+                configuration.getTools()),
             new CaffeineCacheStatsCounter(NAMESPACE, "process", meterRegistry));
 
     decisionRequirementsCache =
@@ -280,7 +281,9 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
             new DecisionEvaluationHandler(
                 indexDescriptors.get(DecisionInstanceTemplate.class).getFullQualifiedName()),
             new ProcessHandler(
-                indexDescriptors.get(ProcessIndex.class).getFullQualifiedName(), processCache),
+                indexDescriptors.get(ProcessIndex.class).getFullQualifiedName(),
+                processCache,
+                configuration.getTools()),
             new EmbeddedFormHandler(indexDescriptors.get(FormIndex.class).getFullQualifiedName()),
             new FormHandler(
                 indexDescriptors.get(FormIndex.class).getFullQualifiedName(), formCache),

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/ElasticsearchAdapter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/ElasticsearchAdapter.java
@@ -26,7 +26,7 @@ import io.camunda.search.schema.elasticsearch.ElasticsearchEngineClient;
 import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
 import io.camunda.zeebe.exporter.common.cache.decisionRequirements.CachedDecisionRequirementsEntity;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
-import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
+import io.camunda.zeebe.exporter.common.extensionproperty.ExtensionPropertyConfiguration;
 import java.io.IOException;
 
 class ElasticsearchAdapter implements ClientAdapter {
@@ -79,7 +79,7 @@ class ElasticsearchAdapter implements ClientAdapter {
 
     @Override
     public CacheLoader<Long, CachedProcessEntity> getProcessCacheLoader(
-        final String processIndexName, final ToolsConfiguration toolsConfiguration) {
+        final String processIndexName, final ExtensionPropertyConfiguration toolsConfiguration) {
       return new ElasticSearchProcessCacheLoader(client, processIndexName, toolsConfiguration);
     }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/ElasticsearchAdapter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/ElasticsearchAdapter.java
@@ -79,8 +79,10 @@ class ElasticsearchAdapter implements ClientAdapter {
 
     @Override
     public CacheLoader<Long, CachedProcessEntity> getProcessCacheLoader(
-        final String processIndexName, final ExtensionPropertyConfiguration toolsConfiguration) {
-      return new ElasticSearchProcessCacheLoader(client, processIndexName, toolsConfiguration);
+        final String processIndexName,
+        final ExtensionPropertyConfiguration extensionPropertiesConfiguration) {
+      return new ElasticSearchProcessCacheLoader(
+          client, processIndexName, extensionPropertiesConfiguration);
     }
 
     @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/ElasticsearchAdapter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/ElasticsearchAdapter.java
@@ -26,6 +26,7 @@ import io.camunda.search.schema.elasticsearch.ElasticsearchEngineClient;
 import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
 import io.camunda.zeebe.exporter.common.cache.decisionRequirements.CachedDecisionRequirementsEntity;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
+import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
 import java.io.IOException;
 
 class ElasticsearchAdapter implements ClientAdapter {
@@ -78,8 +79,8 @@ class ElasticsearchAdapter implements ClientAdapter {
 
     @Override
     public CacheLoader<Long, CachedProcessEntity> getProcessCacheLoader(
-        final String processIndexName) {
-      return new ElasticSearchProcessCacheLoader(client, processIndexName);
+        final String processIndexName, final ToolsConfiguration toolsConfiguration) {
+      return new ElasticSearchProcessCacheLoader(client, processIndexName, toolsConfiguration);
     }
 
     @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/OpensearchAdapter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/OpensearchAdapter.java
@@ -25,7 +25,7 @@ import io.camunda.search.schema.opensearch.OpensearchEngineClient;
 import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
 import io.camunda.zeebe.exporter.common.cache.decisionRequirements.CachedDecisionRequirementsEntity;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
-import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
+import io.camunda.zeebe.exporter.common.extensionproperty.ExtensionPropertyConfiguration;
 import java.io.IOException;
 import org.opensearch.client.opensearch.OpenSearchClient;
 
@@ -79,7 +79,7 @@ class OpensearchAdapter implements ClientAdapter {
 
     @Override
     public CacheLoader<Long, CachedProcessEntity> getProcessCacheLoader(
-        final String processIndexName, final ToolsConfiguration toolsConfiguration) {
+        final String processIndexName, final ExtensionPropertyConfiguration toolsConfiguration) {
       return new OpenSearchProcessCacheLoader(client, processIndexName, toolsConfiguration);
     }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/OpensearchAdapter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/OpensearchAdapter.java
@@ -79,8 +79,10 @@ class OpensearchAdapter implements ClientAdapter {
 
     @Override
     public CacheLoader<Long, CachedProcessEntity> getProcessCacheLoader(
-        final String processIndexName, final ExtensionPropertyConfiguration toolsConfiguration) {
-      return new OpenSearchProcessCacheLoader(client, processIndexName, toolsConfiguration);
+        final String processIndexName,
+        final ExtensionPropertyConfiguration extensionPropertiesConfiguration) {
+      return new OpenSearchProcessCacheLoader(
+          client, processIndexName, extensionPropertiesConfiguration);
     }
 
     @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/OpensearchAdapter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/OpensearchAdapter.java
@@ -25,6 +25,7 @@ import io.camunda.search.schema.opensearch.OpensearchEngineClient;
 import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
 import io.camunda.zeebe.exporter.common.cache.decisionRequirements.CachedDecisionRequirementsEntity;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
+import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
 import java.io.IOException;
 import org.opensearch.client.opensearch.OpenSearchClient;
 
@@ -78,8 +79,8 @@ class OpensearchAdapter implements ClientAdapter {
 
     @Override
     public CacheLoader<Long, CachedProcessEntity> getProcessCacheLoader(
-        final String processIndexName) {
-      return new OpenSearchProcessCacheLoader(client, processIndexName);
+        final String processIndexName, final ToolsConfiguration toolsConfiguration) {
+      return new OpenSearchProcessCacheLoader(client, processIndexName, toolsConfiguration);
     }
 
     @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/ExporterEntityCacheProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/ExporterEntityCacheProvider.java
@@ -20,7 +20,7 @@ public interface ExporterEntityCacheProvider {
       String batchOperationIndexName);
 
   CacheLoader<Long, CachedProcessEntity> getProcessCacheLoader(
-      String processIndexName, ExtensionPropertyConfiguration toolsConfiguration);
+      String processIndexName, ExtensionPropertyConfiguration extensionPropertiesConfiguration);
 
   CacheLoader<Long, CachedDecisionRequirementsEntity> getDecisionRequirementsCacheLoader(
       String decisionIndexName);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/ExporterEntityCacheProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/ExporterEntityCacheProvider.java
@@ -12,13 +12,15 @@ import io.camunda.exporter.cache.form.CachedFormEntity;
 import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
 import io.camunda.zeebe.exporter.common.cache.decisionRequirements.CachedDecisionRequirementsEntity;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
+import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
 
 public interface ExporterEntityCacheProvider {
 
   CacheLoader<String, CachedBatchOperationEntity> getBatchOperationCacheLoader(
       String batchOperationIndexName);
 
-  CacheLoader<Long, CachedProcessEntity> getProcessCacheLoader(String processIndexName);
+  CacheLoader<Long, CachedProcessEntity> getProcessCacheLoader(
+      String processIndexName, ToolsConfiguration toolsConfiguration);
 
   CacheLoader<Long, CachedDecisionRequirementsEntity> getDecisionRequirementsCacheLoader(
       String decisionIndexName);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/ExporterEntityCacheProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/ExporterEntityCacheProvider.java
@@ -12,7 +12,7 @@ import io.camunda.exporter.cache.form.CachedFormEntity;
 import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
 import io.camunda.zeebe.exporter.common.cache.decisionRequirements.CachedDecisionRequirementsEntity;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
-import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
+import io.camunda.zeebe.exporter.common.extensionproperty.ExtensionPropertyConfiguration;
 
 public interface ExporterEntityCacheProvider {
 
@@ -20,7 +20,7 @@ public interface ExporterEntityCacheProvider {
       String batchOperationIndexName);
 
   CacheLoader<Long, CachedProcessEntity> getProcessCacheLoader(
-      String processIndexName, ToolsConfiguration toolsConfiguration);
+      String processIndexName, ExtensionPropertyConfiguration toolsConfiguration);
 
   CacheLoader<Long, CachedDecisionRequirementsEntity> getDecisionRequirementsCacheLoader(
       String decisionIndexName);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/process/ElasticSearchProcessCacheLoader.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/process/ElasticSearchProcessCacheLoader.java
@@ -23,15 +23,15 @@ public class ElasticSearchProcessCacheLoader implements CacheLoader<Long, Cached
 
   private final ElasticsearchClient client;
   private final String processIndexName;
-  private final ExtensionPropertyConfiguration toolsConfiguration;
+  private final ExtensionPropertyConfiguration extensionPropertiesConfiguration;
 
   public ElasticSearchProcessCacheLoader(
       final ElasticsearchClient client,
       final String processIndexName,
-      final ExtensionPropertyConfiguration toolsConfiguration) {
+      final ExtensionPropertyConfiguration extensionPropertiesConfiguration) {
     this.client = client;
     this.processIndexName = processIndexName;
-    this.toolsConfiguration = toolsConfiguration;
+    this.extensionPropertiesConfiguration = extensionPropertiesConfiguration;
   }
 
   @Override
@@ -44,7 +44,9 @@ public class ElasticSearchProcessCacheLoader implements CacheLoader<Long, Cached
       final var processEntity = response.source();
       final var processDiagramData =
           ProcessCacheUtil.extractProcessDiagramData(
-              processEntity.getBpmnXml(), processEntity.getBpmnProcessId(), toolsConfiguration);
+              processEntity.getBpmnXml(),
+              processEntity.getBpmnProcessId(),
+              extensionPropertiesConfiguration);
       return new CachedProcessEntity(
           processEntity.getName(),
           processEntity.getVersion(),

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/process/ElasticSearchProcessCacheLoader.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/process/ElasticSearchProcessCacheLoader.java
@@ -11,6 +11,7 @@ import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import com.github.benmanes.caffeine.cache.CacheLoader;
 import io.camunda.webapps.schema.entities.ProcessEntity;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
+import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
 import io.camunda.zeebe.exporter.common.utils.ProcessCacheUtil;
 import java.io.IOException;
 import org.slf4j.Logger;
@@ -22,11 +23,15 @@ public class ElasticSearchProcessCacheLoader implements CacheLoader<Long, Cached
 
   private final ElasticsearchClient client;
   private final String processIndexName;
+  private final ToolsConfiguration toolsConfiguration;
 
   public ElasticSearchProcessCacheLoader(
-      final ElasticsearchClient client, final String processIndexName) {
+      final ElasticsearchClient client,
+      final String processIndexName,
+      final ToolsConfiguration toolsConfiguration) {
     this.client = client;
     this.processIndexName = processIndexName;
+    this.toolsConfiguration = toolsConfiguration;
   }
 
   @Override
@@ -39,7 +44,7 @@ public class ElasticSearchProcessCacheLoader implements CacheLoader<Long, Cached
       final var processEntity = response.source();
       final var processDiagramData =
           ProcessCacheUtil.extractProcessDiagramData(
-              processEntity.getBpmnXml(), processEntity.getBpmnProcessId());
+              processEntity.getBpmnXml(), processEntity.getBpmnProcessId(), toolsConfiguration);
       return new CachedProcessEntity(
           processEntity.getName(),
           processEntity.getVersion(),

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/process/ElasticSearchProcessCacheLoader.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/process/ElasticSearchProcessCacheLoader.java
@@ -11,7 +11,7 @@ import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import com.github.benmanes.caffeine.cache.CacheLoader;
 import io.camunda.webapps.schema.entities.ProcessEntity;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
-import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
+import io.camunda.zeebe.exporter.common.extensionproperty.ExtensionPropertyConfiguration;
 import io.camunda.zeebe.exporter.common.utils.ProcessCacheUtil;
 import java.io.IOException;
 import org.slf4j.Logger;
@@ -23,12 +23,12 @@ public class ElasticSearchProcessCacheLoader implements CacheLoader<Long, Cached
 
   private final ElasticsearchClient client;
   private final String processIndexName;
-  private final ToolsConfiguration toolsConfiguration;
+  private final ExtensionPropertyConfiguration toolsConfiguration;
 
   public ElasticSearchProcessCacheLoader(
       final ElasticsearchClient client,
       final String processIndexName,
-      final ToolsConfiguration toolsConfiguration) {
+      final ExtensionPropertyConfiguration toolsConfiguration) {
     this.client = client;
     this.processIndexName = processIndexName;
     this.toolsConfiguration = toolsConfiguration;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/process/OpenSearchProcessCacheLoader.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/process/OpenSearchProcessCacheLoader.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.cache.process;
 import com.github.benmanes.caffeine.cache.CacheLoader;
 import io.camunda.webapps.schema.entities.ProcessEntity;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
+import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
 import io.camunda.zeebe.exporter.common.utils.ProcessCacheUtil;
 import java.io.IOException;
 import org.opensearch.client.opensearch.OpenSearchClient;
@@ -21,11 +22,15 @@ public class OpenSearchProcessCacheLoader implements CacheLoader<Long, CachedPro
 
   private final OpenSearchClient client;
   private final String processIndexName;
+  private final ToolsConfiguration toolsConfiguration;
 
   public OpenSearchProcessCacheLoader(
-      final OpenSearchClient client, final String processIndexName) {
+      final OpenSearchClient client,
+      final String processIndexName,
+      final ToolsConfiguration toolsConfiguration) {
     this.client = client;
     this.processIndexName = processIndexName;
+    this.toolsConfiguration = toolsConfiguration;
   }
 
   @Override
@@ -38,7 +43,7 @@ public class OpenSearchProcessCacheLoader implements CacheLoader<Long, CachedPro
       final var processEntity = response.source();
       final var processDiagramData =
           ProcessCacheUtil.extractProcessDiagramData(
-              processEntity.getBpmnXml(), processEntity.getBpmnProcessId());
+              processEntity.getBpmnXml(), processEntity.getBpmnProcessId(), toolsConfiguration);
       return new CachedProcessEntity(
           processEntity.getName(),
           processEntity.getVersion(),

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/process/OpenSearchProcessCacheLoader.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/process/OpenSearchProcessCacheLoader.java
@@ -22,15 +22,15 @@ public class OpenSearchProcessCacheLoader implements CacheLoader<Long, CachedPro
 
   private final OpenSearchClient client;
   private final String processIndexName;
-  private final ExtensionPropertyConfiguration toolsConfiguration;
+  private final ExtensionPropertyConfiguration extensionPropertiesConfiguration;
 
   public OpenSearchProcessCacheLoader(
       final OpenSearchClient client,
       final String processIndexName,
-      final ExtensionPropertyConfiguration toolsConfiguration) {
+      final ExtensionPropertyConfiguration extensionPropertiesConfiguration) {
     this.client = client;
     this.processIndexName = processIndexName;
-    this.toolsConfiguration = toolsConfiguration;
+    this.extensionPropertiesConfiguration = extensionPropertiesConfiguration;
   }
 
   @Override
@@ -43,7 +43,9 @@ public class OpenSearchProcessCacheLoader implements CacheLoader<Long, CachedPro
       final var processEntity = response.source();
       final var processDiagramData =
           ProcessCacheUtil.extractProcessDiagramData(
-              processEntity.getBpmnXml(), processEntity.getBpmnProcessId(), toolsConfiguration);
+              processEntity.getBpmnXml(),
+              processEntity.getBpmnProcessId(),
+              extensionPropertiesConfiguration);
       return new CachedProcessEntity(
           processEntity.getName(),
           processEntity.getVersion(),

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/process/OpenSearchProcessCacheLoader.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/process/OpenSearchProcessCacheLoader.java
@@ -10,7 +10,7 @@ package io.camunda.exporter.cache.process;
 import com.github.benmanes.caffeine.cache.CacheLoader;
 import io.camunda.webapps.schema.entities.ProcessEntity;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
-import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
+import io.camunda.zeebe.exporter.common.extensionproperty.ExtensionPropertyConfiguration;
 import io.camunda.zeebe.exporter.common.utils.ProcessCacheUtil;
 import java.io.IOException;
 import org.opensearch.client.opensearch.OpenSearchClient;
@@ -22,12 +22,12 @@ public class OpenSearchProcessCacheLoader implements CacheLoader<Long, CachedPro
 
   private final OpenSearchClient client;
   private final String processIndexName;
-  private final ToolsConfiguration toolsConfiguration;
+  private final ExtensionPropertyConfiguration toolsConfiguration;
 
   public OpenSearchProcessCacheLoader(
       final OpenSearchClient client,
       final String processIndexName,
-      final ToolsConfiguration toolsConfiguration) {
+      final ExtensionPropertyConfiguration toolsConfiguration) {
     this.client = client;
     this.processIndexName = processIndexName;
     this.toolsConfiguration = toolsConfiguration;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -11,8 +11,8 @@ import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.search.schema.config.IndexConfiguration;
 import io.camunda.search.schema.config.RetentionConfiguration;
 import io.camunda.zeebe.exporter.common.auditlog.AuditLogConfiguration;
+import io.camunda.zeebe.exporter.common.extensionproperty.ExtensionPropertyConfiguration;
 import io.camunda.zeebe.exporter.common.historydeletion.HistoryDeletionConfiguration;
-import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
 
 public class ExporterConfiguration {
 
@@ -31,7 +31,7 @@ public class ExporterConfiguration {
   private HistoryDeletionConfiguration historyDeletion = new HistoryDeletionConfiguration();
   private boolean createSchema = true;
   private boolean skipVariableWriteWithoutUserTasks = false;
-  private ToolsConfiguration tools = new ToolsConfiguration();
+  private ExtensionPropertyConfiguration extensionProperties = new ExtensionPropertyConfiguration();
 
   public AuditLogConfiguration getAuditLog() {
     return auditLog;
@@ -154,12 +154,12 @@ public class ExporterConfiguration {
     this.batchOperation = batchOperation;
   }
 
-  public ToolsConfiguration getTools() {
-    return tools;
+  public ExtensionPropertyConfiguration getExtensionProperties() {
+    return extensionProperties;
   }
 
-  public void setTools(final ToolsConfiguration tools) {
-    this.tools = tools;
+  public void setExtensionProperties(final ExtensionPropertyConfiguration extensionProperties) {
+    this.extensionProperties = extensionProperties;
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AbstractEventHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AbstractEventHandler.java
@@ -38,7 +38,7 @@ import io.camunda.webapps.schema.entities.messagesubscription.MessageSubscriptio
 import io.camunda.webapps.schema.entities.messagesubscription.MessageSubscriptionState;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
-import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
+import io.camunda.zeebe.exporter.common.extensionproperty.ExtensionPropertyConfiguration;
 import io.camunda.zeebe.exporter.common.utils.ProcessCacheUtil;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
@@ -50,9 +50,10 @@ public abstract class AbstractEventHandler<R extends RecordValue>
     implements ExportHandler<MessageSubscriptionEntity, R> {
   protected static final String ID_PATTERN = "%s_%s";
   protected final String indexName;
-  protected final ToolsConfiguration toolConfig;
+  protected final ExtensionPropertyConfiguration toolConfig;
 
-  public AbstractEventHandler(final String indexName, final ToolsConfiguration toolConfig) {
+  public AbstractEventHandler(
+      final String indexName, final ExtensionPropertyConfiguration toolConfig) {
     this.indexName = indexName;
     this.toolConfig = toolConfig;
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AbstractEventHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AbstractEventHandler.java
@@ -50,12 +50,12 @@ public abstract class AbstractEventHandler<R extends RecordValue>
     implements ExportHandler<MessageSubscriptionEntity, R> {
   protected static final String ID_PATTERN = "%s_%s";
   protected final String indexName;
-  protected final ExtensionPropertyConfiguration toolConfig;
+  protected final ExtensionPropertyConfiguration extensionPropertyConfig;
 
   public AbstractEventHandler(
-      final String indexName, final ExtensionPropertyConfiguration toolConfig) {
+      final String indexName, final ExtensionPropertyConfiguration extensionPropertyConfig) {
     this.indexName = indexName;
-    this.toolConfig = toolConfig;
+    this.extensionPropertyConfig = extensionPropertyConfig;
   }
 
   @Override
@@ -152,13 +152,14 @@ public abstract class AbstractEventHandler<R extends RecordValue>
               .map(p -> p.get(elementId))
               .orElse(Map.of());
       entity
-          .setToolName(ProcessCacheUtil.getToolName(ext, toolConfig.getExtensionPropertyToolName()))
+          .setToolName(
+              ProcessCacheUtil.getToolName(ext, extensionPropertyConfig.getToolNameProperty()))
           .setInboundConnectorType(
               ProcessCacheUtil.getInboundConnectorType(
-                  ext, toolConfig.getExtensionPropertyInboundConnectorType()))
+                  ext, extensionPropertyConfig.getInboundConnectorTypeProperty()))
           .setToolProperties(
               ProcessCacheUtil.getToolProperties(
-                  ext, toolConfig.getExtensionPropertyPrefixToolProperties()));
+                  ext, extensionPropertyConfig.getToolPropertiesPrefix()));
     }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MessageSubscriptionFromMessageStartEventSubscriptionHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MessageSubscriptionFromMessageStartEventSubscriptionHandler.java
@@ -15,7 +15,7 @@ import io.camunda.webapps.schema.entities.messagesubscription.MessageSubscriptio
 import io.camunda.webapps.schema.entities.messagesubscription.MessageSubscriptionMetadataEntity;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
-import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
+import io.camunda.zeebe.exporter.common.extensionproperty.ExtensionPropertyConfiguration;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
@@ -38,7 +38,7 @@ public class MessageSubscriptionFromMessageStartEventSubscriptionHandler
   public MessageSubscriptionFromMessageStartEventSubscriptionHandler(
       final String indexName,
       final ExporterEntityCache<Long, CachedProcessEntity> processCache,
-      final ToolsConfiguration toolConfig) {
+      final ExtensionPropertyConfiguration toolConfig) {
     super(indexName, toolConfig);
     this.processCache = processCache;
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MessageSubscriptionFromMessageStartEventSubscriptionHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MessageSubscriptionFromMessageStartEventSubscriptionHandler.java
@@ -38,8 +38,8 @@ public class MessageSubscriptionFromMessageStartEventSubscriptionHandler
   public MessageSubscriptionFromMessageStartEventSubscriptionHandler(
       final String indexName,
       final ExporterEntityCache<Long, CachedProcessEntity> processCache,
-      final ExtensionPropertyConfiguration toolConfig) {
-    super(indexName, toolConfig);
+      final ExtensionPropertyConfiguration extensionPropertyConfig) {
+    super(indexName, extensionPropertyConfig);
     this.processCache = processCache;
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MessageSubscriptionFromProcessMessageSubscriptionHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MessageSubscriptionFromProcessMessageSubscriptionHandler.java
@@ -16,7 +16,7 @@ import io.camunda.webapps.schema.entities.messagesubscription.MessageSubscriptio
 import io.camunda.webapps.schema.entities.messagesubscription.MessageSubscriptionMetadataEntity;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
-import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
+import io.camunda.zeebe.exporter.common.extensionproperty.ExtensionPropertyConfiguration;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
@@ -42,7 +42,7 @@ public class MessageSubscriptionFromProcessMessageSubscriptionHandler
       final String indexName,
       final ExporterMetadata exporterMetadata,
       final ExporterEntityCache<Long, CachedProcessEntity> processCache,
-      final ToolsConfiguration toolConfig) {
+      final ExtensionPropertyConfiguration toolConfig) {
     super(indexName, toolConfig);
     this.exporterMetadata = exporterMetadata;
     this.processCache = processCache;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MessageSubscriptionFromProcessMessageSubscriptionHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MessageSubscriptionFromProcessMessageSubscriptionHandler.java
@@ -42,8 +42,8 @@ public class MessageSubscriptionFromProcessMessageSubscriptionHandler
       final String indexName,
       final ExporterMetadata exporterMetadata,
       final ExporterEntityCache<Long, CachedProcessEntity> processCache,
-      final ExtensionPropertyConfiguration toolConfig) {
-    super(indexName, toolConfig);
+      final ExtensionPropertyConfiguration extensionPropertyConfig) {
+    super(indexName, extensionPropertyConfig);
     this.exporterMetadata = exporterMetadata;
     this.processCache = processCache;
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ProcessHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ProcessHandler.java
@@ -13,7 +13,7 @@ import io.camunda.webapps.schema.entities.ProcessEntity;
 import io.camunda.webapps.schema.entities.ProcessFlowNodeEntity;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
-import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
+import io.camunda.zeebe.exporter.common.extensionproperty.ExtensionPropertyConfiguration;
 import io.camunda.zeebe.exporter.common.utils.ProcessCacheUtil;
 import io.camunda.zeebe.model.bpmn.instance.FlowNode;
 import io.camunda.zeebe.protocol.record.Record;
@@ -31,12 +31,12 @@ public class ProcessHandler implements ExportHandler<ProcessEntity, Process> {
 
   private final String indexName;
   private final ExporterEntityCache<Long, CachedProcessEntity> processCache;
-  private final ToolsConfiguration toolsConfiguration;
+  private final ExtensionPropertyConfiguration toolsConfiguration;
 
   public ProcessHandler(
       final String indexName,
       final ExporterEntityCache<Long, CachedProcessEntity> processCache,
-      final ToolsConfiguration toolsConfiguration) {
+      final ExtensionPropertyConfiguration toolsConfiguration) {
     this.indexName = indexName;
     this.processCache = processCache;
     this.toolsConfiguration = toolsConfiguration;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ProcessHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ProcessHandler.java
@@ -13,6 +13,7 @@ import io.camunda.webapps.schema.entities.ProcessEntity;
 import io.camunda.webapps.schema.entities.ProcessFlowNodeEntity;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
+import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
 import io.camunda.zeebe.exporter.common.utils.ProcessCacheUtil;
 import io.camunda.zeebe.model.bpmn.instance.FlowNode;
 import io.camunda.zeebe.protocol.record.Record;
@@ -30,11 +31,15 @@ public class ProcessHandler implements ExportHandler<ProcessEntity, Process> {
 
   private final String indexName;
   private final ExporterEntityCache<Long, CachedProcessEntity> processCache;
+  private final ToolsConfiguration toolsConfiguration;
 
   public ProcessHandler(
-      final String indexName, final ExporterEntityCache<Long, CachedProcessEntity> processCache) {
+      final String indexName,
+      final ExporterEntityCache<Long, CachedProcessEntity> processCache,
+      final ToolsConfiguration toolsConfiguration) {
     this.indexName = indexName;
     this.processCache = processCache;
+    this.toolsConfiguration = toolsConfiguration;
   }
 
   @Override
@@ -92,7 +97,9 @@ public class ProcessHandler implements ExportHandler<ProcessEntity, Process> {
       final var flowNodes = reader.extractFlowNodes();
       extractProcessModelData(reader, entity, flowNodes);
       hasUserTasks = ProcessModelReader.hasUserTasks(flowNodes);
-      elementExtensionProperties = ProcessModelReader.extractExtensionProperties(flowNodes);
+      elementExtensionProperties =
+          ProcessModelReader.extractExtensionProperties(
+              flowNodes, toolsConfiguration.extensionPropertyFilter());
     } else {
       hasUserTasks = true;
       elementExtensionProperties = Map.of();

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ProcessHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ProcessHandler.java
@@ -31,15 +31,15 @@ public class ProcessHandler implements ExportHandler<ProcessEntity, Process> {
 
   private final String indexName;
   private final ExporterEntityCache<Long, CachedProcessEntity> processCache;
-  private final ExtensionPropertyConfiguration toolsConfiguration;
+  private final ExtensionPropertyConfiguration extensionPropertiesConfiguration;
 
   public ProcessHandler(
       final String indexName,
       final ExporterEntityCache<Long, CachedProcessEntity> processCache,
-      final ExtensionPropertyConfiguration toolsConfiguration) {
+      final ExtensionPropertyConfiguration extensionPropertiesConfiguration) {
     this.indexName = indexName;
     this.processCache = processCache;
-    this.toolsConfiguration = toolsConfiguration;
+    this.extensionPropertiesConfiguration = extensionPropertiesConfiguration;
   }
 
   @Override
@@ -99,7 +99,7 @@ public class ProcessHandler implements ExportHandler<ProcessEntity, Process> {
       hasUserTasks = ProcessModelReader.hasUserTasks(flowNodes);
       elementExtensionProperties =
           ProcessModelReader.extractExtensionProperties(
-              flowNodes, toolsConfiguration.extensionPropertyFilter());
+              flowNodes, extensionPropertiesConfiguration.extensionPropertyFilter());
     } else {
       hasUserTasks = true;
       elementExtensionProperties = Map.of();

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/AuditLogExporterFilterAlignmentTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/AuditLogExporterFilterAlignmentTest.java
@@ -166,7 +166,7 @@ class AuditLogExporterFilterAlignmentTest {
     public CacheLoader<Long, CachedProcessEntity> getProcessCacheLoader(
         final String processIndexName,
         final io.camunda.zeebe.exporter.common.extensionproperty.ExtensionPropertyConfiguration
-            toolsConfiguration) {
+            extensionPropertiesConfiguration) {
       return k -> null;
     }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/AuditLogExporterFilterAlignmentTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/AuditLogExporterFilterAlignmentTest.java
@@ -164,7 +164,8 @@ class AuditLogExporterFilterAlignmentTest {
 
     @Override
     public CacheLoader<Long, CachedProcessEntity> getProcessCacheLoader(
-        final String processIndexName) {
+        final String processIndexName,
+        final io.camunda.zeebe.exporter.common.tools.ToolsConfiguration toolsConfiguration) {
       return k -> null;
     }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/AuditLogExporterFilterAlignmentTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/AuditLogExporterFilterAlignmentTest.java
@@ -165,7 +165,8 @@ class AuditLogExporterFilterAlignmentTest {
     @Override
     public CacheLoader<Long, CachedProcessEntity> getProcessCacheLoader(
         final String processIndexName,
-        final io.camunda.zeebe.exporter.common.tools.ToolsConfiguration toolsConfiguration) {
+        final io.camunda.zeebe.exporter.common.extensionproperty.ExtensionPropertyConfiguration
+            toolsConfiguration) {
       return k -> null;
     }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -268,7 +268,7 @@ final class CamundaExporterIT {
     final Record record =
         generateRecordWithSupportedBrokerVersion(valueType, VariableIntent.CREATED);
     final var cacheProvider = mock(ExporterEntityCacheProvider.class);
-    when(cacheProvider.getProcessCacheLoader(anyString())).thenReturn(k -> null);
+    when(cacheProvider.getProcessCacheLoader(anyString(), any())).thenReturn(k -> null);
     when(cacheProvider.getBatchOperationCacheLoader(anyString())).thenReturn(k -> null);
     when(cacheProvider.getDecisionRequirementsCacheLoader(anyString())).thenReturn(k -> null);
     when(cacheProvider.getFormCacheLoader(anyString())).thenReturn(k -> null);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
@@ -138,7 +138,8 @@ final class CamundaExporterTest {
     @Override
     public CacheLoader<Long, CachedProcessEntity> getProcessCacheLoader(
         final String processIndexName,
-        final io.camunda.zeebe.exporter.common.tools.ToolsConfiguration toolsConfiguration) {
+        final io.camunda.zeebe.exporter.common.extensionproperty.ExtensionPropertyConfiguration
+            toolsConfiguration) {
       return k -> null;
     }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
@@ -139,7 +139,7 @@ final class CamundaExporterTest {
     public CacheLoader<Long, CachedProcessEntity> getProcessCacheLoader(
         final String processIndexName,
         final io.camunda.zeebe.exporter.common.extensionproperty.ExtensionPropertyConfiguration
-            toolsConfiguration) {
+            extensionPropertiesConfiguration) {
       return k -> null;
     }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
@@ -137,7 +137,8 @@ final class CamundaExporterTest {
 
     @Override
     public CacheLoader<Long, CachedProcessEntity> getProcessCacheLoader(
-        final String processIndexName) {
+        final String processIndexName,
+        final io.camunda.zeebe.exporter.common.tools.ToolsConfiguration toolsConfiguration) {
       return k -> null;
     }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/cache/ProcessCacheImplIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/cache/ProcessCacheImplIT.java
@@ -25,7 +25,7 @@ import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache.CacheLoaderFailedException;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCacheImpl;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
-import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
+import io.camunda.zeebe.exporter.common.extensionproperty.ExtensionPropertyConfiguration;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.builder.StartEventBuilder;
@@ -177,7 +177,7 @@ class ProcessCacheImplIT {
         new ExporterEntityCacheImpl<>(
             10,
             new ElasticSearchProcessCacheLoader(
-                SEARCH_DB.esClient(), indexName, new ToolsConfiguration()),
+                SEARCH_DB.esClient(), indexName, new ExtensionPropertyConfiguration()),
             new CaffeineCacheStatsCounter(
                 DefaultExporterResourceProvider.NAMESPACE, "ES", new SimpleMeterRegistry())),
         ProcessCacheImplIT::indexInElasticSearch);
@@ -188,7 +188,7 @@ class ProcessCacheImplIT {
         new ExporterEntityCacheImpl<>(
             10,
             new OpenSearchProcessCacheLoader(
-                SEARCH_DB.osClient(), indexName, new ToolsConfiguration()),
+                SEARCH_DB.osClient(), indexName, new ExtensionPropertyConfiguration()),
             new CaffeineCacheStatsCounter(
                 DefaultExporterResourceProvider.NAMESPACE, "OS", new SimpleMeterRegistry())),
         ProcessCacheImplIT::indexInOpenSearch);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/cache/ProcessCacheImplIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/cache/ProcessCacheImplIT.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache.CacheLoaderFailedException;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCacheImpl;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
+import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.builder.StartEventBuilder;
@@ -175,7 +176,8 @@ class ProcessCacheImplIT {
     return new ProcessCacheArgument(
         new ExporterEntityCacheImpl<>(
             10,
-            new ElasticSearchProcessCacheLoader(SEARCH_DB.esClient(), indexName),
+            new ElasticSearchProcessCacheLoader(
+                SEARCH_DB.esClient(), indexName, new ToolsConfiguration()),
             new CaffeineCacheStatsCounter(
                 DefaultExporterResourceProvider.NAMESPACE, "ES", new SimpleMeterRegistry())),
         ProcessCacheImplIT::indexInElasticSearch);
@@ -185,7 +187,8 @@ class ProcessCacheImplIT {
     return new ProcessCacheArgument(
         new ExporterEntityCacheImpl<>(
             10,
-            new OpenSearchProcessCacheLoader(SEARCH_DB.osClient(), indexName),
+            new OpenSearchProcessCacheLoader(
+                SEARCH_DB.osClient(), indexName, new ToolsConfiguration()),
             new CaffeineCacheStatsCounter(
                 DefaultExporterResourceProvider.NAMESPACE, "OS", new SimpleMeterRegistry())),
         ProcessCacheImplIT::indexInOpenSearch);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromMessageStartEventSubscriptionHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromMessageStartEventSubscriptionHandlerTest.java
@@ -22,7 +22,7 @@ import io.camunda.webapps.schema.entities.messagesubscription.MessageSubscriptio
 import io.camunda.webapps.schema.entities.messagesubscription.MessageSubscriptionState;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
-import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
+import io.camunda.zeebe.exporter.common.extensionproperty.ExtensionPropertyConfiguration;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
@@ -50,7 +50,7 @@ final class MessageSubscriptionFromMessageStartEventSubscriptionHandlerTest {
 
   private final MessageSubscriptionFromMessageStartEventSubscriptionHandler underTest =
       new MessageSubscriptionFromMessageStartEventSubscriptionHandler(
-          indexName, processCache, new ToolsConfiguration());
+          indexName, processCache, new ExtensionPropertyConfiguration());
 
   @BeforeEach
   void setUp() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromProcessMessageSubscriptionHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromProcessMessageSubscriptionHandlerTest.java
@@ -25,7 +25,7 @@ import io.camunda.webapps.schema.entities.messagesubscription.MessageSubscriptio
 import io.camunda.webapps.schema.entities.messagesubscription.MessageSubscriptionState;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
-import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
+import io.camunda.zeebe.exporter.common.extensionproperty.ExtensionPropertyConfiguration;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
@@ -56,7 +56,7 @@ final class MessageSubscriptionFromProcessMessageSubscriptionHandlerTest {
 
   private final MessageSubscriptionFromProcessMessageSubscriptionHandler underTest =
       new MessageSubscriptionFromProcessMessageSubscriptionHandler(
-          indexName, exporterMetadata, processCache, new ToolsConfiguration());
+          indexName, exporterMetadata, processCache, new ExtensionPropertyConfiguration());
 
   @BeforeEach
   void resetMetadata() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ProcessHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ProcessHandlerTest.java
@@ -16,6 +16,7 @@ import io.camunda.exporter.cache.TestProcessCache;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.ProcessEntity;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
+import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
@@ -33,7 +34,8 @@ public class ProcessHandlerTest {
   private final ProtocolFactory factory = new ProtocolFactory();
   private final String indexName = "test-process";
   private final TestProcessCache processCache = new TestProcessCache();
-  private final ProcessHandler underTest = new ProcessHandler(indexName, processCache);
+  private final ProcessHandler underTest =
+      new ProcessHandler(indexName, processCache, new ToolsConfiguration());
 
   @Test
   void testGetHandledValueType() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ProcessHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ProcessHandlerTest.java
@@ -16,7 +16,7 @@ import io.camunda.exporter.cache.TestProcessCache;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.ProcessEntity;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
-import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
+import io.camunda.zeebe.exporter.common.extensionproperty.ExtensionPropertyConfiguration;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
@@ -35,7 +35,7 @@ public class ProcessHandlerTest {
   private final String indexName = "test-process";
   private final TestProcessCache processCache = new TestProcessCache();
   private final ProcessHandler underTest =
-      new ProcessHandler(indexName, processCache, new ToolsConfiguration());
+      new ProcessHandler(indexName, processCache, new ExtensionPropertyConfiguration());
 
   @Test
   void testGetHandledValueType() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiverJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiverJobIT.java
@@ -11,6 +11,7 @@ import static io.camunda.exporter.utils.CamundaExporterSchemaUtils.createSchemas
 import static io.camunda.search.test.utils.SearchDBExtension.CUSTOM_PREFIX;
 import static io.camunda.search.test.utils.SearchDBExtension.TEST_INTEGRATION_OPENSEARCH_AWS_URL;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -242,7 +243,7 @@ public abstract class ArchiverJobIT<T extends ArchiverJob<?>> {
 
   private ExporterResourceProvider exporterResourceProvider(final ExporterConfiguration config) {
     final var cacheProvider = mock(ExporterEntityCacheProvider.class);
-    when(cacheProvider.getProcessCacheLoader(anyString())).thenReturn(k -> null);
+    when(cacheProvider.getProcessCacheLoader(anyString(), any())).thenReturn(k -> null);
     when(cacheProvider.getBatchOperationCacheLoader(anyString())).thenReturn(k -> null);
     when(cacheProvider.getDecisionRequirementsCacheLoader(anyString())).thenReturn(k -> null);
     when(cacheProvider.getFormCacheLoader(anyString())).thenReturn(k -> null);

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
@@ -13,8 +13,8 @@ import io.camunda.db.rdbms.write.RdbmsWriterConfig.HistoryConfig;
 import io.camunda.db.rdbms.write.RdbmsWriterConfig.InsertBatchingConfig;
 import io.camunda.zeebe.exporter.api.ExporterException;
 import io.camunda.zeebe.exporter.common.auditlog.AuditLogConfiguration;
+import io.camunda.zeebe.exporter.common.extensionproperty.ExtensionPropertyConfiguration;
 import io.camunda.zeebe.exporter.common.historydeletion.HistoryDeletionConfiguration;
-import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
 import java.time.Duration;
 import java.time.InstantSource;
 import java.util.ArrayList;
@@ -45,7 +45,7 @@ public class ExporterConfiguration {
   private CacheConfiguration decisionRequirementsCache = new CacheConfiguration();
   private CacheConfiguration batchOperationCache = new CacheConfiguration();
   private ReplicationConfiguration asyncReplication = new ReplicationConfiguration();
-  private ToolsConfiguration tools = new ToolsConfiguration();
+  private ExtensionPropertyConfiguration extensionProperties = new ExtensionPropertyConfiguration();
 
   public AuditLogConfiguration getAuditLog() {
     return auditLog;
@@ -152,12 +152,12 @@ public class ExporterConfiguration {
     this.asyncReplication = asyncReplication;
   }
 
-  public ToolsConfiguration getTools() {
-    return tools;
+  public ExtensionPropertyConfiguration getExtensionProperties() {
+    return extensionProperties;
   }
 
-  public void setTools(final ToolsConfiguration tools) {
-    this.tools = tools;
+  public void setExtensionProperties(final ExtensionPropertyConfiguration extensionProperties) {
+    this.extensionProperties = extensionProperties;
   }
 
   public void validate() {

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -184,7 +184,9 @@ public class RdbmsExporterWrapper implements Exporter {
       builder.withHandler(
           ValueType.PROCESS,
           new ProcessExportHandler(
-              rdbmsWriters.getProcessDefinitionWriter(), cacheRegistry.processCache()));
+              rdbmsWriters.getProcessDefinitionWriter(),
+              cacheRegistry.processCache(),
+              config.getTools()));
       builder.withHandler(
           ValueType.MAPPING_RULE,
           new MappingRuleExportHandler(rdbmsWriters.getMappingRuleWriter()));

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -186,7 +186,7 @@ public class RdbmsExporterWrapper implements Exporter {
           new ProcessExportHandler(
               rdbmsWriters.getProcessDefinitionWriter(),
               cacheRegistry.processCache(),
-              config.getTools()));
+              config.getExtensionProperties()));
       builder.withHandler(
           ValueType.MAPPING_RULE,
           new MappingRuleExportHandler(rdbmsWriters.getMappingRuleWriter()));
@@ -265,7 +265,7 @@ public class RdbmsExporterWrapper implements Exporter {
         new MessageSubscriptionExportHandler(
             rdbmsWriters.getMessageSubscriptionWriter(),
             cacheRegistry.processCache(),
-            config.getTools()));
+            config.getExtensionProperties()));
     builder.withHandler(
         ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
         new CorrelatedMessageSubscriptionFromProcessMessageSubscriptionExportHandler(
@@ -279,7 +279,7 @@ public class RdbmsExporterWrapper implements Exporter {
         new MessageSubscriptionFromMessageStartEventSubscriptionExportHandler(
             rdbmsWriters.getMessageSubscriptionWriter(),
             cacheRegistry.processCache(),
-            config.getTools()));
+            config.getExtensionProperties()));
     builder.withHandler(
         ValueType.HISTORY_DELETION,
         new HistoryDeletionDeletedHandler(rdbmsWriters.getHistoryDeletionWriter()));

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/cache/RdbmsCacheRegistry.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/cache/RdbmsCacheRegistry.java
@@ -23,7 +23,7 @@ import io.camunda.zeebe.exporter.common.cache.ExporterEntityCacheImpl;
 import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
 import io.camunda.zeebe.exporter.common.cache.decisionRequirements.CachedDecisionRequirementsEntity;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
-import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
+import io.camunda.zeebe.exporter.common.extensionproperty.ExtensionPropertyConfiguration;
 import io.camunda.zeebe.exporter.common.utils.ProcessCacheUtil;
 import io.camunda.zeebe.util.cache.CaffeineCacheStatsCounter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -52,7 +52,7 @@ public final class RdbmsCacheRegistry {
         createCache(
             config.getProcessCache().getMaxSize(),
             "process",
-            processLoader(rdbmsService, config.getTools()),
+            processLoader(rdbmsService, config.getExtensionProperties()),
             meterRegistry);
     decisionRequirementsCache =
         createCache(
@@ -95,7 +95,7 @@ public final class RdbmsCacheRegistry {
   }
 
   private BulkExporterEntityCacheLoader<Long, CachedProcessEntity> processLoader(
-      final RdbmsService rdbmsService, final ToolsConfiguration toolsConfiguration) {
+      final RdbmsService rdbmsService, final ExtensionPropertyConfiguration toolsConfiguration) {
     final ProcessDefinitionDbReader reader = rdbmsService.getProcessDefinitionReader();
     return new RdbmsEntityCacheLoader<>(
         "Process",
@@ -139,7 +139,7 @@ public final class RdbmsCacheRegistry {
 
   private static CachedProcessEntity toCachedProcessEntity(
       final ProcessDefinitionEntity processDefinitionEntity,
-      final ToolsConfiguration toolsConfiguration) {
+      final ExtensionPropertyConfiguration toolsConfiguration) {
     final var processDiagramData =
         ProcessCacheUtil.extractProcessDiagramData(processDefinitionEntity, toolsConfiguration);
     return new CachedProcessEntity(

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/cache/RdbmsCacheRegistry.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/cache/RdbmsCacheRegistry.java
@@ -95,7 +95,8 @@ public final class RdbmsCacheRegistry {
   }
 
   private BulkExporterEntityCacheLoader<Long, CachedProcessEntity> processLoader(
-      final RdbmsService rdbmsService, final ExtensionPropertyConfiguration toolsConfiguration) {
+      final RdbmsService rdbmsService,
+      final ExtensionPropertyConfiguration extensionPropertiesConfiguration) {
     final ProcessDefinitionDbReader reader = rdbmsService.getProcessDefinitionReader();
     return new RdbmsEntityCacheLoader<>(
         "Process",
@@ -107,7 +108,7 @@ public final class RdbmsCacheRegistry {
                         .resultConfig(c -> c.includeXml(true))),
         query -> reader.search(query).items(),
         ProcessDefinitionEntity::processDefinitionKey,
-        entity -> toCachedProcessEntity(entity, toolsConfiguration));
+        entity -> toCachedProcessEntity(entity, extensionPropertiesConfiguration));
   }
 
   private BulkExporterEntityCacheLoader<Long, CachedDecisionRequirementsEntity>
@@ -139,9 +140,10 @@ public final class RdbmsCacheRegistry {
 
   private static CachedProcessEntity toCachedProcessEntity(
       final ProcessDefinitionEntity processDefinitionEntity,
-      final ExtensionPropertyConfiguration toolsConfiguration) {
+      final ExtensionPropertyConfiguration extensionPropertiesConfiguration) {
     final var processDiagramData =
-        ProcessCacheUtil.extractProcessDiagramData(processDefinitionEntity, toolsConfiguration);
+        ProcessCacheUtil.extractProcessDiagramData(
+            processDefinitionEntity, extensionPropertiesConfiguration);
     return new CachedProcessEntity(
         processDefinitionEntity.name(),
         processDefinitionEntity.version(),

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/cache/RdbmsCacheRegistry.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/cache/RdbmsCacheRegistry.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.exporter.common.cache.ExporterEntityCacheImpl;
 import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
 import io.camunda.zeebe.exporter.common.cache.decisionRequirements.CachedDecisionRequirementsEntity;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
+import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
 import io.camunda.zeebe.exporter.common.utils.ProcessCacheUtil;
 import io.camunda.zeebe.util.cache.CaffeineCacheStatsCounter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -51,7 +52,7 @@ public final class RdbmsCacheRegistry {
         createCache(
             config.getProcessCache().getMaxSize(),
             "process",
-            processLoader(rdbmsService),
+            processLoader(rdbmsService, config.getTools()),
             meterRegistry);
     decisionRequirementsCache =
         createCache(
@@ -94,7 +95,7 @@ public final class RdbmsCacheRegistry {
   }
 
   private BulkExporterEntityCacheLoader<Long, CachedProcessEntity> processLoader(
-      final RdbmsService rdbmsService) {
+      final RdbmsService rdbmsService, final ToolsConfiguration toolsConfiguration) {
     final ProcessDefinitionDbReader reader = rdbmsService.getProcessDefinitionReader();
     return new RdbmsEntityCacheLoader<>(
         "Process",
@@ -106,7 +107,7 @@ public final class RdbmsCacheRegistry {
                         .resultConfig(c -> c.includeXml(true))),
         query -> reader.search(query).items(),
         ProcessDefinitionEntity::processDefinitionKey,
-        RdbmsCacheRegistry::toCachedProcessEntity);
+        entity -> toCachedProcessEntity(entity, toolsConfiguration));
   }
 
   private BulkExporterEntityCacheLoader<Long, CachedDecisionRequirementsEntity>
@@ -137,9 +138,10 @@ public final class RdbmsCacheRegistry {
   }
 
   private static CachedProcessEntity toCachedProcessEntity(
-      final ProcessDefinitionEntity processDefinitionEntity) {
+      final ProcessDefinitionEntity processDefinitionEntity,
+      final ToolsConfiguration toolsConfiguration) {
     final var processDiagramData =
-        ProcessCacheUtil.extractProcessDiagramData(processDefinitionEntity);
+        ProcessCacheUtil.extractProcessDiagramData(processDefinitionEntity, toolsConfiguration);
     return new CachedProcessEntity(
         processDefinitionEntity.name(),
         processDefinitionEntity.version(),

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionExportHandler.java
@@ -16,7 +16,7 @@ import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionS
 import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionType;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
-import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
+import io.camunda.zeebe.exporter.common.extensionproperty.ExtensionPropertyConfiguration;
 import io.camunda.zeebe.exporter.common.utils.ProcessCacheUtil;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.Intent;
@@ -38,12 +38,12 @@ public class MessageSubscriptionExportHandler
           ProcessMessageSubscriptionIntent.MIGRATED);
   private final MessageSubscriptionWriter messageSubscriptionWriter;
   private final ExporterEntityCache<Long, CachedProcessEntity> processCache;
-  private final ToolsConfiguration toolConfig;
+  private final ExtensionPropertyConfiguration toolConfig;
 
   public MessageSubscriptionExportHandler(
       final MessageSubscriptionWriter messageSubscriptionWriter,
       final ExporterEntityCache<Long, CachedProcessEntity> processCache,
-      final ToolsConfiguration toolConfig) {
+      final ExtensionPropertyConfiguration toolConfig) {
     this.messageSubscriptionWriter = messageSubscriptionWriter;
     this.processCache = processCache;
     this.toolConfig = toolConfig;

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionExportHandler.java
@@ -38,15 +38,15 @@ public class MessageSubscriptionExportHandler
           ProcessMessageSubscriptionIntent.MIGRATED);
   private final MessageSubscriptionWriter messageSubscriptionWriter;
   private final ExporterEntityCache<Long, CachedProcessEntity> processCache;
-  private final ExtensionPropertyConfiguration toolConfig;
+  private final ExtensionPropertyConfiguration extensionPropertyConfig;
 
   public MessageSubscriptionExportHandler(
       final MessageSubscriptionWriter messageSubscriptionWriter,
       final ExporterEntityCache<Long, CachedProcessEntity> processCache,
-      final ExtensionPropertyConfiguration toolConfig) {
+      final ExtensionPropertyConfiguration extensionPropertyConfig) {
     this.messageSubscriptionWriter = messageSubscriptionWriter;
     this.processCache = processCache;
-    this.toolConfig = toolConfig;
+    this.extensionPropertyConfig = extensionPropertyConfig;
   }
 
   @Override
@@ -100,11 +100,11 @@ public class MessageSubscriptionExportHandler
         .processDefinitionVersion(cached.map(CachedProcessEntity::version).orElse(null))
         .toolProperties(
             ProcessCacheUtil.getToolProperties(
-                ext, toolConfig.getExtensionPropertyPrefixToolProperties()))
-        .toolName(ProcessCacheUtil.getToolName(ext, toolConfig.getExtensionPropertyToolName()))
+                ext, extensionPropertyConfig.getToolPropertiesPrefix()))
+        .toolName(ProcessCacheUtil.getToolName(ext, extensionPropertyConfig.getToolNameProperty()))
         .inboundConnectorType(
             ProcessCacheUtil.getInboundConnectorType(
-                ext, toolConfig.getExtensionPropertyInboundConnectorType()))
+                ext, extensionPropertyConfig.getInboundConnectorTypeProperty()))
         .build();
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionFromMessageStartEventSubscriptionExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionFromMessageStartEventSubscriptionExportHandler.java
@@ -16,7 +16,7 @@ import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionS
 import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionType;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
-import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
+import io.camunda.zeebe.exporter.common.extensionproperty.ExtensionPropertyConfiguration;
 import io.camunda.zeebe.exporter.common.utils.ProcessCacheUtil;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.Intent;
@@ -38,12 +38,12 @@ public class MessageSubscriptionFromMessageStartEventSubscriptionExportHandler
 
   private final MessageSubscriptionWriter messageSubscriptionWriter;
   private final ExporterEntityCache<Long, CachedProcessEntity> processCache;
-  private final ToolsConfiguration toolConfig;
+  private final ExtensionPropertyConfiguration toolConfig;
 
   public MessageSubscriptionFromMessageStartEventSubscriptionExportHandler(
       final MessageSubscriptionWriter messageSubscriptionWriter,
       final ExporterEntityCache<Long, CachedProcessEntity> processCache,
-      final ToolsConfiguration toolConfig) {
+      final ExtensionPropertyConfiguration toolConfig) {
     this.messageSubscriptionWriter = messageSubscriptionWriter;
     this.processCache = processCache;
     this.toolConfig = toolConfig;

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionFromMessageStartEventSubscriptionExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MessageSubscriptionFromMessageStartEventSubscriptionExportHandler.java
@@ -38,15 +38,15 @@ public class MessageSubscriptionFromMessageStartEventSubscriptionExportHandler
 
   private final MessageSubscriptionWriter messageSubscriptionWriter;
   private final ExporterEntityCache<Long, CachedProcessEntity> processCache;
-  private final ExtensionPropertyConfiguration toolConfig;
+  private final ExtensionPropertyConfiguration extensionPropertyConfig;
 
   public MessageSubscriptionFromMessageStartEventSubscriptionExportHandler(
       final MessageSubscriptionWriter messageSubscriptionWriter,
       final ExporterEntityCache<Long, CachedProcessEntity> processCache,
-      final ExtensionPropertyConfiguration toolConfig) {
+      final ExtensionPropertyConfiguration extensionPropertyConfig) {
     this.messageSubscriptionWriter = messageSubscriptionWriter;
     this.processCache = processCache;
-    this.toolConfig = toolConfig;
+    this.extensionPropertyConfig = extensionPropertyConfig;
   }
 
   @Override
@@ -99,11 +99,11 @@ public class MessageSubscriptionFromMessageStartEventSubscriptionExportHandler
         .processDefinitionVersion(cached.map(CachedProcessEntity::version).orElse(null))
         .toolProperties(
             ProcessCacheUtil.getToolProperties(
-                ext, toolConfig.getExtensionPropertyPrefixToolProperties()))
-        .toolName(ProcessCacheUtil.getToolName(ext, toolConfig.getExtensionPropertyToolName()))
+                ext, extensionPropertyConfig.getToolPropertiesPrefix()))
+        .toolName(ProcessCacheUtil.getToolName(ext, extensionPropertyConfig.getToolNameProperty()))
         .inboundConnectorType(
             ProcessCacheUtil.getInboundConnectorType(
-                ext, toolConfig.getExtensionPropertyInboundConnectorType()))
+                ext, extensionPropertyConfig.getInboundConnectorTypeProperty()))
         .build();
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ProcessExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ProcessExportHandler.java
@@ -12,7 +12,7 @@ import io.camunda.db.rdbms.write.service.ProcessDefinitionWriter;
 import io.camunda.exporter.rdbms.RdbmsExportHandler;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
-import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
+import io.camunda.zeebe.exporter.common.extensionproperty.ExtensionPropertyConfiguration;
 import io.camunda.zeebe.exporter.common.utils.ProcessCacheUtil;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -29,12 +29,12 @@ public class ProcessExportHandler implements RdbmsExportHandler<Process> {
 
   private final ProcessDefinitionWriter processDefinitionWriter;
   private final ExporterEntityCache<Long, CachedProcessEntity> processCache;
-  private final ToolsConfiguration toolsConfiguration;
+  private final ExtensionPropertyConfiguration toolsConfiguration;
 
   public ProcessExportHandler(
       final ProcessDefinitionWriter processDefinitionWriter,
       final ExporterEntityCache<Long, CachedProcessEntity> processCache,
-      final ToolsConfiguration toolsConfiguration) {
+      final ExtensionPropertyConfiguration toolsConfiguration) {
     this.processDefinitionWriter = processDefinitionWriter;
     this.processCache = processCache;
     this.toolsConfiguration = toolsConfiguration;

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ProcessExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ProcessExportHandler.java
@@ -12,6 +12,7 @@ import io.camunda.db.rdbms.write.service.ProcessDefinitionWriter;
 import io.camunda.exporter.rdbms.RdbmsExportHandler;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
+import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
 import io.camunda.zeebe.exporter.common.utils.ProcessCacheUtil;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -28,12 +29,15 @@ public class ProcessExportHandler implements RdbmsExportHandler<Process> {
 
   private final ProcessDefinitionWriter processDefinitionWriter;
   private final ExporterEntityCache<Long, CachedProcessEntity> processCache;
+  private final ToolsConfiguration toolsConfiguration;
 
   public ProcessExportHandler(
       final ProcessDefinitionWriter processDefinitionWriter,
-      final ExporterEntityCache<Long, CachedProcessEntity> processCache) {
+      final ExporterEntityCache<Long, CachedProcessEntity> processCache,
+      final ToolsConfiguration toolsConfiguration) {
     this.processDefinitionWriter = processDefinitionWriter;
     this.processCache = processCache;
+    this.toolsConfiguration = toolsConfiguration;
   }
 
   @Override
@@ -59,7 +63,9 @@ public class ProcessExportHandler implements RdbmsExportHandler<Process> {
       final var flowNodes = processModelReader.extractFlowNodes();
       final var flowNodesMap = ProcessCacheUtil.getFlowNodesMap(flowNodes);
       final var hasUserTasks = ProcessModelReader.hasUserTasks(flowNodes);
-      final var extensionProperties = ProcessModelReader.extractExtensionProperties(flowNodes);
+      final var extensionProperties =
+          ProcessModelReader.extractExtensionProperties(
+              flowNodes, toolsConfiguration.extensionPropertyFilter());
       cachedProcessEntity =
           new CachedProcessEntity(
               dbModel.name(),

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ProcessExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ProcessExportHandler.java
@@ -29,15 +29,15 @@ public class ProcessExportHandler implements RdbmsExportHandler<Process> {
 
   private final ProcessDefinitionWriter processDefinitionWriter;
   private final ExporterEntityCache<Long, CachedProcessEntity> processCache;
-  private final ExtensionPropertyConfiguration toolsConfiguration;
+  private final ExtensionPropertyConfiguration extensionPropertiesConfiguration;
 
   public ProcessExportHandler(
       final ProcessDefinitionWriter processDefinitionWriter,
       final ExporterEntityCache<Long, CachedProcessEntity> processCache,
-      final ExtensionPropertyConfiguration toolsConfiguration) {
+      final ExtensionPropertyConfiguration extensionPropertiesConfiguration) {
     this.processDefinitionWriter = processDefinitionWriter;
     this.processCache = processCache;
-    this.toolsConfiguration = toolsConfiguration;
+    this.extensionPropertiesConfiguration = extensionPropertiesConfiguration;
   }
 
   @Override
@@ -65,7 +65,7 @@ public class ProcessExportHandler implements RdbmsExportHandler<Process> {
       final var hasUserTasks = ProcessModelReader.hasUserTasks(flowNodes);
       final var extensionProperties =
           ProcessModelReader.extractExtensionProperties(
-              flowNodes, toolsConfiguration.extensionPropertyFilter());
+              flowNodes, extensionPropertiesConfiguration.extensionPropertyFilter());
       cachedProcessEntity =
           new CachedProcessEntity(
               dbModel.name(),

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/message/MessageSubscriptionExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/message/MessageSubscriptionExportHandlerTest.java
@@ -21,7 +21,7 @@ import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionS
 import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionType;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
-import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
+import io.camunda.zeebe.exporter.common.extensionproperty.ExtensionPropertyConfiguration;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
@@ -52,7 +52,8 @@ final class MessageSubscriptionExportHandlerTest {
       mock(ExporterEntityCache.class);
 
   private final MessageSubscriptionExportHandler underTest =
-      new MessageSubscriptionExportHandler(writer, processCache, new ToolsConfiguration());
+      new MessageSubscriptionExportHandler(
+          writer, processCache, new ExtensionPropertyConfiguration());
 
   @ParameterizedTest
   @EnumSource(

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/message/MessageSubscriptionFromMessageStartEventSubscriptionExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/message/MessageSubscriptionFromMessageStartEventSubscriptionExportHandlerTest.java
@@ -21,7 +21,7 @@ import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionS
 import io.camunda.search.entities.MessageSubscriptionEntity.MessageSubscriptionType;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
-import io.camunda.zeebe.exporter.common.tools.ToolsConfiguration;
+import io.camunda.zeebe.exporter.common.extensionproperty.ExtensionPropertyConfiguration;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
@@ -52,7 +52,7 @@ final class MessageSubscriptionFromMessageStartEventSubscriptionExportHandlerTes
 
   private final MessageSubscriptionFromMessageStartEventSubscriptionExportHandler underTest =
       new MessageSubscriptionFromMessageStartEventSubscriptionExportHandler(
-          writer, processCache, new ToolsConfiguration());
+          writer, processCache, new ExtensionPropertyConfiguration());
 
   @ParameterizedTest
   @EnumSource(MessageStartEventSubscriptionIntent.class)

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/modelreader/ProcessModelReader.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/modelreader/ProcessModelReader.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Predicate;
 import org.camunda.bpm.model.xml.instance.ModelElementInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -94,13 +95,13 @@ public final class ProcessModelReader {
 
   /**
    * Returns a map of elementId → zeebe:properties (name→value) for all flow nodes that carry
-   * zeebe:properties extension elements.
+   * zeebe:properties extension elements, retaining only entries whose name passes the given filter.
    */
   public static Map<String, Map<String, String>> extractExtensionProperties(
-      final Collection<FlowNode> flowNodes) {
+      final Collection<FlowNode> flowNodes, final Predicate<String> propertyNameFilter) {
     final Map<String, Map<String, String>> result = new HashMap<>();
     for (final FlowNode flowNode : flowNodes) {
-      final var props = zeebePropertiesAsMap(flowNode);
+      final var props = zeebePropertiesAsMap(flowNode, propertyNameFilter);
       if (!props.isEmpty()) {
         result.put(flowNode.getId(), props);
       }
@@ -108,7 +109,8 @@ public final class ProcessModelReader {
     return result;
   }
 
-  private static Map<String, String> zeebePropertiesAsMap(final BaseElement element) {
+  private static Map<String, String> zeebePropertiesAsMap(
+      final BaseElement element, final Predicate<String> propertyNameFilter) {
     return getExtensionElementQuery(element, ZeebeProperties.class)
         .flatMap(Query::findSingleResult)
         .map(
@@ -119,7 +121,11 @@ public final class ProcessModelReader {
                       p -> {
                         final String name = p.getName();
                         final String value = p.getValue();
-                        if (name != null && !name.isBlank() && value != null && !value.isBlank()) {
+                        if (name != null
+                            && !name.isBlank()
+                            && value != null
+                            && !value.isBlank()
+                            && propertyNameFilter.test(name)) {
                           map.put(name, value);
                         }
                       });

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/modelreader/ProcessModelReader.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/modelreader/ProcessModelReader.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Predicate;
+import org.apache.commons.lang3.StringUtils;
 import org.camunda.bpm.model.xml.instance.ModelElementInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -121,10 +122,8 @@ public final class ProcessModelReader {
                       p -> {
                         final String name = p.getName();
                         final String value = p.getValue();
-                        if (name != null
-                            && !name.isBlank()
-                            && value != null
-                            && !value.isBlank()
+                        if (StringUtils.isNotBlank(name)
+                            && StringUtils.isNotBlank(value)
                             && propertyNameFilter.test(name)) {
                           map.put(name, value);
                         }

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/modelreader/ProcessModelReaderTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/modelreader/ProcessModelReaderTest.java
@@ -290,7 +290,8 @@ public class ProcessModelReaderTest {
     final var reader = ProcessModelReader.of(bpmnBytes, processId);
     assertThat(reader).isPresent();
     final var allProps =
-        ProcessModelReader.extractExtensionProperties(reader.get().extractFlowNodes());
+        ProcessModelReader.extractExtensionProperties(
+            reader.get().extractFlowNodes(), name -> true);
 
     // then — StartEvent_1 has publicAccess=true
     assertThat(allProps).containsKey("StartEvent_1");
@@ -310,7 +311,8 @@ public class ProcessModelReaderTest {
     final var reader = ProcessModelReader.of(bpmnBytes, processId);
     assertThat(reader).isPresent();
     final var allProps =
-        ProcessModelReader.extractExtensionProperties(reader.get().extractFlowNodes());
+        ProcessModelReader.extractExtensionProperties(
+            reader.get().extractFlowNodes(), name -> true);
 
     // then
     assertThat(allProps).isEmpty();
@@ -327,7 +329,8 @@ public class ProcessModelReaderTest {
     final var reader = ProcessModelReader.of(bpmnBytes, processId);
     assertThat(reader).isPresent();
     final var allProps =
-        ProcessModelReader.extractExtensionProperties(reader.get().extractFlowNodes());
+        ProcessModelReader.extractExtensionProperties(
+            reader.get().extractFlowNodes(), name -> true);
 
     // then — only the valid publicAccess property should be present
     assertThat(allProps).containsKey("StartEvent_1");


### PR DESCRIPTION
## Summary

Closes #52708

- **Cache bloat (A):** `ProcessModelReader.extractExtensionProperties` now requires a filter predicate — no unfiltered overload exists. `ToolsConfiguration.extensionPropertyFilter()` is the single canonical definition of which zeebe:properties are tool-related. All cache-population paths (ES/OS loaders, `ProcessHandler`, `ProcessExportHandler`, RDBMS) thread `ToolsConfiguration` through and apply the filter, so only `toolName`, `inboundConnectorType`, and `io.camunda.tool:*` properties are retained.

- **RDBMS truncation (B):** `MessageSubscriptionWriter` now injects `VendorDatabaseProperties` and calls `truncateToolFields()` before every insert and update. `MessageSubscriptionDbModel.truncateToolFields` truncates `toolName` and `inboundConnectorType`, following the same pattern as `AuditLogWriter`/`AuditLogDbModel`.

## Test plan

- [x] `ProcessModelReaderTest` — 14 tests, all pass; includes `extractExtensionProperties` with filter
- [x] `ProcessCacheUtilTest` — 4 tests, all pass; includes `shouldOnlyRetainKnownToolPropertiesInProcessCache`
- [x] `ProcessHandlerTest` — 12 tests, all pass
- [x] `MessageSubscriptionWriterTest` — 6 tests, all pass; covers within-limit, char-limit truncation on create/update

🤖 Generated with [Claude Code](https://claude.com/claude-code)